### PR TITLE
Improve UI for switching on/off PGP signing and encryption

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/crypto/PgpData.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/PgpData.java
@@ -9,40 +9,12 @@ public class PgpData implements Serializable {
     protected long mEncryptionKeyIds[] = null;
     protected long mSignatureKeyId = 0;
     protected String mSignatureUserId = null;
-    protected boolean mSignatureSuccess = false;
-    protected boolean mSignatureUnknown = false;
     protected String mDecryptedData = null;
     protected String mEncryptedData = null;
     
     // new API
-    protected OpenPgpSignatureResult mSignatureResult;
-
-    public OpenPgpSignatureResult getSignatureResult() {
-        return mSignatureResult;
-    }
-
-    public void setSignatureResult(OpenPgpSignatureResult signatureResult) {
-        this.mSignatureResult = signatureResult;
-    }
-
-    public void setSignatureKeyId(long keyId) {
-        mSignatureKeyId = keyId;
-    }
-
-    public long getSignatureKeyId() {
-        return mSignatureKeyId;
-    }
-
     public void setEncryptionKeys(long keyIds[]) {
         mEncryptionKeyIds = keyIds;
-    }
-
-    public long[] getEncryptionKeys() {
-        return mEncryptionKeyIds;
-    }
-
-    public boolean hasSignatureKey() {
-        return mSignatureKeyId != 0;
     }
 
     public boolean hasEncryptionKeys() {
@@ -59,33 +31,5 @@ public class PgpData implements Serializable {
 
     public String getDecryptedData() {
         return mDecryptedData;
-    }
-
-    public void setDecryptedData(String data) {
-        mDecryptedData = data;
-    }
-
-    public void setSignatureUserId(String userId) {
-        mSignatureUserId = userId;
-    }
-
-    public String getSignatureUserId() {
-        return mSignatureUserId;
-    }
-
-    public boolean getSignatureSuccess() {
-        return mSignatureSuccess;
-    }
-
-    public void setSignatureSuccess(boolean success) {
-        mSignatureSuccess = success;
-    }
-
-    public boolean getSignatureUnknown() {
-        return mSignatureUnknown;
-    }
-
-    public void setSignatureUnknown(boolean unknown) {
-        mSignatureUnknown = unknown;
     }
 }

--- a/k9mail/src/main/res/layout/message_compose.xml
+++ b/k9mail/src/main/res/layout/message_compose.xml
@@ -1,314 +1,281 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
-    android:orientation="vertical">
+    android:fillViewport="true"
+    android:scrollbarStyle="insideOverlay">
 
-    <ScrollView
+    <LinearLayout
         android:layout_width="fill_parent"
-        android:layout_height="0dip"
-        android:layout_weight="1"
-        android:scrollbarStyle="insideOverlay"
-        android:fillViewport="true">
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <LinearLayout
             android:layout_width="fill_parent"
             android:layout_height="wrap_content"
-            android:orientation="vertical" >
+            android:layout_marginBottom="4dp"
+            android:background="#45bcbcbc"
+            android:orientation="vertical"
+            android:paddingTop="6dp">
 
-            <LinearLayout
+            <Button
+                android:id="@+id/identity"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:layout_marginBottom="4dp"
-                android:paddingTop="6dp"
-                android:orientation="vertical"
-                android:background="#45bcbcbc">
+                android:layout_marginLeft="6dip"
+                android:layout_marginRight="6dip"
+                android:gravity="center_vertical" />
 
-                <Button
-                    android:id="@+id/identity"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:gravity="center_vertical"
-                    android:layout_marginLeft="6dip"
-                    android:layout_marginRight="6dip"/>
+            <LinearLayout
+                android:id="@+id/to_wrapper"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="6dip"
+                android:layout_marginRight="6dip"
+                android:baselineAligned="true"
+                android:gravity="bottom">
 
-                <LinearLayout
-                    android:id="@+id/to_wrapper"
+                <MultiAutoCompleteTextView
+                    android:id="@+id/to"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:baselineAligned="true"
-                    android:gravity="bottom"
-                    android:layout_marginLeft="6dip"
                     android:layout_marginRight="6dip"
-                    android:layout_width="fill_parent">
-
-                    <MultiAutoCompleteTextView
-                        android:id="@+id/to"
-                        android:layout_height="wrap_content"
-                        android:inputType="textEmailAddress|textMultiLine"
-                        android:imeOptions="actionNext"
-                        android:hint="@string/message_compose_to_hint"
-                        android:textAppearance="?android:attr/textAppearanceMedium"
-                        android:layout_width="0dp"
-                        android:layout_marginRight="6dip"
-                        android:layout_weight="1"/>
-
-                    <ImageButton
-                        android:id="@+id/add_to"
-                        android:contentDescription="@string/message_compose_description_add_to"
-                        android:src="?attr/messageComposeAddContactImage"
-                        android:layout_height="wrap_content"
-                        android:layout_width="wrap_content"
-                        android:padding="8dip"
-                        android:layout_marginTop="1dip"/>
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/cc_wrapper"
-                    android:visibility="gone"
-                    android:layout_height="wrap_content"
-                    android:baselineAligned="true"
-                    android:gravity="bottom"
-                    android:layout_marginLeft="6dip"
-                    android:layout_marginRight="6dip"
-                    android:layout_width="fill_parent">
-
-                    <MultiAutoCompleteTextView
-                        android:id="@+id/cc"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"
-                        android:layout_marginRight="6dip"
-                        android:inputType="textEmailAddress|textMultiLine"
-                        android:imeOptions="actionNext"
-                        android:hint="@string/message_compose_cc_hint"
-                        android:textAppearance="?android:attr/textAppearanceMedium"/>
-
-                    <ImageButton
-                        android:id="@+id/add_cc"
-                        android:contentDescription="@string/message_compose_description_add_cc"
-                        android:src="?attr/messageComposeAddContactImage"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:padding="8dip"
-                        android:layout_marginTop="1dip"/>
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/bcc_wrapper"
-                    android:visibility="gone"
-                    android:layout_height="wrap_content"
-                    android:baselineAligned="true"
-                    android:gravity="bottom"
-                    android:layout_marginLeft="6dip"
-                    android:layout_marginRight="6dip"
-                    android:layout_width="fill_parent">
-
-                    <MultiAutoCompleteTextView
-                        android:id="@+id/bcc"
-                        android:layout_width="0dp"
-                        android:layout_height="wrap_content"
-                        android:layout_marginRight="6dip"
-                        android:layout_weight="1"
-                        android:inputType="textEmailAddress|textMultiLine"
-                        android:imeOptions="actionNext"
-                        android:hint="@string/message_compose_bcc_hint"
-                        android:textAppearance="?android:attr/textAppearanceMedium"/>
-
-                    <ImageButton
-                        android:id="@+id/add_bcc"
-                        android:contentDescription="@string/message_compose_description_add_bcc"
-                        android:layout_marginTop="1dip"
-                        android:layout_height="wrap_content"
-                        android:layout_width="wrap_content"
-                        android:padding="8dip"
-                        android:src="?attr/messageComposeAddContactImage"/>
-
-                </LinearLayout>
-
-                <LinearLayout
-                    android:id="@+id/layout_encrypt"
-                    android:orientation="horizontal"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:visibility="gone"
-                    android:paddingLeft="6dip"
-                    android:paddingRight="6dip">
-
-                    <LinearLayout
-                        android:orientation="horizontal"
-                        android:layout_gravity="center_vertical"
-                       android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1">
-
-                        <CheckBox
-                            android:text="@string/btn_crypto_sign"
-                            android:id="@+id/cb_crypto_signature"
-                            android:layout_gravity="center_vertical"
-                            android:layout_width="wrap_content"
-                            android:layout_height="wrap_content"/>
-
-                        <LinearLayout
-                            android:orientation="vertical"
-                            android:layout_gravity="center_vertical"
-                            android:layout_height="wrap_content"
-                            android:layout_width="wrap_content"
-                            android:paddingRight="2dip">
-
-                            <TextView
-                                android:id="@+id/userId"
-                                android:ellipsize="end"
-                                android:textAppearance="?android:attr/textAppearanceSmall"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"/>
-
-                            <TextView
-                                android:id="@+id/userIdRest"
-                                android:textSize="10sp"
-                                android:ellipsize="end"
-                                android:layout_width="wrap_content"
-                                android:layout_height="wrap_content"/>
-
-                        </LinearLayout>
-
-                    </LinearLayout>
-
-                    <CheckBox
-                        android:text="@string/btn_encrypt"
-                        android:id="@+id/cb_encrypt"
-                        android:layout_gravity="center_vertical"
-                        android:layout_width="wrap_content"
-                        android:layout_height="wrap_content"
-                        android:layout_weight="1"/>
-
-                </LinearLayout>
-
-                <EditText
-                    android:id="@+id/subject"
-                    android:layout_width="fill_parent"
-                    android:layout_height="wrap_content"
-                    android:layout_marginLeft="6dip"
-                    android:layout_marginRight="6dip"
-                    android:hint="@string/message_compose_subject_hint"
-                    android:inputType="textEmailSubject|textAutoCorrect|textCapSentences|textImeMultiLine"
+                    android:layout_weight="1"
+                    android:hint="@string/message_compose_to_hint"
                     android:imeOptions="actionNext"
-                    android:singleLine="true"
+                    android:inputType="textEmailAddress|textMultiLine"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <!--
-                    Empty container for storing attachments. We'll stick
-                    instances of message_compose_attachment.xml in here.
-                -->
-                <LinearLayout
-                    android:id="@+id/attachments"
-                    android:layout_width="fill_parent"
+                <ImageButton
+                    android:id="@+id/add_to"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:orientation="vertical" />
-
-                <View
-                    android:layout_width="fill_parent"
-                    android:layout_height="1dip"
-                    android:background="@drawable/divider_horizontal_email" />
+                    android:layout_marginTop="1dip"
+                    android:contentDescription="@string/message_compose_description_add_to"
+                    android:padding="8dip"
+                    android:src="?attr/messageComposeAddContactImage" />
 
             </LinearLayout>
 
-            <!-- We have to use "wrap_content" (not "0dip") for "layout_height", otherwise the
-                 EditText won't properly grow in height while the user is typing the message -->
-            <view
-                class="com.fsck.k9.ui.EolConvertingEditText"
-                android:id="@+id/message_content"
+            <LinearLayout
+                android:id="@+id/cc_wrapper"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:layout_weight="1"
-                android:gravity="top"
-                android:hint="@string/message_compose_content_hint"
-                android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
-                android:imeOptions="actionDone|flagNoEnterAction"
-                android:minLines="3"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
+                android:layout_marginLeft="6dip"
+                android:layout_marginRight="6dip"
+                android:baselineAligned="true"
+                android:gravity="bottom"
+                android:visibility="gone">
 
-            <view
-                class="com.fsck.k9.ui.EolConvertingEditText"
-                android:id="@+id/upper_signature"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:gravity="top"
-                android:minLines="0"
-                android:hint="@string/message_compose_signature_hint"
-                android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <Button
-                android:id="@+id/quoted_text_show"
-                android:text="@string/message_compose_show_quoted_text_action"
-                android:textSize="16sp"
-                android:padding="0dip"
-                android:layout_gravity="right"
-                android:layout_height="wrap_content"
-                android:layout_width="match_parent"/>
-
-            <!-- Quoted text bar -->
-            <RelativeLayout
-                android:id="@+id/quoted_text_bar"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content">
-
-                <view
-                    class="com.fsck.k9.ui.EolConvertingEditText"
-                    android:id="@+id/quoted_text"
-                    android:layout_width="fill_parent"
+                <MultiAutoCompleteTextView
+                    android:id="@+id/cc"
+                    android:layout_width="0dp"
                     android:layout_height="wrap_content"
-                    android:gravity="top"
-                    android:minLines="3"
-                    android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
+                    android:layout_marginRight="6dip"
+                    android:layout_weight="1"
+                    android:hint="@string/message_compose_cc_hint"
+                    android:imeOptions="actionNext"
+                    android:inputType="textEmailAddress|textMultiLine"
                     android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <com.fsck.k9.view.MessageWebView
-                    android:id="@+id/quoted_html"
-                    android:layout_height="wrap_content"
-                    android:layout_width="fill_parent" />
-
-                <LinearLayout
-                    android:id="@+id/quoted_text_buttons"
+                <ImageButton
+                    android:id="@+id/add_cc"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:layout_alignParentTop="true"
-                    android:layout_alignParentRight="true">
+                    android:layout_marginTop="1dip"
+                    android:contentDescription="@string/message_compose_description_add_cc"
+                    android:padding="8dip"
+                    android:src="?attr/messageComposeAddContactImage" />
 
-                    <ImageButton
-                        android:id="@+id/quoted_text_edit"
-                        android:contentDescription="@string/message_compose_description_edit_quoted_text"
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/bcc_wrapper"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="6dip"
+                android:layout_marginRight="6dip"
+                android:baselineAligned="true"
+                android:gravity="bottom"
+                android:visibility="gone">
+
+                <MultiAutoCompleteTextView
+                    android:id="@+id/bcc"
+                    android:layout_width="0dp"
+                    android:layout_height="wrap_content"
+                    android:layout_marginRight="6dip"
+                    android:layout_weight="1"
+                    android:hint="@string/message_compose_bcc_hint"
+                    android:imeOptions="actionNext"
+                    android:inputType="textEmailAddress|textMultiLine"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <ImageButton
+                    android:id="@+id/add_bcc"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="1dip"
+                    android:contentDescription="@string/message_compose_description_add_bcc"
+                    android:padding="8dip"
+                    android:src="?attr/messageComposeAddContactImage" />
+
+            </LinearLayout>
+
+                <LinearLayout
+                    android:id="@+id/layout_encrypt"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:orientation="horizontal">
+
+                    <Switch
+                        android:id="@+id/signature_switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+
+                    <ImageView
+                        android:id="@+id/signature_indicator"
+                        android:paddingRight="8dp"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginRight="8dip"
-                        android:background="@drawable/btn_edit" />
+                        android:src="@drawable/status_signature_verified_cutout" />
 
-                    <ImageButton
-                        android:id="@+id/quoted_text_delete"
-                        android:contentDescription="@string/message_compose_description_delete_quoted_text"
+                    <Switch
+                        android:id="@+id/encrypt_switch"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content" />
+
+                    <ImageView
+                        android:id="@+id/encrypt_indicator"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:background="@drawable/btn_dialog" />
+                        android:src="@drawable/status_lock_closed" />
 
                 </LinearLayout>
 
-            </RelativeLayout>
 
-            <view
-                class="com.fsck.k9.ui.EolConvertingEditText"
-                android:id="@+id/lower_signature"
+            <EditText
+                android:id="@+id/subject"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:gravity="top"
-                android:minLines="0"
-                android:hint="@string/message_compose_signature_hint"
-                android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
+                android:layout_marginLeft="6dip"
+                android:layout_marginRight="6dip"
+                android:hint="@string/message_compose_subject_hint"
+                android:imeOptions="actionNext"
+                android:inputType="textEmailSubject|textAutoCorrect|textCapSentences|textImeMultiLine"
+                android:singleLine="true"
                 android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <!--
+                Empty container for storing attachments. We'll stick
+                instances of message_compose_attachment.xml in here.
+            -->
+            <LinearLayout
+                android:id="@+id/attachments"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical" />
+
+            <View
+                android:layout_width="fill_parent"
+                android:layout_height="1dip"
+                android:background="@drawable/divider_horizontal_email" />
 
         </LinearLayout>
 
-    </ScrollView>
+        <!-- We have to use "wrap_content" (not "0dip") for "layout_height", otherwise the
+             EditText won't properly grow in height while the user is typing the message -->
+        <view
+            android:id="@+id/message_content"
+            class="com.fsck.k9.ui.EolConvertingEditText"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:gravity="top"
+            android:hint="@string/message_compose_content_hint"
+            android:imeOptions="actionDone|flagNoEnterAction"
+            android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
+            android:minLines="3"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-</LinearLayout>
+        <view
+            android:id="@+id/upper_signature"
+            class="com.fsck.k9.ui.EolConvertingEditText"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:gravity="top"
+            android:hint="@string/message_compose_signature_hint"
+            android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
+            android:minLines="0"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <Button
+            android:id="@+id/quoted_text_show"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="right"
+            android:padding="0dip"
+            android:text="@string/message_compose_show_quoted_text_action"
+            android:textSize="16sp" />
+
+        <!-- Quoted text bar -->
+        <RelativeLayout
+            android:id="@+id/quoted_text_bar"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content">
+
+            <view
+                android:id="@+id/quoted_text"
+                class="com.fsck.k9.ui.EolConvertingEditText"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:gravity="top"
+                android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
+                android:minLines="3"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <com.fsck.k9.view.MessageWebView
+                android:id="@+id/quoted_html"
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content" />
+
+            <LinearLayout
+                android:id="@+id/quoted_text_buttons"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_alignParentRight="true"
+                android:layout_alignParentTop="true">
+
+                <ImageButton
+                    android:id="@+id/quoted_text_edit"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_marginRight="8dip"
+                    android:background="@drawable/btn_edit"
+                    android:contentDescription="@string/message_compose_description_edit_quoted_text" />
+
+                <ImageButton
+                    android:id="@+id/quoted_text_delete"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="@drawable/btn_dialog"
+                    android:contentDescription="@string/message_compose_description_delete_quoted_text" />
+
+            </LinearLayout>
+
+        </RelativeLayout>
+
+        <view
+            android:id="@+id/lower_signature"
+            class="com.fsck.k9.ui.EolConvertingEditText"
+            android:layout_width="fill_parent"
+            android:layout_height="wrap_content"
+            android:gravity="top"
+            android:hint="@string/message_compose_signature_hint"
+            android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
+            android:minLines="0"
+            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+    </LinearLayout>
+
+</ScrollView>


### PR DESCRIPTION
The Idea is to use the same design language as is used when displaying messages so users get to know what these icons mean.
Also we will add a settings thingy next to it as the next step.
Also cleaned up stuff around legacy PgpData - should be removed completely as @dschuermann suggested - but let's do it in small steps

![output_optimized](https://cloud.githubusercontent.com/assets/111600/5963256/db9d6cb0-a7ea-11e4-9ee7-450d0c5aee17.gif)
