### PR TITLE
3674: Illegal characters removed from file names when saving them on the device

### DIFF
--- a/src/com/fsck/k9/view/AttachmentView.java
+++ b/src/com/fsck/k9/view/AttachmentView.java
@@ -212,7 +212,7 @@ public class AttachmentView extends FrameLayout {
             out.flush();
             out.close();
             in.close();
-            attachmentSaved(filename.toString());
+            attachmentSaved(file.toString());
             new MediaScannerNotifier(mContext, file);
         } catch (IOException ioe) {
             attachmentNotSaved();


### PR DESCRIPTION
It was created a method that only allows a certain range of characters to be used in file names when saving them on the device using the writeFile method. 

Now, the set of characters allowed are:
- letters, numbers, spaces, sharp, dollar sign, percent sign, at , single quotation mark, parenthesis, hyphen, underline, curly brackets, tilde, dot, comma, ampersand and circum­flex.
