### PR TITLE
treat mailto: URI parameters case-insensitive

### DIFF
--- a/src/com/fsck/k9/activity/MessageCompose.java
+++ b/src/com/fsck/k9/activity/MessageCompose.java
@@ -3257,7 +3257,8 @@ public class MessageCompose extends K9Activity implements OnClickListener, OnFoc
          * creating a new hierarchical dummy Uri object with the query
          * parameters of the original URI.
          */
-        Uri uri = Uri.parse("foo://bar?" + mailtoUri.getEncodedQuery());
+        CaseInsensitiveParamWrapper uri = new CaseInsensitiveParamWrapper(
+                Uri.parse("foo://bar?" + mailtoUri.getEncodedQuery()));
 
         // Read additional recipients from the "to" parameter.
         List<String> to = uri.getQueryParameters("to");
@@ -3288,6 +3289,24 @@ public class MessageCompose extends K9Activity implements OnClickListener, OnFoc
         List<String> body = uri.getQueryParameters("body");
         if (!body.isEmpty()) {
             mMessageContentView.setText(body.get(0));
+        }
+    }
+
+    private static class CaseInsensitiveParamWrapper {
+        private final Uri uri;
+
+        public CaseInsensitiveParamWrapper(Uri uri) {
+            this.uri = uri;
+        }
+
+        public List<String> getQueryParameters(String key) {
+            final List<String> params = new ArrayList<String>();
+            for (String paramName : uri.getQueryParameterNames()) {
+                if (paramName.equalsIgnoreCase(key)) {
+                    params.addAll(uri.getQueryParameters(paramName));
+                }
+            }
+            return params;
         }
     }
 


### PR DESCRIPTION
Although RFC defines such parameters case-sensitive, some applications still use capitalized versions like "Subject" and "Body". Since the Java Uri parser is case-sensitive, this patch wraps calls to it with a version that allows for case-insensitive parameter name matching.

Cleaner version of #205
Feature request in Google Groups: https://groups.google.com/forum/?fromgroups=#!topic/k-9-mail/WN9xcM_QIFw
