### PR TITLE
added "mQuotedHtmlContent.setFooterInsertionPoint(bodyOffset);" 

### DIFF
--- a/src/com/fsck/k9/activity/MessageCompose.java
+++ b/src/com/fsck/k9/activity/MessageCompose.java
@@ -2183,7 +2183,9 @@ public class MessageCompose extends K9Activity implements OnClickListener, OnFoc
                         if (quotedHTML.length() > 0) {
                             mQuotedHtmlContent = new InsertableHtmlContent();
                             mQuotedHtmlContent.setQuotedContent(quotedHTML);
+                            // We don't know if bodyOffset refers to the header or to the footer
                             mQuotedHtmlContent.setHeaderInsertionPoint(bodyOffset);
+                            mQuotedHtmlContent.setFooterInsertionPoint(bodyOffset);
                             mQuotedHTML.loadDataWithBaseURL("http://", mQuotedHtmlContent.getQuotedContent(), "text/html", "utf-8", null);
                         }
                     }


### PR DESCRIPTION
added `mQuotedHtmlContent.setFooterInsertionPoint(bodyOffset);` because `bodyOffset` could refer to header or footer.

`bodyOffset` refers to the preferred offset (reply after quote or before) when first saved, but when opening saved drafts it was only applied to `headerInsertionPoint`, while later `footerInsertionPoint` is returned (never changed from default of 0) when `insertionLocation == InsertionLocation.AFTER_QUOTE`. this created messed up emails, not just putting the reply before instead of after.
