### PR TITLE
move NetworkType to k9mail-library, use on StoreConfig

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/NetworkType.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/NetworkType.java
@@ -1,0 +1,25 @@
+package com.fsck.k9.mail;
+
+import android.net.ConnectivityManager;
+
+/**
+ * Enum for some of
+ * https://developer.android.com/reference/android/net/ConnectivityManager.html#TYPE_MOBILE etc.
+ */
+public enum NetworkType {
+
+    WIFI,
+    MOBILE,
+    OTHER;
+
+    public static NetworkType fromConnectivityManagerType(int type){
+        switch (type) {
+            case ConnectivityManager.TYPE_MOBILE:
+                return MOBILE;
+            case ConnectivityManager.TYPE_WIFI:
+                return WIFI;
+            default:
+                return OTHER;
+        }
+    }
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
@@ -1,12 +1,14 @@
 package com.fsck.k9.mail.store;
 
 
+import com.fsck.k9.mail.NetworkType;
+
 public interface StoreConfig {
     String getStoreUri();
     String getTransportUri();
 
     boolean subscribedFoldersOnly();
-    boolean useCompression(int type);
+    boolean useCompression(NetworkType type);
 
     String getInboxFolderName();
     String getOutboxFolderName();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -11,6 +11,7 @@ import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.NetworkType;
 import com.fsck.k9.mail.filter.Base64;
 import com.fsck.k9.mail.filter.PeekableInputStream;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
@@ -471,7 +472,8 @@ class ImapConnection {
             if (K9MailLib.isDebug()) {
                 Log.d(LOG_TAG, "On network type " + type);
             }
-            useCompression = mSettings.useCompression(type);
+            useCompression = mSettings.useCompression(
+                    NetworkType.fromConnectivityManagerType(type));
         }
         if (K9MailLib.isDebug()) {
             Log.d(LOG_TAG, "useCompression " + useCompression);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapSettings.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapSettings.java
@@ -2,6 +2,7 @@ package com.fsck.k9.mail.store.imap;
 
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.ConnectionSecurity;
+import com.fsck.k9.mail.NetworkType;
 
 /**
  * Settings source for IMAP. Implemented in order to remove coupling between {@link ImapStore} and {@link ImapConnection}.
@@ -21,7 +22,7 @@ interface ImapSettings {
 
     String getClientCertificateAlias();
 
-    boolean useCompression(int type);
+    boolean useCompression(NetworkType type);
 
     String getPathPrefix();
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -37,6 +37,7 @@ import android.os.PowerManager;
 import android.text.TextUtils;
 import android.util.Log;
 
+import com.fsck.k9.mail.NetworkType;
 import com.fsck.k9.mail.internet.MimeMessageHelper;
 import com.fsck.k9.mail.power.TracingPowerManager;
 import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
@@ -2932,7 +2933,7 @@ public class ImapStore extends RemoteStore {
         }
 
         @Override
-        public boolean useCompression(final int type) {
+        public boolean useCompression(final NetworkType type) {
             return mStoreConfig.useCompression(type);
         }
 

--- a/k9mail/src/androidTest/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -13,6 +13,8 @@ import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.NetworkType;
+
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -167,7 +169,7 @@ public class ImapConnectionTest  {
         }
 
         @Override
-        public boolean useCompression(int type) {
+        public boolean useCompression(NetworkType type) {
             return false;
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -27,6 +27,7 @@ import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.NetworkType;
 import com.fsck.k9.mail.Store;
 import com.fsck.k9.mail.Folder.FolderClass;
 import com.fsck.k9.mail.filter.Base64;
@@ -94,12 +95,6 @@ public class Account implements BaseAccount, StoreConfig {
             }
             throw new IllegalArgumentException("DeletePolicy " + initialSetting + " unknown");
         }
-    }
-
-    public enum NetworkType {
-        WIFI,
-        MOBILE,
-        OTHER
     }
 
     public static final MessageFormat DEFAULT_MESSAGE_FORMAT = MessageFormat.HTML;
@@ -1301,19 +1296,6 @@ public class Account implements BaseAccount, StoreConfig {
         }
 
         return useCompression;
-    }
-
-    public boolean useCompression(int type) {
-        NetworkType networkType = NetworkType.OTHER;
-        switch (type) {
-        case ConnectivityManager.TYPE_MOBILE:
-            networkType = NetworkType.MOBILE;
-            break;
-        case ConnectivityManager.TYPE_WIFI:
-            networkType = NetworkType.WIFI;
-            break;
-        }
-        return useCompression(networkType);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -17,7 +17,7 @@ import android.widget.CompoundButton.OnCheckedChangeListener;
 
 import com.fsck.k9.*;
 import com.fsck.k9.Account.FolderMode;
-import com.fsck.k9.Account.NetworkType;
+import com.fsck.k9.mail.NetworkType;
 import com.fsck.k9.activity.K9Activity;
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
 import com.fsck.k9.helper.Utility;


### PR DESCRIPTION
I would like to use the StoreConfig interface instead of the 'evil mutable' Account class on the AccountSetupIncoming activity. This merge request will help implement that.