### PR TITLE
Creating and Initializing special accounts variables of the Accounts activity to avoid NullPointerException

### DIFF
--- a/src/com/fsck/k9/activity/Accounts.java
+++ b/src/com/fsck/k9/activity/Accounts.java
@@ -106,6 +106,11 @@ public class Accounts extends K9ListActivity implements OnItemClickListener, OnC
      */
     private static final Flag[] EMPTY_FLAG_ARRAY = new Flag[0];
 
+    /**
+     * Number of special accounts ('Unified Inbox' and 'All Messages')
+     */
+    private static final int SPECIAL_ACCOUNTS_COUNT = 2;
+
     private static final int DIALOG_REMOVE_ACCOUNT = 1;
     private static final int DIALOG_CLEAR_ACCOUNT = 2;
     private static final int DIALOG_RECREATE_ACCOUNT = 3;
@@ -325,13 +330,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener, OnC
         super.onCreate(icicle);
 
         if (!K9.isHideSpecialAccounts()) {
-            unreadAccount = new SearchAccount(this, false, null, null);
-            unreadAccount.setDescription(getString(R.string.search_all_messages_title));
-            unreadAccount.setEmail(getString(R.string.search_all_messages_detail));
-
-            integratedInboxAccount = new SearchAccount(this, true, null,  null);
-            integratedInboxAccount.setDescription(getString(R.string.integrated_inbox_title));
-            integratedInboxAccount.setEmail(getString(R.string.integrated_inbox_detail));
+            createSpecialAccounts();
         }
 
         Account[] accounts = Preferences.getPreferences(this).getAccounts();
@@ -372,6 +371,19 @@ public class Accounts extends K9ListActivity implements OnItemClickListener, OnC
         if (mNonConfigurationInstance != null) {
             mNonConfigurationInstance.restore(this);
         }
+    }
+
+    /**
+     * Creates and initializes the special accounts ('Integrated Inbox' and 'All Messages')
+     */
+    private void createSpecialAccounts() {
+        unreadAccount = new SearchAccount(this, false, null, null);
+        unreadAccount.setDescription(getString(R.string.search_all_messages_title));
+        unreadAccount.setEmail(getString(R.string.search_all_messages_detail));
+
+        integratedInboxAccount = new SearchAccount(this, true, null, null);
+        integratedInboxAccount.setDescription(getString(R.string.integrated_inbox_title));
+        integratedInboxAccount.setEmail(getString(R.string.integrated_inbox_detail));
     }
 
     @SuppressWarnings("unchecked")
@@ -458,9 +470,13 @@ public class Accounts extends K9ListActivity implements OnItemClickListener, OnC
         accounts = Preferences.getPreferences(this).getAccounts();
 
         List<BaseAccount> newAccounts;
-        if (!K9.isHideSpecialAccounts()
-                && accounts.length > 0) {
-            newAccounts = new ArrayList<BaseAccount>(accounts.length + 2);
+        if (!K9.isHideSpecialAccounts() && accounts.length > 0) {
+            if (integratedInboxAccount == null || unreadAccount == null) {
+                createSpecialAccounts();
+            }
+
+            newAccounts = new ArrayList<BaseAccount>(accounts.length +
+                    SPECIAL_ACCOUNTS_COUNT);
             newAccounts.add(integratedInboxAccount);
             newAccounts.add(unreadAccount);
         } else {


### PR DESCRIPTION
Creating and initializing special accounts in the refresh method of the Accounts activity to avoid NullPointerException that can be thrown when the activity is resumed. This error forced the application to close right away and happened because the initialization of the special accounts variables is done in the onCreate method of Accounts activity only when the 'hide special accounts' selection isn't checked.

Scenario that caused the error:
1. Before starting the application the option 'hide special accounts' is checked
2. The user starts the application and changes this option in the menu
3. The user clicks back button 2 times to come back to Accounts screen
4. NullPointerException forces the application to close

Constant added to represent the number of special accounts to be used in the initialization of the ArrayList that represents the special accounts to be used in the list adapter of the activity.
