### PR TITLE
IMAP Keywords support.

### DIFF
--- a/src/com/fsck/k9/mail/Flag.java
+++ b/src/com/fsck/k9/mail/Flag.java
@@ -3,14 +3,30 @@ package com.fsck.k9.mail;
 
 /**
  * Flags that can be applied to Messages.
+ * 
+ * Update: to support IMAP keywords ( custom flags ) this enum became
+ * a class. This class was constructed to resemble enums. Since Java
+ * enums are objects internally anyway ( implemented similar to these ) 
+ * this will not be noticably slower.
+ * 
+ * The extra field bCustom denotes custom flags. These get an prefix
+ * attached internally. When using the flags with external servers,..
+ * one should use the realName() method.
  */
-public enum Flag {
-    DELETED,
-    SEEN,
-    ANSWERED,
-    FLAGGED,
-    DRAFT,
-    RECENT,
+public class Flag {
+	
+	/*
+	 * IMAP Spec flags.
+	 */
+    public static final Flag DELETED = new Flag("DELETED", "\\Deleted");
+    public static final Flag SEEN = new Flag("SEEN", "\\Seen");
+    public static final Flag ANSWERED = new Flag("ANSWERED", "\\Answered");
+    public static final Flag FLAGGED = new Flag("FLAGGED", "\\Flagged");
+    
+    public static final Flag DRAFT = new Flag("DRAFT", "\\Draft");
+    public static final Flag RECENT = new Flag("RECENT", "\\Recent");
+    
+    private static final Flag[] IMAP_FLAGS = new Flag[] {DELETED, SEEN, ANSWERED, FLAGGED, DRAFT, RECENT};
 
     /*
      * The following flags are for internal library use only.
@@ -18,40 +34,129 @@ public enum Flag {
     /**
      * Delete and remove from the LocalStore immediately.
      */
-    X_DESTROYED,
+    public static final Flag X_DESTROYED = new Flag("X_DESTROYED");
 
     /**
      * Sending of an unsent message failed. It will be retried. Used to show status.
      */
-    X_SEND_FAILED,
+    public static final Flag X_SEND_FAILED = new Flag("X_SEND_FAILED");
 
     /**
      * Sending of an unsent message is in progress.
      */
-    X_SEND_IN_PROGRESS,
+    public static final Flag X_SEND_IN_PROGRESS = new Flag("X_SEND_IN_PROGRESS");
 
     /**
      * Indicates that a message is fully downloaded from the server and can be viewed normally.
      * This does not include attachments, which are never downloaded fully.
      */
-    X_DOWNLOADED_FULL,
+    public static final Flag X_DOWNLOADED_FULL = new Flag("X_DOWNLOADED_FULL");
 
     /**
      * Indicates that a message is partially downloaded from the server and can be viewed but
      * more content is available on the server.
      * This does not include attachments, which are never downloaded fully.
      */
-    X_DOWNLOADED_PARTIAL,
+    public static final Flag X_DOWNLOADED_PARTIAL = new Flag("X_DOWNLOADED_PARTIAL");
 
     /**
      * Indicates that the copy of a message to the Sent folder has started.
      */
-    X_REMOTE_COPY_STARTED,
+    public static final Flag X_REMOTE_COPY_STARTED = new Flag("X_REMOTE_COPY_STARTED");
 
     /**
      * Indicates that all headers of the message have been stored in the
      * database. If this is false, additional headers might be retrieved from
      * the server (if the message is still there).
      */
-    X_GOT_ALL_HEADERS,
+    public static final Flag X_GOT_ALL_HEADERS = new Flag("X_GOT_ALL_HEADERS");
+    
+    /*
+     * Predefined Prefixes
+     */
+    private static final String USER_PREFIX = "USER_";
+    
+    private final String name;
+    private final String internal_name;
+    protected boolean bCustom;
+    
+    /**
+     * When a Flag is created dynamically we know it's a custom flag.
+     * @param name Name of the flag.
+     * @return Newly created Flag object.
+     */
+    public static Flag CreateFlag(String name) {
+    	Flag tmpFlag = new Flag(USER_PREFIX+name, name);
+    	tmpFlag.bCustom = true;
+    	return tmpFlag;
+	}
+    
+    private Flag(String name){
+    	this(name, name);
+    }
+    
+    private Flag(String internal_name, String name){
+    	this.name = name;
+    	this.bCustom = true;
+    	this.internal_name = internal_name;
+    }
+    
+    /**
+     * Returns the predefined static flag object if any. Otherwise a new
+     * custom flag is created and returned.
+     * 
+     * TODO We might not want to create a custom flag by default and just
+     * throw an exception. Only 10 uses of this method so refactoring possible.
+     * Catching the exception should then proceed with a CreateFlag(name) call.
+     * 
+     * @param name Name of Flag wanted.
+     * @return	Predefined Flag object if any otherwise new custom Flag.
+     * @throws IllegalArgumentException Thrown when the field is not accessible.
+     */
+    public static Flag valueOf(String name) throws IllegalArgumentException{
+    	try {
+			return (Flag)(Flag.class.getField(name).get(null));
+		} catch (NoSuchFieldException e) {
+			// not a predefined flag
+			return Flag.CreateFlag(name);
+		} catch (IllegalAccessException e) {
+			throw new IllegalArgumentException(e);
+		}
+    }
+    
+    /**
+     * Returns the predefined flag matching the given "real name". For 
+     * example "\\Deleted" will return the DELETED flag. When no such
+     * flag exists we assume it's a custom flag and create it.
+     * 
+     * TODO this could be faster this way: 
+     * http://java.dzone.com/articles/enum-tricks-customized-valueof
+     * 
+     * Since it's only used once I don't see the point.
+     * 
+     * @param real_name Real name to look for.
+     * @return The flag that was found or created.
+     */
+    public static Flag valueOfByRealName(String internal_name){
+    	for( Flag f : IMAP_FLAGS )
+    		if(f.internal_name.equalsIgnoreCase(internal_name))
+    			return f;
+    	return Flag.CreateFlag(internal_name);
+    }
+    
+    @Override
+    public String toString() { return name; }
+    
+    public String name() { return name; }
+    
+    /**
+     * Returns the real keyword name without user prefix. This is
+     * for non-internal use ( syncing with IMAP for example ).
+     * 
+     * @return Real keyword string.
+     */
+    public String realName(){
+    	return internal_name;
+    }
+    
 }

--- a/src/com/fsck/k9/mail/Flag.java
+++ b/src/com/fsck/k9/mail/Flag.java
@@ -16,6 +16,12 @@ package com.fsck.k9.mail;
 public class Flag {
 	
 	/*
+	 * IMPORTANT!!
+	 * 
+	 * INTERNAL NAME MUST EQUAL THE NAME OF THE FIELD!!!
+	 */
+	
+	/*
 	 * IMAP Spec flags.
 	 */
     public static final Flag DELETED = new Flag("DELETED", "\\Deleted");
@@ -76,49 +82,62 @@ public class Flag {
      */
     private static final String USER_PREFIX = "USER_";
     
-    private final String name;
-    private final String internal_name;
+    private final String name;				// for use towards third party 	ex. "\\Deleted"
+    private final String internal_name;		// for internal use in database,...   ex. "DELETED"
     protected boolean bCustom;
     
     /**
      * When a Flag is created dynamically we know it's a custom flag.
-     * @param name Name of the flag.
+     * 
+     * @param name Internal name of the flag.
      * @return Newly created Flag object.
      */
-    public static Flag CreateFlag(String name) {
-    	Flag tmpFlag = new Flag(USER_PREFIX+name, name);
+    public static Flag CreateFlag(String internal_name) {
+    	Flag tmpFlag = new Flag(USER_PREFIX+internal_name, internal_name);
     	tmpFlag.bCustom = true;
     	return tmpFlag;
 	}
     
-    private Flag(String name){
-    	this(name, name);
-    }
-    
-    private Flag(String internal_name, String name){
-    	this.name = name;
-    	this.bCustom = true;
-    	this.internal_name = internal_name;
+    private Flag(String internal_name){
+    	this(internal_name, internal_name);
     }
     
     /**
+     * Create a new Flag. This doesn't create a custom flag, it's used to define
+     * the predefined flags.
+     * 
+     * @param internal_name Name for internal use in database,...   ex. "DELETED"
+     * @param name Name for use towards third party ( ex. "\\Deleted" )
+     */
+    private Flag(String internal_name, String name){
+    	this.name = name;
+    	this.bCustom = false;
+    	this.internal_name = internal_name;
+    }
+    
+    /** 
      * Returns the predefined static flag object if any. Otherwise a new
      * custom flag is created and returned.
      * 
-     * TODO We might not want to create a custom flag by default and just
-     * throw an exception. Only 10 uses of this method so refactoring possible.
-     * Catching the exception should then proceed with a CreateFlag(name) call.
+     * When the name starts with the USER_PREFIX we don't add it again to
+     * create a new one. This is the case for example when this is called with
+     * strings retrieved from the database.
+     * 
+     * IMPORTANT remember the name of the field of predefined flags must equal the
+     * internal name!
      * 
      * @param name Name of Flag wanted.
      * @return	Predefined Flag object if any otherwise new custom Flag.
      * @throws IllegalArgumentException Thrown when the field is not accessible.
      */
-    public static Flag valueOf(String name) throws IllegalArgumentException{
+    public static Flag valueOf(String internal_name) throws IllegalArgumentException{
     	try {
-			return (Flag)(Flag.class.getField(name).get(null));
+			return (Flag)(Flag.class.getField(internal_name).get(null));
 		} catch (NoSuchFieldException e) {
 			// not a predefined flag
-			return Flag.CreateFlag(name);
+			if(internal_name.startsWith(USER_PREFIX))
+				return Flag.CreateFlag(internal_name.substring(USER_PREFIX.length()));
+			else return Flag.CreateFlag(internal_name);
 		} catch (IllegalAccessException e) {
 			throw new IllegalArgumentException(e);
 		}
@@ -129,25 +148,24 @@ public class Flag {
      * example "\\Deleted" will return the DELETED flag. When no such
      * flag exists we assume it's a custom flag and create it.
      * 
-     * TODO this could be faster this way: 
+     * ! this could be faster this way: 
      * http://java.dzone.com/articles/enum-tricks-customized-valueof
-     * 
      * Since it's only used once I don't see the point.
      * 
      * @param real_name Real name to look for.
      * @return The flag that was found or created.
      */
-    public static Flag valueOfByRealName(String internal_name){
+    public static Flag valueOfByRealName(String name){
     	for( Flag f : IMAP_FLAGS )
-    		if(f.internal_name.equalsIgnoreCase(internal_name))
+    		if(f.name.equalsIgnoreCase(name))
     			return f;
-    	return Flag.CreateFlag(internal_name);
+    	return Flag.CreateFlag(name);
     }
     
     @Override
-    public String toString() { return name; }
+    public String toString() { return internal_name; }
     
-    public String name() { return name; }
+    public String name() { return internal_name; }
     
     /**
      * Returns the real keyword name without user prefix. This is
@@ -156,7 +174,7 @@ public class Flag {
      * @return Real keyword string.
      */
     public String realName(){
-    	return internal_name;
+    	return name;
     }
     
 }

--- a/src/com/fsck/k9/mail/Flag.java
+++ b/src/com/fsck/k9/mail/Flag.java
@@ -3,35 +3,35 @@ package com.fsck.k9.mail;
 
 /**
  * Flags that can be applied to Messages.
- * 
+ *
  * Update: to support IMAP keywords ( custom flags ) this enum became
  * a class. This class was constructed to resemble enums. Since Java
- * enums are objects internally anyway ( implemented similar to these ) 
+ * enums are objects internally anyway ( implemented similar to these )
  * this will not be noticably slower.
- * 
+ *
  * The extra field bCustom denotes custom flags. These get an prefix
  * attached internally. When using the flags with external servers,..
  * one should use the realName() method.
  */
 public class Flag {
-	
-	/*
-	 * IMPORTANT!!
-	 * 
-	 * INTERNAL NAME MUST EQUAL THE NAME OF THE FIELD!!!
-	 */
-	
-	/*
-	 * IMAP Spec flags.
-	 */
+
+    /*
+     * IMPORTANT!!
+     *
+     * INTERNAL NAME MUST EQUAL THE NAME OF THE FIELD!!!
+     */
+
+    /*
+     * IMAP Spec flags.
+     */
     public static final Flag DELETED = new Flag("DELETED", "\\Deleted");
     public static final Flag SEEN = new Flag("SEEN", "\\Seen");
     public static final Flag ANSWERED = new Flag("ANSWERED", "\\Answered");
     public static final Flag FLAGGED = new Flag("FLAGGED", "\\Flagged");
-    
+
     public static final Flag DRAFT = new Flag("DRAFT", "\\Draft");
     public static final Flag RECENT = new Flag("RECENT", "\\Recent");
-    
+
     private static final Flag[] IMAP_FLAGS = new Flag[] {DELETED, SEEN, ANSWERED, FLAGGED, DRAFT, RECENT};
 
     /*
@@ -76,115 +76,119 @@ public class Flag {
      * the server (if the message is still there).
      */
     public static final Flag X_GOT_ALL_HEADERS = new Flag("X_GOT_ALL_HEADERS");
-    
+
     /*
      * Predefined Prefixes
      */
     private static final String USER_PREFIX = "USER_";
-    
+
     private final String mName;				// for use towards third party 	ex. "\\Deleted"
-    										// when internal name = name we refer to it as just name
+    // when internal name = name we refer to it as just name
     private final String mInternalName;		// for internal use in database,...   ex. "DELETED"
     protected boolean mCustom;
-    
+
     /**
      * When a Flag is created dynamically we know it's a custom flag.
-     * 
+     *
      * @param mName Internal name of the flag.
      * @return Newly created Flag object.
      */
-    public static Flag CreateFlag(String name) {
-    	Flag tmpFlag = new Flag(USER_PREFIX+name, name);
-    	tmpFlag.mCustom = true;
-    	return tmpFlag;
-	}
-    
-    private Flag(String name){
-    	this(name, name);
+    public static Flag createFlag(String name) {
+        Flag tmpFlag = new Flag(USER_PREFIX+name, name);
+        tmpFlag.mCustom = true;
+        return tmpFlag;
     }
-    
+
+    private Flag(String name) {
+        this(name, name);
+    }
+
     /**
      * Create a new Flag. This doesn't create a custom flag, it's used to define
      * the predefined flags.
-     * 
-     * @param internal_name Name for internal use in database,...   ex. "DELETED"
+     *
+     * @param internalName Name for internal use in database,...   ex. "DELETED"
      * @param name Name for use towards third party ( ex. "\\Deleted" )
      */
-    private Flag(String internal_name, String name){
-    	this.mName = name;
-    	this.mCustom = false;
-    	this.mInternalName = internal_name;
+    private Flag(String internalName, String name) {
+        this.mName = name;
+        this.mCustom = false;
+        this.mInternalName = internalName;
     }
-    
-    /** 
+
+    /**
      * Returns the predefined static flag object if any. Otherwise a new
      * custom flag is created and returned.
-     * 
+     *
      * When the name starts with the USER_PREFIX we don't add it again to
      * create a new one. This is the case for example when this is called with
      * strings retrieved from the database.
-     * 
+     *
      * IMPORTANT remember the name of the field of predefined flags must equal the
      * internal name!
-     * 
+     *
      * @param mName Name of Flag wanted.
      * @return	Predefined Flag object if any otherwise new custom Flag.
      * @throws IllegalArgumentException Thrown when the field is not accessible.
      */
-    public static Flag valueOf(String internal_name) throws IllegalArgumentException{
-    	try {
-			return (Flag)(Flag.class.getField(internal_name).get(null));
-		} catch (NoSuchFieldException e) {
-			// not a predefined flag
-			if(internal_name.startsWith(USER_PREFIX))
-				return Flag.CreateFlag(internal_name.substring(USER_PREFIX.length()));
-			else return Flag.CreateFlag(internal_name);
-		} catch (IllegalAccessException e) {
-			throw new IllegalArgumentException(e);
-		}
+    public static Flag valueOf(String internalName) throws IllegalArgumentException {
+        try {
+            return (Flag)(Flag.class.getField(internalName).get(null));
+        } catch (NoSuchFieldException e) {
+            // not a predefined flag
+            if(internalName.startsWith(USER_PREFIX))
+                return Flag.createFlag(internalName.substring(USER_PREFIX.length()));
+            else return Flag.createFlag(internalName);
+        } catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(e);
+        }
     }
-    
+
     /**
-     * Returns the predefined flag matching the given "real name". For 
+     * Returns the predefined flag matching the given "real name". For
      * example "\\Deleted" will return the DELETED flag. When no such
      * flag exists we assume it's a custom flag and create it.
-     * 
-     * ! this could be faster this way: 
+     *
+     * ! this could be faster this way:
      * http://java.dzone.com/articles/enum-tricks-customized-valueof
      * Since it's only used once I don't see the point.
-     * 
+     *
      * @param real_name Real name to look for.
      * @return The flag that was found or created.
      */
-    public static Flag valueOfByRealName(String name){
-    	for( Flag f : IMAP_FLAGS )
-    		if(f.mName.equalsIgnoreCase(name))
-    			return f;
-    	return Flag.CreateFlag(name);
+    public static Flag valueOfByRealName(String name) {
+        for( Flag f : IMAP_FLAGS )
+            if(f.mName.equalsIgnoreCase(name))
+                return f;
+        return Flag.createFlag(name);
     }
-    
+
     @Override
-    public String toString() { return mInternalName; }
-    
-    public String name() { return mInternalName; }
-    
+    public String toString() {
+        return mInternalName;
+    }
+
+    public String name() {
+        return mInternalName;
+    }
+
     /**
      * Returns the real keyword name without user prefix. This is
      * for non-internal use ( syncing with IMAP for example ).
-     * 
+     *
      * @return Real keyword string.
      */
-    public String realName(){
-    	return mName;
+    public String realName() {
+        return mName;
     }
-    
+
     @Override
     public boolean equals(Object o) {
-    	if ( o instanceof Flag ){
-    		Flag f = (Flag)o;
-    		return ( (f) == this ||
-    				(f.mCustom == this.mCustom && f.mInternalName == this.mInternalName 
-    				&& f.mName == this.mName));
-    	}else return false;
+        if ( o instanceof Flag ) {
+            Flag f = (Flag)o;
+            return ( (f) == this ||
+                     (f.mCustom == this.mCustom && f.mInternalName == this.mInternalName
+                      && f.mName == this.mName));
+        } else return false;
     }
 }

--- a/src/com/fsck/k9/mail/Flag.java
+++ b/src/com/fsck/k9/mail/Flag.java
@@ -82,24 +82,25 @@ public class Flag {
      */
     private static final String USER_PREFIX = "USER_";
     
-    private final String name;				// for use towards third party 	ex. "\\Deleted"
-    private final String internal_name;		// for internal use in database,...   ex. "DELETED"
-    protected boolean bCustom;
+    private final String mName;				// for use towards third party 	ex. "\\Deleted"
+    										// when internal name = name we refer to it as just name
+    private final String mInternalName;		// for internal use in database,...   ex. "DELETED"
+    protected boolean mCustom;
     
     /**
      * When a Flag is created dynamically we know it's a custom flag.
      * 
-     * @param name Internal name of the flag.
+     * @param mName Internal name of the flag.
      * @return Newly created Flag object.
      */
-    public static Flag CreateFlag(String internal_name) {
-    	Flag tmpFlag = new Flag(USER_PREFIX+internal_name, internal_name);
-    	tmpFlag.bCustom = true;
+    public static Flag CreateFlag(String name) {
+    	Flag tmpFlag = new Flag(USER_PREFIX+name, name);
+    	tmpFlag.mCustom = true;
     	return tmpFlag;
 	}
     
-    private Flag(String internal_name){
-    	this(internal_name, internal_name);
+    private Flag(String name){
+    	this(name, name);
     }
     
     /**
@@ -110,9 +111,9 @@ public class Flag {
      * @param name Name for use towards third party ( ex. "\\Deleted" )
      */
     private Flag(String internal_name, String name){
-    	this.name = name;
-    	this.bCustom = false;
-    	this.internal_name = internal_name;
+    	this.mName = name;
+    	this.mCustom = false;
+    	this.mInternalName = internal_name;
     }
     
     /** 
@@ -126,7 +127,7 @@ public class Flag {
      * IMPORTANT remember the name of the field of predefined flags must equal the
      * internal name!
      * 
-     * @param name Name of Flag wanted.
+     * @param mName Name of Flag wanted.
      * @return	Predefined Flag object if any otherwise new custom Flag.
      * @throws IllegalArgumentException Thrown when the field is not accessible.
      */
@@ -157,15 +158,15 @@ public class Flag {
      */
     public static Flag valueOfByRealName(String name){
     	for( Flag f : IMAP_FLAGS )
-    		if(f.name.equalsIgnoreCase(name))
+    		if(f.mName.equalsIgnoreCase(name))
     			return f;
     	return Flag.CreateFlag(name);
     }
     
     @Override
-    public String toString() { return internal_name; }
+    public String toString() { return mInternalName; }
     
-    public String name() { return internal_name; }
+    public String name() { return mInternalName; }
     
     /**
      * Returns the real keyword name without user prefix. This is
@@ -174,7 +175,7 @@ public class Flag {
      * @return Real keyword string.
      */
     public String realName(){
-    	return name;
+    	return mName;
     }
     
 }

--- a/src/com/fsck/k9/mail/Flag.java
+++ b/src/com/fsck/k9/mail/Flag.java
@@ -178,4 +178,13 @@ public class Flag {
     	return mName;
     }
     
+    @Override
+    public boolean equals(Object o) {
+    	if ( o instanceof Flag ){
+    		Flag f = (Flag)o;
+    		return ( (f) == this ||
+    				(f.mCustom == this.mCustom && f.mInternalName == this.mInternalName 
+    				&& f.mName == this.mName));
+    	}else return false;
+    }
 }

--- a/src/com/fsck/k9/mail/Flag.java
+++ b/src/com/fsck/k9/mail/Flag.java
@@ -19,7 +19,8 @@ public class Flag {
      * IMPORTANT WARNING!!
      *
      * DO NOT ADD STATIC FIELDS TO THIS CLASS UNLESS THEY ARE
-     * NEW FLAGS THAT GET PREDEFINED.
+     * NEW FLAGS THAT GET PREDEFINED. IF YOU DO ADD A NEW PREDEFINED
+     * FLAG ADD IT IN THE valueOfByRealName() METHOD BELOW TOO!
      */
 
     /*
@@ -81,10 +82,10 @@ public class Flag {
      */
     private static final String USER_PREFIX = "USER_";
 
-    private final String mName;             // for use towards third party  ex. "\\Deleted"
     // when internal name = name we refer to it as just name
+    private final String mName;             // for use towards third party  ex. "\\Deleted"
     private final String mInternalName;     // for internal use in database,...   ex. "DELETED"
-    protected boolean mCustom;
+    protected final boolean mCustom;
 
     /**
      * When a Flag is created dynamically we know it's a custom flag.
@@ -93,8 +94,7 @@ public class Flag {
      * @return Newly created Flag object.
      */
     public static Flag createFlag(String name) {
-        Flag tmpFlag = new Flag(USER_PREFIX + name, name);
-        tmpFlag.mCustom = true;
+        Flag tmpFlag = new Flag(USER_PREFIX + name, name, true);
         return tmpFlag;
     }
 
@@ -110,8 +110,12 @@ public class Flag {
      * @param name Name for use towards third party ( ex. "\\Deleted" )
      */
     private Flag(String internalName, String name) {
+        this(internalName, name, false);
+    }
+
+    private Flag(String internalName, String name, boolean isCustom) {
         this.mName = name;
-        this.mCustom = false;
+        this.mCustom = isCustom;
         this.mInternalName = internalName;
     }
 
@@ -147,6 +151,11 @@ public class Flag {
     }
 
     /**
+     * NOTE
+     * This method is intended to be used with Flags which have a different
+     * internal and external name! Else use valueOf(String) !!
+     *
+     *
      * Returns the predefined flag matching the given "real name". For
      * example "\\Deleted" will return the DELETED flag. When no such
      * flag exists we assume it's a custom flag and create it.
@@ -159,10 +168,15 @@ public class Flag {
      * @return The flag that was found or created.
      */
     public static Flag valueOfByRealName(String name) {
-        for (Flag f : new Flag[] {DELETED, SEEN, ANSWERED, FLAGGED, DRAFT, RECENT})
+        for (Flag f : new Flag[] {DELETED, SEEN, ANSWERED, FLAGGED, DRAFT, RECENT,
+                                  X_DESTROYED, X_DOWNLOADED_FULL, X_DOWNLOADED_PARTIAL, X_GOT_ALL_HEADERS,
+                                  X_REMOTE_COPY_STARTED, X_SEND_FAILED, X_SEND_IN_PROGRESS
+                                 }) {
             if (f.mName.equalsIgnoreCase(name)) {
                 return f;
             }
+        }
+
         return Flag.createFlag(name);
     }
 
@@ -190,10 +204,15 @@ public class Flag {
         if (o instanceof Flag) {
             Flag f = (Flag)o;
             return ((f) == this ||
-                    (f.mCustom == this.mCustom && f.mInternalName == this.mInternalName
-                     && f.mName == this.mName));
+                    (f.mCustom == this.mCustom && f.mInternalName.equals(this.mInternalName)
+                     && f.mName.equals(this.mName)));
         } else {
             return false;
         }
+    }
+
+    @Override
+    public int hashCode() {
+        return mInternalName.hashCode();
     }
 }

--- a/src/com/fsck/k9/mail/Flag.java
+++ b/src/com/fsck/k9/mail/Flag.java
@@ -16,9 +16,10 @@ package com.fsck.k9.mail;
 public class Flag {
 
     /*
-     * IMPORTANT!!
+     * IMPORTANT WARNING!!
      *
-     * INTERNAL NAME MUST EQUAL THE NAME OF THE FIELD!!!
+     * DO NOT ADD STATIC FIELDS TO THIS CLASS UNLESS THEY ARE
+     * NEW FLAGS THAT GET PREDEFINED.
      */
 
     /*
@@ -31,8 +32,6 @@ public class Flag {
 
     public static final Flag DRAFT = new Flag("DRAFT", "\\Draft");
     public static final Flag RECENT = new Flag("RECENT", "\\Recent");
-
-    private static final Flag[] IMAP_FLAGS = new Flag[] {DELETED, SEEN, ANSWERED, FLAGGED, DRAFT, RECENT};
 
     /*
      * The following flags are for internal library use only.
@@ -82,9 +81,9 @@ public class Flag {
      */
     private static final String USER_PREFIX = "USER_";
 
-    private final String mName;				// for use towards third party 	ex. "\\Deleted"
+    private final String mName;             // for use towards third party  ex. "\\Deleted"
     // when internal name = name we refer to it as just name
-    private final String mInternalName;		// for internal use in database,...   ex. "DELETED"
+    private final String mInternalName;     // for internal use in database,...   ex. "DELETED"
     protected boolean mCustom;
 
     /**
@@ -94,7 +93,7 @@ public class Flag {
      * @return Newly created Flag object.
      */
     public static Flag createFlag(String name) {
-        Flag tmpFlag = new Flag(USER_PREFIX+name, name);
+        Flag tmpFlag = new Flag(USER_PREFIX + name, name);
         tmpFlag.mCustom = true;
         return tmpFlag;
     }
@@ -128,17 +127,20 @@ public class Flag {
      * internal name!
      *
      * @param mName Name of Flag wanted.
-     * @return	Predefined Flag object if any otherwise new custom Flag.
+     * @return  Predefined Flag object if any otherwise new custom Flag.
      * @throws IllegalArgumentException Thrown when the field is not accessible.
      */
     public static Flag valueOf(String internalName) throws IllegalArgumentException {
         try {
+            // the argument being 'null' implies we look for a static field
             return (Flag)(Flag.class.getField(internalName).get(null));
         } catch (NoSuchFieldException e) {
             // not a predefined flag
-            if(internalName.startsWith(USER_PREFIX))
+            if (internalName.startsWith(USER_PREFIX)) {
                 return Flag.createFlag(internalName.substring(USER_PREFIX.length()));
-            else return Flag.createFlag(internalName);
+            } else {
+                return Flag.createFlag(internalName);
+            }
         } catch (IllegalAccessException e) {
             throw new IllegalArgumentException(e);
         }
@@ -157,9 +159,10 @@ public class Flag {
      * @return The flag that was found or created.
      */
     public static Flag valueOfByRealName(String name) {
-        for( Flag f : IMAP_FLAGS )
-            if(f.mName.equalsIgnoreCase(name))
+        for (Flag f : new Flag[] {DELETED, SEEN, ANSWERED, FLAGGED, DRAFT, RECENT})
+            if (f.mName.equalsIgnoreCase(name)) {
                 return f;
+            }
         return Flag.createFlag(name);
     }
 
@@ -184,11 +187,13 @@ public class Flag {
 
     @Override
     public boolean equals(Object o) {
-        if ( o instanceof Flag ) {
+        if (o instanceof Flag) {
             Flag f = (Flag)o;
-            return ( (f) == this ||
-                     (f.mCustom == this.mCustom && f.mInternalName == this.mInternalName
-                      && f.mName == this.mName));
-        } else return false;
+            return ((f) == this ||
+                    (f.mCustom == this.mCustom && f.mInternalName == this.mInternalName
+                     && f.mName == this.mName));
+        } else {
+            return false;
+        }
     }
 }

--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -1616,16 +1616,7 @@ public class ImapStore extends Store {
                 ImapList flags = fetchList.getKeyedList("FLAGS");
                 if (flags != null) {
                     for (int i = 0, count = flags.size(); i < count; i++) {
-                        String flag = flags.getString(i);
-                        if (flag.equalsIgnoreCase("\\Deleted")) {
-                            message.setFlagInternal(Flag.DELETED, true);
-                        } else if (flag.equalsIgnoreCase("\\Answered")) {
-                            message.setFlagInternal(Flag.ANSWERED, true);
-                        } else if (flag.equalsIgnoreCase("\\Seen")) {
-                            message.setFlagInternal(Flag.SEEN, true);
-                        } else if (flag.equalsIgnoreCase("\\Flagged")) {
-                            message.setFlagInternal(Flag.FLAGGED, true);
-                        }
+                        message.setFlagInternal(Flag.valueOfByRealName(flags.getString(i)), true);
                     }
                 }
             }
@@ -2058,16 +2049,7 @@ public class ImapStore extends Store {
         private String combineFlags(Flag[] flags) {
             ArrayList<String> flagNames = new ArrayList<String>();
             for (Flag flag : flags) {
-                if (flag == Flag.SEEN) {
-                    flagNames.add("\\Seen");
-                } else if (flag == Flag.DELETED) {
-                    flagNames.add("\\Deleted");
-                } else if (flag == Flag.ANSWERED) {
-                    flagNames.add("\\Answered");
-                } else if (flag == Flag.FLAGGED) {
-                    flagNames.add("\\Flagged");
-                }
-
+            	flagNames.add(flag.realName());
             }
             return Utility.combine(flagNames.toArray(new String[flagNames.size()]), ' ');
         }

--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -2049,7 +2049,9 @@ public class ImapStore extends Store {
         private String combineFlags(Flag[] flags) {
             ArrayList<String> flagNames = new ArrayList<String>();
             for (Flag flag : flags) {
-            	flagNames.add(flag.realName());
+            	// client's can't add the RECENT flag!
+            	if( !flag.equals(Flag.RECENT) )
+            		flagNames.add(flag.realName());
             }
             return Utility.combine(flagNames.toArray(new String[flagNames.size()]), ' ');
         }


### PR DESCRIPTION
Hi,

This adds IMAP keywords support ( custom flags ). The Flag enum is a class now. Predefined flags ( all the current ones ) are still only instantiated once. The Flag class is created to resemble an Enum. Only custom flags could exist multiple times at runtime.

Main feature for K-9 is a more complete IMAP implementation. I'll also use these as an option in the local saved searches feature. It could then allow a synced labeling of messages by the user.