### PR TITLE
archive action improvement

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -681,6 +681,10 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_identities_label">Manage identities</string>
     <string name="account_settings_identities_summary">Set up alternate \'From\' addresses and signatures</string>
 
+    <string name="account_settings_folders_archive">Archive options</string>
+    <string name="account_settings_use_folder_structure_when_archive">Keep the folder structure when archive</string>
+    <string name="account_settings_mark_as_read_when_archive">Mark as read when archive</string>
+
     <string name="manage_identities_title">Manage identities</string>
 
     <string name="manage_identities_context_menu_title">Manage identity</string>

--- a/res/xml/account_settings_preferences.xml
+++ b/res/xml/account_settings_preferences.xml
@@ -296,6 +296,24 @@
             android:title="@string/archive_folder_label"
             android:dialogTitle="@string/archive_folder_label" />
 
+        <PreferenceScreen
+            android:title="@string/account_settings_folders_archive"
+            android:key="archive_options">
+
+            <CheckBoxPreference
+                android:persistent="false"
+                android:key="use_folder_structure_when_archive"
+                android:title="@string/account_settings_use_folder_structure_when_archive"
+                android:defaultValue="false" />
+
+            <CheckBoxPreference
+                android:persistent="false"
+                android:key="mark_as_read_when_archive"
+                android:title="@string/account_settings_mark_as_read_when_archive"
+                android:defaultValue="false" />
+        
+        </PreferenceScreen>
+
         <ListPreference
             android:persistent="false"
             android:key="drafts_folder"

--- a/src/com/fsck/k9/Account.java
+++ b/src/com/fsck/k9/Account.java
@@ -213,6 +213,8 @@ public class Account implements BaseAccount {
     private boolean mAllowRemoteSearch;
     private boolean mRemoteSearchFullText;
     private int mRemoteSearchNumResults;
+    private boolean mMarkAsReadWhenArchive;
+    private boolean mUseFolderStructureWhenArchive;
 
     private CryptoProvider mCryptoProvider = null;
 
@@ -313,6 +315,8 @@ public class Account implements BaseAccount {
         mEnabled = true;
         mMarkMessageAsReadOnView = true;
         mAlwaysShowCcBcc = false;
+        mMarkAsReadWhenArchive = false;
+        mUseFolderStructureWhenArchive = false;
 
         searchableFolders = Searchable.ALL;
 
@@ -499,6 +503,9 @@ public class Account implements BaseAccount {
         mMarkMessageAsReadOnView = prefs.getBoolean(mUuid + ".markMessageAsReadOnView", true);
         mAlwaysShowCcBcc = prefs.getBoolean(mUuid + ".alwaysShowCcBcc", false);
 
+        mMarkAsReadWhenArchive = prefs.getBoolean(mUuid + ".markAsReadWhenArchive",false);
+        mUseFolderStructureWhenArchive = prefs.getBoolean(mUuid + ".useFolderStructureWhenArchive",false);
+
         cacheChips();
 
         // Use email address as account description if necessary
@@ -594,6 +601,8 @@ public class Account implements BaseAccount {
         editor.remove(mUuid + ".messageFormat");
         editor.remove(mUuid + ".messageReadReceipt");
         editor.remove(mUuid + ".notifyMailCheck");
+        editor.remove(mUuid + ".mMarkAsReadWhenArchive");
+        editor.remove(mUuid + ".mUseFolderStructureWhenArchive");
         for (String type : networkTypes) {
             editor.remove(mUuid + ".useCompression." + type);
         }
@@ -769,6 +778,8 @@ public class Account implements BaseAccount {
         editor.putString(mUuid + ".ringtone", mNotificationSetting.getRingtone());
         editor.putBoolean(mUuid + ".led", mNotificationSetting.isLed());
         editor.putInt(mUuid + ".ledColor", mNotificationSetting.getLedColor());
+        editor.putBoolean(mUuid + ".mMarkAsReadWhenArchive",mMarkAsReadWhenArchive);
+        editor.putBoolean(mUuid + ".mUseFolderStructureWhenArchive",mUseFolderStructureWhenArchive);
 
         for (String type : networkTypes) {
             Boolean useCompression = compressionMap.get(type);
@@ -1773,6 +1784,20 @@ public class Account implements BaseAccount {
 
     public void setRemoteSearchFullText(boolean val) {
         mRemoteSearchFullText = val;
+    }
+
+    public boolean isMarkAsReadWhenArchive() {
+        return mMarkAsReadWhenArchive;
+    }
+    public void setMarkAsReadWhenArchive(boolean val) {
+        mMarkAsReadWhenArchive = val;
+    }
+
+    public boolean isUseFolderStructureWhenArchive() {
+        return mUseFolderStructureWhenArchive;
+    }
+    public void setUseFolderStructureWhenArchive(boolean val) {
+        mUseFolderStructureWhenArchive = val;
     }
 
     /**

--- a/src/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/src/com/fsck/k9/activity/setup/AccountSettings.java
@@ -123,6 +123,9 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_SPAM_FOLDER = "spam_folder";
     private static final String PREFERENCE_TRASH_FOLDER = "trash_folder";
     private static final String PREFERENCE_ALWAYS_SHOW_CC_BCC = "always_show_cc_bcc";
+    private static final String PREFERENCE_ARCHIVE_OPTIONS="archive_options";
+    private static final String PREFERENCE_MARK_AS_READ_WHEN_ARCHIVE = "mark_as_read_when_archive";
+    private static final String PREFERENCE_USE_FOLDER_STRUCTURE_WHEN_ARCHIVE = "use_folder_structure_when_archive";
 
 
     private Account mAccount;
@@ -196,6 +199,10 @@ public class AccountSettings extends K9PreferenceActivity {
     private ListPreference mTrashFolder;
     private CheckBoxPreference mAlwaysShowCcBcc;
 
+    private PreferenceScreen mArchiveOptions;
+    private CheckBoxPreference mUseFolderStructureWhenArchive;
+    private CheckBoxPreference mMarkAsReadWhenArchive;
+
 
     public static void actionSettings(Context context, Account account) {
         Intent i = new Intent(context, AccountSettings.class);
@@ -254,6 +261,13 @@ public class AccountSettings extends K9PreferenceActivity {
 
         mAlwaysShowCcBcc = (CheckBoxPreference) findPreference(PREFERENCE_ALWAYS_SHOW_CC_BCC);
         mAlwaysShowCcBcc.setChecked(mAccount.isAlwaysShowCcBcc());
+
+        mArchiveOptions = (PreferenceScreen) findPreference(PREFERENCE_ARCHIVE_OPTIONS);
+        mMarkAsReadWhenArchive = (CheckBoxPreference) findPreference(PREFERENCE_MARK_AS_READ_WHEN_ARCHIVE);
+        mMarkAsReadWhenArchive.setChecked(mAccount.isMarkAsReadWhenArchive());
+
+        mUseFolderStructureWhenArchive = (CheckBoxPreference) findPreference(PREFERENCE_USE_FOLDER_STRUCTURE_WHEN_ARCHIVE);
+        mUseFolderStructureWhenArchive.setChecked(mAccount.isUseFolderStructureWhenArchive());
 
         mMessageReadReceipt = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGE_READ_RECEIPT);
         mMessageReadReceipt.setChecked(mAccount.isMessageReadReceiptAlways());
@@ -830,6 +844,9 @@ public class AccountSettings extends K9PreferenceActivity {
             mAccount.setRemoteSearchNumResults(Integer.parseInt(mRemoteSearchNumResults.getValue()));
             //mAccount.setRemoteSearchFullText(mRemoteSearchFullText.isChecked());
         }
+
+        mAccount.setMarkAsReadWhenArchive(mMarkAsReadWhenArchive.isChecked());
+        mAccount.setUseFolderStructureWhenArchive(mMarkAsReadWhenArchive.isChecked());
 
         boolean needsRefresh = mAccount.setAutomaticCheckIntervalMinutes(Integer.parseInt(mCheckFrequency.getValue()));
         needsRefresh |= mAccount.setFolderSyncMode(Account.FolderMode.valueOf(mSyncMode.getValue()));

--- a/src/com/fsck/k9/fragment/MessageListFragment.java
+++ b/src/com/fsck/k9/fragment/MessageListFragment.java
@@ -2493,13 +2493,22 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
     }
 
     private void onArchive(final List<Message> messages) {
-        Map<Account, List<Message>> messagesByAccount = groupMessagesByAccount(messages);
 
-        for (Entry<Account, List<Message>> entry : messagesByAccount.entrySet()) {
-            Account account = entry.getKey();
-            String archiveFolder = account.getArchiveFolderName();
+        setFlagForSelected(Flag.SEEN, true);
 
-            if (!K9.FOLDER_NONE.equals(archiveFolder)) {
+        Map<Folder, List<Message>> messagesByFolder = groupMessagesByFolder(messages);
+
+        for (Entry<Folder, List<Message>> entry : messagesByFolder.entrySet()) {
+            Folder folder  = entry.getKey();
+            Account account = folder.getAccount();
+            String archiveTopFolder = account.getArchiveFolderName();
+
+            String archiveFolder = new String(archiveTopFolder);
+            if (!K9.FOLDER_NONE.equals(archiveTopFolder)) {
+                if (account.isUseFolderStructureWhenArchive()) {
+                    String archiveSubFolder = folder.getName();
+                    archiveFolder = archiveTopFolder + "." + archiveSubFolder;
+                }
                 move(entry.getValue(), archiveFolder);
             }
         }
@@ -2520,6 +2529,23 @@ public class MessageListFragment extends SherlockFragment implements OnItemClick
         }
         return messagesByAccount;
     }
+
+    private Map<Folder, List<Message>> groupMessagesByFolder(final List<Message> messages) {
+        Map<Folder, List<Message>> messagesByFolder = new HashMap<Folder, List<Message>>();
+        for (Message message : messages) {
+            Folder folder = message.getFolder();
+
+            List<Message> msgList = messagesByFolder.get(folder);
+            if (msgList == null) {
+                msgList = new ArrayList<Message>();
+                messagesByFolder.put(folder, msgList);
+            }
+
+            msgList.add(message);
+        }
+        return messagesByFolder;
+    }
+
 
     private void onSpam(Message message) {
         onSpam(Collections.singletonList(message));

--- a/src/com/fsck/k9/fragment/MessageViewFragment.java
+++ b/src/com/fsck/k9/fragment/MessageViewFragment.java
@@ -404,7 +404,19 @@ public class MessageViewFragment extends SherlockFragment implements OnClickList
     }
 
     public void onArchive() {
-        onRefile(mAccount.getArchiveFolderName());
+        if (mMessage != null) {
+            if (mAccount.isMarkAsReadWhenArchive()) {
+                if (! mMessage.isSet(Flag.SEEN)) {
+                    onToggleRead();
+                }
+            }
+            if (mAccount.isUseFolderStructureWhenArchive()) {
+                String archiveFolder = mAccount.getArchiveFolderName() + "." + mMessage.getFolder().getName();
+                onRefile(archiveFolder);
+            } else {
+                onRefile(mAccount.getArchiveFolderName());
+            }
+        }
     }
 
     public void onSpam() {

--- a/src/com/fsck/k9/preferences/AccountSettings.java
+++ b/src/com/fsck/k9/preferences/AccountSettings.java
@@ -225,6 +225,12 @@ public class AccountSettings {
         s.put("remoteSearchFullText", Settings.versions(
                 new V(18, new BooleanSetting(false))
             ));
+        s.put("markAsReadWhenArchive", Settings.versions(
+                new V(32, new BooleanSetting(false))
+            ));
+        s.put("useFolderStructureWhenArchive", Settings.versions(
+                new V(32, new BooleanSetting(false))
+            ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/src/com/fsck/k9/preferences/Settings.java
+++ b/src/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 31;
+    public static final int VERSION = 32;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,


### PR DESCRIPTION
This commit add an option to keep the folder structure in the archive
folder. If checked the message are moved in the folder composed by
the archive folder and its current folder.

This commit add an option to mark the messages as read when archived. If
checked the message(s) are flagged as SEEN.
