### PR TITLE
Use correct sub-part of a multipart message when getting text.

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -130,7 +130,7 @@ public class LocalMessage extends MimeMessage {
             }
         } else {
             // We successfully found an HTML part; do the necessary character set decoding.
-            text = MessageExtractor.getTextFromPart(this);
+            text = MessageExtractor.getTextFromPart(part);
         }
         return text;
     }


### PR DESCRIPTION
946565347a758a0ff239b809a3c4fa6278af962e passed 'this' to
getTextFromPart() which could be a multipart. This caused
all multipart messages to show 'No text' as the body.

Fix it by passing it the correct 'part' that was found.
