### PR TITLE
Added placeholder for application ID

### DIFF
--- a/k9mail/src/main/AndroidManifest.xml
+++ b/k9mail/src/main/AndroidManifest.xml
@@ -29,36 +29,36 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <permission
-        android:name="com.fsck.k9.permission.READ_ATTACHMENT"
+        android:name="${applicationId}.permission.READ_ATTACHMENT"
         android:description="@string/read_attachment_desc"
         android:label="@string/read_attachment_label"
         android:permissionGroup="android.permission-group.MESSAGES"
         android:protectionLevel="dangerous"/>
-    <uses-permission android:name="com.fsck.k9.permission.READ_ATTACHMENT"/>
+    <uses-permission android:name="${applicationId}.permission.READ_ATTACHMENT"/>
 
     <permission
-        android:name="com.fsck.k9.permission.REMOTE_CONTROL"
+        android:name="${applicationId}.permission.REMOTE_CONTROL"
         android:description="@string/remote_control_desc"
         android:label="@string/remote_control_label"
         android:permissionGroup="android.permission-group.MESSAGES"
         android:protectionLevel="dangerous"/>
-    <uses-permission android:name="com.fsck.k9.permission.REMOTE_CONTROL"/>
+    <uses-permission android:name="${applicationId}.permission.REMOTE_CONTROL"/>
 
     <permission
-        android:name="com.fsck.k9.permission.READ_MESSAGES"
+        android:name="${applicationId}.permission.READ_MESSAGES"
         android:description="@string/read_messages_desc"
         android:label="@string/read_messages_label"
         android:permissionGroup="android.permission-group.MESSAGES"
         android:protectionLevel="dangerous"/>
-    <uses-permission android:name="com.fsck.k9.permission.READ_MESSAGES"/>
+    <uses-permission android:name="${applicationId}.permission.READ_MESSAGES"/>
 
     <permission
-        android:name="com.fsck.k9.permission.DELETE_MESSAGES"
+        android:name="${applicationId}.permission.DELETE_MESSAGES"
         android:description="@string/delete_messages_desc"
         android:label="@string/delete_messages_label"
         android:permissionGroup="android.permission-group.MESSAGES"
         android:protectionLevel="dangerous"/>
-    <uses-permission android:name="com.fsck.k9.permission.DELETE_MESSAGES"/>
+    <uses-permission android:name="${applicationId}.permission.DELETE_MESSAGES"/>
 
 
     <application
@@ -98,7 +98,7 @@
             android:configChanges="locale"
             android:excludeFromRecents="true"
             android:label="@string/prefs_title"
-            android:taskAffinity="com.fsck.k9.activity.setup.Prefs"/>
+            android:taskAffinity="${applicationId}.activity.setup.Prefs"/>
 
         <activity
             android:name=".activity.setup.WelcomeMessage"
@@ -315,12 +315,12 @@
         <receiver
             android:name=".service.RemoteControlReceiver"
             android:enabled="true"
-            android:permission="com.fsck.k9.permission.REMOTE_CONTROL">
+            android:permission="${applicationId}.permission.REMOTE_CONTROL">
             <intent-filter>
-                <action android:name="com.fsck.k9.K9RemoteControl.set"/>
+                <action android:name="${applicationId}.K9RemoteControl.set"/>
             </intent-filter>
             <intent-filter>
-                <action android:name="com.fsck.k9.K9RemoteControl.requestAccounts"/>
+                <action android:name="${applicationId}.K9RemoteControl.requestAccounts"/>
             </intent-filter>
         </receiver>
 
@@ -383,7 +383,7 @@
         <service
             android:name=".service.RemoteControlService"
             android:enabled="true"
-            android:permission="com.fsck.k9.permission.REMOTE_CONTROL"/>
+            android:permission="${applicationId}.permission.REMOTE_CONTROL"/>
 
         <service
             android:name=".service.SleepService"
@@ -395,24 +395,24 @@
 
         <provider
             android:name=".provider.AttachmentProvider"
-            android:authorities="com.fsck.k9.attachmentprovider"
+            android:authorities="${applicationId}.attachmentprovider"
             android:exported="true"
             android:grantUriPermissions="true"
             android:multiprocess="true"
-            android:readPermission="com.fsck.k9.permission.READ_ATTACHMENT"/>
+            android:readPermission="${applicationId}.permission.READ_ATTACHMENT"/>
 
         <provider
             android:name=".provider.MessageProvider"
-            android:authorities="com.fsck.k9.messageprovider"
+            android:authorities="${applicationId}.messageprovider"
             android:exported="true"
             android:grantUriPermissions="true"
             android:multiprocess="true"
-            android:readPermission="com.fsck.k9.permission.READ_MESSAGES"
-            android:writePermission="com.fsck.k9.permission.DELETE_MESSAGES"/>
+            android:readPermission="${applicationId}.permission.READ_MESSAGES"
+            android:writePermission="${applicationId}.permission.DELETE_MESSAGES"/>
 
         <provider
             android:name=".provider.EmailProvider"
-            android:authorities="com.fsck.k9.provider.email"
+            android:authorities="${applicationId}.provider.email"
             android:exported="false"/>
 
     </application>

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -339,18 +339,18 @@ public class K9 extends Application {
     public static class Intents {
 
         public static class EmailReceived {
-            public static final String ACTION_EMAIL_RECEIVED    = "com.fsck.k9.intent.action.EMAIL_RECEIVED";
-            public static final String ACTION_EMAIL_DELETED     = "com.fsck.k9.intent.action.EMAIL_DELETED";
-            public static final String ACTION_REFRESH_OBSERVER  = "com.fsck.k9.intent.action.REFRESH_OBSERVER";
-            public static final String EXTRA_ACCOUNT            = "com.fsck.k9.intent.extra.ACCOUNT";
-            public static final String EXTRA_FOLDER             = "com.fsck.k9.intent.extra.FOLDER";
-            public static final String EXTRA_SENT_DATE          = "com.fsck.k9.intent.extra.SENT_DATE";
-            public static final String EXTRA_FROM               = "com.fsck.k9.intent.extra.FROM";
-            public static final String EXTRA_TO                 = "com.fsck.k9.intent.extra.TO";
-            public static final String EXTRA_CC                 = "com.fsck.k9.intent.extra.CC";
-            public static final String EXTRA_BCC                = "com.fsck.k9.intent.extra.BCC";
-            public static final String EXTRA_SUBJECT            = "com.fsck.k9.intent.extra.SUBJECT";
-            public static final String EXTRA_FROM_SELF          = "com.fsck.k9.intent.extra.FROM_SELF";
+            public static final String ACTION_EMAIL_RECEIVED = BuildConfig.APPLICATION_ID + ".intent.action.EMAIL_RECEIVED";
+            public static final String ACTION_EMAIL_DELETED = BuildConfig.APPLICATION_ID + ".intent.action.EMAIL_DELETED";
+            public static final String ACTION_REFRESH_OBSERVER = BuildConfig.APPLICATION_ID + ".intent.action.REFRESH_OBSERVER";
+            public static final String EXTRA_ACCOUNT = BuildConfig.APPLICATION_ID + ".intent.extra.ACCOUNT";
+            public static final String EXTRA_FOLDER = BuildConfig.APPLICATION_ID + ".intent.extra.FOLDER";
+            public static final String EXTRA_SENT_DATE = BuildConfig.APPLICATION_ID + ".intent.extra.SENT_DATE";
+            public static final String EXTRA_FROM = BuildConfig.APPLICATION_ID + ".intent.extra.FROM";
+            public static final String EXTRA_TO = BuildConfig.APPLICATION_ID + ".intent.extra.TO";
+            public static final String EXTRA_CC = BuildConfig.APPLICATION_ID + ".intent.extra.CC";
+            public static final String EXTRA_BCC = BuildConfig.APPLICATION_ID + ".intent.extra.BCC";
+            public static final String EXTRA_SUBJECT = BuildConfig.APPLICATION_ID + ".intent.extra.SUBJECT";
+            public static final String EXTRA_FROM_SELF = BuildConfig.APPLICATION_ID + ".intent.extra.FROM_SELF";
         }
 
         public static class Share {
@@ -359,7 +359,7 @@ public class K9 extends Application {
              * because of different semantics (String array vs. string with comma separated
              * email addresses)
              */
-            public static final String EXTRA_FROM               = "com.fsck.k9.intent.extra.SENDER";
+            public static final String EXTRA_FROM = BuildConfig.APPLICATION_ID + ".intent.extra.SENDER";
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -22,6 +22,7 @@ import android.widget.TextView;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.FolderMode;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
@@ -31,14 +32,14 @@ import com.fsck.k9.mail.Folder;
 
 
 public class ChooseFolder extends K9ListActivity {
-    public static final String EXTRA_ACCOUNT = "com.fsck.k9.ChooseFolder_account";
-    public static final String EXTRA_CUR_FOLDER = "com.fsck.k9.ChooseFolder_curfolder";
-    public static final String EXTRA_SEL_FOLDER = "com.fsck.k9.ChooseFolder_selfolder";
-    public static final String EXTRA_NEW_FOLDER = "com.fsck.k9.ChooseFolder_newfolder";
-    public static final String EXTRA_MESSAGE = "com.fsck.k9.ChooseFolder_message";
-    public static final String EXTRA_SHOW_CURRENT = "com.fsck.k9.ChooseFolder_showcurrent";
-    public static final String EXTRA_SHOW_FOLDER_NONE = "com.fsck.k9.ChooseFolder_showOptionNone";
-    public static final String EXTRA_SHOW_DISPLAYABLE_ONLY = "com.fsck.k9.ChooseFolder_showDisplayableOnly";
+    public static final String EXTRA_ACCOUNT = BuildConfig.APPLICATION_ID + ".ChooseFolder_account";
+    public static final String EXTRA_CUR_FOLDER = BuildConfig.APPLICATION_ID + ".ChooseFolder_curfolder";
+    public static final String EXTRA_SEL_FOLDER = BuildConfig.APPLICATION_ID + ".ChooseFolder_selfolder";
+    public static final String EXTRA_NEW_FOLDER = BuildConfig.APPLICATION_ID + ".ChooseFolder_newfolder";
+    public static final String EXTRA_MESSAGE = BuildConfig.APPLICATION_ID + ".ChooseFolder_message";
+    public static final String EXTRA_SHOW_CURRENT = BuildConfig.APPLICATION_ID + ".ChooseFolder_showcurrent";
+    public static final String EXTRA_SHOW_FOLDER_NONE = BuildConfig.APPLICATION_ID + ".ChooseFolder_showOptionNone";
+    public static final String EXTRA_SHOW_DISPLAYABLE_ONLY = BuildConfig.APPLICATION_ID + ".ChooseFolder_showDisplayableOnly";
 
 
     String mFolder;

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
@@ -10,6 +10,7 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
 import com.fsck.k9.Account;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.Identity;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
@@ -19,8 +20,8 @@ public class ChooseIdentity extends K9ListActivity {
     Account mAccount;
     ArrayAdapter<String> adapter;
 
-    public static final String EXTRA_ACCOUNT = "com.fsck.k9.ChooseIdentity_account";
-    public static final String EXTRA_IDENTITY = "com.fsck.k9.ChooseIdentity_identity";
+    public static final String EXTRA_ACCOUNT = BuildConfig.APPLICATION_ID + ".ChooseIdentity_account";
+    public static final String EXTRA_IDENTITY = BuildConfig.APPLICATION_ID + ".ChooseIdentity_identity";
 
     protected List<Identity> identities = null;
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/EditIdentity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/EditIdentity.java
@@ -7,6 +7,7 @@ import android.widget.CompoundButton;
 import android.widget.EditText;
 import android.widget.LinearLayout;
 import com.fsck.k9.Account;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.Identity;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
@@ -14,9 +15,9 @@ import java.util.List;
 
 public class EditIdentity extends K9Activity {
 
-    public static final String EXTRA_IDENTITY = "com.fsck.k9.EditIdentity_identity";
-    public static final String EXTRA_IDENTITY_INDEX = "com.fsck.k9.EditIdentity_identity_index";
-    public static final String EXTRA_ACCOUNT = "com.fsck.k9.EditIdentity_account";
+    public static final String EXTRA_IDENTITY = BuildConfig.APPLICATION_ID + ".EditIdentity_identity";
+    public static final String EXTRA_IDENTITY_INDEX = BuildConfig.APPLICATION_ID + ".EditIdentity_identity_index";
+    public static final String EXTRA_ACCOUNT = BuildConfig.APPLICATION_ID + ".EditIdentity_account";
 
     private Account mAccount;
     private Identity mIdentity;

--- a/k9mail/src/main/java/com/fsck/k9/activity/ManageIdentities.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ManageIdentities.java
@@ -11,13 +11,14 @@ import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.ListView;
 import android.widget.Toast;
 
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.Identity;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
 
 public class ManageIdentities extends ChooseIdentity {
     private boolean mIdentitiesChanged = false;
-    public static final String EXTRA_IDENTITIES = "com.fsck.k9.EditIdentity_identities";
+    public static final String EXTRA_IDENTITIES = BuildConfig.APPLICATION_ID + ".EditIdentity_identities";
 
     private static final int ACTIVITY_EDIT_IDENTITY = 1;
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -72,6 +72,7 @@ import android.widget.Toast;
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.MessageFormat;
 import com.fsck.k9.Account.QuoteStyle;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.EmailAddressAdapter;
 import com.fsck.k9.EmailAddressValidator;
 import com.fsck.k9.FontSizes;
@@ -135,41 +136,41 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
     private static final long INVALID_DRAFT_ID = MessagingController.INVALID_MESSAGE_ID;
 
-    private static final String ACTION_COMPOSE = "com.fsck.k9.intent.action.COMPOSE";
-    private static final String ACTION_REPLY = "com.fsck.k9.intent.action.REPLY";
-    private static final String ACTION_REPLY_ALL = "com.fsck.k9.intent.action.REPLY_ALL";
-    private static final String ACTION_FORWARD = "com.fsck.k9.intent.action.FORWARD";
-    private static final String ACTION_EDIT_DRAFT = "com.fsck.k9.intent.action.EDIT_DRAFT";
+    private static final String ACTION_COMPOSE = BuildConfig.APPLICATION_ID + ".intent.action.COMPOSE";
+    private static final String ACTION_REPLY = BuildConfig.APPLICATION_ID + ".intent.action.REPLY";
+    private static final String ACTION_REPLY_ALL = BuildConfig.APPLICATION_ID + ".intent.action.REPLY_ALL";
+    private static final String ACTION_FORWARD = BuildConfig.APPLICATION_ID + ".intent.action.FORWARD";
+    private static final String ACTION_EDIT_DRAFT = BuildConfig.APPLICATION_ID + ".intent.action.EDIT_DRAFT";
 
     private static final String EXTRA_ACCOUNT = "account";
     private static final String EXTRA_MESSAGE_BODY  = "messageBody";
     private static final String EXTRA_MESSAGE_REFERENCE = "message_reference";
 
     private static final String STATE_KEY_ATTACHMENTS =
-        "com.fsck.k9.activity.MessageCompose.attachments";
+            BuildConfig.APPLICATION_ID + ".activity.MessageCompose.attachments";
     private static final String STATE_KEY_CC_SHOWN =
-        "com.fsck.k9.activity.MessageCompose.ccShown";
+            BuildConfig.APPLICATION_ID + ".activity.MessageCompose.ccShown";
     private static final String STATE_KEY_BCC_SHOWN =
-        "com.fsck.k9.activity.MessageCompose.bccShown";
+            BuildConfig.APPLICATION_ID + ".activity.MessageCompose.bccShown";
     private static final String STATE_KEY_QUOTED_TEXT_MODE =
-        "com.fsck.k9.activity.MessageCompose.QuotedTextShown";
+            BuildConfig.APPLICATION_ID + ".activity.MessageCompose.QuotedTextShown";
     private static final String STATE_KEY_SOURCE_MESSAGE_PROCED =
-        "com.fsck.k9.activity.MessageCompose.stateKeySourceMessageProced";
-    private static final String STATE_KEY_DRAFT_ID = "com.fsck.k9.activity.MessageCompose.draftId";
-    private static final String STATE_KEY_HTML_QUOTE = "com.fsck.k9.activity.MessageCompose.HTMLQuote";
+            BuildConfig.APPLICATION_ID + ".activity.MessageCompose.stateKeySourceMessageProced";
+    private static final String STATE_KEY_DRAFT_ID = BuildConfig.APPLICATION_ID + ".activity.MessageCompose.draftId";
+    private static final String STATE_KEY_HTML_QUOTE = BuildConfig.APPLICATION_ID + ".activity.MessageCompose.HTMLQuote";
     private static final String STATE_IDENTITY_CHANGED =
-        "com.fsck.k9.activity.MessageCompose.identityChanged";
+            BuildConfig.APPLICATION_ID + ".activity.MessageCompose.identityChanged";
     private static final String STATE_IDENTITY =
-        "com.fsck.k9.activity.MessageCompose.identity";
+            BuildConfig.APPLICATION_ID + ".activity.MessageCompose.identity";
     private static final String STATE_PGP_DATA = "pgpData";
-    private static final String STATE_IN_REPLY_TO = "com.fsck.k9.activity.MessageCompose.inReplyTo";
-    private static final String STATE_REFERENCES = "com.fsck.k9.activity.MessageCompose.references";
-    private static final String STATE_KEY_READ_RECEIPT = "com.fsck.k9.activity.MessageCompose.messageReadReceipt";
-    private static final String STATE_KEY_DRAFT_NEEDS_SAVING = "com.fsck.k9.activity.MessageCompose.mDraftNeedsSaving";
+    private static final String STATE_IN_REPLY_TO = BuildConfig.APPLICATION_ID + ".activity.MessageCompose.inReplyTo";
+    private static final String STATE_REFERENCES = BuildConfig.APPLICATION_ID + ".activity.MessageCompose.references";
+    private static final String STATE_KEY_READ_RECEIPT = BuildConfig.APPLICATION_ID + ".activity.MessageCompose.messageReadReceipt";
+    private static final String STATE_KEY_DRAFT_NEEDS_SAVING = BuildConfig.APPLICATION_ID + ".activity.MessageCompose.mDraftNeedsSaving";
     private static final String STATE_KEY_FORCE_PLAIN_TEXT =
-            "com.fsck.k9.activity.MessageCompose.forcePlainText";
+            BuildConfig.APPLICATION_ID + ".activity.MessageCompose.forcePlainText";
     private static final String STATE_KEY_QUOTED_TEXT_FORMAT =
-            "com.fsck.k9.activity.MessageCompose.quotedTextFormat";
+            BuildConfig.APPLICATION_ID + ".activity.MessageCompose.quotedTextFormat";
     private static final String STATE_KEY_NUM_ATTACHMENTS_LOADING = "numAttachmentsLoading";
     private static final String STATE_KEY_WAITING_FOR_ATTACHMENTS = "waitingForAttachments";
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -29,6 +29,7 @@ import android.widget.Toast;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.SortType;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.SplitViewMode;
 import com.fsck.k9.Preferences;
@@ -78,8 +79,8 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     private static final String EXTRA_MESSAGE_REFERENCE = "message_reference";
 
     // used for remote search
-    public static final String EXTRA_SEARCH_ACCOUNT = "com.fsck.k9.search_account";
-    private static final String EXTRA_SEARCH_FOLDER = "com.fsck.k9.search_folder";
+    public static final String EXTRA_SEARCH_ACCOUNT = BuildConfig.APPLICATION_ID + ".search_account";
+    private static final String EXTRA_SEARCH_FOLDER = BuildConfig.APPLICATION_ID + ".search_folder";
 
     private static final String STATE_DISPLAY_MODE = "displayMode";
     private static final String STATE_MESSAGE_LIST_WAS_DISPLAYED = "messageListWasDisplayed";

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -27,6 +27,7 @@ import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.EditText;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.EmailAddressValidator;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
@@ -54,12 +55,12 @@ import com.fsck.k9.view.ClientCertificateSpinner.OnClientCertificateChangedListe
  */
 public class AccountSetupBasics extends K9Activity
     implements OnClickListener, TextWatcher, OnCheckedChangeListener, OnClientCertificateChangedListener {
-    private final static String EXTRA_ACCOUNT = "com.fsck.k9.AccountSetupBasics.account";
+    private final static String EXTRA_ACCOUNT = BuildConfig.APPLICATION_ID + ".AccountSetupBasics.account";
     private final static int DIALOG_NOTE = 1;
     private final static String STATE_KEY_PROVIDER =
-            "com.fsck.k9.AccountSetupBasics.provider";
+            BuildConfig.APPLICATION_ID + ".AccountSetupBasics.provider";
     private final static String STATE_KEY_CHECKED_INCOMING =
-            "com.fsck.k9.AccountSetupBasics.checkedIncoming";
+            BuildConfig.APPLICATION_ID + ".AccountSetupBasics.checkedIncoming";
 
     private EditText mEmailView;
     private EditText mPasswordView;

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
@@ -22,8 +22,8 @@ import com.fsck.k9.service.MailService;
 
 public class FolderSettings extends K9PreferenceActivity {
 
-    private static final String EXTRA_FOLDER_NAME = "com.fsck.k9.folderName";
-    private static final String EXTRA_ACCOUNT = "com.fsck.k9.account";
+    private static final String EXTRA_FOLDER_NAME = BuildConfig.APPLICATION_ID + ".folderName";
+    private static final String EXTRA_ACCOUNT = BuildConfig.APPLICATION_ID + ".account";
 
     private static final String PREFERENCE_TOP_CATERGORY = "folder_settings";
     private static final String PREFERENCE_DISPLAY_CLASS = "folder_settings_folder_display_mode";

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -43,6 +43,7 @@ import android.util.Log;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.AccountStats;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationHideSubject;
 import com.fsck.k9.K9.Intents;
@@ -140,15 +141,15 @@ public class MessagingController implements Runnable {
      * So 25k gives good performance and a reasonable data footprint. Sounds good to me.
      */
 
-    private static final String PENDING_COMMAND_MOVE_OR_COPY = "com.fsck.k9.MessagingController.moveOrCopy";
-    private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK = "com.fsck.k9.MessagingController.moveOrCopyBulk";
-    private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW = "com.fsck.k9.MessagingController.moveOrCopyBulkNew";
-    private static final String PENDING_COMMAND_EMPTY_TRASH = "com.fsck.k9.MessagingController.emptyTrash";
-    private static final String PENDING_COMMAND_SET_FLAG_BULK = "com.fsck.k9.MessagingController.setFlagBulk";
-    private static final String PENDING_COMMAND_SET_FLAG = "com.fsck.k9.MessagingController.setFlag";
-    private static final String PENDING_COMMAND_APPEND = "com.fsck.k9.MessagingController.append";
-    private static final String PENDING_COMMAND_MARK_ALL_AS_READ = "com.fsck.k9.MessagingController.markAllAsRead";
-    private static final String PENDING_COMMAND_EXPUNGE = "com.fsck.k9.MessagingController.expunge";
+    private static final String PENDING_COMMAND_MOVE_OR_COPY = BuildConfig.APPLICATION_ID + ".MessagingController.moveOrCopy";
+    private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK = BuildConfig.APPLICATION_ID + ".MessagingController.moveOrCopyBulk";
+    private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW = BuildConfig.APPLICATION_ID + ".MessagingController.moveOrCopyBulkNew";
+    private static final String PENDING_COMMAND_EMPTY_TRASH = BuildConfig.APPLICATION_ID + ".MessagingController.emptyTrash";
+    private static final String PENDING_COMMAND_SET_FLAG_BULK = BuildConfig.APPLICATION_ID + ".MessagingController.setFlagBulk";
+    private static final String PENDING_COMMAND_SET_FLAG = BuildConfig.APPLICATION_ID + ".MessagingController.setFlag";
+    private static final String PENDING_COMMAND_APPEND = BuildConfig.APPLICATION_ID + ".MessagingController.append";
+    private static final String PENDING_COMMAND_MARK_ALL_AS_READ = BuildConfig.APPLICATION_ID + ".MessagingController.markAllAsRead";
+    private static final String PENDING_COMMAND_EXPUNGE = BuildConfig.APPLICATION_ID + ".MessagingController.expunge";
 
     public static class UidReverseComparator implements Comparator<Message> {
         @Override

--- a/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.cache.EmailProviderCacheCursor;
 import com.fsck.k9.helper.Utility;
@@ -43,7 +44,7 @@ import android.text.TextUtils;
 public class EmailProvider extends ContentProvider {
     private static final UriMatcher sUriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
 
-    public static final String AUTHORITY = "com.fsck.k9.provider.email";
+    public static final String AUTHORITY = BuildConfig.APPLICATION_ID +".provider.email";
 
     public static final Uri CONTENT_URI = Uri.parse("content://" + AUTHORITY);
 

--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -21,6 +21,7 @@ import android.util.Log;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.AccountStats;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.FolderInfoHolder;
@@ -940,7 +941,7 @@ public class MessageProvider extends ContentProvider {
         }
     }
 
-    public static final String AUTHORITY = "com.fsck.k9.messageprovider";
+    public static final String AUTHORITY = BuildConfig.APPLICATION_ID + ".messageprovider";
 
     public static final Uri CONTENT_URI = Uri.parse("content://" + AUTHORITY);
 

--- a/k9mail/src/main/java/com/fsck/k9/remotecontrol/K9RemoteControl.java
+++ b/k9mail/src/main/java/com/fsck/k9/remotecontrol/K9RemoteControl.java
@@ -5,6 +5,8 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 
+import com.fsck.k9.BuildConfig;
+
 /**
  * Utillity definitions for Android applications to control the behavior of K-9 Mail.  All such applications must declare the following permission:
  * <uses-permission android:name="com.fsck.k9.permission.REMOTE_CONTROL"/>
@@ -24,14 +26,14 @@ public class K9RemoteControl {
      * Permission that every application sending a broadcast to K-9 for Remote Control purposes should send on every broadcast.
      * Prevent other applications from intercepting the broadcasts.
      */
-    public final static String K9_REMOTE_CONTROL_PERMISSION = "com.fsck.k9.permission.REMOTE_CONTROL";
+    public final static String K9_REMOTE_CONTROL_PERMISSION = BuildConfig.APPLICATION_ID + ".permission.REMOTE_CONTROL";
     /**
      * {@link Intent} Action to be sent to K-9 using {@link ContextWrapper.sendOrderedBroadcast} in order to fetch the list of configured Accounts.
      * The responseData will contain two String[] with keys K9_ACCOUNT_UUIDS and K9_ACCOUNT_DESCRIPTIONS
      */
-    public final static String K9_REQUEST_ACCOUNTS = "com.fsck.k9.K9RemoteControl.requestAccounts";
-    public final static String K9_ACCOUNT_UUIDS = "com.fsck.k9.K9RemoteControl.accountUuids";
-    public final static String K9_ACCOUNT_DESCRIPTIONS = "com.fsck.k9.K9RemoteControl.accountDescriptions";
+    public final static String K9_REQUEST_ACCOUNTS = BuildConfig.APPLICATION_ID + ".K9RemoteControl.requestAccounts";
+    public final static String K9_ACCOUNT_UUIDS = BuildConfig.APPLICATION_ID + ".K9RemoteControl.accountUuids";
+    public final static String K9_ACCOUNT_DESCRIPTIONS = BuildConfig.APPLICATION_ID + ".K9RemoteControl.accountDescriptions";
 
     /**
      * The {@link {@link Intent}} Action to set in order to cause K-9 to check mail.  (Not yet implemented)
@@ -41,17 +43,17 @@ public class K9RemoteControl {
     /**
      * The {@link {@link Intent}} Action to set when remotely changing K-9 Mail settings
      */
-    public final static String K9_SET = "com.fsck.k9.K9RemoteControl.set";
+    public final static String K9_SET = BuildConfig.APPLICATION_ID + ".K9RemoteControl.set";
     /**
      * The key of the {@link Intent} Extra to set to hold the UUID of a single Account's settings to change.  Used only if K9_ALL_ACCOUNTS
      * is absent or false.
      */
-    public final static String K9_ACCOUNT_UUID = "com.fsck.k9.K9RemoteControl.accountUuid";
+    public final static String K9_ACCOUNT_UUID = BuildConfig.APPLICATION_ID + ".K9RemoteControl.accountUuid";
     /**
      * The key of the {@link Intent} Extra to set to control if the settings will apply to all Accounts, or to the one
      * specified with K9_ACCOUNT_UUID
      */
-    public final static String K9_ALL_ACCOUNTS = "com.fsck.k9.K9RemoteControl.allAccounts";
+    public final static String K9_ALL_ACCOUNTS = BuildConfig.APPLICATION_ID + ".K9RemoteControl.allAccounts";
 
     public final static String K9_ENABLED = "true";
     public final static String K9_DISABLED = "false";
@@ -60,17 +62,17 @@ public class K9RemoteControl {
      * Key for the {@link Intent} Extra for controlling whether notifications will be generated for new unread mail.
      * Acceptable values are K9_ENABLED and K9_DISABLED
      */
-    public final static String K9_NOTIFICATION_ENABLED = "com.fsck.k9.K9RemoteControl.notificationEnabled";
+    public final static String K9_NOTIFICATION_ENABLED = BuildConfig.APPLICATION_ID + ".K9RemoteControl.notificationEnabled";
     /*
      * Key for the {@link Intent} Extra for controlling whether K-9 will sound the ringtone for new unread mail.
      * Acceptable values are K9_ENABLED and K9_DISABLED
      */
-    public final static String K9_RING_ENABLED = "com.fsck.k9.K9RemoteControl.ringEnabled";
+    public final static String K9_RING_ENABLED = BuildConfig.APPLICATION_ID + ".K9RemoteControl.ringEnabled";
     /*
      * Key for the {@link Intent} Extra for controlling whether K-9 will activate the vibrator for new unread mail.
      * Acceptable values are K9_ENABLED and K9_DISABLED
      */
-    public final static String K9_VIBRATE_ENABLED = "com.fsck.k9.K9RemoteControl.vibrateEnabled";
+    public final static String K9_VIBRATE_ENABLED = BuildConfig.APPLICATION_ID + ".K9RemoteControl.vibrateEnabled";
 
     public final static String K9_FOLDERS_NONE = "NONE";
     public final static String K9_FOLDERS_ALL = "ALL";
@@ -82,27 +84,27 @@ public class K9RemoteControl {
      * Acceptable values are K9_FOLDERS_ALL, K9_FOLDERS_FIRST_CLASS, K9_FOLDERS_FIRST_AND_SECOND_CLASS,
      * K9_FOLDERS_NOT_SECOND_CLASS, K9_FOLDERS_NONE
      */
-    public final static String K9_PUSH_CLASSES = "com.fsck.k9.K9RemoteControl.pushClasses";
+    public final static String K9_PUSH_CLASSES = BuildConfig.APPLICATION_ID + ".K9RemoteControl.pushClasses";
     /**
      * Key for the {@link Intent} Extra to set for controlling which folders to be synchronized with Poll.
      * Acceptable values are K9_FOLDERS_ALL, K9_FOLDERS_FIRST_CLASS, K9_FOLDERS_FIRST_AND_SECOND_CLASS,
      * K9_FOLDERS_NOT_SECOND_CLASS, K9_FOLDERS_NONE
      */
-    public final static String K9_POLL_CLASSES = "com.fsck.k9.K9RemoteControl.pollClasses";
+    public final static String K9_POLL_CLASSES = BuildConfig.APPLICATION_ID + ".K9RemoteControl.pollClasses";
 
     public final static String[] K9_POLL_FREQUENCIES = { "-1", "1", "5", "10", "15", "30", "60", "120", "180", "360", "720", "1440"};
     /**
      * Key for the {@link Intent} Extra to set with the desired poll frequency.  The value is a String representing a number of minutes.
      * Acceptable values are available in K9_POLL_FREQUENCIES
      */
-    public final static String K9_POLL_FREQUENCY = "com.fsck.k9.K9RemoteControl.pollFrequency";
+    public final static String K9_POLL_FREQUENCY = BuildConfig.APPLICATION_ID + ".K9RemoteControl.pollFrequency";
 
     /**
      * Key for the {@link Intent} Extra to set for controlling K-9's global "Background sync" setting.
      * Acceptable values are K9_BACKGROUND_OPERATIONS_ALWAYS, K9_BACKGROUND_OPERATIONS_NEVER
      * K9_BACKGROUND_OPERATIONS_WHEN_CHECKED_AUTO_SYNC
      */
-    public final static String K9_BACKGROUND_OPERATIONS = "com.fsck.k9.K9RemoteControl.backgroundOperations";
+    public final static String K9_BACKGROUND_OPERATIONS = BuildConfig.APPLICATION_ID + ".K9RemoteControl.backgroundOperations";
     public final static String K9_BACKGROUND_OPERATIONS_ALWAYS = "ALWAYS";
     public final static String K9_BACKGROUND_OPERATIONS_NEVER = "NEVER";
     public final static String K9_BACKGROUND_OPERATIONS_WHEN_CHECKED_AUTO_SYNC = "WHEN_CHECKED_AUTO_SYNC";
@@ -111,7 +113,7 @@ public class K9RemoteControl {
      * Key for the {@link Intent} Extra to set for controlling which display theme K-9 will use.  Acceptable values are
      * K9_THEME_LIGHT, K9_THEME_DARK
      */
-    public final static String K9_THEME = "com.fsck.k9.K9RemoteControl.theme";
+    public final static String K9_THEME = BuildConfig.APPLICATION_ID + ".K9RemoteControl.theme";
     public final static String K9_THEME_LIGHT = "LIGHT";
     public final static String K9_THEME_DARK = "DARK";
 

--- a/k9mail/src/main/java/com/fsck/k9/service/BootReceiver.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/BootReceiver.java
@@ -11,16 +11,17 @@ import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.util.Log;
 
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 
 public class BootReceiver extends CoreReceiver {
 
-    public static final String FIRE_INTENT = "com.fsck.k9.service.BroadcastReceiver.fireIntent";
-    public static final String SCHEDULE_INTENT = "com.fsck.k9.service.BroadcastReceiver.scheduleIntent";
-    public static final String CANCEL_INTENT = "com.fsck.k9.service.BroadcastReceiver.cancelIntent";
+    public static final String FIRE_INTENT = BuildConfig.APPLICATION_ID + ".service.BroadcastReceiver.fireIntent";
+    public static final String SCHEDULE_INTENT = BuildConfig.APPLICATION_ID + ".service.BroadcastReceiver.scheduleIntent";
+    public static final String CANCEL_INTENT = BuildConfig.APPLICATION_ID + ".service.BroadcastReceiver.cancelIntent";
 
-    public static final String ALARMED_INTENT = "com.fsck.k9.service.BroadcastReceiver.pendingIntent";
-    public static final String AT_TIME = "com.fsck.k9.service.BroadcastReceiver.atTime";
+    public static final String ALARMED_INTENT = BuildConfig.APPLICATION_ID + ".service.BroadcastReceiver.pendingIntent";
+    public static final String AT_TIME = BuildConfig.APPLICATION_ID + ".service.BroadcastReceiver.atTime";
 
     @Override
     public Integer receive(Context context, Intent intent, Integer tmpWakeLockId) {

--- a/k9mail/src/main/java/com/fsck/k9/service/CoreReceiver.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/CoreReceiver.java
@@ -10,15 +10,16 @@ import android.content.Intent;
 import android.os.PowerManager;
 import android.util.Log;
 
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.mail.power.TracingPowerManager;
 import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
 
 public class CoreReceiver extends BroadcastReceiver {
 
-    public static final String WAKE_LOCK_RELEASE = "com.fsck.k9.service.CoreReceiver.wakeLockRelease";
+    public static final String WAKE_LOCK_RELEASE = BuildConfig.APPLICATION_ID + ".service.CoreReceiver.wakeLockRelease";
 
-    public static final String WAKE_LOCK_ID = "com.fsck.k9.service.CoreReceiver.wakeLockId";
+    public static final String WAKE_LOCK_ID = BuildConfig.APPLICATION_ID + ".service.CoreReceiver.wakeLockId";
 
     private static ConcurrentHashMap<Integer, TracingWakeLock> wakeLocks = new ConcurrentHashMap<Integer, TracingWakeLock>();
     private static AtomicInteger wakeLockSeq = new AtomicInteger(0);

--- a/k9mail/src/main/java/com/fsck/k9/service/CoreService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/CoreService.java
@@ -12,6 +12,8 @@ import android.content.Intent;
 import android.os.IBinder;
 import android.os.PowerManager;
 import android.util.Log;
+
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.mail.power.TracingPowerManager;
@@ -57,7 +59,7 @@ import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
  */
 public abstract class CoreService extends Service {
 
-    public static final String WAKE_LOCK_ID = "com.fsck.k9.service.CoreService.wakeLockId";
+    public static final String WAKE_LOCK_ID = BuildConfig.APPLICATION_ID + ".service.CoreService.wakeLockId";
 
     private static ConcurrentHashMap<Integer, TracingWakeLock> sWakeLocks =
         new ConcurrentHashMap<Integer, TracingWakeLock>();

--- a/k9mail/src/main/java/com/fsck/k9/service/DatabaseUpgradeService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/DatabaseUpgradeService.java
@@ -12,6 +12,7 @@ import android.support.v4.content.LocalBroadcastManager;
 import android.util.Log;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.UpgradeDatabases;
@@ -69,7 +70,7 @@ public class DatabaseUpgradeService extends Service {
      * Action used to start this service.
      */
     private static final String ACTION_START_SERVICE =
-            "com.fsck.k9.service.DatabaseUpgradeService.startService";
+            BuildConfig.APPLICATION_ID + ".service.DatabaseUpgradeService.startService";
 
     private static final String WAKELOCK_TAG = "DatabaseUpgradeService";
     private static final long WAKELOCK_TIMEOUT = 10 * 60 * 1000;    // 10 minutes

--- a/k9mail/src/main/java/com/fsck/k9/service/MailService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/MailService.java
@@ -12,6 +12,7 @@ import android.os.IBinder;
 import android.util.Log;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.Account.FolderMode;
@@ -20,14 +21,14 @@ import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Pusher;
 
 public class MailService extends CoreService {
-    private static final String ACTION_CHECK_MAIL = "com.fsck.k9.intent.action.MAIL_SERVICE_WAKEUP";
-    private static final String ACTION_RESET = "com.fsck.k9.intent.action.MAIL_SERVICE_RESET";
-    private static final String ACTION_RESCHEDULE_POLL = "com.fsck.k9.intent.action.MAIL_SERVICE_RESCHEDULE_POLL";
-    private static final String ACTION_CANCEL = "com.fsck.k9.intent.action.MAIL_SERVICE_CANCEL";
-    private static final String ACTION_REFRESH_PUSHERS = "com.fsck.k9.intent.action.MAIL_SERVICE_REFRESH_PUSHERS";
-    private static final String ACTION_RESTART_PUSHERS = "com.fsck.k9.intent.action.MAIL_SERVICE_RESTART_PUSHERS";
-    private static final String CONNECTIVITY_CHANGE = "com.fsck.k9.intent.action.MAIL_SERVICE_CONNECTIVITY_CHANGE";
-    private static final String CANCEL_CONNECTIVITY_NOTICE = "com.fsck.k9.intent.action.MAIL_SERVICE_CANCEL_CONNECTIVITY_NOTICE";
+    private static final String ACTION_CHECK_MAIL = BuildConfig.APPLICATION_ID + ".intent.action.MAIL_SERVICE_WAKEUP";
+    private static final String ACTION_RESET = BuildConfig.APPLICATION_ID + ".intent.action.MAIL_SERVICE_RESET";
+    private static final String ACTION_RESCHEDULE_POLL = BuildConfig.APPLICATION_ID + ".intent.action.MAIL_SERVICE_RESCHEDULE_POLL";
+    private static final String ACTION_CANCEL = BuildConfig.APPLICATION_ID + ".intent.action.MAIL_SERVICE_CANCEL";
+    private static final String ACTION_REFRESH_PUSHERS = BuildConfig.APPLICATION_ID + ".intent.action.MAIL_SERVICE_REFRESH_PUSHERS";
+    private static final String ACTION_RESTART_PUSHERS = BuildConfig.APPLICATION_ID + ".intent.action.MAIL_SERVICE_RESTART_PUSHERS";
+    private static final String CONNECTIVITY_CHANGE = BuildConfig.APPLICATION_ID + ".intent.action.MAIL_SERVICE_CONNECTIVITY_CHANGE";
+    private static final String CANCEL_CONNECTIVITY_NOTICE = BuildConfig.APPLICATION_ID + ".intent.action.MAIL_SERVICE_CANCEL_CONNECTIVITY_NOTICE";
 
     private static long nextCheck = -1;
     private static boolean pushingRequested = false;
@@ -164,7 +165,7 @@ public class MailService extends CoreService {
 
     private void cancel() {
         Intent i = new Intent();
-        i.setClassName(getApplication().getPackageName(), "com.fsck.k9.service.MailService");
+        i.setClassName(getApplication().getPackageName(), BuildConfig.APPLICATION_ID +".service.MailService");
         i.setAction(ACTION_CHECK_MAIL);
         BootReceiver.cancelIntent(this, i);
     }
@@ -305,7 +306,7 @@ public class MailService extends CoreService {
             }
 
             Intent i = new Intent();
-            i.setClassName(getApplication().getPackageName(), "com.fsck.k9.service.MailService");
+            i.setClassName(getApplication().getPackageName(), BuildConfig.APPLICATION_ID +".service.MailService");
             i.setAction(ACTION_CHECK_MAIL);
             BootReceiver.scheduleIntent(MailService.this, nextTime, i);
         }
@@ -411,7 +412,7 @@ public class MailService extends CoreService {
             if (K9.DEBUG)
                 Log.d(K9.LOG_TAG, "Next pusher refresh scheduled for " + new Date(nextTime));
             Intent i = new Intent();
-            i.setClassName(getApplication().getPackageName(), "com.fsck.k9.service.MailService");
+            i.setClassName(getApplication().getPackageName(), BuildConfig.APPLICATION_ID +".service.MailService");
             i.setAction(ACTION_REFRESH_PUSHERS);
             BootReceiver.scheduleIntent(MailService.this, nextTime, i);
         }

--- a/k9mail/src/main/java/com/fsck/k9/service/NotificationActionService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/NotificationActionService.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.MessageCompose;
@@ -19,10 +20,10 @@ import android.content.Intent;
 import android.util.Log;
 
 public class NotificationActionService extends CoreService {
-    private final static String REPLY_ACTION = "com.fsck.k9.service.NotificationActionService.REPLY_ACTION";
-    private final static String READ_ALL_ACTION = "com.fsck.k9.service.NotificationActionService.READ_ALL_ACTION";
-    private final static String DELETE_ALL_ACTION = "com.fsck.k9.service.NotificationActionService.DELETE_ALL_ACTION";
-    private final static String ACKNOWLEDGE_ACTION = "com.fsck.k9.service.NotificationActionService.ACKNOWLEDGE_ACTION";
+    private final static String REPLY_ACTION = BuildConfig.APPLICATION_ID + ".service.NotificationActionService.REPLY_ACTION";
+    private final static String READ_ALL_ACTION = BuildConfig.APPLICATION_ID + ".service.NotificationActionService.READ_ALL_ACTION";
+    private final static String DELETE_ALL_ACTION = BuildConfig.APPLICATION_ID + ".service.NotificationActionService.DELETE_ALL_ACTION";
+    private final static String ACKNOWLEDGE_ACTION = BuildConfig.APPLICATION_ID + ".service.NotificationActionService.ACKNOWLEDGE_ACTION";
 
     private final static String EXTRA_ACCOUNT = "account";
     private final static String EXTRA_MESSAGE = "message";

--- a/k9mail/src/main/java/com/fsck/k9/service/PollService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/PollService.java
@@ -15,8 +15,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PollService extends CoreService {
-    private static String START_SERVICE = "com.fsck.k9.service.PollService.startService";
-    private static String STOP_SERVICE = "com.fsck.k9.service.PollService.stopService";
+    private static String START_SERVICE = BuildConfig.APPLICATION_ID + ".service.PollService.startService";
+    private static String STOP_SERVICE = BuildConfig.APPLICATION_ID + ".service.PollService.stopService";
 
     private Listener mListener = new Listener();
 

--- a/k9mail/src/main/java/com/fsck/k9/service/PushService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/PushService.java
@@ -4,11 +4,13 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
 import android.util.Log;
+
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 
 public class PushService extends CoreService {
-    private static String START_SERVICE = "com.fsck.k9.service.PushService.startService";
-    private static String STOP_SERVICE = "com.fsck.k9.service.PushService.stopService";
+    private static String START_SERVICE = BuildConfig.APPLICATION_ID + ".service.PushService.startService";
+    private static String STOP_SERVICE = BuildConfig.APPLICATION_ID + ".service.PushService.stopService";
 
     public static void startService(Context context) {
         Intent i = new Intent();

--- a/k9mail/src/main/java/com/fsck/k9/service/RemoteControlService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/RemoteControlService.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.service;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.remotecontrol.K9RemoteControl;
 import com.fsck.k9.Preferences;
@@ -20,10 +21,10 @@ import android.widget.Toast;
 import java.util.List;
 
 public class RemoteControlService extends CoreService {
-    private final static String RESCHEDULE_ACTION = "com.fsck.k9.service.RemoteControlService.RESCHEDULE_ACTION";
-    private final static String PUSH_RESTART_ACTION = "com.fsck.k9.service.RemoteControlService.PUSH_RESTART_ACTION";
+    private final static String RESCHEDULE_ACTION = BuildConfig.APPLICATION_ID + ".service.RemoteControlService.RESCHEDULE_ACTION";
+    private final static String PUSH_RESTART_ACTION = BuildConfig.APPLICATION_ID + ".service.RemoteControlService.PUSH_RESTART_ACTION";
 
-    private final static String SET_ACTION = "com.fsck.k9.service.RemoteControlService.SET_ACTION";
+    private final static String SET_ACTION = BuildConfig.APPLICATION_ID + ".service.RemoteControlService.SET_ACTION";
 
     public static void set(Context context, Intent i, Integer wakeLockId) {
         //  Intent i = new Intent();
@@ -135,14 +136,14 @@ public class RemoteControlService extends CoreService {
 
                         if (needsReschedule) {
                             Intent i = new Intent();
-                            i.setClassName(getApplication().getPackageName(), "com.fsck.k9.service.RemoteControlService");
+                            i.setClassName(getApplication().getPackageName(), BuildConfig.APPLICATION_ID + ".service.RemoteControlService");
                             i.setAction(RESCHEDULE_ACTION);
                             long nextTime = System.currentTimeMillis() + 10000;
                             BootReceiver.scheduleIntent(RemoteControlService.this, nextTime, i);
                         }
                         if (needsPushRestart) {
                             Intent i = new Intent();
-                            i.setClassName(getApplication().getPackageName(), "com.fsck.k9.service.RemoteControlService");
+                            i.setClassName(getApplication().getPackageName(), BuildConfig.APPLICATION_ID + ".service.RemoteControlService");
                             i.setAction(PUSH_RESTART_ACTION);
                             long nextTime = System.currentTimeMillis() + 10000;
                             BootReceiver.scheduleIntent(RemoteControlService.this, nextTime, i);

--- a/k9mail/src/main/java/com/fsck/k9/service/SleepService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/SleepService.java
@@ -3,6 +3,8 @@ package com.fsck.k9.service;
 import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
+
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
 
@@ -13,8 +15,8 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 public class SleepService extends CoreService {
 
-    private static String ALARM_FIRED = "com.fsck.k9.service.SleepService.ALARM_FIRED";
-    private static String LATCH_ID = "com.fsck.k9.service.SleepService.LATCH_ID_EXTRA";
+    private static String ALARM_FIRED = BuildConfig.APPLICATION_ID + ".service.SleepService.ALARM_FIRED";
+    private static String LATCH_ID = BuildConfig.APPLICATION_ID + ".SleepService.LATCH_ID_EXTRA";
 
 
     private static ConcurrentHashMap<Integer, SleepDatum> sleepData = new ConcurrentHashMap<Integer, SleepDatum>();
@@ -32,7 +34,7 @@ public class SleepService extends CoreService {
         sleepData.put(id, sleepDatum);
 
         Intent i = new Intent();
-        i.setClassName(context.getPackageName(), "com.fsck.k9.service.SleepService");
+        i.setClassName(context.getPackageName(), BuildConfig.APPLICATION_ID + ".service.SleepService");
         i.putExtra(LATCH_ID, id);
         i.setAction(ALARM_FIRED + "." + id);
         long startTime = System.currentTimeMillis();


### PR DESCRIPTION
Hello, I have modified every occurrence of "com.fsck.k9", sometimes it still appears but it is on some .xml files and I don't want to crash everything, I did not changed those files except AndroidManifest. So now every .java class have "BuildConfig.Application_ID". If you have any suggestions or some errors which I haven't seen don't hesitate to tell me.
Now, could I delete the previous pull request ? Because this one contains every class's ocurences.