### PR TITLE
Change smtp+tls default port to 587.

### DIFF
--- a/src/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/src/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -80,10 +80,10 @@ public class SmtpTransport extends Transport {
             port = 25;
         } else if (scheme.equals("smtp+tls")) {
             connectionSecurity = ConnectionSecurity.STARTTLS_OPTIONAL;
-            port = 25;
+            port = 587;
         } else if (scheme.equals("smtp+tls+")) {
             connectionSecurity = ConnectionSecurity.STARTTLS_REQUIRED;
-            port = 25;
+            port = 587;
         } else if (scheme.equals("smtp+ssl+")) {
             connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED;
             port = 465;


### PR DESCRIPTION
I noticed this when trying to connect to an outlook.com address. It seems like an error in our source since we indicate ourselves it should be 587:
https://github.com/k9mail/k-9/blob/master/res/xml/providers.xml#L66

Strange there were no complains? Just close if I'm mistaken.
