### PR TITLE
Fix for issue 2955 ( third time good time :D )

### DIFF
--- a/src/com/fsck/k9/activity/MessageList.java
+++ b/src/com/fsck/k9/activity/MessageList.java
@@ -699,7 +699,7 @@ public class MessageList
     @Override
     public void onResume() {
         super.onResume();
-
+        
         if (mAccount != null && !mAccount.isAvailable(this)) {
             onAccountUnavailable();
             return;
@@ -727,6 +727,9 @@ public class MessageList
             }
 
         } else {
+        	// reread the selected date format preference in case it has changed
+        	mMessageHelper.refresh();
+        	
             new Thread() {
                 @Override
                 public void run() {

--- a/src/com/fsck/k9/helper/MessageHelper.java
+++ b/src/com/fsck/k9/helper/MessageHelper.java
@@ -99,4 +99,9 @@ public class MessageHelper {
             return mDateFormat.format(date);
         }
     }
+
+	public void refresh() {
+        mDateFormat = DateFormatter.getDateFormat(mContext);
+        mTodayDateFormat = android.text.format.DateFormat.getTimeFormat(mContext);	
+	}
 }


### PR DESCRIPTION
The date format preference is now refreshed each time the messages get listed.

Changed two files.
The commit message is what is should be now and the comment removed. Left one line of it because we now refresh each time, it's not really necesarry if an extra variable in the K9 class would be kept "isDateChanged", a bit like the managedBackButton flag. But I think this doesn't cause a real overhead by just refreshing it every time.

PS. Obra: the fix went quick, the whole git part took me some time to figure out.
