### PR TITLE
Per-identity sent folders

### DIFF
--- a/res/layout/edit_identity.xml
+++ b/res/layout/edit_identity.xml
@@ -111,12 +111,14 @@
             android:layout_width="fill_parent"
             android:layout_height="fill_parent"
             android:orientation="horizontal">
-            <EditText
+            <TextView
                 android:id="@+id/sent_folder"
                 android:singleLine="false"
                 android:layout_height="wrap_content"
                 android:layout_width="wrap_content"
-                android:hint="@string/edit_identity_sent_folder_hint"/>
+                android:hint="@string/edit_identity_sent_folder_hint"
+                android:editable="false"
+                android:enabled="false"/>
             <Button
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"

--- a/res/layout/edit_identity.xml
+++ b/res/layout/edit_identity.xml
@@ -99,5 +99,29 @@
 	            android:layout_width="fill_parent" 
 	            android:hint="@string/edit_identity_signature_hint"/>
     	</LinearLayout>
+        <TextView
+            android:text="@string/edit_identity_sent_folder_label"
+            android:layout_height="wrap_content"
+            android:layout_width="fill_parent"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            android:textColor="?android:attr/textColorPrimary"
+            />
+        <LinearLayout
+            android:id="@+id/sent_folder_layout"
+            android:layout_width="fill_parent"
+            android:layout_height="fill_parent"
+            android:orientation="horizontal">
+            <EditText
+                android:id="@+id/sent_folder"
+                android:singleLine="false"
+                android:layout_height="wrap_content"
+                android:layout_width="wrap_content"
+                android:hint="@string/edit_identity_sent_folder_hint"/>
+            <Button
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/edit_identity_choose_sent_folder_button"
+                android:id="@+id/choose_folder"/>
+        </LinearLayout>
     </LinearLayout>
 </ScrollView>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -717,6 +717,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="edit_identity_reply_to_hint">(Optional)</string>
     <string name="edit_identity_signature_label">Signature</string>
     <string name="edit_identity_signature_hint">(Optional)</string>
+    <string name="edit_identity_sent_folder_label">Sent folder</string>
+    <string name="edit_identity_sent_folder_hint">Account Default</string>
+    <string name="edit_identity_choose_sent_folder_button">Choose folder...</string>
 
     <string name="account_settings_signature_use_label">Use Signature</string>
     <string name="account_settings_signature_label">Signature</string>

--- a/src/com/fsck/k9/Account.java
+++ b/src/com/fsck/k9/Account.java
@@ -93,6 +93,7 @@ public class Account implements BaseAccount {
     public static final String IDENTITY_NAME_KEY = "name";
     public static final String IDENTITY_EMAIL_KEY = "email";
     public static final String IDENTITY_DESCRIPTION_KEY = "description";
+    public static final String IDENTITY_SENT_FOLDER_KEY = "sentFolder";
 
     /*
      * http://developer.android.com/design/style/color.html
@@ -1362,6 +1363,7 @@ public class Account implements BaseAccount {
             String signature = prefs.getString(mUuid + ".signature." + ident, null);
             String description = prefs.getString(mUuid + "." + IDENTITY_DESCRIPTION_KEY + "." + ident, null);
             final String replyTo = prefs.getString(mUuid + ".replyTo." + ident, null);
+            final String sentFolder = prefs.getString(mUuid + "." + IDENTITY_SENT_FOLDER_KEY + "." + ident, null);
             if (email != null) {
                 Identity identity = new Identity();
                 identity.setName(name);
@@ -1370,6 +1372,7 @@ public class Account implements BaseAccount {
                 identity.setSignature(signature);
                 identity.setDescription(description);
                 identity.setReplyTo(replyTo);
+                identity.setSentFolder(sentFolder);
                 newIdentities.add(identity);
                 gotOne = true;
             }
@@ -1406,6 +1409,8 @@ public class Account implements BaseAccount {
                 editor.remove(mUuid + ".signature." + ident);
                 editor.remove(mUuid + "." + IDENTITY_DESCRIPTION_KEY + "." + ident);
                 editor.remove(mUuid + ".replyTo." + ident);
+                editor.remove(mUuid + "." + IDENTITY_SENT_FOLDER_KEY + "." + ident);
+
                 gotOne = true;
             }
             ident++;
@@ -1423,6 +1428,7 @@ public class Account implements BaseAccount {
             editor.putString(mUuid + ".signature." + ident, identity.getSignature());
             editor.putString(mUuid + "." + IDENTITY_DESCRIPTION_KEY + "." + ident, identity.getDescription());
             editor.putString(mUuid + ".replyTo." + ident, identity.getReplyTo());
+            editor.putString(mUuid + "." + IDENTITY_SENT_FOLDER_KEY + "." + ident, identity.getSentFolder());
             ident++;
         }
     }

--- a/src/com/fsck/k9/Identity.java
+++ b/src/com/fsck/k9/Identity.java
@@ -60,9 +60,13 @@ public class Identity implements Serializable {
         this.replyTo = replyTo;
     }
 
-    public synchronized String getSentFolder() { return sentFolder; }
+    public synchronized String getSentFolder() {
+        return sentFolder;
+    }
 
-    public synchronized void setSentFolder(String sentFolder) { this.sentFolder = sentFolder; }
+    public synchronized void setSentFolder(String sentFolder) {
+        this.sentFolder = sentFolder;
+    }
 
     @Override
     public synchronized String toString() {

--- a/src/com/fsck/k9/Identity.java
+++ b/src/com/fsck/k9/Identity.java
@@ -10,6 +10,7 @@ public class Identity implements Serializable {
     private String mSignature;
     private boolean mSignatureUse;
     private String replyTo;
+    private String sentFolder;
 
     public synchronized String getName() {
         return mName;
@@ -59,8 +60,12 @@ public class Identity implements Serializable {
         this.replyTo = replyTo;
     }
 
+    public synchronized String getSentFolder() { return sentFolder; }
+
+    public synchronized void setSentFolder(String sentFolder) { this.sentFolder = sentFolder; }
+
     @Override
     public synchronized String toString() {
-        return "Account.Identity(description=" + mDescription + ", name=" + mName + ", email=" + mEmail + ", replyTo=" + replyTo + ", signature=" + mSignature;
+        return "Account.Identity(description=" + mDescription + ", name=" + mName + ", email=" + mEmail + ", replyTo=" + replyTo + ", signature=" + mSignature + ", sentFolder=" + sentFolder;
     }
 }

--- a/src/com/fsck/k9/K9.java
+++ b/src/com/fsck/k9/K9.java
@@ -323,6 +323,8 @@ public class K9 extends Application {
 
     public static final String IDENTITY_HEADER = "X-K9mail-Identity";
 
+    public static final String SENT_FOLDER_HEADER = "X-K9mail-Sent-Folder";
+
     /**
      * Specifies how many messages will be shown in a folder by default. This number is set
      * on each new folder and can be incremented with "Load more messages..." by the

--- a/src/com/fsck/k9/activity/EditIdentity.java
+++ b/src/com/fsck/k9/activity/EditIdentity.java
@@ -100,7 +100,6 @@ public class EditIdentity extends K9Activity {
         }
 
         mSentFolderButtonView = (Button) findViewById(R.id.choose_folder);
-        mSentFolderView = (TextView) findViewById(R.id.sent_folder);
         mSentFolderButtonView.setOnClickListener(new View.OnClickListener()
         {
             @Override
@@ -113,6 +112,9 @@ public class EditIdentity extends K9Activity {
                 startActivityForResult(chooseIntent, ACTIVITY_CHOOSE_FOLDER);
             }
         });
+
+        mSentFolderView = (TextView) findViewById(R.id.sent_folder);
+        mSentFolderView.setText(mIdentity.getSentFolder());
     }
 
     private void saveIdentity() {
@@ -123,6 +125,7 @@ public class EditIdentity extends K9Activity {
         mIdentity.setName(mNameView.getText().toString());
         mIdentity.setSignatureUse(mSignatureUse.isChecked());
         mIdentity.setSignature(mSignatureView.getText().toString());
+        mIdentity.setSentFolder(mSentFolderView.getText().toString());
 
         if (mReplyTo.getText().length() == 0) {
             mIdentity.setReplyTo(null);

--- a/src/com/fsck/k9/activity/EditIdentity.java
+++ b/src/com/fsck/k9/activity/EditIdentity.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.activity;
 
+import android.content.Intent;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
@@ -7,8 +8,11 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.LinearLayout;
+import android.widget.TextView;
+
 import com.fsck.k9.Account;
 import com.fsck.k9.Identity;
+import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
 import java.util.List;
@@ -18,6 +22,8 @@ public class EditIdentity extends K9Activity {
     public static final String EXTRA_IDENTITY = "com.fsck.k9.EditIdentity_identity";
     public static final String EXTRA_IDENTITY_INDEX = "com.fsck.k9.EditIdentity_identity_index";
     public static final String EXTRA_ACCOUNT = "com.fsck.k9.EditIdentity_account";
+
+    private static final int ACTIVITY_CHOOSE_FOLDER = 1;
 
     private Account mAccount;
     private Identity mIdentity;
@@ -31,7 +37,7 @@ public class EditIdentity extends K9Activity {
     private EditText mNameView;
     private EditText mReplyTo;
     private Button mSentFolderButtonView;
-    private EditText mSentFolderView;
+    private TextView mSentFolderView;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -94,7 +100,19 @@ public class EditIdentity extends K9Activity {
         }
 
         mSentFolderButtonView = (Button) findViewById(R.id.choose_folder);
-        mSentFolderView = (EditText) findViewById(R.id.sent_folder);
+        mSentFolderView = (TextView) findViewById(R.id.sent_folder);
+        mSentFolderButtonView.setOnClickListener(new View.OnClickListener()
+        {
+            @Override
+            public void onClick(View view)
+            {
+                Intent chooseIntent = new Intent(EditIdentity.this, ChooseFolder.class);
+                chooseIntent.putExtra(ChooseFolder.EXTRA_ACCOUNT, mAccount.getUuid());
+                chooseIntent.putExtra(ChooseFolder.EXTRA_SHOW_CURRENT, "yes");
+                chooseIntent.putExtra(ChooseFolder.EXTRA_SHOW_FOLDER_NONE, "yes");
+                startActivityForResult(chooseIntent, ACTIVITY_CHOOSE_FOLDER);
+            }
+        });
     }
 
     private void saveIdentity() {
@@ -135,5 +153,23 @@ public class EditIdentity extends K9Activity {
     public void onSaveInstanceState(Bundle outState) {
         super.onSaveInstanceState(outState);
         outState.putSerializable(EXTRA_IDENTITY, mIdentity);
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        if (resultCode == RESULT_OK)
+        {
+            switch (requestCode)
+            {
+                case ACTIVITY_CHOOSE_FOLDER:
+                    String folder = data.getStringExtra(ChooseFolder.EXTRA_NEW_FOLDER);
+                    if (folder.equals(K9.FOLDER_NONE))
+                        folder = null;
+                    mSentFolderView.setText(folder);
+                    break;
+            }
+        }
+        super.onActivityResult(requestCode, resultCode, data);
     }
 }

--- a/src/com/fsck/k9/activity/EditIdentity.java
+++ b/src/com/fsck/k9/activity/EditIdentity.java
@@ -2,6 +2,7 @@ package com.fsck.k9.activity;
 
 import android.os.Bundle;
 import android.view.View;
+import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.EditText;
@@ -29,6 +30,8 @@ public class EditIdentity extends K9Activity {
 //  private EditText mAlwaysBccView;
     private EditText mNameView;
     private EditText mReplyTo;
+    private Button mSentFolderButtonView;
+    private EditText mSentFolderView;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -65,6 +68,7 @@ public class EditIdentity extends K9Activity {
         mReplyTo = (EditText) findViewById(R.id.reply_to);
         mReplyTo.setText(mIdentity.getReplyTo());
 
+
 //      mAccountAlwaysBcc = (EditText)findViewById(R.id.bcc);
 //      mAccountAlwaysBcc.setText(mIdentity.getAlwaysBcc());
 
@@ -88,6 +92,9 @@ public class EditIdentity extends K9Activity {
         } else {
             mSignatureLayout.setVisibility(View.GONE);
         }
+
+        mSentFolderButtonView = (Button) findViewById(R.id.choose_folder);
+        mSentFolderView = (EditText) findViewById(R.id.sent_folder);
     }
 
     private void saveIdentity() {

--- a/src/com/fsck/k9/activity/EditIdentity.java
+++ b/src/com/fsck/k9/activity/EditIdentity.java
@@ -100,11 +100,9 @@ public class EditIdentity extends K9Activity {
         }
 
         mSentFolderButtonView = (Button) findViewById(R.id.choose_folder);
-        mSentFolderButtonView.setOnClickListener(new View.OnClickListener()
-        {
+        mSentFolderButtonView.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(View view)
-            {
+            public void onClick(View view) {
                 Intent chooseIntent = new Intent(EditIdentity.this, ChooseFolder.class);
                 chooseIntent.putExtra(ChooseFolder.EXTRA_ACCOUNT, mAccount.getUuid());
                 chooseIntent.putExtra(ChooseFolder.EXTRA_SHOW_CURRENT, "yes");
@@ -159,18 +157,15 @@ public class EditIdentity extends K9Activity {
     }
 
     @Override
-    protected void onActivityResult(int requestCode, int resultCode, Intent data)
-    {
-        if (resultCode == RESULT_OK)
-        {
-            switch (requestCode)
-            {
-                case ACTIVITY_CHOOSE_FOLDER:
-                    String folder = data.getStringExtra(ChooseFolder.EXTRA_NEW_FOLDER);
-                    if (folder.equals(K9.FOLDER_NONE))
-                        folder = null;
-                    mSentFolderView.setText(folder);
-                    break;
+    protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+        if (resultCode == RESULT_OK) {
+            switch (requestCode) {
+            case ACTIVITY_CHOOSE_FOLDER:
+                String folder = data.getStringExtra(ChooseFolder.EXTRA_NEW_FOLDER);
+                if (folder.equals(K9.FOLDER_NONE))
+                    folder = null;
+                mSentFolderView.setText(folder);
+                break;
             }
         }
         super.onActivityResult(requestCode, resultCode, data);

--- a/src/com/fsck/k9/activity/MessageCompose.java
+++ b/src/com/fsck/k9/activity/MessageCompose.java
@@ -3629,7 +3629,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
              */
             MimeMessage message;
             try {
-                message = createMessage(false);  // isDraft = true
+                message = createMessage(false);  // isDraft = false
             } catch (MessagingException me) {
                 Log.e(K9.LOG_TAG, "Failed to create new message for send or save.", me);
                 throw new RuntimeException("Failed to create a new message for send or save.", me);

--- a/src/com/fsck/k9/activity/MessageCompose.java
+++ b/src/com/fsck/k9/activity/MessageCompose.java
@@ -1511,6 +1511,10 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             message.addHeader(K9.IDENTITY_HEADER, buildIdentityHeader(body, bodyPlain));
         }
 
+        String sentFolder = mIdentity.getSentFolder();
+        if (sentFolder != null && sentFolder.length() > 0)
+            message.addHeader(K9.SENT_FOLDER_HEADER, sentFolder);
+
         return message;
     }
 

--- a/src/com/fsck/k9/activity/MessageCompose.java
+++ b/src/com/fsck/k9/activity/MessageCompose.java
@@ -2908,6 +2908,11 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         Identity newIdentity = new Identity();
+        if (message.getHeader(K9.SENT_FOLDER_HEADER) != null && message.getHeader(K9.SENT_FOLDER_HEADER).length > 0 && message.getHeader(K9.SENT_FOLDER_HEADER)[0] != null) {
+            newIdentity.setSentFolder(message.getHeader(K9.SENT_FOLDER_HEADER)[0]);
+        }
+
+
         if (k9identity.containsKey(IdentityField.SIGNATURE)) {
             newIdentity.setSignatureUse(true);
             newIdentity.setSignature(k9identity.get(IdentityField.SIGNATURE));

--- a/src/com/fsck/k9/controller/MessagingController.java
+++ b/src/com/fsck/k9/controller/MessagingController.java
@@ -3557,8 +3557,7 @@ public class MessagingController implements Runnable {
 
                         String identitySentFolder = null;
                         String[] identitySentFolderArray = message.getHeader(K9.SENT_FOLDER_HEADER);
-                        if (identitySentFolderArray != null && identitySentFolderArray.length > 0)
-                        {
+                        if (identitySentFolderArray != null && identitySentFolderArray.length > 0) {
                             if (identitySentFolderArray.length > 1)
                                 throw new RuntimeException("Found more than one " + K9.SENT_FOLDER_HEADER + " header - coding error");
                             identitySentFolder = identitySentFolderArray[0];

--- a/src/com/fsck/k9/controller/MessagingController.java
+++ b/src/com/fsck/k9/controller/MessagingController.java
@@ -3564,21 +3564,37 @@ public class MessagingController implements Runnable {
                         message.setFlag(Flag.SEEN, true);
                         progress++;
                         for (MessagingListener l : getListeners()) {
+                            // MJH: I can't figure out if it matters that this sent folder name may be wrong if a per-identity
+                            // sent folder is being used. We could fix this case, but I'm not sure how we'd fix the initial call
+                            // at the top of this loop, and I'm not sure if we're supposed to use the same folder name on each
+                            // call around this loop.
                             l.synchronizeMailboxProgress(account, account.getSentFolderName(), progress, todo);
                         }
-                        if (!account.hasSentFolder()) {
+
+                        String identitySentFolder = null;
+                        String[] identitySentFolderArray = message.getHeader(K9.SENT_FOLDER_HEADER);
+                        if (identitySentFolderArray != null && identitySentFolderArray.length > 0)
+                        {
+                            if (identitySentFolderArray.length > 1)
+                                throw new RuntimeException("Found more than one " + K9.SENT_FOLDER_HEADER + " header - coding error");
+                            identitySentFolder = identitySentFolderArray[0];
+                        }
+
+                        if (!account.hasSentFolder() && identitySentFolder == null) {
                             if (K9.DEBUG)
-                                Log.i(K9.LOG_TAG, "Account does not have a sent mail folder; deleting sent message");
+                                Log.i(K9.LOG_TAG, "Account or identity does not have a sent mail folder; deleting sent message");
                             message.setFlag(Flag.DELETED, true);
                         } else {
-                            LocalFolder localSentFolder = (LocalFolder) localStore.getFolder(account.getSentFolderName());
+                            String localSentFolderName = identitySentFolder != null ? identitySentFolder : account.getSentFolderName();
+                            LocalFolder localSentFolder = (LocalFolder) localStore.getFolder(localSentFolderName);
+
                             if (K9.DEBUG)
-                                Log.i(K9.LOG_TAG, "Moving sent message to folder '" + account.getSentFolderName() + "' (" + localSentFolder.getId() + ") ");
+                                Log.i(K9.LOG_TAG, "Moving sent message to folder '" + localSentFolderName + "' (" + localSentFolder.getId() + ") ");
 
                             localFolder.moveMessages(new Message[] { message }, localSentFolder);
 
                             if (K9.DEBUG)
-                                Log.i(K9.LOG_TAG, "Moved sent message to folder '" + account.getSentFolderName() + "' (" + localSentFolder.getId() + ") ");
+                                Log.i(K9.LOG_TAG, "Moved sent message to folder '" + localSentFolderName + "' (" + localSentFolder.getId() + ") ");
 
                             PendingCommand command = new PendingCommand();
                             command.command = PENDING_COMMAND_APPEND;


### PR DESCRIPTION
Hi,

[Note: not quite ready for merge yet, but I would be interested in feedback]

This is a patch I've been working on to allow a different Sent folder to be used for each account identity. Is this any use to the project?

By default, messages are saved to the account's default Sent folder, but this can be overridden for each individual identity by picking a folder in the Identity settings.

A couple of things I wasn't sure about:

1) It might be nicer to use the dialog based folder picker as used in the existing Folder settings screen, rather than the ChooseFolder full screen activity. However, this would involve factoring out the dialog code, so I chose this solution for the initial version as it was much easier as the ChooseFolder activity was already easily reusable.

2) I've annotated a few parts of the code with "MJH" where I wasn't sure if I was doing the right thing or not.

3) I wasn't sure if I needed special code to make sure that the folder actually exists before writing a message to it.

Please let me know if this is useful, and if so if you are happy with the general approach. I'm happy to tweak it as necessary for this to be included upstream.

Thanks!