### PR TITLE
"Erneut senden" missverständlich

### DIFF
--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -89,7 +89,7 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
   <string name="okay_action">OK</string>
   <string name="cancel_action">Abbrechen</string>
   <string name="send_action">Senden</string>
-  <string name="send_again_action">Erneut senden</string>
+  <string name="send_again_action">Als neu bearbeiten</string>
   <string name="select_action">Auswählen</string>
   <string name="deselect_action">Abwählen</string>
   <string name="reply_action">Antworten</string>


### PR DESCRIPTION
Ich hatte öfters das Problem, dass Mails wegen schlechter Internet-Verbindung nicht gesendet werden konnten. Wähle ich die nicht versandte Nachricht dann im Postausgang aus, kann ich sie "erneut senden". Ich dachte (im Kontext meines Problems), das würde einfach die selbe Mail erneut senden, mit der es ein Problem gab. In Wirklichkeit wird aber eine neue Nachricht mit dem gleichen Inhalt angelegt. In dieser neuen Übersetzung habe ich mich an Bezeichnung eben dieser Funktion in Thunderbird orientiert: "Als neu bearbeiten"
