### PR TITLE
Transitivity test for equals() on MessageReferenceTest

### DIFF
--- a/k9mail/src/androidTest/java/com/fsck/k9/activity/MessageReferenceTest.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/activity/MessageReferenceTest.java
@@ -124,6 +124,18 @@ public class MessageReferenceTest {
         assertEqualsReturnsFalseSymmetrically(messageReferenceOne, messageReferenceTwo);
     }
 
+    @Test
+    public void equalsTransitivityTest() {
+        MessageReference messageReferenceOne = createMessageReference("account", "folder", "uid");
+        MessageReference messageReferenceTwo = createMessageReference("account", "folder", "uid");
+        MessageReference messageReferenceThree = createMessageReference("account", "folder", "uid");
+
+        assertEqualsReturnsTrueSymmetrically(messageReferenceOne, messageReferenceTwo);
+        assertEqualsReturnsTrueSymmetrically(messageReferenceTwo, messageReferenceThree);
+        assertEqualsReturnsTrueSymmetrically(messageReferenceOne, messageReferenceThree);
+
+    }
+
     private MessageReference createMessageReference(String accountUuid, String folderName, String uid) {
         MessageReference messageReference = new MessageReference();
         messageReference.accountUuid = accountUuid;


### PR DESCRIPTION
Hi,
This is just a little pull request  in order to test the  transitivity of hashcode.
