### PR TITLE
HtmlConverter: Fix horizontal rule replacement.

### DIFF
--- a/src/com/fsck/k9/helper/HtmlConverter.java
+++ b/src/com/fsck/k9/helper/HtmlConverter.java
@@ -279,8 +279,10 @@ public class HtmlConverter {
                    HTML_BLOCKQUOTE_END + "$1"
                );
 
-        // Replace lines of -,= or _ with horizontal rules
-        text = text.replaceAll("\\s*([-=_]{30,}+)\\s*", "<hr />");
+        // Replace lines of -,=,_ or scissors (%<,>%,8<,>8) with horizontal rules
+        text = text.replaceAll("(^|" + HTML_NEWLINE +
+                               ")\\s*(([-=_]|%&lt;|<gt>%|8&lt;|<gt>8)+\\s*)+(" +
+                               HTML_NEWLINE + "|$)", "<hr />");
 
         StringBuffer sb = new StringBuffer(text.length() + TEXT_TO_HTML_EXTRA_BUFFER_LENGTH);
 

--- a/tests/src/com/fsck/k9/helper/HtmlConverterTest.java
+++ b/tests/src/com/fsck/k9/helper/HtmlConverterTest.java
@@ -181,4 +181,30 @@ public class HtmlConverterTest extends TestCase {
                 "http://example.com/" +
                 "</a>", outputBuffer.toString());
     }
+
+    public void testReplaceHorizontalRules() {
+        // check in between text
+        String text = "hello\n--- --- --- --- --- --- --- --- ---\nfoo bar";
+        String result = HtmlConverter.textToHtml(text);
+        assertEquals("<pre class=\"k9mail\">hello<hr />foo bar</pre>",
+                     result);
+
+        // check beginning of text
+        text = "---------------------------\nfoo bar";
+        result = HtmlConverter.textToHtml(text);
+        assertEquals("<pre class=\"k9mail\"><hr />foo bar</pre>",
+                     result);
+
+        // check end of text
+        text = "hello\n__________________________________";
+        result = HtmlConverter.textToHtml(text);
+        assertEquals("<pre class=\"k9mail\">hello<hr /></pre>",
+                     result);
+
+        // check scissors
+        text = "hello\n-- %< -------------- >8 --\nworld\n";
+        result = HtmlConverter.textToHtml(text);
+        assertEquals("<pre class=\"k9mail\">hello<hr />world<br /></pre>",
+                     result);
+    }
 }


### PR DESCRIPTION
- Replace full line with horizontal rule.  (Currently only the space and 30+ - are replaced)
- Accept "Scissors" (%<, >%, 8<, >8).  Scissors are used by, e.g., git
  when formatting patches.
- Add unit tests for horizontal rule replacement.
