### PR TITLE
Add e2e test for sending

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -583,7 +583,9 @@ class ImapConnection {
                 connectException = e;
             }
         }
-        throw new MessagingException("Cannot connect to host", connectException);
+        throw new MessagingException(
+                "Cannot connect to host " + settings.getHost() + " on port " + settings.getPort(),
+                connectException);
     }
 
     private void adjustDNSCacheTTL() {

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -8,6 +8,7 @@ repositories {
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots/"
     }
+    mavenLocal()
 }
 
 dependencies {
@@ -26,7 +27,17 @@ dependencies {
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.0'
     androidTestCompile('com.icegreen:greenmail:1.4.1-SNAPSHOT') {
         exclude group: 'junit'
+
+        // stock JavaMail does not work on Android
+        exclude group: 'com.sun.mail'
+        exclude group: 'javax.mail'
+        exclude group: 'javax.activation'
     }
+
+    // Forked version of javax.mail required to run Greenmail on Android
+    androidTestCompile 'eu.ocathain.com.sun.mail:javax.mail:1.5.3-SNAPSHOT'
+    androidTestCompile 'eu.ocathain.javax.activation:activation:1.1.1-SNAPSHOT'
+
     androidTestCompile 'com.madgag.spongycastle:pg:1.51.0.0'
 }
 
@@ -75,6 +86,7 @@ android {
         exclude 'META-INF/NOTICE'
         exclude 'META-INF/NOTICE.txt'
         exclude 'LICENSE.txt'
+        exclude 'LICENSE'
     }
 
     compileOptions {

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -8,7 +8,6 @@ repositories {
     maven {
         url "https://oss.sonatype.org/content/repositories/snapshots/"
     }
-    mavenLocal()
 }
 
 dependencies {

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     }
 
     // Forked version of javax.mail required to run Greenmail on Android
-    androidTestCompile 'eu.ocathain.com.sun.mail:javax.mail:1.5.3'
+    androidTestCompile 'eu.ocathain.com.sun.mail:javax.mail:1.5.2'
     androidTestCompile 'eu.ocathain.javax.activation:activation:1.1.1'
 
     androidTestCompile 'com.madgag.spongycastle:pg:1.51.0.0'

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -34,8 +34,8 @@ dependencies {
     }
 
     // Forked version of javax.mail required to run Greenmail on Android
-    androidTestCompile 'eu.ocathain.com.sun.mail:javax.mail:1.5.3-SNAPSHOT'
-    androidTestCompile 'eu.ocathain.javax.activation:activation:1.1.1-SNAPSHOT'
+    androidTestCompile 'eu.ocathain.com.sun.mail:javax.mail:1.5.3'
+    androidTestCompile 'eu.ocathain.javax.activation:activation:1.1.1'
 
     androidTestCompile 'com.madgag.spongycastle:pg:1.51.0.0'
 }

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/A010_AccountIntegrationTest.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/A010_AccountIntegrationTest.java
@@ -4,8 +4,10 @@ import com.fsck.k9.activity.Accounts;
 import com.fsck.k9.endtoend.framework.AccountForTest;
 import com.fsck.k9.endtoend.framework.ApplicationState;
 import com.fsck.k9.endtoend.pages.AccountsPage;
+
 import org.junit.Test;
 
+import java.util.Iterator;
 
 /**
  * Creates and removes accounts.
@@ -32,7 +34,9 @@ public class A010_AccountIntegrationTest extends AbstractEndToEndTest<Accounts>{
         assertFalse("NB: this test is order dependent and requires A000_WelcomeAndSetupAccountIntegrationTest to run first",
                 ApplicationState.getInstance().accounts.isEmpty());
 
-        AccountForTest accountForTest = ApplicationState.getInstance().accounts.get(0);
+        Iterator<AccountForTest> iterator = ApplicationState.getInstance().accounts.iterator();
+
+        AccountForTest accountForTest = iterator.next();
         accountsPage.assertAccountExists(accountForTest.description);
 
         accountsPage.clickLongOnAccount(accountForTest);
@@ -42,6 +46,8 @@ public class A010_AccountIntegrationTest extends AbstractEndToEndTest<Accounts>{
         accountsPage.clickOK();
 
         accountsPage.assertAccountDoesNotExist(accountForTest.description);
+
+        iterator.remove();
 
     }
 }

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/A020_SendEmailTest.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/A020_SendEmailTest.java
@@ -1,0 +1,45 @@
+package com.fsck.k9.endtoend;
+
+import com.fsck.k9.activity.Accounts;
+import com.fsck.k9.endtoend.framework.AccountForTest;
+import com.fsck.k9.endtoend.framework.ApplicationState;
+import com.fsck.k9.endtoend.pages.AccountsPage;
+import com.fsck.k9.endtoend.pages.ComposePage;
+import com.fsck.k9.endtoend.pages.FolderPage;
+
+import org.junit.Test;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+/**
+ * Tests sending an email. An account must already be set up.
+ */
+public class A020_SendEmailTest extends AbstractEndToEndTest<Accounts> {
+
+    public A020_SendEmailTest() {
+        super(Accounts.class);
+    }
+
+    @Test
+    public void testSendEmail() throws Exception {
+        final AccountForTest accountForTest = ApplicationState.getInstance().accounts.get(0);
+        accountForTest.stubMailServer.restart();
+
+        FolderPage folderPage = new AccountsPage().clickOnAccount(accountForTest);
+        ComposePage composePage = folderPage.clickCompose();
+        composePage.inputTo(accountForTest.name + "@example.com");
+
+        composePage.inputSubject("Test email from " + getClass().getSimpleName() + " at "
+                + new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").format(new Date()));
+
+        composePage.inputMessageContent("Content of email from " + getClass().getSimpleName());
+
+        composePage.send();
+
+        assertTrue(accountForTest.stubMailServer.getReceivedMessages().isEmpty());
+        accountForTest.stubMailServer.waitForMessage();
+
+    }
+
+}

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/AbstractEndToEndTest.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/AbstractEndToEndTest.java
@@ -8,7 +8,9 @@ import android.support.test.runner.AndroidJUnit4;
 import android.test.ActivityInstrumentationTestCase2;
 import android.util.Log;
 
+import com.fsck.k9.K9;
 import com.fsck.k9.R;
+import com.fsck.k9.endtoend.framework.AccountForTest;
 import com.fsck.k9.endtoend.framework.ApplicationState;
 import com.fsck.k9.endtoend.framework.StubMailServer;
 import com.fsck.k9.endtoend.pages.WelcomeMessagePage;
@@ -36,14 +38,13 @@ public abstract class AbstractEndToEndTest<T extends Activity> extends ActivityI
         this.bypassWelcome = bypassWelcome;
     }
 
-    @BeforeClass
-    public static void beforeClass() {
-        ApplicationState.getInstance().stubMailServer = new StubMailServer();
-    }
 
     @AfterClass
     public static void afterClass() {
-        ApplicationState.getInstance().stubMailServer.stop();
+        for (AccountForTest account : ApplicationState.getInstance().accounts) {
+            Log.d(K9.LOG_TAG + "-test", "Stopping mail server for account " + account.name);
+            account.stubMailServer.stop();
+        }
     }
 
     @Before

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/AccountSetupFlow.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/AccountSetupFlow.java
@@ -40,7 +40,7 @@ public class AccountSetupFlow {
         IncomingServerSettingsPage incoming = accountTypePage.clickImap();
 
 
-        StubMailServer stubMailServer = ApplicationState.getInstance().stubMailServer;
+        StubMailServer stubMailServer = new StubMailServer();
 
         OutgoingServerSettingsPage outgoing = setupIncomingServerAndClickNext(incoming, stubMailServer);
 

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/framework/ApplicationState.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/framework/ApplicationState.java
@@ -12,8 +12,6 @@ public class ApplicationState {
 
     public final List<AccountForTest> accounts = new ArrayList<AccountForTest>();
 
-    public StubMailServer stubMailServer;
-
     public static ApplicationState getInstance() {
         return state;
     }

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/framework/StubMailServer.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/framework/StubMailServer.java
@@ -7,26 +7,37 @@ import com.icegreen.greenmail.user.GreenMailUser;
 import com.icegreen.greenmail.util.GreenMail;
 import com.icegreen.greenmail.util.ServerSetup;
 
+import java.util.Arrays;
+import java.util.List;
+
+import javax.mail.internet.MimeMessage;
+
 /**
  * Configuration and management of a pair of stub servers for use by an account.
  */
 public class StubMailServer {
-    private static final ServerSetup IMAP_SERVER_SETUP = new ServerSetup(10143, "127.0.0.2", ServerSetup.PROTOCOL_IMAP);
-    private static final ServerSetup SMTP_SERVER_SETUP = new ServerSetup(10587, "127.0.0.2", ServerSetup.PROTOCOL_SMTP);
 
     /**
      * Stub server that speaks SMTP, IMAP etc., that K-9 can talk to.
      */
     private GreenMail greenmail;
 
-    public StubMailServer() {
+    private int offset;
 
-        greenmail = new GreenMail(new ServerSetup[]{IMAP_SERVER_SETUP, SMTP_SERVER_SETUP});
+    /**
+     * ensures multiple instances do not conflict.
+     */
+    private static int sharedOffset = 0;
+
+    public StubMailServer() {
+        offset = ++sharedOffset;
+
+        greenmail = new GreenMail(new ServerSetup[]{getImapServerSetup(), getSmtpServerSetup()});
         GreenMailUser user = greenmail
                 .setUser(UserForImap.TEST_USER.emailAddress, UserForImap.TEST_USER.loginUsername,
                         UserForImap.TEST_USER.password);
 
-        for (String mailbox : new String[] {"Drafts", "Spam"}) {
+        for (String mailbox : new String[] {"Drafts", "Spam", "Sent"}) {
             Log.d(K9.LOG_TAG, "creating mailbox "+mailbox);
             try {
                 greenmail.getManagers().getImapHostManager().createMailbox(user, mailbox);
@@ -35,26 +46,48 @@ public class StubMailServer {
             }
         }
         greenmail.start();
+
+    }
+
+    private ServerSetup getSmtpServerSetup() {
+        return new ServerSetup(10587 + offset, "127.0.0.2", ServerSetup.PROTOCOL_SMTP);
+    }
+
+    private ServerSetup getImapServerSetup() {
+        return new ServerSetup(10143 + offset, "127.0.0.2", ServerSetup.PROTOCOL_IMAP);
     }
 
     public String getSmtpBindAddress() {
-        return SMTP_SERVER_SETUP.getBindAddress();
+        return getSmtpServerSetup().getBindAddress();
     }
 
     public int getSmtpPort() {
-        return SMTP_SERVER_SETUP.getPort();
+        return getSmtpServerSetup().getPort();
     }
 
     public String getImapBindAddress() {
-        return IMAP_SERVER_SETUP.getBindAddress();
+        return getImapServerSetup().getBindAddress();
     }
 
     public int getImapPort() {
-        return IMAP_SERVER_SETUP.getPort();
+        return getImapServerSetup().getPort();
     }
 
     public void stop() {
         greenmail.stop();
+    }
+
+    public List<MimeMessage> getReceivedMessages() {
+        return Arrays.asList(greenmail.getReceivedMessages());
+    }
+
+    public void restart() {
+        greenmail.start();
+
+    }
+
+    public void waitForMessage() {
+        greenmail.waitForIncomingEmail(60000L, 1);
     }
 }
 

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/pages/AccountsPage.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/pages/AccountsPage.java
@@ -3,7 +3,10 @@ package com.fsck.k9.endtoend.pages;
 import com.fsck.k9.R;
 import com.fsck.k9.endtoend.framework.AccountForTest;
 import android.support.test.espresso.NoMatchingViewException;
+import android.support.test.espresso.ViewAction;
 import android.support.test.espresso.ViewAssertion;
+import android.support.test.espresso.ViewInteraction;
+
 
 import static android.support.test.espresso.Espresso.onView;
 import static android.support.test.espresso.action.ViewActions.click;
@@ -42,8 +45,17 @@ public class AccountsPage extends AbstractPage {
         assertAccount(accountDisplayName, false);
     }
 
+    public FolderPage clickOnAccount(AccountForTest accountForTest) {
+        performOnAccountView(accountForTest, click());
+        return new FolderPage();
+    }
+
     public void clickLongOnAccount(AccountForTest accountForTest) {
-        onView(withText(accountForTest.description)).perform(longClick());
+        performOnAccountView(accountForTest, longClick());
+    }
+
+    private ViewInteraction performOnAccountView(AccountForTest accountForTest, ViewAction viewAction) {
+        return onView(withText(accountForTest.description)).perform(viewAction);
     }
 
     public void clickRemoveInAccountMenu() {
@@ -53,4 +65,5 @@ public class AccountsPage extends AbstractPage {
     public void clickOK() {
         onView(withText("OK")).perform(click());
     }
+
 }

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/pages/ComposePage.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/pages/ComposePage.java
@@ -1,0 +1,27 @@
+package com.fsck.k9.endtoend.pages;
+
+import com.fsck.k9.R;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.action.ViewActions.typeText;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+public class ComposePage extends AbstractPage {
+
+    public void inputTo(String toAddress) {
+        onView(withId(R.id.to)).perform(typeText(toAddress));
+    }
+
+    public void inputSubject(String subject) {
+        onView(withId(R.id.subject)).perform(typeText(subject));
+    }
+
+    public void inputMessageContent(String messageText) {
+        onView(withId(R.id.message_content)).perform(typeText(messageText));
+    }
+
+    public void send() {
+        onView(withId(R.id.send)).perform(click());
+    }
+}

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/pages/FolderPage.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/pages/FolderPage.java
@@ -1,0 +1,17 @@
+package com.fsck.k9.endtoend.pages;
+
+
+import com.fsck.k9.R;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+public class FolderPage extends AbstractPage {
+
+    public ComposePage clickCompose() {
+        onView(withId(R.id.compose)).perform(click());
+        return new ComposePage();
+    }
+
+}


### PR DESCRIPTION
Added a test for sending an email and verifying it was received by the server.

Made each test have its own server(s) on separate ports to aid maintenance.

This fails intermittently without https://github.com/k9mail/k-9/pull/601 also being merged.

The extra `eu.ocathain.*` java.mail dependencies are uploaded to the OSS snapshots repository so this should build for everyone.