### PR TITLE
Make k9mail-library compatible with API level 7

### DIFF
--- a/k9mail-library/build.gradle
+++ b/k9mail-library/build.gradle
@@ -19,7 +19,7 @@ android {
     buildToolsVersion '21.1.2'
 
     defaultConfig {
-        minSdkVersion 15
+        minSdkVersion 7
         targetSdkVersion 21
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/filter/Base64.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/filter/Base64.java
@@ -17,8 +17,8 @@
 
 package com.fsck.k9.mail.filter;
 
+import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
-import java.nio.charset.Charset;
 
 /**
  * Provides Base64 encoding and decoding as defined by RFC 2045.
@@ -241,7 +241,12 @@ public class Base64 {
         }
         this.decodeSize = encodeSize - 1;
         if (containsBase64Byte(lineSeparator)) {
-            String sep = new String(lineSeparator, Charset.forName("UTF-8"));
+            String sep;
+            try {
+                sep = new String(lineSeparator, "UTF-8");
+            } catch (UnsupportedEncodingException e) {
+                throw new RuntimeException(e);
+            }
 
             throw new IllegalArgumentException("lineSeperator must not contain base64 characters: [" + sep + "]");
         }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/DecoderUtil.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/DecoderUtil.java
@@ -1,12 +1,13 @@
 
 package com.fsck.k9.mail.internet;
 
+import android.text.TextUtils;
 import android.util.Log;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.io.UnsupportedEncodingException;
 
 import org.apache.james.mime4j.codec.Base64InputStream;
 import org.apache.james.mime4j.codec.QuotedPrintableInputStream;
@@ -32,7 +33,7 @@ class DecoderUtil {
      * @return the decoded string.
      */
     private static String decodeB(String encodedWord, String charset) {
-        byte[] bytes = encodedWord.getBytes(Charset.forName("US-ASCII"));
+        byte[] bytes = getBytes(encodedWord, "US-ASCII");
 
         Base64InputStream is = new Base64InputStream(new ByteArrayInputStream(bytes));
         try {
@@ -65,7 +66,7 @@ class DecoderUtil {
             }
         }
 
-        byte[] bytes = sb.toString().getBytes(Charset.forName("US-ASCII"));
+        byte[] bytes = getBytes(sb.toString(), "US-ASCII");
 
         QuotedPrintableInputStream is = new QuotedPrintableInputStream(new ByteArrayInputStream(bytes));
         try {
@@ -168,7 +169,7 @@ class DecoderUtil {
             return null;
         }
 
-        if (encodedText.isEmpty()) {
+        if (TextUtils.isEmpty(encodedText)) {
             Log.w(LOG_TAG, "Missing encoded text in encoded word: '" + body.substring(begin, end) + "'");
             return null;
         }
@@ -180,6 +181,14 @@ class DecoderUtil {
         } else {
             Log.w(LOG_TAG, "Warning: Unknown encoding in encoded word '" + body.substring(begin, end) + "'");
             return null;
+        }
+    }
+
+    public static byte[] getBytes(String s, String charset) {
+        try {
+            return s.getBytes(charset);
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
         }
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.mail.internet;
 
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.fsck.k9.mail.Body;
@@ -54,7 +55,7 @@ public class MessageExtractor {
                             in.read(buf, 0, buf.length);
                             String str = new String(buf, "US-ASCII");
 
-                            if (str.isEmpty()) {
+                            if (TextUtils.isEmpty(str)) {
                                 return "";
                             }
                             Pattern p = Pattern.compile("<meta http-equiv=\"?Content-Type\"? content=\"text/html; charset=(.+?)\">", Pattern.CASE_INSENSITIVE);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
@@ -1,6 +1,8 @@
 package com.fsck.k9.mail.ssl;
 
 import android.content.Context;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.text.TextUtils;
 import android.util.Log;
 
@@ -142,7 +144,11 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
         TrustManager[] trustManagers = new TrustManager[] { TrustManagerFactory.get(host, port) };
         KeyManager[] keyManagers = null;
         if (!TextUtils.isEmpty(clientCertificateAlias)) {
-            keyManagers = new KeyManager[] { new KeyChainKeyManager(context, clientCertificateAlias) };
+            if (VERSION.SDK_INT >= VERSION_CODES.ICE_CREAM_SANDWICH) {
+                keyManagers = new KeyManager[] { new KeyChainKeyManager(context, clientCertificateAlias) };
+            } else {
+                throw new KeyManagementException("clientCertificates are not supported with this version of Android");
+            }
         }
 
         SSLContext sslContext = SSLContext.getInstance("TLS");

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/KeyChainKeyManager.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/KeyChainKeyManager.java
@@ -14,8 +14,10 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.X509ExtendedKeyManager;
 import javax.security.auth.x500.X500Principal;
 
+import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
+import android.os.Build.VERSION_CODES;
 import android.security.KeyChain;
 import android.security.KeyChainException;
 import android.util.Log;
@@ -31,6 +33,7 @@ import static com.fsck.k9.mail.CertificateValidationException.Reason.RetrievalFa
  * For client certificate authentication! Provide private keys and certificates
  * during the TLS handshake using the Android 4.0 KeyChain API.
  */
+@TargetApi(VERSION_CODES.ICE_CREAM_SANDWICH)
 class KeyChainKeyManager extends X509ExtendedKeyManager {
 
     private static PrivateKey sClientCertificateReferenceWorkaround;


### PR DESCRIPTION
Since we extracted the email handling code into its own module we can also handle API dependencies differently. With some minor changes we could easily support almost all versions of Android, at least for the email/protocol handling parts.

I realise this might be somewhat controversial but just wanted to put it up for discussion.
