### PR TITLE
Prefer Integer.valueOf over explicit boxing

### DIFF
--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -2982,7 +2982,7 @@ public class ImapStore extends Store {
                 message.parse(literal);
 
                 // Return placeholder object
-                return new Integer(1);
+                return Integer.valueOf(1);
             }
             return null;
         }


### PR DESCRIPTION
Addresses a FindBugs complaint.
