### PR TITLE
Fixed Account Colors

### DIFF
--- a/src/com/fsck/k9/Account.java
+++ b/src/com/fsck/k9/Account.java
@@ -10,12 +10,15 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
+import android.graphics.Color;
 import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.util.Log;
@@ -40,8 +43,6 @@ import com.fsck.k9.search.SearchSpecification.SearchCondition;
 import com.fsck.k9.search.SearchSpecification.Searchfield;
 import com.fsck.k9.view.ColorChip;
 import com.larswerkman.colorpicker.ColorPicker;
-
-import java.util.HashMap;
 
 /**
  * Account stores all of the settings for a single account defined by the user. It is able to save
@@ -89,6 +90,20 @@ public class Account implements BaseAccount {
     public static final String IDENTITY_NAME_KEY = "name";
     public static final String IDENTITY_EMAIL_KEY = "email";
     public static final String IDENTITY_DESCRIPTION_KEY = "description";
+
+    private static final String EMPTY = "empty";
+
+    /*
+        http://developer.android.com/design/style/color.html
+        Note: Order does matter, it's the order in which they will be picked.
+    */
+    public static final Integer[] PREDEFINED_COLORS = new Integer[] {
+            Color.parseColor("#0099CC"),    // blue
+            Color.parseColor("#669900"),    // green
+            Color.parseColor("#FF8800"),    // orange
+            Color.parseColor("#CC0000"),     // red
+            Color.parseColor("#9933CC")    // purple
+    };
 
     public enum SortType {
         SORT_DATE(R.string.sort_earliest_first, R.string.sort_latest_first, false),
@@ -280,7 +295,7 @@ public class Account implements BaseAccount {
         mAutoExpandFolderName = INBOX;
         mInboxFolderName = INBOX;
         mMaxPushFolders = 10;
-        mChipColor = ColorPicker.getRandomColor();
+        mChipColor = pickColor(context);
         goToUnreadMessageSearch = false;
         mNotificationShowsUnreadCount = true;
         subscribedFoldersOnly = false;
@@ -324,6 +339,65 @@ public class Account implements BaseAccount {
         mNotificationSetting.setLedColor(mChipColor);
 
         cacheChips();
+    }
+
+    /*
+     * Pick a nice Android guidelines color if we haven't used them all yet.
+     */
+    private int pickColor(Context context) {
+        SharedPreferences prefs = Preferences.getPreferences(context).getPreferences();
+        String availableColors = prefs.getString("availableColors","");
+
+        if (!availableColors.equals(EMPTY)) {
+
+            // first run
+            if (availableColors.isEmpty()) {
+                availableColors = Utility.combine(Account.PREDEFINED_COLORS, ',');
+            }
+
+            String[] colors = availableColors.split(",");
+
+            // determine remaining colors
+            String remainingColors = "";
+            if (colors.length > 1) {
+                remainingColors = Utility.combine(Arrays.copyOfRange(colors, 1, colors.length), ',');
+            } else {
+                remainingColors = EMPTY;
+            }
+
+            // save remaining colors
+            SharedPreferences.Editor editor = prefs.edit();
+            editor.putString("availableColors", remainingColors);
+            editor.commit();
+
+            return Integer.parseInt(colors[0]);
+        } else {
+            return ColorPicker.getRandomColor();
+        }
+    }
+
+    /*
+        Put the account color back in circulation if it's a predefined one,
+        we also want to maintain the order of preference.
+    */
+    private String calculateAvailableColors(Preferences preferences, int currentColor) {
+        ArrayList<Integer> newAvailableColors = new ArrayList<Integer>();
+        HashSet<Integer> oldAvailableColors = new HashSet<Integer>();
+        String oldColors = preferences.getPreferences().getString("availableColors", "");
+
+        if (!oldColors.equals(EMPTY)) {
+            for (String color : oldColors.split(",")) {
+                oldAvailableColors.add(Integer.parseInt(color));
+            }
+        }
+
+        for (Integer color : PREDEFINED_COLORS) {
+            if (color == currentColor || oldAvailableColors.contains(color)) {
+                newAvailableColors.add(color);
+            }
+        }
+
+        return Utility.combine(newAvailableColors.toArray(), ',');
     }
 
     protected Account(Preferences preferences, String uuid) {
@@ -490,6 +564,11 @@ public class Account implements BaseAccount {
         if (newUuids.size() < uuids.length) {
             String accountUuids = Utility.combine(newUuids.toArray(), ',');
             editor.putString("accountUuids", accountUuids);
+        }
+
+        // Put color back in circulation if necesarry
+        if (Arrays.asList(PREDEFINED_COLORS).contains(mChipColor)) {
+            editor.putString("availableColors", calculateAvailableColors(preferences, mChipColor));
         }
 
         editor.remove(mUuid + ".storeUri");
@@ -805,10 +884,17 @@ public class Account implements BaseAccount {
     }
 
 
-    public synchronized void setChipColor(int color) {
+    public synchronized void setChipColor(Context context, int color) {
+        // release current color if predefined one
+        if (Arrays.asList(PREDEFINED_COLORS).contains(mChipColor)) {
+            String availableColors = calculateAvailableColors(Preferences.getPreferences(context), color);
+            SharedPreferences.Editor editor = Preferences.getPreferences(context).getPreferences().edit();
+            editor.putString("availableColors", availableColors);
+            editor.commit();
+        }
+
         mChipColor = color;
         cacheChips();
-
     }
 
     public synchronized void cacheChips() {

--- a/src/com/fsck/k9/preferences/GlobalSettings.java
+++ b/src/com/fsck/k9/preferences/GlobalSettings.java
@@ -21,6 +21,7 @@ import com.fsck.k9.K9.SplitViewMode;
 import com.fsck.k9.K9.Theme;
 import com.fsck.k9.R;
 import com.fsck.k9.Account.SortType;
+import com.fsck.k9.helper.Utility;
 import com.fsck.k9.preferences.Settings.*;
 
 public class GlobalSettings {
@@ -221,6 +222,9 @@ public class GlobalSettings {
         s.put("showContactPicture", Settings.versions(
                 new V(25, new BooleanSetting(true))
             ));
+        s.put("availableColors", Settings.versions(
+                new V(26, new StringSetting(Utility.combine(Account.PREDEFINED_COLORS, ',')))
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/src/com/fsck/k9/preferences/Settings.java
+++ b/src/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 26;
+    public static final int VERSION = 27;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,


### PR DESCRIPTION
Add a series of predefined account colors and pick those if any remain before generating complete random one.

The predefined ones are taken from here:
http://developer.android.com/design/style/color.html

The list is very easy to change, just add/remove or change them in the Account class. The order there is important, it will always be maintained as the order of preference.
