### PR TITLE
swap 'compose' and 'check mail' buttons in message lists

### DIFF
--- a/res/menu/message_list_option.xml
+++ b/res/menu/message_list_option.xml
@@ -2,11 +2,11 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item
-        android:id="@+id/compose"
-        android:alphabeticShortcut="c"
-        android:icon="?attr/iconActionCompose"
+        android:id="@+id/check_mail"
+        android:alphabeticShortcut="r"
+        android:icon="?attr/iconActionRefresh"
         android:showAsAction="always"
-        android:title="@string/compose_action"/>
+        android:title="@string/check_mail_action"/>
     <item
         android:id="@+id/set_sort"
         android:icon="?attr/iconActionSort"
@@ -37,6 +37,12 @@
         </menu>
     </item>
     <item
+        android:id="@+id/compose"
+        android:alphabeticShortcut="c"
+        android:icon="?attr/iconActionCompose"
+        android:showAsAction="always"
+        android:title="@string/compose_action"/>
+    <item
         android:id="@+id/select_all"
         android:icon="?attr/iconMenuSelectAll"
         android:showAsAction="never"
@@ -47,12 +53,6 @@
         android:icon="?attr/iconActionRefresh"
         android:showAsAction="never"
         android:title="@string/send_messages_action"/>
-    <item
-        android:id="@+id/check_mail"
-        android:alphabeticShortcut="r"
-        android:icon="?attr/iconActionRefresh"
-        android:showAsAction="always"
-        android:title="@string/check_mail_action"/>
     <item
         android:id="@+id/expunge"
         android:showAsAction="never"


### PR DESCRIPTION
now account list, folder list, and message list are consistent
