### PR TITLE
Fix background color of message list

### DIFF
--- a/res/values/themes.xml
+++ b/res/values/themes.xml
@@ -38,7 +38,7 @@
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_light</item>
         <item name="messageListSelectedBackgroundColor">#8038B8E2</item>
         <item name="messageListReadItemBackgroundColor">#80cdcdcd</item>
-        <item name="messageListUnreadItemBackgroundColor">#00ffffff</item>
+        <item name="messageListUnreadItemBackgroundColor">#FFFFFFFF</item>
         <item name="messageListThreadCountForegroundColor">?android:attr/colorBackground</item>
         <item name="messageListThreadCountBackground">@drawable/thread_count_box_light</item>
         <item name="messageListActiveItemBackgroundColor">#ff2ea7d1</item>

--- a/src/com/fsck/k9/fragment/MessageListFragment.java
+++ b/src/com/fsck/k9/fragment/MessageListFragment.java
@@ -1903,7 +1903,9 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
                 getActivity().getTheme().resolveAttribute(res, outValue, true);
                 view.setBackgroundColor(outValue.data);
             } else {
-                view.setBackgroundColor(Color.TRANSPARENT);
+                TypedValue outValue = new TypedValue();
+                getActivity().getTheme().resolveAttribute(R.attr.messageListUnreadItemBackgroundColor, outValue, true);
+                view.setBackgroundColor(outValue.data);           
             }
 
             if (mActiveMessage != null) {


### PR DESCRIPTION
fix issue where color of message list became grey when accesing message list view from message view (using back). This only happended if the backgroundcolor markup for unread messages was unselected in the prefs.

Fixed this by applying the UnreadColor Instead of transparent, and also fixed this color to be non opaque, cause the issue was triggered by a grey background on some surrounding view
