### PR TITLE
Configure mail notifications by folder class

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -231,6 +231,22 @@
         <item>1000</item>
     </string-array>
 
+    <string-array name="account_settings_folder_notify_new_mail_mode_entries">
+        <item>@string/account_settings_folder_notify_new_mail_mode_all</item>
+        <item>@string/account_settings_folder_notify_new_mail_mode_first_class</item>
+        <item>@string/account_settings_folder_notify_new_mail_mode_first_and_second_class</item>
+        <item>@string/account_settings_folder_notify_new_mail_mode_not_second_class</item>
+        <item>@string/account_settings_folder_notify_new_mail_mode_none</item>
+    </string-array>
+
+    <string-array name="account_settings_folder_notify_new_mail_mode_values" translatable="false">
+        <item>ALL</item>
+        <item>FIRST_CLASS</item>
+        <item>FIRST_AND_SECOND_CLASS</item>
+        <item>NOT_SECOND_CLASS</item>
+        <item>NONE</item>
+    </string-array>
+
     <string-array name="account_settings_folder_target_mode_entries">
         <item>@string/account_settings_folder_target_mode_all</item>
         <item>@string/account_settings_folder_target_mode_first_class</item>
@@ -279,6 +295,20 @@
     </string-array>
 
     <string-array name="folder_settings_folder_push_mode_values" translatable="false">
+        <item>NO_CLASS</item>
+        <item>FIRST_CLASS</item>
+        <item>SECOND_CLASS</item>
+        <item>INHERITED</item>
+    </string-array>
+
+    <string-array name="folder_settings_folder_notify_mode_entries">
+        <item>@string/folder_settings_folder_notify_mode_normal</item>
+        <item>@string/folder_settings_folder_notify_mode_first_class</item>
+        <item>@string/folder_settings_folder_notify_mode_second_class</item>
+        <item>@string/folder_settings_folder_notify_mode_inherited</item>
+    </string-array>
+
+    <string-array name="folder_settings_folder_notify_mode_values" translatable="false">
         <item>NO_CLASS</item>
         <item>FIRST_CLASS</item>
         <item>SECOND_CLASS</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -504,6 +504,14 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_default_label">Default account</string>
     <string name="account_settings_default_summary">Send mail from this account by default</string>
     <string name="account_settings_notify_label">New mail notifications</string>
+
+    <string name="account_settings_folder_notify_new_mail_mode_label">Notifications folders</string>
+    <string name="account_settings_folder_notify_new_mail_mode_all">All</string>
+    <string name="account_settings_folder_notify_new_mail_mode_first_class">Only 1st Class folders</string>
+    <string name="account_settings_folder_notify_new_mail_mode_first_and_second_class">1st and 2nd Class folders</string>
+    <string name="account_settings_folder_notify_new_mail_mode_not_second_class">All except 2nd Class folders</string>
+    <string name="account_settings_folder_notify_new_mail_mode_none">None</string>
+
     <string name="account_settings_notify_sync_label">Sync notifications</string>
     <string name="account_settings_email_label">Your email address</string>
     <string name="account_settings_notify_summary">Notify in status bar when mail arrives</string>
@@ -654,6 +662,12 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="folder_settings_folder_push_mode_first_class">1st Class</string>
     <string name="folder_settings_folder_push_mode_second_class">2nd Class</string>
     <string name="folder_settings_folder_push_mode_inherited">Same as sync class</string>
+
+    <string name="folder_settings_folder_notify_mode_label">Folder notification class</string>
+    <string name="folder_settings_folder_notify_mode_normal">None</string>
+    <string name="folder_settings_folder_notify_mode_first_class">1st Class</string>
+    <string name="folder_settings_folder_notify_mode_second_class">2nd Class</string>
+    <string name="folder_settings_folder_notify_mode_inherited">Same as push class</string>
 
     <string name="account_settings_incoming_label">Incoming server</string>
     <string name="account_settings_incoming_summary">Configure the incoming mail server</string>

--- a/res/xml/account_settings_preferences.xml
+++ b/res/xml/account_settings_preferences.xml
@@ -343,6 +343,15 @@
             android:defaultValue="true"
             android:summary="@string/account_settings_notify_summary" />
 
+        <ListPreference
+            android:persistent="false"
+            android:key="folder_notify_new_mail_mode"
+            android:dependency="account_notify"
+            android:title="@string/account_settings_folder_notify_new_mail_mode_label"
+            android:entries="@array/account_settings_folder_notify_new_mail_mode_entries"
+            android:entryValues="@array/account_settings_folder_notify_new_mail_mode_values"
+            android:dialogTitle="@string/account_settings_folder_notify_new_mail_mode_label" />
+
         <CheckBoxPreference
             android:persistent="false"
             android:key="account_notify_self"

--- a/res/xml/folder_settings_preferences.xml
+++ b/res/xml/folder_settings_preferences.xml
@@ -58,6 +58,14 @@
             android:entryValues="@array/folder_settings_folder_push_mode_values"
             android:dialogTitle="@string/folder_settings_folder_push_mode_label" />
 
+        <ListPreference
+            android:persistent="false"
+            android:key="folder_settings_folder_notify_mode"
+            android:title="@string/folder_settings_folder_notify_mode_label"
+            android:entries="@array/folder_settings_folder_notify_mode_entries"
+            android:entryValues="@array/folder_settings_folder_notify_mode_values"
+            android:dialogTitle="@string/folder_settings_folder_notify_mode_label" />
+
         <CheckBoxPreference
             android:persistent="false"
             android:key="folder_settings_include_in_integrated_inbox"

--- a/src/com/fsck/k9/Account.java
+++ b/src/com/fsck/k9/Account.java
@@ -164,6 +164,7 @@ public class Account implements BaseAccount {
     private long mLastAutomaticCheckTime;
     private long mLatestOldMessageSeenTime;
     private boolean mNotifyNewMail;
+    private FolderMode mFolderNotifyNewMailMode;
     private boolean mNotifySelfNewMail;
     private String mInboxFolderName;
     private String mDraftsFolderName;
@@ -275,6 +276,7 @@ public class Account implements BaseAccount {
         mDisplayCount = K9.DEFAULT_VISIBLE_LIMIT;
         mAccountNumber = -1;
         mNotifyNewMail = true;
+        mFolderNotifyNewMailMode = FolderMode.ALL;
         mNotifySync = true;
         mNotifySelfNewMail = true;
         mFolderDisplayMode = FolderMode.NOT_SECOND_CLASS;
@@ -384,6 +386,12 @@ public class Account implements BaseAccount {
         mLastAutomaticCheckTime = prefs.getLong(mUuid + ".lastAutomaticCheckTime", 0);
         mLatestOldMessageSeenTime = prefs.getLong(mUuid + ".latestOldMessageSeenTime", 0);
         mNotifyNewMail = prefs.getBoolean(mUuid + ".notifyNewMail", false);
+        try {
+            mFolderNotifyNewMailMode = FolderMode.valueOf(prefs.getString(mUuid  + ".folderNotifyNewMailMode",
+                                                 FolderMode.ALL.name()));
+        } catch (Exception e) {
+            mFolderNotifyNewMailMode = FolderMode.ALL;
+        }
         mNotifySelfNewMail = prefs.getBoolean(mUuid + ".notifySelfNewMail", true);
         mNotifySync = prefs.getBoolean(mUuid + ".notifyMailCheck", false);
         mDeletePolicy = prefs.getInt(mUuid + ".deletePolicy", 0);
@@ -707,6 +715,7 @@ public class Account implements BaseAccount {
         editor.putLong(mUuid + ".lastAutomaticCheckTime", mLastAutomaticCheckTime);
         editor.putLong(mUuid + ".latestOldMessageSeenTime", mLatestOldMessageSeenTime);
         editor.putBoolean(mUuid + ".notifyNewMail", mNotifyNewMail);
+        editor.putString(mUuid + ".folderNotifyNewMailMode", mFolderNotifyNewMailMode.name());
         editor.putBoolean(mUuid + ".notifySelfNewMail", mNotifySelfNewMail);
         editor.putBoolean(mUuid + ".notifyMailCheck", mNotifySync);
         editor.putInt(mUuid + ".deletePolicy", mDeletePolicy);
@@ -1060,6 +1069,14 @@ public class Account implements BaseAccount {
 
     public synchronized void setNotifyNewMail(boolean notifyNewMail) {
         this.mNotifyNewMail = notifyNewMail;
+    }
+
+    public synchronized FolderMode getFolderNotifyNewMailMode() {
+        return mFolderNotifyNewMailMode;
+    }
+
+    public synchronized void setFolderNotifyNewMailMode(FolderMode folderNotifyNewMailMode) {
+        this.mFolderNotifyNewMailMode = folderNotifyNewMailMode;
     }
 
     public synchronized int getDeletePolicy() {

--- a/src/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/src/com/fsck/k9/activity/setup/AccountSettings.java
@@ -73,6 +73,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_DEFAULT = "account_default";
     private static final String PREFERENCE_SHOW_PICTURES = "show_pictures_enum";
     private static final String PREFERENCE_NOTIFY = "account_notify";
+    private static final String PREFERENCE_NOTIFY_NEW_MAIL_MODE = "folder_notify_new_mail_mode";
     private static final String PREFERENCE_NOTIFY_SELF = "account_notify_self";
     private static final String PREFERENCE_NOTIFY_SYNC = "account_notify_sync";
     private static final String PREFERENCE_VIBRATE = "account_vibrate";
@@ -142,6 +143,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private ListPreference mMessageSize;
     private CheckBoxPreference mAccountDefault;
     private CheckBoxPreference mAccountNotify;
+    private ListPreference mAccountNotifyNewMailMode;
     private CheckBoxPreference mAccountNotifySelf;
     private ListPreference mAccountShowPictures;
     private CheckBoxPreference mAccountNotifySync;
@@ -573,6 +575,19 @@ public class AccountSettings extends K9PreferenceActivity {
         mAccountNotify = (CheckBoxPreference) findPreference(PREFERENCE_NOTIFY);
         mAccountNotify.setChecked(mAccount.isNotifyNewMail());
 
+        mAccountNotifyNewMailMode = (ListPreference) findPreference(PREFERENCE_NOTIFY_NEW_MAIL_MODE);
+        mAccountNotifyNewMailMode.setValue(mAccount.getFolderNotifyNewMailMode().name());
+        mAccountNotifyNewMailMode.setSummary(mAccountNotifyNewMailMode.getEntry());
+        mAccountNotifyNewMailMode.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                final String summary = newValue.toString();
+                int index = mAccountNotifyNewMailMode.findIndexOfValue(summary);
+                mAccountNotifyNewMailMode.setSummary(mAccountNotifyNewMailMode.getEntries()[index]);
+                mAccountNotifyNewMailMode.setValue(summary);
+                return false;
+            }
+        });
+
         mAccountNotifySelf = (CheckBoxPreference) findPreference(PREFERENCE_NOTIFY_SELF);
         mAccountNotifySelf.setChecked(mAccount.isNotifySelfNewMail());
 
@@ -769,6 +784,7 @@ public class AccountSettings extends K9PreferenceActivity {
         mAccount.setDescription(mAccountDescription.getText());
         mAccount.setMarkMessageAsReadOnView(mMarkMessageAsReadOnView.isChecked());
         mAccount.setNotifyNewMail(mAccountNotify.isChecked());
+        mAccount.setFolderNotifyNewMailMode(Account.FolderMode.valueOf(mAccountNotifyNewMailMode.getValue()));
         mAccount.setNotifySelfNewMail(mAccountNotifySelf.isChecked());
         mAccount.setShowOngoing(mAccountNotifySync.isChecked());
         mAccount.setDisplayCount(Integer.parseInt(mDisplayCount.getValue()));

--- a/src/com/fsck/k9/activity/setup/FolderSettings.java
+++ b/src/com/fsck/k9/activity/setup/FolderSettings.java
@@ -29,6 +29,7 @@ public class FolderSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_DISPLAY_CLASS = "folder_settings_folder_display_mode";
     private static final String PREFERENCE_SYNC_CLASS = "folder_settings_folder_sync_mode";
     private static final String PREFERENCE_PUSH_CLASS = "folder_settings_folder_push_mode";
+    private static final String PREFERENCE_NOTIFY_CLASS = "folder_settings_folder_notify_mode";
     private static final String PREFERENCE_IN_TOP_GROUP = "folder_settings_in_top_group";
     private static final String PREFERENCE_INTEGRATE = "folder_settings_include_in_integrated_inbox";
 
@@ -39,6 +40,7 @@ public class FolderSettings extends K9PreferenceActivity {
     private ListPreference mDisplayClass;
     private ListPreference mSyncClass;
     private ListPreference mPushClass;
+    private ListPreference mNotifyClass;
 
     public static void actionSettings(Context context, Account account, String folderName) {
         Intent i = new Intent(context, FolderSettings.class);
@@ -124,6 +126,19 @@ public class FolderSettings extends K9PreferenceActivity {
                 return false;
             }
         });
+
+        mNotifyClass = (ListPreference) findPreference(PREFERENCE_NOTIFY_CLASS);
+        mNotifyClass.setValue(mFolder.getRawNotifyClass().name());
+        mNotifyClass.setSummary(mNotifyClass.getEntry());
+        mNotifyClass.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                final String summary = newValue.toString();
+                int index = mNotifyClass.findIndexOfValue(summary);
+                mNotifyClass.setSummary(mNotifyClass.getEntries()[index]);
+                mNotifyClass.setValue(summary);
+                return false;
+            }
+        });
     }
 
     private void saveSettings() throws MessagingException {
@@ -135,6 +150,7 @@ public class FolderSettings extends K9PreferenceActivity {
         mFolder.setDisplayClass(FolderClass.valueOf(mDisplayClass.getValue()));
         mFolder.setSyncClass(FolderClass.valueOf(mSyncClass.getValue()));
         mFolder.setPushClass(FolderClass.valueOf(mPushClass.getValue()));
+        mFolder.setNotifyClass(FolderClass.valueOf(mNotifyClass.getValue()));
 
         mFolder.save();
 

--- a/src/com/fsck/k9/controller/MessagingController.java
+++ b/src/com/fsck/k9/controller/MessagingController.java
@@ -4617,6 +4617,31 @@ public class MessagingController implements Runnable {
             return false;
         }
 
+        Account.FolderMode aDisplayMode = account.getFolderDisplayMode();
+        Account.FolderMode aNotifyMode = account.getFolderNotifyNewMailMode();
+        Folder.FolderClass fDisplayClass = localFolder.getDisplayClass();
+        Folder.FolderClass fNotifyClass = localFolder.getNotifyClass();
+
+        if (modeMismatch(aDisplayMode, fDisplayClass)) {
+            // Never notify a folder that isn't displayed
+            /*
+              if (K9.DEBUG)
+              Log.v(K9.LOG_TAG, "Not notifying folder " + localFolder.getName() +
+              " which is in display mode " + fDisplayClass + " while account is in display mode " + aDisplayMode);
+            */
+            return false;
+        }
+
+        if (modeMismatch(aNotifyMode, fNotifyClass)) {
+            // Do not notify folders in the wrong class
+            /*
+              if (K9.DEBUG)
+              Log.v(K9.LOG_TAG, "Not notifying folder " + localFolder.getName() +
+              " which is in notify mode " + fNotifyClass + " while account is in notify mode " + aNotifyMode);
+            */
+            return false;
+        }
+
         // If the account is a POP3 account and the message is older than the oldest message we've
         // previously seen, then don't notify about it.
         if (account.getStoreUri().startsWith("pop3") &&

--- a/src/com/fsck/k9/mail/Folder.java
+++ b/src/com/fsck/k9/mail/Folder.java
@@ -222,6 +222,9 @@ public abstract class Folder {
     public FolderClass getPushClass() {
         return getSyncClass();
     }
+    public FolderClass getNotifyClass() {
+        return getPushClass();
+    }
 
     public void refresh(Preferences preferences) throws MessagingException {
 

--- a/src/com/fsck/k9/preferences/AccountSettings.java
+++ b/src/com/fsck/k9/preferences/AccountSettings.java
@@ -138,6 +138,9 @@ public class AccountSettings {
         s.put("notifyNewMail", Settings.versions(
                 new V(1, new BooleanSetting(false))
             ));
+        s.put("folderNotifyNewMailMode", Settings.versions(
+                new V(33, new EnumSetting<FolderMode>(FolderMode.class, FolderMode.ALL))
+            ));
         s.put("notifySelfNewMail", Settings.versions(
                 new V(1, new BooleanSetting(true))
             ));

--- a/src/com/fsck/k9/preferences/FolderSettings.java
+++ b/src/com/fsck/k9/preferences/FolderSettings.java
@@ -28,6 +28,9 @@ public class FolderSettings {
         s.put("displayMode", Settings.versions(
                 new V(1, new EnumSetting<FolderClass>(FolderClass.class, FolderClass.NO_CLASS))
             ));
+        s.put("notifyMode", Settings.versions(
+                new V(33, new EnumSetting<FolderClass>(FolderClass.class, FolderClass.INHERITED))
+            ));
         s.put("syncMode", Settings.versions(
                 new V(1, new EnumSetting<FolderClass>(FolderClass.class, FolderClass.INHERITED))
             ));

--- a/src/com/fsck/k9/preferences/Settings.java
+++ b/src/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 32;
+    public static final int VERSION = 33;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,


### PR DESCRIPTION
In response to Issue 1794,
- add a configuration option in the account preferences to show
  notifications only for 1st/2nd/etc class folders
- add an option in the folder preferences to set the notification class
  as 1st, 2nd or inherited from the folder's push class

The default behaviour remains unchanged.
