### PR TITLE
Fix MessageProvider/delete handling of subfolders

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -1025,7 +1025,9 @@ public class MessageProvider extends ContentProvider {
         segments = uri.getPathSegments();
         accountId = Integer.parseInt(segments.get(1));
         folderName = segments.get(2);
-        msgUid = segments.get(3);
+        for (int i = 3; i < segments.length - 1; i++)
+            folderName += "/" + segments.get(i);
+        msgUid = segments.get(segments.length - 1);
 
         // get account
         Account myAccount = null;


### PR DESCRIPTION
Figured it was easier to submit a PR than describe the issue and suggest a fix :)

If you have subfolders and attempt to use MessageProvider/delete, the subfolder gets misinterpreted as the message ID.

The fix should be something like this, although I haven't tested it.