### PR TITLE
HTML tag cleanup

### DIFF
--- a/src/com/fsck/k9/view/SingleMessageView.java
+++ b/src/com/fsck/k9/view/SingleMessageView.java
@@ -624,9 +624,7 @@ public class SingleMessageView extends LinearLayout implements OnClickListener,
     }
 
     public void showStatusMessage(String status) {
-        String text = "<html><body><div style=\"text-align:center; color: grey;\">" +
-                status +
-                "</div></body></html>";
+        String text = "<div style=\"text-align:center; color: grey;\">" + status + "</div>";
         loadBodyFromText(text);
         mCryptoView.hide();
     }


### PR DESCRIPTION
Effective with earlier commit e2c5229e854e2ef62585f919a15660cba2489b04,
messages are wrapped with &lt;html> tags at display time, rather than
when messages are saved.

This commit removes tags from existing saved messages and
also removes the tags from a status message.

Not a critical issue -- It just provides consistency.
