### PR TITLE
Hierarchical folder list

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -149,6 +149,7 @@
             android:name=".activity.ChooseFolder"
             android:theme="@style/Theme.K9Dialog"
             android:label="@string/choose_folder_title"
+            android:uiOptions="splitActionBarWhenNarrow"
             android:configChanges="locale"
             android:noHistory="true"
             >

--- a/res/layout/accounts_item.xml
+++ b/res/layout/accounts_item.xml
@@ -45,33 +45,5 @@
     </LinearLayout>
 
     <include layout="@layout/accounts_folders_icons" />
-    <LinearLayout
-        android:id="@+id/folder_button_wrapper"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:orientation="horizontal"
-        >
-    
-        <View
-            android:layout_width="1dp"
-            android:layout_height="match_parent"
-            android:layout_marginLeft="2dip"
-            android:layout_marginRight="4dip"
-            android:background="?attr/compatDividerVertical"
-            android:layout_alignParentTop="true"/>
-    <ImageButton
-        android:id="@+id/folders"
-        android:gravity="center_vertical"
-        android:focusable="false"
-        android:layout_marginRight="3dip"
-        android:src="?attr/iconFolder"
-        android:background="?attr/compatSelectableItemBackground"
-        android:layout_width="wrap_content"
-        android:layout_height="fill_parent"
-        android:padding="8dp"
-        android:paddingLeft="16dp"
-        android:paddingRight="16dp"
-        />
-
-</LinearLayout>
+    <include layout="@layout/folder_list_subfolder"/>
 </LinearLayout>

--- a/res/layout/folder_list_item.xml
+++ b/res/layout/folder_list_item.xml
@@ -8,6 +8,7 @@
     android:paddingRight="4dip"
     android:paddingBottom="2dip"
     android:orientation="horizontal"
+    android:descendantFocusability="blocksDescendants"
     android:gravity="center_vertical" >
 
     <View
@@ -48,4 +49,5 @@
     </LinearLayout>
 
     <include layout="@layout/accounts_folders_icons" />
+    <include layout="@layout/folder_list_subfolder"/>
 </LinearLayout>

--- a/res/layout/folder_list_subfolder.xml
+++ b/res/layout/folder_list_subfolder.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout
+        xmlns:android="http://schemas.android.com/apk/res/android" android:id="@+id/folder_button_wrapper"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        >
+
+    <View
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="2dip"
+            android:layout_marginRight="4dip"
+            android:background="?attr/compatDividerVertical"
+            android:layout_alignParentTop="true"/>
+    <ImageButton
+            android:id="@+id/folders"
+            android:gravity="center_vertical"
+            android:focusable="false"
+            android:layout_marginRight="3dip"
+            android:src="?attr/iconFolder"
+            android:background="?attr/compatSelectableItemBackground"
+            android:layout_width="wrap_content"
+            android:layout_height="fill_parent"
+            android:padding="8dp"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            />
+
+</LinearLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -130,6 +130,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="spam_action">Spam</string>
     <string name="forward_action">Forward</string>
     <string name="move_action">Move</string>
+    <string name="folder_selected">Selected folder</string>
     <string name="single_message_options_action">Send</string>
     <string name="refile_action">Refile</string>
     <string name="continue_action">Continue</string>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -319,6 +319,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_registered_name_color_changed">Colorize names in your contact list</string>
     <string name="global_settings_folderlist_wrap_folder_names_label">Wrap long folder names</string>
     <string name="global_settings_folderlist_wrap_folder_names_summary">Use multiple lines to show long folder names</string>
+    <string name="global_settings_folderlist_hierarchy_label">Hierarchical folder list</string>
+    <string name="global_settings_folderlist_hierarchy_summary">Show folder tree as hierarchy rather than as a flat list.</string>
 
     <string name="global_settings_messageview_fixedwidth_label">Fixed-width fonts</string>
     <string name="global_settings_messageview_fixedwidth_summary">Use a fixed-width font when showing plain-text messages</string>

--- a/res/xml/global_preferences.xml
+++ b/res/xml/global_preferences.xml
@@ -123,6 +123,14 @@
                 android:title="@string/global_settings_folderlist_wrap_folder_names_label"
                 android:summary="@string/global_settings_folderlist_wrap_folder_names_summary" />
 
+            <CheckBoxPreference
+                    android:persistent="false"
+                    android:key="folderlist_hierarchy"
+                    android:title="@string/global_settings_folderlist_hierarchy_label"
+                    android:summary="@string/global_settings_folderlist_hierarchy_summary" />
+
+
+
         </PreferenceCategory>
 
         <PreferenceCategory

--- a/src/com/fsck/k9/Account.java
+++ b/src/com/fsck/k9/Account.java
@@ -169,6 +169,7 @@ public class Account implements BaseAccount {
     private String mArchiveFolderName;
     private String mSpamFolderName;
     private String mAutoExpandFolderName;
+    private String mPathDelimiter;
     private FolderMode mFolderDisplayMode;
     private FolderMode mFolderSyncMode;
     private FolderMode mFolderPushMode;
@@ -396,6 +397,7 @@ public class Account implements BaseAccount {
         mTrashFolderName = prefs.getString(mUuid  + ".trashFolderName", "Trash");
         mArchiveFolderName = prefs.getString(mUuid  + ".archiveFolderName", "Archive");
         mSpamFolderName = prefs.getString(mUuid  + ".spamFolderName", "Spam");
+        mPathDelimiter = prefs.getString(mUuid + ".pathDelimiter", null);
         mExpungePolicy = prefs.getString(mUuid  + ".expungePolicy", EXPUNGE_IMMEDIATELY);
         mSyncRemoteDeletions = prefs.getBoolean(mUuid  + ".syncRemoteDeletions", true);
 
@@ -546,6 +548,7 @@ public class Account implements BaseAccount {
         editor.remove(mUuid + ".trashFolderName");
         editor.remove(mUuid + ".archiveFolderName");
         editor.remove(mUuid + ".spamFolderName");
+        editor.remove(mUuid + ".pathDelimiter");
         editor.remove(mUuid + ".autoExpandFolderName");
         editor.remove(mUuid + ".accountNumber");
         editor.remove(mUuid + ".vibrate");
@@ -707,6 +710,7 @@ public class Account implements BaseAccount {
         editor.putString(mUuid + ".trashFolderName", mTrashFolderName);
         editor.putString(mUuid + ".archiveFolderName", mArchiveFolderName);
         editor.putString(mUuid + ".spamFolderName", mSpamFolderName);
+        editor.putString(mUuid + ".pathDelimiter", mPathDelimiter);
         editor.putString(mUuid + ".autoExpandFolderName", mAutoExpandFolderName);
         editor.putInt(mUuid + ".accountNumber", mAccountNumber);
         editor.putString(mUuid + ".sortTypeEnum", mSortType.name());
@@ -1165,6 +1169,15 @@ public class Account implements BaseAccount {
 
     public synchronized void setSpamFolderName(String spamFolderName) {
         mSpamFolderName = spamFolderName;
+    }
+
+
+    public synchronized  String getPathDelimiter() {
+        return mPathDelimiter;
+    }
+
+    public synchronized void setPathDelimiter(String pathDelimiter) {
+        mPathDelimiter = pathDelimiter;
     }
 
     /**

--- a/src/com/fsck/k9/K9.java
+++ b/src/com/fsck/k9/K9.java
@@ -250,6 +250,7 @@ public class K9 extends Application {
     private static String mQuietTimeEnds = null;
     private static String mAttachmentDefaultPath = "";
     private static boolean mWrapFolderNames = false;
+    private static boolean mFolderHierarchy = true;
 
     private static boolean useGalleryBugWorkaround = false;
     private static boolean galleryBuggy;
@@ -514,6 +515,7 @@ public class K9 extends Application {
         editor.putBoolean("messageViewReturnToList", mMessageViewReturnToList);
         editor.putBoolean("messageViewShowNext", mMessageViewShowNext);
         editor.putBoolean("wrapFolderNames", mWrapFolderNames);
+        editor.putBoolean("folderHierarchy", mFolderHierarchy);
 
         editor.putString("language", language);
         editor.putInt("theme", theme.ordinal());
@@ -708,6 +710,7 @@ public class K9 extends Application {
         mMessageViewReturnToList = sprefs.getBoolean("messageViewReturnToList", false);
         mMessageViewShowNext = sprefs.getBoolean("messageViewShowNext", false);
         mWrapFolderNames = sprefs.getBoolean("wrapFolderNames", false);
+        mFolderHierarchy = sprefs.getBoolean("folderHierarchy", true);
 
         useGalleryBugWorkaround = sprefs.getBoolean("useGalleryBugWorkaround", K9.isGalleryBuggy());
 
@@ -1241,6 +1244,13 @@ public class K9 extends Application {
     }
     public static void setWrapFolderNames(final boolean state) {
         mWrapFolderNames = state;
+    }
+
+    public static boolean folderHierarchy() {
+        return mFolderHierarchy;
+    }
+    public static void setFolderHierarchy(final boolean state) {
+        mFolderHierarchy = state;
     }
 
     public static String getAttachmentDefaultPath() {

--- a/src/com/fsck/k9/activity/Accounts.java
+++ b/src/com/fsck/k9/activity/Accounts.java
@@ -651,6 +651,8 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
      * @return false if unsuccessfull
      */
     private boolean onOpenAccount(BaseAccount account) {
+        Log.d("FOLDERS", "Accounts::onOpenAccount()");
+
         if (account instanceof SearchAccount) {
             SearchAccount searchAccount = (SearchAccount)account;
             MessageList.actionDisplaySearch(this, searchAccount.getRelatedSearch(), false, false);
@@ -1192,6 +1194,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
     }
 
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+        Log.d("FOLDERS", "Accounts::onItemClick(" + position + ")");
         BaseAccount account = (BaseAccount)parent.getItemAtPosition(position);
         onOpenAccount(account);
     }

--- a/src/com/fsck/k9/activity/Accounts.java
+++ b/src/com/fsck/k9/activity/Accounts.java
@@ -651,8 +651,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
      * @return false if unsuccessfull
      */
     private boolean onOpenAccount(BaseAccount account) {
-        Log.d("FOLDERS", "Accounts::onOpenAccount()");
-
         if (account instanceof SearchAccount) {
             SearchAccount searchAccount = (SearchAccount)account;
             MessageList.actionDisplaySearch(this, searchAccount.getRelatedSearch(), false, false);
@@ -1194,7 +1192,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
     }
 
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        Log.d("FOLDERS", "Accounts::onItemClick(" + position + ")");
         BaseAccount account = (BaseAccount)parent.getItemAtPosition(position);
         onOpenAccount(account);
     }

--- a/src/com/fsck/k9/activity/ChooseFolder.java
+++ b/src/com/fsck/k9/activity/ChooseFolder.java
@@ -6,6 +6,8 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.widget.AdapterView;
+import android.widget.Toast;
+import com.fsck.k9.R;
 
 public class ChooseFolder extends FolderList {
     public static final String EXTRA_ACCOUNT = FolderList.EXTRA_ACCOUNT;
@@ -38,6 +40,9 @@ public class ChooseFolder extends FolderList {
 
                 setResult(RESULT_OK, result);
                 finish();
+
+                Toast toast = Toast.makeText(context, context.getString(R.string.folder_selected) + " " + ((FolderInfoHolder) mAdapter.getItem(position)).name, Toast.LENGTH_LONG);
+                toast.show();
             }
         });
     }

--- a/src/com/fsck/k9/activity/ChooseFolder.java
+++ b/src/com/fsck/k9/activity/ChooseFolder.java
@@ -1,391 +1,44 @@
 
 package com.fsck.k9.activity;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-
 import android.content.Intent;
 import android.os.Bundle;
-import android.os.Handler;
 import android.util.Log;
-import com.actionbarsherlock.view.Menu;
-import com.actionbarsherlock.view.MenuItem;
-import com.actionbarsherlock.view.Window;
-import com.actionbarsherlock.widget.SearchView;
-
 import android.view.View;
 import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.Filter;
-import android.widget.ListView;
-import android.widget.TextView;
 
-import com.fsck.k9.Account;
-import com.fsck.k9.Account.FolderMode;
-import com.fsck.k9.K9;
-import com.fsck.k9.Preferences;
-import com.fsck.k9.R;
-import com.fsck.k9.controller.MessagingController;
-import com.fsck.k9.controller.MessagingListener;
-import com.fsck.k9.mail.Folder;
-import com.fsck.k9.mail.MessagingException;
+public class ChooseFolder extends FolderList {
+    public static final String EXTRA_ACCOUNT = FolderList.EXTRA_ACCOUNT;
 
-public class ChooseFolder extends K9ListActivity {
-    public static final String EXTRA_ACCOUNT = "com.fsck.k9.ChooseFolder_account";
     public static final String EXTRA_CUR_FOLDER = "com.fsck.k9.ChooseFolder_curfolder";
     public static final String EXTRA_SEL_FOLDER = "com.fsck.k9.ChooseFolder_selfolder";
     public static final String EXTRA_NEW_FOLDER = "com.fsck.k9.ChooseFolder_newfolder";
     public static final String EXTRA_MESSAGE = "com.fsck.k9.ChooseFolder_message";
     public static final String EXTRA_SHOW_CURRENT = "com.fsck.k9.ChooseFolder_showcurrent";
-    public static final String EXTRA_SHOW_FOLDER_NONE = "com.fsck.k9.ChooseFolder_showOptionNone";
     public static final String EXTRA_SHOW_DISPLAYABLE_ONLY = "com.fsck.k9.ChooseFolder_showDisplayableOnly";
 
-
     String mFolder;
-    String mSelectFolder;
-    Account mAccount;
-    MessageReference mMessageReference;
-    ArrayAdapter<String> mAdapter;
-    private ChooseFolderHandler mHandler = new ChooseFolderHandler();
-    String mHeldInbox = null;
-    boolean mHideCurrentFolder = true;
-    boolean mShowOptionNone = false;
-    boolean mShowDisplayableOnly = false;
-
-    /**
-     * What folders to display.<br/>
-     * Initialized to whatever is configured
-     * but can be overridden via {@link #onOptionsItemSelected(MenuItem)}
-     * while this activity is showing.
-     */
-    private Account.FolderMode mMode;
-
-    /**
-     * Current filter used by our ArrayAdapter.<br/>
-     * Created on the fly and invalidated if a new
-     * set of folders is chosen via {@link #onOptionsItemSelected(MenuItem)}
-     */
-    private FolderListFilter<String> mMyFilter = null;
-
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
-        setContentView(R.layout.list_content_simple);
-
-        getListView().setFastScrollEnabled(true);
-        getListView().setItemsCanFocus(false);
-        getListView().setChoiceMode(ListView.CHOICE_MODE_NONE);
         Intent intent = getIntent();
-        String accountUuid = intent.getStringExtra(EXTRA_ACCOUNT);
-        mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
-        mMessageReference = intent.getParcelableExtra(EXTRA_MESSAGE);
         mFolder = intent.getStringExtra(EXTRA_CUR_FOLDER);
-        mSelectFolder = intent.getStringExtra(EXTRA_SEL_FOLDER);
-        if (intent.getStringExtra(EXTRA_SHOW_CURRENT) != null) {
-            mHideCurrentFolder = false;
-        }
-        if (intent.getStringExtra(EXTRA_SHOW_FOLDER_NONE) != null) {
-            mShowOptionNone = true;
-        }
-        if (intent.getStringExtra(EXTRA_SHOW_DISPLAYABLE_ONLY) != null) {
-            mShowDisplayableOnly = true;
-        }
-        if (mFolder == null)
-            mFolder = "";
+        mAdapter.getHierarchyFilter().filterParent(mFolder);
 
-        mAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1) {
-            private Filter myFilter = null;
-
-            @Override
-            public Filter getFilter() {
-                if (myFilter == null) {
-                    myFilter = new FolderListFilter<String>(this);
-                }
-                return myFilter;
-            }
-        };
-
-        setListAdapter(mAdapter);
-
-        mMode = mAccount.getFolderTargetMode();
-        MessagingController.getInstance(getApplication()).listFolders(mAccount, false, mListener);
-
-        this.getListView().setOnItemClickListener(new AdapterView.OnItemClickListener() {
-            @Override
+        mListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                Log.d("FOLDERS", "mListView.onItemClick(, , position = " + position + ")");
                 Intent result = new Intent();
                 result.putExtra(EXTRA_ACCOUNT, mAccount.getUuid());
                 result.putExtra(EXTRA_CUR_FOLDER, mFolder);
-                String destFolderName = (String)((TextView)view).getText();
-                if (mHeldInbox != null && getString(R.string.special_mailbox_name_inbox).equals(destFolderName)) {
-                    destFolderName = mHeldInbox;
-                }
-                result.putExtra(EXTRA_NEW_FOLDER, destFolderName);
-                result.putExtra(EXTRA_MESSAGE, mMessageReference);
+
+                result.putExtra(EXTRA_NEW_FOLDER, ((FolderInfoHolder) mAdapter.getItem(position)).name);
+
                 setResult(RESULT_OK, result);
                 finish();
             }
         });
     }
-
-    class ChooseFolderHandler extends Handler {
-        private static final int MSG_PROGRESS = 1;
-        private static final int MSG_SET_SELECTED_FOLDER = 2;
-
-        @Override
-        public void handleMessage(android.os.Message msg) {
-            switch (msg.what) {
-                case MSG_PROGRESS: {
-                    setSupportProgressBarIndeterminateVisibility(msg.arg1 != 0);
-                    break;
-                }
-                case MSG_SET_SELECTED_FOLDER: {
-                    getListView().setSelection(msg.arg1);
-                    break;
-                }
-            }
-        }
-
-        public void progress(boolean progress) {
-            android.os.Message msg = new android.os.Message();
-            msg.what = MSG_PROGRESS;
-            msg.arg1 = progress ? 1 : 0;
-            sendMessage(msg);
-        }
-
-        public void setSelectedFolder(int position) {
-            android.os.Message msg = new android.os.Message();
-            msg.what = MSG_SET_SELECTED_FOLDER;
-            msg.arg1 = position;
-            sendMessage(msg);
-        }
-    }
-
-    @Override
-    public boolean onCreateOptionsMenu(Menu menu) {
-        super.onCreateOptionsMenu(menu);
-        getSupportMenuInflater().inflate(R.menu.folder_select_option, menu);
-        configureFolderSearchView(menu);
-        return true;
-    }
-
-    private void configureFolderSearchView(Menu menu) {
-        final MenuItem folderMenuItem = menu.findItem(R.id.filter_folders);
-        final SearchView folderSearchView = (SearchView) folderMenuItem.getActionView();
-        folderSearchView.setQueryHint(getString(R.string.folder_list_filter_hint));
-        folderSearchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
-
-            @Override
-            public boolean onQueryTextSubmit(String query) {
-                folderMenuItem.collapseActionView();
-                return true;
-            }
-
-            @Override
-            public boolean onQueryTextChange(String newText) {
-                mAdapter.getFilter().filter(newText);
-                return true;
-            }
-        });
-    }
-
-    @Override
-    public boolean onOptionsItemSelected(MenuItem item) {
-        switch (item.getItemId()) {
-            case R.id.display_1st_class: {
-                setDisplayMode(FolderMode.FIRST_CLASS);
-                return true;
-            }
-            case R.id.display_1st_and_2nd_class: {
-                setDisplayMode(FolderMode.FIRST_AND_SECOND_CLASS);
-                return true;
-            }
-            case R.id.display_not_second_class: {
-                setDisplayMode(FolderMode.NOT_SECOND_CLASS);
-                return true;
-            }
-            case R.id.display_all: {
-                setDisplayMode(FolderMode.ALL);
-                return true;
-            }
-            case R.id.list_folders: {
-                onRefresh();
-                return true;
-            }
-            default: {
-                return super.onOptionsItemSelected(item);
-            }
-        }
-    }
-
-    private void onRefresh() {
-        MessagingController.getInstance(getApplication()).listFolders(mAccount, true, mListener);
-    }
-
-    private void setDisplayMode(FolderMode aMode) {
-        mMode = aMode;
-        // invalidate the current filter as it is working on an inval
-        if (mMyFilter != null) {
-            mMyFilter.invalidate();
-        }
-        //re-populate the list
-        MessagingController.getInstance(getApplication()).listFolders(mAccount, false, mListener);
-    }
-
-    private MessagingListener mListener = new MessagingListener() {
-        @Override
-        public void listFoldersStarted(Account account) {
-            if (!account.equals(mAccount)) {
-                return;
-            }
-            mHandler.progress(true);
-        }
-
-        @Override
-        public void listFoldersFailed(Account account, String message) {
-            if (!account.equals(mAccount)) {
-                return;
-            }
-            mHandler.progress(false);
-        }
-
-        @Override
-        public void listFoldersFinished(Account account) {
-            if (!account.equals(mAccount)) {
-                return;
-            }
-            mHandler.progress(false);
-        }
-        @Override
-        public void listFolders(Account account, Folder[] folders) {
-            if (!account.equals(mAccount)) {
-                return;
-            }
-            Account.FolderMode aMode = mMode;
-            Preferences prefs = Preferences.getPreferences(getApplication().getApplicationContext());
-
-            List<String> newFolders = new ArrayList<String>();
-            List<String> topFolders = new ArrayList<String>();
-
-            for (Folder folder : folders) {
-                String name = folder.getName();
-
-                // Inbox needs to be compared case-insensitively
-                if (mHideCurrentFolder && (name.equals(mFolder) || (
-                        mAccount.getInboxFolderName().equalsIgnoreCase(mFolder) &&
-                        mAccount.getInboxFolderName().equalsIgnoreCase(name)))) {
-                    continue;
-                }
-                try {
-                    folder.refresh(prefs);
-                    Folder.FolderClass fMode = folder.getDisplayClass();
-
-                    if ((aMode == Account.FolderMode.FIRST_CLASS &&
-                            fMode != Folder.FolderClass.FIRST_CLASS) || (
-                                aMode == Account.FolderMode.FIRST_AND_SECOND_CLASS &&
-                                fMode != Folder.FolderClass.FIRST_CLASS &&
-                                fMode != Folder.FolderClass.SECOND_CLASS) || (
-                                aMode == Account.FolderMode.NOT_SECOND_CLASS &&
-                                fMode == Folder.FolderClass.SECOND_CLASS)) {
-                        continue;
-                    }
-                } catch (MessagingException me) {
-                    Log.e(K9.LOG_TAG, "Couldn't get prefs to check for displayability of folder " +
-                            folder.getName(), me);
-                }
-
-                if (folder.isInTopGroup()) {
-                    topFolders.add(name);
-                } else {
-                    newFolders.add(name);
-                }
-            }
-
-            final Comparator<String> comparator = new Comparator<String>() {
-                @Override
-                public int compare(String s1, String s2) {
-                    int ret = s1.compareToIgnoreCase(s2);
-                    return (ret != 0) ? ret : s1.compareTo(s2);
-                }
-            };
-
-            Collections.sort(topFolders, comparator);
-            Collections.sort(newFolders, comparator);
-
-            List<String> localFolders = new ArrayList<String>(newFolders.size() +
-                    topFolders.size() + ((mShowOptionNone) ? 1 : 0));
-
-            if (mShowOptionNone) {
-                localFolders.add(K9.FOLDER_NONE);
-            }
-
-            localFolders.addAll(topFolders);
-            localFolders.addAll(newFolders);
-
-            int selectedFolder = -1;
-
-            /*
-             * We're not allowed to change the adapter from a background thread, so we collect the
-             * folder names and update the adapter in the UI thread (see finally block).
-             */
-            final List<String> folderList = new ArrayList<String>();
-            try {
-                int position = 0;
-                for (String name : localFolders) {
-                    if (mAccount.getInboxFolderName().equalsIgnoreCase(name)) {
-                        folderList.add(getString(R.string.special_mailbox_name_inbox));
-                        mHeldInbox = name;
-                    } else if (!K9.ERROR_FOLDER_NAME.equals(name) &&
-                            !account.getOutboxFolderName().equals(name)) {
-                        folderList.add(name);
-                    }
-
-                    if (mSelectFolder != null) {
-                        /*
-                         * Never select EXTRA_CUR_FOLDER (mFolder) if EXTRA_SEL_FOLDER
-                         * (mSelectedFolder) was provided.
-                         */
-
-                        if (name.equals(mSelectFolder)) {
-                            selectedFolder = position;
-                        }
-                    } else if (name.equals(mFolder) || (
-                            mAccount.getInboxFolderName().equalsIgnoreCase(mFolder) &&
-                            mAccount.getInboxFolderName().equalsIgnoreCase(name))) {
-                        selectedFolder = position;
-                    }
-                    position++;
-                }
-            } finally {
-                runOnUiThread(new Runnable() {
-                    @Override
-                    public void run() {
-                        // Now we're in the UI-thread, we can safely change the contents of the adapter.
-                        mAdapter.clear();
-                        for (String folderName: folderList) {
-                            mAdapter.add(folderName);
-                        }
-
-                        mAdapter.notifyDataSetChanged();
-
-                        /*
-                         * Only enable the text filter after the list has been
-                         * populated to avoid possible race conditions because our
-                         * FolderListFilter isn't really thread-safe.
-                         */
-                        getListView().setTextFilterEnabled(true);
-                    }
-                });
-            }
-
-            if (selectedFolder != -1) {
-                mHandler.setSelectedFolder(selectedFolder);
-            }
-        }
-    };
-}
+};

--- a/src/com/fsck/k9/activity/ChooseFolder.java
+++ b/src/com/fsck/k9/activity/ChooseFolder.java
@@ -31,7 +31,6 @@ public class ChooseFolder extends FolderList {
 
         mListView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                Log.d("FOLDERS", "mListView.onItemClick(, , position = " + position + ")");
                 Intent result = new Intent();
                 result.putExtra(EXTRA_ACCOUNT, mAccount.getUuid());
                 result.putExtra(EXTRA_CUR_FOLDER, mFolder);

--- a/src/com/fsck/k9/activity/FolderList.java
+++ b/src/com/fsck/k9/activity/FolderList.java
@@ -1202,21 +1202,23 @@ public class FolderList extends K9ListActivity {
                         continue;
                     }
 
-                    if (value.displayName.startsWith(folder) && !value.displayName.equals(folder)) { // only display stuff in the current folder
-                        String subname = value.displayName.substring(folder.length());
+                    if (value.name.startsWith(folder) && !value.name.equals(folder)) { // only display stuff in the current folder
+                        String subname = value.name.substring(folder.length());
 
                         if (subname.indexOf('/') != -1) { // a subsubfolder
-                            Log.d("FOLDER", "Skipping subsubfolder " + value.displayName);
-                            continue;
+                            Log.d("FOLDER", "Skipping subsubfolder " + value.name);
                         }
-                        else
-                            Log.d("FOLDER", "including " + value.displayName);
+                        else {
+                            Log.d("FOLDER", "including " + value.name + " displayname: " + value.displayName);
 
-                        value.displayName = subname;
-                        newValues.add(value);
+                            if (value.name.equals(value.displayName))
+                                value.displayName = subname;
+
+                            newValues.add(value);
+                        }
                     }
                     else
-                        Log.d("FOLDER", "Skipping " + value.displayName);
+                        Log.d("FOLDER", "Skipping not in current path " + value.displayName);
                 }
 
                 results.values = newValues;

--- a/src/com/fsck/k9/activity/FolderList.java
+++ b/src/com/fsck/k9/activity/FolderList.java
@@ -770,28 +770,30 @@ public class FolderList extends K9ListActivity {
 
                     Folder previous = null;
                     for (Folder folder : folders) {
-                        String folderString = folder.getName();
-                        int index = folderString.lastIndexOf(mAdapter.getHierarchyFilter().getPathDelimiter());
+                        if (K9.folderHierarchy()) {
+                            String folderString = folder.getName();
+                            int index = folderString.lastIndexOf(mAdapter.getHierarchyFilter().getPathDelimiter());
 
-                        //Log.v("FOLDER", "List: " + folder.getName() + " found slash at " + index);
+                            //Log.v("FOLDER", "List: " + folder.getName() + " found slash at " + index);
 
-                        while (index != -1) {
-                            //Log.d("FOLDER", "working on substring: " + substring + " soon to be shortened to: " + substring.substring(0, index));
+                            while (index != -1) {
+                                //Log.d("FOLDER", "working on substring: " + substring + " soon to be shortened to: " + substring.substring(0, index));
 
-                            folderString = folderString.substring(0, index); // get this folders' parent
+                                folderString = folderString.substring(0, index); // get this folders' parent
 
-                            if (previous == null || ! previous.getName().startsWith(folderString)) {
-                                Log.d("FOLDER", "Artificial fake folder: " + folderString);
+                                if (previous == null || ! previous.getName().startsWith(folderString)) {
+                                    Log.d("FOLDER", "Artificial fake folder: " + folderString);
 
-                                FolderInfoHolder holder = new FolderInfoHolder();
-                                holder.name = folderString;
-                                holder.displayName = folderString;
-                                holder.folder = new FakeFolder(account, folderString);
+                                    FolderInfoHolder holder = new FolderInfoHolder();
+                                    holder.name = folderString;
+                                    holder.displayName = folderString;
+                                    holder.folder = new FakeFolder(account, folderString);
 
-                                newFolders.add(holder);
+                                    newFolders.add(holder);
+                                }
+
+                                index = folderString.lastIndexOf(mAdapter.getHierarchyFilter().getPathDelimiter());
                             }
-
-                            index = folderString.lastIndexOf(mAdapter.getHierarchyFilter().getPathDelimiter());
                         }
 
 
@@ -1236,7 +1238,7 @@ public class FolderList extends K9ListActivity {
 
                 final ArrayList<FolderInfoHolder> newValues = new ArrayList<FolderInfoHolder>();
 
-                if (!enabled) { // no folder hierarchy
+                if (!K9.folderHierarchy()) { // no folder hierarchy
                     newValues.ensureCapacity(mFolders.size());
 
                     for (final FolderInfoHolder value : mFolders)

--- a/src/com/fsck/k9/activity/FolderList.java
+++ b/src/com/fsck/k9/activity/FolderList.java
@@ -411,6 +411,24 @@ public class FolderList extends K9ListActivity {
             setDisplayMode(FolderMode.ALL);
             return true;
         }
+        case KeyEvent.KEYCODE_BACK: {
+            String currentFolder = mAdapter.getHierarchyFilter().getFolder();
+            Log.d("FOLDER", "Back key event, folder filter: " + currentFolder);
+            if (! currentFolder.equals("") ) { // are we in some subfolder?
+                int index = currentFolder.lastIndexOf('/');
+
+                String newFolder;
+                if (index == -1)
+                    newFolder = "";
+                else
+                    newFolder = currentFolder.substring(0, currentFolder.lastIndexOf('/'));
+
+                mAdapter.getHierarchyFilter().filter(newFolder);
+
+                return true;
+            }
+        }
+
         }//switch
 
 
@@ -660,7 +678,7 @@ public class FolderList extends K9ListActivity {
         private ArrayList<FolderInfoHolder> mFolders = new ArrayList<FolderInfoHolder>();
         private List<FolderInfoHolder> mFilteredFolders = Collections.unmodifiableList(mFolders);
         private Filter mFilter = new FolderListFilter();
-        private Filter mHierarchyFilter = new FolderHierarchyFilter();
+        private FolderHierarchyFilter mHierarchyFilter = new FolderHierarchyFilter();
 
         public Object getItem(long position) {
             return getItem((int)position);
@@ -1172,18 +1190,25 @@ public class FolderList extends K9ListActivity {
             return mFilter;
         }
 
-        public Filter getHierarchyFilter() {
+        public FolderHierarchyFilter getHierarchyFilter() {
             return mHierarchyFilter;
         }
 
         public class FolderHierarchyFilter extends Filter {
             private boolean enabled = true;
+            String currentFolder;
+
+            public String getFolder() {
+                return currentFolder;
+            }
 
             @Override
             protected FilterResults performFiltering(CharSequence constraint) {
                 Log.d("FOLDER", "FolderHierarchyFilter.performFiltering(" + constraint.toString() + ")");
 
                 String folder = constraint.toString();
+                currentFolder = folder;
+
                 if (!folder.equals(""))
                     folder = folder + "/";
 

--- a/src/com/fsck/k9/activity/FolderList.java
+++ b/src/com/fsck/k9/activity/FolderList.java
@@ -442,7 +442,7 @@ public class FolderList extends K9ListActivity {
             MailService.actionRestartPushers(this, null);
         }
         mAdapter.getFilter().filter(null);
-        mAdapter.getHierarchyFilter().filter(null);
+        mAdapter.getHierarchyFilter().filter("");
         onRefresh(false);
     }
 
@@ -1262,7 +1262,9 @@ public class FolderList extends K9ListActivity {
             protected FilterResults performFiltering(CharSequence constraint) {
 
                 String folder;
-                if (constraint == null || constraint.equals(""))
+                if (constraint == null)
+                    folder = mCurrentFolder;
+                else if (constraint.equals(""))
                     folder = "";
                 else
                     folder = constraint.toString() + getPathDelimiter();

--- a/src/com/fsck/k9/activity/FolderList.java
+++ b/src/com/fsck/k9/activity/FolderList.java
@@ -118,7 +118,6 @@ public class FolderList extends K9ListActivity {
                     mAdapter.mFolders.clear();
                     mAdapter.mFolders.addAll(newFolders);
                     mAdapter.mFilteredFolders = mAdapter.mFolders;
-                    Log.d("FOLDERS", "newFolders(" + newFolders.size() +") -> going to call getHierarchyFilter().filter(null)");
                     mAdapter.getHierarchyFilter().filter(null);
                     mHandler.dataChanged();
                 }
@@ -260,7 +259,6 @@ public class FolderList extends K9ListActivity {
 
         mListView.setOnItemClickListener(new OnItemClickListener() {
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                Log.d("FOLDERS", "mListView.onItemClick(, , position = " + position + ")");
                 onOpenFolder(((FolderInfoHolder) mAdapter.getItem(position)).name);
             }
         });
@@ -410,7 +408,6 @@ public class FolderList extends K9ListActivity {
         }
         case KeyEvent.KEYCODE_BACK: {
             String currentFolder = mAdapter.getHierarchyFilter().getFolder();
-            Log.d("FOLDER", "Back key event, folder filter: " + currentFolder);
             if (! currentFolder.equals("") ) { // are we in some subfolder?
                 if (currentFolder.endsWith(mAdapter.getHierarchyFilter().getPathDelimiter()))
                     currentFolder = currentFolder.substring(0, currentFolder.length()-1);
@@ -448,7 +445,6 @@ public class FolderList extends K9ListActivity {
 
 
     private void onRefresh(final boolean forceRemote) {
-        Log.d("FOLDERS", "FolderList::onRefresh()");
         MessagingController.getInstance(getApplication()).listFolders(mAccount, forceRemote, mAdapter.mListener);
     }
 
@@ -582,19 +578,6 @@ public class FolderList extends K9ListActivity {
      }
 
     private void onOpenFolder(String folder) {
-        // if is parent folder: { show subfolders } else { $current_code }
-
-        Log.d("FOLDER", "onOpenFolder: " + folder);
-
-        // check if folder has *any* subfolders
-        /*for (FolderInfoHolder f: mAdapter.mFolders) {
-            if (f.name.startsWith(folder) && f.name.length() > folder.length()) {
-                //Log.d("FOLDER", "found subfolder for " + folder + ": " +f.name);
-                mAdapter.getHierarchyFilter().filter(folder);
-                return;
-            }
-        }*/
-
         LocalSearch search = new LocalSearch(folder);
         search.addAccountUuid(mAccount.getUuid());
         search.addAllowedFolder(folder);
@@ -629,8 +612,6 @@ public class FolderList extends K9ListActivity {
 
             @Override
             public boolean onQueryTextChange(String newText) {
-                Log.d("FOLDERS", "onQueryTextChange(" + newText + ")");
-
                 mAdapter.getFilter().filter(newText);
                 if (newText == null || newText.equals(""))
                     mAdapter.getHierarchyFilter().filter(null);
@@ -756,15 +737,10 @@ public class FolderList extends K9ListActivity {
                     mHandler.dataChanged();
                 }
                 super.listFoldersFinished(account);
-
-                //Log.d("FOLDERS", "listFoldersFinished() -> going to call getHierarchyFilter().filter(null)");
-                //mAdapter.getHierarchyFilter().filter(null);
             }
 
             @Override
             public void listFolders(Account account, Folder[] folders) {
-                Log.d("FOLDERS", "FolderList.listFolders(" + account.getName() + " ?= mAccount: " + mAccount.getName() + "," + folders.length + ")");
-
                 if (account.equals(mAccount)) {
                     Arrays.sort(folders);
 
@@ -780,15 +756,11 @@ public class FolderList extends K9ListActivity {
                             String folderString = folder.getName();
                             int index = folderString.lastIndexOf(mAdapter.getHierarchyFilter().getPathDelimiter());
 
-                            Log.v("FOLDERS", "List: " + folder.getName() + " found slash at " + index);
-
                             while (index != -1) {
-                                //Log.d("FOLDER", "working on substring: " + substring + " soon to be shortened to: " + substring.substring(0, index));
-
                                 folderString = folderString.substring(0, index); // get this folders' parent
 
                                 if (previous == null || ! previous.getName().startsWith(folderString)) {
-                                    Log.d("FOLDER", "Artificial fake folder: " + folderString);
+                                    //Log.d(K9.LOG_TAG, "Artificial fake folder: " + folderString);
 
                                     FolderInfoHolder holder = new FolderInfoHolder();
                                     holder.name = folderString;
@@ -847,8 +819,6 @@ public class FolderList extends K9ListActivity {
                         previous = folder;
                     }
 
-                    Log.d("FOLDERS", "Found " + newFolders.size() + " + " + topFolders.size() + " folders");
-
                     Collections.sort(newFolders);
                     Collections.sort(topFolders);
                     topFolders.addAll(newFolders);
@@ -856,9 +826,6 @@ public class FolderList extends K9ListActivity {
 
                 }
                 super.listFolders(account, folders);
-
-                //Log.d("FOLDERS", "going to call getHierarchyFilter().filter(null)");
-                //getHierarchyFilter().filter(null);
             }
 
             @Override
@@ -1038,8 +1005,6 @@ public class FolderList extends K9ListActivity {
         }
 
         public View getItemView(int itemPosition, View convertView, ViewGroup parent) {
-            //Log.d("FOLDERS", "getItemView(int itemPosition = " + itemPosition + ", ...)");
-
             FolderInfoHolder folder = (FolderInfoHolder) getItem(itemPosition);
             View view;
             if (convertView != null) {
@@ -1166,23 +1131,17 @@ public class FolderList extends K9ListActivity {
 
         private boolean hasSubFolder(String folder) {
             for (FolderInfoHolder f: mAdapter.mFolders) {
-                if (f.name.startsWith(folder + mAdapter.getHierarchyFilter().getPathDelimiter()) && f.name.length() > folder.length()) {
-                    //Log.d("FOLDERS", "hasSubFolder(" + folder + "): " +f.name);
+                if (f.name.startsWith(folder + mAdapter.getHierarchyFilter().getPathDelimiter()) && f.name.length() > folder.length())
                     return true;
-                }
             }
 
-            Log.d("FOLDERS", "hasSubFolder(" + folder + "): false");
             return false;
         }
 
         private OnClickListener createFolderOpener(final String folder) {
-            Log.d("FOLDERS", "createFolderOpener(" + folder + ")");
-
             return new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    Log.d("FOLDERS", "createFolderOpener(" + folder + ").onClick()");
                     mAdapter.getHierarchyFilter().filter(folder);
                 }
             };
@@ -1369,7 +1328,6 @@ public class FolderList extends K9ListActivity {
             super();
             mCurrentFolder = "";
             mPathDelimiter = pathDelimiter;
-            Log.d(K9.LOG_TAG, "FolderHierarchyFilter got path delimiter: " + mPathDelimiter);
             mFolders = folders;
         }
 
@@ -1405,14 +1363,12 @@ public class FolderList extends K9ListActivity {
             else
                 folder = constraint.toString() + getPathDelimiter();
 
-            Log.d("FOLDER", "FolderHierarchyFilter.performFiltering(" + folder + ")");
             mCurrentFolder = folder;
             FilterResults results = new FilterResults();
 
             final ArrayList<FolderInfoHolder> newValues = new ArrayList<FolderInfoHolder>();
 
             if (!K9.folderHierarchy()) { // no folder hierarchy
-                Log.d("FOLDERS", "no hierarchy");
                 newValues.ensureCapacity(mFolders.size());
 
                 for (final FolderInfoHolder value : mFolders)
@@ -1420,7 +1376,6 @@ public class FolderList extends K9ListActivity {
                         newValues.add(value);
             }
             else { // with folder hierarchy
-                Log.d("FOLDERS", "working on building hierarchy for " + mFolders.size() + " folders");
                 for (final FolderInfoHolder value : mFolders) {
                     if (value.displayName == null) {
                         continue;
@@ -1430,10 +1385,10 @@ public class FolderList extends K9ListActivity {
                         String subname = value.name.substring(folder.length());
 
                         if (subname.indexOf(getPathDelimiter()) != -1) { // a subsubfolder
-                            //Log.d("FOLDER", "Skipping subsubfolder " + value.name);
+                            //Log.d(K9.LOG_TAG, "Skipping subsubfolder " + value.name);
                         }
                         else {
-                            //Log.d("FOLDER", "including " + value.name + " displayname: " + value.displayName);
+                            //Log.d(K9.LOG_TAG, "including " + value.name + " displayname: " + value.displayName);
 
                             if (value.name.equals(value.displayName))
                                 value.displayName = subname;
@@ -1442,7 +1397,7 @@ public class FolderList extends K9ListActivity {
                         }
                     }
                     // else
-                    //     Log.d("FOLDER", "Skipping not in current path " + value.displayName);
+                    //     Log.d(K9.LOG_TAG, "Skipping not in current path " + value.displayName);
                 }
             }
 

--- a/src/com/fsck/k9/activity/FolderList.java
+++ b/src/com/fsck/k9/activity/FolderList.java
@@ -77,7 +77,7 @@ public class FolderList extends K9ListActivity {
     private int mUnreadMessageCount;
 
     private FontSizes mFontSizes = K9.getFontSizes();
-    private Context context;
+    protected Context context;
 
     private MenuItem mRefreshMenuItem;
     private View mActionBarProgressView;

--- a/src/com/fsck/k9/activity/FolderList.java
+++ b/src/com/fsck/k9/activity/FolderList.java
@@ -62,6 +62,8 @@ public class FolderList extends K9ListActivity {
 
     private static final String EXTRA_FROM_SHORTCUT = "fromShortcut";
 
+    private static final String CURRENT_FOLDER = "hierarchyFilterFolder";
+
     private static final boolean REFRESH_REMOTE = true;
 
     protected ListView mListView;
@@ -278,6 +280,22 @@ public class FolderList extends K9ListActivity {
         }
     }
 
+    @Override
+    public void onSaveInstanceState(Bundle outState) {
+        super.onSaveInstanceState(outState);
+
+        // persist which folder is currently open over a device rotation
+        outState.putString(CURRENT_FOLDER, mAdapter.getHierarchyFilter().getFolder());
+    }
+
+    @Override
+    public void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+
+        // restore which folder is currently open after a device rotation
+        mAdapter.getHierarchyFilter().setFolder(savedInstanceState.getString(CURRENT_FOLDER, null));
+    }
+
     private void initializeActionBar() {
         mActionBar.setDisplayShowCustomEnabled(true);
         mActionBar.setCustomView(R.layout.actionbar_custom);
@@ -315,21 +333,9 @@ public class FolderList extends K9ListActivity {
 
     private void initializeActivityView() {
         mAdapter = new FolderListAdapter();
-        restorePreviousData();
         setListAdapter(mAdapter);
         getListView().setTextFilterEnabled(mAdapter.getFilter() != null); // should never be false but better safe then sorry
     }
-
-    @SuppressWarnings("unchecked")
-    private void restorePreviousData() {
-        final Object previousData = getLastNonConfigurationInstance();
-
-        if (previousData != null) {
-            mAdapter.mFolders = (ArrayList<FolderInfoHolder>) previousData;
-            mAdapter.mFilteredFolders = Collections.unmodifiableList(mAdapter.mFolders);
-        }
-    }
-
 
     @Override public Object onRetainNonConfigurationInstance() {
         return (mAdapter == null) ? null : mAdapter.mFolders;
@@ -1333,6 +1339,13 @@ public class FolderList extends K9ListActivity {
 
         public String getFolder() {
             return mCurrentFolder;
+        }
+
+        public void setFolder(String folder) {
+            if (folder != null)
+                mCurrentFolder = folder;
+            else if (mCurrentFolder == null)
+                mCurrentFolder = "";
         }
 
         public String getPathDelimiter() {

--- a/src/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/src/com/fsck/k9/activity/setup/AccountSettings.java
@@ -957,8 +957,6 @@ public class AccountSettings extends K9PreferenceActivity {
         selectIntent.putExtra(ChooseFolder.EXTRA_ACCOUNT, mAccount.getUuid());
 
         selectIntent.putExtra(ChooseFolder.EXTRA_CUR_FOLDER, mAutoExpandFolder.getSummary());
-        selectIntent.putExtra(ChooseFolder.EXTRA_SHOW_CURRENT, "yes");
-        selectIntent.putExtra(ChooseFolder.EXTRA_SHOW_FOLDER_NONE, "yes");
         selectIntent.putExtra(ChooseFolder.EXTRA_SHOW_DISPLAYABLE_ONLY, "yes");
         startActivityForResult(selectIntent, SELECT_AUTO_EXPAND_FOLDER);
     }

--- a/src/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/src/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -224,6 +224,7 @@ public class AccountSetupBasics extends K9Activity
                 mAccount.setSpamFolderName(getString(R.string.special_mailbox_name_spam));
             }
             mAccount.setSentFolderName(getString(R.string.special_mailbox_name_sent));
+
             if (incomingUri.toString().startsWith("imap")) {
                 mAccount.setDeletePolicy(Account.DELETE_POLICY_ON_DELETE);
             } else if (incomingUri.toString().startsWith("pop3")) {

--- a/src/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/src/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -120,6 +120,8 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
                         }
                         store.checkSettings();
 
+                        mAccount.setPathDelimiter(store.getPathDelimiter());
+
                         if (store instanceof WebDavStore) {
                             setMessage(R.string.account_setup_check_settings_fetch);
                         }

--- a/src/com/fsck/k9/activity/setup/Prefs.java
+++ b/src/com/fsck/k9/activity/setup/Prefs.java
@@ -92,6 +92,7 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_BACKGROUND_AS_UNREAD_INDICATOR = "messagelist_background_as_unread_indicator";
     private static final String PREFERENCE_THREADED_VIEW = "threaded_view";
     private static final String PREFERENCE_FOLDERLIST_WRAP_NAME = "folderlist_wrap_folder_name";
+    private static final String PREFERENCE_FOLDERLIST_HIERARCHY = "folderlist_hierarchy";
     private static final String PREFERENCE_SPLITVIEW_MODE = "splitview_mode";
 
     private static final int ACTIVITY_CHOOSE_FOLDER = 1;
@@ -128,6 +129,7 @@ public class Prefs extends K9PreferenceActivity {
     private CheckBoxPreference mDebugLogging;
     private CheckBoxPreference mSensitiveLogging;
     private CheckBoxPreference mWrapFolderNames;
+    private CheckBoxPreference mFolderHierarchy;
 
     private CheckBoxPreference mQuietTimeEnabled;
     private com.fsck.k9.preferences.TimePickerPreference mQuietTimeStarts;
@@ -399,6 +401,9 @@ public class Prefs extends K9PreferenceActivity {
         mWrapFolderNames = (CheckBoxPreference)findPreference(PREFERENCE_FOLDERLIST_WRAP_NAME);
         mWrapFolderNames.setChecked(K9.wrapFolderNames());
 
+        mFolderHierarchy = (CheckBoxPreference)findPreference(PREFERENCE_FOLDERLIST_HIERARCHY);
+        mFolderHierarchy.setChecked(K9.folderHierarchy());
+
         mSplitViewMode = (ListPreference) findPreference(PREFERENCE_SPLITVIEW_MODE);
         initListPreference(mSplitViewMode, K9.getSplitViewMode().name(),
                 mSplitViewMode.getEntries(), mSplitViewMode.getEntryValues());
@@ -469,6 +474,7 @@ public class Prefs extends K9PreferenceActivity {
         K9.setQuietTimeStarts(mQuietTimeStarts.getTime());
         K9.setQuietTimeEnds(mQuietTimeEnds.getTime());
         K9.setWrapFolderNames(mWrapFolderNames.isChecked());
+        K9.setFolderHierarchy(mFolderHierarchy.isChecked());
 
         if (mNotificationQuickDelete != null) {
             K9.setNotificationQuickDeleteBehaviour(

--- a/src/com/fsck/k9/mail/Folder.java
+++ b/src/com/fsck/k9/mail/Folder.java
@@ -11,7 +11,7 @@ import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessageRetrievalListener;
 
 
-public abstract class Folder {
+public abstract class Folder implements Comparable<Folder> {
     protected final Account mAccount;
 
     private String status = null;
@@ -245,5 +245,18 @@ public abstract class Folder {
     public List<Message> search(String queryString, final Flag[] requiredFlags, final Flag[] forbiddenFlags)
         throws MessagingException {
         throw new MessagingException("K-9 does not support searches on this folder type");
+    }
+
+    public int compareTo(Folder o) {
+        String s1 = getName();
+        String s2 = o.getName();
+
+        int ret = s1.compareToIgnoreCase(s2);
+        if (ret != 0) {
+            return ret;
+        } else {
+            return s1.compareTo(s2);
+        }
+
     }
 }

--- a/src/com/fsck/k9/mail/Store.java
+++ b/src/com/fsck/k9/mail/Store.java
@@ -209,5 +209,7 @@ public abstract class Store {
         return mAccount;
     }
 
-
+    public String getPathDelimiter() {
+        return null;
+    }
 }

--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -359,7 +359,7 @@ public class ImapStore extends Store {
     private AuthType mAuthType;
     private volatile String mPathPrefix;
     private volatile String mCombinedPrefix = null;
-    private volatile String mPathDelimeter = null;
+    private volatile String mPathDelimiter = null;
 
     public class StoreImapSettings implements ImapSettings {
 
@@ -409,13 +409,13 @@ public class ImapStore extends Store {
         }
 
         @Override
-        public String getPathDelimeter() {
-            return mPathDelimeter;
+        public String getPathDelimiter() {
+            return mPathDelimiter;
         }
 
         @Override
-        public void setPathDelimeter(String delimeter) {
-            mPathDelimeter = delimeter;
+        public void setPathDelimiter(String delimiter) {
+            mPathDelimiter = delimiter;
         }
 
         @Override
@@ -505,7 +505,7 @@ public class ImapStore extends Store {
         if (mCombinedPrefix == null) {
             if (mPathPrefix != null) {
                 String tmpPrefix = mPathPrefix.trim();
-                String tmpDelim = (mPathDelimeter != null ? mPathDelimeter.trim() : "");
+                String tmpDelim = (mPathDelimiter != null ? mPathDelimiter.trim() : "");
                 if (tmpPrefix.endsWith(tmpDelim)) {
                     mCombinedPrefix = tmpPrefix;
                 } else if (tmpPrefix.length() > 0) {
@@ -582,8 +582,8 @@ public class ImapStore extends Store {
 
                 String folder = decodedFolderName;
 
-                if (mPathDelimeter == null) {
-                    mPathDelimeter = response.getString(2);
+                if (mPathDelimiter == null) {
+                    mPathDelimiter = response.getString(2);
                     mCombinedPrefix = null;
                 }
 
@@ -669,8 +669,8 @@ public class ImapStore extends Store {
                     continue;
                 }
 
-                if (mPathDelimeter == null) {
-                    mPathDelimeter = response.getString(2);
+                if (mPathDelimiter == null) {
+                    mPathDelimiter = response.getString(2);
                     mCombinedPrefix = null;
                 }
 
@@ -2595,10 +2595,10 @@ public class ImapStore extends Store {
                                             Log.d(K9.LOG_TAG, "Got first personal namespaces: " + firstNamespace);
                                         bracketed = (ImapList)firstNamespace;
                                         mSettings.setPathPrefix(bracketed.getString(0));
-                                        mSettings.setPathDelimeter(bracketed.getString(1));
+                                        mSettings.setPathDelimiter(bracketed.getString(1));
                                         mSettings.setCombinedPrefix(null);
                                         if (K9.DEBUG)
-                                            Log.d(K9.LOG_TAG, "Got path '" + mSettings.getPathPrefix() + "' and separator '" + mSettings.getPathDelimeter() + "'");
+                                            Log.d(K9.LOG_TAG, "Got path '" + mSettings.getPathPrefix() + "' and separator '" + mSettings.getPathDelimiter() + "'");
                                     }
                                 }
                             }
@@ -2609,20 +2609,20 @@ public class ImapStore extends Store {
                         mSettings.setPathPrefix("");
                     }
                 }
-                if (mSettings.getPathDelimeter() == null) {
+                if (mSettings.getPathDelimiter() == null) {
                     try {
                         List<ImapResponse> nameResponses =
                             executeSimpleCommand(String.format("LIST \"\" \"\""));
                         for (ImapResponse response : nameResponses) {
                             if (ImapResponseParser.equalsIgnoreCase(response.get(0), "LIST")) {
-                                mSettings.setPathDelimeter(response.getString(2));
+                                mSettings.setPathDelimiter(response.getString(2));
                                 mSettings.setCombinedPrefix(null);
                                 if (K9.DEBUG)
-                                    Log.d(K9.LOG_TAG, "Got path delimeter '" + mSettings.getPathDelimeter() + "' for " + getLogId());
+                                    Log.d(K9.LOG_TAG, "Got path delimiter '" + mSettings.getPathDelimiter() + "' for " + getLogId());
                             }
                         }
                     } catch (Exception e) {
-                        Log.e(K9.LOG_TAG, "Unable to get path delimeter using LIST", e);
+                        Log.e(K9.LOG_TAG, "Unable to get path delimiter using LIST", e);
                     }
                 }
 

--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -416,6 +416,7 @@ public class ImapStore extends Store {
         @Override
         public void setPathDelimiter(String delimiter) {
             mPathDelimiter = delimiter;
+            mAccount.setPathDelimiter(delimiter);
         }
 
         @Override
@@ -589,6 +590,7 @@ public class ImapStore extends Store {
 
                 if (mPathDelimiter == null) {
                     mPathDelimiter = response.getString(2);
+                    mAccount.setPathDelimiter(mPathDelimiter);
                     mCombinedPrefix = null;
                 }
 
@@ -676,6 +678,7 @@ public class ImapStore extends Store {
 
                 if (mPathDelimiter == null) {
                     mPathDelimiter = response.getString(2);
+                    mAccount.setPathDelimiter(mPathDelimiter);
                     mCombinedPrefix = null;
                 }
 

--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -521,6 +521,11 @@ public class ImapStore extends Store {
     }
 
     @Override
+    public String getPathDelimiter() {
+        return mPathDelimiter;
+    }
+
+    @Override
     public List <? extends Folder > getPersonalNamespaces(boolean forceListAll) throws MessagingException {
         ImapConnection connection = getConnection();
         try {

--- a/src/com/fsck/k9/mail/store/WebDavStore.java
+++ b/src/com/fsck/k9/mail/store/WebDavStore.java
@@ -84,6 +84,7 @@ public class WebDavStore extends Store {
     private static final String DAV_MAIL_OUTBOX_FOLDER = "outbox";
     private static final String DAV_MAIL_SENT_FOLDER = "sentitems";
 
+    private static final String mPathDelimiter = "/";
 
     /**
      * Decodes a WebDavStore URI.
@@ -1268,9 +1269,14 @@ public class WebDavStore extends Store {
         }
     }
 
-    /*************************************************************************
-     * Helper and Inner classes
-     */
+    @Override
+    public String getPathDelimiter() {
+        return mPathDelimiter;
+    }
+
+        /*************************************************************************
+         * Helper and Inner classes
+         */
 
     /**
      * A WebDav Folder

--- a/src/com/fsck/k9/mail/store/WebDavStore.java
+++ b/src/com/fsck/k9/mail/store/WebDavStore.java
@@ -456,6 +456,8 @@ public class WebDavStore extends Store {
         if (folderName != null)
             mAccount.setSentFolderName(folderName);
 
+        mAccount.setPathDelimiter(mPathDelimiter);
+
         /**
          * Next we get all the folders (including "special" ones)
          */

--- a/src/com/fsck/k9/mail/transport/imap/ImapSettings.java
+++ b/src/com/fsck/k9/mail/transport/imap/ImapSettings.java
@@ -26,9 +26,9 @@ public interface ImapSettings {
 
     void setPathPrefix(String prefix);
 
-    String getPathDelimeter();
+    String getPathDelimiter();
 
-    void setPathDelimeter(String delimeter);
+    void setPathDelimiter(String delimiter);
 
     String getCombinedPrefix();
 

--- a/src/com/fsck/k9/preferences/GlobalSettings.java
+++ b/src/com/fsck/k9/preferences/GlobalSettings.java
@@ -200,6 +200,9 @@ public class GlobalSettings {
         s.put("wrapFolderNames", Settings.versions(
                 new V(22, new BooleanSetting(false))
             ));
+        s.put("folderHierarchy", Settings.versions(
+                new V(29, new BooleanSetting(true))
+            ));
         s.put("notificationHideSubject", Settings.versions(
                 new V(12, new EnumSetting<NotificationHideSubject>(
                         NotificationHideSubject.class, NotificationHideSubject.NEVER))

--- a/src/com/fsck/k9/preferences/Settings.java
+++ b/src/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 28;
+    public static final int VERSION = 29;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,


### PR DESCRIPTION
I have spent some time working on implementing a hierarchical folder list view as requested in issue 17 (https://code.google.com/p/k9mail/issues/detail?id=17). 

It's likely that the current state of affairs breaks some things (haven't tested any out of pop3, webdav and imap servers other than dovecot with / as path separator) - so I'd be more interested in a review and suggestions for improvements rather than necessarily a merge at this point.

Brief summary of is modified:
- FolderList gets an additional FolderHierarchyFilter class that picks out a specific part of the folder tree, its filter() method is (hopefully) called at the appropriate locations in the code
- the folder_list_item gets an additional folder icon (stolen from accounts_item) for browsing into a folder
- there is a new FakeFolder class that is used to introduce missing pieces in the tree hierarchy to the FolderList (i.e. there may be a folder a/b on imap, where the parent folder a is not a mail-folder on the server and thus not in the list returned by the imap server)
- a major thing is how to get the correct hierarchy separator from the servers, I think I may have go that working by now (it is now cached in the account settings), haven't tested it for anything other than / though (there seem to be . and \ out in the wild)
- introduces a global boolean setting folderHierarchy for enabling/disabling the hierarchical folder list display, bumps settings version to 29

- I replaced the ChooseFolder class by a class derived from FolderList, thereby reducing code duplication and imho improving user interface consistency (on the other hand the code in FolderList is much more complex than ChooseFolder had been previously...). The original ChooseFolder class got some flags from its intent that I now blatantly disregard -- I wasn't sure what they were about...

Traditional flat folder list:
![image](https://f.cloud.github.com/assets/4450993/944623/97464e58-02c6-11e3-8553-a60c07ef22e1.png)
Hierarchical folder list:
![image](https://f.cloud.github.com/assets/4450993/944622/93c29cf0-02c6-11e3-9152-7295fe72003f.png)
