### PR TITLE
Manifest fixes

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -319,9 +319,6 @@
             <intent-filter>
                 <action android:name="com.android.sync.SYNC_CONN_STATUS_CHANGED"/>
             </intent-filter>
-            <intent-filter>
-                <action android:name="com.fsck.k9.service.BroadcastReceiver.scheduleIntent"/>
-            </intent-filter>
         </receiver>
 
         <receiver


### PR DESCRIPTION
Don't expose functionality that is only used internally.

I briefly tested the changed version to make sure the affected broadcasts still work locally. But I'd appreciate a quick sanity check by a second pair of eyes.
