### PR TITLE
Better singleAccountMode check.

### DIFF
--- a/src/com/fsck/k9/fragment/MessageListFragment.java
+++ b/src/com/fsck/k9/fragment/MessageListFragment.java
@@ -916,6 +916,11 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
                 for (int i = 0, len = accounts.length; i < len; i++) {
                     mAccountUuids[i] = accounts[i].getUuid();
                 }
+
+                if (mAccountUuids.length == 1) {
+                    mSingleAccountMode = true;
+                    mAccount = accounts[0];
+                }
             } else {
                 mAccountUuids = accountUuids;
             }


### PR DESCRIPTION
If messagelist started from Unified localsearch, verify if we are really dealing with multiple accounts. If not then set SingleAccountMode anyway.
