### PR TITLE
Set SNI hostname if we can for TLS connections

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
@@ -164,6 +164,7 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
             trustedSocket = socketFactory.createSocket(socket, host, port, true);
         }
         hardenSocket((SSLSocket) trustedSocket);
+        setSNIHost(socketFactory, (SSLSocket) trustedSocket, host);
         return trustedSocket;
     }
 
@@ -173,6 +174,19 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
         }
         if (ENABLED_PROTOCOLS != null) {
             sock.setEnabledProtocols(ENABLED_PROTOCOLS);
+        }
+    }
+
+    public static void setSNIHost(final SSLSocketFactory factory, final SSLSocket socket, final String hostname) {
+        if (factory instanceof android.net.SSLCertificateSocketFactory && android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            ((android.net.SSLCertificateSocketFactory)factory).setHostname(socket, hostname);
+        } else {
+            try {
+                socket.getClass().getMethod("setHostname", String.class).invoke(socket, hostname);
+            } catch (Throwable e) {
+                // ignore any error, we just can't set the hostname...
+                Log.e(LOG_TAG, "Could not call SSLSocket#setHostname(String) method ", e);
+            }
         }
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
@@ -62,6 +62,7 @@ public class WebDavSocketFactory implements LayeredSocketFactory {
                 port,
                 autoClose
         );
+        com.fsck.k9.mail.ssl.DefaultTrustedSocketFactory.setSNIHost(mSocketFactory, sslSocket, host);
         //hostnameVerifier.verify(host, sslSocket);
         // verifyHostName() didn't blowup - good!
         return sslSocket;


### PR DESCRIPTION
This patch sets the SNI hostname for TLS connections, using documented APIs for newer androids, and undocumented which works on most androids back to 2.3. This is required for any TLS connection that requires SNI to pick the correct certificate to send to the client (or multiplex based on SNI, which is what I'm using it for).