### PR TITLE
Fix notification click behaviour for multiple accounts.

### DIFF
--- a/src/com/fsck/k9/controller/MessagingController.java
+++ b/src/com/fsck/k9/controller/MessagingController.java
@@ -4806,8 +4806,8 @@ public class MessagingController implements Runnable {
             targetIntent = FolderList.actionHandleNotification(context, account, initialFolder);
         }
 
-        PendingIntent pi = PendingIntent.getActivity(context, 0, targetIntent, PendingIntent.FLAG_UPDATE_CURRENT);
-        builder.setContentIntent(pi);
+        builder.setContentIntent(PendingIntent.getActivity(context,
+                account.getAccountNumber(), targetIntent, PendingIntent.FLAG_UPDATE_CURRENT));
         builder.setDeleteIntent(NotificationActionService.getAcknowledgeIntent(context, account));
 
         // Only ring or vibrate if we have not done so already on this account and fetch


### PR DESCRIPTION
Test case:
- Have two accounts A and B
- Get a mail on A
- Get a mail on B
- Click on the notification for A

Result:
You end up seeing the message from B instead of A

The reason for that is that we need to register separate PendingIntents
for each account.
