### PR TITLE
Fix sorting of threaded messages.

### DIFF
--- a/src/com/fsck/k9/provider/EmailProvider.java
+++ b/src/com/fsck/k9/provider/EmailProvider.java
@@ -418,8 +418,7 @@ public class EmailProvider extends ContentProvider {
 
                     if (!StringUtils.isNullOrEmpty(sortOrder)) {
                         query.append(" ORDER BY ");
-                        query.append(SqlQueryBuilder.addPrefixToSelection(MESSAGES_COLUMNS,
-                                "u.", sortOrder));
+                        query.append(sortOrder);
                     }
 
                     // We need the selection arguments twice. Once for each sub query.


### PR DESCRIPTION
I do not even try to pretend I fully understand the threaded query, but what I understand is that we select the columns from the grouped query (and u is the ungrouped query) so I think we should sort by the grouped column as well.

Fixes sorting of the threaded message list for me.
