### PR TITLE
Improve handling of From: Headers without parseable email addresses (fixe

### DIFF
--- a/src/com/fsck/k9/mail/Address.java
+++ b/src/com/fsck/k9/mail/Address.java
@@ -150,7 +150,7 @@ public class Address {
         } catch (MimeException pe) {
             Log.e(K9.LOG_TAG, "MimeException in Address.parse()", pe);
             //but we do an silent failover : we just use the given string as name with empty address
-            addresses.add(new Address("", addressList));
+            addresses.add(new Address(null, addressList,false));
         }
         return addresses.toArray(EMPTY_ADDRESS_ARRAY);
     }

--- a/tests/src/com/fsck/k9/helper/Address.java
+++ b/tests/src/com/fsck/k9/helper/Address.java
@@ -1,0 +1,37 @@
+package com.fsck.k9.helper;
+import junit.framework.TestCase;
+
+public class Address extends TestCase {
+    /**
+     * test the possibility to parse "From:" fields with no email.
+     * for example: From: News for Vector Limited - Google Finance
+     * http://code.google.com/p/k9mail/issues/detail?id=3814
+     */
+    public void testParseWithMissingEmail() {
+        com.fsck.k9.mail.Address[] addresses =  com.fsck.k9.mail.Address.parse("NAME ONLY");
+        assertEquals(1, addresses.length);
+        assertEquals(null, addresses[0].getAddress());
+        assertEquals("NAME ONLY", addresses[0].getPersonal());
+    }
+
+    /**
+     * test name + valid email
+     */
+    public void testPraseWithValidEmail() {
+        com.fsck.k9.mail.Address[] addresses =  com.fsck.k9.mail.Address.parse("Max Mustermann <maxmuster@mann.com>");
+        assertEquals(1, addresses.length);
+        assertEquals("maxmuster@mann.com", addresses[0].getAddress());
+        assertEquals("Max Mustermann", addresses[0].getPersonal());
+    }
+    /**
+     * test with multi email addresses
+     */
+    public void testPraseWithValidEmailMulti() {
+        com.fsck.k9.mail.Address[] addresses =  com.fsck.k9.mail.Address.parse("lorem@ipsum.us,mark@twain.com");
+        assertEquals(2, addresses.length);
+        assertEquals("lorem@ipsum.us", addresses[0].getAddress());
+        assertEquals(null, addresses[0].getPersonal());
+        assertEquals("mark@twain.com", addresses[1].getAddress());
+        assertEquals(null, addresses[1].getPersonal());
+    }
+}


### PR DESCRIPTION
Improve handling of From: Headers without parseable email addresses (fixes 3814)

http://code.google.com/p/k9mail/issues/detail?id=3814
