### PR TITLE
Newfeature

### DIFF
--- a/src/com/fsck/k9/view/AttachmentView.java
+++ b/src/com/fsck/k9/view/AttachmentView.java
@@ -203,7 +203,7 @@ public class AttachmentView extends FrameLayout {
      */
     public void writeFile(File directory) {
         try {
-        	String filename = removeSpecialCharacters(name);
+       	    String filename = removeSpecialCharacters(name);
             File file = Utility.createUniqueFile(directory, filename);
             Uri uri = AttachmentProvider.getAttachmentUri(mAccount, part.getAttachmentId());
             InputStream in = mContext.getContentResolver().openInputStream(uri);


### PR DESCRIPTION
3674: A method was added to remove illegal characters from file names that cause errors when saving a file on android. The characters that are being removed are: backslash, forward slash, asterisk and interrogation point.
