### PR TITLE
Enable fulltext imap search

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -1707,8 +1707,7 @@ public class Account implements BaseAccount, StoreConfig {
         mAlwaysShowCcBcc = show;
     }
     public boolean isRemoteSearchFullText() {
-        return false;   // Temporarily disabled
-        //return mRemoteSearchFullText;
+        return mRemoteSearchFullText;
     }
 
     public void setRemoteSearchFullText(boolean val) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -183,11 +183,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private PreferenceScreen mSearchScreen;
     private CheckBoxPreference mCloudSearchEnabled;
     private ListPreference mRemoteSearchNumResults;
-    /*
-     * Temporarily removed because search results aren't displayed to the user.
-     * So this feature is useless.
-     */
-    //private CheckBoxPreference mRemoteSearchFullText;
+    private CheckBoxPreference mRemoteSearchFullText;
 
     private ListPreference mLocalStorageProvider;
     private ListPreference mArchiveFolder;
@@ -515,7 +511,7 @@ public class AccountSettings extends K9PreferenceActivity {
                 }
             }
         );
-        //mRemoteSearchFullText = (CheckBoxPreference) findPreference(PREFERENCE_REMOTE_SEARCH_FULL_TEXT);
+        mRemoteSearchFullText = (CheckBoxPreference) findPreference(PREFERENCE_REMOTE_SEARCH_FULL_TEXT);
 
         mPushPollOnConnect = (CheckBoxPreference) findPreference(PREFERENCE_PUSH_POLL_ON_CONNECT);
         mIdleRefreshPeriod = (ListPreference) findPreference(PREFERENCE_IDLE_REFRESH_PERIOD);
@@ -527,7 +523,7 @@ public class AccountSettings extends K9PreferenceActivity {
             String searchNumResults = Integer.toString(mAccount.getRemoteSearchNumResults());
             mRemoteSearchNumResults.setValue(searchNumResults);
             updateRemoteSearchLimit(searchNumResults);
-            //mRemoteSearchFullText.setChecked(mAccount.isRemoteSearchFullText());
+            mRemoteSearchFullText.setChecked(mAccount.isRemoteSearchFullText());
 
             mIdleRefreshPeriod.setValue(String.valueOf(mAccount.getIdleRefreshMinutes()));
             mIdleRefreshPeriod.setSummary(mIdleRefreshPeriod.getEntry());
@@ -807,7 +803,7 @@ public class AccountSettings extends K9PreferenceActivity {
             mAccount.setMaxPushFolders(Integer.parseInt(mMaxPushFolders.getValue()));
             mAccount.setAllowRemoteSearch(mCloudSearchEnabled.isChecked());
             mAccount.setRemoteSearchNumResults(Integer.parseInt(mRemoteSearchNumResults.getValue()));
-            //mAccount.setRemoteSearchFullText(mRemoteSearchFullText.isChecked());
+            mAccount.setRemoteSearchFullText(mRemoteSearchFullText.isChecked());
         }
 
         boolean needsRefresh = mAccount.setAutomaticCheckIntervalMinutes(Integer.parseInt(mCheckFrequency.getValue()));

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -848,6 +848,8 @@ public class MessagingController implements Runnable {
         header.add(FetchProfile.Item.ENVELOPE);
         final FetchProfile structure = new FetchProfile();
         structure.add(FetchProfile.Item.STRUCTURE);
+        final FetchProfile body = new FetchProfile();
+        body.add(FetchProfile.Item.BODY);
 
         int i = 0;
         for (Message message : messages) {
@@ -858,6 +860,7 @@ public class MessagingController implements Runnable {
                 remoteFolder.fetch(Collections.singletonList(message), header, null);
                 //fun fact: ImapFolder.fetch can't handle getting STRUCTURE at same time as headers
                 remoteFolder.fetch(Collections.singletonList(message), structure, null);
+                remoteFolder.fetch(Collections.singletonList(message), body, null);
                 localFolder.appendMessages(Collections.singletonList(message));
                 localMsg = localFolder.getMessage(message.getUid());
             }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -849,7 +849,7 @@ public class MessagingController implements Runnable {
         final FetchProfile structure = new FetchProfile();
         structure.add(FetchProfile.Item.STRUCTURE);
         final FetchProfile body = new FetchProfile();
-        body.add(FetchProfile.Item.BODY);
+        body.add(FetchProfile.Item.BODY_SANE);
 
         int i = 0;
         for (Message message : messages) {

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -451,14 +451,12 @@
             android:dialogTitle="@string/account_settings_remote_search_num_label"
             android:dependency="remote_search_enabled"/>
 
-        <!-- Temporarily removed
         <CheckBoxPreference
             android:key="account_remote_search_full_text"
             android:title="@string/account_settings_remote_search_full_text"
             android:summary="@string/account_settings_remote_search_full_text_summary"
             android:persistent="false"
             android:dependency="remote_search_enabled"/>
-        -->
 
     </PreferenceScreen>
 


### PR DESCRIPTION
IMAP full text search was disabled in aea95b1493776d5e12ff984c91948e0451933eca due to the fact that no results are presented to the user.

In these commits I am re-enabling it with the assumption that we are going to fetch the message body when searching, because as far as I can tell this is the only way to present the search results. It may be better to fetch the body only when isRemoteSearchFullText() is true, but I am not sure how to check for that inside MessagingController.

I have tested this on the 5.0 branch and it is working well for me with Dovecot IMAP server using the Solr fts search plugin. 
