### PR TITLE
Support GCM cipher suites.

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
@@ -32,6 +32,12 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
 
     // Order taken from OpenSSL 1.0.1c
     protected static final String ORDERED_KNOWN_CIPHERS[] = {
+            "TLS_ECDHE_RSA_AES_256_GCM_SHA384",
+            "TLS_ECDHE_ECDSA_AES_256_GCM_SHA384",
+            "TLS_ECDHE_RSA_AES_128_GCM_SHA256",
+            "TLS_ECDHE_ECDSA_AES_128_GCM_SHA256",
+            "TLS_DHE_RSA_AES_256_GCM_SHA384",
+            "TLS_DHE_RSA_AES_128_GCM_SHA256",
             "TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
             "TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA",
             "TLS_DHE_RSA_WITH_AES_256_CBC_SHA",


### PR DESCRIPTION
Adds the common GCM cipher suites to the top of the list. These are ciphers with no known vulnerabilities or weaknesses.

Fixes #641.

Not tested, because the current build system seems to want to download and execute random code off the Internet, which I'm not comfortable doing.