### PR TITLE
Caching for contactnames.

### DIFF
--- a/src/com/fsck/k9/activity/MessageInfoHolder.java
+++ b/src/com/fsck/k9/activity/MessageInfoHolder.java
@@ -10,7 +10,6 @@ public class MessageInfoHolder {
     public String compareSubject;
     public CharSequence sender;
     public String senderAddress;
-    public String compareCounterparty;
     public String[] recipients;
     public String uid;
     public boolean read;

--- a/src/com/fsck/k9/mail/Address.java
+++ b/src/com/fsck/k9/mail/Address.java
@@ -26,19 +26,6 @@ import com.fsck.k9.helper.Utility;
 
 public class Address {
     /**
-     * If the number of addresses exceeds this value the addresses aren't
-     * resolved to the names of Android contacts.
-     *
-     * <p>
-     * TODO: This number was chosen arbitrarily and should be determined by
-     * performance tests.
-     * </p>
-     *
-     * @see Address#toFriendly(Address[], Contacts)
-     */
-    private static final int TOO_MANY_ADDRESSES = 50;
-
-    /**
      * Immutable empty {@link Address} array
      */
     private static final Address[] EMPTY_ADDRESS_ARRAY = new Address[0];
@@ -217,15 +204,6 @@ public class Address {
     }
 
     /**
-     * Returns either the personal portion of the Address or the address portion if the personal
-     * is not available.
-     * @return
-     */
-    public CharSequence toFriendly() {
-        return toFriendly((Contacts)null);
-    }
-
-    /**
      * Returns the name of the contact this email address belongs to if
      * the {@link Contacts contacts} parameter is not {@code null} and a
      * contact is found. Otherwise the personal portion of the {@link Address}
@@ -262,30 +240,6 @@ public class Address {
         }
 
         return (!StringUtils.isNullOrEmpty(mPersonal)) ? mPersonal : mAddress;
-    }
-
-    public static CharSequence toFriendly(Address[] addresses) {
-        return toFriendly(addresses, null);
-    }
-
-    public static CharSequence toFriendly(Address[] addresses, Contacts contacts) {
-        if (addresses == null) {
-            return null;
-        }
-
-        if (addresses.length >= TOO_MANY_ADDRESSES) {
-            // Don't look up contacts if the number of addresses is very high.
-            contacts = null;
-        }
-
-        SpannableStringBuilder sb = new SpannableStringBuilder();
-        for (int i = 0; i < addresses.length; i++) {
-            sb.append(addresses[i].toFriendly(contacts));
-            if (i < addresses.length - 1) {
-                sb.append(',');
-            }
-        }
-        return sb;
     }
 
     /**

--- a/src/com/fsck/k9/view/MessageHeader.java
+++ b/src/com/fsck/k9/view/MessageHeader.java
@@ -217,9 +217,9 @@ public class MessageHeader extends ScrollView implements OnClickListener {
 
     public void populate(final Message message, final Account account) throws MessagingException {
         final Contacts contacts = K9.showContactName() ? mContacts : null;
-        final CharSequence from = Address.toFriendly(message.getFrom(), contacts);
-        final CharSequence to = Address.toFriendly(message.getRecipients(Message.RecipientType.TO), contacts);
-        final CharSequence cc = Address.toFriendly(message.getRecipients(Message.RecipientType.CC), contacts);
+        final CharSequence from = mMessageHelper.buildFriendlyAddresses(message.getFrom(), contacts);
+        final CharSequence to = mMessageHelper.buildFriendlyAddresses(message.getRecipients(Message.RecipientType.TO), contacts);
+        final CharSequence cc = mMessageHelper.buildFriendlyAddresses(message.getRecipients(Message.RecipientType.CC), contacts);
 
         Address[] fromAddrs = message.getFrom();
         Address[] toAddrs = message.getRecipients(Message.RecipientType.TO);


### PR DESCRIPTION
Hi,

This patch achieves two thing:
- Caching for contact names when creating the 'display name'. I read in comment that we should do that so I did.
- Better separation between Address and MessageHelper. I felt like an address should concern 1 address so I moved some functionallity that handled mutiple ones to the MessageHelper class ( this also better suited my caching ).

This isn't a big patch and I don't know if it actually in reallity realised a small performance gain but I needed this for another project and I thought I might as well offer it to K-9.

I compiled and tested it, seems like I didn't break anything this time :+1: 

If not needed/wanted feel free to just close this pull request.
