### PR TITLE
Fix: HELO/EHLO with literal IPv6 address not conformant to RFC5321

### DIFF
--- a/src/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/src/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -245,7 +245,7 @@ public class SmtpTransport extends Transport {
                 // characters (see issue 2143), so use IP address.
                 if (!ipAddr.equals("")) {
                     if (localAddress instanceof Inet6Address) {
-                        localHost = "[IPV6:" + ipAddr + "]";
+                        localHost = "[IPv6:" + ipAddr + "]";
                     } else {
                         localHost = "[" + ipAddr + "]";
                     }


### PR DESCRIPTION
Fixed https://github.com/typingArtist/k-9/issues/1.

HELO/EHLO IPv6 address literalsare now conforming to RFC5321.

A K-9 client trying to send mail to a mailhub via SMTP has to send a HELO/EHLO message. The name given must be in a form specified by RFC5321. In the special case that the FQDN of the host cannot be determined, the literal address must be given as specified by Section 4.1.3 of RFC5321. The only valid form for the literal is "[IPv6:", followed by the IPv6 address in one of some forms, followed by a trailing "]".

The current bug in K-9 Mail is small. It uses the prefix "[IPV6:" instead of "[IPv6:". Note the wrong upper-case letter "V" instead of the lower-case letter "v". There are SMTP servers out there that nail all clients down to RFC conformance, and K-9 has to fully adhere to the standards.

Please pull.
