### PR TITLE
Make IMAP autoconfig recognize "Draft" as drafts folder

### DIFF
--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -685,7 +685,7 @@ public class ImapStore extends Store {
                 ImapList attributes = response.getList(1);
                 for (int i = 0, count = attributes.size(); i < count; i++) {
                     String attribute = attributes.getString(i);
-                    if (attribute.equals("\\Drafts")) {
+                    if (attribute.equals("\\Drafts") || (attribute.equals("\\Draft") && !mAccount.hasDraftsFolder())) {
                         mAccount.setDraftsFolderName(decodedFolderName);
                         if (K9.DEBUG) Log.d(K9.LOG_TAG, "Folder auto-configuration detected draft folder: " + decodedFolderName);
                     } else if (attribute.equals("\\Sent")) {


### PR DESCRIPTION
Yahoo names it "Draft"  instead of the more common "Drafts".
