### PR TITLE
Issue 1424: saving duplicate or similar drafts fixed.

### DIFF
--- a/src/com/fsck/k9/activity/MessageCompose.java
+++ b/src/com/fsck/k9/activity/MessageCompose.java
@@ -794,12 +794,7 @@ public class MessageCompose extends K9Activity implements OnClickListener, OnFoc
     public void onPause() {
         super.onPause();
         MessagingController.getInstance(getApplication()).removeListener(mListener);
-    }
-
-    // Save email as draft when activity is changed (go to home screen, call received)
-    @Override
-    public void onStop() {
-        super.onStop();
+        // Save email as draft when activity is changed (go to home screen, call received) or screen locked
         // don't do this if only changing orientations
         if ((getChangingConfigurations() & ActivityInfo.CONFIG_ORIENTATION) == 0) {
             // don't do this if selecting signature or if "Encrypt" is checked or if adding an attachment


### PR DESCRIPTION
See commit notes for details.

No longer creates duplicate or similar drafts, and does not save messaged marked to be encrypted (those are still saved in a Bundle).
