### PR TITLE
Support for SMTP authentication methods that are not announced by the server.

### DIFF
--- a/src/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/src/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -16,6 +16,8 @@ import android.widget.CompoundButton.OnCheckedChangeListener;
 import com.fsck.k9.*;
 import com.fsck.k9.activity.K9Activity;
 import com.fsck.k9.helper.Utility;
+import com.fsck.k9.mail.transport.SmtpTransport;
+
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -45,10 +47,13 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         "webdav", "webdav+ssl", "webdav+ssl+", "webdav+tls", "webdav+tls+"
     };
     */
-
     private static final String authTypes[] = {
-        "PLAIN", "CRAM_MD5"
+        SmtpTransport.AUTH_AUTOMATIC,
+        SmtpTransport.AUTH_LOGIN,
+        SmtpTransport.AUTH_PLAIN,
+        SmtpTransport.AUTH_CRAM_MD5,
     };
+    
     private EditText mUsernameView;
     private EditText mPasswordView;
     private EditText mServerView;
@@ -117,14 +122,10 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
             new SpinnerOption(4, getString(R.string.account_setup_incoming_security_tls_label)),
         };
 
-        // This needs to be kept in sync with the list at the top of the file.
-        // that makes me somewhat unhappy
-        SpinnerOption authTypeSpinnerOptions[] = {
-            new SpinnerOption(0, "PLAIN"),
-            new SpinnerOption(1, "CRAM_MD5")
-        };
-
-
+        SpinnerOption authTypeSpinnerOptions[] = new SpinnerOption[authTypes.length];
+        for (int i = 0; i < authTypes.length; i++) {
+            authTypeSpinnerOptions[i] = new SpinnerOption(i, authTypes[i]);
+        }
 
         ArrayAdapter<SpinnerOption> securityTypesAdapter = new ArrayAdapter<SpinnerOption>(this,
                 android.R.layout.simple_spinner_item, securityTypes);

--- a/src/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/src/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -39,6 +39,14 @@ public class SmtpTransport extends Transport {
 
     public static final int CONNECTION_SECURITY_SSL_OPTIONAL = 4;
 
+    public static final String AUTH_PLAIN = "PLAIN";
+
+    public static final String AUTH_CRAM_MD5 = "CRAM_MD5";
+
+    public static final String AUTH_LOGIN = "LOGIN";
+
+    public static final String AUTH_AUTOMATIC = "AUTOMATIC";
+
     String mHost;
 
     int mPort;
@@ -227,22 +235,29 @@ public class SmtpTransport extends Transport {
             boolean authLoginSupported = false;
             boolean authPlainSupported = false;
             boolean authCramMD5Supported = false;
-            for (String result : results) {
-                if (result.matches(".*AUTH.*LOGIN.*$")) {
-                    authLoginSupported = true;
-                }
-                if (result.matches(".*AUTH.*PLAIN.*$")) {
-                    authPlainSupported = true;
-                }
-                if (result.matches(".*AUTH.*CRAM-MD5.*$") && mAuthType != null && mAuthType.equals("CRAM_MD5")) {
-                    authCramMD5Supported = true;
-                }
-                if (result.matches(".*SIZE \\d*$")) {
-                    try {
-                        mLargestAcceptableMessage = Integer.parseInt(result.substring(result.lastIndexOf(' ') + 1));
-                    } catch (Exception e) {
-                        if (K9.DEBUG && K9.DEBUG_PROTOCOL_SMTP) {
-                            Log.d(K9.LOG_TAG, "Tried to parse " + result + " and get an int out of the last word: " + e);
+            if (mAuthType != null) {
+                authLoginSupported = mAuthType.equals(AUTH_LOGIN);
+                authPlainSupported = mAuthType.equals(AUTH_PLAIN);
+                authCramMD5Supported = mAuthType.equals(AUTH_CRAM_MD5);
+            }
+            if (mAuthType == null || mAuthType.equals(AUTH_AUTOMATIC)) {
+                for (String result : results) {
+                    if (result.matches(".*AUTH.*LOGIN.*$")) {
+                        authLoginSupported = true;
+                    }
+                    if (result.matches(".*AUTH.*PLAIN.*$")) {
+                        authPlainSupported = true;
+                    }
+                    if (result.matches(".*AUTH.*CRAM-MD5.*$")) {
+                        authCramMD5Supported = true;
+                    }
+                    if (result.matches(".*SIZE \\d*$")) {
+                        try {
+                            mLargestAcceptableMessage = Integer.parseInt(result.substring(result.lastIndexOf(' ') + 1));
+                        } catch (Exception e) {
+                            if (K9.DEBUG && K9.DEBUG_PROTOCOL_SMTP) {
+                                Log.d(K9.LOG_TAG, "Tried to parse " + result + " and get an int out of the last word: " + e);
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
- Added AUTOMATIC as a new authentication method that will automatically choose the best authentication method (basically old behavior with CRAM_MD5). All other options will now enforce the selected authentication method.
- Added LOGIN as selectable option.
- Cleaned up code so strings to the different authentication methods are only defined once.
