### PR TITLE
treat mailto: URI parameters case-insensitive

### DIFF
--- a/src/com/fsck/k9/activity/MessageCompose.java
+++ b/src/com/fsck/k9/activity/MessageCompose.java
@@ -3292,7 +3292,7 @@ public class MessageCompose extends K9Activity implements OnClickListener, OnFoc
     }
 
     // Regex for URI parameter names
-    private static final Pattern QUERY_HFNAME = Pattern.compile("(?:^|&)([a-zA-Z]+)=");
+    private static final Pattern QUERY_HFNAME = Pattern.compile("(?:^|&)([a-zA-Z]*[A-Z][a-zA-Z]*)=");
 
     /**
      * Convert URI parameter names to lower case


### PR DESCRIPTION
Although RFC defines such parameters case-sensitive, some applications still use capitalized versions like `Subject` and `Body`. Since the Java Uri parser is case-sensitive, this patch replaces all URI parameter names with a lower-case version, and since all parameter name requests are also done in lower-case, this effectively makes the `mailto:` handler logic case-insensitive.

Feature request in Google Groups: https://groups.google.com/forum/?fromgroups=#!topic/k-9-mail/WN9xcM_QIFw
