### PR TITLE
Remove the coupling of Client Certificates and Auth Type External for SMTP

### DIFF
--- a/res/layout/account_setup_outgoing.xml
+++ b/res/layout/account_setup_outgoing.xml
@@ -75,6 +75,7 @@
                 android:visibility="gone">
 
                 <TextView
+                    android:id="@+id/account_username_label"
                     android:text="@string/account_setup_outgoing_username_label"
                     android:layout_height="wrap_content"
                     android:layout_width="fill_parent"
@@ -88,6 +89,7 @@
                     android:layout_height="wrap_content"
                     android:layout_width="fill_parent"
                     android:contentDescription="@string/account_setup_outgoing_username_label" />
+
 
                 <TextView
                     android:text="@string/account_setup_outgoing_authentication_label"
@@ -117,23 +119,36 @@
                     android:layout_height="wrap_content"
                     android:layout_width="fill_parent"
                     android:contentDescription="@string/account_setup_outgoing_password_label" />
+            </LinearLayout>
 
+            <CheckBox
+                android:id="@+id/account_require_client_certificate"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/account_setup_outgoing_require_client_certificate_label" />
+            
+            <LinearLayout 
+                android:id="@+id/account_require_client_certificate_settings"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:orientation="vertical"
+                android:visibility="gone">
+                
                 <TextView
                     android:id="@+id/account_client_certificate_label"
                     android:text="@string/account_setup_incoming_client_certificate_label"
                     android:layout_height="wrap_content"
                     android:layout_width="fill_parent"
                     android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:visibility="gone" />
+                    android:textColor="?android:attr/textColorPrimary" />
 
                 <com.fsck.k9.view.ClientCertificateSpinner
                     android:id="@+id/account_client_certificate_spinner"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:visibility="gone" />
+                    android:layout_width="fill_parent" />
+                
             </LinearLayout>
-
+            
             <View
                 android:layout_width="fill_parent"
                 android:layout_height="0dip"

--- a/res/layout/account_setup_outgoing.xml
+++ b/res/layout/account_setup_outgoing.xml
@@ -75,7 +75,6 @@
                 android:visibility="gone">
 
                 <TextView
-                    android:id="@+id/account_username_label"
                     android:text="@string/account_setup_outgoing_username_label"
                     android:layout_height="wrap_content"
                     android:layout_width="fill_parent"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -374,7 +374,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_setup_auth_type_normal_password">Normal password</string>
     <string name="account_setup_auth_type_insecure_password">Password, transmitted insecurely</string>
     <string name="account_setup_auth_type_encrypted_password">Encrypted password</string>
-    <string name="account_setup_auth_type_tls_client_certificate">Client certificate</string>
+    <string name="account_setup_auth_type_normal_external">External</string>
+    <string name="account_setup_auth_type_insecure_external">External, transmitted insecurely</string>
+
 
     <string name="account_setup_incoming_title">Incoming server settings</string>
     <string name="account_setup_incoming_username_label">Username</string>
@@ -436,6 +438,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_setup_outgoing_port_label">Port</string>
     <string name="account_setup_outgoing_security_label">Security</string>
     <string name="account_setup_outgoing_require_login_label">Require sign-in.</string>
+    <string name="account_setup_outgoing_require_client_certificate_label">Require client certificate.</string>
     <string name="account_setup_outgoing_username_label">Username</string>
     <string name="account_setup_outgoing_password_label">Password</string>
     <string name="account_setup_outgoing_authentication_label">Authentication</string>

--- a/src/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/src/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -44,7 +44,6 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     private EditText mPasswordView;
     private ClientCertificateSpinner mClientCertificateSpinner;
     private TextView mPasswordLabelView;
-    private TextView mUsernameLabelView;
     private EditText mServerView;
     private EditText mPortView;
     private String mCurrentPortViewSetting;
@@ -102,7 +101,6 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         mPasswordView = (EditText)findViewById(R.id.account_password);
         mClientCertificateSpinner = (ClientCertificateSpinner)findViewById(R.id.account_client_certificate_spinner);
         mPasswordLabelView = (TextView)findViewById(R.id.account_password_label);
-        mUsernameLabelView = (TextView)findViewById(R.id.account_username_label);
         mServerView = (EditText)findViewById(R.id.account_server);
         mPortView = (EditText)findViewById(R.id.account_port);
         mRequireLoginView = (CheckBox)findViewById(R.id.account_require_login);
@@ -266,18 +264,18 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         });
         
         mRequireClientCertificateView.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
-			
-			@Override
-			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-				mRequireClientCertificateSettingsView.setVisibility(isChecked ? View.VISIBLE : View.GONE);
-				
-				if(isChecked) {
-					mClientCertificateSpinner.chooseCertificate();
-				}
-				
-                validateFields();				
-			}
-		});
+            
+            @Override
+            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+                mRequireClientCertificateSettingsView.setVisibility(isChecked ? View.VISIBLE : View.GONE);
+                
+                if(isChecked) {
+                    mClientCertificateSpinner.chooseCertificate();
+                }
+                
+                validateFields();                
+            }
+        });
         
         mRequireLoginView.setOnCheckedChangeListener(this);
         mClientCertificateSpinner.setOnClientCertificateChangedListener(clientCertificateChangedListener);
@@ -330,15 +328,11 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
 
         if (isAuthTypeExternal) {
             // hide password fields
-        	mUsernameView.setVisibility(View.VISIBLE);
-        	mUsernameLabelView.setVisibility(View.VISIBLE);
             mPasswordView.setVisibility(View.GONE);
             mPasswordLabelView.setVisibility(View.GONE);
         }
         else {
-            // show password fields
-        	mUsernameView.setVisibility(View.VISIBLE);
-        	mUsernameLabelView.setVisibility(View.VISIBLE);    		
+            // show password fields        
             mPasswordView.setVisibility(View.VISIBLE);
             mPasswordLabelView.setVisibility(View.VISIBLE);
         }
@@ -348,20 +342,20 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
      * Shows/hides client certificate options
      */
     private void updateViewFromConnectionSecurity() {
-    	ConnectionSecurity connectionSecurity = (ConnectionSecurity) mSecurityTypeView.getSelectedItem();
-    	boolean isConnectionSecure = !(ConnectionSecurity.NONE == connectionSecurity);
-    	
-    	if(isConnectionSecure) {
-    		mRequireClientCertificateView.setVisibility(View.VISIBLE);
-    		if(mRequireClientCertificateView.isChecked()) {
-    			//do not show client certificate options if user does not need a client certificate
-    			mRequireClientCertificateSettingsView.setVisibility(View.VISIBLE);
-    		}
-    	}
-    	else {
-    		mRequireClientCertificateView.setVisibility(View.GONE);
-    		mRequireClientCertificateSettingsView.setVisibility(View.GONE);
-    	}
+        ConnectionSecurity connectionSecurity = (ConnectionSecurity) mSecurityTypeView.getSelectedItem();
+        boolean isConnectionSecure = !(ConnectionSecurity.NONE == connectionSecurity);
+        
+        if(isConnectionSecure) {
+            mRequireClientCertificateView.setVisibility(View.VISIBLE);
+            if(mRequireClientCertificateView.isChecked()) {
+                //do not show client certificate options if user does not need a client certificate
+                mRequireClientCertificateSettingsView.setVisibility(View.VISIBLE);
+            }
+        }
+        else {
+            mRequireClientCertificateView.setVisibility(View.GONE);
+            mRequireClientCertificateSettingsView.setVisibility(View.GONE);
+        }
     }
     
     /**
@@ -465,14 +459,14 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
 
             authType = (AuthType) mAuthTypeView.getSelectedItem();
             if (AuthType.EXTERNAL == authType) {
-            	//nothing to do
+                //nothing to do
             } else {
                 password = mPasswordView.getText().toString();
             }
         }
         
         if(mRequireClientCertificateView.isChecked() && ConnectionSecurity.NONE != securityType) {
-        	clientCertificateAlias = mClientCertificateSpinner.getAlias();
+            clientCertificateAlias = mClientCertificateSpinner.getAlias();
         }
 
         String newHost = mServerView.getText().toString();

--- a/src/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/src/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -12,7 +12,6 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.widget.*;
-import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 
 import com.fsck.k9.*;
@@ -44,13 +43,15 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     private EditText mUsernameView;
     private EditText mPasswordView;
     private ClientCertificateSpinner mClientCertificateSpinner;
-    private TextView mClientCertificateLabelView;
     private TextView mPasswordLabelView;
+    private TextView mUsernameLabelView;
     private EditText mServerView;
     private EditText mPortView;
     private String mCurrentPortViewSetting;
     private CheckBox mRequireLoginView;
     private ViewGroup mRequireLoginSettingsView;
+    private CheckBox mRequireClientCertificateView;
+    private ViewGroup mRequireClientCertificateSettingsView;
     private Spinner mSecurityTypeView;
     private int mCurrentSecurityTypeViewPosition;
     private Spinner mAuthTypeView;
@@ -100,12 +101,14 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         mUsernameView = (EditText)findViewById(R.id.account_username);
         mPasswordView = (EditText)findViewById(R.id.account_password);
         mClientCertificateSpinner = (ClientCertificateSpinner)findViewById(R.id.account_client_certificate_spinner);
-        mClientCertificateLabelView = (TextView)findViewById(R.id.account_client_certificate_label);
         mPasswordLabelView = (TextView)findViewById(R.id.account_password_label);
+        mUsernameLabelView = (TextView)findViewById(R.id.account_username_label);
         mServerView = (EditText)findViewById(R.id.account_server);
         mPortView = (EditText)findViewById(R.id.account_port);
         mRequireLoginView = (CheckBox)findViewById(R.id.account_require_login);
         mRequireLoginSettingsView = (ViewGroup)findViewById(R.id.account_require_login_settings);
+        mRequireClientCertificateView = (CheckBox)findViewById(R.id.account_require_client_certificate);
+        mRequireClientCertificateSettingsView = (ViewGroup)findViewById(R.id.account_require_client_certificate_settings);
         mSecurityTypeView = (Spinner)findViewById(R.id.account_security_type);
         mAuthTypeView = (Spinner)findViewById(R.id.account_auth_type);
         mNextButton = (Button)findViewById(R.id.next);
@@ -166,7 +169,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
                 mCurrentSecurityTypeViewPosition = savedInstanceState.getInt(STATE_SECURITY_TYPE_POSITION);
             }
             mSecurityTypeView.setSelection(mCurrentSecurityTypeViewPosition, false);
-
+            updateViewFromConnectionSecurity();
+            
             if (settings.username != null && !settings.username.isEmpty()) {
                 mUsernameView.setText(settings.username);
                 mRequireLoginView.setChecked(true);
@@ -179,6 +183,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
 
             if (settings.clientCertificateAlias != null) {
                 mClientCertificateSpinner.setAlias(settings.clientCertificateAlias);
+                mRequireClientCertificateView.setChecked(true);
+                updateViewFromConnectionSecurity();
             }
 
             if (settings.host != null) {
@@ -228,30 +234,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
                  */
                 if (mCurrentSecurityTypeViewPosition != position) {
                     updatePortFromSecurityType();
-
-                    boolean isInsecure = (ConnectionSecurity.NONE == mSecurityTypeView.getSelectedItem());
-                    boolean isAuthExternal = (AuthType.EXTERNAL == mAuthTypeView.getSelectedItem());
-                    boolean loginNotRequired = !mRequireLoginView.isChecked();
-
-                    /*
-                     * If the user selects ConnectionSecurity.NONE, a
-                     * warning would normally pop up if the authentication
-                     * is AuthType.EXTERNAL (i.e., using client
-                     * certificates). But such a warning is irrelevant if
-                     * login is not required. So to avoid such a warning
-                     * (generated in validateFields()) under those
-                     * conditions, we change the (irrelevant) authentication
-                     * method to PLAIN.
-                     */
-                    if (isInsecure && isAuthExternal && loginNotRequired) {
-                        OnItemSelectedListener onItemSelectedListener = mAuthTypeView.getOnItemSelectedListener();
-                        mAuthTypeView.setOnItemSelectedListener(null);
-                        mCurrentAuthTypeViewPosition = mAuthTypeAdapter.getPosition(AuthType.PLAIN);
-                        mAuthTypeView.setSelection(mCurrentAuthTypeViewPosition, false);
-                        mAuthTypeView.setOnItemSelectedListener(onItemSelectedListener);
-                        updateViewFromAuthType();
-                    }
-
+                    updateViewFromConnectionSecurity();
                     validateFields();
                 }
             }
@@ -272,12 +255,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
                 validateFields();
                 AuthType selection = (AuthType) mAuthTypeView.getSelectedItem();
 
-                // Have the user select (or confirm) the client certificate
-                if (AuthType.EXTERNAL == selection) {
-
-                    // This may again invoke validateFields()
-                    mClientCertificateSpinner.chooseCertificate();
-                } else {
+                // have the user type in the password
+                if (AuthType.EXTERNAL != selection) {
                     mPasswordView.requestFocus();
                 }
             }
@@ -285,7 +264,21 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
             @Override
             public void onNothingSelected(AdapterView<?> parent) { /* unused */ }
         });
-
+        
+        mRequireClientCertificateView.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+			
+			@Override
+			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+				mRequireClientCertificateSettingsView.setVisibility(isChecked ? View.VISIBLE : View.GONE);
+				
+				if(isChecked) {
+					mClientCertificateSpinner.chooseCertificate();
+				}
+				
+                validateFields();				
+			}
+		});
+        
         mRequireLoginView.setOnCheckedChangeListener(this);
         mClientCertificateSpinner.setOnClientCertificateChangedListener(clientCertificateChangedListener);
         mUsernameView.addTextChangedListener(validationTextWatcher);
@@ -311,6 +304,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         } else {
             mRequireLoginSettingsView.setVisibility(View.GONE);
         }
+        
+        updateViewFromConnectionSecurity();
     }
 
     @Override
@@ -327,29 +322,48 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     }
 
     /**
-     * Shows/hides password field and client certificate spinner
+     * Shows/hides password field
      */
     private void updateViewFromAuthType() {
         AuthType authType = (AuthType) mAuthTypeView.getSelectedItem();
         boolean isAuthTypeExternal = (AuthType.EXTERNAL == authType);
 
         if (isAuthTypeExternal) {
-
-            // hide password fields, show client certificate fields
+            // hide password fields
+        	mUsernameView.setVisibility(View.VISIBLE);
+        	mUsernameLabelView.setVisibility(View.VISIBLE);
             mPasswordView.setVisibility(View.GONE);
             mPasswordLabelView.setVisibility(View.GONE);
-            mClientCertificateLabelView.setVisibility(View.VISIBLE);
-            mClientCertificateSpinner.setVisibility(View.VISIBLE);
-        } else {
-
-            // show password fields, hide client certificate fields
+        }
+        else {
+            // show password fields
+        	mUsernameView.setVisibility(View.VISIBLE);
+        	mUsernameLabelView.setVisibility(View.VISIBLE);    		
             mPasswordView.setVisibility(View.VISIBLE);
             mPasswordLabelView.setVisibility(View.VISIBLE);
-            mClientCertificateLabelView.setVisibility(View.GONE);
-            mClientCertificateSpinner.setVisibility(View.GONE);
         }
     }
 
+    /**
+     * Shows/hides client certificate options
+     */
+    private void updateViewFromConnectionSecurity() {
+    	ConnectionSecurity connectionSecurity = (ConnectionSecurity) mSecurityTypeView.getSelectedItem();
+    	boolean isConnectionSecure = !(ConnectionSecurity.NONE == connectionSecurity);
+    	
+    	if(isConnectionSecure) {
+    		mRequireClientCertificateView.setVisibility(View.VISIBLE);
+    		if(mRequireClientCertificateView.isChecked()) {
+    			//do not show client certificate options if user does not need a client certificate
+    			mRequireClientCertificateSettingsView.setVisibility(View.VISIBLE);
+    		}
+    	}
+    	else {
+    		mRequireClientCertificateView.setVisibility(View.GONE);
+    		mRequireClientCertificateSettingsView.setVisibility(View.GONE);
+    	}
+    }
+    
     /**
      * This is invoked only when the user makes changes to a widget, not when
      * widgets are changed programmatically.  (The logic is simpler when you know
@@ -362,61 +376,27 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         ConnectionSecurity connectionSecurity = (ConnectionSecurity) mSecurityTypeView.getSelectedItem();
         boolean hasConnectionSecurity = (connectionSecurity != ConnectionSecurity.NONE);
 
-        if (isAuthTypeExternal && !hasConnectionSecurity) {
-
-            // Notify user of an invalid combination of AuthType.EXTERNAL & ConnectionSecurity.NONE
-            String toastText = getString(R.string.account_setup_outgoing_invalid_setting_combo_notice,
-                    getString(R.string.account_setup_incoming_auth_type_label),
-                    AuthType.EXTERNAL.toString(),
-                    getString(R.string.account_setup_incoming_security_label),
-                    ConnectionSecurity.NONE.toString());
-            Toast.makeText(this, toastText, Toast.LENGTH_LONG).show();
-
-            // Reset the views back to their previous settings without recursing through here again
-            OnItemSelectedListener onItemSelectedListener = mAuthTypeView.getOnItemSelectedListener();
-            mAuthTypeView.setOnItemSelectedListener(null);
-            mAuthTypeView.setSelection(mCurrentAuthTypeViewPosition, false);
-            mAuthTypeView.setOnItemSelectedListener(onItemSelectedListener);
-            updateViewFromAuthType();
-
-            onItemSelectedListener = mSecurityTypeView.getOnItemSelectedListener();
-            mSecurityTypeView.setOnItemSelectedListener(null);
-            mSecurityTypeView.setSelection(mCurrentSecurityTypeViewPosition, false);
-            mSecurityTypeView.setOnItemSelectedListener(onItemSelectedListener);
-            updateAuthPlainTextFromSecurityType((ConnectionSecurity) mSecurityTypeView.getSelectedItem());
-
-            mPortView.removeTextChangedListener(validationTextWatcher);
-            mPortView.setText(mCurrentPortViewSetting);
-            mPortView.addTextChangedListener(validationTextWatcher);
-
-            authType = (AuthType) mAuthTypeView.getSelectedItem();
-            isAuthTypeExternal = (AuthType.EXTERNAL == authType);
-
-            connectionSecurity = (ConnectionSecurity) mSecurityTypeView.getSelectedItem();
-            hasConnectionSecurity = (connectionSecurity != ConnectionSecurity.NONE);
-        } else {
-            mCurrentAuthTypeViewPosition = mAuthTypeView.getSelectedItemPosition();
-            mCurrentSecurityTypeViewPosition = mSecurityTypeView.getSelectedItemPosition();
-            mCurrentPortViewSetting = mPortView.getText().toString();
-        }
+        mCurrentAuthTypeViewPosition = mAuthTypeView.getSelectedItemPosition();
+        mCurrentSecurityTypeViewPosition = mSecurityTypeView.getSelectedItemPosition();
+        mCurrentPortViewSetting = mPortView.getText().toString();
 
         boolean hasValidCertificateAlias = mClientCertificateSpinner.getAlias() != null;
+        
         boolean hasValidUserName = Utility.requiredFieldValid(mUsernameView);
 
         boolean hasValidPasswordSettings = hasValidUserName
                 && !isAuthTypeExternal
                 && Utility.requiredFieldValid(mPasswordView);
-
-        boolean hasValidExternalAuthSettings = hasValidUserName
-                && isAuthTypeExternal
-                && hasConnectionSecurity
+        
+        boolean hasValidCertificateClientCertificateSettings = hasConnectionSecurity
                 && hasValidCertificateAlias;
 
         mNextButton
                 .setEnabled(Utility.domainFieldValid(mServerView)
                         && Utility.requiredFieldValid(mPortView)
                         && (!mRequireLoginView.isChecked()
-                                || hasValidPasswordSettings || hasValidExternalAuthSettings));
+                                || hasValidPasswordSettings || isAuthTypeExternal)
+                        && (!mRequireClientCertificateView.isChecked() || hasValidCertificateClientCertificateSettings));
         Utility.setCompoundDrawablesAlpha(mNextButton, mNextButton.isEnabled() ? 255 : 128);
     }
 
@@ -452,9 +432,11 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         switch (securityType) {
         case NONE:
             AuthType.PLAIN.useInsecureText(true, mAuthTypeAdapter);
+            AuthType.EXTERNAL.useInsecureText(true, mAuthTypeAdapter);
             break;
         default:
             AuthType.PLAIN.useInsecureText(false, mAuthTypeAdapter);
+            AuthType.EXTERNAL.useInsecureText(false, mAuthTypeAdapter);
         }
     }
 
@@ -483,10 +465,14 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
 
             authType = (AuthType) mAuthTypeView.getSelectedItem();
             if (AuthType.EXTERNAL == authType) {
-                clientCertificateAlias = mClientCertificateSpinner.getAlias();
+            	//nothing to do
             } else {
                 password = mPasswordView.getText().toString();
             }
+        }
+        
+        if(mRequireClientCertificateView.isChecked() && ConnectionSecurity.NONE != securityType) {
+        	clientCertificateAlias = mClientCertificateSpinner.getAlias();
         }
 
         String newHost = mServerView.getText().toString();

--- a/src/com/fsck/k9/mail/AuthType.java
+++ b/src/com/fsck/k9/mail/AuthType.java
@@ -33,8 +33,21 @@ public enum AuthType {
 
     CRAM_MD5(R.string.account_setup_auth_type_encrypted_password),
 
-    EXTERNAL(R.string.account_setup_auth_type_tls_client_certificate),
+    EXTERNAL(R.string.account_setup_auth_type_normal_external){
 
+        @Override
+        public void useInsecureText(boolean insecure, ArrayAdapter<AuthType> authTypesAdapter) {
+            if (insecure) {
+                mResourceId = R.string.account_setup_auth_type_insecure_external;
+            } else {
+                mResourceId = R.string.account_setup_auth_type_normal_external;
+            }
+            authTypesAdapter.notifyDataSetChanged();
+        }
+    },
+    
+    //if no authentication is to take place - e.g. the require sign in checkbox was not clicked
+    NOAUTH(0),
     /*
      * The following are obsolete authentication settings that were used with
      * SMTP. They are no longer presented to the user as options, but they may

--- a/src/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/src/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -34,13 +34,11 @@ public class SmtpTransport extends Transport {
     /**
      * Decodes a SmtpTransport URI.
      * 
-     * NOTE: In contrast to ImapStore and Pop3Store, the authType is appended at the end!
-     *
      * <p>Possible forms:</p>
      * <pre>
-     * smtp://user:password:auth@server:port ConnectionSecurity.NONE
-     * smtp+tls+://user:password:auth@server:port ConnectionSecurity.STARTTLS_REQUIRED
-     * smtp+ssl+://user:password:auth@server:port ConnectionSecurity.SSL_TLS_REQUIRED
+     * smtp://user:password:auth:clientcert@server:port ConnectionSecurity.NONE
+     * smtp+tls+://user:password:auth:clientcert@server:port ConnectionSecurity.STARTTLS_REQUIRED
+     * smtp+ssl+://user:password:auth:clientcert@server:port ConnectionSecurity.SSL_TLS_REQUIRED
      * </pre>
      */
     public static ServerSettings decodeUri(String uri) {
@@ -102,7 +100,7 @@ public class SmtpTransport extends Transport {
                     username = URLDecoder.decode(userInfoParts[0], "UTF-8");
                     password = URLDecoder.decode(userInfoParts[1], "UTF-8");
                 } else if (userInfoParts.length == 3) {
-                    // NOTE: In SmptTransport URIs, the authType comes last!
+                    // NOTE: In SmtpTransport URIs, the authType comes in the third position!
                     authType = AuthType.valueOf(userInfoParts[2]);
                     username = URLDecoder.decode(userInfoParts[0], "UTF-8");
                     if (authType == AuthType.EXTERNAL) {
@@ -110,7 +108,15 @@ public class SmtpTransport extends Transport {
                     } else {
                         password = URLDecoder.decode(userInfoParts[1], "UTF-8");
                     }
+                } else if (userInfoParts.length == 4) {
+                	authType = AuthType.valueOf(userInfoParts[2]);
+                	username = URLDecoder.decode(userInfoParts[0], "UTF-8");
+                	if (authType != AuthType.EXTERNAL) {
+                		password = URLDecoder.decode(userInfoParts[1], "UTF-8");
+                	}
+                	clientCertificateAlias = URLDecoder.decode(userInfoParts[3], "UTF-8");
                 }
+                
             } catch (UnsupportedEncodingException enc) {
                 // This shouldn't happen since the encoding is hardcoded to UTF-8
                 throw new IllegalArgumentException("Couldn't urldecode username or password.", enc);
@@ -167,12 +173,12 @@ public class SmtpTransport extends Transport {
         // NOTE: authType is append at last item, in contrast to ImapStore and Pop3Store!
         if (authType != null) {
             if (AuthType.EXTERNAL == authType) {
-                userInfo = userEnc + ":" + clientCertificateAliasEnc + ":" + authType.name();
+                userInfo = userEnc + "::" + authType.name() + clientCertificateAliasEnc;
             } else {
-                userInfo = userEnc + ":" + passwordEnc + ":" + authType.name();
+                userInfo = userEnc + ":" + passwordEnc + ":" + authType.name() + clientCertificateAliasEnc;
             }
         } else {
-            userInfo = userEnc + ":" + passwordEnc;
+            userInfo = userEnc + ":" + passwordEnc + ":"+ AuthType.NOAUTH.name() +":" + clientCertificateAliasEnc;
         }
         try {
             return new URI(scheme, userInfo, server.host, server.port, null, null,
@@ -324,6 +330,7 @@ public class SmtpTransport extends Transport {
                 }
             }
 
+            //TODO: with the introduction of AuthType.NOAUTH the following if statement might be superfluous
             if (mUsername != null
                     && mUsername.length() > 0
                     && (mPassword != null && mPassword.length() > 0 || AuthType.EXTERNAL == mAuthType)) {
@@ -372,6 +379,10 @@ public class SmtpTransport extends Transport {
                         throw new MessagingException(K9.app.getString(R.string.auth_external_error));
                     }
                     break;
+                    
+                case NOAUTH:
+                	//authentication not needed - nothing to do
+                	break;
 
                 /*
                  * AUTOMATIC is an obsolete option which is unavailable to users,

--- a/src/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/src/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -109,12 +109,12 @@ public class SmtpTransport extends Transport {
                         password = URLDecoder.decode(userInfoParts[1], "UTF-8");
                     }
                 } else if (userInfoParts.length == 4) {
-                	authType = AuthType.valueOf(userInfoParts[2]);
-                	username = URLDecoder.decode(userInfoParts[0], "UTF-8");
-                	if (authType != AuthType.EXTERNAL) {
-                		password = URLDecoder.decode(userInfoParts[1], "UTF-8");
-                	}
-                	clientCertificateAlias = URLDecoder.decode(userInfoParts[3], "UTF-8");
+                    authType = AuthType.valueOf(userInfoParts[2]);
+                    username = URLDecoder.decode(userInfoParts[0], "UTF-8");
+                    if (authType != AuthType.EXTERNAL) {
+                        password = URLDecoder.decode(userInfoParts[1], "UTF-8");
+                    }
+                    clientCertificateAlias = URLDecoder.decode(userInfoParts[3], "UTF-8");
                 }
                 
             } catch (UnsupportedEncodingException enc) {
@@ -381,8 +381,8 @@ public class SmtpTransport extends Transport {
                     break;
                     
                 case NOAUTH:
-                	//authentication not needed - nothing to do
-                	break;
+                    //authentication not needed - nothing to do
+                    break;
 
                 /*
                  * AUTOMATIC is an obsolete option which is unavailable to users,


### PR DESCRIPTION
Currently client certificates can only be used in combination with the EXTERNAL authentication mechanism. This pull request removes this coupling as there is no necessity for it. The EXTERNAL authentication mechanism could even be used without STARTTLS or SSL/TLS (see e.g. https://tools.ietf.org/html/rfc4422#appendix-A). However, doing so would be a security problem comparable to a cleartext username+password transmission.

With this pull request client certificates can be used in combination with every authentication mechanism present in k9. They can also be used without an authentication mechanism.
Also it is possible to use the EXTERNAL authentication mechanism with an empty string now.

There are also other people who see the need for this: https://groups.google.com/forum/#!topic/k-9-mail/FuUP7oSwYe0