### PR TITLE
Add SSL required for provider gmx.de (Issue 5876)

### DIFF
--- a/res/xml/providers.xml
+++ b/res/xml/providers.xml
@@ -224,8 +224,8 @@
         <outgoing uri="smtp+ssl://mx.freenet.de" username="$email" />
     </provider>
     <provider id="gmx" label="GMX" domain="gmx.de">
-        <incoming uri="pop3://pop.gmx.net" username="$email" />
-        <outgoing uri="smtp://mail.gmx.net" username="$email" />
+        <incoming uri="pop3+ssl+://pop.gmx.net" username="$email" />
+        <outgoing uri="smtp+ssl+://mail.gmx.net" username="$email" />
     </provider>
     <provider id="T-Online" label="T-Online" domain="t-online.de">
         <incoming uri="pop3://popmail.t-online.de" username="$email" />


### PR DESCRIPTION
Acountsetup: Add SSL required for provider gmx.de (Issue 5876)
http://code.google.com/p/k9mail/issues/detail?id=5876
