### PR TITLE
Don't throw CertificateValidationException for all SSLExceptions.

### DIFF
--- a/src/com/fsck/k9/mail/store/ImapStore.java
+++ b/src/com/fsck/k9/mail/store/ImapStore.java
@@ -23,6 +23,7 @@ import java.nio.charset.CharsetDecoder;
 import java.nio.charset.CodingErrorAction;
 import java.security.GeneralSecurityException;
 import java.security.Security;
+import java.security.cert.CertificateException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -2616,7 +2617,11 @@ public class ImapStore extends Store {
                 }
 
             } catch (SSLException e) {
-                throw new CertificateValidationException(e.getMessage(), e);
+                if (e.getCause() instanceof CertificateException) {
+                    throw new CertificateValidationException(e.getMessage(), e);
+                } else {
+                    throw e;
+                }
             } catch (GeneralSecurityException gse) {
                 throw new MessagingException(
                     "Unable to open connection to IMAP server due to security error.", gse);


### PR DESCRIPTION
An interrupted connection attempt to the server yields an SSLException
as well, like this:

E/k9      ( 6937): Caused by: javax.net.ssl.SSLHandshakeException: Connection closed by peer
E/k9      ( 6937):      at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
E/k9      ( 6937):      at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:302)
E/k9      ( 6937):      at com.android.org.conscrypt.OpenSSLSocketImpl.waitForHandshake(OpenSSLSocketImpl.java:598)
E/k9      ( 6937):      at com.android.org.conscrypt.OpenSSLSocketImpl.getInputStream(OpenSSLSocketImpl.java:560)
E/k9      ( 6937):      at com.fsck.k9.mail.store.ImapStore$ImapConnection.open(ImapStore.java:2459)

We don't want the user to notify of 'certificate problems' in that case.
Fix it by checking whether the SSLException was actually triggered by a
CertificateException.
