### PR TITLE
Added feature to allow coerion to plaintext for html messages

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -315,6 +315,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_folderlist_wrap_folder_names_label">Wrap long folder names</string>
     <string name="global_settings_folderlist_wrap_folder_names_summary">Use multiple lines to show long folder names</string>
 
+    <string name="global_settings_messageview_alwaysplain_label">Always use plain-text</string>
+    <string name="global_settings_messageview_alwaysplain_summary">Convert HTML messages to plain-text</string>
     <string name="global_settings_messageview_fixedwidth_label">Fixed-width fonts</string>
     <string name="global_settings_messageview_fixedwidth_summary">Use a fixed-width font when showing plain-text messages</string>
     <string name="global_settings_messageview_autofit_width_label">Auto-fit messages</string>

--- a/res/xml/global_preferences.xml
+++ b/res/xml/global_preferences.xml
@@ -223,6 +223,12 @@
 
             <CheckBoxPreference
                 android:persistent="false"
+                android:key="messageview_always_use_plaintext"
+                android:title="@string/global_settings_messageview_alwaysplain_label"
+                android:summary="@string/global_settings_messageview_alwaysplain_summary" />
+
+            <CheckBoxPreference
+                android:persistent="false"
                 android:key="messageview_fixedwidth_font"
                 android:title="@string/global_settings_messageview_fixedwidth_label"
                 android:summary="@string/global_settings_messageview_fixedwidth_summary" />

--- a/src/com/fsck/k9/K9.java
+++ b/src/com/fsck/k9/K9.java
@@ -244,6 +244,7 @@ public class K9 extends Application {
     private static boolean mChangeContactNameColor = false;
     private static int mContactNameColor = 0xff00008f;
     private static boolean sShowContactPicture = true;
+    private static boolean mMessageViewUsePlainTextOnly = false;
     private static boolean mMessageViewFixedWidthFont = false;
     private static boolean mMessageViewReturnToList = false;
     private static boolean mMessageViewShowNext = false;
@@ -531,6 +532,7 @@ public class K9 extends Application {
         editor.putBoolean("showContactPicture", sShowContactPicture);
         editor.putBoolean("changeRegisteredNameColor", mChangeContactNameColor);
         editor.putInt("registeredNameColor", mContactNameColor);
+        editor.putBoolean("messageViewUsePlainTextOnly", mMessageViewUsePlainTextOnly);
         editor.putBoolean("messageViewFixedWidthFont", mMessageViewFixedWidthFont);
         editor.putBoolean("messageViewReturnToList", mMessageViewReturnToList);
         editor.putBoolean("messageViewShowNext", mMessageViewShowNext);
@@ -741,6 +743,7 @@ public class K9 extends Application {
         sShowContactPicture = sprefs.getBoolean("showContactPicture", true);
         mChangeContactNameColor = sprefs.getBoolean("changeRegisteredNameColor", false);
         mContactNameColor = sprefs.getInt("registeredNameColor", 0xff00008f);
+        mMessageViewUsePlainTextOnly = sprefs.getBoolean("messageViewUsePlainTextOnly", false);
         mMessageViewFixedWidthFont = sprefs.getBoolean("messageViewFixedWidthFont", false);
         mMessageViewReturnToList = sprefs.getBoolean("messageViewReturnToList", false);
         mMessageViewShowNext = sprefs.getBoolean("messageViewShowNext", false);
@@ -1134,6 +1137,14 @@ public class K9 extends Application {
 
     public static void setContactNameColor(int contactNameColor) {
         mContactNameColor = contactNameColor;
+    }
+
+    public static boolean messageViewUsePlainTextOnly() {
+        return mMessageViewUsePlainTextOnly;
+    }
+
+    public static void setMessageViewUsePlainTextOnly(boolean plain) {
+        mMessageViewUsePlainTextOnly = plain;
     }
 
     public static boolean messageViewFixedWidthFont() {

--- a/src/com/fsck/k9/activity/setup/Prefs.java
+++ b/src/com/fsck/k9/activity/setup/Prefs.java
@@ -76,6 +76,7 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_MESSAGELIST_SHOW_CONTACT_PICTURE = "messagelist_show_contact_picture";
     private static final String PREFERENCE_MESSAGELIST_COLORIZE_MISSING_CONTACT_PICTURES =
             "messagelist_colorize_missing_contact_pictures";
+    private static final String PREFERENCE_MESSAGEVIEW_ALWAYSPLAIN= "messageview_always_use_plaintext";
     private static final String PREFERENCE_MESSAGEVIEW_FIXEDWIDTH = "messageview_fixedwidth_font";
     private static final String PREFERENCE_MESSAGEVIEW_VISIBLE_REFILE_ACTIONS = "messageview_visible_refile_actions";
 
@@ -131,6 +132,7 @@ public class Prefs extends K9PreferenceActivity {
     private CheckBoxPreference mChangeContactNameColor;
     private CheckBoxPreference mShowContactPicture;
     private CheckBoxPreference mColorizeMissingContactPictures;
+    private CheckBoxPreference mAlwaysPlain;
     private CheckBoxPreference mFixedWidth;
     private CheckBoxPreference mReturnToList;
     private CheckBoxPreference mShowNext;
@@ -294,6 +296,9 @@ public class Prefs extends K9PreferenceActivity {
                 return false;
             }
         });
+
+        mAlwaysPlain = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGEVIEW_ALWAYSPLAIN);
+        mAlwaysPlain.setChecked(K9.messageViewUsePlainTextOnly());
 
         mFixedWidth = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGEVIEW_FIXEDWIDTH);
         mFixedWidth.setChecked(K9.messageViewFixedWidthFont());
@@ -499,6 +504,7 @@ public class Prefs extends K9PreferenceActivity {
         K9.setUseBackgroundAsUnreadIndicator(mBackgroundAsUnreadIndicator.isChecked());
         K9.setThreadedViewEnabled(mThreadedView.isChecked());
         K9.setChangeContactNameColor(mChangeContactNameColor.isChecked());
+        K9.setMessageViewUsePlainTextOnly(mAlwaysPlain.isChecked());
         K9.setMessageViewFixedWidthFont(mFixedWidth.isChecked());
         K9.setMessageViewReturnToList(mReturnToList.isChecked());
         K9.setMessageViewShowNext(mShowNext.isChecked());

--- a/src/com/fsck/k9/preferences/GlobalSettings.java
+++ b/src/com/fsck/k9/preferences/GlobalSettings.java
@@ -145,6 +145,9 @@ public class GlobalSettings {
         s.put("messageListStars", Settings.versions(
                 new V(1, new BooleanSetting(true))
             ));
+        s.put("messageViewUsePlainTextOnly", Settings.versions(
+                new V(1, new BooleanSetting(false))
+            ));
         s.put("messageViewFixedWidthFont", Settings.versions(
                 new V(1, new BooleanSetting(false))
             ));

--- a/src/com/fsck/k9/preferences/GlobalSettings.java
+++ b/src/com/fsck/k9/preferences/GlobalSettings.java
@@ -146,7 +146,7 @@ public class GlobalSettings {
                 new V(1, new BooleanSetting(true))
             ));
         s.put("messageViewUsePlainTextOnly", Settings.versions(
-                new V(1, new BooleanSetting(false))
+                new V(32, new BooleanSetting(false))
             ));
         s.put("messageViewFixedWidthFont", Settings.versions(
                 new V(1, new BooleanSetting(false))

--- a/src/com/fsck/k9/preferences/Settings.java
+++ b/src/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 31;
+    public static final int VERSION = 32;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,

--- a/src/com/fsck/k9/view/MessageWebView.java
+++ b/src/com/fsck/k9/view/MessageWebView.java
@@ -146,15 +146,14 @@ public class MessageWebView extends RigidWebView {
      * </p>
      *
      * @param text
-     *      The message body to display.  Assumed to be MIME type text/html.
-     *      Now reads pref to assume MIME type to text/plain when requested.
+     *      The message body to display.  
      */
     public void setText(String text) {
      // Include a meta tag so the WebView will not use a fixed viewport width of 980 px
         String content, mime;
 
         if(K9.messageViewUsePlainTextOnly()){ 
-          content = HtmlConverter.htmlToText(text);
+          content = text;
           mime = "text/plain";
         } else {
           content = "<html><head><meta name=\"viewport\" content=\"width=device-width\"/>";

--- a/src/com/fsck/k9/view/MessageWebView.java
+++ b/src/com/fsck/k9/view/MessageWebView.java
@@ -147,19 +147,29 @@ public class MessageWebView extends RigidWebView {
      *
      * @param text
      *      The message body to display.  Assumed to be MIME type text/html.
+     *      Now reads pref to assume MIME type to text/plain when requested.
      */
     public void setText(String text) {
      // Include a meta tag so the WebView will not use a fixed viewport width of 980 px
-        String content = "<html><head><meta name=\"viewport\" content=\"width=device-width\"/>";
-        if (K9.getK9MessageViewTheme() == K9.Theme.DARK)  {
-            content += "<style type=\"text/css\">" +
-                   "* { background: black ! important; color: #F3F3F3 !important }" +
-                   ":link, :link * { color: #CCFF33 !important }" +
-                   ":visited, :visited * { color: #551A8B !important }</style> ";
+        String content, mime;
+
+        if(K9.messageViewUsePlainTextOnly()){ 
+          content = HtmlConverter.htmlToText(text);
+          mime = "text/plain";
+        } else {
+          content = "<html><head><meta name=\"viewport\" content=\"width=device-width\"/>";
+          if (K9.getK9MessageViewTheme() == K9.Theme.DARK)  {
+              content += "<style type=\"text/css\">" +
+                     "* { background: black ! important; color: #F3F3F3 !important }" +
+                     ":link, :link * { color: #CCFF33 !important }" +
+                     ":visited, :visited * { color: #551A8B !important }</style> ";
+          }
+          content += HtmlConverter.cssStylePre();
+          content += "</head><body>" + text + "</body></html>";
+          mime = "text/html";
         }
-        content += HtmlConverter.cssStylePre();
-        content += "</head><body>" + text + "</body></html>";
-        loadDataWithBaseURL("http://", content, "text/html", "utf-8", null);
+
+        loadDataWithBaseURL("http://", content, mime, "utf-8", null);
         resumeTimers();
     }
 


### PR DESCRIPTION
For 5 years (since I've been using android) I've been waiting for an email client which allows me to read and write email in plain text only (as in Thunderbird, on the gui or as in many email clients over tty).

K9 seemed to be the closest by allowing me to only compose in plain text and to use monospace font when viewing text/plain messages.  However, even in K9 it seems that html was always preferred.

This feature was requested multiple times in multiple issues threads, a quick search turned up these: Issue 1714, Issue 2132, Issue 6079, Issue 4456.  My implementation was probably rudimentary and possibly buggy, but it got me what I wanted and I'm now using it on all my devices so I thought I'd issue a pull request in case it's helpful for others.

I love k9, now that it has this last feature from my fork, it does everything I want from an android email client.

Thanks for all the hard work!