### PR TITLE
Fix issue 4771 - work around > getting included in URLs when linkifying text/plain emails

### DIFF
--- a/src/com/fsck/k9/helper/HtmlConverter.java
+++ b/src/com/fsck/k9/helper/HtmlConverter.java
@@ -248,7 +248,11 @@ public class HtmlConverter {
                     if (isStartOfLine) {
                         quotesThisLine++;
                     } else {
-                        buff.append("&gt;");
+                        // We use a token here which can't occur in htmlified text because &gt; is valid
+                        // within links (where > is not), and linkifying links will include it if we
+                        // do it here. We'll make another pass and change this back to &gt; after
+                        // the linkification is done.
+                        buff.append("<gt>");
                     }
                     break;
                 case '\r':
@@ -321,6 +325,9 @@ public class HtmlConverter {
         }
 
         text = sb.toString();
+
+        // Above we replaced > with <gt>, now make it &gt;
+        text = text.replaceAll("<gt>", "&gt;");
 
         return text;
     }


### PR DESCRIPTION
http://code.google.com/p/k9mail/issues/detail?id=4771

&amp;gt; is valid within links, so when we replace > with &amp;gt; at the beginning of the text-to-html conversion, it gets included in URLs when linkified.  Converting &gt; to &amp;gt; after linkifying would break the HTML tags, though.  Instead, replace &gt; with &lt;gt&gt; on the frist pass, then do a search/replace on that to change it back to &amp;gt; after the linkification is done.
