### PR TITLE
Removing unused imports

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/AccountList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/AccountList.java
@@ -1,7 +1,6 @@
 package com.fsck.k9.activity;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 import android.os.AsyncTask;


### PR DESCRIPTION
After code analysis of the project, some unused imports were found.
Starting a new branch to reorganize them,
and beginning with unused java.util.Arrays import in AccountList class.