### PR TITLE
StrictMode stacktrace since stream was not closed properly

### DIFF
--- a/src/com/fsck/k9/mail/internet/BinaryTempFileBody.java
+++ b/src/com/fsck/k9/mail/internet/BinaryTempFileBody.java
@@ -36,9 +36,15 @@ public class BinaryTempFileBody implements Body {
     }
 
     public InputStream getInputStream() throws MessagingException {
+        InputStream is = null;
+        FileInputStream fis = null;
         try {
-            return new BinaryTempFileBodyInputStream(new FileInputStream(mFile));
+            fis = new FileInputStream(mFile);
+            is = new BinaryTempFileBodyInputStream(fis);
+            return is;
         } catch (IOException ioe) {
+            try { if (fis != null) { fis.close(); } } catch (IOException e) { }
+            try { if (is != null) { is.close(); } } catch (IOException e) { }
             throw new MessagingException("Unable to open body", ioe);
         }
     }


### PR DESCRIPTION
When the device lost connectivity, a StrictMode error could be thrown since
the stream had not been closed.
