### PR TITLE
Add IMAP provider info for fastmail.fm

### DIFF
--- a/res/xml/providers.xml
+++ b/res/xml/providers.xml
@@ -198,6 +198,11 @@
         <outgoing uri="smtp+ssl+://smtp.mail.yahoo.com" username="$email" />
     </provider>
 
+    <!-- Australia -->
+    <provider id="fastmail-fm" label="Fastmail" domain="fastmail.fm">
+        <incoming uri="imap+ssl+://mail.messagingengine.com" username="$email" />
+        <outgoing uri="smtp+ssl+://mail.messagingengine.com" username="$email" />
+    </provider>
 
    <!-- UK -->
     <provider id="aol-uk" label="AOL" domain="aol.co.uk">


### PR DESCRIPTION
Lets K9 automatically configure the IMAP and SMTP ports for fastmail.fm
accounts.

Fastmail allows users to create accounts with many different domains, all with the same IMAP and SMTP servers.  In the interest of not bloating res/xml/providers.xml, I've elected to only add the main "fastmail.fm" domain.  If there is any interest (by K9 devs or otherwise) for the other [supported domains](https://www.fastmail.fm/help/signup_domains.html), I'm willing to add the relevant provider elements.
