### PR TITLE
Issue 4592 (6179/6187/6308)  IDN support

### DIFF
--- a/src/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/src/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -494,10 +494,10 @@ public class SmtpTransport extends Transport {
 
         Address[] from = message.getFrom();
         try {
-            executeSimpleCommand("MAIL FROM:" + "<" + from[0].getAddress() + ">"
+            executeSimpleCommand("MAIL FROM:" + "<" + IDN.toASCII(from[0].getAddress()) + ">"
                     + (m8bitEncodingAllowed ? " BODY=8BITMIME" : ""));
             for (String address : addresses) {
-                executeSimpleCommand("RCPT TO:" + "<" + address + ">");
+                executeSimpleCommand("RCPT TO:" + "<" + IDN.toASCII(address) + ">");
             }
             executeSimpleCommand("DATA");
 
@@ -507,7 +507,7 @@ public class SmtpTransport extends Transport {
 
             message.writeTo(msgOut);
 
-            // We use BufferedOutputStream. So make sure to call flush() !
+            // We use BufferedOutputStream. So make sure to call flush()! 
             msgOut.flush();
 
             possibleSend = true; // After the "\r\n." is attempted, we may have sent the message


### PR DESCRIPTION
IDN support (Domain names like müster.de) was several times already requested.
This is a proposal for including the IDN support on SMTP side (sending). IDN is state of the art.
Methods provided by java.net.IDN

As I don't have a JAVA development kit running, I cannot test the changes.
Methods from java.net.IDN   should be already imported by "import java.net.*".

Java document sources:
http://docs.oracle.com/javase/6/docs/api/java/net/IDN.html
