### PR TITLE
BF+ENH: do not ignore case while comparing folder name + a debug message

### DIFF
--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -827,7 +827,7 @@ public class ImapStore extends Store {
 
         public String getPrefixedName() throws MessagingException {
             String prefixedName = "";
-            if (!mAccount.getInboxFolderName().equalsIgnoreCase(mName)) {
+            if (!mAccount.getInboxFolderName().equals(mName)) {
                 ImapConnection connection = null;
                 synchronized (this) {
                     if (mConnection == null) {
@@ -850,6 +850,8 @@ public class ImapStore extends Store {
             }
 
             prefixedName += mName;
+            if (K9.DEBUG)
+                Log.i(K9.LOG_TAG, "ImapFolder.getPrefixedName: " + mName + " --> " + prefixedName);
             return prefixedName;
         }
 


### PR DESCRIPTION
This might be specific to my setup where I have INBOX.Inbox which I am actually interested more than in pure INBOX.  Because comparison is done after stripping INBOX. prefix and ignoring the case, obviously INBOX masks out INBOX.Inbox.  This patch might not be acceptable as is, moreover there were arguments on IRC that my setup brakes the standard but I somewhat disagree, and IIRC other email clients I have tried did not have similar issues in accessing it.
