### PR TITLE
RFC: Fetch attachments while MessageCompose activity is running

### DIFF
--- a/res/layout/message_compose_attachment.xml
+++ b/res/layout/message_compose_attachment.xml
@@ -1,36 +1,55 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	android:layout_width="fill_parent"
-	android:layout_height="54dip"
-	android:paddingRight="6dip"
-	android:paddingTop="6dip"
-	android:paddingBottom="6dip">
-	<ImageButton
-		android:id="@+id/attachment_delete"
-		android:src="@drawable/ic_delete"
-		android:layout_alignParentRight="true"
-		android:layout_height="42dip"
-		android:layout_width="42dip" />
-	<TextView
-		android:id="@+id/attachment_name"
-		android:textAppearance="?android:attr/textAppearanceMedium"
-		android:textColor="?android:attr/textColorSecondary"
-		android:layout_width="1dip"
-		android:layout_height="42dip"
-		android:background="?attr/messageViewAttachmentBackground"
-		android:paddingLeft="36dip"
-		android:singleLine="true"
-		android:ellipsize="start"
-		android:gravity="center_vertical"
-		android:layout_marginLeft="6dip"
-		android:layout_marginRight="4dip"
-		android:layout_alignParentLeft="true"
-		android:layout_toLeftOf="@id/attachment_delete" />
-	<ImageView
-		android:layout_width="wrap_content"
-		android:layout_height="wrap_content"
-		android:src="@drawable/ic_email_attachment"
-		android:layout_marginLeft="1dip"
-		android:layout_centerVertical="true" />
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="fill_parent"
+    android:layout_height="54dip"
+    android:paddingRight="6dip"
+    android:paddingTop="6dip"
+    android:paddingBottom="6dip">
+
+    <ImageButton
+        android:id="@+id/attachment_delete"
+        android:src="@drawable/ic_delete"
+        android:layout_alignParentRight="true"
+        android:layout_height="42dip"
+        android:layout_width="42dip" />
+
+    <LinearLayout
+        android:layout_width="1dip"
+        android:layout_height="42dip"
+        android:layout_alignParentLeft="true"
+        android:layout_toLeftOf="@id/attachment_delete"
+        android:layout_marginLeft="6dip"
+        android:layout_marginRight="4dip"
+        android:paddingLeft="36dip"
+        android:gravity="center_vertical"
+        android:background="?attr/messageViewAttachmentBackground"
+        android:orientation="horizontal">
+
+        <TextView
+            android:id="@+id/attachment_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="?android:attr/textColorSecondary"
+            android:singleLine="true"
+            android:ellipsize="start"/>
+
+        <ProgressBar
+            android:id="@+id/progressBar"
+            style="?android:attr/progressBarStyleSmall"
+            android:layout_width="32dp"
+            android:layout_height="fill_parent"
+            android:layout_marginLeft="4dp"/>
+
+    </LinearLayout>
+
+    <ImageView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:src="@drawable/ic_email_attachment"
+        android:layout_marginLeft="1dip"
+        android:layout_centerVertical="true" />
+
 </RelativeLayout>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1147,4 +1147,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="preposition_for_date">on <xliff:g id="date">%s</xliff:g></string>
 
     <string name="mark_all_as_read">Mark all as read</string>
+
+    <string name="loading_attachment">Loading attachment…</string>
 </resources>

--- a/src/com/fsck/k9/activity/K9Activity.java
+++ b/src/com/fsck/k9/activity/K9Activity.java
@@ -3,12 +3,12 @@ package com.fsck.k9.activity;
 import android.os.Bundle;
 import android.view.MotionEvent;
 
-import com.actionbarsherlock.app.SherlockActivity;
+import com.actionbarsherlock.app.SherlockFragmentActivity;
 import com.fsck.k9.activity.K9ActivityCommon.K9ActivityMagic;
 import com.fsck.k9.activity.misc.SwipeGestureDetector.OnSwipeGestureListener;
 
 
-public class K9Activity extends SherlockActivity implements K9ActivityMagic {
+public class K9Activity extends SherlockFragmentActivity implements K9ActivityMagic {
 
     private K9ActivityCommon mBase;
 

--- a/src/com/fsck/k9/activity/loader/AttachmentContentLoader.java
+++ b/src/com/fsck/k9/activity/loader/AttachmentContentLoader.java
@@ -1,0 +1,81 @@
+package com.fsck.k9.activity.loader;
+
+import android.content.Context;
+import android.support.v4.content.AsyncTaskLoader;
+import android.util.Log;
+
+import com.fsck.k9.K9;
+import com.fsck.k9.activity.misc.Attachment;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Loader to fetch the content of an attachment.
+ *
+ * This will copy the data to a temporary file in our app's cache directory.
+ */
+public class AttachmentContentLoader extends AsyncTaskLoader<Attachment> {
+    private static final String FILENAME_PREFIX = "attachment";
+
+    private final Attachment mAttachment;
+
+    public AttachmentContentLoader(Context context, Attachment attachment) {
+        super(context);
+        mAttachment = attachment;
+    }
+
+    @Override
+    protected void onStartLoading() {
+        if (mAttachment.state == Attachment.LoadingState.COMPLETE) {
+            deliverResult(mAttachment);
+        }
+
+        if (takeContentChanged() || mAttachment.state == Attachment.LoadingState.METADATA) {
+            forceLoad();
+        }
+    }
+
+    @Override
+    public Attachment loadInBackground() {
+        Context context = getContext();
+
+        try {
+            File file = File.createTempFile(FILENAME_PREFIX, null, context.getCacheDir());
+            file.deleteOnExit();
+
+            if (K9.DEBUG) {
+                Log.v(K9.LOG_TAG, "Saving attachment to " + file.getAbsolutePath());
+            }
+
+            InputStream in = context.getContentResolver().openInputStream(mAttachment.uri);
+            try {
+                FileOutputStream out = new FileOutputStream(file);
+                try {
+                    IOUtils.copy(in, out);
+                } finally {
+                    out.close();
+                }
+            } finally {
+                in.close();
+            }
+
+            mAttachment.filename = file.getAbsolutePath();
+            mAttachment.state = Attachment.LoadingState.COMPLETE;
+
+            return mAttachment;
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        mAttachment.filename = null;
+        mAttachment.state = Attachment.LoadingState.CANCELLED;
+
+        return mAttachment;
+    }
+}

--- a/src/com/fsck/k9/activity/loader/AttachmentInfoLoader.java
+++ b/src/com/fsck/k9/activity/loader/AttachmentInfoLoader.java
@@ -1,0 +1,100 @@
+package com.fsck.k9.activity.loader;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.database.Cursor;
+import android.net.Uri;
+import android.provider.OpenableColumns;
+import android.support.v4.content.AsyncTaskLoader;
+import android.util.Log;
+
+import com.fsck.k9.K9;
+import com.fsck.k9.activity.misc.Attachment;
+import com.fsck.k9.mail.internet.MimeUtility;
+
+import java.io.File;
+
+/**
+ * Loader to fetch metadata of an attachment.
+ */
+public class AttachmentInfoLoader  extends AsyncTaskLoader<Attachment> {
+    private final Attachment mAttachment;
+
+    public AttachmentInfoLoader(Context context, Attachment attachment) {
+        super(context);
+        mAttachment = attachment;
+    }
+
+    @Override
+    protected void onStartLoading() {
+        if (mAttachment.state == Attachment.LoadingState.METADATA) {
+            deliverResult(mAttachment);
+        }
+
+        if (takeContentChanged() || mAttachment.state == Attachment.LoadingState.URI_ONLY) {
+            forceLoad();
+        }
+    }
+
+    @Override
+    public Attachment loadInBackground() {
+        Uri uri = mAttachment.uri;
+        String contentType = mAttachment.contentType;
+
+        long size = -1;
+        String name = null;
+
+        ContentResolver contentResolver = getContext().getContentResolver();
+
+        Cursor metadataCursor = contentResolver.query(
+                uri,
+                new String[] { OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE },
+                null,
+                null,
+                null);
+
+        if (metadataCursor != null) {
+            try {
+                if (metadataCursor.moveToFirst()) {
+                    name = metadataCursor.getString(0);
+                    size = metadataCursor.getInt(1);
+                }
+            } finally {
+                metadataCursor.close();
+            }
+        }
+
+        if (name == null) {
+            name = uri.getLastPathSegment();
+        }
+
+        String usableContentType = contentType;
+        if ((usableContentType == null) || (usableContentType.indexOf('*') != -1)) {
+            usableContentType = contentResolver.getType(uri);
+        }
+        if (usableContentType == null) {
+            usableContentType = MimeUtility.getMimeTypeByExtension(name);
+        }
+
+        if (size <= 0) {
+            String uriString = uri.toString();
+            if (uriString.startsWith("file://")) {
+                Log.v(K9.LOG_TAG, uriString.substring("file://".length()));
+                File f = new File(uriString.substring("file://".length()));
+                size = f.length();
+            } else {
+                Log.v(K9.LOG_TAG, "Not a file: " + uriString);
+            }
+        } else {
+            Log.v(K9.LOG_TAG, "old attachment.size: " + size);
+        }
+        Log.v(K9.LOG_TAG, "new attachment.size: " + size);
+
+        mAttachment.contentType = usableContentType;
+        mAttachment.name = name;
+        mAttachment.size = size;
+        mAttachment.state = Attachment.LoadingState.METADATA;
+
+        return mAttachment;
+    }
+}

--- a/src/com/fsck/k9/activity/misc/Attachment.java
+++ b/src/com/fsck/k9/activity/misc/Attachment.java
@@ -1,0 +1,129 @@
+package com.fsck.k9.activity.misc;
+
+import android.net.Uri;
+import android.os.Parcel;
+import android.os.Parcelable;
+
+/**
+ * Container class for information about an attachment.
+ *
+ * This is used by {@link com.fsck.k9.activity.MessageCompose} to fetch and manage attachments.
+ */
+public class Attachment implements Parcelable {
+    /**
+     * The URI pointing to the source of the attachment.
+     *
+     * In most cases this will be a {@code content://}-URI.
+     */
+    public Uri uri;
+
+    /**
+     * The current loading state.
+     */
+    public LoadingState state;
+
+    /**
+     * The ID of the loader that is used to load the metadata or contents.
+     */
+    public int loaderId;
+
+    /**
+     * The content type of the attachment.
+     *
+     * Only valid when {@link #state} is {@link LoadingState#METADATA} or
+     * {@link LoadingState#COMPLETE}.
+     */
+    public String contentType;
+
+    /**
+     * The (file)name of the attachment.
+     *
+     * Only valid when {@link #state} is {@link LoadingState#METADATA} or
+     * {@link LoadingState#COMPLETE}.
+     */
+    public String name;
+
+    /**
+     * The size of the attachment.
+     *
+     * Only valid when {@link #state} is {@link LoadingState#METADATA} or
+     * {@link LoadingState#COMPLETE}.
+     */
+    public long size;
+
+    /**
+     * The name of the temporary file containing the local copy of the attachment.
+     *
+     * Only valid when {@link #state} is {@link LoadingState#COMPLETE}.
+     */
+    public String filename;
+
+
+    public Attachment() {}
+
+    public static enum LoadingState {
+        /**
+         * The only thing we know about this attachment is {@link #uri}.
+         */
+        URI_ONLY,
+
+        /**
+         * The metadata of this attachment have been loaded.
+         *
+         * {@link #contentType}, {@link #name}, and {@link #size} should contain usable values.
+         */
+        METADATA,
+
+        /**
+         * The contents of the attachments have been copied to the temporary file {@link #filename}.
+         */
+        COMPLETE,
+
+        /**
+         * Something went wrong while trying to fetch the attachment's contents.
+         */
+        CANCELLED
+    }
+
+
+    // === Parcelable ===
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeParcelable(uri, flags);
+        dest.writeSerializable(state);
+        dest.writeInt(loaderId);
+        dest.writeString(contentType);
+        dest.writeSerializable(name);
+        dest.writeLong(size);
+        dest.writeString(filename);
+    }
+
+    public static final Parcelable.Creator<Attachment> CREATOR =
+            new Parcelable.Creator<Attachment>() {
+        @Override
+        public Attachment createFromParcel(Parcel in) {
+            return new Attachment(in);
+        }
+
+        @Override
+        public Attachment[] newArray(int size) {
+            return new Attachment[size];
+        }
+    };
+
+    public Attachment(Parcel in) {
+        uri = in.readParcelable(Uri.class.getClassLoader());
+        state = (LoadingState) in.readSerializable();
+        loaderId = in.readInt();
+        contentType = in.readString();
+        name = in.readString();
+        size = in.readLong();
+        filename = in.readString();
+    }
+}


### PR DESCRIPTION
Android allows other apps to access protected content of an app without requesting the
necessary permission when the app returns an Intent with FLAG_GRANT_READ_URI_PERMISSION.
This regularly happens as a result of ACTION_PICK, i.e. what we use to pick content to be
attached to a message. Accessing that content only works while the receiving activity is
running. Afterwards accessing the content throws a SecurityException because of the missing
permission.
This commit changes K-9 Mail's behavior to copy the content to a temporary file in K-9's
cache directory while the activity is still running.

Fixes issue 4847, 5821

This also fixes bugs related to the fact that K-9 Mail didn't save a copy of attached content
in the message database.

Fixes issue 1187, 3330, 4930
## 

What's missing; comments/code welcome:
- A way to prevent the user from sending the message while one or more attachments are still being copied
- A way to prevent the user from closing the activity while one or more attachments are still being copied (only if a draft needs to be saved; otherwise we don't care)
- Remove temporary files...
  - when discarding the message
  - after saving as draft
  - after sending the message

Optimizations that would be useful:
- Don't copy the contents of attachments that are already in the message database to a temporary file, e.g. when opening a draft for editing or forwading a message
