### PR TITLE
Don't save to drafts if drafts folder is -NONE-

### DIFF
--- a/src/com/fsck/k9/activity/MessageCompose.java
+++ b/src/com/fsck/k9/activity/MessageCompose.java
@@ -1531,8 +1531,9 @@ public class MessageCompose extends K9Activity implements OnClickListener, OnFoc
 
         mDraftNeedsSaving = false;
 
-        if (!draftsDisabled())
+        if (!draftsDisabled()) {
             saveMessage();
+        }
     }
 
     public void onEncryptionKeySelectionDone() {
@@ -2012,8 +2013,9 @@ public class MessageCompose extends K9Activity implements OnClickListener, OnFoc
         getMenuInflater().inflate(R.menu.message_compose_option, menu);
 
         // Disable the 'Save' menu option if folder is set to NONE
-        if (draftsDisabled())
+        if (draftsDisabled()) {
             menu.findItem(R.id.save).setEnabled(false);
+        }
 
         /*
          * Show the menu items "Add attachment (Image)" and "Add attachment (Video)"
@@ -2040,7 +2042,7 @@ public class MessageCompose extends K9Activity implements OnClickListener, OnFoc
     public void onBackPressed() {
         if (mEncryptCheckbox.isChecked()) {
             showDialog(DIALOG_REFUSE_TO_SAVE_DRAFT_MARKED_ENCRYPTED);
-        } else if (!mDraftNeedsSaving || (mDraftNeedsSaving && draftsDisabled())) {
+        } else if (!mDraftNeedsSaving || draftsDisabled()) {
             Toast.makeText(MessageCompose.this, getString(R.string.message_discarded_toast), Toast.LENGTH_LONG).show();
             super.onBackPressed();
         } else


### PR DESCRIPTION
Added code to make sure that if the draft folder is set to -NONE-, the folder doesn't get created and drafts are not saved.

Also the 'save' menu button also gets disabled and users don't get an option to save if they press back to exit message composition.

(Issue 3508)
