### PR TITLE
Fix message list item background color.

### DIFF
--- a/src/com/fsck/k9/fragment/MessageListFragment.java
+++ b/src/com/fsck/k9/fragment/MessageListFragment.java
@@ -1881,11 +1881,11 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
             }
 
             // Background indicator
-            if (selected || K9.useBackgroundAsUnreadIndicator()) {
+            {
                 int res;
                 if (selected) {
                     res = R.attr.messageListSelectedBackgroundColor;
-                } else if (read) {
+                } else if (read && K9.useBackgroundAsUnreadIndicator()) {
                     res = R.attr.messageListReadItemBackgroundColor;
                 } else {
                     res = R.attr.messageListUnreadItemBackgroundColor;


### PR DESCRIPTION
Bug occurred only when the "Dim messages
after reading" preference was unchecked (i.e.,
K9.useBackgroundAsUnreadIndicator() == false).

Once an item was selected, its background would
continue to indicate 'selected' even after the
item was deselected.
