### PR TITLE
MessageView theme toggle: change the theme of the whole activity and not just the background of the WebView

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -164,8 +164,8 @@ http://k9mail.googlecode.com/
     <string name="hide_full_header_action">Hide full header</string>
     <string name="select_text_action">Select text</string>
 
-    <string name="message_view_theme_action_dark">Change background to black</string>
-    <string name="message_view_theme_action_light">Change background to white</string>
+    <string name="message_view_theme_action_dark">Switch to dark theme</string>
+    <string name="message_view_theme_action_light">Switch to light theme</string>
 
     <string name="mark_as_unread_action">Mark as unread</string>
     <string name="add_cc_bcc_action">Add Cc/Bcc</string>

--- a/src/com/fsck/k9/activity/MessageView.java
+++ b/src/com/fsck/k9/activity/MessageView.java
@@ -303,6 +303,7 @@ public class MessageView extends K9Activity implements OnClickListener {
     @Override
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+        setTheme(K9.getK9ThemeResourceId(K9.getK9MessageViewTheme()));
         requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
         setContentView(R.layout.message_view);
 
@@ -623,7 +624,14 @@ public class MessageView extends K9Activity implements OnClickListener {
                 return null;
             }
         }.execute();
-        displayMessage(mMessageReference);
+
+        // restart the current activity, so that the theme change can be applied
+        Intent intent = getIntent();
+        intent.addFlags(Intent.FLAG_ACTIVITY_NO_ANIMATION);
+        finish();
+        overridePendingTransition(0, 0); // disable animations to speed up the switch
+        startActivity(intent);
+        overridePendingTransition(0, 0);
     }
 
     private void startRefileActivity(int activity) {

--- a/src/com/fsck/k9/view/MessageWebView.java
+++ b/src/com/fsck/k9/view/MessageWebView.java
@@ -98,9 +98,6 @@ public class MessageWebView extends TitleBarWebView {
             // Black theme should get a black webview background
             // we'll set the background of the messages on load
             this.setBackgroundColor(0xff000000);
-        } else {
-            // multitoggle requires reset to white
-            this.setBackgroundColor(0xffffffff);
         }
 
         final WebSettings webSettings = this.getSettings();

--- a/src/com/fsck/k9/view/SingleMessageView.java
+++ b/src/com/fsck/k9/view/SingleMessageView.java
@@ -720,7 +720,7 @@ public class SingleMessageView extends LinearLayout implements OnClickListener,
         showShowPicturesAction(false);
         mAttachments.removeAllViews();
         mHiddenAttachments.removeAllViews();
-        mMessageContentView.configure();
+
         /*
          * Clear the WebView content
          *


### PR DESCRIPTION
Using dark theme with white WebView background looks very ugly,
especially when a "download complete message" or a "show images"
button is present.

This change applies the theme to the whole activity.

Also changed the text for the toggle menu. It's also shorter now,
and isn't cut off anymore on hdpi/480px wide devices.
