### PR TITLE
Change preventing accidental new mail discard

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -168,6 +168,7 @@ public class K9 extends Application {
     private static boolean mAnimations = true;
 
     private static boolean mConfirmDelete = false;
+    private static boolean mConfirmMenuDiscard = true;
     private static boolean mConfirmDeleteStarred = false;
     private static boolean mConfirmSpam = false;
     private static boolean mConfirmDeleteFromNotification = true;
@@ -504,6 +505,7 @@ public class K9 extends Application {
         editor.putBoolean("fixedMessageViewTheme", useFixedMessageTheme);
 
         editor.putBoolean("confirmDelete", mConfirmDelete);
+        editor.putBoolean("confirmMenuDiscard", mConfirmMenuDiscard);
         editor.putBoolean("confirmDeleteStarred", mConfirmDeleteStarred);
         editor.putBoolean("confirmSpam", mConfirmSpam);
         editor.putBoolean("confirmDeleteFromNotification", mConfirmDeleteFromNotification);
@@ -724,6 +726,7 @@ public class K9 extends Application {
         mHideTimeZone = sprefs.getBoolean("hideTimeZone", false);
 
         mConfirmDelete = sprefs.getBoolean("confirmDelete", false);
+        mConfirmMenuDiscard = sprefs.getBoolean("confirmMenuDiscard", true);
         mConfirmDeleteStarred = sprefs.getBoolean("confirmDeleteStarred", false);
         mConfirmSpam = sprefs.getBoolean("confirmSpam", false);
         mConfirmDeleteFromNotification = sprefs.getBoolean("confirmDeleteFromNotification", true);
@@ -1182,8 +1185,16 @@ public class K9 extends Application {
         return mConfirmSpam;
     }
 
+    public static boolean confirmMenuDiscard() {
+        return mConfirmMenuDiscard;
+    }
+
     public static void setConfirmSpam(final boolean confirm) {
         mConfirmSpam = confirm;
+    }
+
+    public static void setConfirmMenuDiscard(final boolean confirm) {
+        mConfirmMenuDiscard = confirm;
     }
 
     public static boolean confirmDeleteFromNotification() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1939,7 +1939,28 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             }
         }
     }
-
+    
+    private void askBeforeDiscard(){
+        if(K9.confirmMenuDiscard()){
+                AlertDialog.Builder alertDialog = new AlertDialog.Builder(MessageCompose.this);
+                alertDialog.setTitle(R.string.dialog_confirm_delete_title);
+                alertDialog.setMessage(R.string.dialog_confirm_delete_message);
+                alertDialog.setPositiveButton(R.string.dialog_confirm_delete_confirm_button, new DialogInterface.OnClickListener() {                
+                    public void onClick(DialogInterface dialog, int which){
+                        onDiscard();
+                    }
+                });        
+                alertDialog.setNegativeButton(R.string.dialog_confirm_delete_cancel_button, new DialogInterface.OnClickListener(){
+                    public void onClick(DialogInterface dialog, int which){
+                    }
+                });                
+                alertDialog.show();
+        }else{
+                onDiscard();
+        }
+    }
+    
+                
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
@@ -1955,7 +1976,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 }
                 break;
             case R.id.discard:
-                onDiscard();
+                askBeforeDiscard();
+                
                 break;
             case R.id.add_cc_bcc:
                 onAddCcBcc();

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -405,8 +405,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
                 mSearch.or(new SearchCondition(SearchField.SENDER, Attribute.CONTAINS, query));
                 mSearch.or(new SearchCondition(SearchField.SUBJECT, Attribute.CONTAINS, query));
-//jab to remove exception
-//                mSearch.or(new SearchCondition(SearchField.MESSAGE_CONTENTS, Attribute.CONTAINS, query));
+                mSearch.or(new SearchCondition(SearchField.MESSAGE_CONTENTS, Attribute.CONTAINS, query));
 
                 Bundle appData = intent.getBundleExtra(SearchManager.APP_DATA);
                 if (appData != null) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -405,7 +405,8 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
                 mSearch.or(new SearchCondition(SearchField.SENDER, Attribute.CONTAINS, query));
                 mSearch.or(new SearchCondition(SearchField.SUBJECT, Attribute.CONTAINS, query));
-                mSearch.or(new SearchCondition(SearchField.MESSAGE_CONTENTS, Attribute.CONTAINS, query));
+//jab to remove exception
+//                mSearch.or(new SearchCondition(SearchField.MESSAGE_CONTENTS, Attribute.CONTAINS, query));
 
                 Bundle appData = intent.getBundleExtra(SearchManager.APP_DATA);
                 if (appData != null) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -211,7 +211,6 @@ public class Prefs extends K9PreferenceActivity {
         mConfirmActions = (CheckBoxListPreference) findPreference(PREFERENCE_CONFIRM_ACTIONS);
 
         boolean canDeleteFromNotification = MessagingController.platformSupportsExtendedNotifications();
-//jab was 4 3 (two lines)
         CharSequence[] confirmActionEntries = new CharSequence[canDeleteFromNotification ? 5 : 4];
         boolean[] confirmActionValues = new boolean[canDeleteFromNotification ? 5 : 4];
         int index = 0;
@@ -224,7 +223,6 @@ public class Prefs extends K9PreferenceActivity {
             confirmActionEntries[index] = getString(R.string.global_settings_confirm_action_delete_notif);
             confirmActionValues[index++] = K9.confirmDeleteFromNotification();
         }
-//jab
         confirmActionEntries[index] = getString(R.string.global_settings_confirm_action_spam);
         confirmActionValues[index++] = K9.confirmSpam();
         confirmActionEntries[index] = getString(R.string.global_settings_confirm_menu_discard);
@@ -460,7 +458,6 @@ public class Prefs extends K9PreferenceActivity {
         if (MessagingController.platformSupportsExtendedNotifications()) {
             K9.setConfirmDeleteFromNotification(mConfirmActions.getCheckedItems()[index++]);
         }
-//jab
         K9.setConfirmSpam(mConfirmActions.getCheckedItems()[index++]);
         K9.setConfirmMenuDiscard(mConfirmActions.getCheckedItems()[index++]);
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -211,6 +211,7 @@ public class Prefs extends K9PreferenceActivity {
         mConfirmActions = (CheckBoxListPreference) findPreference(PREFERENCE_CONFIRM_ACTIONS);
 
         boolean canDeleteFromNotification = MessagingController.platformSupportsExtendedNotifications();
+//jab was 4 3 (two lines)
         CharSequence[] confirmActionEntries = new CharSequence[canDeleteFromNotification ? 5 : 4];
         boolean[] confirmActionValues = new boolean[canDeleteFromNotification ? 5 : 4];
         int index = 0;
@@ -223,6 +224,7 @@ public class Prefs extends K9PreferenceActivity {
             confirmActionEntries[index] = getString(R.string.global_settings_confirm_action_delete_notif);
             confirmActionValues[index++] = K9.confirmDeleteFromNotification();
         }
+//jab
         confirmActionEntries[index] = getString(R.string.global_settings_confirm_action_spam);
         confirmActionValues[index++] = K9.confirmSpam();
         confirmActionEntries[index] = getString(R.string.global_settings_confirm_menu_discard);
@@ -458,6 +460,7 @@ public class Prefs extends K9PreferenceActivity {
         if (MessagingController.platformSupportsExtendedNotifications()) {
             K9.setConfirmDeleteFromNotification(mConfirmActions.getCheckedItems()[index++]);
         }
+//jab
         K9.setConfirmSpam(mConfirmActions.getCheckedItems()[index++]);
         K9.setConfirmMenuDiscard(mConfirmActions.getCheckedItems()[index++]);
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -211,8 +211,9 @@ public class Prefs extends K9PreferenceActivity {
         mConfirmActions = (CheckBoxListPreference) findPreference(PREFERENCE_CONFIRM_ACTIONS);
 
         boolean canDeleteFromNotification = MessagingController.platformSupportsExtendedNotifications();
-        CharSequence[] confirmActionEntries = new CharSequence[canDeleteFromNotification ? 4 : 3];
-        boolean[] confirmActionValues = new boolean[canDeleteFromNotification ? 4 : 3];
+//jab was 4 3 (two lines)
+        CharSequence[] confirmActionEntries = new CharSequence[canDeleteFromNotification ? 5 : 4];
+        boolean[] confirmActionValues = new boolean[canDeleteFromNotification ? 5 : 4];
         int index = 0;
 
         confirmActionEntries[index] = getString(R.string.global_settings_confirm_action_delete);
@@ -223,8 +224,11 @@ public class Prefs extends K9PreferenceActivity {
             confirmActionEntries[index] = getString(R.string.global_settings_confirm_action_delete_notif);
             confirmActionValues[index++] = K9.confirmDeleteFromNotification();
         }
+//jab
         confirmActionEntries[index] = getString(R.string.global_settings_confirm_action_spam);
         confirmActionValues[index++] = K9.confirmSpam();
+        confirmActionEntries[index] = getString(R.string.global_settings_confirm_menu_discard);
+        confirmActionValues[index++] = K9.confirmMenuDiscard();
 
         mConfirmActions.setItems(confirmActionEntries);
         mConfirmActions.setCheckedItems(confirmActionValues);
@@ -456,7 +460,9 @@ public class Prefs extends K9PreferenceActivity {
         if (MessagingController.platformSupportsExtendedNotifications()) {
             K9.setConfirmDeleteFromNotification(mConfirmActions.getCheckedItems()[index++]);
         }
+//jab
         K9.setConfirmSpam(mConfirmActions.getCheckedItems()[index++]);
+        K9.setConfirmMenuDiscard(mConfirmActions.getCheckedItems()[index++]);
 
         K9.setMeasureAccounts(mMeasureAccounts.isChecked());
         K9.setCountSearchMessages(mCountSearch.isChecked());

--- a/k9mail/src/main/res/values-de/strings.xml
+++ b/k9mail/src/main/res/values-de/strings.xml
@@ -270,6 +270,7 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
   <string name="global_settings_confirm_action_delete">Löschen</string>
   <string name="global_settings_confirm_action_delete_starred">Sternmarkierte Löschen (nur in Nachrichtenansicht)</string>
   <string name="global_settings_confirm_action_spam">Spam</string>
+  <string name="global_settings_confirm_menu_discard">Verwerfen im Nachrichterstellenmenu</string>
   <string name="global_settings_confirm_action_delete_notif">Löschen (aus Benachrichtigung)</string>
   <string name="global_settings_privacy_hide_useragent">K-9 nicht als Mailprogramm in Kopfzeilen eintragen</string>
   <string name="global_settings_privacy_hide_timezone">UTC als Zeitzone in Kopfzeilen verwenden</string>

--- a/k9mail/src/main/res/values-de/strings.xml
+++ b/k9mail/src/main/res/values-de/strings.xml
@@ -270,7 +270,6 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
   <string name="global_settings_confirm_action_delete">Löschen</string>
   <string name="global_settings_confirm_action_delete_starred">Sternmarkierte Löschen (nur in Nachrichtenansicht)</string>
   <string name="global_settings_confirm_action_spam">Spam</string>
-  <string name="global_settings_confirm_menu_discard">Verwerfen im Nachrichterstellenmenu</string>
   <string name="global_settings_confirm_action_delete_notif">Löschen (aus Benachrichtigung)</string>
   <string name="global_settings_privacy_hide_useragent">K-9 nicht als Mailprogramm in Kopfzeilen eintragen</string>
   <string name="global_settings_privacy_hide_timezone">UTC als Zeitzone in Kopfzeilen verwenden</string>

--- a/k9mail/src/main/res/values-de/strings.xml
+++ b/k9mail/src/main/res/values-de/strings.xml
@@ -101,7 +101,7 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
   <string name="single_message_options_action">Senden…</string>
   <string name="refile_action">Umsortieren…</string>
   <string name="done_action">Fertig</string>
-  <string name="discard_action">Verwerfen</string>
+  <string name="discard_action">Verwerfen </string>
   <string name="save_draft_action">Als Entwurf speichern</string>
   <string name="check_mail_action">E-Mail abrufen</string>
   <string name="send_messages_action">Nachrichten senden</string>
@@ -270,6 +270,7 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
   <string name="global_settings_confirm_action_delete">Löschen</string>
   <string name="global_settings_confirm_action_delete_starred">Sternmarkierte Löschen (nur in Nachrichtenansicht)</string>
   <string name="global_settings_confirm_action_spam">Spam</string>
+  <string name="global_settings_confirm_menu_discard">Verwerfen im Nachrichterstellenmenu</string>
   <string name="global_settings_confirm_action_delete_notif">Löschen (aus Benachrichtigung)</string>
   <string name="global_settings_privacy_hide_useragent">K-9 nicht als Mailprogramm in Kopfzeilen eintragen</string>
   <string name="global_settings_privacy_hide_timezone">UTC als Zeitzone in Kopfzeilen verwenden</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -329,6 +329,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_confirm_action_delete">Delete</string>
     <string name="global_settings_confirm_action_delete_starred">Delete Starred (in message view)</string>
     <string name="global_settings_confirm_action_spam">Spam</string>
+    <string name="global_settings_confirm_menu_discard">Discard at Message Compose Menu</string>
     <string name="global_settings_confirm_action_delete_notif">Delete (from notification)</string>
 
     <string name="global_settings_privacy_hide_useragent">Remove K-9 User-Agent from mail headers</string>


### PR DESCRIPTION
Hi,

I added a confirm dialog if accidently pressed discard menu entry in the message compose string. The dialog is default on and can be disabled in global settings > interaction > notifications

Cheers
Joerg

P.S: Being new on github. Once you accepted the pull (and if I need space), can I delete my fork ? 