### PR TITLE
Add SEEN to list of flags when deleting a message.

### DIFF
--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -1243,7 +1243,7 @@ public class ImapStore extends Store {
                 return;
 
             if (trashFolderName == null || getName().equalsIgnoreCase(trashFolderName)) {
-                setFlags(messages, new Flag[] { Flag.DELETED }, true);
+                setFlags(messages, new Flag[] { Flag.DELETED, Flag.SEEN }, true);
             } else {
                 ImapFolder remoteTrashFolder = (ImapFolder)getStore().getFolder(trashFolderName);
                 String remoteTrashName = encodeString(encodeFolderName(remoteTrashFolder.getPrefixedName()));

--- a/tests/project.properties
+++ b/tests/project.properties
@@ -8,4 +8,4 @@
 # project structure.
 
 # Project target.
-target=android-15
+target=android-17


### PR DESCRIPTION
Currently when you delete a message it only sets the DELETED flag, so unless you also always expunge immediately afterwards (not always desirable), any other processes examining the IMAP mailbox will see an unread (albeit deleted) message. Since most MUAs check only the number of unread messages to determine whether new mail has arrived, and not whether those new messages also were deleted, they will report that there is new mail in the mailbox even after you deleted it with K-9 Mail.

This patch sets the SEEN flag when you delete the message, solving this problem.
