### PR TITLE
Fixing warnings

### DIFF
--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/A010_AccountIntegrationTest.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/A010_AccountIntegrationTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
  * Because of the way K-9 shows the start page, there must already be two accounts
  * in existence for this test to work.
  */
-public class A010_AccountIntegrationTest extends AbstractEndToEndTest<Accounts>{
+public class A010_AccountIntegrationTest extends AbstractEndToEndTest<Accounts> {
 
     public A010_AccountIntegrationTest() {
         super(Accounts.class);

--- a/k9mail/src/androidTest/java/com/fsck/k9/endtoend/framework/StubMailServer.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/endtoend/framework/StubMailServer.java
@@ -27,7 +27,7 @@ public class StubMailServer {
                         UserForImap.TEST_USER.password);
 
         for (String mailbox : new String[] {"Drafts", "Spam"}) {
-            Log.d(K9.LOG_TAG, "creating mailbox "+mailbox);
+            Log.d(K9.LOG_TAG, "creating mailbox " + mailbox);
             try {
                 greenmail.getManagers().getImapHostManager().createMailbox(user, mailbox);
             } catch (Exception e) {
@@ -57,4 +57,3 @@ public class StubMailServer {
         greenmail.stop();
     }
 }
-

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -19,7 +19,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.graphics.Color;
-import android.net.ConnectivityManager;
+//import android.net.ConnectivityManager;
 import android.net.Uri;
 import android.util.Log;
 
@@ -34,7 +34,7 @@ import com.fsck.k9.mail.filter.Base64;
 import com.fsck.k9.mail.store.RemoteStore;
 import com.fsck.k9.mail.store.StoreConfig;
 import com.fsck.k9.mailstore.StorageManager;
-import com.fsck.k9.mailstore.StorageManager.StorageProvider;
+//import com.fsck.k9.mailstore.StorageManager.StorageProvider;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.provider.EmailProvider;
 import com.fsck.k9.provider.EmailProvider.StatsColumns;
@@ -379,7 +379,8 @@ public class Account implements BaseAccount, StoreConfig {
         SharedPreferences prefs = preferences.getPreferences();
 
         mStoreUri = Base64.decode(prefs.getString(mUuid + ".storeUri", null));
-        mLocalStorageProviderId = prefs.getString(mUuid + ".localStorageProvider", StorageManager.getInstance(K9.app).getDefaultProviderId());
+        mLocalStorageProviderId = prefs.getString(mUuid + ".localStorageProvider",
+                                                  StorageManager.getInstance(K9.app).getDefaultProviderId());
         mTransportUri = Base64.decode(prefs.getString(mUuid + ".transportUri", null));
         mDescription = prefs.getString(mUuid + ".description", null);
         mAlwaysBcc = prefs.getString(mUuid + ".alwaysBcc", mAlwaysBcc);
@@ -609,8 +610,8 @@ public class Account implements BaseAccount, StoreConfig {
         if (moveUp) {
             for (int i = 0; i < uuids.length; i++) {
                 if (i > 0 && uuids[i].equals(mUuid)) {
-                    newUuids[i] = newUuids[i-1];
-                    newUuids[i-1] = mUuid;
+                    newUuids[i] = newUuids[i - 1];
+                    newUuids[i - 1] = mUuid;
                 }
                 else {
                     newUuids[i] = uuids[i];
@@ -620,8 +621,8 @@ public class Account implements BaseAccount, StoreConfig {
         else {
             for (int i = uuids.length - 1; i >= 0; i--) {
                 if (i < uuids.length - 1 && uuids[i].equals(mUuid)) {
-                    newUuids[i] = newUuids[i+1];
-                    newUuids[i+1] = mUuid;
+                    newUuids[i] = newUuids[i + 1];
+                    newUuids[i + 1] = mUuid;
                 }
                 else {
                     newUuids[i] = uuids[i];
@@ -1305,7 +1306,7 @@ public class Account implements BaseAccount, StoreConfig {
     @Override
     public boolean equals(Object o) {
         if (o instanceof Account) {
-            return ((Account)o).mUuid.equals(mUuid);
+            return ((Account) o).mUuid.equals(mUuid);
         }
         return super.equals(o);
     }
@@ -1516,7 +1517,8 @@ public class Account implements BaseAccount, StoreConfig {
             now.set(Calendar.MILLISECOND, 0);
             if (age < 28) {
                 now.add(Calendar.DATE, age * -1);
-            } else switch (age) {
+            } else {
+                switch (age) {
                 case 28:
                     now.add(Calendar.MONTH, -1);
                     break;
@@ -1533,6 +1535,7 @@ public class Account implements BaseAccount, StoreConfig {
                     now.add(Calendar.YEAR, -1);
                     break;
                 }
+            }
 
             return now.getTime();
         }

--- a/k9mail/src/main/java/com/fsck/k9/BaseAccount.java
+++ b/k9mail/src/main/java/com/fsck/k9/BaseAccount.java
@@ -1,9 +1,9 @@
 package com.fsck.k9;
 
 public interface BaseAccount {
-    public String getEmail();
-    public void setEmail(String email);
-    public String getDescription();
-    public void setDescription(String description);
-    public String getUuid();
+    String getEmail();
+    void setEmail(String email);
+    String getDescription();
+    void setDescription(String description);
+    String getUuid();
 }

--- a/k9mail/src/main/java/com/fsck/k9/Identity.java
+++ b/k9mail/src/main/java/com/fsck/k9/Identity.java
@@ -61,6 +61,7 @@ public class Identity implements Serializable {
 
     @Override
     public synchronized String toString() {
-        return "Account.Identity(description=" + mDescription + ", name=" + mName + ", email=" + mEmail + ", replyTo=" + replyTo + ", signature=" + mSignature;
+        return "Account.Identity(description=" + mDescription + ", name=" + mName +
+            ", email=" + mEmail + ", replyTo=" + replyTo + ", signature=" + mSignature;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -29,7 +29,7 @@ import android.util.Log;
 
 import com.fsck.k9.Account.SortType;
 import com.fsck.k9.activity.MessageCompose;
-import com.fsck.k9.activity.UpgradeDatabases;
+//import com.fsck.k9.activity.UpgradeDatabases;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.controller.MessagingListener;
 import com.fsck.k9.mail.Address;
@@ -52,7 +52,7 @@ public class K9 extends Application {
      * components') should implement this interface and register using
      * {@link K9#registerApplicationAware(ApplicationAware)}.
      */
-    public static interface ApplicationAware {
+    public interface ApplicationAware {
         /**
          * Called when the Application instance is available and ready.
          *
@@ -575,7 +575,8 @@ public class K9 extends Application {
         MessagingController.getInstance(this).addListener(new MessagingListener() {
             private void broadcastIntent(String action, Account account, String folder, Message message) {
                 try {
-                    Uri uri = Uri.parse("email://messages/" + account.getAccountNumber() + "/" + Uri.encode(folder) + "/" + Uri.encode(message.getUid()));
+                    Uri uri = Uri.parse("email://messages/" + account.getAccountNumber() + "/" +
+                                        Uri.encode(folder) + "/" + Uri.encode(message.getUid()));
                     Intent intent = new Intent(action, uri);
                     intent.putExtra(K9.Intents.EmailReceived.EXTRA_ACCOUNT, account.getDescription());
                     intent.putExtra(K9.Intents.EmailReceived.EXTRA_FOLDER, folder);
@@ -587,12 +588,13 @@ public class K9 extends Application {
                     intent.putExtra(K9.Intents.EmailReceived.EXTRA_SUBJECT, message.getSubject());
                     intent.putExtra(K9.Intents.EmailReceived.EXTRA_FROM_SELF, account.isAnIdentity(message.getFrom()));
                     K9.this.sendBroadcast(intent);
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.d(K9.LOG_TAG, "Broadcasted: action=" + action
                               + " account=" + account.getDescription()
                               + " folder=" + folder
                               + " message uid=" + message.getUid()
                              );
+                    }
 
                 } catch (MessagingException e) {
                     Log.w(K9.LOG_TAG, "Error: action=" + action
@@ -754,7 +756,7 @@ public class K9 extends Application {
         }
 
         String lockScreenNotificationVisibility = sprefs.getString("lockScreenNotificationVisibility", null);
-        if(lockScreenNotificationVisibility != null) {
+        if (lockScreenNotificationVisibility != null) {
             sLockScreenNotificationVisibility = LockScreenNotificationVisibility.valueOf(lockScreenNotificationVisibility);
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/PRNGFixes.java
+++ b/k9mail/src/main/java/com/fsck/k9/PRNGFixes.java
@@ -41,7 +41,7 @@ public final class PRNGFixes {
             getBuildFingerprintAndDeviceSerial();
 
     /** Hidden constructor to prevent instantiation. */
-    private PRNGFixes() {}
+    private PRNGFixes() { }
 
     /**
      * Applies all fixes.

--- a/k9mail/src/main/java/com/fsck/k9/Throttle.java
+++ b/k9mail/src/main/java/com/fsck/k9/Throttle.java
@@ -72,13 +72,13 @@ public class Throttle {
     }
 
     /** Constructor that takes custom timeout */
-    public Throttle(String name, Runnable callback, Handler handler,int minTimeout,
+    public Throttle(String name, Runnable callback, Handler handler, int minTimeout,
             int maxTimeout) {
         this(name, callback, handler, minTimeout, maxTimeout, Clock.INSTANCE, TIMER);
     }
 
     /** Constructor for tests */
-    /* package */ Throttle(String name, Runnable callback, Handler handler,int minTimeout,
+    /* package */ Throttle(String name, Runnable callback, Handler handler, int minTimeout,
             int maxTimeout, Clock clock, Timer timer) {
         if (maxTimeout < minTimeout) {
             throw new IllegalArgumentException();
@@ -103,7 +103,9 @@ public class Throttle {
 
     public void cancelScheduledCallback() {
         if (mRunningTimerTask != null) {
-            if (DEBUG) debugLog("Canceling scheduled callback");
+            if (DEBUG) {
+                debugLog("Canceling scheduled callback");
+            }
             mRunningTimerTask.cancel();
             mRunningTimerTask = null;
         }
@@ -116,24 +118,34 @@ public class Throttle {
             if (mTimeout >= mMaxTimeout) {
                 mTimeout = mMaxTimeout;
             }
-            if (DEBUG) debugLog("Timeout extended " + mTimeout);
+            if (DEBUG) {
+                debugLog("Timeout extended " + mTimeout);
+            }
         } else {
             mTimeout = mMinTimeout;
-            if (DEBUG) debugLog("Timeout reset to " + mTimeout);
+            if (DEBUG) {
+                debugLog("Timeout reset to " + mTimeout);
+            }
         }
 
         mLastEventTime = now;
     }
 
     public void onEvent() {
-        if (DEBUG) debugLog("onEvent");
+        if (DEBUG) {
+            debugLog("onEvent");
+        }
 
         updateTimeout();
 
         if (isCallbackScheduled()) {
-            if (DEBUG) debugLog("    callback already scheduled");
+            if (DEBUG) {
+                debugLog("    callback already scheduled");
+            }
         } else {
-            if (DEBUG) debugLog("    scheduling callback");
+            if (DEBUG) {
+                debugLog("    scheduling callback");
+            }
             mRunningTimerTask = new MyTimerTask();
             mTimer.schedule(mRunningTimerTask, mTimeout);
         }
@@ -161,7 +173,9 @@ public class Throttle {
             public void run() {
                 mRunningTimerTask = null;
                 if (!mCanceled) { // This check has to be done on the UI thread.
-                    if (DEBUG) debugLog("Kicking callback");
+                    if (DEBUG) {
+                        debugLog("Kicking callback");
+                    }
                     mCallback.run();
                 }
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -204,7 +204,8 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                         stats.size = newSize;
                     }
                     String toastText = getString(R.string.account_size_changed, account.getDescription(),
-                                                 SizeFormatter.formatSize(getApplication(), oldSize), SizeFormatter.formatSize(getApplication(), newSize));
+                                                 SizeFormatter.formatSize(getApplication(), oldSize),
+                                                 SizeFormatter.formatSize(getApplication(), newSize));
 
                     Toast toast = Toast.makeText(getApplication(), toastText, Toast.LENGTH_LONG);
                     toast.show();
@@ -268,16 +269,17 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         public void accountStatusChanged(BaseAccount account, AccountStats stats) {
             AccountStats oldStats = accountStats.get(account.getUuid());
             int oldUnreadMessageCount = 0;
+            AccountStats statsLocal = stats;
             if (oldStats != null) {
                 oldUnreadMessageCount = oldStats.unreadMessageCount;
             }
-            if (stats == null) {
-                stats = new AccountStats(); // empty stats for unavailable accounts
-                stats.available = false;
+            if (statsLocal == null) {
+                statsLocal = new AccountStats(); // empty stats for unavailable accounts
+                statsLocal.available = false;
             }
-            accountStats.put(account.getUuid(), stats);
+            accountStats.put(account.getUuid(), statsLocal);
             if (account instanceof Account) {
-                mUnreadMessageCount += stats.unreadMessageCount - oldUnreadMessageCount;
+                mUnreadMessageCount += statsLocal.unreadMessageCount - oldUnreadMessageCount;
             }
             mHandler.dataChanged();
             pendingWork.remove(account);
@@ -286,7 +288,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 mHandler.progress(Window.PROGRESS_END);
                 mHandler.refreshTitle();
             } else {
-                int level = (Window.PROGRESS_END / mAdapter.getCount()) * (mAdapter.getCount() - pendingWork.size()) ;
+                int level = (Window.PROGRESS_END / mAdapter.getCount()) * (mAdapter.getCount() - pendingWork.size());
                 mHandler.progress(level);
             }
         }
@@ -477,7 +479,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
     @SuppressWarnings("unchecked")
     private void restoreAccountStats(Bundle icicle) {
         if (icicle != null) {
-            Map<String, AccountStats> oldStats = (Map<String, AccountStats>)icicle.get(ACCOUNT_STATS);
+            Map<String, AccountStats> oldStats = (Map<String, AccountStats>) icicle.get(ACCOUNT_STATS);
             if (oldStats != null) {
                 accountStats.putAll(oldStats);
             }
@@ -657,10 +659,10 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
      */
     private boolean onOpenAccount(BaseAccount account) {
         if (account instanceof SearchAccount) {
-            SearchAccount searchAccount = (SearchAccount)account;
+            SearchAccount searchAccount = (SearchAccount) account;
             MessageList.actionDisplaySearch(this, searchAccount.getRelatedSearch(), false, false);
         } else {
-            Account realAccount = (Account)account;
+            Account realAccount = (Account) account;
             if (!realAccount.isEnabled()) {
                 onActivateAccount(realAccount);
                 return false;
@@ -678,7 +680,8 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 LocalSearch search = new LocalSearch(realAccount.getAutoExpandFolderName());
                 search.addAllowedFolder(realAccount.getAutoExpandFolderName());
                 search.addAccountUuid(realAccount.getUuid());
-                MessageList.actionDisplaySearch(this, search, false, true);}
+                MessageList.actionDisplaySearch(this, search, false, true);
+            }
         }
         return true;
     }
@@ -1177,14 +1180,14 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
     @Override
     public boolean onContextItemSelected(android.view.MenuItem item) {
-        AdapterContextMenuInfo menuInfo = (AdapterContextMenuInfo)item.getMenuInfo();
+        AdapterContextMenuInfo menuInfo = (AdapterContextMenuInfo) item.getMenuInfo();
         // submenus don't actually set the menuInfo, so the "advanced"
         // submenu wouldn't work.
         if (menuInfo != null) {
-            mSelectedContextAccount = (BaseAccount)getListView().getItemAtPosition(menuInfo.position);
+            mSelectedContextAccount = (BaseAccount) getListView().getItemAtPosition(menuInfo.position);
         }
         if (mSelectedContextAccount instanceof Account) {
-            Account realAccount = (Account)mSelectedContextAccount;
+            Account realAccount = (Account) mSelectedContextAccount;
             switch (item.getItemId()) {
                 case R.id.delete_account:
                     onDeleteAccount(realAccount);
@@ -1237,7 +1240,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
     }
 
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        BaseAccount account = (BaseAccount)parent.getItemAtPosition(position);
+        BaseAccount account = (BaseAccount) parent.getItemAtPosition(position);
         onOpenAccount(account);
     }
 
@@ -1433,8 +1436,9 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
     @Override
     protected void onActivityResult(int requestCode, int resultCode, Intent data) {
         Log.i(K9.LOG_TAG, "onActivityResult requestCode = " + requestCode + ", resultCode = " + resultCode + ", data = " + data);
-        if (resultCode != RESULT_OK)
+        if (resultCode != RESULT_OK) {
             return;
+        }
         if (data == null) {
             return;
         }
@@ -1761,7 +1765,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
                 holder.chip = view.findViewById(R.id.chip);
                 holder.folders = (ImageButton) view.findViewById(R.id.folders);
-                holder.accountsItemLayout = (LinearLayout)view.findViewById(R.id.accounts_item_layout);
+                holder.accountsItemLayout = (LinearLayout) view.findViewById(R.id.accounts_item_layout);
 
                 view.setTag(holder);
             }
@@ -1793,7 +1797,9 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 holder.newMessageCountWrapper.setVisibility(unreadMessageCount > 0 ? View.VISIBLE : View.GONE);
 
                 holder.flaggedMessageCount.setText(Integer.toString(stats.flaggedMessageCount));
-                holder.flaggedMessageCountWrapper.setVisibility(K9.messageListStars() && stats.flaggedMessageCount > 0 ? View.VISIBLE : View.GONE);
+                holder.flaggedMessageCountWrapper.setVisibility(K9.messageListStars() &&
+                                                                stats.flaggedMessageCount > 0 ?
+                                                                View.VISIBLE : View.GONE);
 
                 holder.flaggedMessageCountWrapper.setOnClickListener(createFlaggedSearchListener(account));
                 holder.newMessageCountWrapper.setOnClickListener(createUnreadSearchListener(account));
@@ -1811,16 +1817,19 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 holder.flaggedMessageCountWrapper.setVisibility(View.GONE);
             }
             if (account instanceof Account) {
-                Account realAccount = (Account)account;
+                Account realAccount = (Account) account;
 
                 holder.chip.setBackgroundColor(realAccount.getChipColor());
 
-                holder.flaggedMessageCountIcon.setBackgroundDrawable( realAccount.generateColorChip(false, false, false, false,true).drawable() );
-                holder.newMessageCountIcon.setBackgroundDrawable( realAccount.generateColorChip(false, false, false, false, false).drawable() );
+                holder.flaggedMessageCountIcon.setBackgroundDrawable(realAccount.generateColorChip(false, false,
+                                                                                                   false, false,
+                                                                                                   true).drawable());
+                holder.newMessageCountIcon.setBackgroundDrawable(realAccount.generateColorChip(false, false, false,
+                                                                                               false, false).drawable());
 
             } else {
                 holder.chip.setBackgroundColor(0xff999999);
-                holder.newMessageCountIcon.setBackgroundDrawable( new ColorChip(0xff999999, false, ColorChip.CIRCULAR).drawable() );
+                holder.newMessageCountIcon.setBackgroundDrawable(new ColorChip(0xff999999, false, ColorChip.CIRCULAR).drawable());
                 holder.flaggedMessageCountIcon.setBackgroundDrawable(new ColorChip(0xff999999, false, ColorChip.STAR).drawable());
             }
 
@@ -1836,8 +1845,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 holder.folders.setVisibility(View.VISIBLE);
                 holder.folders.setOnClickListener(new OnClickListener() {
                     public void onClick(View v) {
-                        FolderList.actionHandleAccount(Accounts.this, (Account)account);
-
+                        FolderList.actionHandleAccount(Accounts.this, (Account) account);
                     }
                 });
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -42,7 +42,8 @@ public class ActivityListener extends MessagingListener {
 
             if (mLoadingFolderName != null || mLoadingHeaderFolderName != null) {
                 String displayName = mLoadingFolderName;
-                if ((mAccount != null) && (mAccount.getInboxFolderName() != null) && mAccount.getInboxFolderName().equalsIgnoreCase(displayName)) {
+                if ((mAccount != null) && (mAccount.getInboxFolderName() != null) &&
+                    mAccount.getInboxFolderName().equalsIgnoreCase(displayName)) {
                     displayName = context.getString(R.string.special_mailbox_name_inbox);
                 } else if ((mAccount != null) && mAccount.getOutboxFolderName().equals(displayName)) {
                     displayName = context.getString(R.string.special_mailbox_name_outbox);
@@ -50,9 +51,11 @@ public class ActivityListener extends MessagingListener {
 
                 if (mLoadingHeaderFolderName != null) {
 
-                    operation = context.getString(R.string.status_loading_account_folder_headers, mLoadingAccountDescription, displayName, progress);
+                    operation = context.getString(R.string.status_loading_account_folder_headers,
+                                                  mLoadingAccountDescription, displayName, progress);
                 } else {
-                    operation = context.getString(R.string.status_loading_account_folder, mLoadingAccountDescription, displayName, progress);
+                    operation = context.getString(R.string.status_loading_account_folder,
+                                                  mLoadingAccountDescription, displayName, progress);
                 }
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -93,8 +93,9 @@ public class ChooseFolder extends K9ListActivity {
         if (intent.getStringExtra(EXTRA_SHOW_DISPLAYABLE_ONLY) != null) {
             mShowDisplayableOnly = true;
         }
-        if (mFolder == null)
+        if (mFolder == null) {
             mFolder = "";
+        }
 
         mAdapter = new ArrayAdapter<String>(this, android.R.layout.simple_list_item_1) {
             private Filter myFilter = null;
@@ -119,7 +120,7 @@ public class ChooseFolder extends K9ListActivity {
                 Intent result = new Intent();
                 result.putExtra(EXTRA_ACCOUNT, mAccount.getUuid());
                 result.putExtra(EXTRA_CUR_FOLDER, mFolder);
-                String destFolderName = ((TextView)view).getText().toString();
+                String destFolderName = ((TextView) view).getText().toString();
                 if (mHeldInbox != null && getString(R.string.special_mailbox_name_inbox).equals(destFolderName)) {
                     destFolderName = mHeldInbox;
                 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/EditIdentity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/EditIdentity.java
@@ -34,7 +34,7 @@ public class EditIdentity extends K9Activity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        mIdentity = (Identity)getIntent().getSerializableExtra(EXTRA_IDENTITY);
+        mIdentity = (Identity) getIntent().getSerializableExtra(EXTRA_IDENTITY);
         mIdentityIndex = getIntent().getIntExtra(EXTRA_IDENTITY_INDEX, -1);
         String accountUuid = getIntent().getStringExtra(EXTRA_ACCOUNT);
         mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
@@ -50,16 +50,16 @@ public class EditIdentity extends K9Activity {
          * we saved
          */
         if (savedInstanceState != null && savedInstanceState.containsKey(EXTRA_IDENTITY)) {
-            mIdentity = (Identity)savedInstanceState.getSerializable(EXTRA_IDENTITY);
+            mIdentity = (Identity) savedInstanceState.getSerializable(EXTRA_IDENTITY);
         }
 
-        mDescriptionView = (EditText)findViewById(R.id.description);
+        mDescriptionView = (EditText) findViewById(R.id.description);
         mDescriptionView.setText(mIdentity.getDescription());
 
-        mNameView = (EditText)findViewById(R.id.name);
+        mNameView = (EditText) findViewById(R.id.name);
         mNameView.setText(mIdentity.getName());
 
-        mEmailView = (EditText)findViewById(R.id.email);
+        mEmailView = (EditText) findViewById(R.id.email);
         mEmailView.setText(mIdentity.getEmail());
 
         mReplyTo = (EditText) findViewById(R.id.reply_to);
@@ -68,9 +68,9 @@ public class EditIdentity extends K9Activity {
 //      mAccountAlwaysBcc = (EditText)findViewById(R.id.bcc);
 //      mAccountAlwaysBcc.setText(mIdentity.getAlwaysBcc());
 
-        mSignatureLayout = (LinearLayout)findViewById(R.id.signature_layout);
-        mSignatureUse = (CheckBox)findViewById(R.id.signature_use);
-        mSignatureView = (EditText)findViewById(R.id.signature);
+        mSignatureLayout = (LinearLayout) findViewById(R.id.signature_layout);
+        mSignatureUse = (CheckBox) findViewById(R.id.signature_use);
+        mSignatureView = (EditText) findViewById(R.id.signature);
         mSignatureUse.setChecked(mIdentity.getSignatureUse());
         mSignatureUse.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/EmailAddressList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/EmailAddressList.java
@@ -41,7 +41,7 @@ public class EmailAddressList extends K9ListActivity implements OnItemClickListe
 
     @Override
     public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-        String item = (String)parent.getItemAtPosition(position);
+        String item = (String) parent.getItemAtPosition(position);
 
         Toast.makeText(EmailAddressList.this, item, Toast.LENGTH_LONG).show();
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
@@ -42,10 +42,11 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
     }
 
     private String truncateStatus(String mess) {
+        String returnedMess = mess;
         if (mess != null && mess.length() > 27) {
-            mess = mess.substring(0, 27);
+            returnedMess = mess.substring(0, 27);
         }
-        return mess;
+        return returnedMess;
     }
 
     // constructor for an empty object for comparisons

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -147,7 +147,9 @@ public class FolderList extends K9ListActivity {
         public void accountSizeChanged(final long oldSize, final long newSize) {
             runOnUiThread(new Runnable() {
                 public void run() {
-                    String toastText = getString(R.string.account_size_changed, mAccount.getDescription(), SizeFormatter.formatSize(getApplication(), oldSize), SizeFormatter.formatSize(getApplication(), newSize));
+                    String toastText = getString(R.string.account_size_changed, mAccount.getDescription(),
+                                                 SizeFormatter.formatSize(getApplication(), oldSize),
+                                                 SizeFormatter.formatSize(getApplication(), newSize));
 
                     Toast toast = Toast.makeText(getApplication(), toastText, Toast.LENGTH_LONG);
                     toast.show();
@@ -267,7 +269,7 @@ public class FolderList extends K9ListActivity {
         mListView.setScrollingCacheEnabled(false);
         mListView.setOnItemClickListener(new OnItemClickListener() {
             public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-                onOpenFolder(((FolderInfoHolder)mAdapter.getItem(position)).name);
+                onOpenFolder(((FolderInfoHolder) mAdapter.getItem(position)).name);
             }
         });
         registerForContextMenu(mListView);
@@ -376,8 +378,9 @@ public class FolderList extends K9ListActivity {
             finish();
             return;
         }
-        if (mAdapter == null)
+        if (mAdapter == null) {
             initializeActivityView();
+        }
 
         mHandler.refreshTitle();
 
@@ -427,11 +430,11 @@ public class FolderList extends K9ListActivity {
             setDisplayMode(FolderMode.ALL);
             return true;
         }
-        }//switch
+        } //switch
 
 
         return super.onKeyDown(keyCode, event);
-    }//onKeyDown
+    } //onKeyDown
 
     private void setDisplayMode(FolderMode newMode) {
         mAccount.setFolderDisplayMode(newMode);
@@ -630,7 +633,7 @@ public class FolderList extends K9ListActivity {
     }
 
     @Override public boolean onContextItemSelected(android.view.MenuItem item) {
-        AdapterContextMenuInfo info = (AdapterContextMenuInfo) item .getMenuInfo();
+        AdapterContextMenuInfo info = (AdapterContextMenuInfo) item.getMenuInfo();
         FolderInfoHolder folder = (FolderInfoHolder) mAdapter.getItem(info.position);
 
         switch (item.getItemId()) {
@@ -664,7 +667,7 @@ public class FolderList extends K9ListActivity {
         private Filter mFilter = new FolderListFilter();
 
         public Object getItem(long position) {
-            return getItem((int)position);
+            return getItem((int) position);
         }
 
         public Object getItem(int position) {
@@ -673,7 +676,7 @@ public class FolderList extends K9ListActivity {
 
 
         public long getItemId(int position) {
-            return mFilteredFolders.get(position).folder.getName().hashCode() ;
+            return mFilteredFolders.get(position).folder.getName().hashCode();
         }
 
         public int getCount() {
@@ -983,7 +986,7 @@ public class FolderList extends K9ListActivity {
                 holder.folderStatus = (TextView) view.findViewById(R.id.folder_status);
                 holder.activeIcons = (RelativeLayout) view.findViewById(R.id.active_icons);
                 holder.chip = view.findViewById(R.id.chip);
-                holder.folderListItemLayout = (LinearLayout)view.findViewById(R.id.folder_list_item_layout);
+                holder.folderListItemLayout = (LinearLayout) view.findViewById(R.id.folder_list_item_layout);
                 holder.rawFolderName = folder.name;
 
                 view.setTag(holder);
@@ -1028,7 +1031,7 @@ public class FolderList extends K9ListActivity {
                 holder.folderStatus.setVisibility(View.GONE);
             }
 
-            if(folder.unreadMessageCount == -1) {
+            if (folder.unreadMessageCount == -1) {
                folder.unreadMessageCount = 0;
                 try {
                     folder.unreadMessageCount  = folder.folder.getUnreadMessageCount();
@@ -1065,7 +1068,7 @@ public class FolderList extends K9ListActivity {
                         createFlaggedSearch(mAccount, folder));
                 holder.flaggedMessageCountWrapper.setVisibility(View.VISIBLE);
                 holder.flaggedMessageCountIcon.setBackgroundDrawable(
-                        mAccount.generateColorChip(false, false, false, false,true).drawable());
+                        mAccount.generateColorChip(false, false, false, false, true).drawable());
             } else {
                 holder.flaggedMessageCountWrapper.setVisibility(View.GONE);
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/ManageIdentities.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ManageIdentities.java
@@ -70,7 +70,7 @@ public class ManageIdentities extends ChooseIdentity {
 
     @Override
     public boolean onContextItemSelected(android.view.MenuItem item) {
-        AdapterContextMenuInfo menuInfo = (AdapterContextMenuInfo)item.getMenuInfo();
+        AdapterContextMenuInfo menuInfo = (AdapterContextMenuInfo) item.getMenuInfo();
         switch (item.getItemId()) {
         case R.id.edit:
             editItem(menuInfo.position);

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -82,7 +82,7 @@ import com.fsck.k9.activity.loader.AttachmentInfoLoader;
 import com.fsck.k9.activity.misc.Attachment;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.controller.MessagingListener;
-import com.fsck.k9.crypto.OpenPgpApiHelper;
+//import com.fsck.k9.crypto.OpenPgpApiHelper;
 import com.fsck.k9.crypto.PgpData;
 import com.fsck.k9.fragment.ProgressDialogFragment;
 import com.fsck.k9.helper.ContactItem;
@@ -569,18 +569,18 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             onAddCcBcc();
         }
 
-        EolConvertingEditText upperSignature = (EolConvertingEditText)findViewById(R.id.upper_signature);
-        EolConvertingEditText lowerSignature = (EolConvertingEditText)findViewById(R.id.lower_signature);
+        EolConvertingEditText upperSignature = (EolConvertingEditText) findViewById(R.id.upper_signature);
+        EolConvertingEditText lowerSignature = (EolConvertingEditText) findViewById(R.id.lower_signature);
 
-        mMessageContentView = (EolConvertingEditText)findViewById(R.id.message_content);
+        mMessageContentView = (EolConvertingEditText) findViewById(R.id.message_content);
         mMessageContentView.getInputExtras(true).putBoolean("allowEmoji", true);
 
-        mAttachments = (LinearLayout)findViewById(R.id.attachments);
-        mQuotedTextShow = (Button)findViewById(R.id.quoted_text_show);
+        mAttachments = (LinearLayout) findViewById(R.id.attachments);
+        mQuotedTextShow = (Button) findViewById(R.id.quoted_text_show);
         mQuotedTextBar = findViewById(R.id.quoted_text_bar);
-        mQuotedTextEdit = (ImageButton)findViewById(R.id.quoted_text_edit);
+        mQuotedTextEdit = (ImageButton) findViewById(R.id.quoted_text_edit);
         ImageButton mQuotedTextDelete = (ImageButton) findViewById(R.id.quoted_text_delete);
-        mQuotedText = (EolConvertingEditText)findViewById(R.id.quoted_text);
+        mQuotedText = (EolConvertingEditText) findViewById(R.id.quoted_text);
         mQuotedText.getInputExtras(true).putBoolean("allowEmoji", true);
 
         mQuotedHTML = (MessageWebView) findViewById(R.id.quoted_html);
@@ -749,7 +749,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
         mOpenPgpProvider = mAccount.getOpenPgpProvider();
         if (isCryptoProviderEnabled()) {
-            mCryptoSignatureCheckbox = (CheckBox)findViewById(R.id.cb_crypto_signature);
+            mCryptoSignatureCheckbox = (CheckBox) findViewById(R.id.cb_crypto_signature);
             final OnCheckedChangeListener updateListener = new OnCheckedChangeListener() {
                 @Override
                 public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
@@ -757,9 +757,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 }
             };
             mCryptoSignatureCheckbox.setOnCheckedChangeListener(updateListener);
-            mCryptoSignatureUserId = (TextView)findViewById(R.id.userId);
-            mCryptoSignatureUserIdRest = (TextView)findViewById(R.id.userIdRest);
-            mEncryptCheckbox = (CheckBox)findViewById(R.id.cb_encrypt);
+            mCryptoSignatureUserId = (TextView) findViewById(R.id.userId);
+            mCryptoSignatureUserIdRest = (TextView) findViewById(R.id.userIdRest);
+            mEncryptCheckbox = (CheckBox) findViewById(R.id.cb_encrypt);
             mEncryptCheckbox.setOnCheckedChangeListener(updateListener);
 
             if (mSourceMessageBody != null) {
@@ -1093,7 +1093,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         mDraftId = savedInstanceState.getLong(STATE_KEY_DRAFT_ID);
-        mIdentity = (Identity)savedInstanceState.getSerializable(STATE_IDENTITY);
+        mIdentity = (Identity) savedInstanceState.getSerializable(STATE_IDENTITY);
         mIdentityChanged = savedInstanceState.getBoolean(STATE_IDENTITY_CHANGED);
         mPgpData = (PgpData) savedInstanceState.getSerializable(STATE_PGP_DATA);
         mInReplyTo = savedInstanceState.getString(STATE_IN_REPLY_TO);
@@ -1319,13 +1319,15 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
         if (mMessageReference != null && mMessageReference.getFlag() != null) {
             if (K9.DEBUG) {
-                Log.d(K9.LOG_TAG, "Setting referenced message (" + mMessageReference.getFolderName() + ", " + mMessageReference.getUid() + ") flag to " + mMessageReference.getFlag());
+                Log.d(K9.LOG_TAG, "Setting referenced message (" + mMessageReference.getFolderName() + ", " +
+                      mMessageReference.getUid() + ") flag to " + mMessageReference.getFlag());
             }
 
             final Account account = Preferences.getPreferences(this).getAccount(mMessageReference.getAccountUuid());
             final String folderName = mMessageReference.getFolderName();
             final String sourceMessageUid = mMessageReference.getUid();
-            MessagingController.getInstance(getApplication()).setFlag(account, folderName, sourceMessageUid, mMessageReference.getFlag(), true);
+            MessagingController.getInstance(getApplication()).setFlag(account, folderName, sourceMessageUid,
+                                                                      mMessageReference.getFlag(), true);
         }
 
         mDraftNeedsSaving = false;
@@ -1369,9 +1371,10 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                     try {
                         final String output = os.toString("UTF-8");
 
-                        if (K9.DEBUG)
+                        if (K9.DEBUG) {
                             Log.d(OpenPgpApi.TAG, "result: " + os.toByteArray().length +
                                     " str=" + output);
+                        }
 
                         mPgpData.setEncryptedData(output);
                         onSend();
@@ -1461,7 +1464,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
     private void onReadReceipt() {
         CharSequence txt;
-        if (mReadReceipt == false) {
+        if (!mReadReceipt) {
             txt = getString(R.string.read_receipt_enabled);
             mReadReceipt = true;
         } else {
@@ -2379,7 +2382,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         // Decode the identity header when loading a draft.
         // See buildIdentityHeader(TextBody) for a detailed description of the composition of this blob.
         Map<IdentityField, String> k9identity = new HashMap<IdentityField, String>();
-        if (message.getHeader(K9.IDENTITY_HEADER) != null && message.getHeader(K9.IDENTITY_HEADER).length > 0 && message.getHeader(K9.IDENTITY_HEADER)[0] != null) {
+        if (message.getHeader(K9.IDENTITY_HEADER) != null && message.getHeader(K9.IDENTITY_HEADER).length > 0 &&
+            message.getHeader(K9.IDENTITY_HEADER)[0] != null) {
             k9identity = IdentityHeaderParser.parse(message.getHeader(K9.IDENTITY_HEADER)[0]);
         }
 
@@ -2501,7 +2505,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 mQuotedTextFormat = SimpleMessageFormat.HTML;
                 String text = MessageExtractor.getTextFromPart(part);
                 if (K9.DEBUG) {
-                    Log.d(K9.LOG_TAG, "Loading message with offset " + bodyOffset + ", length " + bodyLength + ". Text length is " + text.length() + ".");
+                    Log.d(K9.LOG_TAG, "Loading message with offset " + bodyOffset + ", length " + bodyLength +
+                          ". Text length is " + text.length() + ".");
                 }
 
                 if (bodyOffset + bodyLength > text.length()) {
@@ -2566,7 +2571,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         if (textPart != null) {
             String text = MessageExtractor.getTextFromPart(textPart);
             if (K9.DEBUG) {
-                Log.d(K9.LOG_TAG, "Loading message with offset " + bodyOffset + ", length " + bodyLength + ". Text length is " + text.length() + ".");
+                Log.d(K9.LOG_TAG, "Loading message with offset " + bodyOffset + ", length " + bodyLength +
+                      ". Text length is " + text.length() + ".");
             }
 
             // If we had a body length (and it was valid), separate the composition from the quoted text
@@ -2809,9 +2815,11 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private static final int FIND_INSERTION_POINT_FIRST_GROUP = 1;
     // HTML bits to insert as appropriate
     // TODO is it safe to assume utf-8 here?
-    private static final String FIND_INSERTION_POINT_HTML_CONTENT = "<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\">\r\n<html>";
+    private static final String FIND_INSERTION_POINT_HTML_CONTENT =
+		"<!DOCTYPE html PUBLIC \"-//W3C//DTD HTML 4.0 Transitional//EN\">\r\n<html>";
     private static final String FIND_INSERTION_POINT_HTML_END_CONTENT = "</html>";
-    private static final String FIND_INSERTION_POINT_HEAD_CONTENT = "<head><meta content=\"text/html; charset=utf-8\" http-equiv=\"Content-Type\"></head>";
+    private static final String FIND_INSERTION_POINT_HEAD_CONTENT =
+		"<head><meta content=\"text/html; charset=utf-8\" http-equiv=\"Content-Type\"></head>";
     // Index of the start of the beginning of a String.
     private static final int FIND_INSERTION_POINT_START_OF_STRING = 0;
 
@@ -2879,7 +2887,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             newContent.insert(htmlMatcher.end(FIND_INSERTION_POINT_FIRST_GROUP), FIND_INSERTION_POINT_HEAD_CONTENT);
             insertable.setQuotedContent(newContent);
             // The new insertion point is the end of the HTML tag, plus the length of the HEAD content.
-            insertable.setHeaderInsertionPoint(htmlMatcher.end(FIND_INSERTION_POINT_FIRST_GROUP) + FIND_INSERTION_POINT_HEAD_CONTENT.length());
+            insertable.setHeaderInsertionPoint(htmlMatcher.end(FIND_INSERTION_POINT_FIRST_GROUP) +
+											   FIND_INSERTION_POINT_HEAD_CONTENT.length());
         } else {
             // If we have none of the above, we probably have a fragment of HTML.  Yahoo! and Gmail both do this.
             // Again, we add a HEAD, but not BODY.
@@ -2991,7 +3000,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         public void messageUidChanged(Account account, String folder, String oldUid, String newUid) {
             // Track UID changes of the source message
             if (mMessageReference != null) {
-                final Account sourceAccount = Preferences.getPreferences(MessageCompose.this).getAccount(mMessageReference.getAccountUuid());
+                final Account sourceAccount =
+					Preferences.getPreferences(MessageCompose.this).getAccount(mMessageReference.getAccountUuid());
                 final String sourceFolder = mMessageReference.getFolderName();
                 final String sourceMessageUid = mMessageReference.getUid();
 
@@ -3165,7 +3175,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
      * @return Quoted text.
      * @throws MessagingException
      */
-    private String quoteOriginalTextMessage(final Message originalMessage, final String messageBody, final QuoteStyle quoteStyle) throws MessagingException {
+    private String quoteOriginalTextMessage(final Message originalMessage, final String messageBody,
+											final QuoteStyle quoteStyle) throws MessagingException {
         String body = messageBody == null ? "" : messageBody;
         String sentDate = getSentDateText(originalMessage);
         if (quoteStyle == QuoteStyle.PREFIX) {
@@ -3196,19 +3207,25 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             quotedText.append("\r\n");
             quotedText.append(getString(R.string.message_compose_quote_header_separator)).append("\r\n");
             if (originalMessage.getFrom() != null && Address.toString(originalMessage.getFrom()).length() != 0) {
-                quotedText.append(getString(R.string.message_compose_quote_header_from)).append(" ").append(Address.toString(originalMessage.getFrom())).append("\r\n");
+				String quoteHeaderFrom = getString(R.string.message_compose_quote_header_from);
+                quotedText.append(quoteHeaderFrom).append(" ").append(Address.toString(originalMessage.getFrom())).append("\r\n");
             }
             if (sentDate.length() != 0) {
                 quotedText.append(getString(R.string.message_compose_quote_header_send_date)).append(" ").append(sentDate).append("\r\n");
             }
             if (originalMessage.getRecipients(RecipientType.TO) != null && originalMessage.getRecipients(RecipientType.TO).length != 0) {
-                quotedText.append(getString(R.string.message_compose_quote_header_to)).append(" ").append(Address.toString(originalMessage.getRecipients(RecipientType.TO))).append("\r\n");
+                String quoteHeaderTo = getString(R.string.message_compose_quote_header_to);
+                String recipientsTo = Address.toString(originalMessage.getRecipients(RecipientType.TO));
+                quotedText.append(quoteHeaderTo).append(" ").append(recipientsTo).append("\r\n");
             }
             if (originalMessage.getRecipients(RecipientType.CC) != null && originalMessage.getRecipients(RecipientType.CC).length != 0) {
-                quotedText.append(getString(R.string.message_compose_quote_header_cc)).append(" ").append(Address.toString(originalMessage.getRecipients(RecipientType.CC))).append("\r\n");
+                String quoteHeaderCC = getString(R.string.message_compose_quote_header_cc);
+                String recipientsCC = Address.toString(originalMessage.getRecipients(RecipientType.CC));
+                quotedText.append(quoteHeaderCC).append(" ").append(recipientsCC).append("\r\n");
             }
             if (originalMessage.getSubject() != null) {
-                quotedText.append(getString(R.string.message_compose_quote_header_subject)).append(" ").append(originalMessage.getSubject()).append("\r\n");
+                String quoteHeaderSubject = getString(R.string.message_compose_quote_header_subject);
+                quotedText.append(quoteHeaderSubject).append(" ").append(originalMessage.getSubject()).append("\r\n");
             }
             quotedText.append("\r\n");
 
@@ -3229,7 +3246,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
      * @return Modified insertable message.
      * @throws MessagingException
      */
-    private InsertableHtmlContent quoteOriginalHtmlMessage(final Message originalMessage, final String messageBody, final QuoteStyle quoteStyle) throws MessagingException {
+    private InsertableHtmlContent quoteOriginalHtmlMessage(final Message originalMessage, final String messageBody,
+														   final QuoteStyle quoteStyle) throws MessagingException {
         InsertableHtmlContent insertable = findInsertionPoints(messageBody);
 
         String sentDate = getSentDateText(originalMessage);
@@ -3259,7 +3277,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
             StringBuilder header = new StringBuilder();
             header.append("<div style='font-size:10.0pt;font-family:\"Tahoma\",\"sans-serif\";padding:3.0pt 0in 0in 0in'>\r\n");
-            header.append("<hr style='border:none;border-top:solid #E1E1E1 1.0pt'>\r\n"); // This gets converted into a horizontal line during html to text conversion.
+			// This gets converted into a horizontal line during html to text conversion.
+            header.append("<hr style='border:none;border-top:solid #E1E1E1 1.0pt'>\r\n");
             if (originalMessage.getFrom() != null && Address.toString(originalMessage.getFrom()).length() != 0) {
                 header.append("<b>").append(getString(R.string.message_compose_quote_header_from)).append("</b> ")
                     .append(HtmlConverter.textToHtmlFragment(Address.toString(originalMessage.getFrom())))

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageInfoHolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageInfoHolder.java
@@ -35,7 +35,7 @@ public class MessageInfoHolder {
         if (!(o instanceof MessageInfoHolder)) {
             return false;
         }
-        MessageInfoHolder other = (MessageInfoHolder)o;
+        MessageInfoHolder other = (MessageInfoHolder) o;
         return message.equals(other.message);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -724,8 +724,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         // Swallow these events too to avoid the audible notification of a volume change
         if (K9.useVolumeKeysForListNavigationEnabled()) {
             if ((keyCode == KeyEvent.KEYCODE_VOLUME_UP) || (keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.v(K9.LOG_TAG, "Swallowed key up.");
+                }
                 return true;
             }
         }
@@ -928,7 +929,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     public boolean onCreateOptionsMenu(Menu menu) {
         getMenuInflater().inflate(R.menu.message_list_option, menu);
         mMenu = menu;
-        mMenuButtonCheckMail= menu.findItem(R.id.check_mail);
+        mMenuButtonCheckMail = menu.findItem(R.id.check_mail);
         return true;
     }
 
@@ -1275,8 +1276,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         FragmentTransaction ft = getFragmentManager().beginTransaction();
 
         ft.replace(R.id.message_list_container, fragment);
-        if (addToBackStack)
+        if (addToBackStack) {
             ft.addToBackStack(null);
+        }
 
         mMessageListFragment = fragment;
 
@@ -1380,8 +1382,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 mMenuButtonCheckMail.setActionView(null);
             }
         } else {
-            if (mMenuButtonCheckMail != null)
+            if (mMenuButtonCheckMail != null) {
                 mMenuButtonCheckMail.setActionView(null);
+            }
             if (enable) {
                 mActionBarProgress.setVisibility(ProgressBar.VISIBLE);
             } else {

--- a/k9mail/src/main/java/com/fsck/k9/activity/NotificationDeleteConfirmation.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/NotificationDeleteConfirmation.java
@@ -2,7 +2,7 @@ package com.fsck.k9.activity;
 
 import java.io.Serializable;
 import java.util.ArrayList;
-import java.util.List;
+//import java.util.List;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -16,7 +16,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
-import com.fsck.k9.helper.Utility;
+//import com.fsck.k9.helper.Utility;
 import com.fsck.k9.service.NotificationActionService;
 
 public class NotificationDeleteConfirmation extends Activity {

--- a/k9mail/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
@@ -4,15 +4,15 @@ import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
-import com.fsck.k9.mail.Store;
+//import com.fsck.k9.mail.Store;
 import com.fsck.k9.service.DatabaseUpgradeService;
 
-import android.app.Activity;
+//import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.content.SharedPreferences;
+//import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.support.v4.content.LocalBroadcastManager;
 import android.widget.TextView;

--- a/k9mail/src/main/java/com/fsck/k9/activity/misc/Attachment.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/misc/Attachment.java
@@ -59,7 +59,7 @@ public class Attachment implements Parcelable {
     public String filename;
 
 
-    public Attachment() {}
+    public Attachment() { }
 
     public static enum LoadingState {
         /**

--- a/k9mail/src/main/java/com/fsck/k9/activity/misc/ContactPictureLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/misc/ContactPictureLoader.java
@@ -61,7 +61,7 @@ public class ContactPictureLoader {
     /**
      * @see <a href="http://developer.android.com/design/style/color.html">Color palette used</a>
      */
-    private final static int CONTACT_DUMMY_COLORS_ARGB[] = {
+    private final int CONTACT_DUMMY_COLORS_ARGB[] = {
         0xff33B5E5,
         0xffAA66CC,
         0xff99CC00,

--- a/k9mail/src/main/java/com/fsck/k9/activity/misc/NonConfigurationInstance.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/misc/NonConfigurationInstance.java
@@ -21,7 +21,7 @@ public interface NonConfigurationInstance {
      *
      * @see Activity#onRetainNonConfigurationInstance()
      */
-    public boolean retain();
+    boolean retain();
 
     /**
      * Connect this retained {@code NonConfigurationInstance} to the new {@link Activity} instance
@@ -34,5 +34,5 @@ public interface NonConfigurationInstance {
      * @param activity
      *         The new {@code Activity} instance. Never {@code null}.
      */
-    public void restore(Activity activity);
+    void restore(Activity activity);
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/misc/SwipeGestureDetector.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/misc/SwipeGestureDetector.java
@@ -2,7 +2,7 @@ package com.fsck.k9.activity.misc;
 
 import android.content.Context;
 import android.view.MotionEvent;
-import android.view.GestureDetector.OnGestureListener;
+//import android.view.GestureDetector.OnGestureListener;
 import android.view.GestureDetector.SimpleOnGestureListener;
 
 
@@ -45,18 +45,20 @@ public class SwipeGestureDetector extends SimpleOnGestureListener {
     public boolean onFling(MotionEvent e1, MotionEvent e2, float velocityX, float velocityY) {
         // Apparently sometimes e1 is null
         // Found a workaround here: http://stackoverflow.com/questions/4151385/
-        if (e1 == null) {
-            e1 = mLastOnDownEvent;
+        MotionEvent localEvent1 = e1;
+
+        if (localEvent1 == null) {
+            localEvent1 = mLastOnDownEvent;
         }
 
         // Make sure we avoid NullPointerExceptions
-        if (e1 == null || e2 == null) {
+        if (localEvent1 == null || e2 == null) {
             return false;
         }
 
         // Calculate how much was actually swiped.
-        final float deltaX = e2.getX() - e1.getX();
-        final float deltaY = e2.getY() - e1.getY();
+        final float deltaX = e2.getX() - localEvent1.getX();
+        final float deltaY = e2.getY() - localEvent1.getY();
 
         // Calculate the minimum distance required for this to be considered a swipe.
         final int minDistance = (int) Math.abs(deltaY * 4);
@@ -67,9 +69,9 @@ public class SwipeGestureDetector extends SimpleOnGestureListener {
             }
 
             if (deltaX < (minDistance * -1)) {
-                mListener.onSwipeRightToLeft(e1, e2);
+                mListener.onSwipeRightToLeft(localEvent1, e2);
             } else if (deltaX > minDistance) {
-                mListener.onSwipeLeftToRight(e1, e2);
+                mListener.onSwipeLeftToRight(localEvent1, e2);
             } else {
                 return false;
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -510,7 +510,7 @@ public class AccountSettings extends K9PreferenceActivity {
         mRemoteSearchNumResults.setOnPreferenceChangeListener(
             new OnPreferenceChangeListener() {
                 public boolean onPreferenceChange(Preference pref, Object newVal) {
-                    updateRemoteSearchLimit((String)newVal);
+                    updateRemoteSearchLimit((String) newVal);
                     return true;
                 }
             }
@@ -635,7 +635,7 @@ public class AccountSettings extends K9PreferenceActivity {
         mAccountLed = (CheckBoxPreference) findPreference(PREFERENCE_NOTIFICATION_LED);
         mAccountLed.setChecked(mAccount.getNotificationSetting().isLed());
 
-        mNotificationOpensUnread = (CheckBoxPreference)findPreference(PREFERENCE_NOTIFICATION_OPENS_UNREAD);
+        mNotificationOpensUnread = (CheckBoxPreference) findPreference(PREFERENCE_NOTIFICATION_OPENS_UNREAD);
         mNotificationOpensUnread.setChecked(mAccount.goToUnreadMessageSearch());
 
         new PopulateFolderPrefsTask().execute();
@@ -787,10 +787,12 @@ public class AccountSettings extends K9PreferenceActivity {
 
         // In webdav account we use the exact folder name also for inbox,
         // since it varies because of internationalization
-        if (mAccount.getStoreUri().startsWith("webdav"))
+        if (mAccount.getStoreUri().startsWith("webdav")) {
             mAccount.setAutoExpandFolderName(mAutoExpandFolder.getValue());
-        else
+        }
+        else {
             mAccount.setAutoExpandFolderName(reverseTranslateFolder(mAutoExpandFolder.getValue()));
+        }
 
         if (mIsMoveCapable) {
             mAccount.setArchiveFolderName(mArchiveFolder.getValue());
@@ -973,7 +975,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
     private void doVibrateTest(Preference preference) {
         // Do the vibration to show the user what it's like.
-        Vibrator vibrate = (Vibrator)preference.getContext().getSystemService(Context.VIBRATOR_SERVICE);
+        Vibrator vibrate = (Vibrator) preference.getContext().getSystemService(Context.VIBRATOR_SERVICE);
         vibrate.vibrate(NotificationSetting.getVibration(
                             Integer.parseInt(mAccountVibratePattern.getValue()),
                             Integer.parseInt(mAccountVibrateTimes.getValue())), -1);
@@ -984,17 +986,20 @@ public class AccountSettings extends K9PreferenceActivity {
      * @param maxResults Search limit to update the summary with.
      */
     private void updateRemoteSearchLimit(String maxResults) {
-        if (maxResults != null) {
-            if (maxResults.equals("0")) {
-                maxResults = getString(R.string.account_settings_remote_search_num_results_entries_all);
+        String maxResultsLocal = maxResults;
+        if (maxResultsLocal != null) {
+            if (maxResultsLocal.equals("0")) {
+                maxResultsLocal = getString(R.string.account_settings_remote_search_num_results_entries_all);
             }
 
-            mRemoteSearchNumResults.setSummary(String.format(getString(R.string.account_settings_remote_search_num_summary), maxResults));
+            String summaryStr = String.format(getString(R.string.account_settings_remote_search_num_summary),
+                                              maxResultsLocal);
+            mRemoteSearchNumResults.setSummary(summaryStr);
         }
     }
 
     private class PopulateFolderPrefsTask extends AsyncTask<Void, Void, Void> {
-        List <? extends Folder > folders = new LinkedList<LocalFolder>();
+        List<?extends Folder> folders = new LinkedList<LocalFolder>();
         String[] allFolderValues;
         String[] allFolderLabels;
 
@@ -1008,7 +1013,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
             // TODO: In the future the call above should be changed to only return remote folders.
             // For now we just remove the Outbox folder if present.
-            Iterator <? extends Folder > iter = folders.iterator();
+            Iterator<?extends Folder> iter = folders.iterator();
             while (iter.hasNext()) {
                 Folder folder = iter.next();
                 if (mAccount.getOutboxFolderName().equals(folder.getName())) {
@@ -1033,17 +1038,17 @@ public class AccountSettings extends K9PreferenceActivity {
 
         @Override
         protected void onPreExecute() {
-            mAutoExpandFolder = (ListPreference)findPreference(PREFERENCE_AUTO_EXPAND_FOLDER);
+            mAutoExpandFolder = (ListPreference) findPreference(PREFERENCE_AUTO_EXPAND_FOLDER);
             mAutoExpandFolder.setEnabled(false);
-            mArchiveFolder = (ListPreference)findPreference(PREFERENCE_ARCHIVE_FOLDER);
+            mArchiveFolder = (ListPreference) findPreference(PREFERENCE_ARCHIVE_FOLDER);
             mArchiveFolder.setEnabled(false);
-            mDraftsFolder = (ListPreference)findPreference(PREFERENCE_DRAFTS_FOLDER);
+            mDraftsFolder = (ListPreference) findPreference(PREFERENCE_DRAFTS_FOLDER);
             mDraftsFolder.setEnabled(false);
-            mSentFolder = (ListPreference)findPreference(PREFERENCE_SENT_FOLDER);
+            mSentFolder = (ListPreference) findPreference(PREFERENCE_SENT_FOLDER);
             mSentFolder.setEnabled(false);
-            mSpamFolder = (ListPreference)findPreference(PREFERENCE_SPAM_FOLDER);
+            mSpamFolder = (ListPreference) findPreference(PREFERENCE_SPAM_FOLDER);
             mSpamFolder.setEnabled(false);
-            mTrashFolder = (ListPreference)findPreference(PREFERENCE_TRASH_FOLDER);
+            mTrashFolder = (ListPreference) findPreference(PREFERENCE_TRASH_FOLDER);
             mTrashFolder.setEnabled(false);
 
             if (!mIsMoveCapable) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -82,12 +82,12 @@ public class AccountSetupBasics extends K9Activity
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.account_setup_basics);
-        mEmailView = (EditText)findViewById(R.id.account_email);
-        mPasswordView = (EditText)findViewById(R.id.account_password);
-        mClientCertificateCheckBox = (CheckBox)findViewById(R.id.account_client_certificate);
-        mClientCertificateSpinner = (ClientCertificateSpinner)findViewById(R.id.account_client_certificate_spinner);
-        mNextButton = (Button)findViewById(R.id.next);
-        mManualSetupButton = (Button)findViewById(R.id.manual_setup);
+        mEmailView = (EditText) findViewById(R.id.account_email);
+        mPasswordView = (EditText) findViewById(R.id.account_password);
+        mClientCertificateCheckBox = (CheckBox) findViewById(R.id.account_client_certificate);
+        mClientCertificateSpinner = (ClientCertificateSpinner) findViewById(R.id.account_client_certificate_spinner);
+        mNextButton = (Button) findViewById(R.id.next);
+        mManualSetupButton = (Button) findViewById(R.id.manual_setup);
         mShowPasswordCheckBox = (CheckBox) findViewById(R.id.show_password);
         mNextButton.setOnClickListener(this);
         mManualSetupButton.setOnClickListener(this);
@@ -98,7 +98,7 @@ public class AccountSetupBasics extends K9Activity
         mPasswordView.addTextChangedListener(this);
         mClientCertificateCheckBox.setOnCheckedChangeListener(this);
         mClientCertificateSpinner.setOnClientCertificateChangedListener(this);
-        mShowPasswordCheckBox.setOnCheckedChangeListener (new OnCheckedChangeListener() {
+        mShowPasswordCheckBox.setOnCheckedChangeListener(new OnCheckedChangeListener() {
             @Override
             public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
                 showPassword(isChecked);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -41,18 +41,18 @@ import java.util.Locale;
 /**
  * Checks the given settings to make sure that they can be used to send and
  * receive mail.
- * 
+ *
  * XXX NOTE: The manifest for this app has it ignore config changes, because
  * it doesn't correctly deal with restarting while its thread is running.
  */
 public class AccountSetupCheckSettings extends K9Activity implements OnClickListener,
-        ConfirmationDialogFragmentListener{
+        ConfirmationDialogFragmentListener {
 
     public static final int ACTIVITY_REQUEST_CODE = 1;
 
     private static final String EXTRA_ACCOUNT = "account";
 
-    private static final String EXTRA_CHECK_DIRECTION ="checkDirection";
+    private static final String EXTRA_CHECK_DIRECTION = "checkDirection";
 
     public enum CheckDirection {
         INCOMING,
@@ -85,8 +85,8 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.account_setup_check_settings);
-        mMessageView = (TextView)findViewById(R.id.message);
-        mProgressBar = (ProgressBar)findViewById(R.id.progress);
+        mMessageView = (TextView) findViewById(R.id.message);
+        mProgressBar = (ProgressBar) findViewById(R.id.progress);
         findViewById(R.id.cancel).setOnClickListener(this);
 
         setMessage(R.string.account_setup_check_settings_retr_info_msg);
@@ -170,7 +170,7 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
                     //  by a subjectDN not matching the server even though a
                     //  SubjectAltName matches)
                     try {
-                        final Collection < List<? >> subjectAlternativeNames = chain[i].getSubjectAlternativeNames();
+                        final Collection<List<?>> subjectAlternativeNames = chain[i].getSubjectAlternativeNames();
                         if (subjectAlternativeNames != null) {
                             // The list of SubjectAltNames may be very long
                             //TODO: localize this string
@@ -182,7 +182,7 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
                             String transportURIHost = (Uri.parse(mAccount.getTransportUri())).getHost();
 
                             for (List<?> subjectAlternativeName : subjectAlternativeNames) {
-                                Integer type = (Integer)subjectAlternativeName.get(0);
+                                Integer type = (Integer) subjectAlternativeName.get(0);
                                 Object value = subjectAlternativeName.get(1);
                                 String name;
                                 switch (type.intValue()) {
@@ -190,10 +190,10 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
                                     Log.w(K9.LOG_TAG, "SubjectAltName of type OtherName not supported.");
                                     continue;
                                 case 1: // RFC822Name
-                                    name = (String)value;
+                                    name = (String) value;
                                     break;
                                 case 2:  // DNSName
-                                    name = (String)value;
+                                    name = (String) value;
                                     break;
                                 case 3:
                                     Log.w(K9.LOG_TAG, "unsupported SubjectAltName of type x400Address");
@@ -205,10 +205,10 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
                                     Log.w(K9.LOG_TAG, "unsupported SubjectAltName of type ediPartyName");
                                     continue;
                                 case 6:  // Uri
-                                    name = (String)value;
+                                    name = (String) value;
                                     break;
                                 case 7: // ip-address
-                                    name = (String)value;
+                                    name = (String) value;
                                     break;
                                 default:
                                     Log.w(K9.LOG_TAG, "unsupported SubjectAltName of unknown type");
@@ -277,7 +277,7 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
     /**
      * Permanently accepts a certificate for the INCOMING or OUTGOING direction
      * by adding it to the local key store.
-     * 
+     *
      * @param certificate
      */
     private void acceptCertificate(X509Certificate certificate) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
@@ -55,18 +55,18 @@ public class AccountSetupComposition extends K9Activity {
             mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
         }
 
-        mAccountName = (EditText)findViewById(R.id.account_name);
+        mAccountName = (EditText) findViewById(R.id.account_name);
         mAccountName.setText(mAccount.getName());
 
-        mAccountEmail = (EditText)findViewById(R.id.account_email);
+        mAccountEmail = (EditText) findViewById(R.id.account_email);
         mAccountEmail.setText(mAccount.getEmail());
 
-        mAccountAlwaysBcc = (EditText)findViewById(R.id.account_always_bcc);
+        mAccountAlwaysBcc = (EditText) findViewById(R.id.account_always_bcc);
         mAccountAlwaysBcc.setText(mAccount.getAlwaysBcc());
 
-        mAccountSignatureLayout = (LinearLayout)findViewById(R.id.account_signature_layout);
+        mAccountSignatureLayout = (LinearLayout) findViewById(R.id.account_signature_layout);
 
-        mAccountSignatureUse = (CheckBox)findViewById(R.id.account_signature_use);
+        mAccountSignatureUse = (CheckBox) findViewById(R.id.account_signature_use);
         boolean useSignature = mAccount.getSignatureUse();
         mAccountSignatureUse.setChecked(useSignature);
         mAccountSignatureUse.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
@@ -83,10 +83,10 @@ public class AccountSetupComposition extends K9Activity {
             }
         });
 
-        mAccountSignature = (EditText)findViewById(R.id.account_signature);
+        mAccountSignature = (EditText) findViewById(R.id.account_signature);
 
-        mAccountSignatureBeforeLocation = (RadioButton)findViewById(R.id.account_signature_location_before_quoted_text);
-        mAccountSignatureAfterLocation = (RadioButton)findViewById(R.id.account_signature_location_after_quoted_text);
+        mAccountSignatureBeforeLocation = (RadioButton) findViewById(R.id.account_signature_location_before_quoted_text);
+        mAccountSignatureAfterLocation = (RadioButton) findViewById(R.id.account_signature_location_after_quoted_text);
 
         if (useSignature) {
             mAccountSignature.setText(mAccount.getSignature());

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -97,26 +97,26 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
         super.onCreate(savedInstanceState);
         setContentView(R.layout.account_setup_incoming);
 
-        mUsernameView = (EditText)findViewById(R.id.account_username);
-        mPasswordView = (EditText)findViewById(R.id.account_password);
-        mClientCertificateSpinner = (ClientCertificateSpinner)findViewById(R.id.account_client_certificate_spinner);
-        mClientCertificateLabelView = (TextView)findViewById(R.id.account_client_certificate_label);
-        mPasswordLabelView = (TextView)findViewById(R.id.account_password_label);
+        mUsernameView = (EditText) findViewById(R.id.account_username);
+        mPasswordView = (EditText) findViewById(R.id.account_password);
+        mClientCertificateSpinner = (ClientCertificateSpinner) findViewById(R.id.account_client_certificate_spinner);
+        mClientCertificateLabelView = (TextView) findViewById(R.id.account_client_certificate_label);
+        mPasswordLabelView = (TextView) findViewById(R.id.account_password_label);
         TextView serverLabelView = (TextView) findViewById(R.id.account_server_label);
-        mServerView = (EditText)findViewById(R.id.account_server);
-        mPortView = (EditText)findViewById(R.id.account_port);
-        mSecurityTypeView = (Spinner)findViewById(R.id.account_security_type);
-        mAuthTypeView = (Spinner)findViewById(R.id.account_auth_type);
-        mImapAutoDetectNamespaceView = (CheckBox)findViewById(R.id.imap_autodetect_namespace);
-        mImapPathPrefixView = (EditText)findViewById(R.id.imap_path_prefix);
-        mWebdavPathPrefixView = (EditText)findViewById(R.id.webdav_path_prefix);
-        mWebdavAuthPathView = (EditText)findViewById(R.id.webdav_auth_path);
-        mWebdavMailboxPathView = (EditText)findViewById(R.id.webdav_mailbox_path);
-        mNextButton = (Button)findViewById(R.id.next);
-        mCompressionMobile = (CheckBox)findViewById(R.id.compression_mobile);
-        mCompressionWifi = (CheckBox)findViewById(R.id.compression_wifi);
-        mCompressionOther = (CheckBox)findViewById(R.id.compression_other);
-        mSubscribedFoldersOnly = (CheckBox)findViewById(R.id.subscribed_folders_only);
+        mServerView = (EditText) findViewById(R.id.account_server);
+        mPortView = (EditText) findViewById(R.id.account_port);
+        mSecurityTypeView = (Spinner) findViewById(R.id.account_security_type);
+        mAuthTypeView = (Spinner) findViewById(R.id.account_auth_type);
+        mImapAutoDetectNamespaceView = (CheckBox) findViewById(R.id.imap_autodetect_namespace);
+        mImapPathPrefixView = (EditText) findViewById(R.id.imap_path_prefix);
+        mWebdavPathPrefixView = (EditText) findViewById(R.id.webdav_path_prefix);
+        mWebdavAuthPathView = (EditText) findViewById(R.id.webdav_auth_path);
+        mWebdavMailboxPathView = (EditText) findViewById(R.id.webdav_mailbox_path);
+        mNextButton = (Button) findViewById(R.id.next);
+        mCompressionMobile = (CheckBox) findViewById(R.id.compression_mobile);
+        mCompressionWifi = (CheckBox) findViewById(R.id.compression_wifi);
+        mCompressionOther = (CheckBox) findViewById(R.id.compression_other);
+        mSubscribedFoldersOnly = (CheckBox) findViewById(R.id.subscribed_folders_only);
 
         mNextButton.setOnClickListener(this);
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
@@ -38,9 +38,9 @@ public class AccountSetupNames extends K9Activity implements OnClickListener {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.account_setup_names);
-        mDescription = (EditText)findViewById(R.id.account_description);
-        mName = (EditText)findViewById(R.id.account_name);
-        mDoneButton = (Button)findViewById(R.id.done);
+        mDescription = (EditText) findViewById(R.id.account_description);
+        mName = (EditText) findViewById(R.id.account_name);
+        mDoneButton = (Button) findViewById(R.id.done);
         mDoneButton.setOnClickListener(this);
 
         TextWatcher validationTextWatcher = new TextWatcher() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
@@ -42,11 +42,11 @@ public class AccountSetupOptions extends K9Activity implements OnClickListener {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.account_setup_options);
 
-        mCheckFrequencyView = (Spinner)findViewById(R.id.account_check_frequency);
-        mDisplayCountView = (Spinner)findViewById(R.id.account_display_count);
-        mNotifyView = (CheckBox)findViewById(R.id.account_notify);
-        mNotifySyncView = (CheckBox)findViewById(R.id.account_notify_sync);
-        mPushEnable = (CheckBox)findViewById(R.id.account_enable_push);
+        mCheckFrequencyView = (Spinner) findViewById(R.id.account_check_frequency);
+        mDisplayCountView = (Spinner) findViewById(R.id.account_display_count);
+        mNotifyView = (CheckBox) findViewById(R.id.account_notify);
+        mNotifySyncView = (CheckBox) findViewById(R.id.account_notify_sync);
+        mPushEnable = (CheckBox) findViewById(R.id.account_enable_push);
 
         findViewById(R.id.next).setOnClickListener(this);
 
@@ -132,9 +132,9 @@ public class AccountSetupOptions extends K9Activity implements OnClickListener {
         mAccount.setDescription(mAccount.getEmail());
         mAccount.setNotifyNewMail(mNotifyView.isChecked());
         mAccount.setShowOngoing(mNotifySyncView.isChecked());
-        mAccount.setAutomaticCheckIntervalMinutes((Integer)((SpinnerOption)mCheckFrequencyView
+        mAccount.setAutomaticCheckIntervalMinutes((Integer) ((SpinnerOption) mCheckFrequencyView
                 .getSelectedItem()).value);
-        mAccount.setDisplayCount((Integer)((SpinnerOption)mDisplayCountView
+        mAccount.setDisplayCount((Integer) ((SpinnerOption) mDisplayCountView
                                            .getSelectedItem()).value);
 
         if (mPushEnable.isChecked()) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -95,18 +95,18 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         }
 
 
-        mUsernameView = (EditText)findViewById(R.id.account_username);
-        mPasswordView = (EditText)findViewById(R.id.account_password);
-        mClientCertificateSpinner = (ClientCertificateSpinner)findViewById(R.id.account_client_certificate_spinner);
-        mClientCertificateLabelView = (TextView)findViewById(R.id.account_client_certificate_label);
-        mPasswordLabelView = (TextView)findViewById(R.id.account_password_label);
-        mServerView = (EditText)findViewById(R.id.account_server);
-        mPortView = (EditText)findViewById(R.id.account_port);
-        mRequireLoginView = (CheckBox)findViewById(R.id.account_require_login);
-        mRequireLoginSettingsView = (ViewGroup)findViewById(R.id.account_require_login_settings);
-        mSecurityTypeView = (Spinner)findViewById(R.id.account_security_type);
-        mAuthTypeView = (Spinner)findViewById(R.id.account_auth_type);
-        mNextButton = (Button)findViewById(R.id.next);
+        mUsernameView = (EditText) findViewById(R.id.account_username);
+        mPasswordView = (EditText) findViewById(R.id.account_password);
+        mClientCertificateSpinner = (ClientCertificateSpinner) findViewById(R.id.account_client_certificate_spinner);
+        mClientCertificateLabelView = (TextView) findViewById(R.id.account_client_certificate_label);
+        mPasswordLabelView = (TextView) findViewById(R.id.account_password_label);
+        mServerView = (EditText) findViewById(R.id.account_server);
+        mPortView = (EditText) findViewById(R.id.account_port);
+        mRequireLoginView = (CheckBox) findViewById(R.id.account_require_login);
+        mRequireLoginSettingsView = (ViewGroup) findViewById(R.id.account_require_login_settings);
+        mSecurityTypeView = (Spinner) findViewById(R.id.account_security_type);
+        mAuthTypeView = (Spinner) findViewById(R.id.account_auth_type);
+        mNextButton = (Button) findViewById(R.id.next);
 
         mNextButton.setOnClickListener(this);
 
@@ -466,7 +466,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
 
         String newHost = mServerView.getText().toString();
         int newPort = Integer.parseInt(mPortView.getText().toString());
-        ServerSettings server = new ServerSettings(Type.SMTP, newHost, newPort, securityType, authType, username, password, clientCertificateAlias);
+        ServerSettings server =
+            new ServerSettings(Type.SMTP, newHost, newPort, securityType, authType, username, password, clientCertificateAlias);
         uri = Transport.createTransportUri(server);
         mAccount.deleteCertificate(newHost, newPort, CheckDirection.OUTGOING);
         mAccount.setTransportUri(uri);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AuthTypeAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AuthTypeAdapter.java
@@ -35,14 +35,14 @@ class AuthTypeAdapter extends ArrayAdapter<AuthTypeHolder> {
      *            "Password, transmitted insecurely"
      */
     public void useInsecureText(boolean insecure) {
-        for (int i=0; i<getCount(); i++) {
+        for (int i = 0; i < getCount(); i++) {
             getItem(i).setInsecure(insecure);
         }
         notifyDataSetChanged();
     }
 
     public int getAuthPosition(AuthType authenticationType) {
-        for (int i=0; i<getCount(); i++) {
+        for (int i = 0; i < getCount(); i++) {
             if (getItem(i).authType == authenticationType) {
                 return i;
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/ConnectionSecurityAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/ConnectionSecurityAdapter.java
@@ -28,7 +28,7 @@ class ConnectionSecurityAdapter extends ArrayAdapter<ConnectionSecurityHolder> {
     }
 
     public int getConnectionSecurityPosition(ConnectionSecurity connectionSecurity) {
-        for (int i=0; i<getCount(); i++) {
+        for (int i = 0; i < getCount(); i++) {
             if (getItem(i).connectionSecurity == connectionSecurity) {
                 return i;
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
@@ -53,7 +53,7 @@ public class FolderSettings extends K9PreferenceActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        String folderName = (String)getIntent().getSerializableExtra(EXTRA_FOLDER_NAME);
+        String folderName = (String) getIntent().getSerializableExtra(EXTRA_FOLDER_NAME);
         String accountUuid = getIntent().getStringExtra(EXTRA_ACCOUNT);
         Account mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
 
@@ -81,9 +81,9 @@ public class FolderSettings extends K9PreferenceActivity {
         category.setTitle(displayName);
 
 
-        mInTopGroup = (CheckBoxPreference)findPreference(PREFERENCE_IN_TOP_GROUP);
+        mInTopGroup = (CheckBoxPreference) findPreference(PREFERENCE_IN_TOP_GROUP);
         mInTopGroup.setChecked(mFolder.isInTopGroup());
-        mIntegrate = (CheckBoxPreference)findPreference(PREFERENCE_INTEGRATE);
+        mIntegrate = (CheckBoxPreference) findPreference(PREFERENCE_INTEGRATE);
         mIntegrate.setChecked(mFolder.isIntegrate());
 
         mDisplayClass = (ListPreference) findPreference(PREFERENCE_DISPLAY_CLASS);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -195,17 +195,19 @@ public class Prefs extends K9PreferenceActivity {
             }
         });
 
-        mAnimations = (CheckBoxPreference)findPreference(PREFERENCE_ANIMATIONS);
+        mAnimations = (CheckBoxPreference) findPreference(PREFERENCE_ANIMATIONS);
         mAnimations.setChecked(K9.showAnimations());
 
-        mGestures = (CheckBoxPreference)findPreference(PREFERENCE_GESTURES);
+        mGestures = (CheckBoxPreference) findPreference(PREFERENCE_GESTURES);
         mGestures.setChecked(K9.gesturesEnabled());
 
-        mVolumeNavigation = (CheckBoxListPreference)findPreference(PREFERENCE_VOLUME_NAVIGATION);
-        mVolumeNavigation.setItems(new CharSequence[] {getString(R.string.volume_navigation_message), getString(R.string.volume_navigation_list)});
-        mVolumeNavigation.setCheckedItems(new boolean[] {K9.useVolumeKeysForNavigationEnabled(), K9.useVolumeKeysForListNavigationEnabled()});
+        mVolumeNavigation = (CheckBoxListPreference) findPreference(PREFERENCE_VOLUME_NAVIGATION);
+        mVolumeNavigation.setItems(new CharSequence[] {getString(R.string.volume_navigation_message),
+                                                       getString(R.string.volume_navigation_list)});
+        mVolumeNavigation.setCheckedItems(new boolean[] {K9.useVolumeKeysForNavigationEnabled(),
+                                                         K9.useVolumeKeysForListNavigationEnabled()});
 
-        mStartIntegratedInbox = (CheckBoxPreference)findPreference(PREFERENCE_START_INTEGRATED_INBOX);
+        mStartIntegratedInbox = (CheckBoxPreference) findPreference(PREFERENCE_START_INTEGRATED_INBOX);
         mStartIntegratedInbox.setChecked(K9.startIntegratedInbox());
 
         mConfirmActions = (CheckBoxListPreference) findPreference(PREFERENCE_CONFIRM_ACTIONS);
@@ -232,44 +234,44 @@ public class Prefs extends K9PreferenceActivity {
         mNotificationHideSubject = setupListPreference(PREFERENCE_NOTIFICATION_HIDE_SUBJECT,
                 K9.getNotificationHideSubject().toString());
 
-        mMeasureAccounts = (CheckBoxPreference)findPreference(PREFERENCE_MEASURE_ACCOUNTS);
+        mMeasureAccounts = (CheckBoxPreference) findPreference(PREFERENCE_MEASURE_ACCOUNTS);
         mMeasureAccounts.setChecked(K9.measureAccounts());
 
-        mCountSearch = (CheckBoxPreference)findPreference(PREFERENCE_COUNT_SEARCH);
+        mCountSearch = (CheckBoxPreference) findPreference(PREFERENCE_COUNT_SEARCH);
         mCountSearch.setChecked(K9.countSearchMessages());
 
-        mHideSpecialAccounts = (CheckBoxPreference)findPreference(PREFERENCE_HIDE_SPECIAL_ACCOUNTS);
+        mHideSpecialAccounts = (CheckBoxPreference) findPreference(PREFERENCE_HIDE_SPECIAL_ACCOUNTS);
         mHideSpecialAccounts.setChecked(K9.isHideSpecialAccounts());
 
 
         mPreviewLines = setupListPreference(PREFERENCE_MESSAGELIST_PREVIEW_LINES,
                                             Integer.toString(K9.messageListPreviewLines()));
 
-        mSenderAboveSubject = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_SENDER_ABOVE_SUBJECT);
+        mSenderAboveSubject = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGELIST_SENDER_ABOVE_SUBJECT);
         mSenderAboveSubject.setChecked(K9.messageListSenderAboveSubject());
-        mCheckboxes = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_CHECKBOXES);
+        mCheckboxes = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGELIST_CHECKBOXES);
         mCheckboxes.setChecked(K9.messageListCheckboxes());
 
-        mStars = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_STARS);
+        mStars = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGELIST_STARS);
         mStars.setChecked(K9.messageListStars());
 
-        mShowCorrespondentNames = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_SHOW_CORRESPONDENT_NAMES);
+        mShowCorrespondentNames = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGELIST_SHOW_CORRESPONDENT_NAMES);
         mShowCorrespondentNames.setChecked(K9.showCorrespondentNames());
 
-        mShowContactName = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_SHOW_CONTACT_NAME);
+        mShowContactName = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGELIST_SHOW_CONTACT_NAME);
         mShowContactName.setChecked(K9.showContactName());
 
-        mShowContactPicture = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_SHOW_CONTACT_PICTURE);
+        mShowContactPicture = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGELIST_SHOW_CONTACT_PICTURE);
         mShowContactPicture.setChecked(K9.showContactPicture());
 
-        mColorizeMissingContactPictures = (CheckBoxPreference)findPreference(
+        mColorizeMissingContactPictures = (CheckBoxPreference) findPreference(
                 PREFERENCE_MESSAGELIST_COLORIZE_MISSING_CONTACT_PICTURES);
         mColorizeMissingContactPictures.setChecked(K9.isColorizeMissingContactPictures());
 
-        mBackgroundAsUnreadIndicator = (CheckBoxPreference)findPreference(PREFERENCE_BACKGROUND_AS_UNREAD_INDICATOR);
+        mBackgroundAsUnreadIndicator = (CheckBoxPreference) findPreference(PREFERENCE_BACKGROUND_AS_UNREAD_INDICATOR);
         mBackgroundAsUnreadIndicator.setChecked(K9.useBackgroundAsUnreadIndicator());
 
-        mChangeContactNameColor = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_CONTACT_NAME_COLOR);
+        mChangeContactNameColor = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGELIST_CONTACT_NAME_COLOR);
         mChangeContactNameColor.setChecked(K9.changeContactNameColor());
 
         mThreadedView = (CheckBoxPreference) findPreference(PREFERENCE_THREADED_VIEW);
@@ -294,7 +296,7 @@ public class Prefs extends K9PreferenceActivity {
             }
         });
 
-        mFixedWidth = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGEVIEW_FIXEDWIDTH);
+        mFixedWidth = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGEVIEW_FIXEDWIDTH);
         mFixedWidth.setChecked(K9.messageViewFixedWidthFont());
 
         mReturnToList = (CheckBoxPreference) findPreference(PREFERENCE_MESSAGEVIEW_RETURN_TO_LIST);
@@ -349,10 +351,10 @@ public class Prefs extends K9PreferenceActivity {
 
         mBackgroundOps = setupListPreference(PREFERENCE_BACKGROUND_OPS, K9.getBackgroundOps().name());
 
-        mDebugLogging = (CheckBoxPreference)findPreference(PREFERENCE_DEBUG_LOGGING);
-        mSensitiveLogging = (CheckBoxPreference)findPreference(PREFERENCE_SENSITIVE_LOGGING);
-        mHideUserAgent = (CheckBoxPreference)findPreference(PREFERENCE_HIDE_USERAGENT);
-        mHideTimeZone = (CheckBoxPreference)findPreference(PREFERENCE_HIDE_TIMEZONE);
+        mDebugLogging = (CheckBoxPreference) findPreference(PREFERENCE_DEBUG_LOGGING);
+        mSensitiveLogging = (CheckBoxPreference) findPreference(PREFERENCE_SENSITIVE_LOGGING);
+        mHideUserAgent = (CheckBoxPreference) findPreference(PREFERENCE_HIDE_USERAGENT);
+        mHideTimeZone = (CheckBoxPreference) findPreference(PREFERENCE_HIDE_TIMEZONE);
 
         mDebugLogging.setChecked(K9.DEBUG);
         mSensitiveLogging.setChecked(K9.DEBUG_SENSITIVE);
@@ -389,7 +391,7 @@ public class Prefs extends K9PreferenceActivity {
             };
         });
 
-        mWrapFolderNames = (CheckBoxPreference)findPreference(PREFERENCE_FOLDERLIST_WRAP_NAME);
+        mWrapFolderNames = (CheckBoxPreference) findPreference(PREFERENCE_FOLDERLIST_WRAP_NAME);
         mWrapFolderNames.setChecked(K9.wrapFolderNames());
 
         mVisibleRefileActions = (CheckBoxListPreference) findPreference(PREFERENCE_MESSAGEVIEW_VISIBLE_REFILE_ACTIONS);
@@ -494,7 +496,7 @@ public class Prefs extends K9PreferenceActivity {
                     NotificationQuickDelete.valueOf(mNotificationQuickDelete.getValue()));
         }
 
-        if(mLockScreenNotificationVisibility != null) {
+        if (mLockScreenNotificationVisibility != null) {
             K9.setLockScreenNotificationVisibility(
                 K9.LockScreenNotificationVisibility.valueOf(mLockScreenNotificationVisibility.getValue()));
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/SliderPreference.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/SliderPreference.java
@@ -123,12 +123,12 @@ public class SliderPreference extends DialogPreference {
     }
 
     public void setValue(float value) {
-        value = Math.max(0, Math.min(value, 1)); // clamp to [0, 1]
+        float valueLocal = Math.max(0, Math.min(value, 1)); // clamp to [0, 1]
         if (shouldPersist()) {
-            persistFloat(value);
+            persistFloat(valueLocal);
         }
-        if (value != mValue) {
-            mValue = value;
+        if (valueLocal != mValue) {
+            mValue = valueLocal;
             notifyChanged();
         }
     }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -166,10 +166,12 @@ public class MessagingController implements Runnable {
                 return 0;
             }
             //reversed intentionally.
-            if (id1 < id2)
+            if (id1 < id2) {
                 return 1;
-            if (id1 > id2)
+            }
+            if (id1 > id2) {
                 return -1;
+            }
             return 0;
         }
     }
@@ -399,8 +401,10 @@ public class MessagingController implements Runnable {
                 if (command != null) {
                     commandDescription = command.description;
 
-                    if (K9.DEBUG)
-                        Log.i(K9.LOG_TAG, "Running " + (command.isForeground ? "Foreground" : "Background") + " command '" + command.description + "', seq = " + command.sequence);
+                    if (K9.DEBUG) {
+                        Log.i(K9.LOG_TAG, "Running " + (command.isForeground ? "Foreground" : "Background") +
+                              " command '" + command.description + "', seq = " + command.sequence);
+                    }
 
                     mBusy = true;
                     try {
@@ -422,9 +426,10 @@ public class MessagingController implements Runnable {
                         } .start();
                     }
 
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.i(K9.LOG_TAG, (command.isForeground ? "Foreground" : "Background") +
                               " Command '" + command.description + "' completed");
+                    }
 
                     for (MessagingListener l : getListeners(command.listener)) {
                         l.controllerCommandCompleted(!mCommands.isEmpty());
@@ -445,7 +450,8 @@ public class MessagingController implements Runnable {
         putCommand(mCommands, description, listener, runnable, false);
     }
 
-    private void putCommand(BlockingQueue<Command> queue, String description, MessagingListener listener, Runnable runnable, boolean isForeground) {
+    private void putCommand(BlockingQueue<Command> queue, String description, MessagingListener listener,
+                            Runnable runnable, boolean isForeground) {
         int retries = 10;
         Exception e = null;
         while (retries-- > 0) {
@@ -538,7 +544,7 @@ public class MessagingController implements Runnable {
         for (MessagingListener l : getListeners(listener)) {
             l.listFoldersStarted(account);
         }
-        List <? extends Folder > localFolders = null;
+        List<?extends Folder> localFolders = null;
         if (!account.isAvailable(context)) {
             Log.i(K9.LOG_TAG, "not listing folders of unavailable account");
         } else {
@@ -579,11 +585,11 @@ public class MessagingController implements Runnable {
         put("doRefreshRemote", listener, new Runnable() {
             @Override
             public void run() {
-                List <? extends Folder > localFolders = null;
+                List<?extends Folder> localFolders = null;
                 try {
                     Store store = account.getRemoteStore();
 
-                    List <? extends Folder > remoteFolders = store.getPersonalNamespaces(false);
+                    List<?extends Folder> remoteFolders = store.getPersonalNamespaces(false);
 
                     LocalStore localStore = account.getLocalStore();
                     Set<String> remoteFolderNames = new HashSet<String>();
@@ -676,9 +682,9 @@ public class MessagingController implements Runnable {
             // Collecting statistics of the search result
             MessageRetrievalListener retrievalListener = new MessageRetrievalListener<LocalMessage>() {
                 @Override
-                public void messageStarted(String message, int number, int ofTotal) {}
+                public void messageStarted(String message, int number, int ofTotal) { }
                 @Override
-                public void messagesFinished(int number) {}
+                public void messagesFinished(int number) { }
                 @Override
 
                 public void messageFinished(LocalMessage message, int number, int ofTotal) {
@@ -808,7 +814,8 @@ public class MessagingController implements Runnable {
 
     }
 
-    public void loadSearchResults(final Account account, final String folderName, final List<Message> messages, final MessagingListener listener) {
+    public void loadSearchResults(final Account account, final String folderName, final List<Message> messages,
+                                  final MessagingListener listener) {
         threadPool.execute(new Runnable() {
             @Override
             public void run() {
@@ -842,7 +849,8 @@ public class MessagingController implements Runnable {
         });
     }
 
-    public void loadSearchResultsSynchronous(List<Message> messages, LocalFolder localFolder, Folder remoteFolder, MessagingListener listener) throws MessagingException {
+    public void loadSearchResultsSynchronous(List<Message> messages, LocalFolder localFolder,
+                                             Folder remoteFolder, MessagingListener listener) throws MessagingException {
         final FetchProfile header = new FetchProfile();
         header.add(FetchProfile.Item.FLAGS);
         header.add(FetchProfile.Item.ENVELOPE);
@@ -897,7 +905,8 @@ public class MessagingController implements Runnable {
      * @param listener
      * @param providedRemoteFolder TODO
      */
-    public void synchronizeMailbox(final Account account, final String folder, final MessagingListener listener, final Folder providedRemoteFolder) {
+    public void synchronizeMailbox(final Account account, final String folder, final MessagingListener listener,
+                                   final Folder providedRemoteFolder) {
         putBackground("synchronizeMailbox", listener, new Runnable() {
             @Override
             public void run() {
@@ -915,12 +924,14 @@ public class MessagingController implements Runnable {
      * TODO Break this method up into smaller chunks.
      * @param providedRemoteFolder TODO
      */
-    private void synchronizeMailboxSynchronous(final Account account, final String folder, final MessagingListener listener, Folder providedRemoteFolder) {
+    private void synchronizeMailboxSynchronous(final Account account, final String folder,
+                                               final MessagingListener listener, Folder providedRemoteFolder) {
         Folder remoteFolder = null;
         LocalFolder tLocalFolder = null;
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "Synchronizing folder " + account.getDescription() + ":" + folder);
+        }
 
         for (MessagingListener l : getListeners(listener)) {
             l.synchronizeMailboxStarted(account, folder);
@@ -938,8 +949,9 @@ public class MessagingController implements Runnable {
 
         Exception commandException = null;
         try {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "SYNC: About to process pending commands for account " + account.getDescription());
+            }
 
             try {
                 processPendingCommandsSynchronous(account);
@@ -954,8 +966,9 @@ public class MessagingController implements Runnable {
              * Get the message list from the local store and create an index of
              * the uids within the list.
              */
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "SYNC: About to get local folder " + folder);
+            }
 
             final LocalStore localStore = account.getLocalStore();
             tLocalFolder = localStore.getFolder(folder);
@@ -969,17 +982,19 @@ public class MessagingController implements Runnable {
             }
 
             if (providedRemoteFolder != null) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.v(K9.LOG_TAG, "SYNC: using providedRemoteFolder " + folder);
+                }
                 remoteFolder = providedRemoteFolder;
             } else {
                 Store remoteStore = account.getRemoteStore();
 
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.v(K9.LOG_TAG, "SYNC: About to get remote folder " + folder);
+                }
                 remoteFolder = remoteStore.getFolder(folder);
 
-                if (! verifyOrCreateRemoteSpecialFolder(account, folder, remoteFolder, listener)) {
+                if (!verifyOrCreateRemoteSpecialFolder(account, folder, remoteFolder, listener)) {
                     return;
                 }
 
@@ -1005,13 +1020,15 @@ public class MessagingController implements Runnable {
                 /*
                  * Open the remote folder. This pre-loads certain metadata like message count.
                  */
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.v(K9.LOG_TAG, "SYNC: About to open remote folder " + folder);
+                }
 
                 remoteFolder.open(Folder.OPEN_MODE_RW);
                 if (Expunge.EXPUNGE_ON_POLL == account.getExpungePolicy()) {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.d(K9.LOG_TAG, "SYNC: Expunging folder " + account.getDescription() + ":" + folder);
+                    }
                     remoteFolder.expunge();
                 }
 
@@ -1031,8 +1048,9 @@ public class MessagingController implements Runnable {
             final List<Message> remoteMessages = new ArrayList<Message>();
             Map<String, Message> remoteUidMap = new HashMap<String, Message>();
 
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "SYNC: Remote message count for folder " + folder + " is " + remoteMessageCount);
+            }
             final Date earliestDate = account.getEarliestPollDate();
 
 
@@ -1046,8 +1064,9 @@ public class MessagingController implements Runnable {
                 }
                 int remoteEnd = remoteMessageCount;
 
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.v(K9.LOG_TAG, "SYNC: About to get messages " + remoteStart + " through " + remoteEnd + " for folder " + folder);
+                }
 
                 final AtomicInteger headerProgress = new AtomicInteger(0);
                 for (MessagingListener l : getListeners(listener)) {
@@ -1070,8 +1089,9 @@ public class MessagingController implements Runnable {
                         remoteUidMap.put(thisMess.getUid(), thisMess);
                     }
                 }
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.v(K9.LOG_TAG, "SYNC: Got " + remoteUidMap.size() + " messages for folder " + folder);
+                }
 
                 for (MessagingListener l : getListeners(listener)) {
                     l.synchronizeMailboxHeadersFinished(account, folder, headerProgress.get(), remoteUidMap.size());
@@ -1118,9 +1138,10 @@ public class MessagingController implements Runnable {
             localFolder.setLastChecked(System.currentTimeMillis());
             localFolder.setStatus(null);
 
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "Done synchronizing folder " + account.getDescription() + ":" + folder +
                       " @ " + new Date() + " with " + newMessages + " new messages");
+            }
 
             for (MessagingListener l : getListeners(listener)) {
                 l.synchronizeMailboxFinished(account, folder, remoteMessageCount, newMessages);
@@ -1137,8 +1158,9 @@ public class MessagingController implements Runnable {
                 }
             }
 
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "Done synchronizing folder " + account.getDescription() + ":" + folder);
+            }
 
         } catch (Exception e) {
             Log.e(K9.LOG_TAG, "synchronizeMailbox", e);
@@ -1187,7 +1209,9 @@ public class MessagingController implements Runnable {
      * designed and on Imap folders during error conditions. This allows us
      * to treat Pop3 and Imap the same in this code.
      */
-    private boolean verifyOrCreateRemoteSpecialFolder(final Account account, final String folder, final Folder remoteFolder, final MessagingListener listener) throws MessagingException {
+    private boolean verifyOrCreateRemoteSpecialFolder(final Account account, final String folder,
+                                                      final Folder remoteFolder,
+                                                      final MessagingListener listener) throws MessagingException {
         if (folder.equals(account.getTrashFolderName()) ||
                 folder.equals(account.getSentFolderName()) ||
                 folder.equals(account.getDraftsFolderName())) {
@@ -1196,8 +1220,9 @@ public class MessagingController implements Runnable {
                     for (MessagingListener l : getListeners(listener)) {
                         l.synchronizeMailboxFinished(account, folder, 0, 0);
                     }
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.i(K9.LOG_TAG, "Done synchronizing folder " + folder);
+                    }
 
                     return false;
                 }
@@ -1255,7 +1280,8 @@ public class MessagingController implements Runnable {
         List<Message> messages = new ArrayList<Message>(inputMessages);
 
         for (Message message : messages) {
-            evaluateMessageForDownload(message, folder, localFolder, remoteFolder, account, unsyncedMessages, syncFlagMessages , flagSyncOnly);
+            evaluateMessageForDownload(message, folder, localFolder, remoteFolder, account,
+                                       unsyncedMessages, syncFlagMessages , flagSyncOnly);
         }
 
         final AtomicInteger progress = new AtomicInteger(0);
@@ -1264,8 +1290,9 @@ public class MessagingController implements Runnable {
             l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
         }
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "SYNC: Have " + unsyncedMessages.size() + " unsynced messages");
+        }
 
         messages.clear();
         final List<Message> largeMessages = new ArrayList<Message>();
@@ -1290,8 +1317,9 @@ public class MessagingController implements Runnable {
             }
             fp.add(FetchProfile.Item.ENVELOPE);
 
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "SYNC: About to fetch " + unsyncedMessages.size() + " unsynced messages for folder " + folder);
+            }
 
 
             fetchUnsyncedMessages(account, remoteFolder, unsyncedMessages, smallMessages, largeMessages, progress, todo, fp);
@@ -1312,11 +1340,12 @@ public class MessagingController implements Runnable {
 
         }
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "SYNC: Have "
                   + largeMessages.size() + " large messages and "
                   + smallMessages.size() + " small messages out of "
                   + unsyncedMessages.size() + " unsynced messages");
+        }
 
         unsyncedMessages.clear();
 
@@ -1348,8 +1377,9 @@ public class MessagingController implements Runnable {
 
         refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages, progress, todo);
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "SYNC: Synced remote messages for folder " + folder + ", " + newMessages.get() + " new messages");
+        }
 
         localFolder.purgeToVisibleLimit(new MessageRemovalListener() {
             @Override
@@ -1397,13 +1427,15 @@ public class MessagingController implements Runnable {
         if (localMessage == null) {
             if (!flagSyncOnly) {
                 if (!message.isSet(Flag.X_DOWNLOADED_FULL) && !message.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.v(K9.LOG_TAG, "Message with uid " + message.getUid() + " has not yet been downloaded");
+                    }
 
                     unsyncedMessages.add(message);
                 } else {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.v(K9.LOG_TAG, "Message with uid " + message.getUid() + " is partially or fully downloaded");
+                    }
 
                     // Store the updated message locally
                     localFolder.appendMessages(Collections.singletonList(message));
@@ -1422,13 +1454,15 @@ public class MessagingController implements Runnable {
                 }
             }
         } else if (!localMessage.isSet(Flag.DELETED)) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "Message with uid " + message.getUid() + " is present in the local store");
+            }
 
             if (!localMessage.isSet(Flag.X_DOWNLOADED_FULL) && !localMessage.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.v(K9.LOG_TAG, "Message with uid " + message.getUid()
                           + " is not downloaded, even partially; trying again");
+                }
 
                 unsyncedMessages.add(message);
             } else {
@@ -1487,7 +1521,7 @@ public class MessagingController implements Runnable {
             }
 
             @Override
-            public void messageStarted(String uid, int number, int ofTotal) {}
+            public void messageStarted(String uid, int number, int ofTotal) { }
 
             @Override
             public void messagesFinished(int total) {
@@ -1497,7 +1531,8 @@ public class MessagingController implements Runnable {
         });
     }
 
-    private boolean shouldImportMessage(final Account account, final String folder, final Message message, final AtomicInteger progress, final Date earliestDate) {
+    private boolean shouldImportMessage(final Account account, final String folder, final Message message,
+                                        final AtomicInteger progress, final Date earliestDate) {
 
         if (account.isSearchByDateCapable() && message.olderThan(earliestDate)) {
             if (K9.DEBUG) {
@@ -1521,8 +1556,9 @@ public class MessagingController implements Runnable {
 
         final Date earliestDate = account.getEarliestPollDate();
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "SYNC: Fetching small messages for folder " + folder);
+        }
 
         remoteFolder.fetch(smallMessages,
         fp, new MessageRetrievalListener<T>() {
@@ -1550,9 +1586,10 @@ public class MessagingController implements Runnable {
                         newMessages.incrementAndGet();
                     }
 
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.v(K9.LOG_TAG, "About to notify listeners that we got a new small message "
                               + account + ":" + folder + ":" + message.getUid());
+                    }
 
                     // Update the listener with what we've found
                     for (MessagingListener l : getListeners()) {
@@ -1576,14 +1613,15 @@ public class MessagingController implements Runnable {
             }
 
             @Override
-            public void messageStarted(String uid, int number, int ofTotal) {}
+            public void messageStarted(String uid, int number, int ofTotal) { }
 
             @Override
-            public void messagesFinished(int total) {}
+            public void messagesFinished(int total) { }
         });
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "SYNC: Done fetching small messages for folder " + folder);
+        }
     }
 
 
@@ -1600,8 +1638,9 @@ public class MessagingController implements Runnable {
 
         final Date earliestDate = account.getEarliestPollDate();
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "SYNC: Fetching large messages for folder " + folder);
+        }
 
         remoteFolder.fetch(largeMessages, fp, null);
         for (T message : largeMessages) {
@@ -1645,7 +1684,8 @@ public class MessagingController implements Runnable {
                      * If there is no limit on autodownload size, that's the same as the message
                      * being smaller than the max size
                      */
-                    if (account.getMaximumAutoDownloadMessageSize() == 0 || message.getSize() < account.getMaximumAutoDownloadMessageSize()) {
+                    if (account.getMaximumAutoDownloadMessageSize() == 0 ||
+                        message.getSize() < account.getMaximumAutoDownloadMessageSize()) {
                         localMessage.setFlag(Flag.X_DOWNLOADED_FULL, true);
                     } else {
                         // Set a flag indicating that the message has been partially downloaded and
@@ -1678,9 +1718,10 @@ public class MessagingController implements Runnable {
                 // viewed.
                 localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, true);
             }
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "About to notify listeners that we got a new large message "
                       + account + ":" + folder + ":" + message.getUid());
+            }
 
             // Update the listener with what we've found
             progress.incrementAndGet();
@@ -1707,9 +1748,10 @@ public class MessagingController implements Runnable {
                 notifyAccount(context, account, localMessage, unreadBeforeStart);
             }
 
-        }//for large messages
-        if (K9.DEBUG)
+        } //for large messages
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "SYNC: Done fetching large messages for folder " + folder);
+        }
 
     }
 
@@ -1722,9 +1764,10 @@ public class MessagingController implements Runnable {
 
         final String folder = remoteFolder.getName();
         if (remoteFolder.supportsFetchingFlags()) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "SYNC: About to sync flags for "
                       + syncFlagMessages.size() + " remote messages for folder " + folder);
+            }
 
             FetchProfile fp = new FetchProfile();
             fp.add(FetchProfile.Item.FLAGS);
@@ -1869,8 +1912,9 @@ public class MessagingController implements Runnable {
         try {
             for (PendingCommand command : commands) {
                 processingCommand = command;
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "Processing pending command '" + command + "'");
+                }
 
                 String[] components = command.command.split("\\.");
                 String commandTitle = components[components.length - 1];
@@ -1903,8 +1947,9 @@ public class MessagingController implements Runnable {
                         processPendingExpunge(command, account);
                     }
                     localStore.removePendingCommand(command);
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.d(K9.LOG_TAG, "Done processing pending command '" + command + "'");
+                    }
                 } catch (MessagingException me) {
                     if (me.isPermanentFailure()) {
                         addErrorMessage(account, null, me);
@@ -1990,7 +2035,8 @@ public class MessagingController implements Runnable {
                           " same message id");
                     String rUid = remoteFolder.getUidFromMessageId(localMessage);
                     if (rUid != null) {
-                        Log.w(K9.LOG_TAG, "Local message has flag " + Flag.X_REMOTE_COPY_STARTED + " already set, and there is a remote message with " +
+                        Log.w(K9.LOG_TAG, "Local message has flag " + Flag.X_REMOTE_COPY_STARTED +
+                              " already set, and there is a remote message with " +
                               " uid " + rUid + ", assuming message was already copied and aborting this copy");
 
                         String oldUid = localMessage.getUid();
@@ -2086,7 +2132,8 @@ public class MessagingController implements Runnable {
         queuePendingCommand(account, command);
     }
 
-    private void queueMoveOrCopy(Account account, String srcFolder, String destFolder, boolean isCopy, String uids[], Map<String, String> uidMap) {
+    private void queueMoveOrCopy(Account account, String srcFolder, String destFolder, boolean isCopy,
+                                 String uids[], Map<String, String> uidMap) {
         if (uidMap == null || uidMap.isEmpty()) {
             queueMoveOrCopy(account, srcFolder, destFolder, isCopy, uids);
         } else {
@@ -2211,15 +2258,17 @@ public class MessagingController implements Runnable {
                 throw new MessagingException("processingPendingMoveOrCopy: could not open remoteSrcFolder " + srcFolder + " read/write", true);
             }
 
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "processingPendingMoveOrCopy: source folder = " + srcFolder
                       + ", " + messages.size() + " messages, destination folder = " + destFolder + ", isCopy = " + isCopy);
+            }
 
-            Map <String, String> remoteUidMap = null;
+            Map<String, String> remoteUidMap = null;
 
             if (!isCopy && destFolder.equals(account.getTrashFolderName())) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "processingPendingMoveOrCopy doing special case for deleting message");
+                }
 
                 String destFolderName = destFolder;
                 if (K9.FOLDER_NONE.equals(destFolderName)) {
@@ -2236,8 +2285,9 @@ public class MessagingController implements Runnable {
                 }
             }
             if (!isCopy && Expunge.EXPUNGE_IMMEDIATELY == account.getExpungePolicy()) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "processingPendingMoveOrCopy expunging folder " + account.getDescription() + ":" + srcFolder);
+                }
 
                 remoteSrcFolder.expunge();
             }
@@ -2341,8 +2391,9 @@ public class MessagingController implements Runnable {
         if (account.getErrorFolderName().equals(folder)) {
             return;
         }
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "processPendingSetFlagOld: folder = " + folder + ", uid = " + uid);
+        }
 
         boolean newState = Boolean.parseBoolean(command.arguments[2]);
 
@@ -2392,8 +2443,9 @@ public class MessagingController implements Runnable {
         if (account.getErrorFolderName().equals(folder)) {
             return;
         }
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "processPendingExpunge: folder = " + folder);
+        }
 
         Store remoteStore = account.getRemoteStore();
         Folder remoteFolder = remoteStore.getFolder(folder);
@@ -2406,8 +2458,9 @@ public class MessagingController implements Runnable {
                 return;
             }
             remoteFolder.expunge();
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "processPendingExpunge: complete for folder = " + folder);
+            }
         } finally {
             closeFolder(remoteFolder);
         }
@@ -2452,13 +2505,15 @@ public class MessagingController implements Runnable {
             throw new MessagingException("processPendingMoveOrCopyOld: remoteMessage " + uid + " does not exist", true);
         }
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "processPendingMoveOrCopyOld: source folder = " + srcFolder
                   + ", uid = " + uid + ", destination folder = " + destFolder + ", isCopy = " + isCopy);
+        }
 
         if (!isCopy && destFolder.equals(account.getTrashFolderName())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "processPendingMoveOrCopyOld doing special case for deleting message");
+            }
 
             remoteMessage.delete(account.getTrashFolderName());
             remoteSrcFolder.close();
@@ -2657,8 +2712,9 @@ public class MessagingController implements Runnable {
 
     public void markAllMessagesRead(final Account account, final String folder) {
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "Marking all messages in " + account.getDescription() + ":" + folder + " as read");
+        }
         List<String> args = new ArrayList<String>();
         args.add(folder);
         PendingCommand command = new PendingCommand();
@@ -3105,8 +3161,9 @@ public class MessagingController implements Runnable {
                         l.loadAttachmentFinished(account, message, part);
                     }
                 } catch (MessagingException me) {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.v(K9.LOG_TAG, "Exception loading attachment", me);
+                    }
 
                     for (MessagingListener l : getListeners(listener)) {
                         l.loadAttachmentFailed(account, message, part, me.getMessage());
@@ -3393,8 +3450,10 @@ public class MessagingController implements Runnable {
             fp.add(FetchProfile.Item.ENVELOPE);
             fp.add(FetchProfile.Item.BODY);
 
-            if (K9.DEBUG)
-                Log.i(K9.LOG_TAG, "Scanning folder '" + account.getOutboxFolderName() + "' (" + ((LocalFolder)localFolder).getId() + ") for messages to send");
+            if (K9.DEBUG) {
+                Log.i(K9.LOG_TAG, "Scanning folder '" + account.getOutboxFolderName() + "' (" +
+					  ((LocalFolder) localFolder).getId() + ") for messages to send");
+            }
 
             Transport transport = Transport.getInstance(K9.app, account);
             for (Message message : localMessages) {
@@ -3409,8 +3468,9 @@ public class MessagingController implements Runnable {
                         count = oldCount;
                     }
 
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.i(K9.LOG_TAG, "Send count for message " + message.getUid() + " is " + count.get());
+                    }
 
                     if (count.incrementAndGet() > K9.MAX_SEND_ATTEMPTS) {
                         Log.e(K9.LOG_TAG, "Send count for message " + message.getUid() + " can't be delivered after " + K9.MAX_SEND_ATTEMPTS + " attempts.  Giving up until the user restarts the device");
@@ -3433,8 +3493,9 @@ public class MessagingController implements Runnable {
 
 
                         message.setFlag(Flag.X_SEND_IN_PROGRESS, true);
-                        if (K9.DEBUG)
+                        if (K9.DEBUG) {
                             Log.i(K9.LOG_TAG, "Sending message with UID " + message.getUid());
+                        }
                         transport.sendMessage(message);
                         message.setFlag(Flag.X_SEND_IN_PROGRESS, false);
                         message.setFlag(Flag.SEEN, true);
@@ -3443,18 +3504,23 @@ public class MessagingController implements Runnable {
                             l.synchronizeMailboxProgress(account, account.getSentFolderName(), progress, todo);
                         }
                         if (!account.hasSentFolder()) {
-                            if (K9.DEBUG)
+                            if (K9.DEBUG) {
                                 Log.i(K9.LOG_TAG, "Account does not have a sent mail folder; deleting sent message");
+                            }
                             message.setFlag(Flag.DELETED, true);
                         } else {
                             LocalFolder localSentFolder = (LocalFolder) localStore.getFolder(account.getSentFolderName());
-                            if (K9.DEBUG)
-                                Log.i(K9.LOG_TAG, "Moving sent message to folder '" + account.getSentFolderName() + "' (" + localSentFolder.getId() + ") ");
+                            if (K9.DEBUG) {
+                                Log.i(K9.LOG_TAG, "Moving sent message to folder '" + account.getSentFolderName() +
+									  "' (" + localSentFolder.getId() + ") ");
+                            }
 
                             localFolder.moveMessages(Collections.singletonList(message), localSentFolder);
 
-                            if (K9.DEBUG)
-                                Log.i(K9.LOG_TAG, "Moved sent message to folder '" + account.getSentFolderName() + "' (" + localSentFolder.getId() + ") ");
+                            if (K9.DEBUG) {
+                                Log.i(K9.LOG_TAG, "Moved sent message to folder '" + account.getSentFolderName() +
+                                      "' (" + localSentFolder.getId() + ") ");
+                            }
 
                             PendingCommand command = new PendingCommand();
                             command.command = PENDING_COMMAND_APPEND;
@@ -3778,9 +3844,10 @@ public class MessagingController implements Runnable {
                     origUidMap.put(message.getUid(), message);
                 }
 
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "moveOrCopyMessageSynchronous: source folder = " + srcFolder
                           + ", " + messages.size() + " messages, " + ", destination folder = " + destFolder + ", isCopy = " + isCopy);
+                }
 
                 if (isCopy) {
                     FetchProfile fp = new FetchProfile();
@@ -3952,8 +4019,9 @@ public class MessagingController implements Runnable {
             localFolder = localStore.getFolder(folder);
             Map<String, String> uidMap = null;
             if (folder.equals(account.getTrashFolderName()) || !account.hasTrashFolder()) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "Deleting messages in trash folder or trash set to -None-, not copying");
+                }
 
                 localFolder.setFlags(messages, Collections.singleton(Flag.DELETED), true);
             } else {
@@ -3962,8 +4030,9 @@ public class MessagingController implements Runnable {
                     localTrashFolder.create(Folder.FolderType.HOLDS_MESSAGES);
                 }
                 if (localTrashFolder.exists()) {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.d(K9.LOG_TAG, "Deleting messages in normal folder, moving");
+                    }
 
                     uidMap = localFolder.moveMessages(messages, localTrashFolder);
 
@@ -3977,8 +4046,9 @@ public class MessagingController implements Runnable {
                 }
             }
 
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "Delete policy for account " + account.getDescription() + " is " + account.getDeletePolicy());
+            }
 
             if (folder.equals(account.getOutboxFolderName())) {
                 for (Message message : messages) {
@@ -4005,8 +4075,9 @@ public class MessagingController implements Runnable {
                 queueSetFlag(account, folder, Boolean.toString(true), Flag.SEEN.toString(), uids);
                 processPendingCommands(account);
             } else {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "Delete policy " + account.getDeletePolicy() + " prevents delete from server");
+                }
             }
 
             unsuppressMessages(account, messages);
@@ -4117,18 +4188,20 @@ public class MessagingController implements Runnable {
     }
 
     public void sendAlternate(final Context context, Account account, Message message) {
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "About to load message " + account.getDescription() + ":" + message.getFolder().getName()
                   + ":" + message.getUid() + " for sendAlternate");
+        }
 
         loadMessageForView(account, message.getFolder().getName(),
         message.getUid(), new MessagingListener() {
             @Override
             public void loadMessageForViewBodyAvailable(Account account, String folder, String uid,
             Message message) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "Got message " + account.getDescription() + ":" + folder
                           + ":" + message.getUid() + " for sendAlternate");
+                }
 
                 try {
                     Intent msg = new Intent(Intent.ACTION_SEND);
@@ -4207,8 +4280,9 @@ public class MessagingController implements Runnable {
             public void run() {
 
                 try {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.i(K9.LOG_TAG, "Starting mail check");
+                    }
                     Preferences prefs = Preferences.getPreferences(context);
 
                     Collection<Account> accounts;
@@ -4262,13 +4336,15 @@ public class MessagingController implements Runnable {
         }
         final long accountInterval = account.getAutomaticCheckIntervalMinutes() * 60 * 1000;
         if (!ignoreLastCheckedTime && accountInterval <= 0) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "Skipping synchronizing account " + account.getDescription());
+            }
             return;
         }
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "Synchronizing account " + account.getDescription());
+        }
 
         account.setRingNotified(false);
 
@@ -4315,8 +4391,9 @@ public class MessagingController implements Runnable {
             putBackground("clear notification flag for " + account.getDescription(), null, new Runnable() {
                 @Override
                 public void run() {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.v(K9.LOG_TAG, "Clearing notification flag for " + account.getDescription());
+					}
                     account.setRingNotified(false);
                     try {
                         AccountStats stats = account.getStats(context);
@@ -4343,16 +4420,18 @@ public class MessagingController implements Runnable {
         final MessagingListener listener) {
 
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.v(K9.LOG_TAG, "Folder " + folder.getName() + " was last synced @ " +
                   new Date(folder.getLastChecked()));
+        }
 
         if (!ignoreLastCheckedTime && folder.getLastChecked() >
                 (System.currentTimeMillis() - accountInterval)) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "Not syncing folder " + folder.getName()
                       + ", previously synced @ " + new Date(folder.getLastChecked())
                       + " which would be too recent for the account period");
+            }
 
             return;
         }
@@ -4369,10 +4448,11 @@ public class MessagingController implements Runnable {
 
                     if (!ignoreLastCheckedTime && tLocalFolder.getLastChecked() >
                     (System.currentTimeMillis() - accountInterval)) {
-                        if (K9.DEBUG)
+                        if (K9.DEBUG) {
                             Log.v(K9.LOG_TAG, "Not running Command for folder " + folder.getName()
                                   + ", previously synced @ " + new Date(folder.getLastChecked())
                                   + " which would be too recent for the account period");
+                        }
                         return;
                     }
                     notifyFetchingMail(account, folder);
@@ -4530,9 +4610,10 @@ public class MessagingController implements Runnable {
             try {
                 Integer messageUid = Integer.parseInt(message.getUid());
                 if (messageUid <= localFolder.getLastUid()) {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.d(K9.LOG_TAG, "Message uid is " + messageUid + ", max message uid is " +
                               localFolder.getLastUid() + ".  Skipping notification.");
+                    }
                     return false;
                 }
             } catch (NumberFormatException e) {
@@ -5259,8 +5340,9 @@ public class MessagingController implements Runnable {
 
                     continue;
                 }
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "Starting pusher for " + account.getDescription() + ":" + folder.getName());
+                }
 
                 names.add(folder.getName());
             }
@@ -5270,9 +5352,10 @@ public class MessagingController implements Runnable {
                 int maxPushFolders = account.getMaxPushFolders();
 
                 if (names.size() > maxPushFolders) {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.i(K9.LOG_TAG, "Count of folders to push for account " + account.getDescription() + " is " + names.size()
                               + ", greater than limit of " + maxPushFolders + ", truncating");
+                    }
 
                     names = names.subList(0, maxPushFolders);
                 }
@@ -5280,8 +5363,9 @@ public class MessagingController implements Runnable {
                 try {
                     Store store = account.getRemoteStore();
                     if (!store.isPushCapable()) {
-                        if (K9.DEBUG)
+                        if (K9.DEBUG) {
                             Log.i(K9.LOG_TAG, "Account " + account.getDescription() + " is not push capable, skipping");
+                        }
 
                         return false;
                     }
@@ -5299,8 +5383,9 @@ public class MessagingController implements Runnable {
 
                 return true;
             } else {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "No folders are configured for pushing in account " + account.getDescription());
+                }
                 return false;
             }
 
@@ -5311,8 +5396,9 @@ public class MessagingController implements Runnable {
     }
 
     public void stopAllPushing() {
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "Stopping all pushers");
+        }
 
         Iterator<Pusher> iter = pushers.values().iterator();
         while (iter.hasNext()) {
@@ -5323,9 +5409,10 @@ public class MessagingController implements Runnable {
     }
 
     public void messagesArrived(final Account account, final Folder remoteFolder, final List<Message> messages, final boolean flagSyncOnly) {
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "Got new pushed email messages for account " + account.getDescription()
                   + ", folder " + remoteFolder.getName());
+        }
 
         final CountDownLatch latch = new CountDownLatch(1);
         putBackground("Push messageArrived of account " + account.getDescription()
@@ -5346,8 +5433,9 @@ public class MessagingController implements Runnable {
                     localFolder.setLastPush(System.currentTimeMillis());
                     localFolder.setStatus(null);
 
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.i(K9.LOG_TAG, "messagesArrived newCount = " + newCount + ", unread count = " + unreadMessageCount);
+                    }
 
                     if (unreadMessageCount == 0) {
                         notifyAccountCancel(context, account);
@@ -5384,8 +5472,9 @@ public class MessagingController implements Runnable {
         } catch (Exception e) {
             Log.e(K9.LOG_TAG, "Interrupted while awaiting latch release", e);
         }
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "MessagingController.messagesArrivedLatch released");
+        }
     }
 
     public void systemStatusChanged() {

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2305,7 +2305,7 @@ public class MessagingController implements Runnable {
                     Message localDestMessage = localDestFolder.getMessage(localDestUid);
                     if (localDestMessage != null) {
                         localDestMessage.setUid(newUid);
-                        localDestFolder.changeUid((LocalMessage)localDestMessage);
+                        localDestFolder.changeUid((LocalMessage) localDestMessage);
                         for (MessagingListener l : getListeners()) {
                             l.messageUidChanged(account, destFolder, localDestUid, newUid);
                         }
@@ -2684,7 +2684,7 @@ public class MessagingController implements Runnable {
             }
 
             Store localStore = account.getLocalStore();
-            LocalFolder localFolder = (LocalFolder)localStore.getFolder(account.getErrorFolderName());
+            LocalFolder localFolder = (LocalFolder) localStore.getFolder(account.getErrorFolderName());
             MimeMessage message = new MimeMessage();
 
             MimeMessageHelper.setBody(message, new TextBody(body));
@@ -3473,7 +3473,9 @@ public class MessagingController implements Runnable {
                     }
 
                     if (count.incrementAndGet() > K9.MAX_SEND_ATTEMPTS) {
-                        Log.e(K9.LOG_TAG, "Send count for message " + message.getUid() + " can't be delivered after " + K9.MAX_SEND_ATTEMPTS + " attempts.  Giving up until the user restarts the device");
+                        Log.e(K9.LOG_TAG, "Send count for message " + message.getUid() +
+                              " can't be delivered after " + K9.MAX_SEND_ATTEMPTS +
+                              " attempts.  Giving up until the user restarts the device");
                         notifySendTempFailed(account, new MessagingException(message.getSubject()));
                         continue;
                     }
@@ -4305,8 +4307,9 @@ public class MessagingController implements Runnable {
                     @Override
                     public void run() {
 
-                        if (K9.DEBUG)
+                        if (K9.DEBUG) {
                             Log.i(K9.LOG_TAG, "Finished mail sync");
+                        }
 
                         if (wakeLock != null) {
                             wakeLock.release();
@@ -5170,7 +5173,7 @@ public class MessagingController implements Runnable {
     /** Cancel a notification of new email messages */
     public void notifyAccountCancel(Context context, Account account) {
         NotificationManager notifMgr =
-            (NotificationManager)context.getSystemService(Context.NOTIFICATION_SERVICE);
+            (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         notifMgr.cancel(account.getAccountNumber());
         notifMgr.cancel(-1000 - account.getAccountNumber());
         notificationData.remove(account.getAccountNumber());

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
@@ -40,8 +40,9 @@ public class MessagingControllerPushReceiver implements PushReceiver {
     }
 
     public void syncFolder(Folder folder) {
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.v(K9.LOG_TAG, "syncFolder(" + folder.getName() + ")");
+        }
         final CountDownLatch latch = new CountDownLatch(1);
         controller.synchronizeMailbox(account, folder.getName(), new MessagingListener() {
             @Override
@@ -57,12 +58,14 @@ public class MessagingControllerPushReceiver implements PushReceiver {
             }
         }, folder);
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.v(K9.LOG_TAG, "syncFolder(" + folder.getName() + ") about to await latch release");
+        }
         try {
             latch.await();
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "syncFolder(" + folder.getName() + ") got latch release");
+            }
         } catch (Exception e) {
             Log.e(K9.LOG_TAG, "Interrupted while awaiting latch release", e);
         }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
@@ -24,128 +24,128 @@ import com.fsck.k9.mailstore.LocalMessage;
  * </p>
  */
 public class MessagingListener {
-    public void searchStats(AccountStats stats) {}
+    public void searchStats(AccountStats stats) { }
 
 
-    public void accountStatusChanged(BaseAccount account, AccountStats stats) {}
+    public void accountStatusChanged(BaseAccount account, AccountStats stats) { }
 
-    public void accountSizeChanged(Account account, long oldSize, long newSize) {}
-
-
-    public void listFoldersStarted(Account account) {}
-
-    public void listFolders(Account account, List<? extends Folder> folders) {}
-
-    public void listFoldersFinished(Account account) {}
-
-    public void listFoldersFailed(Account account, String message) {}
+    public void accountSizeChanged(Account account, long oldSize, long newSize) { }
 
 
-    public void listLocalMessagesStarted(Account account, String folder) {}
+    public void listFoldersStarted(Account account) { }
+
+    public void listFolders(Account account, List<? extends Folder> folders) { }
+
+    public void listFoldersFinished(Account account) { }
+
+    public void listFoldersFailed(Account account, String message) { }
+
+
+    public void listLocalMessagesStarted(Account account, String folder) { }
 
     public void listLocalMessagesAddMessages(Account account, String folder,
-            List<LocalMessage> messages) {}
+            List<LocalMessage> messages) { }
 
-    public void listLocalMessagesUpdateMessage(Account account, String folder, Message message) {}
+    public void listLocalMessagesUpdateMessage(Account account, String folder, Message message) { }
 
-    public void listLocalMessagesRemoveMessage(Account account, String folder, Message message) {}
+    public void listLocalMessagesRemoveMessage(Account account, String folder, Message message) { }
 
-    public void listLocalMessagesFinished(Account account, String folder) {}
+    public void listLocalMessagesFinished(Account account, String folder) { }
 
-    public void listLocalMessagesFailed(Account account, String folder, String message) {}
+    public void listLocalMessagesFailed(Account account, String folder, String message) { }
 
 
-    public void synchronizeMailboxStarted(Account account, String folder) {}
+    public void synchronizeMailboxStarted(Account account, String folder) { }
 
-    public void synchronizeMailboxHeadersStarted(Account account, String folder) {}
+    public void synchronizeMailboxHeadersStarted(Account account, String folder) { }
 
     public void synchronizeMailboxHeadersProgress(Account account, String folder,
-            int completed, int total) {}
+            int completed, int total) { }
 
     public void synchronizeMailboxHeadersFinished(Account account, String folder,
-            int totalMessagesInMailbox, int numNewMessages) {}
+            int totalMessagesInMailbox, int numNewMessages) { }
 
     public void synchronizeMailboxProgress(Account account, String folder, int completed,
-            int total) {}
+            int total) { }
 
-    public void synchronizeMailboxNewMessage(Account account, String folder, Message message) {}
+    public void synchronizeMailboxNewMessage(Account account, String folder, Message message) { }
 
     public void synchronizeMailboxAddOrUpdateMessage(Account account, String folder,
-            Message message) {}
+            Message message) { }
 
     public void synchronizeMailboxRemovedMessage(Account account, String folder,
-            Message message) {}
+            Message message) { }
 
     public void synchronizeMailboxFinished(Account account, String folder,
-            int totalMessagesInMailbox, int numNewMessages) {}
+            int totalMessagesInMailbox, int numNewMessages) { }
 
-    public void synchronizeMailboxFailed(Account account, String folder, String message) {}
+    public void synchronizeMailboxFailed(Account account, String folder, String message) { }
 
 
-    public void loadMessageForViewStarted(Account account, String folder, String uid) {}
+    public void loadMessageForViewStarted(Account account, String folder, String uid) { }
 
     public void loadMessageForViewHeadersAvailable(Account account, String folder, String uid,
-            Message message) {}
+            Message message) { }
 
     public void loadMessageForViewBodyAvailable(Account account, String folder, String uid,
-            Message message) {}
+            Message message) { }
 
     public void loadMessageForViewFinished(Account account, String folder, String uid,
-            LocalMessage message) {}
+            LocalMessage message) { }
 
     public void loadMessageForViewFailed(Account account, String folder, String uid,
-            Throwable t) {}
+            Throwable t) { }
 
     /**
      * Called when a message for view has been fully displayed on the screen.
      */
-    public void messageViewFinished() {}
+    public void messageViewFinished() { }
 
 
-    public void checkMailStarted(Context context, Account account) {}
+    public void checkMailStarted(Context context, Account account) { }
 
-    public void checkMailFinished(Context context, Account account) {}
+    public void checkMailFinished(Context context, Account account) { }
 
-    public void checkMailFailed(Context context, Account account, String reason) {}
-
-
-    public void sendPendingMessagesStarted(Account account) {}
-
-    public void sendPendingMessagesCompleted(Account account) {}
-
-    public void sendPendingMessagesFailed(Account account) {}
+    public void checkMailFailed(Context context, Account account, String reason) { }
 
 
-    public void emptyTrashCompleted(Account account) {}
+    public void sendPendingMessagesStarted(Account account) { }
+
+    public void sendPendingMessagesCompleted(Account account) { }
+
+    public void sendPendingMessagesFailed(Account account) { }
 
 
-    public void folderStatusChanged(Account account, String folderName, int unreadMessageCount) {}
+    public void emptyTrashCompleted(Account account) { }
 
 
-    public void systemStatusChanged() {}
+    public void folderStatusChanged(Account account, String folderName, int unreadMessageCount) { }
 
 
-    public void messageDeleted(Account account, String folder, Message message) {}
-
-    public void messageUidChanged(Account account, String folder, String oldUid, String newUid) {}
+    public void systemStatusChanged() { }
 
 
-    public void setPushActive(Account account, String folderName, boolean enabled) {}
+    public void messageDeleted(Account account, String folder, Message message) { }
+
+    public void messageUidChanged(Account account, String folder, String oldUid, String newUid) { }
 
 
-    public void loadAttachmentFinished(Account account, Message message, Part part) {}
-
-    public void loadAttachmentFailed(Account account, Message message, Part part, String reason) {}
+    public void setPushActive(Account account, String folderName, boolean enabled) { }
 
 
+    public void loadAttachmentFinished(Account account, Message message, Part part) { }
 
-    public void pendingCommandStarted(Account account, String commandTitle) {}
+    public void loadAttachmentFailed(Account account, Message message, Part part, String reason) { }
 
-    public void pendingCommandsProcessing(Account account) {}
 
-    public void pendingCommandCompleted(Account account, String commandTitle) {}
 
-    public void pendingCommandsFinished(Account account) {}
+    public void pendingCommandStarted(Account account, String commandTitle) { }
+
+    public void pendingCommandsProcessing(Account account) { }
+
+    public void pendingCommandCompleted(Account account, String commandTitle) { }
+
+    public void pendingCommandsFinished(Account account) { }
 
 
     /**
@@ -153,7 +153,7 @@ public class MessagingListener {
      *
      * @param folder
      */
-    public void remoteSearchStarted(String folder) {}
+    public void remoteSearchStarted(String folder) { }
 
 
     /**
@@ -177,7 +177,7 @@ public class MessagingListener {
      *  @param folder
      * @param numResults
      */
-    public void remoteSearchFinished(String folder, int numResults, int maxResults, List<Message> extraResults) {}
+    public void remoteSearchFinished(String folder, int numResults, int maxResults, List<Message> extraResults) { }
 
     /**
      * Called when there was a problem with a remote search operation.
@@ -195,7 +195,7 @@ public class MessagingListener {
      *         {@code true} if the controller will continue on to another command immediately.
      *         {@code false} otherwise.
      */
-    public void controllerCommandCompleted(boolean moreCommandsToRun) {}
+    public void controllerCommandCompleted(boolean moreCommandsToRun) { }
 
     public void enableProgressIndicator(boolean enable) { }
 }

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -665,7 +665,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         if (mCurrentFolder != null && mCurrentFolder.loading && mListener.getFolderTotal() > 0) {
             int divisor = mListener.getFolderTotal();
             if (divisor != 0) {
-                level = (Window.PROGRESS_END / divisor) * (mListener.getFolderCompleted()) ;
+                level = (Window.PROGRESS_END / divisor) * (mListener.getFolderCompleted());
                 if (level > Window.PROGRESS_END) {
                     level = Window.PROGRESS_END;
                 }
@@ -1602,7 +1602,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
         menu.setHeaderTitle(subject);
 
-        if(  mSelected.contains(mContextMenuUniqueId)) {
+        if (mSelected.contains(mContextMenuUniqueId)) {
             menu.findItem(R.id.select).setVisible(false);
         } else {
             menu.findItem(R.id.deselect).setVisible(false);
@@ -1879,7 +1879,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
 
             // 1 preview line is needed even if it is set to 0, because subject is part of the same text view
-            holder.preview.setLines(Math.max(mPreviewLines,1));
+            holder.preview.setLines(Math.max(mPreviewLines, 1));
             mFontSizes.setViewTextSize(holder.preview, mFontSizes.getMessageListPreview());
             holder.threadCount = (TextView) view.findViewById(R.id.thread_count);
             mFontSizes.setViewTextSize(holder.threadCount, mFontSizes.getMessageListSubject()); // thread count is next to subject
@@ -2036,11 +2036,11 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
             holder.preview.setText(messageStringBuilder, TextView.BufferType.SPANNABLE);
 
-            Spannable str = (Spannable)holder.preview.getText();
+            Spannable str = (Spannable) holder.preview.getText();
 
             // Create a span section for the sender, and assign the correct font size and weight
             int fontSize = (mSenderAboveSubject) ?
-                    mFontSizes.getMessageListSubject():
+                    mFontSizes.getMessageListSubject() :
                     mFontSizes.getMessageListSender();
 
             AbsoluteSizeSpan span = new AbsoluteSizeSpan(fontSize, true);
@@ -2065,7 +2065,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 statusHolder = mForwardedIcon;
             }
 
-            if (holder.from != null ) {
+            if (holder.from != null) {
                 holder.from.setTypeface(Typeface.create(holder.from.getTypeface(), maybeBoldTypeface));
                 if (mSenderAboveSubject) {
                     holder.from.setCompoundDrawablesWithIntrinsicBounds(
@@ -2080,7 +2080,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 }
             }
 
-            if (holder.subject != null ) {
+            if (holder.subject != null) {
                 if (!mSenderAboveSubject) {
                     holder.subject.setCompoundDrawablesWithIntrinsicBounds(
                             statusHolder, // left
@@ -2241,7 +2241,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         Cursor cursor = (Cursor) mAdapter.getItem(adapterPosition);
         boolean flagged = (cursor.getInt(FLAGGED_COLUMN) == 1);
 
-        setFlag(adapterPosition,Flag.FLAGGED, !flagged);
+        setFlag(adapterPosition, Flag.FLAGGED, !flagged);
     }
 
     private void toggleMessageSelectWithAdapterPosition(int adapterPosition) {

--- a/k9mail/src/main/java/com/fsck/k9/helper/HtmlConverter.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HtmlConverter.java
@@ -57,7 +57,12 @@ public class HtmlConverter {
         + "|u[agksyz]"
         + "|v[aceginu]"
         + "|w[fs]"
-        + "|(?:xn\\-\\-0zwm56d|xn\\-\\-11b5bs3a9aj6g|xn\\-\\-80akhbyknj4f|xn\\-\\-9t4b11yi5a|xn\\-\\-deba0ad|xn\\-\\-fiqs8s|xn\\-\\-fiqz9s|xn\\-\\-fzc2c9e2c|xn\\-\\-g6w251d|xn\\-\\-hgbk6aj7f53bba|xn\\-\\-hlcj6aya9esc7a|xn\\-\\-j6w193g|xn\\-\\-jxalpdlp|xn\\-\\-kgbechtv|xn\\-\\-kprw13d|xn\\-\\-kpry57d|xn\\-\\-mgbaam7a8h|xn\\-\\-mgbayh7gpa|xn\\-\\-mgberp4a5d4ar|xn\\-\\-o3cw4h|xn\\-\\-p1ai|xn\\-\\-pgbs0dh|xn\\-\\-wgbh1c|xn\\-\\-wgbl6a|xn\\-\\-xkc2al3hye2a|xn\\-\\-ygbi2ammx|xn\\-\\-zckzah)"
+        + "|(?:xn\\-\\-0zwm56d|xn\\-\\-11b5bs3a9aj6g|xn\\-\\-80akhbyknj4f|xn\\-\\-9t4b11yi5a|xn\\-"
+		+ "\\-deba0ad|xn\\-\\-fiqs8s|xn\\-\\-fiqz9s|xn\\-\\-fzc2c9e2c|xn\\-\\-g6w251d|xn\\-\\-"
+		+ "hgbk6aj7f53bba|xn\\-\\-hlcj6aya9esc7a|xn\\-\\-j6w193g|xn\\-\\-jxalpdlp|xn\\-\\-"
+		+ "kgbechtv|xn\\-\\-kprw13d|xn\\-\\-kpry57d|xn\\-\\-mgbaam7a8h|xn\\-\\-mgbayh7gpa|xn\\-\\-"
+		+ "mgberp4a5d4ar|xn\\-\\-o3cw4h|xn\\-\\-p1ai|xn\\-\\-pgbs0dh|xn\\-\\-wgbh1c|xn\\-\\-"
+		+ "wgbl6a|xn\\-\\-xkc2al3hye2a|xn\\-\\-ygbi2ammx|xn\\-\\-zckzah)"
         + "|y[et]"
         + "|z[amw]))";
     private static final String BITCOIN_URI_PATTERN =
@@ -88,15 +93,15 @@ public class HtmlConverter {
      * represented as 0xfffc. When displayed, these show up as undisplayed squares. These constants
      * define the object character and the replacement character.
      */
-    private static final char PREVIEW_OBJECT_CHARACTER = (char)0xfffc;
-    private static final char PREVIEW_OBJECT_REPLACEMENT = (char)0x20;  // space
+    private static final char PREVIEW_OBJECT_CHARACTER = (char) 0xfffc;
+    private static final char PREVIEW_OBJECT_REPLACEMENT = (char) 0x20;  // space
 
     /**
      * toHtml() converts non-breaking spaces into the UTF-8 non-breaking space, which doesn't get
      * rendered properly in some clients. Replace it with a simple space.
      */
-    private static final char NBSP_CHARACTER = (char)0x00a0;    // utf-8 non-breaking space
-    private static final char NBSP_REPLACEMENT = (char)0x20;    // space
+    private static final char NBSP_CHARACTER = (char) 0x00a0;    // utf-8 non-breaking space
+    private static final char NBSP_REPLACEMENT = (char) 0x20;    // space
 
     // Number of extra bytes to allocate in a string buffer for htmlification.
     private static final int TEXT_TO_HTML_EXTRA_BUFFER_LENGTH = 512;
@@ -229,7 +234,7 @@ public class HtmlConverter {
                     break;
                 default:
                     buff.append((char)c);
-                }//switch
+                } //switch
             }
         } catch (IOException e) {
             //Should never happen
@@ -339,26 +344,26 @@ public class HtmlConverter {
 
         // Make newlines at the end of blockquotes nicer by putting newlines beyond the first one outside of the
         // blockquote.
-        text = text.replaceAll(
+        String localText = text.replaceAll(
                    "\\Q" + HTML_NEWLINE + "\\E((\\Q" + HTML_NEWLINE + "\\E)+?)\\Q" + HTML_BLOCKQUOTE_END + "\\E",
                    HTML_BLOCKQUOTE_END + "$1"
                );
 
         // Replace lines of -,= or _ with horizontal rules
-        text = text.replaceAll("\\s*([-=_]{30,}+)\\s*", "<hr />");
+        localText = localText.replaceAll("\\s*([-=_]{30,}+)\\s*", "<hr />");
 
-        StringBuffer sb = new StringBuffer(text.length() + TEXT_TO_HTML_EXTRA_BUFFER_LENGTH);
+        StringBuffer sb = new StringBuffer(localText.length() + TEXT_TO_HTML_EXTRA_BUFFER_LENGTH);
 
         sb.append(htmlifyMessageHeader());
-        linkifyText(text, sb);
+        linkifyText(localText, sb);
         sb.append(htmlifyMessageFooter());
 
-        text = sb.toString();
+        localText = sb.toString();
 
         // Above we replaced > with <gt>, now make it &gt;
-        text = text.replaceAll("<gt>", "&gt;");
+        localText = localText.replaceAll("<gt>", "&gt;");
 
-        return text;
+        return localText;
     }
 
     private static void appendchar(StringBuilder buff, int c) {
@@ -473,8 +478,9 @@ public class HtmlConverter {
     private static boolean hasEmoji(String html) {
         for (int i = 0; i < html.length(); ++i) {
             char c = html.charAt(i);
-            if (c >= 0xDBB8 && c < 0xDBBC)
+            if (c >= 0xDBB8 && c < 0xDBBC) {
                 return true;
+            }
         }
         return false;
     }
@@ -488,10 +494,12 @@ public class HtmlConverter {
         for (int i = 0; i < html.length(); i = html.offsetByCodePoints(i, 1)) {
             int codePoint = html.codePointAt(i);
             String emoji = getEmojiForCodePoint(codePoint);
-            if (emoji != null)
+            if (emoji != null) {
                 buff.append("<img src=\"file:///android_asset/emoticons/").append(emoji).append(".gif\" alt=\"").append(emoji).append("\" />");
-            else
+            }
+            else {
                 buff.appendCodePoint(codePoint);
+            }
 
         }
         return buff.toString();

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -455,29 +455,33 @@ public class LocalMessage extends MimeMessage {
 
     @Override
     public void setHeader(String name, String value) throws MessagingException {
-        if (!mHeadersLoaded)
+        if (!mHeadersLoaded) {
             loadHeaders();
+        }
         super.setHeader(name, value);
     }
 
     @Override
     public String[] getHeader(String name) throws MessagingException {
-        if (!mHeadersLoaded)
+        if (!mHeadersLoaded) {
             loadHeaders();
+        }
         return super.getHeader(name);
     }
 
     @Override
     public void removeHeader(String name) throws MessagingException {
-        if (!mHeadersLoaded)
+        if (!mHeadersLoaded) {
             loadHeaders();
+        }
         super.removeHeader(name);
     }
 
     @Override
     public Set<String> getHeaderNames() throws MessagingException {
-        if (!mHeadersLoaded)
+        if (!mHeadersLoaded) {
             loadHeaders();
+        }
         return super.getHeaderNames();
     }
 
@@ -533,9 +537,15 @@ public class LocalMessage extends MimeMessage {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        if (!super.equals(o)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
 
         final LocalMessage that = (LocalMessage) o;
         return !(getAccountUuid() != null ? !getAccountUuid().equals(that.getAccountUuid()) : that.getAccountUuid() != null);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -265,8 +265,9 @@ public class LocalStore extends Store implements Serializable {
     }
 
     public void compact() throws MessagingException {
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "Before compaction size = " + getSize());
+        }
 
         database.execute(false, new DbCallback<Void>() {
             @Override
@@ -275,14 +276,16 @@ public class LocalStore extends Store implements Serializable {
                 return null;
             }
         });
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "After compaction size = " + getSize());
+        }
     }
 
 
     public void clear() throws MessagingException {
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "Before prune size = " + getSize());
+        }
 
         deleteAllMessageDataFromDisk();
         if (K9.DEBUG) {
@@ -359,12 +362,12 @@ public class LocalStore extends Store implements Serializable {
 
     // TODO this takes about 260-300ms, seems slow.
     @Override
-    public List <? extends Folder > getPersonalNamespaces(boolean forceListAll) throws MessagingException {
+    public List<?extends Folder> getPersonalNamespaces(boolean forceListAll) throws MessagingException {
         final List<LocalFolder> folders = new LinkedList<LocalFolder>();
         try {
-            database.execute(false, new DbCallback < List <? extends Folder >> () {
+            database.execute(false, new DbCallback<List<?extends Folder>> () {
                 @Override
-                public List <? extends Folder > doDbWork(final SQLiteDatabase db) throws WrappedException {
+                public List<?extends Folder> doDbWork(final SQLiteDatabase db) throws WrappedException {
                     Cursor cursor = null;
 
                     try {

--- a/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
@@ -120,34 +120,34 @@ public class EmailProvider extends ContentProvider {
     }
 
     public interface SpecialColumns {
-        public static final String ACCOUNT_UUID = "account_uuid";
+        static final String ACCOUNT_UUID = "account_uuid";
 
-        public static final String THREAD_COUNT = "thread_count";
+        static final String THREAD_COUNT = "thread_count";
 
-        public static final String FOLDER_NAME = "name";
-        public static final String INTEGRATE = "integrate";
+        static final String FOLDER_NAME = "name";
+        static final String INTEGRATE = "integrate";
     }
 
     public interface MessageColumns {
-        public static final String ID = "id";
-        public static final String UID = "uid";
-        public static final String INTERNAL_DATE = "internal_date";
-        public static final String SUBJECT = "subject";
-        public static final String DATE = "date";
-        public static final String MESSAGE_ID = "message_id";
-        public static final String SENDER_LIST = "sender_list";
-        public static final String TO_LIST = "to_list";
-        public static final String CC_LIST = "cc_list";
-        public static final String BCC_LIST = "bcc_list";
-        public static final String REPLY_TO_LIST = "reply_to_list";
-        public static final String FLAGS = "flags";
-        public static final String ATTACHMENT_COUNT = "attachment_count";
-        public static final String FOLDER_ID = "folder_id";
-        public static final String PREVIEW = "preview";
-        public static final String READ = "read";
-        public static final String FLAGGED = "flagged";
-        public static final String ANSWERED = "answered";
-        public static final String FORWARDED = "forwarded";
+        static final String ID = "id";
+        static final String UID = "uid";
+        static final String INTERNAL_DATE = "internal_date";
+        static final String SUBJECT = "subject";
+        static final String DATE = "date";
+        static final String MESSAGE_ID = "message_id";
+        static final String SENDER_LIST = "sender_list";
+        static final String TO_LIST = "to_list";
+        static final String CC_LIST = "cc_list";
+        static final String BCC_LIST = "bcc_list";
+        static final String REPLY_TO_LIST = "reply_to_list";
+        static final String FLAGS = "flags";
+        static final String ATTACHMENT_COUNT = "attachment_count";
+        static final String FOLDER_ID = "folder_id";
+        static final String PREVIEW = "preview";
+        static final String READ = "read";
+        static final String FLAGGED = "flagged";
+        static final String ANSWERED = "answered";
+        static final String FORWARDED = "forwarded";
     }
 
     private interface InternalMessageColumns extends MessageColumns {
@@ -157,32 +157,32 @@ public class EmailProvider extends ContentProvider {
     }
 
     public interface FolderColumns {
-        public static final String ID = "id";
-        public static final String NAME = "name";
-        public static final String LAST_UPDATED = "last_updated";
-        public static final String UNREAD_COUNT = "unread_count";
-        public static final String VISIBLE_LIMIT = "visible_limit";
-        public static final String STATUS = "status";
-        public static final String PUSH_STATE = "push_state";
-        public static final String LAST_PUSHED = "last_pushed";
-        public static final String FLAGGED_COUNT = "flagged_count";
-        public static final String INTEGRATE = "integrate";
-        public static final String TOP_GROUP = "top_group";
-        public static final String POLL_CLASS = "poll_class";
-        public static final String PUSH_CLASS = "push_class";
-        public static final String DISPLAY_CLASS = "display_class";
+        static final String ID = "id";
+        static final String NAME = "name";
+        static final String LAST_UPDATED = "last_updated";
+        static final String UNREAD_COUNT = "unread_count";
+        static final String VISIBLE_LIMIT = "visible_limit";
+        static final String STATUS = "status";
+        static final String PUSH_STATE = "push_state";
+        static final String LAST_PUSHED = "last_pushed";
+        static final String FLAGGED_COUNT = "flagged_count";
+        static final String INTEGRATE = "integrate";
+        static final String TOP_GROUP = "top_group";
+        static final String POLL_CLASS = "poll_class";
+        static final String PUSH_CLASS = "push_class";
+        static final String DISPLAY_CLASS = "display_class";
     }
 
     public interface ThreadColumns {
-        public static final String ID = "id";
-        public static final String MESSAGE_ID = "message_id";
-        public static final String ROOT = "root";
-        public static final String PARENT = "parent";
+        static final String ID = "id";
+        static final String MESSAGE_ID = "message_id";
+        static final String ROOT = "root";
+        static final String PARENT = "parent";
     }
 
     public interface StatsColumns {
-        public static final String UNREAD_COUNT = "unread_count";
-        public static final String FLAGGED_COUNT = "flagged_count";
+        static final String UNREAD_COUNT = "unread_count";
+        static final String FLAGGED_COUNT = "flagged_count";
     }
 
     private static final String[] STATS_DEFAULT_PROJECTION = {

--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -321,7 +321,7 @@ public class MessageProvider extends ContentProvider {
                 projectionToUse = projection;
             }
 
-            final LinkedHashMap < String, FieldExtractor < MessageInfoHolder, ? >> extractors = resolveMessageExtractors(projectionToUse, holders.size());
+            final LinkedHashMap<String, FieldExtractor <MessageInfoHolder, ?>> extractors = resolveMessageExtractors(projectionToUse, holders.size());
             final int fieldCount = extractors.size();
 
             final String[] actualProjection = extractors.keySet().toArray(new String[fieldCount]);
@@ -343,8 +343,8 @@ public class MessageProvider extends ContentProvider {
         }
 
         // returns LinkedHashMap (rather than Map) to emphasize the inner element ordering
-        protected LinkedHashMap < String, FieldExtractor < MessageInfoHolder, ? >> resolveMessageExtractors(final String[] projection, int count) {
-            final LinkedHashMap < String, FieldExtractor < MessageInfoHolder, ? >> extractors = new LinkedHashMap < String, FieldExtractor < MessageInfoHolder, ? >> ();
+        protected LinkedHashMap<String, FieldExtractor <MessageInfoHolder, ?>> resolveMessageExtractors(final String[] projection, int count) {
+            final LinkedHashMap<String, FieldExtractor <MessageInfoHolder, ?>> extractors = new LinkedHashMap<String, FieldExtractor <MessageInfoHolder, ?>> ();
 
             for (final String field : projection) {
                 if (extractors.containsKey(field)) {
@@ -410,20 +410,21 @@ public class MessageProvider extends ContentProvider {
         }
 
         public Cursor getAllAccounts(String[] projection) {
+            String[] localProjection = projection;
             // Default projection
-            if(projection == null) {
-                projection = new String[] { FIELD_ACCOUNT_NUMBER, FIELD_ACCOUNT_NAME };
+            if (localProjection == null) {
+                localProjection = new String[] { FIELD_ACCOUNT_NUMBER, FIELD_ACCOUNT_NAME };
             }
 
 
-            MatrixCursor ret = new MatrixCursor(projection);
+            MatrixCursor ret = new MatrixCursor(localProjection);
 
             for (Account account : Preferences.getPreferences(getContext()).getAccounts()) {
-                Object[] values = new Object[projection.length];
+                Object[] values = new Object[localProjection.length];
 
                 // Build account row
                 int fieldIndex = 0;
-                for(String field : projection) {
+                for(String field : localProjection) {
 
                     if(FIELD_ACCOUNT_NUMBER.equals(field)) {
                         values[fieldIndex] = account.getAccountNumber();

--- a/k9mail/src/main/java/com/fsck/k9/service/MailService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/MailService.java
@@ -106,40 +106,48 @@ public class MailService extends CoreService {
 
         syncBlocked = !(doBackground && hasConnectivity);
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "MailService.onStart(" + intent + ", " + startId
                   + "), hasConnectivity = " + hasConnectivity + ", doBackground = " + doBackground);
+        }
 
         // MessagingController.getInstance(getApplication()).addListener(mListener);
         if (ACTION_CHECK_MAIL.equals(intent.getAction())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "***** MailService *****: checking mail");
+            }
             if (hasConnectivity && doBackground) {
                 PollService.startService(this);
             }
             reschedulePollInBackground(hasConnectivity, doBackground, startId, false);
         } else if (ACTION_CANCEL.equals(intent.getAction())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "***** MailService *****: cancel");
+            }
             cancel();
         } else if (ACTION_RESET.equals(intent.getAction())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "***** MailService *****: reschedule");
+            }
             rescheduleAllInBackground(hasConnectivity, doBackground, startId);
         } else if (ACTION_RESTART_PUSHERS.equals(intent.getAction())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "***** MailService *****: restarting pushers");
+            }
             reschedulePushersInBackground(hasConnectivity, doBackground, startId);
         } else if (ACTION_RESCHEDULE_POLL.equals(intent.getAction())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "***** MailService *****: rescheduling poll");
+            }
             reschedulePollInBackground(hasConnectivity, doBackground, startId, true);
         } else if (ACTION_REFRESH_PUSHERS.equals(intent.getAction())) {
             refreshPushersInBackground(hasConnectivity, doBackground, startId);
         } else if (CONNECTIVITY_CHANGE.equals(intent.getAction())) {
             rescheduleAllInBackground(hasConnectivity, doBackground, startId);
-            if (K9.DEBUG)
-                Log.i(K9.LOG_TAG, "Got connectivity action with hasConnectivity = " + hasConnectivity + ", doBackground = " + doBackground);
+            if (K9.DEBUG) {
+                Log.i(K9.LOG_TAG, "Got connectivity action with hasConnectivity = " + hasConnectivity +
+                      ", doBackground = " + doBackground);
+            }
         } else if (CANCEL_CONNECTIVITY_NOTICE.equals(intent.getAction())) {
             /* do nothing */
         }
@@ -148,16 +156,18 @@ public class MailService extends CoreService {
             MessagingController.getInstance(getApplication()).systemStatusChanged();
         }
 
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "MailService.onStart took " + (System.currentTimeMillis() - startTime) + "ms");
+        }
 
         return START_NOT_STICKY;
     }
 
     @Override
     public void onDestroy() {
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.v(K9.LOG_TAG, "***** MailService *****: onDestroy()");
+        }
         super.onDestroy();
         //     MessagingController.getInstance(getApplication()).removeListener(mListener);
     }
@@ -173,8 +183,9 @@ public class MailService extends CoreService {
 
     public static void saveLastCheckEnd(Context context) {
         long lastCheckEnd = System.currentTimeMillis();
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "Saving lastCheckEnd = " + new Date(lastCheckEnd));
+        }
         Preferences prefs = Preferences.getPreferences(context);
         SharedPreferences sPrefs = prefs.getPreferences();
         SharedPreferences.Editor editor = sPrefs.edit();
@@ -341,8 +352,9 @@ public class MailService extends CoreService {
     private void setupPushers() {
         boolean pushing = false;
         for (Account account : Preferences.getPreferences(MailService.this).getAccounts()) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "Setting up pushers for account " + account.getDescription());
+            }
             if (account.isEnabled() && account.isAvailable(getApplicationContext())) {
                 pushing |= MessagingController.getInstance(getApplication()).setupPushing(account);
             } else {
@@ -358,8 +370,9 @@ public class MailService extends CoreService {
     private void refreshPushers() {
         try {
             long nowTime = System.currentTimeMillis();
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "Refreshing pushers");
+            }
             Collection<Pusher> pushers = MessagingController.getInstance(getApplication()).getPushers();
             for (Pusher pusher : pushers) {
                 long lastRefresh = pusher.getLastRefresh();
@@ -406,8 +419,9 @@ public class MailService extends CoreService {
         }
         if (minInterval > 0) {
             long nextTime = System.currentTimeMillis() + minInterval;
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "Next pusher refresh scheduled for " + new Date(nextTime));
+            }
             Intent i = new Intent(this, MailService.class);
             i.setAction(ACTION_REFRESH_PUSHERS);
             BootReceiver.scheduleIntent(MailService.this, nextTime, i);

--- a/k9mail/src/main/java/com/fsck/k9/service/NotificationActionService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/NotificationActionService.java
@@ -80,9 +80,13 @@ public class NotificationActionService extends CoreService {
      * @param messages the messages to move to the spam folder (must be synchronized to allow true as a result)
      * @return true if the ArchiveAllMessages intent is available for the given messages
      */
-    public static boolean isArchiveAllMessagesWearAvaliable(Context context, final Account account, final LinkedList<LocalMessage> messages) {
+    public static boolean isArchiveAllMessagesWearAvaliable(Context context, final Account account,
+                                                            final LinkedList<LocalMessage> messages) {
         final MessagingController controller = MessagingController.getInstance(context);
-        return (account.getArchiveFolderName() != null && !(account.getArchiveFolderName().equals(account.getSpamFolderName()) && K9.confirmSpam()) && isMovePossible(controller, account, account.getSentFolderName(), messages));
+        return (account.getArchiveFolderName() != null &&
+                !(account.getArchiveFolderName().equals(account.getSpamFolderName()) &&
+                  K9.confirmSpam()) &&
+                isMovePossible(controller, account, account.getSentFolderName(), messages));
     }
 
     public static PendingIntent getArchiveAllMessagesIntent(Context context, final Account account, final Serializable refs) {
@@ -135,8 +139,9 @@ public class NotificationActionService extends CoreService {
     }
     @Override
     public int startService(Intent intent, int startId) {
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "NotificationActionService started with startId = " + startId);
+        }
         final Preferences preferences = Preferences.getPreferences(this);
         final MessagingController controller = MessagingController.getInstance(getApplication());
         final Account account = preferences.getAccount(intent.getStringExtra(EXTRA_ACCOUNT));
@@ -144,8 +149,9 @@ public class NotificationActionService extends CoreService {
 
         if (account != null) {
             if (READ_ALL_ACTION.equals(action)) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "NotificationActionService marking messages as read");
+                }
 
                 List<MessageReference> refs =
                         intent.getParcelableArrayListExtra(EXTRA_MESSAGE_LIST);
@@ -153,8 +159,9 @@ public class NotificationActionService extends CoreService {
                     controller.setFlag(account, ref.getFolderName(), ref.getUid(), Flag.SEEN, true);
                 }
             } else if (DELETE_ALL_ACTION.equals(action)) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "NotificationActionService deleting messages");
+                }
 
                 List<MessageReference> refs =
                         intent.getParcelableArrayListExtra(EXTRA_MESSAGE_LIST);
@@ -169,8 +176,9 @@ public class NotificationActionService extends CoreService {
 
                 controller.deleteMessages(messages, null);
             } else if (ARCHIVE_ALL_ACTION.equals(action)) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "NotificationActionService archiving messages");
+                }
 
                 List<MessageReference> refs =
                         intent.getParcelableArrayListExtra(EXTRA_MESSAGE_LIST);
@@ -189,7 +197,9 @@ public class NotificationActionService extends CoreService {
                         && isMovePossible(controller, account, dstFolder, messages)) {
                     for(LocalMessage messageToMove : messages) {
                         if (!controller.isMoveCapable(messageToMove)) {
-                            //Toast toast = Toast.makeText(getActivity(), R.string.move_copy_cannot_copy_unsynced_message, Toast.LENGTH_LONG);
+                            //Toast toast = Toast.makeText(getActivity(),
+                            //                             R.string.move_copy_cannot_copy_unsynced_message,
+                            //                             Toast.LENGTH_LONG);
                             //toast.show();
                             continue;
                         }
@@ -198,8 +208,9 @@ public class NotificationActionService extends CoreService {
                     }
                 }
             } else if (SPAM_ALL_ACTION.equals(action)) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "NotificationActionService moving messages to spam");
+                }
 
                 List<MessageReference> refs =
                         intent.getParcelableArrayListExtra(EXTRA_MESSAGE_LIST);
@@ -222,8 +233,9 @@ public class NotificationActionService extends CoreService {
                     }
                 }
             } else if (REPLY_ACTION.equals(action)) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "NotificationActionService initiating reply");
+                }
 
                 MessageReference ref = intent.getParcelableExtra(EXTRA_MESSAGE);
                 LocalMessage message = ref.restoreToLocalMessage(this);

--- a/k9mail/src/main/java/com/fsck/k9/service/PollService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/PollService.java
@@ -45,27 +45,31 @@ public class PollService extends CoreService {
     @Override
     public int startService(Intent intent, int startId) {
         if (START_SERVICE.equals(intent.getAction())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "PollService started with startId = " + startId);
+            }
 
             MessagingController controller = MessagingController.getInstance(getApplication());
             Listener listener = (Listener)controller.getCheckMailListener();
             if (listener == null) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "***** PollService *****: starting new check");
+                }
                 mListener.setStartId(startId);
                 mListener.wakeLockAcquire();
                 controller.setCheckMailListener(mListener);
                 controller.checkMail(this, null, false, false, mListener);
             } else {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.i(K9.LOG_TAG, "***** PollService *****: renewing WakeLock");
+                }
                 listener.setStartId(startId);
                 listener.wakeLockAcquire();
             }
         } else if (STOP_SERVICE.equals(intent.getAction())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "PollService stopping");
+            }
             stopSelf();
         }
 
@@ -136,8 +140,9 @@ public class PollService extends CoreService {
 
             MailService.actionReschedulePoll(PollService.this, null);
             wakeLockRelease();
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "PollService stopping with startId = " + startId);
+            }
 
             stopSelf(startId);
         }
@@ -145,8 +150,9 @@ public class PollService extends CoreService {
         @Override
         public void checkMailFinished(Context context, Account account) {
 
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.v(K9.LOG_TAG, "***** PollService *****: checkMailFinished");
+            }
             release();
         }
         public int getStartId() {

--- a/k9mail/src/main/java/com/fsck/k9/service/RemoteControlService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/RemoteControlService.java
@@ -37,13 +37,15 @@ public class RemoteControlService extends CoreService {
 
     @Override
     public int startService(final Intent intent, final int startId) {
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "RemoteControlService started with startId = " + startId);
+        }
         final Preferences preferences = Preferences.getPreferences(this);
 
         if (RESCHEDULE_ACTION.equals(intent.getAction())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "RemoteControlService requesting MailService poll reschedule");
+            }
             MailService.actionReschedulePoll(this, null);
         }
         if (PUSH_RESTART_ACTION.equals(intent.getAction())) {
@@ -51,8 +53,9 @@ public class RemoteControlService extends CoreService {
                 Log.i(K9.LOG_TAG, "RemoteControlService requesting MailService push restart");
             MailService.actionRestartPushers(this, null);
         } else if (RemoteControlService.SET_ACTION.equals(intent.getAction())) {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.i(K9.LOG_TAG, "RemoteControlService got request to change settings");
+            }
             execute(getApplication(), new Runnable() {
                 public void run() {
                     try {
@@ -72,8 +75,9 @@ public class RemoteControlService extends CoreService {
                             //warning: account may not be isAvailable()
                             if (allAccounts || account.getUuid().equals(uuid)) {
 
-                                if (K9.DEBUG)
+                                if (K9.DEBUG) {
                                     Log.i(K9.LOG_TAG, "RemoteControlService changing settings for account " + account.getDescription());
+                                }
 
                                 String notificationEnabled = intent.getStringExtra(K9_NOTIFICATION_ENABLED);
                                 String ringEnabled = intent.getStringExtra(K9_RING_ENABLED);
@@ -109,8 +113,9 @@ public class RemoteControlService extends CoreService {
                                 account.save(Preferences.getPreferences(RemoteControlService.this));
                             }
                         }
-                        if (K9.DEBUG)
+                        if (K9.DEBUG) {
                             Log.i(K9.LOG_TAG, "RemoteControlService changing global settings");
+                        }
 
                         String backgroundOps = intent.getStringExtra(K9_BACKGROUND_OPERATIONS);
                         if (K9RemoteControl.K9_BACKGROUND_OPERATIONS_ALWAYS.equals(backgroundOps)

--- a/k9mail/src/main/java/com/fsck/k9/service/SleepService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/SleepService.java
@@ -23,8 +23,9 @@ public class SleepService extends CoreService {
 
     public static void sleep(Context context, long sleepTime, TracingWakeLock wakeLock, long wakeLockTimeout) {
         Integer id = latchId.getAndIncrement();
-        if (K9.DEBUG)
+        if (K9.DEBUG) {
             Log.d(K9.LOG_TAG, "SleepService Preparing CountDownLatch with id = " + id + ", thread " + Thread.currentThread().getName());
+        }
         SleepDatum sleepDatum = new SleepDatum();
         CountDownLatch latch = new CountDownLatch(1);
         sleepDatum.latch = latch;
@@ -45,8 +46,9 @@ public class SleepService extends CoreService {
         try {
             boolean countedDown = latch.await(sleepTime, TimeUnit.MILLISECONDS);
             if (!countedDown) {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "SleepService latch timed out for id = " + id + ", thread " + Thread.currentThread().getName());
+                }
             }
         } catch (InterruptedException ie) {
             Log.e(K9.LOG_TAG, "SleepService Interrupted while awaiting latch", ie);
@@ -54,8 +56,9 @@ public class SleepService extends CoreService {
         SleepDatum releaseDatum = sleepData.remove(id);
         if (releaseDatum == null) {
             try {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "SleepService waiting for reacquireLatch for id = " + id + ", thread " + Thread.currentThread().getName());
+                }
                 if (!sleepDatum.reacquireLatch.await(5000, TimeUnit.MILLISECONDS)) {
                     Log.w(K9.LOG_TAG, "SleepService reacquireLatch timed out for id = " + id + ", thread " + Thread.currentThread().getName());
                 } else if (K9.DEBUG)
@@ -73,8 +76,9 @@ public class SleepService extends CoreService {
         if (actualSleep < sleepTime) {
             Log.w(K9.LOG_TAG, "SleepService sleep time too short: requested was " + sleepTime + ", actual was " + actualSleep);
         } else {
-            if (K9.DEBUG)
+            if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "SleepService requested sleep time was " + sleepTime + ", actual was " + actualSleep);
+            }
         }
     }
 
@@ -86,15 +90,17 @@ public class SleepService extends CoreService {
                 if (latch == null) {
                     Log.e(K9.LOG_TAG, "SleepService No CountDownLatch available with id = " + id);
                 } else {
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.d(K9.LOG_TAG, "SleepService Counting down CountDownLatch with id = " + id);
+                    }
                     latch.countDown();
                 }
                 reacquireWakeLock(sleepDatum);
                 sleepDatum.reacquireLatch.countDown();
             } else {
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "SleepService Sleep for id " + id + " already finished");
+                }
             }
         }
     }
@@ -104,8 +110,9 @@ public class SleepService extends CoreService {
         if (wakeLock != null) {
             synchronized (wakeLock) {
                 long timeout = sleepDatum.timeout;
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "SleepService Acquiring wakeLock for " + timeout + "ms");
+                }
                 wakeLock.acquire(timeout);
             }
         }

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -135,7 +135,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener {
             }
             case R.id.to:
             case R.id.cc: {
-                expand((TextView)view, ((TextView)view).getEllipsize() != null);
+                expand((TextView) view, ((TextView) view).getEllipsize() != null);
                 layoutChanged();
             }
         }
@@ -394,12 +394,12 @@ public class MessageHeader extends LinearLayout implements OnClickListener {
 
     @Override
     public void onRestoreInstanceState(Parcelable state) {
-        if(!(state instanceof SavedState)) {
+        if (!(state instanceof SavedState)) {
             super.onRestoreInstanceState(state);
             return;
         }
 
-        SavedState savedState = (SavedState)state;
+        SavedState savedState = (SavedState) state;
         super.onRestoreInstanceState(savedState.getSuperState());
 
         mSavedState = savedState;


### PR DESCRIPTION
There are many compiler warnings and I'm attempting to clean them up. Presumably Android studio hides these otherwise they'd be rather overwhelming.

It's all trivial stuff which doesn't impact usability or security. Things like line lengths, braces and whitespace.