### PR TITLE
Option to set a custom interval for refreshing the push connection

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -537,7 +537,7 @@ public class AccountSettings extends K9PreferenceActivity {
             if(Arrays.asList(getResources().getStringArray(R.array.idle_refresh_period_values)).contains(Integer.toString(mAccount.getIdleRefreshMinutes())))
                 mIdleRefreshPeriod.setValue(String.valueOf(mAccount.getIdleRefreshMinutes()));
             else
-                mIdleRefreshPeriod.setValue("customize");
+                mIdleRefreshPeriod.setValue("0");
 
             mIdleRefreshPeriod.setSummary(mIdleRefreshPeriod.getEntry());
             mIdleRefreshPeriod.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
@@ -546,7 +546,7 @@ public class AccountSettings extends K9PreferenceActivity {
                     int index = mIdleRefreshPeriod.findIndexOfValue(summary);
                     mIdleRefreshPeriod.setSummary(mIdleRefreshPeriod.getEntries()[index]);
                     mIdleRefreshPeriod.setValue(summary);
-                    if (summary.equals("customize"))
+                    if (summary.equals("0"))
                         mIdleRefreshCustomPeriod.setEnabled(true);
                     else
                         mIdleRefreshCustomPeriod.setEnabled(false);
@@ -555,7 +555,7 @@ public class AccountSettings extends K9PreferenceActivity {
             });
 
             mIdleRefreshCustomPeriod.setSummary(mIdleRefreshCustomPeriod.getTime());
-            if (!mIdleRefreshPeriod.getValue().equals("customize"))
+            if (!mIdleRefreshPeriod.getValue().equals("0"))
                 mIdleRefreshCustomPeriod.setEnabled(false);
             mIdleRefreshCustomPeriod.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
@@ -828,7 +828,7 @@ public class AccountSettings extends K9PreferenceActivity {
         if (mIsPushCapable) {
             mAccount.setPushPollOnConnect(mPushPollOnConnect.isChecked());
 
-            if (mIdleRefreshPeriod.getValue().equals("customize")) {
+            if (mIdleRefreshPeriod.getValue().equals("0")) {
                 mAccount.setIdleRefreshMinutes(mIdleRefreshCustomPeriod.getTimeInMinutes());
             }
             else  {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -1,6 +1,7 @@
 
 package com.fsck.k9.activity.setup;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -44,6 +45,7 @@ import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.Store;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.StorageManager;
+import com.fsck.k9.preferences.TimePickerPreference;
 import com.fsck.k9.service.MailService;
 
 import org.openintents.openpgp.util.OpenPgpAppPreference;
@@ -92,6 +94,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_PUSH_POLL_ON_CONNECT = "push_poll_on_connect";
     private static final String PREFERENCE_MAX_PUSH_FOLDERS = "max_push_folders";
     private static final String PREFERENCE_IDLE_REFRESH_PERIOD = "idle_refresh_period";
+    private static final String PREFERENCE_IDLE_REFRESH_CUSTOM_PERIOD = "idle_refresh_custom_period";
     private static final String PREFERENCE_TARGET_MODE = "folder_target_mode";
     private static final String PREFERENCE_DELETE_POLICY = "delete_policy";
     private static final String PREFERENCE_EXPUNGE_POLICY = "expunge_policy";
@@ -175,6 +178,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private CheckBoxPreference mSyncRemoteDeletions;
     private CheckBoxPreference mPushPollOnConnect;
     private ListPreference mIdleRefreshPeriod;
+    private TimePickerPreference mIdleRefreshCustomPeriod;
     private ListPreference mMaxPushFolders;
     private boolean mHasCrypto = false;
     private OpenPgpAppPreference mCryptoApp;
@@ -519,6 +523,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
         mPushPollOnConnect = (CheckBoxPreference) findPreference(PREFERENCE_PUSH_POLL_ON_CONNECT);
         mIdleRefreshPeriod = (ListPreference) findPreference(PREFERENCE_IDLE_REFRESH_PERIOD);
+        mIdleRefreshCustomPeriod = (TimePickerPreference) findPreference(PREFERENCE_IDLE_REFRESH_CUSTOM_PERIOD);
         mMaxPushFolders = (ListPreference) findPreference(PREFERENCE_MAX_PUSH_FOLDERS);
         if (mIsPushCapable) {
             mPushPollOnConnect.setChecked(mAccount.isPushPollOnConnect());
@@ -529,7 +534,11 @@ public class AccountSettings extends K9PreferenceActivity {
             updateRemoteSearchLimit(searchNumResults);
             //mRemoteSearchFullText.setChecked(mAccount.isRemoteSearchFullText());
 
-            mIdleRefreshPeriod.setValue(String.valueOf(mAccount.getIdleRefreshMinutes()));
+            if(Arrays.asList(getResources().getStringArray(R.array.idle_refresh_period_values)).contains(Integer.toString(mAccount.getIdleRefreshMinutes())))
+                mIdleRefreshPeriod.setValue(String.valueOf(mAccount.getIdleRefreshMinutes()));
+            else
+                mIdleRefreshPeriod.setValue("customize");
+
             mIdleRefreshPeriod.setSummary(mIdleRefreshPeriod.getEntry());
             mIdleRefreshPeriod.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
@@ -537,6 +546,21 @@ public class AccountSettings extends K9PreferenceActivity {
                     int index = mIdleRefreshPeriod.findIndexOfValue(summary);
                     mIdleRefreshPeriod.setSummary(mIdleRefreshPeriod.getEntries()[index]);
                     mIdleRefreshPeriod.setValue(summary);
+                    if (summary.equals("customize"))
+                        mIdleRefreshCustomPeriod.setEnabled(true);
+                    else
+                        mIdleRefreshCustomPeriod.setEnabled(false);
+                    return false;
+                }
+            });
+
+            mIdleRefreshCustomPeriod.setSummary(mIdleRefreshCustomPeriod.getTime());
+            if (!mIdleRefreshPeriod.getValue().equals("customize"))
+                mIdleRefreshCustomPeriod.setEnabled(false);
+            mIdleRefreshCustomPeriod.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    final String summary = newValue.toString();
+                    mIdleRefreshCustomPeriod.setSummary(summary);
                     return false;
                 }
             });
@@ -803,7 +827,14 @@ public class AccountSettings extends K9PreferenceActivity {
         //IMAP stuff
         if (mIsPushCapable) {
             mAccount.setPushPollOnConnect(mPushPollOnConnect.isChecked());
-            mAccount.setIdleRefreshMinutes(Integer.parseInt(mIdleRefreshPeriod.getValue()));
+
+            if (mIdleRefreshPeriod.getValue().equals("customize")) {
+                mAccount.setIdleRefreshMinutes(mIdleRefreshCustomPeriod.getTimeInMinutes());
+            }
+            else  {
+                mAccount.setIdleRefreshMinutes(Integer.parseInt(mIdleRefreshPeriod.getValue()));
+            }
+
             mAccount.setMaxPushFolders(Integer.parseInt(mMaxPushFolders.getValue()));
             mAccount.setAllowRemoteSearch(mCloudSearchEnabled.isChecked());
             mAccount.setRemoteSearchNumResults(Integer.parseInt(mRemoteSearchNumResults.getValue()));

--- a/k9mail/src/main/java/com/fsck/k9/preferences/TimePickerPreference.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/TimePickerPreference.java
@@ -171,6 +171,9 @@ public class TimePickerPreference extends DialogPreference implements
     public String getTime() {
         return getPersistedString(this.defaultValue);
     }
+    public int getTimeInMinutes(){
+        return getHour()*60 + getMinute();
+    }
 
 }
 

--- a/k9mail/src/main/res/values/arrays.xml
+++ b/k9mail/src/main/res/values/arrays.xml
@@ -596,6 +596,7 @@
         <item>@string/idle_refresh_period_36min</item>
         <item>@string/idle_refresh_period_48min</item>
         <item>@string/idle_refresh_period_60min</item>
+        <item>@string/idle_refresh_period_custom</item>
     </string-array>
 
     <string-array name="idle_refresh_period_values" translatable="false">
@@ -608,6 +609,7 @@
         <item>36</item>
         <item>48</item>
         <item>60</item>
+        <item>customize</item>
     </string-array>
 
     <string-array name="account_settings_vibrate_pattern_entries">

--- a/k9mail/src/main/res/values/arrays.xml
+++ b/k9mail/src/main/res/values/arrays.xml
@@ -609,7 +609,7 @@
         <item>36</item>
         <item>48</item>
         <item>60</item>
-        <item>customize</item>
+        <item>0</item>
     </string-array>
 
     <string-array name="account_settings_vibrate_pattern_entries">

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -488,6 +488,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="idle_refresh_period_36min">Every 36 minutes</string>
     <string name="idle_refresh_period_48min">Every 48 minutes</string>
     <string name="idle_refresh_period_60min">Every 60 minutes</string>
+    <string name="idle_refresh_period_custom">Custom</string>
+
+    <string name="idle_custom_refresh_label">Set custom interval to refresh</string>
 
     <string name="account_setup_options_notify_label">Notify me when mail arrives</string>
     <string name="account_setup_options_notify_sync_label">Notify me while mail is being checked</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -178,7 +178,7 @@
                 android:entryValues="@array/idle_refresh_period_values" />
 
             <com.fsck.k9.preferences.TimePickerPreference
-                android:persistent="true"
+                android:persistent="false"
                 android:key="idle_refresh_custom_period"
                 android:title="@string/idle_custom_refresh_label" />
 

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -177,6 +177,11 @@
                 android:entries="@array/idle_refresh_period_entries"
                 android:entryValues="@array/idle_refresh_period_values" />
 
+            <com.fsck.k9.preferences.TimePickerPreference
+                android:persistent="true"
+                android:key="idle_refresh_custom_period"
+                android:title="@string/idle_custom_refresh_label" />
+
         </PreferenceScreen>
 
     </PreferenceScreen>


### PR DESCRIPTION
Attempt to allow more values for the "Refresh Idle connection" setting by adding a "Custom" option