### PR TITLE
Don't throw CertificateValidationException for all SSLExceptions.

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -385,7 +385,11 @@ public class Pop3Store extends RemoteStore {
                             "Unhandled authentication method found in the server settings (bug).");
                 }
             } catch (SSLException e) {
-                throw new CertificateValidationException(e.getMessage(), e);
+            	  if (e.getCause() instanceof CertificateException) {
+                      throw new CertificateValidationException(e.getMessage(), e);
+                  } else {
+                      throw e;
+                  }
             } catch (GeneralSecurityException gse) {
                 throw new MessagingException(
                     "Unable to open connection to POP server due to security error.", gse);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -789,7 +789,11 @@ public class WebDavStore extends RemoteStore {
                                       response.getStatusLine().toString());
             }
         } catch (SSLException e) {
-            throw new CertificateValidationException(e.getMessage(), e);
+        	  if (e.getCause() instanceof CertificateException) {
+                  throw new CertificateValidationException(e.getMessage(), e);
+              } else {
+                  throw e;
+              }
         } catch (IOException ioe) {
             Log.e(LOG_TAG, "IOException: " + ioe + "\nTrace: " + processException(ioe));
             throw new MessagingException("IOException", ioe);


### PR DESCRIPTION
POP3 and WEBDAV fixes.

An interrupted connection attempt to the server yields an SSLException
as well, like this:

E/k9      ( 6937): Caused by: javax.net.ssl.SSLHandshakeException: Connection closed by peer
E/k9      ( 6937):      at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
E/k9      ( 6937):      at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:302)
E/k9      ( 6937):      at com.android.org.conscrypt.OpenSSLSocketImpl.waitForHandshake(OpenSSLSocketImpl.java:598)
E/k9      ( 6937):      at com.android.org.conscrypt.OpenSSLSocketImpl.getInputStream(OpenSSLSocketImpl.java:560)
E/k9      ( 6937):      at com.fsck.k9.mail.store.ImapStore$ImapConnection.open(ImapStore.java:2459)

We don't want the user to notify of 'certificate problems' in that case.
Fix it by checking whether the SSLException was actually triggered by a
CertificateException.