### PR TITLE
Task switching problem

### DIFF
--- a/src/com/fsck/k9/activity/MessageView.java
+++ b/src/com/fsck/k9/activity/MessageView.java
@@ -368,6 +368,7 @@ public class MessageView extends K9Activity implements OnClickListener {
         i.putExtra(EXTRA_MESSAGE_REFERENCE, messRef);
         i.putParcelableArrayListExtra(EXTRA_MESSAGE_REFERENCES, messReferences);
         i.putExtra(EXTRA_ORIGINATING_INTENT, originatingIntent);
+        i.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP|Intent.FLAG_ACTIVITY_NEW_TASK );
         if (extras != null) {
             i.putExtras(extras);
         }


### PR DESCRIPTION
K-9 3.902 has a following problem.
1. Show a message in MessageView.
2. Press HOME button to back home.
3. Re-launch the K-9 and select another message.
4. Show first selected message.

I should report to the issue tracker.
However, it has been already reported on http://code.google.com/p/k9mail/issues/detail?id=2467

This commit is work-around. I'm not well informed about the android multi-tasking.
