### PR TITLE
Fix a typo in Polish translation.

### DIFF
--- a/k9mail/src/main/res/values-pl/strings.xml
+++ b/k9mail/src/main/res/values-pl/strings.xml
@@ -745,7 +745,7 @@ Wszelkie zgłoszenia usterek, zapytania oraz nowe pomysły prosimy przesyłać z
   <string name="messagelist_sent_cc_me_sigil">›</string>
   <string name="error_unable_to_connect">Błąd połączenia.</string>
   <string name="import_export_action">Kopia zapasowa</string>
-  <string name="settings_export_account">Ustawienia konta</string>
+  <string name="settings_export_account">Eksportuj ustawienia konta</string>
   <string name="settings_export_all">Eksport</string>
   <string name="settings_import_dialog_title">Importuj</string>
   <string name="settings_export_dialog_title">Eksportuj</string>


### PR DESCRIPTION
`settings_export_account` is used in the menu that can be activated by long-pressing one account on the main screen. Without this commit, there are two actions named `Ustawienia konta` (`Account settings`), but one of them is actually used to export the settings.