### PR TITLE
Don't write messages without (partial) body to database

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1294,7 +1294,7 @@ public class MessagingController implements Runnable {
                 Log.d(K9.LOG_TAG, "SYNC: About to fetch " + unsyncedMessages.size() + " unsynced messages for folder " + folder);
 
 
-            fetchUnsyncedMessages(account, remoteFolder, localFolder, unsyncedMessages, smallMessages, largeMessages, progress, todo, fp);
+            fetchUnsyncedMessages(account, remoteFolder, unsyncedMessages, smallMessages, largeMessages, progress, todo, fp);
 
             String updatedPushState = localFolder.getPushState();
             for (Message message : unsyncedMessages) {
@@ -1442,7 +1442,6 @@ public class MessagingController implements Runnable {
     }
 
     private <T extends Message> void fetchUnsyncedMessages(final Account account, final Folder<T> remoteFolder,
-                                       final LocalFolder localFolder,
                                        List<T> unsyncedMessages,
                                        final List<Message> smallMessages,
                                        final List<Message> largeMessages,
@@ -1453,18 +1452,12 @@ public class MessagingController implements Runnable {
 
         final Date earliestDate = account.getEarliestPollDate();
 
-        /*
-         * Messages to be batch written
-         */
-        final List<Message> chunk = new ArrayList<Message>(UNSYNC_CHUNK_SIZE);
-
         remoteFolder.fetch(unsyncedMessages, fp,
         new MessageRetrievalListener<T>() {
             @Override
             public void messageFinished(T message, int number, int ofTotal) {
                 try {
                     if (message.isSet(Flag.DELETED) || message.olderThan(earliestDate)) {
-
                         if (K9.DEBUG) {
                             if (message.isSet(Flag.DELETED)) {
                                 Log.v(K9.LOG_TAG, "Newly downloaded message " + account + ":" + folder + ":" + message.getUid()
@@ -1487,24 +1480,6 @@ public class MessagingController implements Runnable {
                     } else {
                         smallMessages.add(message);
                     }
-
-                    // And include it in the view
-                    if (message.getSubject() != null && message.getFrom() != null) {
-                        /*
-                         * We check to make sure that we got something worth
-                         * showing (subject and from) because some protocols
-                         * (POP) may not be able to give us headers for
-                         * ENVELOPE, only size.
-                         */
-
-                        // keep message for delayed storing
-                        chunk.add(message);
-
-                        if (chunk.size() >= UNSYNC_CHUNK_SIZE) {
-                            writeUnsyncedMessages(chunk, localFolder, account, folder);
-                            chunk.clear();
-                        }
-                    }
                 } catch (Exception e) {
                     Log.e(K9.LOG_TAG, "Error while storing downloaded message.", e);
                     addErrorMessage(account, null, e);
@@ -1520,47 +1495,7 @@ public class MessagingController implements Runnable {
             }
 
         });
-        if (!chunk.isEmpty()) {
-            writeUnsyncedMessages(chunk, localFolder, account, folder);
-            chunk.clear();
-        }
     }
-
-    /**
-     * Actual storing of messages
-     *
-     * <br>
-     * FIXME: <strong>This method should really be moved in the above MessageRetrievalListener once {@link MessageRetrievalListener#messagesFinished(int)} is properly invoked by various stores</strong>
-     *
-     * @param messages Never <code>null</code>.
-     * @param localFolder
-     * @param account
-     * @param folder
-     */
-    private void writeUnsyncedMessages(final List<Message> messages, final LocalFolder localFolder, final Account account, final String folder) {
-        if (K9.DEBUG) {
-            Log.v(K9.LOG_TAG, "Batch writing " + Integer.toString(messages.size()) + " messages");
-        }
-        try {
-            // Store the new message locally
-            localFolder.appendMessages(messages);
-
-            for (final Message message : messages) {
-                final LocalMessage localMessage = localFolder.getMessage(message.getUid());
-                syncFlags(localMessage, message);
-                if (K9.DEBUG)
-                    Log.v(K9.LOG_TAG, "About to notify listeners that we got a new unsynced message "
-                          + account + ":" + folder + ":" + message.getUid());
-                for (final MessagingListener l : getListeners()) {
-                    l.synchronizeMailboxAddOrUpdateMessage(account, folder, localMessage);
-                }
-            }
-        } catch (final Exception e) {
-            Log.e(K9.LOG_TAG, "Error while storing downloaded message.", e);
-            addErrorMessage(account, null, e);
-        }
-    }
-
 
     private boolean shouldImportMessage(final Account account, final String folder, final Message message, final AtomicInteger progress, final Date earliestDate) {
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1296,14 +1296,15 @@ public class MessagingController implements Runnable {
 
             fetchUnsyncedMessages(account, remoteFolder, localFolder, unsyncedMessages, smallMessages, largeMessages, progress, todo, fp);
 
-            // If a message didn't exist, messageFinished won't be called, but we shouldn't try again
-            // If we got here, nothing failed
+            String updatedPushState = localFolder.getPushState();
             for (Message message : unsyncedMessages) {
-                String newPushState = remoteFolder.getNewPushState(localFolder.getPushState(), message);
+                String newPushState = remoteFolder.getNewPushState(updatedPushState, message);
                 if (newPushState != null) {
-                    localFolder.setPushState(newPushState);
+                    updatedPushState = newPushState;
                 }
             }
+            localFolder.setPushState(updatedPushState);
+
             if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "SYNC: Synced unsynced messages for folder " + folder);
             }
@@ -1462,10 +1463,6 @@ public class MessagingController implements Runnable {
             @Override
             public void messageFinished(T message, int number, int ofTotal) {
                 try {
-                    String newPushState = remoteFolder.getNewPushState(localFolder.getPushState(), message);
-                    if (newPushState != null) {
-                        localFolder.setPushState(newPushState);
-                    }
                     if (message.isSet(Flag.DELETED) || message.olderThan(earliestDate)) {
 
                         if (K9.DEBUG) {


### PR DESCRIPTION
Opening such messages during download will display "No text" and (probably due to a bug) might lead to the synchronization process being aborted. Instead of fixing the UI issue we now don't write these incomplete messages to the database. This has the potential to massively speed up the sync process. But it will take longer for messages to show up in the message list, especially with slow connections.

PS: Someone really needs to clean up the sync code :)