### PR TITLE
added support for PGP/MIME encrypted emails.

### DIFF
--- a/src/com/fsck/k9/crypto/Apg.java
+++ b/src/com/fsck/k9/crypto/Apg.java
@@ -505,6 +505,11 @@ public class Apg extends CryptoProvider {
             }
             if (part != null) {
                 data = MimeUtility.getTextFromPart(part);
+            } else if (MimeUtility.mimeTypeMatches(message.getMimeType(), "multipart/encrypted")) {
+                part = MimeUtility.findFirstPartByMimeType(message, "application/octet-stream");
+                if (part != null) {
+                    data = MimeUtility.getTextFromPart(part);
+                }
             }
         } catch (MessagingException e) {
             // guess not...


### PR DESCRIPTION
I've added basic support for PGP-MIME based on [RFC 3156](http://tools.ietf.org/html/rfc3156). I have not been able to get the K-9 application to build with either IntelliJ or Android Studio, so I have been unable to test this. However, it appears to be correct based on my limited understanding of the code base.

The lack of support for PGP-MIME is very frustrating as it causes the workflow for a PGP-MIME email to be: select attachment -> view attachment -> select all text -> switch to APG app -> paste text -> type passphrase... etc. This should enable the viewing of PGP-MIME encrypted emails inline, just as if they were a normal PGP encrypted email.

Thanks.
