### PR TITLE
Added SHA-1 checksum to acceptKeyDialog

### DIFF
--- a/src/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/src/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -23,9 +23,13 @@ import com.fsck.k9.mail.Store;
 import com.fsck.k9.mail.Transport;
 import com.fsck.k9.mail.store.TrustManagerFactory;
 import com.fsck.k9.mail.store.WebDavStore;
+import com.fsck.k9.mail.filter.Hex;
 
 import java.security.cert.CertificateException;
+import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
+import java.security.NoSuchAlgorithmException;
+import java.security.MessageDigest;
 
 /**
  * Checks the given settings to make sure that they can be used to send and
@@ -237,11 +241,26 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
 
                 mProgressBar.setIndeterminate(false);
                 StringBuffer chainInfo = new StringBuffer(100);
+                MessageDigest sha1 = null;
+                try {
+                    sha1 = MessageDigest.getInstance("SHA-1");
+                } catch (NoSuchAlgorithmException e) {
+                    Log.e(K9.LOG_TAG, "Error while initializing MessageDigest", e);
+                }
                 for (int i = 0; i < chain.length; i++) {
                     // display certificate chain information
                     chainInfo.append("Certificate chain[" + i + "]:\n");
                     chainInfo.append("Subject: " + chain[i].getSubjectDN().toString() + "\n");
                     chainInfo.append("Issuer: " + chain[i].getIssuerDN().toString() + "\n");
+                    if (sha1 != null) {
+                        sha1.reset();
+                        try {
+                            char[] sha1sum = Hex.encodeHex(sha1.digest(chain[i].getEncoded()));
+                            chainInfo.append("Fingerprint (SHA-1): " + new String(sha1sum) + "\n");
+                        } catch (CertificateEncodingException e) {
+                            Log.e(K9.LOG_TAG, "Error while encoding certificate", e);
+                        }
+                    }
                 }
 
                 new AlertDialog.Builder(AccountSetupCheckSettings.this)


### PR DESCRIPTION
I added a few lines of code to AccountSetupCheckSettings.java to display the SHA-1 checksum of the certificate, because without this, the whole alert window is pointless. I compiled this version and works fine in the emulator: http://vsza.hu/k9mail-patch.png (you can check at http://www.cacert.org/index.php?id=3 that the last line displays the CAcert root checksum correctly)

I tried not reinventing the wheel, so I used com.fsck.k9.mail.filter.Hex to convert the byte[] to a String of hexadecimal digits.
