### PR TITLE
Move master change log to res/xml/changelog_master.xml

### DIFF
--- a/plugins/ckChangeLog/library/res/raw/changelog.xml
+++ b/plugins/ckChangeLog/library/res/raw/changelog.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<changelog />

--- a/plugins/ckChangeLog/library/res/xml/changelog_master.xml
+++ b/plugins/ckChangeLog/library/res/xml/changelog_master.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+The master change log is kept in res/xml/changelog_master.xml.
+Locale specific versions are kept in res/xml-<locale qualifier>/changelog.xml.
+-->
+<changelog />

--- a/plugins/ckChangeLog/library/src/de/cketti/library/changelog/ChangeLog.java
+++ b/plugins/ckChangeLog/library/src/de/cketti/library/changelog/ChangeLog.java
@@ -33,14 +33,12 @@
 package de.cketti.library.changelog;
 
 import java.io.IOException;
-import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
 import org.xmlpull.v1.XmlPullParser;
 import org.xmlpull.v1.XmlPullParserException;
-import org.xmlpull.v1.XmlPullParserFactory;
 
 import android.app.AlertDialog;
 import android.content.Context;
@@ -357,20 +355,13 @@ public class ChangeLog {
 
         Resources resources = mContext.getResources();
 
-        // Read master change log from raw/changelog.xml
+        // Read master change log from xml/changelog_master.xml
+        XmlResourceParser xml = mContext.getResources().getXml(R.xml.changelog_master);
         SparseArray<ReleaseItem> defaultChangelog;
         try {
-            XmlPullParser xml = XmlPullParserFactory.newInstance().newPullParser();
-            InputStreamReader reader = new InputStreamReader(resources.openRawResource(R.raw.changelog));
-            xml.setInput(reader);
-            try {
-                defaultChangelog = readChangeLog(xml, full);
-            } finally {
-                try { reader.close(); } catch (Exception e) { /* do nothing */ }
-            }
-        } catch (XmlPullParserException e) {
-            Log.e(LOG_TAG, "Error reading raw/changelog.xml", e);
-            return null;
+            defaultChangelog = readChangeLog(xml, full);
+        } finally {
+            xml.close();
         }
 
         // Read localized change log from xml[-lang]/changelog.xml

--- a/res/xml/changelog_master.xml
+++ b/res/xml/changelog_master.xml
@@ -1,4 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!--
+The master change log is kept in res/xml/changelog_master.xml.
+Locale specific versions are kept in res/xml-<locale qualifier>/changelog.xml.
+-->
 <changelog>
     <release version="4.508" versioncode="18008" >
         <change>Move 'share' menu item back, at least for the moment</change>


### PR DESCRIPTION
Benefits of this location over res/raw/:

The file will be compiled and stored in a binary format by aapt
which should speed up processing the file when reading.

The XML syntax will be validated by aapt when building.
If the syntax is invalid, the build will fail.
