### PR TITLE
remove redundant cast (Button)

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.java
@@ -7,7 +7,6 @@ import android.os.Bundle;
 import android.util.Log;
 import android.view.View;
 import android.view.View.OnClickListener;
-import android.widget.Button;
 import android.widget.Toast;
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
@@ -41,9 +40,9 @@ public class AccountSetupAccountType extends K9Activity implements OnClickListen
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.account_setup_account_type);
-        ((Button)findViewById(R.id.pop)).setOnClickListener(this);
-        ((Button)findViewById(R.id.imap)).setOnClickListener(this);
-        ((Button)findViewById(R.id.webdav)).setOnClickListener(this);
+        findViewById(R.id.pop).setOnClickListener(this);
+        findViewById(R.id.imap).setOnClickListener(this);
+        findViewById(R.id.webdav).setOnClickListener(this);
 
         String accountUuid = getIntent().getStringExtra(EXTRA_ACCOUNT);
         mAccount = Preferences.getPreferences(this).getAccount(accountUuid);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/WelcomeMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/WelcomeMessage.java
@@ -33,8 +33,8 @@ public class WelcomeMessage extends K9Activity implements OnClickListener{
         welcome.setText(HtmlConverter.htmlToSpanned(getString(R.string.accounts_welcome)));
         welcome.setMovementMethod(LinkMovementMethod.getInstance());
 
-        ((Button) findViewById(R.id.next)).setOnClickListener(this);
-        ((Button) findViewById(R.id.import_settings)).setOnClickListener(this);
+        findViewById(R.id.next).setOnClickListener(this);
+        findViewById(R.id.import_settings).setOnClickListener(this);
     }
 
     @Override


### PR DESCRIPTION
findViewById(R.id.pop) ,
findViewById(R.id.imap) and
findViewById(R.id.webdav)
are Button so it’s redundant to cast it to Button