### PR TITLE
Disabling support for SSLv3 protocol/ciphers and all RC4 ciphers.

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
@@ -48,7 +48,6 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
             "TLS_ECDHE_ECDSA_WITH_3DES_EDE_CBC_SHA",
             "TLS_ECDH_RSA_WITH_3DES_EDE_CBC_SHA",
             "TLS_ECDH_ECDSA_WITH_3DES_EDE_CBC_SHA",
-            "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
             "TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA",
             "TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA",
             "TLS_DHE_RSA_WITH_AES_128_CBC_SHA",
@@ -56,14 +55,6 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
             "TLS_ECDH_RSA_WITH_AES_128_CBC_SHA",
             "TLS_ECDH_ECDSA_WITH_AES_128_CBC_SHA",
             "TLS_RSA_WITH_AES_128_CBC_SHA",
-            "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
-            "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
-            "TLS_ECDH_RSA_WITH_RC4_128_SHA",
-            "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
-            "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
-            "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
-            "SSL_RSA_WITH_RC4_128_SHA",
-            "SSL_RSA_WITH_RC4_128_MD5",
     };
 
     protected static final String[] BLACKLISTED_CIPHERS = {
@@ -74,10 +65,19 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
             "SSL_RSA_EXPORT_WITH_DES40_CBC_SHA",
             "SSL_DHE_RSA_EXPORT_WITH_DES40_CBC_SHA",
             "SSL_DHE_DSS_EXPORT_WITH_DES40_CBC_SHA",
+            "SSL_RSA_WITH_3DES_EDE_CBC_SHA",
+            "SSL_DHE_RSA_WITH_3DES_EDE_CBC_SHA",
+            "SSL_DHE_DSS_WITH_3DES_EDE_CBC_SHA",
+            "TLS_ECDHE_RSA_WITH_RC4_128_SHA",
+            "TLS_ECDHE_ECDSA_WITH_RC4_128_SHA",
+            "TLS_ECDH_RSA_WITH_RC4_128_SHA",
+            "TLS_ECDH_ECDSA_WITH_RC4_128_SHA",
+            "SSL_RSA_WITH_RC4_128_SHA",
+            "SSL_RSA_WITH_RC4_128_MD5",
     };
 
     protected static final String ORDERED_KNOWN_PROTOCOLS[] = {
-            "TLSv1.2", "TLSv1.1", "TLSv1", "SSLv3"
+            "TLSv1.2", "TLSv1.1", "TLSv1"
     };
 
     static {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
@@ -80,6 +80,10 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
             "TLSv1.2", "TLSv1.1", "TLSv1"
     };
 
+    protected static final String[] BLACKLISTED_PROTOCOLS = {
+            "SSLv3"
+    };
+
     static {
         String[] enabledCiphers = null;
         String[] supportedProtocols = null;
@@ -106,7 +110,7 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
                 reorder(enabledCiphers, ORDERED_KNOWN_CIPHERS, BLACKLISTED_CIPHERS);
 
         ENABLED_PROTOCOLS = (supportedProtocols == null) ? null :
-            reorder(supportedProtocols, ORDERED_KNOWN_PROTOCOLS, null);
+            reorder(supportedProtocols, ORDERED_KNOWN_PROTOCOLS, BLACKLISTED_PROTOCOLS);
     }
 
     public DefaultTrustedSocketFactory(Context context) {


### PR DESCRIPTION
Wasn't sure if blacklisting the SSL_* ciphers was necessary after explicitly removing SSLv3 from the protocols list, so let me know if the blacklist should be cleaned of all SSL_* entries now or if this is ok. Seems to work fine in my rudimentary testing.