### PR TITLE
Fix de strings xml

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -317,7 +317,7 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
 
     <string name="global_settings_messageview_fixedwidth_label">Monotype-Schriftart</string>
     <string name="global_settings_messageview_fixedwidth_summary">Schriftart mit gleicher Zeichenbreite für Nur-Text-Nachrichten verwenden</string>
-    <string name="global_settings_messageview_autofit_width_label">Auto-Nachrichtengröße</string>
+    <string name="global_settings_messageview_autofit_width_label">Nachrichtendarstellung</string>
     <string name="global_settings_messageview_autofit_width_summary">Nachrichten auf Displaygröße verkleinern</string>
     <string name="global_settings_messageview_return_to_list_label">Nach Löschen zurück</string>
     <string name="global_settings_messageview_return_to_list_summary">Nach Löschen zur Nachrichtenliste zurückkehren</string>


### PR DESCRIPTION
Translates two strings that were missing for auto fitting the message in the MessageWebView.java
