### PR TITLE
permission to broadcast intent when new emails received

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -29,6 +29,11 @@
 
     <uses-permission android:name="org.thialfihar.android.apg.permission.READ_KEY_DETAILS" />
 
+    <permission android:name="com.fsck.k9.permission.EMAIL_RECEIVED"
+                android:permissionGroup="android.permission-group.MESSAGES"
+                android:protectionLevel="dangerous"
+                android:label="@string/receive_email_label"
+                android:description="@string/receive_email_desc" />
     <permission android:name="com.fsck.k9.permission.READ_ATTACHMENT"
                 android:permissionGroup="android.permission-group.MESSAGES"
                 android:protectionLevel="dangerous"

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -12,6 +12,8 @@
 
     <string name="read_attachment_label">Anhänge der Nachricht lesen</string>
     <string name="read_attachment_desc">Dieser Anwendung erlauben die Anhänge Ihrer Nachrichten zu lesen.</string>
+    <string name="receive_email_label">Benachrichtigung über neue Emails</string>
+    <string name="receive_email_desc">Erlaubt dieser Anwendung über neue Emails benachrichtigt zu werden. Eine Benachrichtigung enthält den Sender, den Empfänger und den Betreff der Emails.</string>
     <string name="read_messages_label">Nachrichten lesen</string>
     <string name="read_messages_desc">Der Anwendung erlauben Ihre Nachrichten zu lesen.</string>
     <string name="delete_messages_label">Nachrichten löschen</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -12,6 +12,8 @@
 
     <string name="read_attachment_label">read Email attachments</string>
     <string name="read_attachment_desc">Allows this application to read your Email attachments.</string>
+    <string name="receive_email_label">receive email notifications</string>
+    <string name="receive_email_desc">Allows this application to receive new email notifications. Notifications includes sender, receiver and subject of emails.</string>
     <string name="read_messages_label">read Emails</string>
     <string name="read_messages_desc">Allows this application to read your Emails.</string>
     <string name="delete_messages_label">Delete Emails</string>

--- a/src/com/fsck/k9/K9.java
+++ b/src/com/fsck/k9/K9.java
@@ -135,6 +135,10 @@ public class K9 extends Application {
 
     public static boolean DEBUG_PROTOCOL_WEBDAV = true;
 
+    /**
+     * only application with this permission should be able to receive emails.
+     */
+    public final static String K9_EMAIL_RECEIVED_PERMISSION = "com.fsck.k9.permission.EMAIL_RECEIVED";
 
 
     /**
@@ -492,7 +496,7 @@ public class K9 extends Application {
                     intent.putExtra(K9.Intents.EmailReceived.EXTRA_BCC, Address.toString(message.getRecipients(Message.RecipientType.BCC)));
                     intent.putExtra(K9.Intents.EmailReceived.EXTRA_SUBJECT, message.getSubject());
                     intent.putExtra(K9.Intents.EmailReceived.EXTRA_FROM_SELF, account.isAnIdentity(message.getFrom()));
-                    K9.this.sendBroadcast(intent);
+                    K9.this.sendBroadcast(intent, K9.K9_EMAIL_RECEIVED_PERMISSION);
                     if (K9.DEBUG)
                         Log.d(K9.LOG_TAG, "Broadcasted: action=" + action
                               + " account=" + account.getDescription()


### PR DESCRIPTION
I added a permission which receivers of the broadcast intent need to have when a new email is received. I think third party apps should only see senders, receivers and subject of new emails if the user allows it.
