### PR TITLE
german translation: use "neu erstellen" instead of "wiederherstellen"

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -454,7 +454,7 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
 
     <string name="compact_action">Komprimieren</string>
     <string name="clear_action">Alle Daten löschen (Vorsicht!)</string>
-    <string name="recreate_action">Daten wiederherstellen (Letzter Ausweg!)</string>
+    <string name="recreate_action">Daten neu erstellen (Letzter Ausweg!)</string>
 
     <string name="account_setup_options_mail_check_frequency_label">E-Mail-Abfrage</string>
     <!-- Frequency also used in account_settings_* -->
@@ -752,7 +752,7 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
 
     <string name="account_delete_dlg_title">Entfernen</string>
 
-    <string name="account_recreate_dlg_title">Konto wiederherstellen</string>
+    <string name="account_recreate_dlg_title">Konto neu erstellen</string>
 
     <string name="account_clear_dlg_title">Nachrichten löschen</string>
 


### PR DESCRIPTION
"wiederherstellen" actually means "to restore", which does not
apply here, and makes people think these options are some sort of
backup/restore operation.

use the proper translation of "re-create" -> "neu erstellen" instead.
