### PR TITLE
Use TrustedSocketFactory for STARTTLS.

### DIFF
--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -2504,8 +2504,8 @@ public class ImapStore extends Store {
                         sslContext.init(null, new TrustManager[] {
                                             TrustManagerFactory.get(mSettings.getHost(), secure)
                                         }, new SecureRandom());
-                        mSocket = sslContext.getSocketFactory().createSocket(mSocket, mSettings.getHost(), mSettings.getPort(),
-                                  true);
+                        mSocket = TrustedSocketFactory.createSocket(sslContext, mSocket,
+                                mSettings.getHost(), mSettings.getPort(), true);
                         mSocket.setSoTimeout(Store.SOCKET_READ_TIMEOUT);
                         mIn = new PeekableInputStream(new BufferedInputStream(mSocket
                                                       .getInputStream(), 1024));

--- a/src/com/fsck/k9/mail/store/Pop3Store.java
+++ b/src/com/fsck/k9/mail/store/Pop3Store.java
@@ -359,8 +359,8 @@ public class Pop3Store extends Store {
                         sslContext.init(null, new TrustManager[] {
                                             TrustManagerFactory.get(mHost, secure)
                                         }, new SecureRandom());
-                        mSocket = sslContext.getSocketFactory().createSocket(mSocket, mHost, mPort,
-                                  true);
+                        mSocket = TrustedSocketFactory.createSocket(sslContext, mSocket, mHost,
+                                mPort, true);
                         mSocket.setSoTimeout(Store.SOCKET_READ_TIMEOUT);
                         mIn = new BufferedInputStream(mSocket.getInputStream(), 1024);
                         mOut = new BufferedOutputStream(mSocket.getOutputStream(), 512);

--- a/src/com/fsck/k9/mail/store/TrustedSocketFactory.java
+++ b/src/com/fsck/k9/mail/store/TrustedSocketFactory.java
@@ -85,6 +85,14 @@ public class TrustedSocketFactory {
         return socket;
     }
 
+    public static Socket createSocket(SSLContext sslContext, Socket s, String host, int port,
+            boolean autoClose) throws IOException {
+        SSLSocket socket = (SSLSocket) sslContext.getSocketFactory().createSocket(s, host, port, autoClose);
+        hardenSocket(socket);
+
+        return socket;
+    }
+
     private static void hardenSocket(SSLSocket sock) {
         if (ENABLED_CIPHERS != null) {
             sock.setEnabledCipherSuites(ENABLED_CIPHERS);

--- a/src/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/src/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -304,8 +304,8 @@ public class SmtpTransport extends Transport {
                     sslContext.init(null, new TrustManager[] {
                                         TrustManagerFactory.get(mHost, secure)
                                     }, new SecureRandom());
-                    mSocket = sslContext.getSocketFactory().createSocket(mSocket, mHost, mPort,
-                              true);
+                    mSocket = TrustedSocketFactory.createSocket(sslContext, mSocket, mHost,
+                              mPort, true);
                     mIn = new PeekableInputStream(new BufferedInputStream(mSocket.getInputStream(),
                                                   1024));
                     mOut = mSocket.getOutputStream();


### PR DESCRIPTION
The new TrustedSocketFactory was only being used for tunnelled connections, not STARTTLS. This adds STARTTLS support, so now TLS 1.2 can be used there. I have tested IMAP and SMTP and they work just fine, but POP3 is only compile-tested (I don't use it).
