### PR TITLE
BF: mAccount must not be accessed before verfied to be non-null

### DIFF
--- a/src/com/fsck/k9/activity/MessageList.java
+++ b/src/com/fsck/k9/activity/MessageList.java
@@ -820,15 +820,14 @@ public class MessageList
         mStars = K9.messageListStars();
         mCheckboxes = K9.messageListCheckboxes();
 
-        mSortType = mAccount.getSortType();
-        mSortAscending = mAccount.isSortAscending(mSortType);
-        mSortDateAscending = mAccount.isSortAscending(SortType.SORT_DATE);
-
         mController.addListener(mAdapter.mListener);
 
         Account[] accountsWithNotification;
         if (mAccount != null) {
             accountsWithNotification = new Account[] { mAccount };
+            mSortType = mAccount.getSortType();
+            mSortAscending = mAccount.isSortAscending(mSortType);
+            mSortDateAscending = mAccount.isSortAscending(SortType.SORT_DATE);
         } else {
             Preferences preferences = Preferences.getPreferences(this);
             accountsWithNotification = preferences.getAccounts();


### PR DESCRIPTION
otherwise obviously leads to crashes.
IMHO this was a logical location to move, and it resolved my issue when
account was not yet accessible due to not yet accepted key upon importing
old settings from a stored file
