### PR TITLE
Prevent exceptions in test when account is deleted

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Preferences.java
+++ b/k9mail/src/main/java/com/fsck/k9/Preferences.java
@@ -99,6 +99,9 @@ public class Preferences {
         return retval;
     }
 
+    /**
+     * @return the Account associated with the given uuid, or null if there is no such account.
+     */
     public synchronized Account getAccount(String uuid) {
         if (accounts == null) {
             loadAccounts();
@@ -146,7 +149,7 @@ public class Preferences {
      */
     public Account getDefaultAccount() {
         String defaultAccountUuid = getPreferences().getString("defaultAccountUuid", null);
-        Account defaultAccount = getAccount(defaultAccountUuid);
+        Account defaultAccount = defaultAccountUuid == null ? null: getAccount(defaultAccountUuid);
 
         if (defaultAccount == null) {
             Collection<Account> accounts = getAvailableAccounts();


### PR DESCRIPTION
I submitted this pull request before, on the old k9mail_pgp_mime repo.

@cketti wasn't happy with the way I worked around the issue of account stats being gathered 
after an account was deleted, but I can't remember the suggestion, and the repo is gone.

So please could you take another look?