### PR TITLE
Updated translations for Catalan.

### DIFF
--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -206,7 +206,7 @@ Si us plau, envia\'ns els errors, contribueix a millorar-lo a
 
     <string name="notification_new_title">Nou correu</string>
     <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> missatges nous</string>
-    <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g>No llegit (<xliff:g id="account">%s</xliff:g>)</string>
+    <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> no llegit(s) (<xliff:g id="account">%s</xliff:g>)</string>
     <string name="notification_additional_messages">i <xliff:g id="additional_messages">%d</xliff:g> més a <xliff:g id="account">%s</xliff:g></string>
 
     <string name="notification_action_reply">Respon</string>


### PR DESCRIPTION
Good day.

Firstly, I'd like to thank all the K-9 team for making the absolute best mail client for Android (and the best mobile client i've ever used).

Secondly, you'll find the updated translations for the Catalan language. You'll see some apostrophes changed too, as the old ones don't follow the typographic conventions for digital text.

I've reviewed the XML file after editing it and can't find many errors, but please tell me if I did any mistake.

Cheers.
