### PR TITLE
message view / list: fix NPE when list is empty

### DIFF
--- a/src/com/fsck/k9/fragment/MessageListFragment.java
+++ b/src/com/fsck/k9/fragment/MessageListFragment.java
@@ -2873,11 +2873,13 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
     }
 
     public boolean isFirst(MessageReference messageReference) {
-        return messageReference.equals(getReferenceForPosition(0));
+        return mAdapter.getCount() == 0 ||
+                messageReference.equals(getReferenceForPosition(0));
     }
 
     public boolean isLast(MessageReference messageReference) {
-        return messageReference.equals(getReferenceForPosition(mAdapter.getCount() - 1));
+        return mAdapter.getCount() == 0 ||
+                messageReference.equals(getReferenceForPosition(mAdapter.getCount() - 1));
     }
 
     private MessageReference getReferenceForPosition(int position) {


### PR DESCRIPTION
This happened for example in a starred-message-only view when
un-starting the last message. This led to isFirst() and isLast()
causing a NullPointerException when trying to update the
previous / next buttons.
