### PR TITLE
Fix translation

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -572,7 +572,7 @@ Willkommen zum \"K-9 Mail\"-Setup. K-9 ist eine quelloffene E-Mail-Anwendung fü
 
     <string name="account_settings_general_title">Allgemeine Einstellungen</string>
     <string name="account_settings_display_prefs_title">Anzeige</string>
-    <string name="account_settings_sync">Ordner synchronisieren</string>
+    <string name="account_settings_sync">Emails abrufen</string>
     <string name="account_settings_folders">Ordner</string>
     <string name="account_settings_message_lists">Liste der Nachrichten</string>
     <string name="account_settings_message_view">Anzeige der Nachricht</string>


### PR DESCRIPTION
this translation was very confusing

> 23:23:02 < toe> hmm... any other ideas? or useful logs i could check?  
> 23:23:07 < cketti> toe: did you check "show only subscribed folders" in incoming server settings?  
> 23:24:13 < toe> where do i find that option?  
> 23:24:32 < cketti> account settings -> fetching mail -> incoming server settings  
> 23:25:18 < toe> i have a german localized version, so i have to search for a moment...  
> 23:26:28 < cketti> "Ordner synchronisieren"  
> 23:26:52 < cketti> "Einstellungen Posteingang"  
> 23:27:45 < cketti> someone mentioned the german translation sucks... now i know what he meant :)  
> 23:27:46 < toe> aaaaaaaaaaaaah  
> 23:28:04 < toe> there we go  
> 23:28:16 < cketti> btw. you can change k9 locale to english if you want to (that's what i do)  
> 23:28:20 < toe> holy crap, some of those options are hard to find ;)  
> 23:28:39 < toe> code hosting was migrated completely to github?  
> 23:28:45 < cketti> yes  
> 23:29:19 < toe> you will get a pull request for that bad translation soon  
> 23:29:33 < toe> Ordner synchronisieren means "folder synchronization"  
