### PR TITLE
Option to show next message after delete by default instead of previous.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -339,6 +339,8 @@ Welcome to K-9 Mail setup.  K-9 is an open source mail client for Android origin
     <string name="global_settings_messageview_fixedwidth_summary">Use a fixed-width font when showing plain-text messages</string>
     <string name="global_settings_messageview_return_to_list_label">Return to list after delete</string>
     <string name="global_settings_messageview_return_to_list_summary">Return to message list after message deletion</string>
+    <string name="global_settings_messageview_show_next_label">Show next message after delete</string>
+    <string name="global_settings_messageview_show_next_summary">Show next message by default after message deletion</string>
 
     <string name="global_settings_confirm_actions_title">Confirm actions</string>
     <string name="global_settings_confirm_actions_summary">Show a dialog whenever you perform selected actions</string>

--- a/res/xml/global_preferences.xml
+++ b/res/xml/global_preferences.xml
@@ -219,6 +219,12 @@
 
         <CheckBoxPreference
             android:persistent="false"
+            android:key="messageview_show_next"
+            android:title="@string/global_settings_messageview_show_next_label"
+            android:summary="@string/global_settings_messageview_show_next_summary" />
+
+        <CheckBoxPreference
+            android:persistent="false"
             android:key="messageview_zoom_controls"
             android:title="@string/settings_messageview_zoom_controls_label"
             android:summary="@string/settings_messageview_zoom_controls_summary" />

--- a/src/com/fsck/k9/K9.java
+++ b/src/com/fsck/k9/K9.java
@@ -168,6 +168,7 @@ public class K9 extends Application {
     private static int mContactNameColor = 0xff00008f;
     private static boolean mMessageViewFixedWidthFont = false;
     private static boolean mMessageViewReturnToList = false;
+    private static boolean mMessageViewShowNext = false;
 
     private static boolean mGesturesEnabled = true;
     private static boolean mUseVolumeKeysForNavigation = false;
@@ -435,6 +436,7 @@ public class K9 extends Application {
         editor.putInt("registeredNameColor", mContactNameColor);
         editor.putBoolean("messageViewFixedWidthFont", mMessageViewFixedWidthFont);
         editor.putBoolean("messageViewReturnToList", mMessageViewReturnToList);
+        editor.putBoolean("messageViewShowNext", mMessageViewShowNext);
 
         editor.putString("language", language);
         editor.putInt("theme", theme);
@@ -491,6 +493,7 @@ public class K9 extends Application {
         mContactNameColor = sprefs.getInt("registeredNameColor", 0xff00008f);
         mMessageViewFixedWidthFont = sprefs.getBoolean("messageViewFixedWidthFont", false);
         mMessageViewReturnToList = sprefs.getBoolean("messageViewReturnToList", false);
+        mMessageViewShowNext = sprefs.getBoolean("messageViewShowNext", false);
 
         useGalleryBugWorkaround = sprefs.getBoolean("useGalleryBugWorkaround", K9.isGalleryBuggy());
 
@@ -873,6 +876,14 @@ public class K9 extends Application {
 
     public static void setMessageViewReturnToList(boolean messageViewReturnToList) {
         mMessageViewReturnToList = messageViewReturnToList;
+    }
+
+    public static boolean messageViewShowNext() {
+        return mMessageViewShowNext;
+    }
+
+    public static void setMessageViewShowNext(boolean messageViewShowNext) {
+        mMessageViewShowNext = messageViewShowNext;
     }
 
     public static Method getMethod(Class<?> classObject, String methodName) {

--- a/src/com/fsck/k9/activity/MessageView.java
+++ b/src/com/fsck/k9/activity/MessageView.java
@@ -89,7 +89,7 @@ public class MessageView extends K9Activity implements OnClickListener {
     private Message mMessage;
     private static final int PREVIOUS = 1;
     private static final int NEXT = 2;
-    private int mLastDirection = PREVIOUS;
+    private int mLastDirection = (K9.messageViewShowNext()) ? NEXT : PREVIOUS;
     private MessagingController mController = MessagingController.getInstance(getApplication());
     private MessageReference mNextMessage = null;
     private MessageReference mPreviousMessage = null;

--- a/src/com/fsck/k9/activity/setup/Prefs.java
+++ b/src/com/fsck/k9/activity/setup/Prefs.java
@@ -69,6 +69,7 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_COMPACT_LAYOUTS = "compact_layouts";
 
     private static final String PREFERENCE_MESSAGEVIEW_RETURN_TO_LIST = "messageview_return_to_list";
+    private static final String PREFERENCE_MESSAGEVIEW_SHOW_NEXT = "messageview_show_next";
     private static final String PREFERENCE_MESSAGEVIEW_ZOOM_CONTROLS_ENABLED = "messageview_zoom_controls";
     private static final String PREFERENCE_QUIET_TIME_ENABLED = "quiet_time_enabled";
     private static final String PREFERENCE_QUIET_TIME_STARTS = "quiet_time_starts";
@@ -106,6 +107,7 @@ public class Prefs extends K9PreferenceActivity {
     private CheckBoxPreference mChangeContactNameColor;
     private CheckBoxPreference mFixedWidth;
     private CheckBoxPreference mReturnToList;
+    private CheckBoxPreference mShowNext;
     private CheckBoxPreference mZoomControlsEnabled;
     private CheckBoxPreference mMobileOptimizedLayout;
     private ListPreference mBackgroundOps;
@@ -256,6 +258,9 @@ public class Prefs extends K9PreferenceActivity {
         mReturnToList = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGEVIEW_RETURN_TO_LIST);
         mReturnToList.setChecked(K9.messageViewReturnToList());
 
+        mShowNext = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGEVIEW_SHOW_NEXT);
+        mShowNext.setChecked(K9.messageViewShowNext());
+
         mZoomControlsEnabled = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGEVIEW_ZOOM_CONTROLS_ENABLED);
         mZoomControlsEnabled.setChecked(K9.zoomControlsEnabled());
 
@@ -365,6 +370,7 @@ public class Prefs extends K9PreferenceActivity {
         K9.setChangeContactNameColor(mChangeContactNameColor.isChecked());
         K9.setMessageViewFixedWidthFont(mFixedWidth.isChecked());
         K9.setMessageViewReturnToList(mReturnToList.isChecked());
+        K9.setMessageViewShowNext(mShowNext.isChecked());
         K9.setMobileOptimizedLayout(mMobileOptimizedLayout.isChecked());
         K9.setQuietTimeEnabled(mQuietTimeEnabled.isChecked());
 


### PR DESCRIPTION
If selected, then automatically select message after delete (default to 'next') instead of automatically select message after delete (default to 'previous'). 
