### PR TITLE
Patch to add keyboard navigation with the J and K keys to MessageList

### DIFF
--- a/src/com/fsck/k9/activity/MessageList.java
+++ b/src/com/fsck/k9/activity/MessageList.java
@@ -1015,11 +1015,15 @@ public class MessageList
     // long delay before the new page appears in either direction.
     private void setOurSelection(int position, int direction) {
 
+        int item_height            = findViewById(R.layout.message_list_item).getHeight();
         int first_visible_position = mListView.getFirstVisiblePosition();
         int last_visible_position  = mListView.getLastVisiblePosition();
-        last_visible_position      = last_visible_position - 1; // sometimes this is 1 too high
+        // check whether GUI reported incorrect number of visible items
+        int widget_height          = mListView.getHeight();
+        if (widget_height < (last_visible_position - first_visible_position + 1) * item_height) {
+            last_visible_position      = last_visible_position - 1; // sometimes this is 1 too high
+        }
         int num_visible_items      = last_visible_position - first_visible_position + 1;
-        int item_height            = findViewById(R.layout.message_list_item).getHeight();
 
         // (A) int position_save = position;  // we will try to put the new selected line where the old one was
         switch (direction) {


### PR DESCRIPTION
Patch to add keyboard navigation with the J and K keys (as in VI) to MessageList
for message_list_items in the Message List. This functionality is
already part of k-9 (in MessageView) for navigating among messages that are
displayed individually. J = down/next. K=up/prior
