### PR TITLE
Don't use StringReader in HtmlConverter as calls to read have unneces…

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/helper/HtmlConverter.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HtmlConverter.java
@@ -2,13 +2,10 @@ package com.fsck.k9.helper;
 
 import android.text.*;
 import android.text.Html.TagHandler;
-import android.util.Log;
 import com.fsck.k9.K9;
 
 import org.xml.sax.XMLReader;
 
-import java.io.IOException;
-import java.io.StringReader;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -211,29 +208,23 @@ public class HtmlConverter {
         // Encode HTML entities to make sure we don't display something evil.
         text = TextUtils.htmlEncode(text);
 
-        StringReader reader = new StringReader(text);
         StringBuilder buff = new StringBuilder(text.length() + TEXT_TO_HTML_EXTRA_BUFFER_LENGTH);
 
         buff.append(htmlifyMessageHeader());
 
-        int c;
-        try {
-            while ((c = reader.read()) != -1) {
-                switch (c) {
-                case '\n':
-                    // pine treats <br> as two newlines, but <br/> as one newline.  Use <br/> so our messages aren't
-                    // doublespaced.
-                    buff.append("<br />");
-                    break;
-                case '\r':
-                    break;
-                default:
-                    buff.append((char)c);
-                }//switch
-            }
-        } catch (IOException e) {
-            //Should never happen
-            Log.e(K9.LOG_TAG, "Could not read string to convert text to HTML:", e);
+        for (int index = 0; index < text.length(); index++) {
+            char c = text.charAt(index);
+            switch (c) {
+            case '\n':
+                // pine treats <br> as two newlines, but <br/> as one newline.  Use <br/> so our messages aren't
+                // doublespaced.
+                buff.append("<br />");
+                break;
+            case '\r':
+                break;
+            default:
+                buff.append(c);
+            }//switch
         }
 
         buff.append(htmlifyMessageFooter());
@@ -274,60 +265,54 @@ public class HtmlConverter {
         if (text.length() > MAX_SMART_HTMLIFY_MESSAGE_LENGTH) {
             return simpleTextToHtml(text);
         }
-        StringReader reader = new StringReader(text);
         StringBuilder buff = new StringBuilder(text.length() + TEXT_TO_HTML_EXTRA_BUFFER_LENGTH);
         boolean isStartOfLine = true;  // Are we currently at the start of a line?
         int spaces = 0;
         int quoteDepth = 0; // Number of DIVs deep we are.
         int quotesThisLine = 0; // How deep we should be quoting for this line.
-        try {
-            int c;
-            while ((c = reader.read()) != -1) {
-                if (isStartOfLine) {
-                    switch (c) {
-                    case ' ':
-                        spaces++;
-                        break;
-                    case '>':
-                        quotesThisLine++;
-                        spaces = 0;
-                        break;
-                    case '\n':
-                        appendbq(buff, quotesThisLine, quoteDepth);
-                        quoteDepth = quotesThisLine;
+        for (int index = 0; index < text.length(); index++) {
+            char c = text.charAt(index);
+            if (isStartOfLine) {
+                switch (c) {
+                case ' ':
+                    spaces++;
+                    break;
+                case '>':
+                    quotesThisLine++;
+                    spaces = 0;
+                    break;
+                case '\n':
+                    appendbq(buff, quotesThisLine, quoteDepth);
+                    quoteDepth = quotesThisLine;
 
-                        appendsp(buff, spaces);
-                        spaces = 0;
+                    appendsp(buff, spaces);
+                    spaces = 0;
 
-                        appendchar(buff, c);
-                        isStartOfLine = true;
-                        quotesThisLine = 0;
-                        break;
-                    default:
-                        isStartOfLine = false;
-
-                        appendbq(buff, quotesThisLine, quoteDepth);
-                        quoteDepth = quotesThisLine;
-
-                        appendsp(buff, spaces);
-                        spaces = 0;
-
-                        appendchar(buff, c);
-                        isStartOfLine = false;
-                        break;
-                    }
-                }
-                else {
                     appendchar(buff, c);
-                    if (c == '\n') {
-                        isStartOfLine = true;
-                        quotesThisLine = 0;
-                    }
+                    isStartOfLine = true;
+                    quotesThisLine = 0;
+                    break;
+                default:
+                    isStartOfLine = false;
+
+                    appendbq(buff, quotesThisLine, quoteDepth);
+                    quoteDepth = quotesThisLine;
+
+                    appendsp(buff, spaces);
+                    spaces = 0;
+
+                    appendchar(buff, c);
+                    isStartOfLine = false;
+                    break;
                 }
             }
-        } catch (IOException e) {
-            //Should never happen
-            Log.e(K9.LOG_TAG, "Could not read string to convert text to HTML:", e);
+            else {
+                appendchar(buff, c);
+                if (c == '\n') {
+                    isStartOfLine = true;
+                    quotesThisLine = 0;
+                }
+            }
         }
         // Close off any quotes we may have opened.
         if (quoteDepth > 0) {


### PR DESCRIPTION
While profiling K-9 Mail on some older devices, I noticed that the performance of `HtmlConverter` was unexpectedly poor, regardless of whether it took the regular or simple conversion path. It turns out that `StringReader#read` acquires a lock internally, which is both unnecessary for the conversion, and adds quite a bit of overhead as it occurs once per character.

I replaced it with an for loop and index that essentially does the same thing as `StringReader`, minus locking.