### PR TITLE
Create the database in a transaction (better performances)

### DIFF
--- a/src/com/fsck/k9/mail/store/LocalStore.java
+++ b/src/com/fsck/k9/mail/store/LocalStore.java
@@ -156,6 +156,8 @@ public class LocalStore extends Store implements Serializable {
 
             AttachmentProvider.clear(mApplication);
 
+            db.beginTransaction();
+            try {
             try {
                 // schema version 29 was when we moved to incremental updates
                 // in the case of a new db or a < v29 db, we blow away and start from scratch
@@ -383,6 +385,11 @@ public class LocalStore extends Store implements Serializable {
 
             if (db.getVersion() != DB_VERSION) {
                 throw new Error("Database upgrade failed!");
+            }
+
+            db.setTransactionSuccessful();
+            } finally {
+                db.endTransaction();
             }
 
             // Unless we're blowing away the whole data store, there's no reason to prune attachments


### PR DESCRIPTION
On my emulator, it takes 70ms instead of 250ms.
On a very specific hardware, it takes 0,5s instead of 4,1s.

I willingly did not indent the code between my try/catch (for the patch to be readable).
