### PR TITLE
Restore saved TCP port setting

### DIFF
--- a/src/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/src/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -62,6 +62,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
 
 
     private int[] mAccountPorts;
+    private int mSavedPort = -1;
     private String mStoreType;
     private EditText mUsernameView;
     private EditText mPasswordView;
@@ -294,6 +295,8 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 throw new Exception("Unknown account type: " + mAccount.getStoreUri());
             }
 
+            mSavedPort = settings.port;
+
             for (int i = 0; i < CONNECTION_SECURITY_TYPES.length; i++) {
                 if (CONNECTION_SECURITY_TYPES[i] == settings.connectionSecurity) {
                     SpinnerOption.setSpinnerOptionValue(mSecurityTypeView, i);
@@ -306,12 +309,6 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
 
             if (settings.host != null) {
                 mServerView.setText(settings.host);
-            }
-
-            if (settings.port != -1) {
-                mPortView.setText(Integer.toString(settings.port));
-            } else {
-                updatePortFromSecurityType();
             }
 
             mSubscribedFoldersOnly.setChecked(mAccount.subscribedFoldersOnly());
@@ -338,7 +335,15 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     }
 
     private void updatePortFromSecurityType() {
-        if (mAccountPorts != null) {
+        if (mSavedPort != -1) {
+            /*
+             * The mSecurityTypeView has just been initialized, triggering its
+             * onItemSelected() listener for the first time. We now initialize
+             * mPortView.
+             */
+            mPortView.setText(Integer.toString(mSavedPort));
+            mSavedPort = -1;  // Initialize mPortView just once.
+        } else if (mAccountPorts != null) {
             int securityType = (Integer)((SpinnerOption)mSecurityTypeView.getSelectedItem()).value;
             mPortView.setText(Integer.toString(mAccountPorts[securityType]));
         }

--- a/src/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/src/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -58,6 +58,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     private EditText mPasswordView;
     private EditText mServerView;
     private EditText mPortView;
+    private int mSavedPort = -1;
     private CheckBox mRequireLoginView;
     private ViewGroup mRequireLoginSettingsView;
     private Spinner mSecurityTypeView;
@@ -224,6 +225,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
             }
 
 
+            mSavedPort = uri.getPort();
+
             for (int i = 0; i < smtpSchemes.length; i++) {
                 if (smtpSchemes[i].equals(uri.getScheme())) {
                     SpinnerOption.setSpinnerOptionValue(mSecurityTypeView, i);
@@ -232,12 +235,6 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
 
             if (uri.getHost() != null) {
                 mServerView.setText(uri.getHost());
-            }
-
-            if (uri.getPort() != -1) {
-                mPortView.setText(Integer.toString(uri.getPort()));
-            } else {
-                updatePortFromSecurityType();
             }
 
             validateFields();
@@ -268,8 +265,18 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     }
 
     private void updatePortFromSecurityType() {
-        int securityType = (Integer)((SpinnerOption)mSecurityTypeView.getSelectedItem()).value;
-        mPortView.setText(Integer.toString(smtpPorts[securityType]));
+        if (mSavedPort != -1) {
+            /*
+             * The mSecurityTypeView has just been initialized, triggering its
+             * onItemSelected() listener for the first time. We now initialize
+             * mPortView.
+             */
+            mPortView.setText(Integer.toString(mSavedPort));
+            mSavedPort = -1;  // Initialize mPortView just once.
+        } else {
+            int securityType = (Integer)((SpinnerOption)mSecurityTypeView.getSelectedItem()).value;
+            mPortView.setText(Integer.toString(smtpPorts[securityType]));
+        }
     }
 
     @Override


### PR DESCRIPTION
This bug occurs with Android 4.1 (Jelly Bean).  Saved TCP port values are no longer being restored when entering the server setup screens.  To reproduce:

Go into Settings -> Account Settings -> Fetching mail -> Incoming server.  Change the port to a non-standard number (e.g., 1234).  Click Next.  You will likely get a 'cannot connect' error -- ignore it.  Click 'continue'.  The port number has now been saved.  Go back into 'Incoming server' again.  Prior to Jelly Bean, you would see the saved port number (1234).  With Jelly Bean, the port number has been reset to a default value.

The cause:

Before this patch, the code in AccountSetupIncoming.onCreate() did the following:

1)  Create mSecurityTypeView, a spinner widget for selecting the server security protocol.

2)  Set an onItemSelected() listener for mSecurityTypeView so that whenever a spinner option value is selected, a call is made to updatePortFromSecurityType() (which sets a default port value based on the selected security protocol).

3)  Initialize the mSecurityTypeView spinner with the saved security protocol option value for the account.

4)  Initialize mPortView (a text widget) with the saved TCP port setting for the account.

On Android versions prior to Jelly Bean, the execution of step (3) immediately resulted in triggering the onItemSelected() listener, resulting in an immediate call to updatePortFromSecurityType() which initialized mPortView with a default value.  However, this default initialization was irrelevant, because mPortView was subsequently reinitialized in step (4).

With Jelly Bean, step (3) still results in triggering the onItemSelected() listener.  However, the subsequent call to updatePortFromSecurityType() is no longer immediate;  instead, the call is posted to the UI message queue to be invoked later -- i.e., the call to updatePortFromSecurityType() is delayed until after step (4), so the saved port value ends up being wiped out and replaced with a default value in the UI.

The problem occurs for both the incoming and outgoing server settings.

This patch moves step (4) from inside of onCreate() to inside of updatePortFromSecurityType().

Tested on Gingerbread, ICS, and Jelly Bean.
