### PR TITLE
Introduce option to hide account color chips

### DIFF
--- a/res/layout/account_chip.xml
+++ b/res/layout/account_chip.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <com.fsck.k9.view.AccountChip
+        android:id="@+id/chip"
+        android:layout_height="match_parent"
+        android:layout_width="8dip"
+        android:layout_marginRight="4dp" />
+
+</merge>

--- a/res/layout/accounts_item.xml
+++ b/res/layout/accounts_item.xml
@@ -9,14 +9,7 @@
         android:descendantFocusability="blocksDescendants"
         android:gravity="center_vertical">
 
-    <View
-            android:id="@+id/chip"
-            android:layout_height="match_parent"
-            android:layout_width="8dip"
-            android:background="#ff336699"
-            android:layout_marginRight="8dip"
-            />
-
+    <include layout="@layout/account_chip"/>
 
     <LinearLayout
             android:layout_width="wrap_content"

--- a/res/layout/choose_account_item.xml
+++ b/res/layout/choose_account_item.xml
@@ -6,10 +6,8 @@
     android:orientation="horizontal"
     android:background="?attr/backgroundColorChooseAccountHeader"
     android:gravity="left|center_vertical">
-    <View
-        android:id="@+id/chip"
-        android:layout_height="fill_parent"
-        android:layout_width="6dp"/>
+
+    <include layout="@layout/account_chip"/>
 
     <TextView
         android:id="@+id/name"

--- a/res/layout/folder_list_item.xml
+++ b/res/layout/folder_list_item.xml
@@ -9,14 +9,7 @@
         android:orientation="horizontal"
         android:gravity="center_vertical">
 
-    <View
-            android:id="@+id/chip"
-            android:layout_height="match_parent"
-            android:layout_width="8dip"
-            android:background="#ff336699"
-            android:layout_marginRight="8dip"
-            />
-
+    <include layout="@layout/account_chip"/>
 
     <LinearLayout
             android:layout_width="fill_parent"

--- a/res/layout/message_list_item.xml
+++ b/res/layout/message_list_item.xml
@@ -6,13 +6,7 @@
               android:layout_gravity="center_vertical"
         >
 
-    <View
-            android:id="@+id/chip"
-            android:adjustViewBounds="false"
-            android:layout_height="match_parent"
-            android:layout_width="8dip"
-            android:layout_marginRight="4dp"
-            />
+    <include layout="@layout/account_chip"/>
 
     <LinearLayout
             android:id="@+id/selected_checkbox_wrapper"

--- a/res/layout/message_view_header.xml
+++ b/res/layout/message_view_header.xml
@@ -12,10 +12,7 @@
         android:orientation="horizontal" >
 
         <!-- Color chip -->
-        <View
-            android:id="@+id/chip"
-            android:layout_width="8dip"
-            android:layout_height="match_parent" />
+        <include layout="@layout/account_chip"/>
 
         <LinearLayout
             android:layout_width="match_parent"

--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -349,6 +349,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_lock_screen_notification_visibility_senders">Message count and senders</string>
     <string name="global_settings_lock_screen_notification_visibility_everything">Same as when screen unlocked</string>
 
+    <string name="global_settings_show_account_colors_title">Show account colors</string>
+    <string name="global_settings_show_account_colors_summary">Show account color chips</string>
+
     <string name="quiet_time">Quiet Time</string>
     <string name="quiet_time_description">Disable ringing, buzzing and flashing at night</string>
     <string name="quiet_time_starts">Quiet Time starts</string>

--- a/res/xml/global_preferences.xml
+++ b/res/xml/global_preferences.xml
@@ -86,6 +86,12 @@
                 android:title="@string/animations_title"
                 android:summary="@string/animations_summary" />
 
+            <CheckBoxPreference
+                android:persistent="false"
+                android:key="showAccountColors"
+                android:title="@string/global_settings_show_account_colors_title"
+                android:summary="@string/global_settings_show_account_colors_summary" />
+
         </PreferenceCategory>
 
         <PreferenceCategory

--- a/src/com/fsck/k9/K9.java
+++ b/src/com/fsck/k9/K9.java
@@ -288,6 +288,8 @@ public class K9 extends Application {
     private static boolean sMessageViewCopyActionVisible = false;
     private static boolean sMessageViewSpamActionVisible = false;
 
+    private static boolean mShowAccountColors = true;
+
 
     /**
      * @see #areDatabasesUpToDate()
@@ -557,6 +559,8 @@ public class K9 extends Application {
         editor.putBoolean("messageViewCopyActionVisible", sMessageViewCopyActionVisible);
         editor.putBoolean("messageViewSpamActionVisible", sMessageViewSpamActionVisible);
 
+        editor.putBoolean("showAccountColors", mShowAccountColors);
+
         fontSizes.save(editor);
     }
 
@@ -804,6 +808,8 @@ public class K9 extends Application {
         sMessageViewMoveActionVisible = sprefs.getBoolean("messageViewMoveActionVisible", false);
         sMessageViewCopyActionVisible = sprefs.getBoolean("messageViewCopyActionVisible", false);
         sMessageViewSpamActionVisible = sprefs.getBoolean("messageViewSpamActionVisible", false);
+
+        mShowAccountColors = sprefs.getBoolean("showAccountColors", true);
 
 
         K9.setK9Language(sprefs.getString("language", ""));
@@ -1365,6 +1371,14 @@ public class K9 extends Application {
 
     public static void setMessageViewSpamActionVisible(boolean visible) {
         sMessageViewSpamActionVisible = visible;
+    }
+
+    public static boolean showAccountColors() {
+        return mShowAccountColors;
+    }
+
+    public static void showAccountColors(boolean show) {
+        mShowAccountColors = show;
     }
 
     /**

--- a/src/com/fsck/k9/activity/setup/Prefs.java
+++ b/src/com/fsck/k9/activity/setup/Prefs.java
@@ -97,6 +97,8 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_FOLDERLIST_WRAP_NAME = "folderlist_wrap_folder_name";
     private static final String PREFERENCE_SPLITVIEW_MODE = "splitview_mode";
 
+    private static final String PREFERENCE_SHOW_ACCOUNT_COLORS = "showAccountColors";
+
     private static final int ACTIVITY_CHOOSE_FOLDER = 1;
 
     // Named indices for the mVisibleRefileActions field
@@ -151,6 +153,8 @@ public class Prefs extends K9PreferenceActivity {
     private CheckBoxPreference mBackgroundAsUnreadIndicator;
     private CheckBoxPreference mThreadedView;
     private ListPreference mSplitViewMode;
+
+    private CheckBoxPreference mShowAccountColors;
 
 
     public static void actionPrefs(Context context) {
@@ -359,6 +363,9 @@ public class Prefs extends K9PreferenceActivity {
         mHideUserAgent.setChecked(K9.hideUserAgent());
         mHideTimeZone.setChecked(K9.hideTimeZone());
 
+        mShowAccountColors = (CheckBoxPreference)findPreference(PREFERENCE_SHOW_ACCOUNT_COLORS);
+        mShowAccountColors.setChecked(K9.showAccountColors());
+
         mAttachmentPathPreference = findPreference(PREFERENCE_ATTACHMENT_DEF_PATH);
         mAttachmentPathPreference.setSummary(K9.getAttachmentDefaultPath());
         mAttachmentPathPreference
@@ -510,6 +517,8 @@ public class Prefs extends K9PreferenceActivity {
         K9.DEBUG_SENSITIVE = mSensitiveLogging.isChecked();
         K9.setHideUserAgent(mHideUserAgent.isChecked());
         K9.setHideTimeZone(mHideTimeZone.isChecked());
+
+        K9.showAccountColors(mShowAccountColors.isChecked());
 
         Editor editor = preferences.edit();
         K9.save(editor);

--- a/src/com/fsck/k9/preferences/GlobalSettings.java
+++ b/src/com/fsck/k9/preferences/GlobalSettings.java
@@ -254,6 +254,9 @@ public class GlobalSettings {
         s.put("lockScreenNotificationVisibility", Settings.versions(
             new V(37, new EnumSetting<>(LockScreenNotificationVisibility.class, LockScreenNotificationVisibility.MESSAGE_COUNT))
         ));
+        s.put("showAccountColors", Settings.versions(
+            new V(38, new BooleanSetting(true))
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/src/com/fsck/k9/preferences/Settings.java
+++ b/src/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 37;
+    public static final int VERSION = 38;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,

--- a/src/com/fsck/k9/view/AccountChip.java
+++ b/src/com/fsck/k9/view/AccountChip.java
@@ -1,0 +1,20 @@
+package com.fsck.k9.view;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.View;
+
+import com.fsck.k9.K9;
+
+public class AccountChip extends View {
+
+    public AccountChip(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        toggleVisibility(K9.showAccountColors());
+    }
+
+    private void toggleVisibility(boolean visible) {
+        int visibility = visible ? View.VISIBLE : View.GONE;
+        setVisibility(visibility);
+    }
+}


### PR DESCRIPTION
The new option hides the chips in messsage list, message header, folder
list and account list views.