### PR TITLE
Remove duplication, enum-ify String

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ServerSettings.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ServerSettings.java
@@ -16,10 +16,13 @@ import java.util.Map;
  * @see com.fsck.k9.mail.store.StoreConfig#getTransportUri()
  */
 public class ServerSettings {
+
+    public enum Type { IMAP, SMTP, WebDAV, POP3 }
+
     /**
-     * Name of the store or transport type (e.g. "IMAP").
+     * Name of the store or transport type (e.g. IMAP).
      */
-    public final String type;
+    public final Type type;
 
     /**
      * The host name of the server.
@@ -99,7 +102,7 @@ public class ServerSettings {
      * @param clientCertificateAlias
      *         see {@link ServerSettings#clientCertificateAlias}
      */
-    public ServerSettings(String type, String host, int port,
+    public ServerSettings(Type type, String host, int port,
             ConnectionSecurity connectionSecurity, AuthType authenticationType, String username,
             String password, String clientCertificateAlias) {
         this.type = type;
@@ -135,7 +138,7 @@ public class ServerSettings {
      * @param extra
      *         see {@link ServerSettings#extra}
      */
-    public ServerSettings(String type, String host, int port,
+    public ServerSettings(Type type, String host, int port,
             ConnectionSecurity connectionSecurity, AuthType authenticationType, String username,
             String password, String clientCertificateAlias, Map<String, String> extra) {
         this.type = type;
@@ -158,7 +161,7 @@ public class ServerSettings {
      * @param type
      *         see {@link ServerSettings#type}
      */
-    public ServerSettings(String type) {
+    public ServerSettings(Type type) {
         this.type = type;
         host = null;
         port = -1;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Transport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Transport.java
@@ -5,6 +5,7 @@ import android.content.Context;
 
 import com.fsck.k9.mail.ssl.DefaultTrustedSocketFactory;
 import com.fsck.k9.mail.store.StoreConfig;
+import com.fsck.k9.mail.ServerSettings.Type;
 import com.fsck.k9.mail.transport.SmtpTransport;
 import com.fsck.k9.mail.transport.WebDavTransport;
 
@@ -63,9 +64,9 @@ public abstract class Transport {
      * @see WebDavTransport#createUri(ServerSettings)
      */
     public static String createTransportUri(ServerSettings server) {
-        if (SmtpTransport.TRANSPORT_TYPE.equals(server.type)) {
+        if (Type.SMTP == server.type) {
             return SmtpTransport.createUri(server);
-        } else if (WebDavTransport.TRANSPORT_TYPE.equals(server.type)) {
+        } else if (Type.WebDAV == server.type) {
             return WebDavTransport.createUri(server);
         } else {
             throw new IllegalArgumentException("Not a valid transport URI");

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/RemoteStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/RemoteStore.java
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager;
 
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.ServerSettings;
+import com.fsck.k9.mail.ServerSettings.Type;
 import com.fsck.k9.mail.Store;
 import com.fsck.k9.mail.ssl.DefaultTrustedSocketFactory;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
@@ -121,11 +122,11 @@ public abstract class RemoteStore extends Store {
      * @see com.fsck.k9.mail.store.webdav.WebDavStore#createUri(com.fsck.k9.mail.ServerSettings)
      */
     public static String createStoreUri(ServerSettings server) {
-        if (ImapStore.STORE_TYPE.equals(server.type)) {
+        if (Type.IMAP == server.type) {
             return ImapStore.createUri(server);
-        } else if (Pop3Store.STORE_TYPE.equals(server.type)) {
+        } else if (Type.POP3 == server.type) {
             return Pop3Store.createUri(server);
-        } else if (WebDavStore.STORE_TYPE.equals(server.type)) {
+        } else if (Type.WebDAV == server.type) {
             return WebDavStore.createUri(server);
         } else {
             throw new IllegalArgumentException("Not a valid store URI");

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -77,7 +77,6 @@ import static com.fsck.k9.mail.K9MailLib.PUSH_WAKE_LOCK_TIMEOUT;
  * </pre>
  */
 public class ImapStore extends RemoteStore {
-    public static final ServerSettings.Type STORE_TYPE = ServerSettings.Type.IMAP;
 
     private static final int IDLE_READ_TIMEOUT_INCREMENT = 5 * 60 * 1000;
     private static final int IDLE_FAILURE_COUNT_LIMIT = 10;
@@ -284,7 +283,7 @@ public class ImapStore extends RemoteStore {
         protected ImapStoreSettings(String host, int port, ConnectionSecurity connectionSecurity,
                 AuthType authenticationType, String username, String password, String clientCertificateAlias,
                 boolean autodetectNamespace, String pathPrefix) {
-            super(STORE_TYPE, host, port, connectionSecurity, authenticationType, username,
+            super(Type.IMAP, host, port, connectionSecurity, authenticationType, username,
                     password, clientCertificateAlias);
             this.autoDetectNamespace = autodetectNamespace;
             this.pathPrefix = pathPrefix;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -77,7 +77,7 @@ import static com.fsck.k9.mail.K9MailLib.PUSH_WAKE_LOCK_TIMEOUT;
  * </pre>
  */
 public class ImapStore extends RemoteStore {
-    public static final String STORE_TYPE = "IMAP";
+    public static final ServerSettings.Type STORE_TYPE = ServerSettings.Type.IMAP;
 
     private static final int IDLE_READ_TIMEOUT_INCREMENT = 5 * 60 * 1000;
     private static final int IDLE_FAILURE_COUNT_LIMIT = 10;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -38,7 +38,6 @@ import static com.fsck.k9.mail.K9MailLib.LOG_TAG;
 import static com.fsck.k9.mail.CertificateValidationException.Reason.MissingCapability;
 
 public class Pop3Store extends RemoteStore {
-    public static final ServerSettings.Type STORE_TYPE = ServerSettings.Type.POP3;
 
     private static final String STLS_COMMAND = "STLS";
     private static final String USER_COMMAND = "USER";
@@ -140,7 +139,7 @@ public class Pop3Store extends RemoteStore {
             }
         }
 
-        return new ServerSettings(STORE_TYPE, host, port, connectionSecurity, authType, username,
+        return new ServerSettings(ServerSettings.Type.POP3, host, port, connectionSecurity, authType, username,
                 password, clientCertificateAlias);
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -38,7 +38,7 @@ import static com.fsck.k9.mail.K9MailLib.LOG_TAG;
 import static com.fsck.k9.mail.CertificateValidationException.Reason.MissingCapability;
 
 public class Pop3Store extends RemoteStore {
-    public static final String STORE_TYPE = "POP3";
+    public static final ServerSettings.Type STORE_TYPE = ServerSettings.Type.POP3;
 
     private static final String STLS_COMMAND = "STLS";
     private static final String USER_COMMAND = "USER";

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -58,7 +58,6 @@ import static com.fsck.k9.mail.K9MailLib.LOG_TAG;
  * </pre>
  */
 public class WebDavStore extends RemoteStore {
-    public static final ServerSettings.Type STORE_TYPE = ServerSettings.Type.WebDAV;
 
     // Authentication types
     private static final short AUTH_TYPE_NONE = 0;
@@ -248,7 +247,7 @@ public class WebDavStore extends RemoteStore {
         protected WebDavStoreSettings(String host, int port, ConnectionSecurity connectionSecurity,
                 AuthType authenticationType, String username, String password, String clientCertificateAlias, String alias,
                 String path, String authPath, String mailboxPath) {
-            super(STORE_TYPE, host, port, connectionSecurity, authenticationType, username,
+            super(Type.WebDAV, host, port, connectionSecurity, authenticationType, username,
                     password, clientCertificateAlias);
             this.alias = alias;
             this.path = path;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -58,7 +58,7 @@ import static com.fsck.k9.mail.K9MailLib.LOG_TAG;
  * </pre>
  */
 public class WebDavStore extends RemoteStore {
-    public static final String STORE_TYPE = "WebDAV";
+    public static final ServerSettings.Type STORE_TYPE = ServerSettings.Type.WebDAV;
 
     // Authentication types
     private static final short AUTH_TYPE_NONE = 0;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -32,7 +32,7 @@ import static com.fsck.k9.mail.CertificateValidationException.Reason.MissingCapa
 public class SmtpTransport extends Transport {
     private TrustedSocketFactory mTrustedSocketFactory;
 
-    public static final String TRANSPORT_TYPE = "SMTP";
+    public static final ServerSettings.Type TRANSPORT_TYPE = ServerSettings.Type.SMTP;
 
     /**
      * Decodes a SmtpTransport URI.

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -32,8 +32,6 @@ import static com.fsck.k9.mail.CertificateValidationException.Reason.MissingCapa
 public class SmtpTransport extends Transport {
     private TrustedSocketFactory mTrustedSocketFactory;
 
-    public static final ServerSettings.Type TRANSPORT_TYPE = ServerSettings.Type.SMTP;
-
     /**
      * Decodes a SmtpTransport URI.
      *
@@ -115,7 +113,7 @@ public class SmtpTransport extends Transport {
             }
         }
 
-        return new ServerSettings(TRANSPORT_TYPE, host, port, connectionSecurity,
+        return new ServerSettings(ServerSettings.Type.SMTP, host, port, connectionSecurity,
                 authType, username, password, clientCertificateAlias);
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/transport/WebDavTransport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/transport/WebDavTransport.java
@@ -16,7 +16,7 @@ import java.util.Collections;
 import static com.fsck.k9.mail.K9MailLib.LOG_TAG;
 
 public class WebDavTransport extends Transport {
-    public static final String TRANSPORT_TYPE = WebDavStore.STORE_TYPE;
+    public static final ServerSettings.Type TRANSPORT_TYPE = WebDavStore.STORE_TYPE;
 
     /**
      * Decodes a WebDavTransport URI.

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/transport/WebDavTransport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/transport/WebDavTransport.java
@@ -16,7 +16,6 @@ import java.util.Collections;
 import static com.fsck.k9.mail.K9MailLib.LOG_TAG;
 
 public class WebDavTransport extends Transport {
-    public static final ServerSettings.Type TRANSPORT_TYPE = WebDavStore.STORE_TYPE;
 
     /**
      * Decodes a WebDavTransport URI.

--- a/k9mail/src/main/java/com/fsck/k9/account/AccountCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/account/AccountCreator.java
@@ -1,0 +1,31 @@
+package com.fsck.k9.account;
+
+import com.fsck.k9.Account.DeletePolicy;
+import com.fsck.k9.mail.ServerSettings.Type;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Deals with logic surrounding account creation.
+ * <p/>
+ * TODO Move much of the code from com.fsck.k9.activity.setup.* into here
+ */
+public class AccountCreator {
+
+    private static Map<Type, DeletePolicy> defaults;
+
+    public static DeletePolicy calculateDefaultDeletePolicy(Type type) {
+        return getDefaults().get(type);
+    }
+
+    private static synchronized Map<Type, DeletePolicy> getDefaults() {
+        if (null == defaults) {
+            defaults = new HashMap<Type, DeletePolicy>();
+            defaults.put(Type.IMAP, DeletePolicy.ON_DELETE);
+            defaults.put(Type.POP3, DeletePolicy.NEVER);
+            defaults.put(Type.WebDAV, DeletePolicy.ON_DELETE);
+        }
+        return defaults;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/account/AccountCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/account/AccountCreator.java
@@ -13,19 +13,16 @@ import java.util.Map;
  */
 public class AccountCreator {
 
-    private static Map<Type, DeletePolicy> defaults;
+    private static Map<Type, DeletePolicy> defaults = new HashMap<Type, DeletePolicy>();
+
+    static {
+        defaults.put(Type.IMAP, DeletePolicy.ON_DELETE);
+        defaults.put(Type.POP3, DeletePolicy.NEVER);
+        defaults.put(Type.WebDAV, DeletePolicy.ON_DELETE);
+    }
 
     public static DeletePolicy calculateDefaultDeletePolicy(Type type) {
-        return getDefaults().get(type);
+        return defaults.get(type);
     }
 
-    private static synchronized Map<Type, DeletePolicy> getDefaults() {
-        if (null == defaults) {
-            defaults = new HashMap<Type, DeletePolicy>();
-            defaults.put(Type.IMAP, DeletePolicy.ON_DELETE);
-            defaults.put(Type.POP3, DeletePolicy.NEVER);
-            defaults.put(Type.WebDAV, DeletePolicy.ON_DELETE);
-        }
-        return defaults;
-    }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -81,7 +81,6 @@ import com.fsck.k9.mail.Transport;
 import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mail.store.RemoteStore;
 import com.fsck.k9.mailstore.StorageManager;
-import com.fsck.k9.mail.store.webdav.WebDavStore;
 import com.fsck.k9.preferences.SettingsExporter;
 import com.fsck.k9.preferences.SettingsImportExportException;
 import com.fsck.k9.preferences.SettingsImporter;
@@ -779,7 +778,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
              * Also don't ask when the AuthType is EXTERNAL.
              */
             boolean configureOutgoingServer = AuthType.EXTERNAL != outgoing.authenticationType
-                    && !WebDavStore.STORE_TYPE.equals(outgoing.type)
+                    && !(ServerSettings.Type.WebDAV == outgoing.type)
                     && outgoing.username != null
                     && !outgoing.username.isEmpty()
                     && (outgoing.password == null || outgoing.password

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -27,7 +27,6 @@ import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.EditText;
 
 import com.fsck.k9.Account;
-import com.fsck.k9.Account.DeletePolicy;
 import com.fsck.k9.EmailAddressValidator;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
@@ -40,9 +39,7 @@ import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mail.Transport;
-import com.fsck.k9.mail.store.imap.ImapStore;
 import com.fsck.k9.mail.store.RemoteStore;
-import com.fsck.k9.mail.transport.SmtpTransport;
 import com.fsck.k9.account.AccountCreator;
 import com.fsck.k9.view.ClientCertificateSpinner;
 import com.fsck.k9.view.ClientCertificateSpinner.OnClientCertificateChangedListener;
@@ -410,9 +407,9 @@ public class AccountSetupBasics extends K9Activity
 
         // set default uris
         // NOTE: they will be changed again in AccountSetupAccountType!
-        ServerSettings storeServer = new ServerSettings(ImapStore.STORE_TYPE, "mail." + domain, -1,
+        ServerSettings storeServer = new ServerSettings(ServerSettings.Type.IMAP, "mail." + domain, -1,
                 ConnectionSecurity.SSL_TLS_REQUIRED, authenticationType, user, password, clientCertificateAlias);
-        ServerSettings transportServer = new ServerSettings(SmtpTransport.TRANSPORT_TYPE, "mail." + domain, -1,
+        ServerSettings transportServer = new ServerSettings(ServerSettings.Type.SMTP, "mail." + domain, -1,
                 ConnectionSecurity.SSL_TLS_REQUIRED, authenticationType, user, password, clientCertificateAlias);
         String storeUri = RemoteStore.createStoreUri(storeServer);
         String transportUri = Transport.createTransportUri(transportServer);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -43,6 +43,7 @@ import com.fsck.k9.mail.Transport;
 import com.fsck.k9.mail.store.imap.ImapStore;
 import com.fsck.k9.mail.store.RemoteStore;
 import com.fsck.k9.mail.transport.SmtpTransport;
+import com.fsck.k9.account.AccountCreator;
 import com.fsck.k9.view.ClientCertificateSpinner;
 import com.fsck.k9.view.ClientCertificateSpinner.OnClientCertificateChangedListener;
 
@@ -321,21 +322,12 @@ public class AccountSetupBasics extends K9Activity
             mAccount.setEmail(email);
             mAccount.setStoreUri(incomingUri.toString());
             mAccount.setTransportUri(outgoingUri.toString());
-            mAccount.setDraftsFolderName(getString(R.string.special_mailbox_name_drafts));
-            mAccount.setTrashFolderName(getString(R.string.special_mailbox_name_trash));
-            mAccount.setArchiveFolderName(getString(R.string.special_mailbox_name_archive));
-            // Yahoo! has a special folder for Spam, called "Bulk Mail".
-            if (incomingUriTemplate.getHost().toLowerCase(Locale.US).endsWith(".yahoo.com")) {
-                mAccount.setSpamFolderName("Bulk Mail");
-            } else {
-                mAccount.setSpamFolderName(getString(R.string.special_mailbox_name_spam));
-            }
-            mAccount.setSentFolderName(getString(R.string.special_mailbox_name_sent));
-            if (incomingUri.toString().startsWith("imap")) {
-                mAccount.setDeletePolicy(DeletePolicy.ON_DELETE);
-            } else if (incomingUri.toString().startsWith("pop3")) {
-                mAccount.setDeletePolicy(DeletePolicy.NEVER);
-            }
+
+            setupFolderNames(incomingUriTemplate.getHost().toLowerCase(Locale.US));
+
+            ServerSettings incomingSettings = RemoteStore.decodeStoreUri(incomingUri.toString());
+            mAccount.setDeletePolicy(AccountCreator.calculateDefaultDeletePolicy(incomingSettings.type));
+
             // Check incoming here.  Then check outgoing in onActivityResult()
             AccountSetupCheckSettings.actionCheckSettings(this, mAccount, CheckDirection.INCOMING);
         } catch (URISyntaxException use) {
@@ -427,21 +419,27 @@ public class AccountSetupBasics extends K9Activity
         mAccount.setStoreUri(storeUri);
         mAccount.setTransportUri(transportUri);
 
+        setupFolderNames(domain);
+
+        AccountSetupAccountType.actionSelectAccountType(this, mAccount, false);
+
+        finish();
+    }
+
+    private void setupFolderNames(String domain) {
         mAccount.setDraftsFolderName(getString(R.string.special_mailbox_name_drafts));
         mAccount.setTrashFolderName(getString(R.string.special_mailbox_name_trash));
         mAccount.setSentFolderName(getString(R.string.special_mailbox_name_sent));
         mAccount.setArchiveFolderName(getString(R.string.special_mailbox_name_archive));
+
         // Yahoo! has a special folder for Spam, called "Bulk Mail".
         if (domain.endsWith(".yahoo.com")) {
             mAccount.setSpamFolderName("Bulk Mail");
         } else {
             mAccount.setSpamFolderName(getString(R.string.special_mailbox_name_spam));
         }
-
-        AccountSetupAccountType.actionSelectAccountType(this, mAccount, false);
-
-        finish();
     }
+
 
     public void onClick(View v) {
         switch (v.getId()) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -251,7 +251,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 if (webDavSettings.mailboxPath != null) {
                     mWebdavMailboxPathView.setText(webDavSettings.mailboxPath);
                 }
-             } else {
+            } else {
                 throw new Exception("Unknown account type: " + mAccount.getStoreUri());
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -16,7 +16,6 @@ import android.widget.AdapterView.OnItemSelectedListener;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 
 import com.fsck.k9.*;
-import com.fsck.k9.Account.DeletePolicy;
 import com.fsck.k9.Account.FolderMode;
 import com.fsck.k9.Account.NetworkType;
 import com.fsck.k9.activity.K9Activity;
@@ -34,6 +33,7 @@ import com.fsck.k9.mail.store.webdav.WebDavStore;
 import com.fsck.k9.mail.store.imap.ImapStore.ImapStoreSettings;
 import com.fsck.k9.mail.store.webdav.WebDavStore.WebDavStoreSettings;
 import com.fsck.k9.mail.transport.SmtpTransport;
+import com.fsck.k9.account.AccountCreator;
 import com.fsck.k9.service.MailService;
 import com.fsck.k9.view.ClientCertificateSpinner;
 import com.fsck.k9.view.ClientCertificateSpinner.OnClientCertificateChangedListener;
@@ -56,7 +56,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     private static final String WEBDAV_PORT = "80";
     private static final String WEBDAV_SSL_PORT = "443";
 
-    private String mStoreType;
+    private ServerSettings.Type mStoreType;
     private EditText mUsernameView;
     private EditText mPasswordView;
     private ClientCertificateSpinner mClientCertificateSpinner;
@@ -202,7 +202,6 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 findViewById(R.id.compression_section).setVisibility(View.GONE);
                 findViewById(R.id.compression_label).setVisibility(View.GONE);
                 mSubscribedFoldersOnly.setVisibility(View.GONE);
-                mAccount.setDeletePolicy(DeletePolicy.NEVER);
             } else if (ImapStore.STORE_TYPE.equals(settings.type)) {
                 serverLabelView.setText(R.string.account_setup_incoming_imap_server_label);
                 mDefaultPort = IMAP_PORT;
@@ -219,7 +218,6 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 findViewById(R.id.webdav_mailbox_alias_section).setVisibility(View.GONE);
                 findViewById(R.id.webdav_owa_path_section).setVisibility(View.GONE);
                 findViewById(R.id.webdav_auth_path_section).setVisibility(View.GONE);
-                mAccount.setDeletePolicy(DeletePolicy.ON_DELETE);
 
                 if (!Intent.ACTION_EDIT.equals(getIntent().getAction())) {
                     findViewById(R.id.imap_folder_setup_section).setVisibility(View.GONE);
@@ -253,10 +251,11 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 if (webDavSettings.mailboxPath != null) {
                     mWebdavMailboxPathView.setText(webDavSettings.mailboxPath);
                 }
-                mAccount.setDeletePolicy(DeletePolicy.ON_DELETE);
-            } else {
+             } else {
                 throw new Exception("Unknown account type: " + mAccount.getStoreUri());
             }
+
+            mAccount.setDeletePolicy(AccountCreator.calculateDefaultDeletePolicy(settings.type));
 
             // Note that mConnectionSecurityChoices is configured above based on server type
             ConnectionSecurityAdapter securityTypesAdapter =

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -24,15 +24,12 @@ import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.ServerSettings;
+import com.fsck.k9.mail.ServerSettings.Type;
 import com.fsck.k9.mail.Store;
 import com.fsck.k9.mail.Transport;
-import com.fsck.k9.mail.store.imap.ImapStore;
-import com.fsck.k9.mail.store.pop3.Pop3Store;
 import com.fsck.k9.mail.store.RemoteStore;
-import com.fsck.k9.mail.store.webdav.WebDavStore;
 import com.fsck.k9.mail.store.imap.ImapStore.ImapStoreSettings;
 import com.fsck.k9.mail.store.webdav.WebDavStore.WebDavStoreSettings;
-import com.fsck.k9.mail.transport.SmtpTransport;
 import com.fsck.k9.account.AccountCreator;
 import com.fsck.k9.service.MailService;
 import com.fsck.k9.view.ClientCertificateSpinner;
@@ -56,7 +53,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     private static final String WEBDAV_PORT = "80";
     private static final String WEBDAV_SSL_PORT = "443";
 
-    private ServerSettings.Type mStoreType;
+    private Type mStoreType;
     private EditText mUsernameView;
     private EditText mPasswordView;
     private ClientCertificateSpinner mClientCertificateSpinner;
@@ -190,7 +187,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
             }
 
             mStoreType = settings.type;
-            if (Pop3Store.STORE_TYPE.equals(settings.type)) {
+            if (Type.POP3 == settings.type) {
                 serverLabelView.setText(R.string.account_setup_incoming_pop_server_label);
                 mDefaultPort = POP3_PORT;
                 mDefaultSslPort = POP3_SSL_PORT;
@@ -202,7 +199,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 findViewById(R.id.compression_section).setVisibility(View.GONE);
                 findViewById(R.id.compression_label).setVisibility(View.GONE);
                 mSubscribedFoldersOnly.setVisibility(View.GONE);
-            } else if (ImapStore.STORE_TYPE.equals(settings.type)) {
+            } else if (Type.IMAP == settings.type) {
                 serverLabelView.setText(R.string.account_setup_incoming_imap_server_label);
                 mDefaultPort = IMAP_PORT;
                 mDefaultSslPort = IMAP_SSL_PORT;
@@ -222,7 +219,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 if (!Intent.ACTION_EDIT.equals(getIntent().getAction())) {
                     findViewById(R.id.imap_folder_setup_section).setVisibility(View.GONE);
                 }
-            } else if (WebDavStore.STORE_TYPE.equals(settings.type)) {
+            } else if (Type.WebDAV == settings.type) {
                 serverLabelView.setText(R.string.account_setup_incoming_webdav_server_label);
                 mDefaultPort = WEBDAV_PORT;
                 mDefaultSslPort = WEBDAV_SSL_PORT;
@@ -550,7 +547,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                     }
 
                     URI oldUri = new URI(mAccount.getTransportUri());
-                    ServerSettings transportServer = new ServerSettings(SmtpTransport.TRANSPORT_TYPE, oldUri.getHost(), oldUri.getPort(),
+                    ServerSettings transportServer = new ServerSettings(Type.SMTP, oldUri.getHost(), oldUri.getPort(),
                             ConnectionSecurity.SSL_TLS_REQUIRED, authType, username, password, clientCertificateAlias);
                     String transportUri = Transport.createTransportUri(transportServer);
                     mAccount.setTransportUri(transportUri);
@@ -586,13 +583,13 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
             int port = Integer.parseInt(mPortView.getText().toString());
 
             Map<String, String> extra = null;
-            if (ImapStore.STORE_TYPE.equals(mStoreType)) {
+            if (Type.IMAP == mStoreType) {
                 extra = new HashMap<String, String>();
                 extra.put(ImapStoreSettings.AUTODETECT_NAMESPACE_KEY,
                         Boolean.toString(mImapAutoDetectNamespaceView.isChecked()));
                 extra.put(ImapStoreSettings.PATH_PREFIX_KEY,
                         mImapPathPrefixView.getText().toString());
-            } else if (WebDavStore.STORE_TYPE.equals(mStoreType)) {
+            } else if (Type.WebDAV == mStoreType) {
                 extra = new HashMap<String, String>();
                 extra.put(WebDavStoreSettings.PATH_KEY,
                         mWebdavPathPrefixView.getText().toString());

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -485,7 +485,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
 
         String newHost = mServerView.getText().toString();
         int newPort = Integer.parseInt(mPortView.getText().toString());
-        String type = SmtpTransport.TRANSPORT_TYPE;
+        ServerSettings.Type type = SmtpTransport.TRANSPORT_TYPE;
         ServerSettings server = new ServerSettings(type, newHost, newPort, securityType, authType, username, password, clientCertificateAlias);
         uri = Transport.createTransportUri(server);
         mAccount.deleteCertificate(newHost, newPort, CheckDirection.OUTGOING);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -20,10 +20,10 @@ import com.fsck.k9.activity.K9Activity;
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.AuthType;
+import com.fsck.k9.mail.ServerSettings.Type;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mail.Transport;
-import com.fsck.k9.mail.transport.SmtpTransport;
 import com.fsck.k9.view.ClientCertificateSpinner;
 import com.fsck.k9.view.ClientCertificateSpinner.OnClientCertificateChangedListener;
 
@@ -485,8 +485,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
 
         String newHost = mServerView.getText().toString();
         int newPort = Integer.parseInt(mPortView.getText().toString());
-        ServerSettings.Type type = SmtpTransport.TRANSPORT_TYPE;
-        ServerSettings server = new ServerSettings(type, newHost, newPort, securityType, authType, username, password, clientCertificateAlias);
+        ServerSettings server = new ServerSettings(Type.SMTP, newHost, newPort, securityType, authType, username, password, clientCertificateAlias);
         uri = Transport.createTransportUri(server);
         mAccount.deleteCertificate(newHost, newPort, CheckDirection.OUTGOING);
         mAccount.setTransportUri(uri);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -225,7 +225,7 @@ public class SettingsExporter {
         // Write incoming server settings
         ServerSettings incoming = RemoteStore.decodeStoreUri(account.getStoreUri());
         serializer.startTag(null, INCOMING_SERVER_ELEMENT);
-        serializer.attribute(null, TYPE_ATTRIBUTE, incoming.type);
+        serializer.attribute(null, TYPE_ATTRIBUTE, incoming.type.name());
 
         writeElement(serializer, HOST_ELEMENT, incoming.host);
         if (incoming.port != -1) {
@@ -257,7 +257,7 @@ public class SettingsExporter {
         // Write outgoing server settings
         ServerSettings outgoing = Transport.decodeTransportUri(account.getTransportUri());
         serializer.startTag(null, OUTGOING_SERVER_ELEMENT);
-        serializer.attribute(null, TYPE_ATTRIBUTE, outgoing.type);
+        serializer.attribute(null, TYPE_ATTRIBUTE, outgoing.type.name());
 
         writeElement(serializer, HOST_ELEMENT, outgoing.host);
         if (outgoing.port != -1) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -384,7 +384,7 @@ public class SettingsImporter {
         boolean createAccountDisabled = AuthType.EXTERNAL != incoming.authenticationType &&
                 (incoming.password == null || incoming.password.isEmpty());
 
-        if (account.outgoing == null && !WebDavStore.STORE_TYPE.equals(account.incoming.type)) {
+        if (account.outgoing == null && !WebDavStore.STORE_TYPE.name().equals(account.incoming.type)) {
             // All account types except WebDAV need to provide outgoing server settings
             throw new InvalidSettingValueException();
         }
@@ -1100,7 +1100,7 @@ public class SettingsImporter {
         private final ImportedServer mImportedServer;
 
         public ImportedServerSettings(ImportedServer server) {
-            super(server.type, server.host, convertPort(server.port),
+            super(ServerSettings.Type.valueOf(server.type), server.host, convertPort(server.port),
                     convertConnectionSecurity(server.connectionSecurity),
                     server.authenticationType, server.username, server.password,
                     server.clientCertificateAlias);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -28,7 +28,6 @@ import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mail.Transport;
 import com.fsck.k9.mail.filter.Base64;
 import com.fsck.k9.mail.store.RemoteStore;
-import com.fsck.k9.mail.store.webdav.WebDavStore;
 import com.fsck.k9.preferences.Settings.InvalidSettingValueException;
 
 public class SettingsImporter {
@@ -384,7 +383,7 @@ public class SettingsImporter {
         boolean createAccountDisabled = AuthType.EXTERNAL != incoming.authenticationType &&
                 (incoming.password == null || incoming.password.isEmpty());
 
-        if (account.outgoing == null && !WebDavStore.STORE_TYPE.name().equals(account.incoming.type)) {
+        if (account.outgoing == null && !ServerSettings.Type.WebDAV.name().equals(account.incoming.type)) {
             // All account types except WebDAV need to provide outgoing server settings
             throw new InvalidSettingValueException();
         }
@@ -403,7 +402,7 @@ public class SettingsImporter {
              * password required if the AuthType is EXTERNAL.
              */
             boolean outgoingPasswordNeeded = AuthType.EXTERNAL != outgoing.authenticationType &&
-                    !WebDavStore.STORE_TYPE.equals(outgoing.type) &&
+                    !(ServerSettings.Type.WebDAV == outgoing.type) &&
                     outgoing.username != null &&
                     !outgoing.username.isEmpty() &&
                     (outgoing.password == null || outgoing.password.isEmpty());

--- a/tests-on-jvm/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreUriTest.java
+++ b/tests-on-jvm/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreUriTest.java
@@ -91,7 +91,7 @@ public class ImapStoreUriTest {
         extra.put("autoDetectNamespace", "false");
         extra.put("pathPrefix", "customPathPrefix");
 
-        ServerSettings settings = new ServerSettings(ImapStore.STORE_TYPE, "server", 143,
+        ServerSettings settings = new ServerSettings(ServerSettings.Type.IMAP, "server", 143,
                 ConnectionSecurity.NONE, AuthType.PLAIN, "user", "pass", null, extra);
 
         String uri = RemoteStore.createStoreUri(settings);
@@ -105,7 +105,7 @@ public class ImapStoreUriTest {
         extra.put("autoDetectNamespace", "false");
         extra.put("pathPrefix", "");
 
-        ServerSettings settings = new ServerSettings(ImapStore.STORE_TYPE, "server", 143,
+        ServerSettings settings = new ServerSettings(ServerSettings.Type.IMAP, "server", 143,
                 ConnectionSecurity.NONE, AuthType.PLAIN, "user", "pass", null, extra);
 
         String uri = RemoteStore.createStoreUri(settings);
@@ -115,7 +115,7 @@ public class ImapStoreUriTest {
 
     @Test
     public void testCreateStoreUriImapNoExtra() {
-        ServerSettings settings = new ServerSettings(ImapStore.STORE_TYPE, "server", 143,
+        ServerSettings settings = new ServerSettings(ServerSettings.Type.IMAP, "server", 143,
                 ConnectionSecurity.NONE, AuthType.PLAIN, "user", "pass", null);
 
         String uri = RemoteStore.createStoreUri(settings);
@@ -128,7 +128,7 @@ public class ImapStoreUriTest {
         Map<String, String> extra = new HashMap<String, String>();
         extra.put("autoDetectNamespace", "true");
 
-        ServerSettings settings = new ServerSettings(ImapStore.STORE_TYPE, "server", 143,
+        ServerSettings settings = new ServerSettings(ServerSettings.Type.IMAP, "server", 143,
                 ConnectionSecurity.NONE, AuthType.PLAIN, "user", "pass", null, extra);
 
         String uri = RemoteStore.createStoreUri(settings);
@@ -138,7 +138,7 @@ public class ImapStoreUriTest {
 
     @Test
     public void testCreateDecodeStoreUriWithSpecialCharactersInUsernameAndPassword() {
-        ServerSettings settings = new ServerSettings(ImapStore.STORE_TYPE, "server", 143,
+        ServerSettings settings = new ServerSettings(ServerSettings.Type.IMAP, "server", 143,
                 ConnectionSecurity.NONE, AuthType.PLAIN, "user@doma:n", "p@ssw:rd%", null, null);
 
         String uri = RemoteStore.createStoreUri(settings);


### PR DESCRIPTION
Planning to separate account creation logic from the activity to enable unit testing. Small refactorings first, so you don't have to review a giant pull request.