### PR TITLE
Lollipop lock screen notifications

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -5,10 +5,6 @@
     android:versionCode="23020"
     android:versionName="5.102">
 
-    <uses-sdk
-        android:minSdkVersion="15"
-        android:targetSdkVersion="17"/>
-
     <uses-feature
         android:name="android.hardware.touchscreen"
         android:required="false"/>

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:0.12.2'
+        classpath 'com.android.tools.build:gradle:1.0.0-rc1'
         classpath 'com.jakewharton.sdkmanager:gradle-plugin:0.12.0'
     }
 }
@@ -27,7 +27,8 @@ dependencies {
     compile 'commons-io:commons-io:2.0.1'
     compile 'com.jcraft:jzlib:1.0.7'
     compile 'com.beetstra.jutf7:jutf7:1.0.0'
-    compile 'com.android.support:support-v13:19.1.0'
+    compile 'com.android.support:support-v4:21.0.2'
+    compile 'com.android.support:support-v13:21.0.2'
     compile 'net.sourceforge.htmlcleaner:htmlcleaner:2.2'
 }
 
@@ -43,7 +44,7 @@ subprojects {
 }
 
 android {
-    compileSdkVersion 19
+    compileSdkVersion 21
     buildToolsVersion '20.0.0'
 
     defaultConfig {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jun 14 01:43:40 CEST 2014
+#Sun Nov 30 16:02:23 PST 2014
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip

--- a/images/drawable-src/ic_action_delete.svg
+++ b/images/drawable-src/ic_action_delete.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<path fill="#FFFFFF" d="M17.5,10.156L17,19.313c0,0-2.281,1.469-5,1.469S7,19.25,7,19.25l-0.5-9.094c0,0,2.969,0.938,5.5,0.938
+	S17.5,10.156,17.5,10.156z"/>
+<path fill="#FFFFFF" d="M14.479,6.17V3.844H9.521V6.17C7.428,6.469,5.969,7.133,5.969,7.906c0,1.053,2.7,1.906,6.031,1.906
+	s6.031-0.854,6.031-1.906C18.031,7.133,16.572,6.469,14.479,6.17z M10.306,6.078V4.656h3.375v1.42C13.146,6.027,12.584,6,12,6
+	C11.411,6,10.844,6.028,10.306,6.078z"/>
+</svg>

--- a/images/drawable-src/ic_action_mark_as_read.svg
+++ b/images/drawable-src/ic_action_mark_as_read.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<polygon fill="#FFFFFF" points="3,11 3,7.612 12,3.338 21,7.612 21,11 19,11 19,9 4,9 4,11 "/>
+<circle fill="#FFFFFF" cx="12" cy="14.612" r="1.788"/>
+<path fill="#FFFFFF" d="M14.646,14.966c-0.175,1.313-1.287,2.329-2.646,2.329c-1.36,0-2.472-1.017-2.646-2.329L3,11.612V21h18
+	v-9.388L14.646,14.966z"/>
+</svg>

--- a/images/drawable-src/ic_action_single_message_options.svg
+++ b/images/drawable-src/ic_action_single_message_options.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+<path fill="#FFFFFF" d="M17.938,10C15.168,10,14,10,14,10v4c0,0,1.843,0,2.939,0c1.18,0,2.078,1.338,2.5,3.18l3.49-1.888
+	C22.93,15.292,21.133,10,17.938,10z"/>
+<polygon fill="#FFFFFF" points="14,4.791 6.825,12.005 14,19.208 "/>
+<polygon fill="#FFFFFF" points="1.825,12.005 9,19.208 9,15.09 5.938,12 9,8.91 9,4.791 "/>
+</svg>

--- a/res/drawable-nodpi-v21/ic_action_delete_dark_vector.xml
+++ b/res/drawable-nodpi-v21/ic_action_delete_dark_vector.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24.0dp"
+    android:height="24.0dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:pathData="M17.5,10.156L17,19.313c0,0-2.281,1.469-5,1.469S7,19.25,7,19.25l-0.5-9.094c0,0,2.969,0.938,5.5,0.938 S17.5,10.156,17.5,10.156z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.8" />
+    <path
+        android:pathData="M14.479,6.17V3.844H9.521V6.17C7.428,6.469,5.969,7.133,5.969,7.906c0,1.053,2.7,1.906,6.031,1.906 s6.031-0.854,6.031-1.906C18.031,7.133,16.572,6.469,14.479,6.17z M10.306,6.078V4.656h3.375v1.42C13.146,6.027,12.584,6,12,6 C11.411,6,10.844,6.028,10.306,6.078z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.8" />
+</vector>

--- a/res/drawable-nodpi-v21/ic_action_mark_as_read_dark_vector.xml
+++ b/res/drawable-nodpi-v21/ic_action_mark_as_read_dark_vector.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24.0dp"
+    android:height="24.0dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:pathData="M3,11L3 7.612 12 3.338 21 7.612 21 11 19 11 19 9 4 9 4 11 z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.8" />
+    <path
+        android:pathData="M10.212,14.612a1.788,1.788 0 1,0 3.576,0a1.788,1.788 0 1,0 -3.576,0"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.8" />
+    <path
+        android:pathData="M14.646,14.966c-0.175,1.313-1.287,2.329-2.646,2.329c-1.36,0-2.472-1.017-2.646-2.329L3,11.612V21h18 v-9.388L14.646,14.966z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.8" />
+</vector>

--- a/res/drawable-nodpi-v21/ic_action_single_message_options_dark_vector.xml
+++ b/res/drawable-nodpi-v21/ic_action_single_message_options_dark_vector.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24.0dp"
+    android:height="24.0dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:pathData="M17.938,10C15.168,10,14,10,14,10v4c0,0,1.843,0,2.939,0c1.18,0,2.078,1.338,2.5,3.18l3.49-1.888	C22.93,15.292,21.133,10,17.938,10z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.8" />
+    <path
+        android:pathData="M14,4.791L6.825 12.005 14 19.208 z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.8" />
+    <path
+        android:pathData="M2.825,12.005L9 19.208 9 15.09 5.938 12 9 8.91 9 4.791 z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.8" />
+</vector>

--- a/res/drawable-nodpi-v21/ic_notify_new_mail_vector.xml
+++ b/res/drawable-nodpi-v21/ic_notify_new_mail_vector.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24.0dp"
+    android:height="24.0dp"
+    android:viewportWidth="24.0"
+    android:viewportHeight="24.0">
+    <path
+        android:pathData="M1,8.655v11.508h22V8.655l-11,5.47L1,8.655z"
+        android:fillColor="#ffffff" />
+    <path
+        android:pathData="M1,3.837v3.062l11,5.467l11-5.467V3.837H1z"
+        android:fillColor="#ffffff" />
+</vector>

--- a/res/values-ca/strings.xml
+++ b/res/values-ca/strings.xml
@@ -158,7 +158,9 @@ Si us plau, envia\'ns els errors, contribueix a millorar-lo a
   <string name="clearing_account">S\'està netejant el compte \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">S\'està creant un compte \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Nou correu</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> missatges nous</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> missatges nous</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> no llegit(s) (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">i <xliff:g id="additional_messages">%d</xliff:g> més a <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Respon</string>

--- a/res/values-cs/strings.xml
+++ b/res/values-cs/strings.xml
@@ -159,7 +159,9 @@ Posílejte prosím chybová hlášení, přispívejte novými funkcemi a ptejte 
   <string name="clearing_account">Čistím účet \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Obnovuji účet \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Nová zpráva</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> nových zpráv</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> nových zpráv</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Nepřečteno (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> více v <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Odpovědět</string>

--- a/res/values-da/strings.xml
+++ b/res/values-da/strings.xml
@@ -155,7 +155,9 @@ Vær venlig at sende fejlrapporter, anmodning om nye funktioner, og spørgsmål 
   <string name="clearing_account">Renser konto \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Genskaber konto \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Ny mail</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> nye meddelelser</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> nye meddelelser</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> ulæst(e) (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> yderligere på <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Svar</string>

--- a/res/values-de/strings.xml
+++ b/res/values-de/strings.xml
@@ -158,7 +158,9 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
   <string name="clearing_account">Konto \'<xliff:g id="account">%s</xliff:g>\' wird bereinigt</string>
   <string name="recreating_account">Konto \"<xliff:g id="account">%s</xliff:g>\' wird wieder hergestellt</string>
   <string name="notification_new_title">Neue Nachricht</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> neue Nachrichten</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> neue Nachrichten</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Ungelesen (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">und <xliff:g id="additional_messages">%d</xliff:g> weitere (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_action_reply">Antworten</string>

--- a/res/values-el/strings.xml
+++ b/res/values-el/strings.xml
@@ -157,7 +157,9 @@
   <string name="clearing_account">Καθαρισμός λογαριασμού \'<xliff:g id="account">%s</xliff:g>\'</string>
   <string name="recreating_account">Ανακατασκευή λογαριασμού \'<xliff:g id="account">%s</xliff:g>\'</string>
   <string name="notification_new_title">Νέο μήνυμα</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> νέα μηνύματα</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> νέα μηνύματα</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> μη αναγνωσμένα (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> περισσότερα στον <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Απάντηση</string>

--- a/res/values-es/strings.xml
+++ b/res/values-es/strings.xml
@@ -157,7 +157,9 @@ Por favor, envía los errores detectados, contribuye con nuevas funcionalidades 
   <string name="clearing_account">Limpiando cuenta \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Recreando cuenta \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Correo nuevo</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> mensajes nuevos</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> mensajes nuevos</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Sin Leer (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> más en <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Responder</string>

--- a/res/values-et/strings.xml
+++ b/res/values-et/strings.xml
@@ -159,7 +159,9 @@ Palun saada infot probleemidest, soovitavatest lisafunktsioonidest ja küsi küs
   <string name="clearing_account">Puhastab kontot \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Taasloob kontot \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Uus meilisõnum</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> uued sõnumid</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> uued sõnumid</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Lugemata (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> rohkemat <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Vasta</string>

--- a/res/values-eu/strings.xml
+++ b/res/values-eu/strings.xml
@@ -157,7 +157,9 @@ Arazoen berri emateko, ezaugarri berriak gehitzeko eta galderak egiteko
   <string name="clearing_account">\"<xliff:g id="account">%s</xliff:g>\" kontua garbitzen</string>
   <string name="recreating_account">\"<xliff:g id="account">%s</xliff:g>\" kontua birsortzen</string>
   <string name="notification_new_title">Eposta berria</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> mezu berri</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> mezu berri</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> irakurgabe (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> gehiago <xliff:g id="account">%s</xliff:g> kontuan</string>
   <string name="notification_action_reply">Erantzun</string>

--- a/res/values-fi/strings.xml
+++ b/res/values-fi/strings.xml
@@ -159,7 +159,9 @@ Virheraportit, osallistuminen projektiin ja kysymykset: Mene osoitteeseen
   <string name="clearing_account">Tyhjennetään tiliä \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Luodaan uudelleen tiliä \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Uusi sähköpostiviesti</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> uutta viestiä</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> uutta viestiä</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> lukematonta (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> viestiä lisää tilillä <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Vastaa</string>

--- a/res/values-fr/strings.xml
+++ b/res/values-fr/strings.xml
@@ -157,7 +157,9 @@ jusqu\'à <xliff:g id="messages_to_load">%d</xliff:g> de plus</string>
   <string name="clearing_account">Effacement du compte «\u00A0<xliff:g id="account">%s</xliff:g>\u00A0»</string>
   <string name="recreating_account">Recréation du compte «\u00A0<xliff:g id="account">%s</xliff:g>\u00A0»</string>
   <string name="notification_new_title">Nouveau courriel</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> nouveaux messages</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> nouveaux messages</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> non lu(s) (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> de plus sur <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Répondre</string>

--- a/res/values-gl-rES/strings.xml
+++ b/res/values-gl-rES/strings.xml
@@ -156,7 +156,9 @@ Envía informes de erro, contribúe con novas funcionalidades e pregunta o que d
   <string name="clearing_account">A limpar a conta \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Volvendo crear a conta \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Correo novo</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> mensaxes novas</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> mensaxes novas</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> sen ler (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> máis en <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Responder</string>

--- a/res/values-hu/strings.xml
+++ b/res/values-hu/strings.xml
@@ -156,7 +156,9 @@ Hibajelentéseivel hozzájárul az újabb verziók tökéletesítéséhez, kérd
   <string name="clearing_account">Fiók takarítása \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">A \"<xliff:g id="account">%s</xliff:g>\" újbóli létrehozása</string>
   <string name="notification_new_title">Új levél</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> új üzenet</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> új üzenet</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Olvasatlan (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> érkezett ide: <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Válasz</string>

--- a/res/values-it/strings.xml
+++ b/res/values-it/strings.xml
@@ -158,7 +158,9 @@ Invia le tue segnalazioni, suggerisci nuove funzionalità e chiedi informazioni 
   <string name="clearing_account">Rimozione account \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Ricrea account \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Nuova posta</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> nuovi messaggi</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> nuovi messaggi</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> non letti (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> altri su <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Rispondi</string>

--- a/res/values-ja/strings.xml
+++ b/res/values-ja/strings.xml
@@ -157,7 +157,9 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
   <string name="clearing_account">アカウント \"<xliff:g id="account">%s</xliff:g>\" をクリアしています</string>
   <string name="recreating_account">アカウント \"<xliff:g id="account">%s</xliff:g>\" を再作成しています</string>
   <string name="notification_new_title">新着メール</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> 件の新着メッセージ</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> 件の新着メッセージ</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> 未読 (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> more on <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">返信</string>

--- a/res/values-ko/strings.xml
+++ b/res/values-ko/strings.xml
@@ -156,7 +156,9 @@ K-9 메일은 대부분의 무료 hotmail 계정을 지원하지 않으며, 다�
   <string name="clearing_account">계정 비우기 \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">계정 재생성 \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">새 메일</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> 통의 새 메일</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> 통의 새 메일</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> 통의 읽지 않은 메일 (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> 통의 메일 추가됨 (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_action_reply">답장</string>

--- a/res/values-lt/strings.xml
+++ b/res/values-lt/strings.xml
@@ -157,7 +157,9 @@ Praneškite apie klaidas, pridėkite naujų galimybių ir užduokite klausimus m
   <string name="clearing_account">Išvaloma paskyra  \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Iš naujo kuriama paskyra  \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Naujas laiškas</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> naujų laiškų</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> naujų laiškų</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Neskaitytų (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> daugiau <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Atsakyti</string>

--- a/res/values-lv/strings.xml
+++ b/res/values-lv/strings.xml
@@ -160,7 +160,9 @@ pat <xliff:g id="messages_to_load">%d</xliff:g> vairāk</string>
   <string name="clearing_account">Iztukšot kontu \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Atjaunot kontu \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Jauna vēstule</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> jaunas vēstules</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> jaunas vēstules</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Nelasītas (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> vairāk <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Atbildēt</string>

--- a/res/values-nb/strings.xml
+++ b/res/values-nb/strings.xml
@@ -159,7 +159,9 @@ til <xliff:g id="messages_to_load">%d</xliff:g> flere</string>
   <string name="clearing_account">Renser konto \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Gjenskaper konto \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Ny e-post</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> ny(e) melding(er)</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> ny(e) melding(er)</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Ulest(e) (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> flere på <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Svar</string>

--- a/res/values-nl/strings.xml
+++ b/res/values-nl/strings.xml
@@ -157,7 +157,9 @@ Graag foutrapporten, bijdrage nieuwe functies en vragen stellen op
   <string name="clearing_account">Account \"<xliff:g id="account">%s</xliff:g>\" wissen</string>
   <string name="recreating_account">Account \"<xliff:g id="account">%s</xliff:g>\" opnieuw instellen</string>
   <string name="notification_new_title">Nieuwe mail</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> nieuwe berichten</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> nieuwe berichten</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Ongelezen (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> meer op <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Antwoorden</string>

--- a/res/values-pl/strings.xml
+++ b/res/values-pl/strings.xml
@@ -157,7 +157,9 @@ Wszelkie zgłoszenia usterek, zapytania oraz nowe pomysły prosimy przesyłać z
   <string name="clearing_account">Czyszczę konto \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Odtwarzam konto \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Nowa wiadomość</string>
-  <string name="notification_new_messages_title">Nowych wiadomości: <xliff:g id="new_message_count">%d</xliff:g></string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other">Nowych wiadomości: <xliff:g id="new_message_count">%d</xliff:g></item>
+  </plurals>
   <string name="notification_new_one_account_fmt">Nowe: <xliff:g id="unread_message_count">%d</xliff:g> (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> więcej na <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Odpowiedz</string>

--- a/res/values-pt-rBR/strings.xml
+++ b/res/values-pt-rBR/strings.xml
@@ -156,7 +156,9 @@ Por favor, nos envie relatórios de bugs, contribua para novas melhorias e faça
   <string name="clearing_account">Limpando conta \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Recriando conta \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Novo e-mail</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> novas mensagens</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> novas mensagens</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> não lidos (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> mais em <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Responder</string>

--- a/res/values-ru/strings.xml
+++ b/res/values-ru/strings.xml
@@ -158,7 +158,9 @@ K-9 Mail — почтовый клиент для Android.
   <string name="clearing_account">Очистка ящика \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Пересоздание ящика \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Новая почта</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> новых</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> новых</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> новых (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> в <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Ответить</string>

--- a/res/values-sk/strings.xml
+++ b/res/values-sk/strings.xml
@@ -158,7 +158,9 @@ Prosím, nahlasujte prípadné chyby, prispievajte novými funkciami a pýtajte 
   <string name="clearing_account">Čistenie účtu \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Obnovovanie účtu \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Nová správa</string>
-  <string name="notification_new_messages_title">Počet nových správ: <xliff:g id="new_message_count">%d</xliff:g></string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other">Počet nových správ: <xliff:g id="new_message_count">%d</xliff:g></item>
+  </plurals>
   <string name="notification_new_one_account_fmt">Počet neprečítaných správ: <xliff:g id="unread_message_count">%d</xliff:g> v <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_additional_messages">+ ďalších <xliff:g id="additional_messages">%d</xliff:g> v <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Odpovedať</string>

--- a/res/values-sv/strings.xml
+++ b/res/values-sv/strings.xml
@@ -158,7 +158,9 @@ Anmäl fel, hjälp till med nya funktioner och ställ frågor på
   <string name="clearing_account">Rensar konto \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Återskapar konto \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Ny e-post</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> nya meddelanden</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> nya meddelanden</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> olästa (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> ytterligare på <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Svara</string>

--- a/res/values-tr/strings.xml
+++ b/res/values-tr/strings.xml
@@ -157,7 +157,9 @@ Lütfen hata raporlarınızı, istediğiniz yeni özellikleri ve sorularınızı
   <string name="clearing_account">Hesap temizleme \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Hesap yenileme \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Yeni posta</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> yeni mesaj</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> yeni mesaj</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Okunmadı (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages"><xliff:g id="additional_messages">%d</xliff:g> daha fazla <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Yanıtla</string>

--- a/res/values-uk/strings.xml
+++ b/res/values-uk/strings.xml
@@ -156,7 +156,9 @@ K-9 Mail це поштовий клієнт з відкритим вихідни
   <string name="clearing_account">Очищення скриньки \"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="recreating_account">Відновлення облікового запису\"<xliff:g id="account">%s</xliff:g>\"</string>
   <string name="notification_new_title">Нова пошта</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> нові повідомлення</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> нові повідомлення</item>
+  </plurals>
   <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Непрочитане (<xliff:g id="account">%s</xliff:g>)</string>
   <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> більше на <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">Відповісти</string>

--- a/res/values-v21/styles.xml
+++ b/res/values-v21/styles.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <!-- On Lollipop, notifications are on white rather than on dark grey, making
+         the title too light. When using targetSdk 17, #ffffffff (which should be
+         white) is being used as a mask or inverted (not sure which). The net
+         effect is that specifying #ffffffff is resulting in black text. This
+         needs to change once we go to targetSdk 21. -->
+    <style name="TextAppearance.StatusBar.EventContent.Emphasized" parent="@android:style/TextAppearance.StatusBar.EventContent">
+        <item name="android:textColor">#ffffffff</item>
+    </style>
+</resources>

--- a/res/values-zh-rCN/strings.xml
+++ b/res/values-zh-rCN/strings.xml
@@ -156,7 +156,9 @@ K-9改进的功能包括：
   <string name="clearing_account">正在清理账户“<xliff:g id="account">%s</xliff:g>”</string>
   <string name="recreating_account">正在重建账户“<xliff:g id="account">%s</xliff:g>”</string>
   <string name="notification_new_title">您有新邮件</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> 新邮件</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> 新邮件</item>
+  </plurals>
   <string name="notification_new_one_account_fmt">您有<xliff:g id="unread_message_count">%d</xliff:g>封未读邮件（<xliff:g id="account">%s</xliff:g>）</string>
   <string name="notification_additional_messages">再加载 <xliff:g id="additional_messages">%d</xliff:g> 条信息, 账户 <xliff:g id="account">%s</xliff:g></string>
   <string name="notification_action_reply">回复</string>

--- a/res/values-zh-rTW/strings.xml
+++ b/res/values-zh-rTW/strings.xml
@@ -128,7 +128,9 @@
   <string name="clearing_account">正在清理帳戶「<xliff:g id="account">%s</xliff:g>」</string>
   <string name="recreating_account">正在重建帳戶「<xliff:g id="account">%s</xliff:g>」</string>
   <string name="notification_new_title">您有新郵件</string>
-  <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> 新訊息</string>
+  <plurals name="notification_new_messages_title">
+    <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> 新訊息</item>
+  </plurals>
   <string name="notification_new_one_account_fmt">您有<xliff:g id="unread_message_count">%d</xliff:g>封未讀郵件（<xliff:g id="account">%s</xliff:g>）</string>
   <string name="notification_additional_messages">+ 來自<xliff:g id="account">%s</xliff:g>已超過<xliff:g id="additional_messages">%d</xliff:g>則訊息 </string>
   <string name="notification_action_reply">回覆</string>

--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -727,6 +727,22 @@
         <item name="3">ALWAYS</item>
     </string-array>
 
+    <string-array name="global_settings_lock_screen_notification_visibility_entries">
+        <item name="0">@string/global_settings_lock_screen_notification_visibility_nothing</item>
+        <item name="1">@string/global_settings_lock_screen_notification_visibility_app_name</item>
+        <item name="2">@string/global_settings_lock_screen_notification_visibility_message_count</item>
+        <item name="3">@string/global_settings_lock_screen_notification_visibility_senders</item>
+        <item name="4">@string/global_settings_lock_screen_notification_visibility_everything</item>
+    </string-array>
+
+    <string-array name="global_settings_lock_screen_notification_visibility_values" translatable="false">
+        <item name="0">NOTHING</item>
+        <item name="1">APP_NAME</item>
+        <item name="2">MESSAGE_COUNT</item>
+        <item name="3">SENDERS</item>
+        <item name="4">EVERYTHING</item>
+    </string-array>
+
     <string-array name="global_settings_splitview_mode_entries">
         <item>@string/global_settings_splitview_always</item>
         <item>@string/global_settings_splitview_never</item>

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -200,7 +200,10 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="recreating_account">Recreating account \"<xliff:g id="account">%s</xliff:g>\"</string>
 
     <string name="notification_new_title">New mail</string>
-    <string name="notification_new_messages_title"><xliff:g id="new_message_count">%d</xliff:g> new messages</string>
+    <plurals name="notification_new_messages_title">
+        <item quantity="one"><xliff:g id="new_message_count">%d</xliff:g> new message</item>
+        <item quantity="other"><xliff:g id="new_message_count">%d</xliff:g> new messages</item>
+    </plurals>
     <string name="notification_new_one_account_fmt"><xliff:g id="unread_message_count">%d</xliff:g> Unread (<xliff:g id="account">%s</xliff:g>)</string>
     <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%d</xliff:g> more on <xliff:g id="account">%s</xliff:g></string>
 
@@ -338,6 +341,13 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_notification_quick_delete_when_single_msg">For single message notification</string>
     <string name="global_settings_notification_quick_delete_always">Always</string>
     <string name="global_settings_notification_quick_delete_description">Show a button in the notification that allows quick message deletion</string>
+
+    <string name="global_settings_lock_screen_notification_visibility_title">Lock Screen Notifications</string>
+    <string name="global_settings_lock_screen_notification_visibility_nothing">No lock screen notifications</string>
+    <string name="global_settings_lock_screen_notification_visibility_app_name">Application name</string>
+    <string name="global_settings_lock_screen_notification_visibility_message_count">Unread message count</string>
+    <string name="global_settings_lock_screen_notification_visibility_senders">Message count and senders</string>
+    <string name="global_settings_lock_screen_notification_visibility_everything">Same as unlocked notification</string>
 
     <string name="quiet_time">Quiet Time</string>
     <string name="quiet_time_description">Disable ringing, buzzing and flashing at night</string>

--- a/res/xml/global_preferences.xml
+++ b/res/xml/global_preferences.xml
@@ -328,6 +328,14 @@
             android:summary="@string/global_settings_notification_quick_delete_description"
             />
 
+        <ListPreference
+            android:key="lock_screen_notification_visibility"
+            android:persistent="false"
+            android:title="@string/global_settings_lock_screen_notification_visibility_title"
+            android:entries="@array/global_settings_lock_screen_notification_visibility_entries"
+            android:entryValues="@array/global_settings_lock_screen_notification_visibility_values"
+            android:dialogTitle="@string/global_settings_lock_screen_notification_visibility_title" />
+
     </PreferenceScreen>
 
     <PreferenceScreen

--- a/src/com/fsck/k9/K9.java
+++ b/src/com/fsck/k9/K9.java
@@ -224,6 +224,17 @@ public class K9 extends Application {
         NEVER
     }
 
+    private static LockScreenNotificationVisibility sLockScreenNotificationVisibility =
+        LockScreenNotificationVisibility.MESSAGE_COUNT;
+
+    public enum LockScreenNotificationVisibility {
+        EVERYTHING,
+        SENDERS,
+        MESSAGE_COUNT,
+        APP_NAME,
+        NOTHING
+    }
+
     /**
      * Controls when to use the message list split view.
      */
@@ -474,6 +485,15 @@ public class K9 extends Application {
         Log.i(K9.LOG_TAG, "Registered: shutdown receiver");
     }
 
+
+    /**
+     * Save settings from our statics into the app database.
+     * <p/>
+     * If you're adding a preference here, odds are you'll need to add it to
+     * {@link com.fsck.k9.preferences.GlobalSettings}, too.
+     *
+     * @param editor Preferences to save into
+     */
     public static void save(SharedPreferences.Editor editor) {
         editor.putBoolean("enableDebugLogging", K9.DEBUG);
         editor.putBoolean("enableSensitiveLogging", K9.DEBUG_SENSITIVE);
@@ -523,6 +543,7 @@ public class K9 extends Application {
 
         editor.putString("notificationHideSubject", sNotificationHideSubject.toString());
         editor.putString("notificationQuickDelete", sNotificationQuickDelete.toString());
+        editor.putString("lockScreenNotificationVisibility", sLockScreenNotificationVisibility.toString());
 
         editor.putString("attachmentdefaultpath", mAttachmentDefaultPath);
         editor.putBoolean("useBackgroundAsUnreadIndicator", sUseBackgroundAsUnreadIndicator);
@@ -675,6 +696,14 @@ public class K9 extends Application {
         }
     }
 
+    /**
+     * Load preferences into our statics.
+     *
+     * If you're adding a preference here, odds are you'll need to add it to
+     * {@link com.fsck.k9.preferences.GlobalSettings}, too.
+     *
+     * @param prefs Preferences to load
+     */
     public static void loadPrefs(Preferences prefs) {
         SharedPreferences sprefs = prefs.getPreferences();
         DEBUG = sprefs.getBoolean("enableDebugLogging", false);
@@ -743,6 +772,11 @@ public class K9 extends Application {
         String notificationQuickDelete = sprefs.getString("notificationQuickDelete", null);
         if (notificationQuickDelete != null) {
             sNotificationQuickDelete = NotificationQuickDelete.valueOf(notificationQuickDelete);
+        }
+
+        String lockScreenNotificationVisibility = sprefs.getString("lockScreenNotificationVisibility", null);
+        if(lockScreenNotificationVisibility != null) {
+            sLockScreenNotificationVisibility = LockScreenNotificationVisibility.valueOf(lockScreenNotificationVisibility);
         }
 
         String splitViewMode = sprefs.getString("splitViewMode", null);
@@ -1195,6 +1229,14 @@ public class K9 extends Application {
 
     public static void setNotificationQuickDeleteBehaviour(final NotificationQuickDelete mode) {
         sNotificationQuickDelete = mode;
+    }
+
+    public static LockScreenNotificationVisibility getLockScreenNotificationVisibility() {
+        return sLockScreenNotificationVisibility;
+    }
+
+    public static void setLockScreenNotificationVisibility(final LockScreenNotificationVisibility visibility) {
+        sLockScreenNotificationVisibility = visibility;
     }
 
     public static boolean wrapFolderNames() {

--- a/src/com/fsck/k9/activity/setup/Prefs.java
+++ b/src/com/fsck/k9/activity/setup/Prefs.java
@@ -82,6 +82,7 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_QUIET_TIME_STARTS = "quiet_time_starts";
     private static final String PREFERENCE_QUIET_TIME_ENDS = "quiet_time_ends";
     private static final String PREFERENCE_NOTIF_QUICK_DELETE = "notification_quick_delete";
+    private static final String PREFERENCE_LOCK_SCREEN_NOTIFICATION_VISIBILITY = "lock_screen_notification_visibility";
     private static final String PREFERENCE_HIDE_USERAGENT = "privacy_hide_useragent";
     private static final String PREFERENCE_HIDE_TIMEZONE = "privacy_hide_timezone";
 
@@ -144,6 +145,7 @@ public class Prefs extends K9PreferenceActivity {
     private com.fsck.k9.preferences.TimePickerPreference mQuietTimeStarts;
     private com.fsck.k9.preferences.TimePickerPreference mQuietTimeEnds;
     private ListPreference mNotificationQuickDelete;
+    private ListPreference mLockScreenNotificationVisibility;
     private Preference mAttachmentPathPreference;
 
     private CheckBoxPreference mBackgroundAsUnreadIndicator;
@@ -337,6 +339,14 @@ public class Prefs extends K9PreferenceActivity {
             mNotificationQuickDelete = null;
         }
 
+        mLockScreenNotificationVisibility = setupListPreference(PREFERENCE_LOCK_SCREEN_NOTIFICATION_VISIBILITY,
+            K9.getLockScreenNotificationVisibility().toString());
+        if (!MessagingController.platformSupportsLockScreenNotifications()) {
+            ((PreferenceScreen) findPreference("notification_preferences"))
+                .removePreference(mLockScreenNotificationVisibility);
+            mLockScreenNotificationVisibility = null;
+        }
+
         mBackgroundOps = setupListPreference(PREFERENCE_BACKGROUND_OPS, K9.getBackgroundOps().name());
 
         mDebugLogging = (CheckBoxPreference)findPreference(PREFERENCE_DEBUG_LOGGING);
@@ -482,6 +492,11 @@ public class Prefs extends K9PreferenceActivity {
         if (mNotificationQuickDelete != null) {
             K9.setNotificationQuickDeleteBehaviour(
                     NotificationQuickDelete.valueOf(mNotificationQuickDelete.getValue()));
+        }
+
+        if(mLockScreenNotificationVisibility != null) {
+            K9.setLockScreenNotificationVisibility(
+                K9.LockScreenNotificationVisibility.valueOf(mLockScreenNotificationVisibility.getValue()));
         }
 
         K9.setSplitViewMode(SplitViewMode.valueOf(mSplitViewMode.getValue()));

--- a/src/com/fsck/k9/preferences/GlobalSettings.java
+++ b/src/com/fsck/k9/preferences/GlobalSettings.java
@@ -23,6 +23,8 @@ import com.fsck.k9.R;
 import com.fsck.k9.Account.SortType;
 import com.fsck.k9.preferences.Settings.*;
 
+import static com.fsck.k9.K9.LockScreenNotificationVisibility;
+
 public class GlobalSettings {
     public static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
     public static final Map<Integer, SettingsUpgrader> UPGRADERS;
@@ -249,6 +251,9 @@ public class GlobalSettings {
         s.put("hideTimeZone", Settings.versions(
                 new V(32, new BooleanSetting(false))
             ));
+        s.put("lockScreenNotificationVisibility", Settings.versions(
+            new V(37, new EnumSetting<>(LockScreenNotificationVisibility.class, LockScreenNotificationVisibility.MESSAGE_COUNT))
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/src/com/fsck/k9/preferences/Settings.java
+++ b/src/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 36;
+    public static final int VERSION = 37;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,


### PR DESCRIPTION
Add support for lock screen notifications on Lollipop.

Vectorize the icons used there (hooray Illustrator).
Bump SDK and support-v4 to 21.0 to get lock screen notification API support.

No changed for notifications on pre-Lollipop devices.
