### PR TITLE
3945: Handling error when there's no File Manager application used in import settings

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1128,4 +1128,10 @@ Welcome to K-9 Mail setup.  K-9 is an open source mail client for Android origin
 
     <string name="unread_widget_label">K-9 Unread</string>
     <string name="unread_widget_select_account">Show unread count for…</string>
+
+    <string name="import_dialog_error_title">Missing File Manager Application</string>
+    <string name="import_dialog_error_message">There is no suitable application to handle
+the import operation. Please install a file manager application from Android Market</string>
+    <string name="open_market">Open Market</string>
+    <string name="close">Close</string>
 </resources>


### PR DESCRIPTION
Issue 3945: A verification was added to guarantee that the requested intent for 'import settings' will have an application to respond.  A dialog is exhibited when there's no suitable application to handle the import settings and it has a more clear message for what the user could do to handle the error. This dialog contains a button to open android market (in case the user want to download this kind of application) and another button to close the dialog.
