### PR TITLE
Update message_compose_reply_header_fmt to have only one newline

### DIFF
--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -260,7 +260,7 @@ Si us plau, envia\'ns els errors, contribueix a millorar-lo a
     <string name="message_compose_quote_header_from">De:</string>
     <string name="message_compose_quote_header_to">A:</string>
     <string name="message_compose_quote_header_cc">A/c:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> ha escrit:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> ha escrit:\n</string>
     <string name="message_compose_error_no_recipients">Has d\'afegir-hi, com a mínim, un destinatari.</string>
     <string name="error_contact_address_not_found">No s\'ha trobat cap adreça de correu.</string>
     <string name="message_compose_attachments_skipped_toast">Alguns adjunts no es poden reenviar perquè no s\'han carregat.</string>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -265,7 +265,7 @@ Posílejte prosím chybová hlášení, přispívejte novými funkcemi a ptejte 
     <string name="message_compose_quote_header_from">Odesílatel:</string>
     <string name="message_compose_quote_header_to">Komu:</string>
     <string name="message_compose_quote_header_cc">Kopie:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> napsal(a):\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> napsal(a):\n</string>
     <string name="message_compose_error_no_recipients">Musíte přidat alespoň jednoho příjemce.</string>
     <string name="error_contact_address_not_found">Nemohla být nalezena adresa.</string>
     <string name="message_compose_attachments_skipped_toast">Některé přílohy nelze přeposlat, protože ještě nebyly staženy.</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -261,7 +261,7 @@ Vær venlig at sende fejlrapporter, anmodning om nye funktioner, og spørgsmål 
     <string name="message_compose_quote_header_from">Fra:</string>
     <string name="message_compose_quote_header_to">Til:</string>
     <string name="message_compose_quote_header_cc">Cc:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> skrev:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> skrev:\n</string>
     <string name="message_compose_error_no_recipients">Du skal angive mindst én modtager.</string>
     <string name="error_contact_address_not_found">Mail addresse ikke fundet.</string>
     <string name="message_compose_attachments_skipped_toast">Nogle vedhæftninger kunne ikke videresendes fordi de ikke er blevet hentet fra server.</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -261,7 +261,7 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
     <string name="message_compose_quote_header_from">Von:</string>
     <string name="message_compose_quote_header_to">An:</string>
     <string name="message_compose_quote_header_cc">CC:</string>
-    <string name="message_compose_reply_header_fmt">\n\n<xliff:g id="sender">%s</xliff:g> schrieb:\n\n</string>
+    <string name="message_compose_reply_header_fmt">\n\n<xliff:g id="sender">%s</xliff:g> schrieb:\n</string>
     <string name="message_compose_error_no_recipients">Sie müssen mindestens einen Empfänger wählen.</string>
     <string name="error_contact_address_not_found">Es wurde keine E-Mail-Adresse für diesen Kontakt gefunden.</string>
     <string name="message_compose_attachments_skipped_toast">Einige Anhänge können nicht weitergeleitet werden, da diese nicht heruntergeladen wurden.</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -257,7 +257,7 @@
     <string name="message_compose_quote_header_from">Από:</string>
     <string name="message_compose_quote_header_to">Προς:</string>
     <string name="message_compose_quote_header_cc">Κοιν:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> έγραψε:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> έγραψε:\n</string>
     <string name="message_compose_error_no_recipients">Πρέπει να συμπεριλάβετε τουλάχιστον έναν παραλήπτη.</string>
     <string name="error_contact_address_not_found">Δεν βρέθηκαν διευθύνσεις ηλεκτρονικού ταχυδρομείου.</string>
     <string name="message_compose_attachments_skipped_toast">Μερικά συνημμένα δεν μπορούν να προωθηθούν γιατί δεν έχουν κατεβεί.</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -260,7 +260,7 @@ Por favor, envía los errores detectados, contribuye con nuevas funcionalidades 
     <string name="message_compose_quote_header_from">De:</string>
     <string name="message_compose_quote_header_to">Para:</string>
     <string name="message_compose_quote_header_cc">CC:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> escribió:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> escribió:\n</string>
     <string name="message_compose_error_no_recipients">Debe añadir al menos un destinatario</string>
     <string name="error_contact_address_not_found">Dirección e-mail no encontrada.</string>
     <string name="message_compose_attachments_skipped_toast">Algunos adjuntos no pueden reenviarse porque no han sido descargados.</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -269,7 +269,7 @@ Virheraportit, osallistuminen projektiin ja kysymykset: Mene osoitteeseen
     <string name="message_compose_quote_header_from">Lähettäjä:</string>
     <string name="message_compose_quote_header_to">Vastaanottaja:</string>
     <string name="message_compose_quote_header_cc">Kopio:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> kirjoitti:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> kirjoitti:\n</string>
     <string name="message_compose_error_no_recipients">Valitse vähintään yksi vastaanottaja.</string>
     <string name="error_contact_address_not_found">Tämän henkilön sähköpostiosoitetta ei löytynyt.</string>
     <string name="message_compose_attachments_skipped_toast">Joitakin liitteitä ei voida lähettää edelleen, koska niitä ei ole ladattu.</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -293,7 +293,7 @@ de plus</string>
     <string name="message_compose_quote_header_from">De\u00A0:</string>
     <string name="message_compose_quote_header_to">À\u00A0:</string>
     <string name="message_compose_quote_header_cc">Cc\u00A0:</string>
-    <string name="message_compose_reply_header_fmt">\n<xliff:g id="sender">%s</xliff:g> a écrit\u00A0:\n\n</string>
+    <string name="message_compose_reply_header_fmt">\n<xliff:g id="sender">%s</xliff:g> a écrit\u00A0:\n</string>
     <string name="message_compose_error_no_recipients">Vous devez ajouter au moins un destinataire.</string>
     <string name="error_contact_address_not_found">Aucune adresse e-mail trouvée</string>
     <string name="message_compose_attachments_skipped_toast">Certaines pièces jointes ne peuvent pas être transmises car elles n\'ont pas été téléchargées.</string>

--- a/res/values-gl/strings.xml
+++ b/res/values-gl/strings.xml
@@ -259,7 +259,7 @@ Por favor, envía os erros detectados, contribúe con novas funcionalidas e preg
     <string name="message_compose_quote_header_from">Dende:</string>
     <string name="message_compose_quote_header_to">Para:</string>
     <string name="message_compose_quote_header_cc">CC:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> escribiu:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> escribiu:\n</string>
     <string name="message_compose_error_no_recipients">Debes engadir un destinatario</string>
     <string name="error_contact_address_not_found">Non atopo enderezo electrónico.</string>
     <string name="message_compose_attachments_skipped_toast">Algúns adxuntos non poden reenviarse porque non foron descargados.</string>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -261,7 +261,7 @@ Hibajelentéseivel hozzájárul az újabb verziók tökéletesítéséhez, kérd
     <string name="message_compose_quote_header_from">Feladó:</string>
     <string name="message_compose_quote_header_to">Címzett:</string>
     <string name="message_compose_quote_header_cc">Másolat:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> írta:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> írta:\n</string>
     <string name="message_compose_error_no_recipients">Legalább egy címzetted adjon meg.</string>
     <string name="error_contact_address_not_found">E-mail cím nem található.</string>
     <string name="message_compose_attachments_skipped_toast">Néhány mellékletet nem lehet továbbítani, mert nem lettek letöltve.</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -261,7 +261,7 @@ Invia le tue segnalazioni, suggerisci nuove funzionalità e chiedi informazioni 
     <string name="message_compose_quote_header_from">Da:</string>
     <string name="message_compose_quote_header_to">A:</string>
     <string name="message_compose_quote_header_cc">Cc:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> ha scritto:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> ha scritto:\n</string>
     <string name="message_compose_error_no_recipients">È necessario specificare almeno un destinatario.</string>
     <string name="error_contact_address_not_found">Nessun indirizzo email trovato.</string>
     <string name="message_compose_attachments_skipped_toast">Alcuni allegati non possono essere inoltrati in quanto non sono stati scaricati.</string>

--- a/res/values-iw/strings.xml
+++ b/res/values-iw/strings.xml
@@ -262,7 +262,7 @@
     <string name="message_compose_quote_header_from">מ:</string>
     <string name="message_compose_quote_header_to">ל:</string>
     <string name="message_compose_quote_header_cc">Cc:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> כותב:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> כותב:\n</string>
     <string name="message_compose_error_no_recipients">עליך להוסיף לפחות נמען אחד.</string>
     <string name="error_contact_address_not_found">לא ניתן למצוא כתובת דוא\"ל.</string>
     <string name="message_compose_attachments_skipped_toast">קבצים מסוימים אינם ניתנים להעברה בגלל שהם לא הורדו.</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -260,7 +260,7 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
     <string name="message_compose_quote_header_from">送信者:</string>
     <string name="message_compose_quote_header_to">宛先:</string>
     <string name="message_compose_quote_header_cc">CC:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> wrote:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> wrote:\n</string>
     <string name="message_compose_error_no_recipients">少なくとも1つの受信者を追加する必要があります</string>
     <string name="error_contact_address_not_found">メールアドレスが登録されていません</string>
     <string name="message_compose_attachments_skipped_toast">ダウンロードしていないため、一部の添付ファイルを転送することはできません。</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -259,7 +259,7 @@ K-9 메일은 대부분의 무료 hotmail 계정을 지원하지 않으며, 다�
     <string name="message_compose_quote_header_from">보낸 사람:</string>
     <string name="message_compose_quote_header_to">받는 사람:</string>
     <string name="message_compose_quote_header_cc">참조:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g>이 씀:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g>이 씀:\n</string>
     <string name="message_compose_error_no_recipients">한 명 이상의 받는 사람을 입력하십시오.</string>
     <string name="error_contact_address_not_found">이메일 주소를 찾을 수 없습니다.</string>
     <string name="message_compose_attachments_skipped_toast">일부 첨부 파일이 다운로드되지 않아 전달될 수 없습니다.</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -260,7 +260,7 @@ Graag foutrapporten, bijdrage nieuwe functies en vragen stellen op
     <string name="message_compose_quote_header_from">Van:</string>
     <string name="message_compose_quote_header_to">Aan:</string>
     <string name="message_compose_quote_header_cc">CC:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> schreef:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> schreef:\n</string>
     <string name="message_compose_error_no_recipients">Minimaal 1 ontvanger kiezen.</string>
     <string name="error_contact_address_not_found">Geen e-mailadres gevonden.</string>
     <string name="message_compose_attachments_skipped_toast">Sommige bijlagen kunnen niet worden doorgestuurd omdat ze niet zijn gedownload.</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -269,7 +269,7 @@ Wszelkie zgłoszenia usterek, zapytania oraz nowe pomysły prosimy przesyłać z
     <string name="message_compose_quote_header_from">Od:</string>
     <string name="message_compose_quote_header_to">Do:</string>
     <string name="message_compose_quote_header_cc">DW:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> napisał:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> napisał:\n</string>
     <string name="message_compose_error_no_recipients">Musisz dodać co najmniej jednego odbiorcę.</string>
     <string name="error_contact_address_not_found">Żaden adres email nie został znaleziony.</string>
     <string name="message_compose_attachments_skipped_toast">Niektóre załączniki nie mogą być przesłane dalej ponieważ nie zostały wcześniej pobrane.</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -257,7 +257,7 @@ Por favor, nos envie relatórios de bugs, contribua para novas melhorias e faça
     <string name="message_compose_quote_header_from">De:</string>
     <string name="message_compose_quote_header_to">Para:</string>
     <string name="message_compose_quote_header_cc">Cc:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> escreveu:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> escreveu:\n</string>
     <string name="message_compose_error_no_recipients">Você deve incluir ao menos um destinatário.</string>
     <string name="error_contact_address_not_found">Não foi possível encontrar o endereço de e-mail.</string>
     <string name="message_compose_attachments_skipped_toast">Alguns anexos não podem ser encaminhados porque não foram inclusos na mensagem.</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -255,7 +255,7 @@ K-9 Mail это программа электронной почты для Andr
     <string name="message_compose_quote_header_from">От:</string>
     <string name="message_compose_quote_header_to">Для:</string>
     <string name="message_compose_quote_header_cc">Копия:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> написал(а):\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> написал(а):\n</string>
     <string name="message_compose_error_no_recipients">Необходимо добавить хотя бы одного адресата.</string>
     <string name="error_contact_address_not_found">Не найден адрес почты.</string>
     <string name="message_compose_attachments_skipped_toast">Некоторые вложения не могут быть пересланы, поскольку они не загрузились.</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -261,7 +261,7 @@ Vänligen skicka felrapporter, hjälp till med nya funktioner och ställ frågor
     <string name="message_compose_quote_header_from">Från:</string>
     <string name="message_compose_quote_header_to">Till:</string>
     <string name="message_compose_quote_header_cc">CC:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> skrev:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> skrev:\n</string>
     <string name="message_compose_error_no_recipients">Du måste ange åtminstone en mottagare.</string>
     <!-- NEW: <string name="error_contact_address_not_found">No email address could be found.</string>-->
     <string name="message_compose_attachments_skipped_toast">Några bilagor kan inte vidarebefordras eftersom de inte har hämtats.</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -261,7 +261,7 @@ Lütfen hata raporlarınızı, istediğiniz yeni özellikleri ve sorularınızı
     <string name="message_compose_quote_header_from">Kimden:</string>
     <string name="message_compose_quote_header_to">Alıcı:</string>
     <string name="message_compose_quote_header_cc">Cc:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> yazdı:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> yazdı:\n</string>
     <string name="message_compose_error_no_recipients">En az bir Alıcı eklemelisiniz.</string>
     <string name="error_contact_address_not_found">E-posta adresi bulunamadı.</string>
     <string name="message_compose_attachments_skipped_toast">Bazı ekler iletilemedi çünkü indirilemedi.</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -261,7 +261,7 @@ K-9 Mail це поштовий клієнт з відкритим вихідни
     <string name="message_compose_quote_header_from">Від:</string>
     <string name="message_compose_quote_header_to">Кому:</string>
     <string name="message_compose_quote_header_cc">Копія:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> написав(ла):\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> написав(ла):\n</string>
     <string name="message_compose_error_no_recipients">Вам необхідно додати хоча б одного одержувача.</string>
     <string name="error_contact_address_not_found">Не знайденої адреси електронної пошти.</string>
     <string name="message_compose_attachments_skipped_toast">Деякі вкладення не можуть бути переслані бо вони не завантажилися.</string>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -254,7 +254,7 @@ K-9改进的功能包括：
     <string name="message_compose_quote_header_from">发件人：</string>
     <string name="message_compose_quote_header_to">收件人：</string>
     <string name="message_compose_quote_header_cc">抄送：</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g>写到：\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g>写到：\n</string>
     <string name="message_compose_error_no_recipients">您必须添加至少一个收件人。</string>
     <string name="error_contact_address_not_found">没有找到收件地址。</string>
     <string name="message_compose_attachments_skipped_toast">由于一些附件还没有被下载，因此无法转发这些附件。</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -254,7 +254,7 @@ K-9改良的功能包括：
     <string name="message_compose_quote_header_from">寄件人：</string>
     <string name="message_compose_quote_header_to">收件人：</string>
     <string name="message_compose_quote_header_cc">副本：</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g>寫到:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g>寫到:\n</string>
     <string name="message_compose_error_no_recipients">必須至少加入一位收件人。</string>
     <string name="error_contact_address_not_found">沒有發現電子郵件地址</string>
     <string name="message_compose_attachments_skipped_toast">由於一些附件還沒有被下載，因此無法轉寄這些附件。</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -269,7 +269,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="message_compose_quote_header_from">From:</string>
     <string name="message_compose_quote_header_to">To:</string>
     <string name="message_compose_quote_header_cc">Cc:</string>
-    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> wrote:\n\n</string>
+    <string name="message_compose_reply_header_fmt"><xliff:g id="sender">%s</xliff:g> wrote:\n</string>
     <string name="message_compose_error_no_recipients">You must add at least one recipient.</string>
     <string name="error_contact_address_not_found">No email address could be found for this contact.</string>
     <string name="message_compose_attachments_skipped_toast">Some attachments cannot be forwarded because they have not been downloaded.</string>


### PR DESCRIPTION
The PREFIX quote style was using an empty line between the header and
the quote. But mail apps using this way of quoting style do not have an
empty line between the quote header and the quote.
