### PR TITLE
Hotkey fix

### DIFF
--- a/src/com/fsck/k9/activity/MessageList.java
+++ b/src/com/fsck/k9/activity/MessageList.java
@@ -1327,12 +1327,11 @@ public class MessageList
         }
 
         boolean retval = true;
-        int position = mListView.getSelectedItemPosition();
         try {
-            if (position >= 0) {
-                MessageInfoHolder message = (MessageInfoHolder) mAdapter.getItem(position);
+            if (mCurrentMessageInfo != null) {
+                MessageInfoHolder message = mCurrentMessageInfo;
 
-                final List<MessageInfoHolder> selection = getSelectionFromMessage(message);
+                final List<MessageInfoHolder> selection = getSelectionFromMessage(mCurrentMessageInfo);
 
                 if (message != null) {
                     switch (keyCode) {


### PR DESCRIPTION
A small fix to get the message-dependent hotkeys working again in MessageList.

I have a number of other small keyboard-related commits on my 'tablet' branch. Not sure if they're of general interest or not.
