### PR TITLE
Fixes issue 6703

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -2285,11 +2285,11 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             mSelectedCount += selectedCountDelta;
         }
 
-        computeBatchDirection();
-        updateActionModeTitle();
-
         // make sure the onPrepareActionMode is called
         mActionMode.invalidate();
+
+        computeBatchDirection();
+        updateActionModeTitle();
 
         computeSelectAllVisibility();
 


### PR DESCRIPTION
- onPrepareActionMode must be called before computeBatchDirection
  because computeBatchDirection ends up referencing mMarkAsRead /
  mMarkAsUnread and mFlag / mUnflag which could be null otherwise.