### PR TITLE
Now shows '*Encrypted*' for message preview when encrypted - issue 575

### DIFF
--- a/k9mail/src/androidTest/java/com/fsck/k9/mailstore/MessageInfoExtractorTest.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/mailstore/MessageInfoExtractorTest.java
@@ -135,6 +135,44 @@ public class MessageInfoExtractorTest {
         assertEquals("text / Includes message titled \"inner message\" containing: html", preview);
     }
 
+    @Test
+    public void shouldPreviewSMimeEncryptedMessage() throws MessagingException {
+        MimeMessage message = new MimeMessage();
+        message.addHeader("Content-Type", "application/pkcs7-mime");
+        MimeMultipart multipart = new MimeMultipart();
+        multipart.setSubType("pkcs7-mime");
+        message.setBody(multipart);
+
+        String preview = new MessageInfoExtractor(getContext(), message).getMessageTextPreview();
+
+        assertEquals("*Encrypted*", preview);
+    }
+
+    @Test
+    public void shouldPreviewPgpMimeEncryptedMessage() throws MessagingException {
+        MimeMessage message = new MimeMessage();
+        message.addHeader("Content-Type", "multipart/encrypted");
+        MimeMultipart multipart = new MimeMultipart();
+        multipart.setSubType("encrypted");
+        message.setBody(multipart);
+
+        String preview = new MessageInfoExtractor(getContext(), message).getMessageTextPreview();
+
+        assertEquals("*Encrypted*", preview);
+    }
+
+    @Test
+    public void shouldPreviewInlineEncryptedMessage() throws MessagingException {
+        MimeMessage message = new MimeMessage();
+        message.addHeader("Content-Type", "text/plain");
+        TextBody body = new TextBody("-----BEGIN PGP MESSAGE----- CIPHERTEXT -----END PGP MESSAGE-----");
+        message.setBody(body);
+
+        String preview = new MessageInfoExtractor(getContext(), message).getMessageTextPreview();
+
+        assertEquals("*Encrypted*", preview);
+    }
+
     private Context getContext() {
         return InstrumentationRegistry.getTargetContext();
     }

--- a/k9mail/src/main/java/com/fsck/k9/crypto/CryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/CryptoHelper.java
@@ -9,6 +9,7 @@ import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MessageExtractor;
 import com.fsck.k9.mail.internet.MimeUtility;
+import org.openintents.openpgp.util.OpenPgpUtils;
 
 
 public class CryptoHelper {
@@ -22,22 +23,78 @@ public class CryptoHelper {
                     ".*?(-----BEGIN PGP SIGNED MESSAGE-----.*?-----BEGIN PGP SIGNATURE-----.*?-----END PGP SIGNATURE-----).*",
                     Pattern.DOTALL);
 
+    public static final String APPLICATION_PKCS7_MIME = "application/pkcs7-mime";
+    public static final String MULTIPART_ENCRYPTED = "multipart/encrypted";
+    public static final String MULTIPART_SIGNED = "multipart/signed";
+    public static final String PROTOCOL_PARAMETER = "protocol";
+    public static final String APPLICATION_PGP_ENCRYPTED = "application/pgp-encrypted";
+    public static final String APPLICATION_PGP_SIGNATURE = "application/pgp-signature";
+    public static final String TEXT_PLAIN = "text/plain";
+
     public CryptoHelper() {
         super();
     }
 
     /**
-     * TODO: use new parseMessage() from PgpUtils to actually parse!
      * @param message
      * @return
      */
-    public boolean isEncrypted(Message message) {
+    public static boolean isSMimeEncrypted(Message message) {
+        String[] contentHeaders = null;
+        try {
+            contentHeaders = message.getHeader("Content-Type");
+        } catch (MessagingException e) {
+            // guess not...
+            // TODO: maybe log this?
+        }
+
+        if (contentHeaders == null) {
+            return false;
+        }
+
+        for (String contentHeader : contentHeaders) {
+            if (contentHeader.equalsIgnoreCase(APPLICATION_PKCS7_MIME)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param message
+     * @return
+     */
+    public static boolean isPgpMimeEncrypted(Message message) {
+        String[] contentHeaders = null;
+        try {
+            contentHeaders = message.getHeader("Content-Type");
+        } catch (MessagingException e) {
+            // guess not...
+            // TODO: maybe log this?
+        }
+
+        if (contentHeaders == null) {
+            return false;
+        }
+
+        for (String contentHeader : contentHeaders) {
+            if (contentHeader.equalsIgnoreCase(MULTIPART_ENCRYPTED)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param message
+     * @return
+     */
+    public static boolean isPgpInlineEncrypted(Message message) {
         String data = null;
         try {
             Part part = MimeUtility.findFirstPartByMimeType(message, "text/plain");
-            if (part == null) {
-                part = MimeUtility.findFirstPartByMimeType(message, "text/html");
-            }
             if (part != null) {
                 data = MessageExtractor.getTextFromPart(part);
             }
@@ -50,8 +107,13 @@ public class CryptoHelper {
             return false;
         }
 
-        Matcher matcher = PGP_MESSAGE.matcher(data);
-        return matcher.matches();
+        switch (OpenPgpUtils.parseMessage(data)) {
+            case OpenPgpUtils.PARSE_RESULT_MESSAGE:
+            case OpenPgpUtils.PARSE_RESULT_SIGNED_MESSAGE:
+                return true;
+            default:
+                return false;
+        }
     }
 
     public boolean isSigned(Message message) {

--- a/k9mail/src/main/java/com/fsck/k9/crypto/CryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/CryptoHelper.java
@@ -39,69 +39,30 @@ public class CryptoHelper {
      * @param message
      * @return
      */
-    public static boolean isSMimeEncrypted(Message message) {
-        String[] contentHeaders = null;
-        try {
-            contentHeaders = message.getHeader("Content-Type");
-        } catch (MessagingException e) {
-            // guess not...
-            // TODO: maybe log this?
-        }
-
-        if (contentHeaders == null) {
-            return false;
-        }
-
-        for (String contentHeader : contentHeaders) {
-            if (contentHeader.equalsIgnoreCase(APPLICATION_PKCS7_MIME)) {
-                return true;
-            }
-        }
-
-        return false;
+    public static boolean isSMimeEncrypted(Message message) throws MessagingException {
+        return contentHeaderContains(message, APPLICATION_PKCS7_MIME);
     }
 
     /**
      * @param message
      * @return
      */
-    public static boolean isPgpMimeEncrypted(Message message) {
-        String[] contentHeaders = null;
-        try {
-            contentHeaders = message.getHeader("Content-Type");
-        } catch (MessagingException e) {
-            // guess not...
-            // TODO: maybe log this?
-        }
-
-        if (contentHeaders == null) {
-            return false;
-        }
-
-        for (String contentHeader : contentHeaders) {
-            if (contentHeader.equalsIgnoreCase(MULTIPART_ENCRYPTED)) {
-                return true;
-            }
-        }
-
-        return false;
+    public static boolean isPgpMimeEncrypted(Message message) throws MessagingException {
+        return contentHeaderContains(message, MULTIPART_ENCRYPTED);
     }
 
     /**
      * @param message
      * @return
      */
-    public static boolean isPgpInlineEncrypted(Message message) {
-        String data = null;
-        try {
-            Part part = MimeUtility.findFirstPartByMimeType(message, "text/plain");
-            if (part != null) {
-                data = MessageExtractor.getTextFromPart(part);
-            }
-        } catch (MessagingException e) {
-            // guess not...
-            // TODO: maybe log this?
+    public static boolean isPgpInlineEncrypted(Message message) throws MessagingException {
+        Part part = MimeUtility.findFirstPartByMimeType(message, "text/plain");
+
+        if (part == null) {
+            return false;
         }
+
+        String data = MessageExtractor.getTextFromPart(part);
 
         if (data == null) {
             return false;
@@ -116,26 +77,19 @@ public class CryptoHelper {
         }
     }
 
-    public boolean isSigned(Message message) {
-        String data = null;
-        try {
-            Part part = MimeUtility.findFirstPartByMimeType(message, "text/plain");
-            if (part == null) {
-                part = MimeUtility.findFirstPartByMimeType(message, "text/html");
-            }
-            if (part != null) {
-                data = MessageExtractor.getTextFromPart(part);
-            }
-        } catch (MessagingException e) {
-            // guess not...
-            // TODO: maybe log this?
-        }
+    private static boolean contentHeaderContains(Message message, String desiredHeader) throws MessagingException {
+        String[] contentHeaders = message.getHeader("Content-Type");
 
-        if (data == null) {
+        if (contentHeaders == null) {
             return false;
         }
 
-        Matcher matcher = PGP_SIGNED_MESSAGE.matcher(data);
-        return matcher.matches();
+        for (String contentHeader : contentHeaders) {
+            if (contentHeader.equalsIgnoreCase(desiredHeader)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
@@ -17,13 +17,6 @@ import org.openintents.openpgp.util.OpenPgpUtils;
 
 
 public class MessageDecryptVerifier {
-    private static final String MULTIPART_ENCRYPTED = "multipart/encrypted";
-    private static final String MULTIPART_SIGNED = "multipart/signed";
-    private static final String PROTOCOL_PARAMETER = "protocol";
-    private static final String APPLICATION_PGP_ENCRYPTED = "application/pgp-encrypted";
-    private static final String APPLICATION_PGP_SIGNATURE = "application/pgp-signature";
-    private static final String TEXT_PLAIN = "text/plain";
-
 
     public static List<Part> findEncryptedParts(Part startPart) {
         List<Part> encryptedParts = new ArrayList<Part>();
@@ -35,7 +28,7 @@ public class MessageDecryptVerifier {
             String mimeType = part.getMimeType();
             Body body = part.getBody();
 
-            if (MULTIPART_ENCRYPTED.equals(mimeType)) {
+            if (CryptoHelper.MULTIPART_ENCRYPTED.equals(mimeType)) {
                 encryptedParts.add(part);
             } else if (body instanceof Multipart) {
                 Multipart multipart = (Multipart) body;
@@ -59,7 +52,7 @@ public class MessageDecryptVerifier {
             String mimeType = part.getMimeType();
             Body body = part.getBody();
 
-            if (MULTIPART_SIGNED.equals(mimeType)) {
+            if (CryptoHelper.MULTIPART_SIGNED.equals(mimeType)) {
                 signedParts.add(part);
             } else if (body instanceof Multipart) {
                 Multipart multipart = (Multipart) body;
@@ -83,7 +76,7 @@ public class MessageDecryptVerifier {
             String mimeType = part.getMimeType();
             Body body = part.getBody();
 
-            if (TEXT_PLAIN.equalsIgnoreCase(mimeType)) {
+            if (CryptoHelper.TEXT_PLAIN.equalsIgnoreCase(mimeType)) {
                 String text = MessageExtractor.getTextFromPart(part);
                 switch (OpenPgpUtils.parseMessage(text)) {
                     case OpenPgpUtils.PARSE_RESULT_MESSAGE:
@@ -104,12 +97,12 @@ public class MessageDecryptVerifier {
 
     public static byte[] getSignatureData(Part part) throws IOException, MessagingException {
 
-        if (MULTIPART_SIGNED.equals(part.getMimeType())) {
+        if (CryptoHelper.MULTIPART_SIGNED.equals(part.getMimeType())) {
             Body body = part.getBody();
             if (body instanceof Multipart) {
                 Multipart multi = (Multipart) body;
                 BodyPart signatureBody = multi.getBodyPart(1);
-                if (APPLICATION_PGP_SIGNATURE.equals(signatureBody.getMimeType())) {
+                if (CryptoHelper.APPLICATION_PGP_SIGNATURE.equals(signatureBody.getMimeType())) {
                     ByteArrayOutputStream bos = new ByteArrayOutputStream();
                     signatureBody.getBody().writeTo(bos);
                     return bos.toByteArray();
@@ -121,7 +114,7 @@ public class MessageDecryptVerifier {
     }
 
     public static boolean isPgpMimeSignedPart(Part part) {
-        return MULTIPART_SIGNED.equals(part.getMimeType());
+        return CryptoHelper.MULTIPART_SIGNED.equals(part.getMimeType());
     }
 
     public static boolean isPgpMimeEncryptedPart(Part part) {
@@ -129,6 +122,6 @@ public class MessageDecryptVerifier {
 //        String contentType = part.getContentType();
 //        String protocol = MimeUtility.getHeaderParameter(contentType, PROTOCOL_PARAMETER);
 //        return APPLICATION_PGP_ENCRYPTED.equals(protocol);
-        return MULTIPART_ENCRYPTED.equals(part.getMimeType());
+        return CryptoHelper.MULTIPART_ENCRYPTED.equals(part.getMimeType());
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageInfoExtractor.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import android.content.Context;
 
+import com.fsck.k9.crypto.CryptoHelper;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
@@ -25,6 +26,11 @@ class MessageInfoExtractor {
     }
 
     public String getMessageTextPreview() throws MessagingException {
+        if (CryptoHelper.isPgpInlineEncrypted(message)
+                || CryptoHelper.isPgpMimeEncrypted(message)
+                || CryptoHelper.isSMimeEncrypted(message)) {
+            return "*Encrypted*";
+        }
         getViewablesIfNecessary();
         return MessagePreviewExtractor.extractPreview(context, viewables);
     }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageInfoExtractor.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import android.content.Context;
 
+import com.fsck.k9.R;
 import com.fsck.k9.crypto.CryptoHelper;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
@@ -29,7 +30,7 @@ class MessageInfoExtractor {
         if (CryptoHelper.isPgpInlineEncrypted(message)
                 || CryptoHelper.isPgpMimeEncrypted(message)
                 || CryptoHelper.isSMimeEncrypted(message)) {
-            return "*Encrypted*";
+            return context.getString(R.string.openpgp_message_preview);
         }
         getViewablesIfNecessary();
         return MessagePreviewExtractor.extractPreview(context, viewables);

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1134,6 +1134,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="openpgp_result_action_lookup">"Lookup"</string>
     <string name="openpgp_result_no_name">"No name"</string>
     <string name="openpgp_result_no_email">"No email"</string>
+    <string name="openpgp_message_preview">"*Encrypted*"</string>
 
     <!-- === Client certificates specific ================================================================== -->
     <string name="account_setup_basics_client_certificate">Use client certificate</string>


### PR DESCRIPTION
https://github.com/k9mail/k-9/issues/575

Should now work for PGP inline, PGP/MIME, and S/MIME encrypted messages. Comments and critiques welcome - this is my first pull request for K9, so please let me know how I can improve.