### PR TITLE
Changed for Android Gradle plugin 0.9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ android {
       assets.srcDirs = ['assets']
     }
 
-    instrumentTest {
+    androidTest {
       manifest.srcFile 'tests/AndroidManifest.xml'
       java.srcDirs = ['tests/src']
       assets.srcDirs = ['tests/assets']


### PR DESCRIPTION
See the http://tools.android.com/tech-docs/new-build-system/migrating_to_09

However, I'm modifying build.gradle to below for IntelliJ IDEA 13.1.1, because it seems not support 0.9 yet.

build.gradle

```
classpath 'com.android.tools.build:gradle:0.8.+'
...
    instrumentTest {
```
