### PR TITLE
Spam Assassin support

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -6,7 +6,7 @@
     >
     <uses-sdk
        android:minSdkVersion="7"
-       android:targetSdkVersion="15"
+       android:targetSdkVersion="16"
        />
     <supports-screens
         android:largeScreens="true"

--- a/README
+++ b/README
@@ -1,0 +1,19 @@
+Current K9 sources from git require SDK AI level 16, so the properties
+files needed to be updated to Android SDK API level 16 instead of
+15.
+
+There are three imports that need to be done to add this to
+eclipse. It's also possible to use 'ant' if your build.xml 
+files are correct. You can set those up with the correct build path
+using this command from the top level directory:
+
+      android update project --path `pwd` --subprojects
+
+The first two projects to import are libraries, which are
+ActionBarSherlock and Android-PullToRefresh. These import weird, so
+after they get imported as 'library', rename them. 
+
+To build, use eclipse or type 'ant debug' at the top level. To install
+the package, it must first be removed, do that like this:
+    
+    adb install -r bin/k9-mail.apk

--- a/ant.properties
+++ b/ant.properties
@@ -19,5 +19,5 @@
 split.density=false
 java.encoding=utf8
 # Project target.
-target=android-15
+target=android-16
 extensible.libs.classpath=compile-only-libs

--- a/plugins/ActionBarSherlock/library/project.properties
+++ b/plugins/ActionBarSherlock/library/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=android-15
+target=Google Inc.:Google APIs:15

--- a/plugins/ActionBarSherlock/library/project.properties
+++ b/plugins/ActionBarSherlock/library/project.properties
@@ -9,4 +9,4 @@
 
 android.library=true
 # Project target.
-target=Google Inc.:Google APIs:15
+target=android-16

--- a/plugins/Android-PullToRefresh/extras/PullToRefreshListFragment/project.properties
+++ b/plugins/Android-PullToRefresh/extras/PullToRefreshListFragment/project.properties
@@ -12,5 +12,5 @@
 
 android.library=true
 # Project target.
-target=android-16
-android.library.reference.1=../../library
+target=Google Inc.:Google APIs:15
+android.library.reference.1=../../../ActionBarSherlock/library

--- a/project.properties
+++ b/project.properties
@@ -11,7 +11,7 @@
 split.density=false
 java.encoding=utf8
 # Project target.
-target=android-15
+target=android-16
 extensible.libs.classpath=compile-only-libs
 android.library.reference.1=plugins/ActionBarSherlock/library
 android.library.reference.2=plugins/Android-PullToRefresh/library

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -627,6 +627,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_sync_remote_deletetions_label">Sync server deletions</string>
     <string name="account_settings_sync_remote_deletetions_summary">Remove messages when deleted on server</string>
 
+    <string name="account_settings_spamass_label">Filter using Spamassassin</string>
+    <string name="account_settings_spamass_summary">Move Flagged Spam messages to Spam folder.</string>
+    
     <string name="folder_settings_title">Folder settings</string>
 
     <string name="folder_settings_in_top_group_label">Show in top group</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -627,7 +627,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_sync_remote_deletetions_label">Sync server deletions</string>
     <string name="account_settings_sync_remote_deletetions_summary">Remove messages when deleted on server</string>
 
-    <string name="account_settings_spamass_label">Filter using Spamassassin</string>
+    <string name="account_settings_spamass_label">Enable Spamassassin support</string>
     <string name="account_settings_spamass_summary">Move Flagged Spam messages to Spam folder.</string>
     
     <string name="folder_settings_title">Folder settings</string>

--- a/res/xml/account_settings_preferences.xml
+++ b/res/xml/account_settings_preferences.xml
@@ -151,6 +151,13 @@
             android:defaultValue="true"
             android:summary="@string/account_settings_sync_remote_deletetions_summary" />
 
+        <CheckBoxPreference
+            android:persistent="false"
+            android:key="account_spamass"
+            android:title="@string/account_settings_spamass_label"
+            android:defaultValue="true"
+            android:summary="@string/account_settings_spamass_summary" />
+
         <ListPreference
             android:persistent="false"
             android:key="delete_policy"

--- a/src/com/fsck/k9/Account.java
+++ b/src/com/fsck/k9/Account.java
@@ -193,6 +193,7 @@ public class Account implements BaseAccount {
     private boolean mReplyAfterQuote;
     private boolean mStripSignature;
     private boolean mSyncRemoteDeletions;
+    private boolean mSpamassFilter;
     private String mCryptoApp;
     private boolean mCryptoAutoSignature;
     private boolean mCryptoAutoEncrypt;
@@ -302,6 +303,7 @@ public class Account implements BaseAccount {
         mReplyAfterQuote = DEFAULT_REPLY_AFTER_QUOTE;
         mStripSignature = DEFAULT_STRIP_SIGNATURE;
         mSyncRemoteDeletions = true;
+        mSpamassFilter = true;
         mCryptoApp = Apg.NAME;
         mCryptoAutoSignature = false;
         mCryptoAutoEncrypt = false;
@@ -371,7 +373,8 @@ public class Account implements BaseAccount {
         mSpamFolderName = prefs.getString(mUuid  + ".spamFolderName", "Spam");
         mExpungePolicy = prefs.getString(mUuid  + ".expungePolicy", EXPUNGE_IMMEDIATELY);
         mSyncRemoteDeletions = prefs.getBoolean(mUuid  + ".syncRemoteDeletions", true);
-
+        mSpamassFilter = prefs.getBoolean(mUuid  + ".spamassFilter", true);
+        
         mMaxPushFolders = prefs.getInt(mUuid + ".maxPushFolders", 10);
         goToUnreadMessageSearch = prefs.getBoolean(mUuid + ".goToUnreadMessageSearch", false);
         mNotificationShowsUnreadCount = prefs.getBoolean(mUuid + ".notificationUnreadCount", true);
@@ -698,6 +701,7 @@ public class Account implements BaseAccount {
         editor.putBoolean(mUuid + ".signatureBeforeQuotedText", this.mIsSignatureBeforeQuotedText);
         editor.putString(mUuid + ".expungePolicy", mExpungePolicy);
         editor.putBoolean(mUuid + ".syncRemoteDeletions", mSyncRemoteDeletions);
+        editor.putBoolean(mUuid + ".spamassfilter", mSpamassFilter);
         editor.putInt(mUuid + ".maxPushFolders", mMaxPushFolders);
         editor.putString(mUuid + ".searchableFolders", searchableFolders.name());
         editor.putInt(mUuid + ".chipColor", mChipColor);
@@ -1706,7 +1710,15 @@ public class Account implements BaseAccount {
         mSyncRemoteDeletions = syncRemoteDeletions;
     }
 
-    public synchronized String getLastSelectedFolderName() {
+    public synchronized boolean spamassFilter() {
+        return mSpamassFilter;
+    }
+
+    public synchronized void setSpamassFilter(boolean spamassFilter) {
+        mSpamassFilter = spamassFilter;
+    }
+
+   public synchronized String getLastSelectedFolderName() {
         return lastSelectedFolderName;
     }
 

--- a/src/com/fsck/k9/Account.java
+++ b/src/com/fsck/k9/Account.java
@@ -303,7 +303,7 @@ public class Account implements BaseAccount {
         mReplyAfterQuote = DEFAULT_REPLY_AFTER_QUOTE;
         mStripSignature = DEFAULT_STRIP_SIGNATURE;
         mSyncRemoteDeletions = true;
-        mSpamassFilter = true;
+        mSpamassFilter = false;
         mCryptoApp = Apg.NAME;
         mCryptoAutoSignature = false;
         mCryptoAutoEncrypt = false;
@@ -373,7 +373,7 @@ public class Account implements BaseAccount {
         mSpamFolderName = prefs.getString(mUuid  + ".spamFolderName", "Spam");
         mExpungePolicy = prefs.getString(mUuid  + ".expungePolicy", EXPUNGE_IMMEDIATELY);
         mSyncRemoteDeletions = prefs.getBoolean(mUuid  + ".syncRemoteDeletions", true);
-        mSpamassFilter = prefs.getBoolean(mUuid  + ".spamassFilter", true);
+        mSpamassFilter = prefs.getBoolean(mUuid  + ".spamassFilter", false);
         
         mMaxPushFolders = prefs.getInt(mUuid + ".maxPushFolders", 10);
         goToUnreadMessageSearch = prefs.getBoolean(mUuid + ".goToUnreadMessageSearch", false);

--- a/src/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/src/com/fsck/k9/activity/setup/AccountSettings.java
@@ -108,6 +108,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_REPLY_AFTER_QUOTE = "reply_after_quote";
     private static final String PREFERENCE_STRIP_SIGNATURE = "strip_signature";
     private static final String PREFERENCE_SYNC_REMOTE_DELETIONS = "account_sync_remote_deletetions";
+    private static final String PREFERENCE_SPAMASS = "account_spamass";
     private static final String PREFERENCE_CRYPTO_APP = "crypto_app";
     private static final String PREFERENCE_CRYPTO_AUTO_SIGNATURE = "crypto_auto_signature";
     private static final String PREFERENCE_CRYPTO_AUTO_ENCRYPT = "crypto_auto_encrypt";
@@ -170,6 +171,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private CheckBoxPreference mReplyAfterQuote;
     private CheckBoxPreference mStripSignature;
     private CheckBoxPreference mSyncRemoteDeletions;
+    private CheckBoxPreference mSpamassFilter;
     private CheckBoxPreference mPushPollOnConnect;
     private ListPreference mIdleRefreshPeriod;
     private ListPreference mMaxPushFolders;
@@ -386,6 +388,9 @@ public class AccountSettings extends K9PreferenceActivity {
 
         mSyncRemoteDeletions = (CheckBoxPreference) findPreference(PREFERENCE_SYNC_REMOTE_DELETIONS);
         mSyncRemoteDeletions.setChecked(mAccount.syncRemoteDeletions());
+        
+        mSpamassFilter = (CheckBoxPreference) findPreference(PREFERENCE_SPAMASS);
+        mSpamassFilter.setChecked(mAccount.spamassFilter());
 
         mSearchableFolders = (ListPreference) findPreference(PREFERENCE_SEARCHABLE_FOLDERS);
         mSearchableFolders.setValue(mAccount.getSearchableFolders().name());
@@ -755,6 +760,7 @@ public class AccountSettings extends K9PreferenceActivity {
             mAccount.setExpungePolicy(mExpungePolicy.getValue());
         }
         mAccount.setSyncRemoteDeletions(mSyncRemoteDeletions.isChecked());
+        mAccount.setSpamassFilter(mSpamassFilter.isChecked());
         mAccount.setSearchableFolders(Account.Searchable.valueOf(mSearchableFolders.getValue()));
         mAccount.setMessageFormat(Account.MessageFormat.valueOf(mMessageFormat.getValue()));
         mAccount.setAlwaysShowCcBcc(mAlwaysShowCcBcc.isChecked());

--- a/src/com/fsck/k9/controller/MessagingController.java
+++ b/src/com/fsck/k9/controller/MessagingController.java
@@ -976,9 +976,10 @@ public class MessagingController implements Runnable {
                 for (Message localMessage : allMessages) {
                 	if (localMessage.getSpamFlag().equalsIgnoreCase("YES")) {
                 		// Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is SPAM");                		// Folder spamFolder = remoteStore.getFolder("Spam");
+                		Log.d("K9-Mail", "moving messages to SPAM folder, from: " + Address.toString(localMessage.getFrom()));
                 		String spamfolder = account.getSpamFolderName();
                 		String inbox = account.getInboxFolderName();
-                		moveToSpam(localMessage, account, inbox, spamfolder);
+                		moveMessage(account, inbox, localMessage, spamfolder, null);
                 		continue;
                 	} else {
                 		// Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is not SPAM");
@@ -1048,13 +1049,6 @@ public class MessagingController implements Runnable {
         }
 
     }
-
-
-    private void moveToSpam(Message message, Account account, String inbox, String spamFolder) {
-		// Move the message to the user specified spam folder.
-    	Log.d("K9-Mail", "moving messages to SPAM folder, from: " + Address.toString(message.getFrom()));
-		moveMessage(account, inbox, message, spamFolder, null);
-	}
 
 	private void closeFolder(Folder f) {
         if (f != null) {

--- a/src/com/fsck/k9/controller/MessagingController.java
+++ b/src/com/fsck/k9/controller/MessagingController.java
@@ -844,8 +844,7 @@ public class MessagingController implements Runnable {
                     return;
                 }
 
-
-                /*
+               /*
                  * Synchronization process:
                  *
                 Open the folder
@@ -976,11 +975,13 @@ public class MessagingController implements Runnable {
             	Message[] allMessages = localFolder.getMessages(null);
                 for (Message localMessage : allMessages) {
                 	if (localMessage.getSpamFlag().equalsIgnoreCase("YES")) {
-                		Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is SPAM");
-                		moveToSpam(localMessage, remoteFolder);
+                		// Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is SPAM");                		// Folder spamFolder = remoteStore.getFolder("Spam");
+                		String spamfolder = account.getSpamFolderName();
+                		String inbox = account.getInboxFolderName();
+                		moveToSpam(localMessage, account, inbox, spamfolder);
                 		continue;
                 	} else {
-                		Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is not SPAM");
+                		// Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is not SPAM");
                 	}
                 }
             }
@@ -1049,16 +1050,10 @@ public class MessagingController implements Runnable {
     }
 
 
-    private void moveToSpam(Message message, Folder localFolder) {
+    private void moveToSpam(Message message, Account account, String inbox, String spamFolder) {
 		// Move the message to the user specified spam folder.
     	Log.d("K9-Mail", "moving messages to SPAM folder, from: " + Address.toString(message.getFrom()));
-  		Folder spamFolder = null;
-		try {
-			localFolder.moveMessages(new Message[] { message }, spamFolder);
-		} catch (MessagingException e) {
-			// TODO Auto-generated catch block
-			e.printStackTrace();
-		}		
+		moveMessage(account, inbox, message, spamFolder, null);
 	}
 
 	private void closeFolder(Folder f) {

--- a/src/com/fsck/k9/controller/MessagingController.java
+++ b/src/com/fsck/k9/controller/MessagingController.java
@@ -927,6 +927,12 @@ public class MessagingController implements Runnable {
                         l.synchronizeMailboxHeadersProgress(account, folder, headerProgress.get(), messageCount);
                     }
                     Message localMessage = localUidMap.get(thisMess.getUid());
+                	if (localMessage.getSpamFlag().equals("YES")) {
+                		Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is SPAM");
+                		continue;
+                 	} else {
+                		Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is not SPAM");
+                	}                    
                     if (localMessage == null || !localMessage.olderThan(earliestDate)) {
                         remoteMessages.add(thisMess);
                         remoteUidMap.put(thisMess.getUid(), thisMess);

--- a/src/com/fsck/k9/controller/MessagingController.java
+++ b/src/com/fsck/k9/controller/MessagingController.java
@@ -975,14 +975,14 @@ public class MessagingController implements Runnable {
             	Message[] allMessages = localFolder.getMessages(null);
                 for (Message localMessage : allMessages) {
                 	if (localMessage.getSpamFlag().equalsIgnoreCase("YES")) {
-                		// Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is SPAM");                		// Folder spamFolder = remoteStore.getFolder("Spam");
-                		Log.d("K9-Mail", "moving messages to SPAM folder, from: " + Address.toString(localMessage.getFrom()));
+                		// Log.d("K9.LOG_TAG", "Message " +  Address.toString(localMessage.getFrom()) + " is SPAM");                		// Folder spamFolder = remoteStore.getFolder("Spam");
+                		Log.d("K9.LOG_TAG", "moving messages to SPAM folder, from: " + Address.toString(localMessage.getFrom()));
                 		String spamfolder = account.getSpamFolderName();
                 		String inbox = account.getInboxFolderName();
                 		moveMessage(account, inbox, localMessage, spamfolder, null);
                 		continue;
                 	} else {
-                		// Log.d("K9-Mail", "Message " +  Address.toString(localMessage.getFrom()) + " is not SPAM");
+                		// Log.d("K9.LOG_TAG", "Message " +  Address.toString(localMessage.getFrom()) + " is not SPAM");
                 	}
                 }
             }

--- a/src/com/fsck/k9/mail/Message.java
+++ b/src/com/fsck/k9/mail/Message.java
@@ -80,6 +80,9 @@ public abstract class Message implements Part, Body {
         return mFolder;
     }
 
+    public abstract String getSpamFlag();
+    public abstract String getSpamStatus();
+    
     public abstract String getSubject();
 
     public abstract void setSubject(String subject) throws MessagingException;

--- a/src/com/fsck/k9/mail/internet/MimeHeader.java
+++ b/src/com/fsck/k9/mail/internet/MimeHeader.java
@@ -76,6 +76,9 @@ public class MimeHeader {
         for (Field field : mFields) {
             if (field.name.equalsIgnoreCase(name)) {
                 values.add(field.value);
+                // Since we found the value, don't keep traversing the
+                // list of header fields.
+                break;
             }
         }
         if (values.isEmpty()) {

--- a/src/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/src/com/fsck/k9/mail/internet/MimeMessage.java
@@ -23,6 +23,8 @@ import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
 
+import android.util.Log;
+
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;
@@ -51,6 +53,9 @@ public class MimeMessage extends Message {
     protected Date mSentDate;
     protected SimpleDateFormat mDateFormat;
 
+    protected String mSpamFlag;
+    protected String mSpamStatus;
+    
     protected Body mBody;
     protected int mSize;
 
@@ -85,6 +90,9 @@ public class MimeMessage extends Message {
 
         mBody = null;
 
+        mSpamFlag = null;
+        mSpamStatus= null;
+        
         MimeConfig parserConfig  = new MimeConfig();
         parserConfig.setMaxHeaderLen(-1); // The default is a mere 10k
         parserConfig.setMaxLineLen(-1); // The default is 1000 characters. Some MUAs generate
@@ -96,7 +104,6 @@ public class MimeMessage extends Message {
             parser.parse(new EOLConvertingInputStream(in));
         } catch (MimeException me) {
             throw new Error(me);
-
         }
     }
 
@@ -577,6 +584,9 @@ public class MimeMessage extends Message {
         message.mReplyTo = mReplyTo;
         message.mReferences = mReferences;
         message.mInReplyTo = mInReplyTo;
+        
+        message.mSpamFlag = mSpamFlag;
+        message.mSpamStatus = mSpamStatus;
     }
 
     @Override
@@ -597,4 +607,56 @@ public class MimeMessage extends Message {
     public boolean hasAttachments() {
         return false;
     }
+
+
+	@Override
+	public String getSpamFlag() {
+		if (mSpamFlag == null) {
+			String flag = MimeUtility.unfold(getFirstHeader("X-Spam-Flag"));
+			// Log.d("K9-Mail", "getSpamFlag(): " + flag);
+			if (flag != null) {
+				mSpamFlag = flag;
+			} else {
+				mSpamFlag = "NO";
+			}
+		}
+		return mSpamFlag;
+	}
+
+
+	@Override
+	public String getSpamStatus() {
+		if (mSpamStatus == null) {
+			String status = MimeUtility.unfold(getFirstHeader("X-Spam-Status"));
+			// Log.d("K9-Mail", "getSpamStatus(): " + status);
+			if (status != null) {
+				mSpamStatus = status;
+			} else {
+				mSpamStatus = "No";
+			}
+		}
+		return mSpamStatus;
+	}
+	
+	public void setSpamFlag(String flag) {
+		// mSpamFlag = MimeUtility.unfold(getFirstHeader("X-Spam-Flag"));
+        try {
+			setHeader("X-Spam-Flag", flag);
+		} catch (UnavailableStorageException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+        mSpamFlag = flag;
+	}
+	
+	public void setSpamStatus(String status) {
+		// mSpamStatus = MimeUtility.unfold(getFirstHeader("X-Spam-Status"));
+        try {
+			setHeader("X-Spam-Status", status);
+		} catch (UnavailableStorageException e) {
+			// TODO Auto-generated catch block
+			e.printStackTrace();
+		}
+        mSpamStatus = status;
+	}
 }

--- a/src/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/src/com/fsck/k9/mail/internet/MimeMessage.java
@@ -613,7 +613,7 @@ public class MimeMessage extends Message {
 	public String getSpamFlag() {
 		if (mSpamFlag == null) {
 			String flag = MimeUtility.unfold(getFirstHeader("X-Spam-Flag"));
-			// Log.d("K9-Mail", "getSpamFlag(): " + flag);
+			// Log.d(K9.LOG_TAG, "getSpamFlag(): " + flag);
 			if (flag != null) {
 				mSpamFlag = flag;
 			} else {
@@ -628,7 +628,7 @@ public class MimeMessage extends Message {
 	public String getSpamStatus() {
 		if (mSpamStatus == null) {
 			String status = MimeUtility.unfold(getFirstHeader("X-Spam-Status"));
-			// Log.d("K9-Mail", "getSpamStatus(): " + status);
+			// Log.d(K9.LOG_TAG, "getSpamStatus(): " + status);
 			if (status != null) {
 				mSpamStatus = status;
 			} else {

--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -1492,6 +1492,7 @@ public class ImapStore extends Store {
                 fetchFields.add("INTERNALDATE");
                 fetchFields.add("RFC822.SIZE");
                 fetchFields.add("BODY.PEEK[HEADER.FIELDS (date subject from content-type to cc " +
+			"x-spam-status x-spam-flag " +
                         "reply-to message-id references in-reply-to " + K9.IDENTITY_HEADER + ")]");
             }
             if (fp.contains(FetchProfile.Item.STRUCTURE)) {

--- a/src/com/fsck/k9/mail/store/LocalStore.java
+++ b/src/com/fsck/k9/mail/store/LocalStore.java
@@ -2545,8 +2545,9 @@ public class LocalStore extends Store implements Serializable {
                                                message.isSet(Flag.FLAGGED) ? 1 : 0,
                                                message.isSet(Flag.ANSWERED) ? 1 : 0,
                                                message.isSet(Flag.FORWARDED) ? 1 : 0,
-                                               message.getSpamStatus() == null ? "Yess" : message.getSpamStatus(),
-					                           message.getSpamFlag() == null ? "Yess" : message.getSpamFlag(),
+                                               /* The spam header fields aren't in all message unless you use SpamAssassin */
+                                               message.getSpamStatus() == null ? "NO" : message.getSpamStatus(),
+					                           message.getSpamFlag() == null ? "NO" : message.getSpamFlag(),
                                                message.mId
                                            });
 
@@ -3407,8 +3408,9 @@ public class LocalStore extends Store implements Serializable {
             boolean answered = (cursor.getInt(20) == 1);
             boolean forwarded = (cursor.getInt(21) == 1);
 
-            this.mSpamStatus = (cursor.isNull(22)) ? "Noo" : cursor.getString(22);
-            this.mSpamFlag = (cursor.isNull(23)) ? "Noo" : cursor.getString(23);           
+            /* The spam header fields aren't in all message unless you use SpamAssassin */
+            this.mSpamStatus = (cursor.isNull(22)) ? "NO" : cursor.getString(22);
+            this.mSpamFlag = (cursor.isNull(23)) ? "NO" : cursor.getString(23);           
              
             setFlagInternal(Flag.DELETED, deleted);
             setFlagInternal(Flag.SEEN, read);

--- a/src/com/fsck/k9/provider/EmailProvider.java
+++ b/src/com/fsck/k9/provider/EmailProvider.java
@@ -84,6 +84,8 @@ public class EmailProvider extends ContentProvider {
         MessageColumns.FLAGGED,
         MessageColumns.ANSWERED,
         MessageColumns.FORWARDED,
+	MessageColumns.SPAM_FLAG,
+	MessageColumns.SPAM_STATUS,
         InternalMessageColumns.DELETED,
         InternalMessageColumns.EMPTY,
         InternalMessageColumns.TEXT_CONTENT,
@@ -152,7 +154,9 @@ public class EmailProvider extends ContentProvider {
         public static final String FLAGGED = "flagged";
         public static final String ANSWERED = "answered";
         public static final String FORWARDED = "forwarded";
-    }
+        public static final String SPAM_FLAG = "x_spam_flag";
+        public static final String SPAM_STATUS = "x_spam_status";
+        }
 
     private interface InternalMessageColumns extends MessageColumns {
         public static final String DELETED = "deleted";

--- a/src/com/fsck/k9/provider/MessageProvider.java
+++ b/src/com/fsck/k9/provider/MessageProvider.java
@@ -382,9 +382,9 @@ public class MessageProvider extends ContentProvider {
                 } else if (MessageColumns.ACCOUNT_NUMBER.equals(field)) {
                     extractors.put(field, new AccountNumberExtractor());
                 } else if (MessageColumns.SPAM_FLAG.equals(field)) {
-                    Log.d("K9-Mail", "SPAM_FLAG: " + field);
+                    Log.d(K9.LOG_TAG, "SPAM_FLAG: " + field);
                 } else if (MessageColumns.SPAM_STATUS.equals(field)) {
-                    Log.d("K9-Mail", "SPAM_STATUS: " + field);
+                    Log.d(K9.LOG_TAG, "SPAM_STATUS: " + field);
                 } else if (MessageColumns.HAS_ATTACHMENTS.equals(field)) {
                     extractors.put(field, new HasAttachmentsExtractor());
                 } else if (MessageColumns.HAS_STAR.equals(field)) {

--- a/src/com/fsck/k9/provider/MessageProvider.java
+++ b/src/com/fsck/k9/provider/MessageProvider.java
@@ -115,6 +115,16 @@ public class MessageProvider extends ContentProvider {
          */
         @Deprecated
         String INCREMENT = "id";
+
+        /**
+         * <P>Type: TEXT</P>
+         */
+ 		String SPAM_FLAG = "spamFlag";
+ 		
+        /**
+         * <P>Type: TEXT</P>
+         */
+ 		String SPAM_STATUS = "spamStatus";
     }
 
     protected static interface QueryHandler {
@@ -371,6 +381,10 @@ public class MessageProvider extends ContentProvider {
                     extractors.put(field, new AccountColorExtractor());
                 } else if (MessageColumns.ACCOUNT_NUMBER.equals(field)) {
                     extractors.put(field, new AccountNumberExtractor());
+                } else if (MessageColumns.SPAM_FLAG.equals(field)) {
+                    Log.d("K9-Mail", "SPAM_FLAG: " + field);
+                } else if (MessageColumns.SPAM_STATUS.equals(field)) {
+                    Log.d("K9-Mail", "SPAM_STATUS: " + field);
                 } else if (MessageColumns.HAS_ATTACHMENTS.equals(field)) {
                     extractors.put(field, new HasAttachmentsExtractor());
                 } else if (MessageColumns.HAS_STAR.equals(field)) {
@@ -941,7 +955,7 @@ public class MessageProvider extends ContentProvider {
     private MessageHelper mMessageHelper;
 
     /**
-     * How many simultaneous cursors we can affort to expose at once
+     * How many simultaneous cursors we can afford to expose at once
      */
     /* package */
     Semaphore mSemaphore = new Semaphore(1);

--- a/src/com/fsck/k9/search/SearchSpecification.java
+++ b/src/com/fsck/k9/search/SearchSpecification.java
@@ -82,7 +82,9 @@ public interface SearchSpecification extends Parcelable {
         READ,
         FLAGGED,
         DISPLAY_CLASS,
-        SEARCHABLE
+        SEARCHABLE,
+        SPAM_FLAG,
+        SPAM_STATUS
     }
 
 

--- a/src/com/fsck/k9/search/SqlQueryBuilder.java
+++ b/src/com/fsck/k9/search/SqlQueryBuilder.java
@@ -177,6 +177,14 @@ public class SqlQueryBuilder {
                 columnName = "display_class";
                 break;
             }
+            case SPAM_STATUS: {
+                columnName = "x_spam_status";
+                break;
+            }
+            case SPAM_FLAG: {
+                columnName = "x_spam_flag";
+                break;
+            }
             case FOLDER:
             case SEARCHABLE: {
                 // Special cases handled in buildWhereClauseInternal()


### PR DESCRIPTION
This branch adds support for the header fields Spam Assassin sets. If X-Spam-Flag is set to YES, then the message is moved to the user specified spam folder. If the message doesn't have these headers, the default is to assume it's not spam, and continue with normal processing. This has been a requested feature from what I can tell, but of course I implemented this cause I run Spam Assassin on my own email server, and also use K9 for reading email when mobile. I'm open to making any suggested changes to this branch.