### PR TITLE
Fix translation

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -12,8 +12,8 @@
     <string name="app_libraries">Wir benutzen die folgenden externen Bibliotheken: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="app_emoji_icons">Emoji Bilder: <xliff:g id="app_emoji_icons_link">%s</xliff:g></string>
 
-    <string name="read_attachment_label">Anlagen der Nachricht lesen</string>
-    <string name="read_attachment_desc">Dieser Anwendung erlauben die Anlagen Ihrer Nachrichten zu lesen.</string>
+    <string name="read_attachment_label">Anhänge der Nachricht lesen</string>
+    <string name="read_attachment_desc">Dieser Anwendung erlauben die Anhänge Ihrer Nachrichten zu lesen.</string>
     <string name="read_messages_label">Nachrichten lesen</string>
     <string name="read_messages_desc">Der Anwendung erlauben Ihre Nachrichten zu lesen.</string>
     <string name="delete_messages_label">Nachrichten löschen</string>
@@ -111,9 +111,9 @@
     <string name="view_hide_details_action">Details anzeigen/verbergen</string>
     <string name="add_cc_bcc_action">CC/BCC hinzufügen</string>
     <string name="edit_subject_action">Betreff bearbeiten</string>
-    <string name="add_attachment_action">Anlage hinzufügen</string>
-    <string name="add_attachment_action_image">Anlage hinzufügen (Bild)</string>
-    <string name="add_attachment_action_video">Anlage hinzufügen (Video)</string>
+    <string name="add_attachment_action">Anhang hinzufügen</string>
+    <string name="add_attachment_action_image">Anhang hinzufügen (Bild)</string>
+    <string name="add_attachment_action_video">Anhang hinzufügen (Video)</string>
     <string name="dump_settings_action">Einstellungen ausgeben (Dump)</string>
     <string name="empty_trash_action">Papierkorb leeren</string>
     <string name="expunge_action">Bereinigen (Expunge)</string>
@@ -214,7 +214,7 @@ Willkommen zum \"K-9 Mail\"-Setup. K-9 ist eine quelloffene E-Mail-Anwendung fü
 \n * Konfiguration einer Antwort-Adresse
 \n * Tastatur-Shortcuts
 \n * Verbesserte IMAP-Unterstützung
-\n * Speichern von Anlagen auf SD-Karte
+\n * Speichern von Anhängen auf SD-Karte
 \n * Papierkorb leeren
 \n * Sortieren der Nachrichten
 \n * ...und viele mehr
@@ -264,8 +264,8 @@ Willkommen zum \"K-9 Mail\"-Setup. K-9 ist eine quelloffene E-Mail-Anwendung fü
     <string name="message_compose_reply_header_fmt">\n\n<xliff:g id="sender">%s</xliff:g> schrieb:\n\n</string>
     <string name="message_compose_quoted_text_label">Zitierter Text</string>
     <string name="message_compose_error_no_recipients">Sie müssen mindestens einen Empfänger wählen.</string>
-    <string name="message_compose_downloading_attachments_toast">Einige Anlagen wurden nicht heruntergeladen. Sie werden automatisch heruntergeladen, bevor diese Nachricht gesendet wird.</string>
-    <string name="message_compose_attachments_skipped_toast">Einige Anlagen können nicht weitergeleitet werden, da diese nicht heruntergeladen wurden.</string>
+    <string name="message_compose_downloading_attachments_toast">Einige Anhänge wurden nicht heruntergeladen. Sie werden automatisch heruntergeladen, bevor diese Nachricht gesendet wird.</string>
+    <string name="message_compose_attachments_skipped_toast">Einige Anhänge können nicht weitergeleitet werden, da diese nicht heruntergeladen wurden.</string>
 
 
 
@@ -280,11 +280,11 @@ Willkommen zum \"K-9 Mail\"-Setup. K-9 ist eine quelloffene E-Mail-Anwendung fü
     <string name="message_view_move_action">Verschieben</string>
     <string name="message_view_spam_action">Spam</string>
     <string name="message_view_datetime_fmt">dd. MMM yyyy HH:mm</string>
-    <string name="message_view_status_attachment_saved">Anlage auf SD-Karte gespeichert als <xliff:g id="filename">%s</xliff:g>.</string>
-    <string name="message_view_status_attachment_not_saved">Anlage konnte nicht auf SD-Karte gespeichert werden.</string>
+    <string name="message_view_status_attachment_saved">Anhänge auf SD-Karte gespeichert als <xliff:g id="filename">%s</xliff:g>.</string>
+    <string name="message_view_status_attachment_not_saved">Anhang konnte nicht auf SD-Karte gespeichert werden.</string>
     <string name="message_view_show_pictures_instructions">Wählen Sie \"Bilder anzeigen\", um eingebettete Bilder abzurufen.</string>
     <string name="message_view_show_pictures_action">Bilder anzeigen</string>
-    <string name="message_view_fetching_attachment_toast">Lade Anlage.</string>
+    <string name="message_view_fetching_attachment_toast">Lade Anhang.</string>
     <string name="message_view_no_viewer">Es wurde kein Anzeigeprogramm für <xliff:g id="mimetype">%s</xliff:g> gefunden.</string>
 
 
@@ -572,7 +572,7 @@ Willkommen zum \"K-9 Mail\"-Setup. K-9 ist eine quelloffene E-Mail-Anwendung fü
 
     <string name="account_settings_general_title">Allgemeine Einstellungen</string>
     <string name="account_settings_display_prefs_title">Anzeige</string>
-    <string name="account_settings_sync">Emails abrufen</string>
+    <string name="account_settings_sync">Nachrichten abrufen</string>
     <string name="account_settings_folders">Ordner</string>
     <string name="account_settings_message_lists">Liste der Nachrichten</string>
     <string name="account_settings_message_view">Anzeige der Nachricht</string>
@@ -766,8 +766,8 @@ Willkommen zum \"K-9 Mail\"-Setup. K-9 ist eine quelloffene E-Mail-Anwendung fü
     <string name="sort_flagged_last">Nicht markierte Nachrichten zuerst</string>
     <string name="sort_unread_first">Ungelesene Nachrichten zuerst</string>
     <string name="sort_unread_last">Gelesene Nachrichten zuerst</string>
-    <string name="sort_attach_first">Nachrichten mit Anlagen zuerst</string>
-    <string name="sort_unattached_first">Nachrichten ohne Anlagen zuerst</string>
+    <string name="sort_attach_first">Nachrichten mit Anhängen zuerst</string>
+    <string name="sort_unattached_first">Nachrichten ohne Anhänge zuerst</string>
 
     <string name="sort_by">Sortieren nach...</string>
     <string name="sort_by_date">Datum</string>
@@ -775,7 +775,7 @@ Willkommen zum \"K-9 Mail\"-Setup. K-9 ist eine quelloffene E-Mail-Anwendung fü
     <string name="sort_by_subject">Betreff</string>
     <string name="sort_by_flag">Wichtigkeit</string>
     <string name="sort_by_unread">Gelesen/Ungelesen</string>
-    <string name="sort_by_attach">Anlage</string>
+    <string name="sort_by_attach">Anhang</string>
     <string name="message_web_view_error">%s</string>
 
     <string name="account_delete_dlg_title">Entfernen</string>
@@ -988,7 +988,7 @@ Willkommen zum \"K-9 Mail\"-Setup. K-9 ist eine quelloffene E-Mail-Anwendung fü
     <string name="message_compose_buggy_gallery">Wählen Sie \"Einstellungen\" -&gt; \"Galerie Work-Around aktivieren\" um Bilder oder Videos mithilfe der 3D-Galerie hinzufügen zu können.</string>
 
     <!-- Note: Contains references to add_attachment_action_image and add_attachment_action_video -->
-    <string name="message_compose_use_workaround">Verwenden Sie \"Anlage hinzufügen (Bild)\" oder \"Anlage hinzufügen (Video)\" um Bilder oder Videos mit der 3D-Galerie hinzuzufügen.</string>
+    <string name="message_compose_use_workaround">Verwenden Sie \"Anhang hinzufügen (Bild)\" oder \"Anhang hinzufügen (Video)\" um Bilder oder Videos mit der 3D-Galerie hinzuzufügen.</string>
 
     <string name="miscellaneous_preferences">Verschiedenes</string>
     <string name="misc_preferences_attachment_title">Galerie Work-Around</string>
@@ -1005,7 +1005,7 @@ Willkommen zum \"K-9 Mail\"-Setup. K-9 ist eine quelloffene E-Mail-Anwendung fü
     <string name="key_id">id: %s</string>
     <string name="insufficient_apg_permissions">K-9 hat keinen Vollzugriff auf APG, bitte dafür K-9 neu installieren.</string>
     <string name="pgp_mime_unsupported">PGP/MIME Nachrichten werden noch nicht unterstützt.</string>
-    <string name="attachment_encryption_unsupported">Achtung: Anlagen werden zur Zeit weder signiert noch verschlüsselt.</string>
+    <string name="attachment_encryption_unsupported">Achtung: Anhänge werden zur Zeit weder signiert noch verschlüsselt.</string>
     <string name="send_aborted">Senden abgebrochen.</string>
 
     <string name="save_or_discard_draft_message_dlg_title">Entwurf speichern?</string>


### PR DESCRIPTION
> 00:11:26 < toe> Anlage is very rarely used in german to describe  
> attachments  
> 00:11:58 < toe> almost only in job applications  
> 00:12:15 < toe> usally you use 'Anhang'    

Also fixed last commit to follow the convention of using 'Nachrichten' instead of 'Emails'.
