### PR TITLE
fix static analysis warnings and stop using nulls everywhere

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Part.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Part.java
@@ -22,6 +22,9 @@ public interface Part {
 
     String getContentId();
 
+    /**
+     * Returns an array of headers of the given name. The array may be empty.
+     */
     String[] getHeader(String name) throws MessagingException;
 
     boolean isMimeType(String mimeType) throws MessagingException;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/JisSupport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/JisSupport.java
@@ -49,8 +49,8 @@ class JisSupport {
 
 
     private static String getJisVariantFromMailerHeaders(Message message) throws MessagingException {
-        String mailerHeaders[] = message.getHeader("X-Mailer");
-        if (mailerHeaders == null || mailerHeaders.length == 0)
+        String[] mailerHeaders = message.getHeader("X-Mailer");
+        if (mailerHeaders.length == 0)
             return null;
 
         if (mailerHeaders[0].startsWith("iPhone Mail ") || mailerHeaders[0].startsWith("iPad Mail "))
@@ -61,8 +61,8 @@ class JisSupport {
 
 
     private static String getJisVariantFromReceivedHeaders(Part message) throws MessagingException {
-        String receivedHeaders[] = message.getHeader("Received");
-        if (receivedHeaders == null)
+        String[] receivedHeaders = message.getHeader("Received");
+        if (receivedHeaders.length == 0)
             return null;
 
         for (String receivedHeader : receivedHeaders) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeHeader.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeHeader.java
@@ -26,7 +26,7 @@ public class MimeHeader {
 
     public String getFirstHeader(String name) {
         String[] header = getHeader(name);
-        if (header == null) {
+        if (header.length == 0) {
             return null;
         }
         return header[0];
@@ -64,9 +64,6 @@ public class MimeHeader {
             if (field.getName().equalsIgnoreCase(name)) {
                 values.add(field.getValue());
             }
-        }
-        if (values.isEmpty()) {
-            return null;
         }
         return values.toArray(EMPTY_STRING_ARRAY);
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -1937,7 +1937,7 @@ public class ImapStore extends RemoteStore {
                 */
                 String[] messageIdHeader = message.getHeader("Message-ID");
 
-                if (messageIdHeader == null || messageIdHeader.length == 0) {
+                if (messageIdHeader.length == 0) {
                     if (K9MailLib.isDebug())
                         Log.d(LOG_TAG, "Did not get a message-id in order to search for UID  for " + getLogId());
                     return null;

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -2379,8 +2379,10 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         // Decode the identity header when loading a draft.
         // See buildIdentityHeader(TextBody) for a detailed description of the composition of this blob.
         Map<IdentityField, String> k9identity = new HashMap<IdentityField, String>();
-        if (message.getHeader(K9.IDENTITY_HEADER).length > 0 && message.getHeader(K9.IDENTITY_HEADER)[0] != null) {
-            k9identity = IdentityHeaderParser.parse(message.getHeader(K9.IDENTITY_HEADER)[0]);
+        String[] identityHeaders = message.getHeader(K9.IDENTITY_HEADER);
+
+        if (identityHeaders.length > 0 && identityHeaders[0] != null) {
+            k9identity = IdentityHeaderParser.parse(identityHeaders[0]);
         }
 
         Identity newIdentity = new Identity();

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -2362,13 +2362,13 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
         // Read In-Reply-To header from draft
         final String[] inReplyTo = message.getHeader("In-Reply-To");
-        if ((inReplyTo != null) && (inReplyTo.length >= 1)) {
+        if (inReplyTo.length >= 1) {
             mInReplyTo = inReplyTo[0];
         }
 
         // Read References header from draft
         final String[] references = message.getHeader("References");
-        if ((references != null) && (references.length >= 1)) {
+        if (references.length >= 1) {
             mReferences = references[0];
         }
 
@@ -2379,7 +2379,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         // Decode the identity header when loading a draft.
         // See buildIdentityHeader(TextBody) for a detailed description of the composition of this blob.
         Map<IdentityField, String> k9identity = new HashMap<IdentityField, String>();
-        if (message.getHeader(K9.IDENTITY_HEADER) != null && message.getHeader(K9.IDENTITY_HEADER).length > 0 && message.getHeader(K9.IDENTITY_HEADER)[0] != null) {
+        if (message.getHeader(K9.IDENTITY_HEADER).length > 0 && message.getHeader(K9.IDENTITY_HEADER)[0] != null) {
             k9identity = IdentityHeaderParser.parse(message.getHeader(K9.IDENTITY_HEADER)[0]);
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -3424,7 +3424,7 @@ public class MessagingController implements Runnable {
                     try {
 
 
-                        if (message.getHeader(K9.IDENTITY_HEADER) != null) {
+                        if (message.getHeader(K9.IDENTITY_HEADER).length > 0) {
                             Log.v(K9.LOG_TAG, "The user has set the Outbox and Drafts folder to the same thing. " +
                                   "This message appears to be a draft, so K-9 will not send it");
                             continue;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -1451,7 +1451,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
     private String getTransferEncoding(Part part) throws MessagingException {
         String[] contentTransferEncoding = part.getHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING);
-        if (contentTransferEncoding != null && contentTransferEncoding.length > 0) {
+        if (contentTransferEncoding.length > 0) {
             return contentTransferEncoding[0].toLowerCase(Locale.US);
         }
 
@@ -1812,14 +1812,14 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         // Get the message IDs from the "References" header line
         String[] referencesArray = message.getHeader("References");
         List<String> messageIds = null;
-        if (referencesArray != null && referencesArray.length > 0) {
+        if (referencesArray.length > 0) {
             messageIds = Utility.extractMessageIds(referencesArray[0]);
         }
 
         // Append the first message ID from the "In-Reply-To" header line
         String[] inReplyToArray = message.getHeader("In-Reply-To");
         String inReplyTo;
-        if (inReplyToArray != null && inReplyToArray.length > 0) {
+        if (inReplyToArray.length > 0) {
             inReplyTo = Utility.extractMessageId(inReplyToArray[0]);
             if (inReplyTo != null) {
                 if (messageIds == null) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessageExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessageExtractor.java
@@ -560,7 +560,7 @@ public class LocalMessageExtractor {
         // attachments.
         if (contentDisposition != null &&
                 MimeUtility.getHeaderParameter(contentDisposition, null).matches("^(?i:inline)") &&
-                part.getHeader(MimeHeader.HEADER_CONTENT_ID) != null) {
+                part.getHeader(MimeHeader.HEADER_CONTENT_ID).length > 0) {
             firstClassAttachment = false;
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -1017,15 +1017,10 @@ public class MessageProvider extends ContentProvider {
 
         // Note: can only delete a message
 
-        List<String> segments = null;
-        int accountId = -1;
-        String folderName = null;
-        String msgUid = null;
-
-        segments = uri.getPathSegments();
-        accountId = Integer.parseInt(segments.get(1));
-        folderName = segments.get(2);
-        msgUid = segments.get(3);
+        List<String> segments = uri.getPathSegments();
+        int accountId = Integer.parseInt(segments.get(1));
+        String folderName = segments.get(2);
+        String msgUid = segments.get(3);
 
         // get account
         Account myAccount = null;
@@ -1039,6 +1034,10 @@ public class MessageProvider extends ContentProvider {
             }
         }
 
+        if (myAccount == null) {
+            throw new IllegalArgumentException("Could not find account with id " + accountId);
+        }
+
         // get localstore parameter
         LocalMessage msg = null;
         try {
@@ -1049,14 +1048,16 @@ public class MessageProvider extends ContentProvider {
             }
             msg = lf.getMessage(msgUid);
         } catch (MessagingException e) {
-            Log.e(K9.LOG_TAG, "Unable to retrieve message", e);
+            throw new RuntimeException(e);
+        }
+
+        if (msg == null) {
+            throw new IllegalArgumentException("Could not find message with id " + msgUid);
         }
 
         // launch command to delete the message
-        if ((myAccount != null) && (msg != null)) {
-            MessagingController controller = MessagingController.getInstance(getContext());
-            controller.deleteMessages(Collections.singletonList(msg), null);
-        }
+        MessagingController controller = MessagingController.getInstance(getContext());
+        controller.deleteMessages(Collections.singletonList(msg), null);
 
         // FIXME return the actual number of deleted messages
         return 0;

--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -1035,7 +1035,7 @@ public class MessageProvider extends ContentProvider {
         }
 
         if (myAccount == null) {
-            throw new IllegalArgumentException("Could not find account with id " + accountId);
+            Log.e(K9.LOG_TAG, "Could not find account with id " + accountId);
         }
 
         // get localstore parameter
@@ -1048,16 +1048,14 @@ public class MessageProvider extends ContentProvider {
             }
             msg = lf.getMessage(msgUid);
         } catch (MessagingException e) {
-            throw new RuntimeException(e);
-        }
-
-        if (msg == null) {
-            throw new IllegalArgumentException("Could not find message with id " + msgUid);
+            Log.e(K9.LOG_TAG, "Unable to retrieve message", e);
         }
 
         // launch command to delete the message
-        MessagingController controller = MessagingController.getInstance(getContext());
-        controller.deleteMessages(Collections.singletonList(msg), null);
+        if ((myAccount != null) && (msg != null)) {
+            MessagingController controller = MessagingController.getInstance(getContext());
+            controller.deleteMessages(Collections.singletonList(msg), null);
+        }
 
         // FIXME return the actual number of deleted messages
         return 0;


### PR DESCRIPTION
Got rid of some null-paranoia.

I am prepared for pushback on changes in `MessageProvider` but I think there is already too much 'the show must go on' mentality in the code.