### PR TITLE
reenable sorting by sender in messagelist

### DIFF
--- a/res/menu/message_list_option.xml
+++ b/res/menu/message_list_option.xml
@@ -143,11 +143,9 @@
             <item
                 android:id="@+id/set_sort_subject"
                 android:title="@string/sort_by_subject"/>
-            <!--
             <item
                 android:id="@+id/set_sort_sender"
                 android:title="@string/sort_by_sender"/>
-            -->
             <item
                 android:id="@+id/set_sort_flag"
                 android:title="@string/sort_by_flag"/>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -735,6 +735,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="sort_latest_first">Latest messages first</string>
     <string name="sort_subject_alpha">Subject alphabetical</string>
     <string name="sort_subject_re_alpha">Subject reverse alphabetical</string>
+    <string name="sort_sender_alpha">Sender alphabetical</string>
+    <string name="sort_sender_re_alpha">Sender reverse alphabetical</string>
     <string name="sort_flagged_first">Starred messages first</string>
     <string name="sort_flagged_last">Unstarred messages first</string>
     <string name="sort_unread_first">Unread messages first</string>
@@ -746,6 +748,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="sort_by_date">Date</string>
     <string name="sort_by_arrival">Arrival</string>
     <string name="sort_by_subject">Subject</string>
+    <string name="sort_by_sender">Sender</string>
     <string name="sort_by_flag">Star</string>
     <string name="sort_by_unread">Read/unread</string>
     <string name="sort_by_attach">Attachments</string>

--- a/src/com/fsck/k9/Account.java
+++ b/src/com/fsck/k9/Account.java
@@ -106,7 +106,7 @@ public class Account implements BaseAccount {
         SORT_DATE(R.string.sort_earliest_first, R.string.sort_latest_first, false),
         SORT_ARRIVAL(R.string.sort_earliest_first, R.string.sort_latest_first, false),
         SORT_SUBJECT(R.string.sort_subject_alpha, R.string.sort_subject_re_alpha, true),
-//        SORT_SENDER(R.string.sort_sender_alpha, R.string.sort_sender_re_alpha, true),
+        SORT_SENDER(R.string.sort_sender_alpha, R.string.sort_sender_re_alpha, true),
         SORT_UNREAD(R.string.sort_unread_first, R.string.sort_unread_last, true),
         SORT_FLAGGED(R.string.sort_flagged_first, R.string.sort_flagged_last, true),
         SORT_ATTACHMENT(R.string.sort_attach_first, R.string.sort_unattached_first, true);

--- a/src/com/fsck/k9/activity/MessageList.java
+++ b/src/com/fsck/k9/activity/MessageList.java
@@ -757,10 +757,10 @@ public class MessageList extends K9FragmentActivity implements MessageListFragme
                 mMessageListFragment.changeSort(SortType.SORT_SUBJECT);
                 return true;
             }
-//            case R.id.set_sort_sender: {
-//                mMessageListFragment.changeSort(SortType.SORT_SENDER);
-//                return true;
-//            }
+            case R.id.set_sort_sender: {
+                mMessageListFragment.changeSort(SortType.SORT_SENDER);
+                return true;
+            }
             case R.id.set_sort_flag: {
                 mMessageListFragment.changeSort(SortType.SORT_FLAGGED);
                 return true;

--- a/src/com/fsck/k9/fragment/MessageListFragment.java
+++ b/src/com/fsck/k9/fragment/MessageListFragment.java
@@ -307,6 +307,25 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
         }
     }
 
+    public static class SenderComparator implements Comparator<Cursor> {
+
+        @Override
+        public int compare(Cursor cursor1, Cursor cursor2) {
+            String sender1 = getSenderAddressFromCursor(cursor1);
+            String sender2 = getSenderAddressFromCursor(cursor2);
+
+            if (sender1 == null && sender2 == null) {
+                return 0;
+            } else if (sender1 == null) {
+                return 1;
+            } else if (sender2 == null) {
+                return -1;
+            } else {
+                return sender1.compareToIgnoreCase(sender2);
+            }
+        }
+    }
+
 
     private static final int ACTIVITY_CHOOSE_FOLDER_MOVE = 1;
     private static final int ACTIVITY_CHOOSE_FOLDER_COPY = 2;
@@ -335,6 +354,7 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
         map.put(SortType.SORT_ARRIVAL, new ArrivalComparator());
         map.put(SortType.SORT_FLAGGED, new FlaggedComparator());
         map.put(SortType.SORT_SUBJECT, new SubjectComparator());
+        map.put(SortType.SORT_SENDER, new SenderComparator());
         map.put(SortType.SORT_UNREAD, new UnreadComparator());
 
         // make it immutable to prevent accidental alteration (content is immutable already)
@@ -1360,10 +1380,10 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
             changeSort(SortType.SORT_SUBJECT);
             return true;
         }
-//        case R.id.set_sort_sender: {
-//            changeSort(SortType.SORT_SENDER);
-//            return true;
-//        }
+        case R.id.set_sort_sender: {
+            changeSort(SortType.SORT_SENDER);
+            return true;
+        }
         case R.id.set_sort_flag: {
             changeSort(SortType.SORT_FLAGGED);
             return true;
@@ -1493,7 +1513,7 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
     }
 
 
-    private String getSenderAddressFromCursor(Cursor cursor) {
+    private static String getSenderAddressFromCursor(Cursor cursor) {
         String fromList = cursor.getString(SENDER_LIST_COLUMN);
         Address[] fromAddrs = Address.unpack(fromList);
         return (fromAddrs.length > 0) ? fromAddrs[0].getAddress() : null;
@@ -3224,11 +3244,11 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
                 sortColumn = "(" + MessageColumns.FLAGGED + " != 1)";
                 break;
             }
-//            case SORT_SENDER: {
-//                //FIXME
-//                sortColumn = MessageColumns.SENDER_LIST;
-//                break;
-//            }
+            case SORT_SENDER: {
+                //FIXME
+                sortColumn = MessageColumns.SENDER_LIST;
+                break;
+            }
             case SORT_SUBJECT: {
                 sortColumn = MessageColumns.SUBJECT + " COLLATE NOCASE";
                 break;


### PR DESCRIPTION
This was disabled in faa666394ce0bf9e4239869ee194991d2f3308f1
because it isn't possible to extract the name of the android
contact in the 'ORDER BY...' clause when querying the database.
Instead it simply sorts by the email address.

This may cause the same contact to appear multiple times in
the list, if they have multiple email addresses assigned.

But in most cases this is good enough and surely better than
not having the option to sort by sender at all.

Desktop mail clients such as Thunderbird also simply use the
sender email information when sorting the column.

This also adds a SenderComparator for usage in the MergeCursor.
