### PR TITLE
Increment mCount only when read() succeeds

### DIFF
--- a/src/com/fsck/k9/mail/filter/FixedLengthInputStream.java
+++ b/src/com/fsck/k9/mail/filter/FixedLengthInputStream.java
@@ -10,9 +10,9 @@ import java.io.InputStream;
  * past where the protocol handler intended the client to read.
  */
 public class FixedLengthInputStream extends InputStream {
-    private InputStream mIn;
-    private int mLength;
-    private int mCount;
+    private final InputStream mIn;
+    private final int mLength;
+    private int mCount = 0;
 
     public FixedLengthInputStream(InputStream in, int length) {
         this.mIn = in;
@@ -27,8 +27,11 @@ public class FixedLengthInputStream extends InputStream {
     @Override
     public int read() throws IOException {
         if (mCount < mLength) {
-            mCount++;
-            return mIn.read();
+            int d = mIn.read();
+            if (d != -1) {
+                mCount++;
+            }
+            return d;
         } else {
             return -1;
         }
@@ -38,12 +41,10 @@ public class FixedLengthInputStream extends InputStream {
     public int read(byte[] b, int offset, int length) throws IOException {
         if (mCount < mLength) {
             int d = mIn.read(b, offset, Math.min(mLength - mCount, length));
-            if (d == -1) {
-                return -1;
-            } else {
+            if (d != -1) {
                 mCount += d;
-                return d;
             }
+            return d;
         } else {
             return -1;
         }
@@ -52,6 +53,15 @@ public class FixedLengthInputStream extends InputStream {
     @Override
     public int read(byte[] b) throws IOException {
         return read(b, 0, b.length);
+    }
+
+    @Override
+    public long skip(long n) throws IOException {
+        long d = mIn.skip(Math.min(n, available()));
+        if (d > 0) {
+            mCount += d;
+        }
+        return d;
     }
 
     @Override


### PR DESCRIPTION
Implement skip which honors mLength.  Tidy up read(byte[], int, int).
Mark some members as final.
