### PR TITLE
Should match the buildToolsVersion with other build.gradle

### DIFF
--- a/plugins/openpgp-api-library/build.gradle
+++ b/plugins/openpgp-api-library/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'android-library'
 
 android {
     compileSdkVersion 17
-    buildToolsVersion '19.0.1'
+    buildToolsVersion '19.0.3'
     
     // NOTE: We are using the old folder structure to also support Eclipse
     sourceSets {


### PR DESCRIPTION
I've got below error. I have installed recent android sdk build tools 19.0.3 only.

```
> gradle tasks
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':tasks'.
> Could not determine the dependencies of task ':plugins:openpgp-api-library:compileReleaseJava'.
```
