### PR TITLE
Fix sendCommand line splitup

### DIFF
--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -2779,10 +2779,8 @@ public class ImapStore extends Store {
             try {
                 open();
                 String tag = Integer.toString(mNextCommandTag++);
-                String commandToSend = tag + " " + command;
+                String commandToSend = tag + " " + command + "\r\n";
                 mOut.write(commandToSend.getBytes());
-                mOut.write('\r');
-                mOut.write('\n');
                 mOut.flush();
 
                 if (K9.DEBUG && K9.DEBUG_PROTOCOL_IMAP) {


### PR DESCRIPTION
When sending a command it would be sent like this:

```
PKG1: 1 STARTTLS
PKG2: \r\n
```

Some mailservers don't accept commands across packets - they expect:

```
PKG1: 1 STARTTLS\r\n
```

I verified that using tcpdump:  http://hastebin.com/tavamepodi
