### PR TITLE
Fix issue 6064: Inline images don't display on KitKat (v. 2)

### DIFF
--- a/src/com/fsck/k9/view/MessageWebView.java
+++ b/src/com/fsck/k9/view/MessageWebView.java
@@ -56,13 +56,14 @@ public class MessageWebView extends RigidWebView {
      * @param shouldBlockNetworkData True if network data should be blocked, false to allow network data.
      */
     public void blockNetworkData(final boolean shouldBlockNetworkData) {
-        WebSettings webSettings = getSettings();
-
-        // Block network loads.
-        webSettings.setBlockNetworkLoads(shouldBlockNetworkData);
-
-        // Block network images.
-        webSettings.setBlockNetworkImage(shouldBlockNetworkData);
+        /*
+         * Block network loads.
+         *
+         * Images with content: URIs will not be blocked, nor
+         * will network images that are already in the WebView cache.
+         *
+         */
+        getSettings().setBlockNetworkLoads(shouldBlockNetworkData);
     }
 
 


### PR DESCRIPTION
(New pull request in lieu of #441)

Eliminate the invocation of
WebSettings.setBlockNetworkImage(boolean flag),
thus maintaining the the default setting of "false".

On Android versions prior to KitKat, this setting has no
effect on inline image attachments loaded with content:
URIs.  Such images would load regardless.

With KitKat, this setting does have an effect -- a
setting of "true" will block image attachments loaded
with content: URIs.

By removing this call, K-9 Mail behaves the same on KitKat
as on earlier Android versions, and the behavior on earlier
versions is unchanged.
