### PR TITLE
Newfeature

### DIFF
--- a/src/com/fsck/k9/activity/MessageList.java
+++ b/src/com/fsck/k9/activity/MessageList.java
@@ -804,16 +804,16 @@ public class MessageList
         Account[] accountsWithNotification = null;
 
         if (mAccount != null) {
-        	accountsWithNotification = new Account[1];
-        	accountsWithNotification[0] = mAccount;
+        	  accountsWithNotification = new Account[1];
+        	  accountsWithNotification[0] = mAccount;
         } else {
-        	Preferences preferences = Preferences.getPreferences(this);
-        	accountsWithNotification = preferences.getAccounts();
+        	  Preferences preferences = Preferences.getPreferences(this);
+        	  accountsWithNotification = preferences.getAccounts();
         }
 
         for (Account accountWithNotification : accountsWithNotification) {
-        	mController.notifyAccountCancel(this, accountWithNotification);
-        	MessagingController.getInstance(getApplication()).notifyAccountCancel(this, accountWithNotification);
+        	  mController.notifyAccountCancel(this, accountWithNotification);
+        	  MessagingController.getInstance(getApplication()).notifyAccountCancel(this, accountWithNotification);
         }
 
         if (mAdapter.messages.isEmpty()) {


### PR DESCRIPTION
3139: Notifications for all accounts removed from status bar when unified inbox is selected, just like when clicking a specific account inbox, but in that case, only notifications from one account are removed from status bar.
