### PR TITLE
Issue741 bug fix

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -690,12 +690,12 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
             }
 
             String parentMimeType = parentPart.getMimeType();
-            if (parentMimeType.startsWith("multipart/")) {
+            if (parentMimeType.toLowerCase().startsWith("multipart/")) {
                 BodyPart bodyPart = new LocalBodyPart(getAccountUuid(), message, id, displayName, size,
                         firstClassAttachment);
                 ((Multipart) parentPart.getBody()).addBodyPart(bodyPart);
                 part = bodyPart;
-            } else if (parentMimeType.startsWith("message/")) {
+            } else if (parentMimeType.toLowerCase().startsWith("message/")) {
                 Message innerMessage = new MimeMessage();
                 parentPart.setBody(innerMessage);
                 part = innerMessage;
@@ -708,7 +708,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         partById.put(id, part);
         part.setServerExtra(serverExtra);
 
-        boolean isMultipart = mimeType.startsWith("multipart/");
+        boolean isMultipart = mimeType.toLowerCase().startsWith("multipart/");
         if (isMultipart) {
             byte[] preamble = cursor.getBlob(11);
             byte[] epilogue = cursor.getBlob(12);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessageExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessageExtractor.java
@@ -479,7 +479,7 @@ public class LocalMessageExtractor {
         Body body = part.getBody();
         if (body instanceof Multipart) {
             Multipart multi = (Multipart) body;
-            if ("multipart/mixed".equals(part.getMimeType())) {
+            if ("multipart/mixed".equalsIgnoreCase(part.getMimeType())) {
                 boolean foundSome = false;
                 for (BodyPart sub : multi.getBodyParts()) {
                     foundSome |= getCryptSubPieces(sub, parts, annotations);


### PR DESCRIPTION
Fixed a bug: when checking the multipart nature of a message part, the comparison was not done case=independent. See #741 for a more complete description of the bug