### PR TITLE
Set Content-Transfer-Encoding to 8bit when this is what is used

### DIFF
--- a/src/com/fsck/k9/mail/internet/MimeBodyPart.java
+++ b/src/com/fsck/k9/mail/internet/MimeBodyPart.java
@@ -71,7 +71,11 @@ public class MimeBodyPart extends BodyPart {
                 contentType += String.format(";\n name=\"%s\"", name);
             }
             setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType);
-            setHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING, "quoted-printable");
+            if ("8bit".equals(body.getEncoding())) {
+                setHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING, "8bit");
+            } else {
+                setHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING, "quoted-printable");
+            }
         }
     }
 

--- a/src/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/src/com/fsck/k9/mail/internet/MimeMessage.java
@@ -359,7 +359,11 @@ public class MimeMessage extends Message {
         } else if (body instanceof TextBody) {
             setHeader(MimeHeader.HEADER_CONTENT_TYPE, String.format("%s;\n charset=utf-8",
                       getMimeType()));
-            setHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING, "quoted-printable");
+            if ("8bit".equals(body.getEncoding())) {
+                setHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING, "8bit");
+            } else {
+                setHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING, "quoted-printable");
+            }
         }
     }
 

--- a/src/com/fsck/k9/mail/internet/TextBody.java
+++ b/src/com/fsck/k9/mail/internet/TextBody.java
@@ -67,6 +67,10 @@ public class TextBody implements Body {
         }
     }
 
+    public String getEncoding() {
+        return encoding;
+    }
+
     public void setEncoding(String encoding) {
         mEncoding = encoding;
     }


### PR DESCRIPTION
When TextBody uses 8bit, using quoted-printable in the
Content-Transfer-Encoding is not a good idea.
