### PR TITLE
Should disable COMPOSE menu item

### DIFF
--- a/src/com/fsck/k9/activity/MessageList.java
+++ b/src/com/fsck/k9/activity/MessageList.java
@@ -973,6 +973,7 @@ public class MessageList extends K9FragmentActivity implements MessageListFragme
             menu.findItem(R.id.previous_message).setVisible(false);
             menu.findItem(R.id.single_message_options).setVisible(false);
             menu.findItem(R.id.delete).setVisible(false);
+            menu.findItem(R.id.compose).setVisible(false);
             menu.findItem(R.id.archive).setVisible(false);
             menu.findItem(R.id.move).setVisible(false);
             menu.findItem(R.id.copy).setVisible(false);
@@ -1091,6 +1092,7 @@ public class MessageList extends K9FragmentActivity implements MessageListFragme
         } else {
             menu.findItem(R.id.set_sort).setVisible(true);
             menu.findItem(R.id.select_all).setVisible(true);
+            menu.findItem(R.id.compose).setVisible(true);
             menu.findItem(R.id.mark_all_as_read).setVisible(
                     mMessageListFragment.isMarkAllAsReadSupported());
 


### PR DESCRIPTION
When message viewing and tap the Next icon, menu icons (previous, next, delete and replys) disappears for an instant.
Then a compose icon remains, then tap it accidentally.

Note: The "Download complete message" button appears bottom of message and tap the Next icon,
the download button goes down below. It is difficult for me to fix it.
