### PR TITLE
Replaced animation of Refresh-Icon in Actionbar at Activity MailList.

### DIFF
--- a/res/anim/rotate_refresh.xml
+++ b/res/anim/rotate_refresh.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<rotate xmlns:android="http://schemas.android.com/apk/res/android"
+    android:duration="600"
+    android:fromDegrees="0"
+    android:interpolator="@android:anim/linear_interpolator"
+    android:pivotX="50%"
+    android:pivotY="50%"
+    android:repeatCount="infinite"
+    android:toDegrees="360" />

--- a/res/layout/actionbar_indeterminate_progress_imageview.xml
+++ b/res/layout/actionbar_indeterminate_progress_imageview.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ImageView xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Widget.Sherlock.ActionButton"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:src="?attr/iconActionRefresh" />

--- a/src/com/fsck/k9/activity/MessageList.java
+++ b/src/com/fsck/k9/activity/MessageList.java
@@ -19,6 +19,7 @@ import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.animation.Animation;
 import android.view.animation.AnimationUtils;
 import android.widget.ProgressBar;
 import android.widget.TextView;
@@ -167,6 +168,8 @@ public class MessageList extends K9FragmentActivity implements MessageListFragme
 
     private ProgressBar mActionBarProgress;
     private MenuItem mMenuButtonCheckMail;
+    private View mCheckMailRefreshView;
+    private Animation mCheckMailRotation;
     private View mActionButtonIndeterminateProgress;
     private int mLastDirection = (K9.messageViewShowNext()) ? NEXT : PREVIOUS;
 
@@ -534,6 +537,12 @@ public class MessageList extends K9FragmentActivity implements MessageListFragme
         mActionBarProgress = (ProgressBar) customView.findViewById(R.id.actionbar_progress);
         mActionButtonIndeterminateProgress =
                 getLayoutInflater().inflate(R.layout.actionbar_indeterminate_progress_actionview, null);
+        
+        if (android.os.Build.VERSION.SDK_INT>=android.os.Build.VERSION_CODES.HONEYCOMB) {
+	    	mCheckMailRefreshView = getLayoutInflater().inflate(R.layout.actionbar_indeterminate_progress_imageview, null);
+	    	mCheckMailRotation = AnimationUtils.loadAnimation(
+	    			MessageList.this, R.anim.rotate_refresh);    
+        }
 
         mActionBar.setDisplayHomeAsUpEnabled(true);
     }
@@ -927,6 +936,7 @@ public class MessageList extends K9FragmentActivity implements MessageListFragme
         getSupportMenuInflater().inflate(R.menu.message_list_option, menu);
         mMenu = menu;
         mMenuButtonCheckMail= menu.findItem(R.id.check_mail);
+        mMenuButtonCheckMail.setActionView(mCheckMailRefreshView);
         return true;
     }
 
@@ -1372,10 +1382,21 @@ public class MessageList extends K9FragmentActivity implements MessageListFragme
         if (mMenuButtonCheckMail != null && mMenuButtonCheckMail.isVisible()) {
             mActionBarProgress.setVisibility(ProgressBar.GONE);
             if (enable) {
-                mMenuButtonCheckMail
-                        .setActionView(mActionButtonIndeterminateProgress);
+            	if (mCheckMailRefreshView != null)  {
+            		mCheckMailRefreshView.startAnimation(mCheckMailRotation);
+            	}
+            	else {
+            		mMenuButtonCheckMail
+            			.setActionView(mActionButtonIndeterminateProgress);
+            	}
             } else {
-                mMenuButtonCheckMail.setActionView(null);
+            	if (mCheckMailRefreshView != null)  {
+            		mCheckMailRefreshView.clearAnimation();
+            		mCheckMailRefreshView.setRotation(0);
+            	}
+            	else {
+            		mMenuButtonCheckMail.setActionView(null);
+            	}
             }
         } else {
             if (mMenuButtonCheckMail != null)


### PR DESCRIPTION
With this commit, the refresh-icon at the mail list will not be replaced with another spinning Icon (that looks totally different), it will now just start rotating.

It has no effect on Android versions below HoneyComb. I don't think this is a big deal, because now the Animations are also different.

If this Commit gets pulled, I will also make this change at the other activities like at the Folders list.
