### PR TITLE
Fixed Issue 4222. Use of the wrong method to get device-SDK version resu...

### DIFF
--- a/src/com/fsck/k9/view/MessageWebView.java
+++ b/src/com/fsck/k9/view/MessageWebView.java
@@ -98,7 +98,13 @@ public class MessageWebView extends WebView {
             webSettings.setLayoutAlgorithm(WebSettings.LayoutAlgorithm.NARROW_COLUMNS);
         }
 
-        if (Integer.parseInt(Build.VERSION.SDK) >= 9 ) {
+        /*
+         * Build.VERSION.SDK is deprecated cause it just returns the
+         * "its raw String representation"
+         *  http://developer.android.com/reference/android/os/Build.VERSION_CODES.html#GINGERBREAD
+         *  http://developer.android.com/reference/android/os/Build.VERSION.html#SDK
+         */
+        if (Build.VERSION.SDK_INT >= 9) {
             setOverScrollMode(OVER_SCROLL_NEVER);
         }
 


### PR DESCRIPTION
...lting in errors on ApiLevel 7 (2.1) devices.

```
Fixed Issue 4222. Use of the wrong method to get device-SDK version resulting in errors on ApiLevel 7 (2.1) devices.
```

http://code.google.com/p/k9mail/issues/detail?id=4222
