### PR TITLE
If selected, send client certificate before password auth

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -167,8 +167,7 @@ public class ImapStore extends RemoteStore {
         if (imapUri.getUserInfo() != null) {
             String userinfo = imapUri.getUserInfo();
             String[] userInfoParts = userinfo.split(":");
-
-            if (userinfo.endsWith(":")) {
+            if (userinfo.endsWith("::")) {
                 // Password is empty. This can only happen after an account was imported.
                 authenticationType = AuthType.valueOf(userInfoParts[0]);
                 username = decodeUtf8(userInfoParts[1]);
@@ -185,6 +184,11 @@ public class ImapStore extends RemoteStore {
                 } else {
                     password = decodeUtf8(userInfoParts[2]);
                 }
+            } else if (userInfoParts.length == 4) {
+                authenticationType = AuthType.valueOf(userInfoParts[0]);
+                username = decodeUtf8(userInfoParts[1]);
+                password = decodeUtf8(userInfoParts[2]);
+                clientCertificateAlias = decodeUtf8(userInfoParts[3]);
             }
         }
 
@@ -247,7 +251,7 @@ public class ImapStore extends RemoteStore {
         if (authType == AuthType.EXTERNAL) {
             userInfo = authType.name() + ":" + userEnc + ":" + clientCertificateAliasEnc;
         } else {
-            userInfo = authType.name() + ":" + userEnc + ":" + passwordEnc;
+            userInfo = authType.name() + ":" + userEnc + ":" + passwordEnc + ":" + clientCertificateAliasEnc;
         }
         try {
             Map<String, String> extra = server.getExtra();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -110,7 +110,12 @@ public class SmtpTransport extends Transport {
                 } else {
                     password = decodeUtf8(userInfoParts[1]);
                 }
-            }
+            } else if (userInfoParts.length == 4) {
+                authType = AuthType.valueOf(userInfoParts[2]);
+                username = decodeUtf8(userInfoParts[0]);
+                password = decodeUtf8(userInfoParts[1]);
+                clientCertificateAlias = decodeUtf8(userInfoParts[3]);
+            } 
         }
 
         return new ServerSettings(ServerSettings.Type.SMTP, host, port, connectionSecurity,
@@ -157,7 +162,7 @@ public class SmtpTransport extends Transport {
             if (AuthType.EXTERNAL == authType) {
                 userInfo = userEnc + ":" + clientCertificateAliasEnc + ":" + authType.name();
             } else {
-                userInfo = userEnc + ":" + passwordEnc + ":" + authType.name();
+                userInfo = userEnc + ":" + passwordEnc + ":" + authType.name() + ":" + clientCertificateAliasEnc;
             }
         } else {
             userInfo = userEnc + ":" + passwordEnc;

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -397,8 +397,8 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
             // show password fields, hide client certificate fields
             mPasswordView.setVisibility(View.VISIBLE);
             mPasswordLabelView.setVisibility(View.VISIBLE);
-            mClientCertificateLabelView.setVisibility(View.GONE);
-            mClientCertificateSpinner.setVisibility(View.GONE);
+            mClientCertificateLabelView.setVisibility(View.VISIBLE);
+            mClientCertificateSpinner.setVisibility(View.VISIBLE);
         }
     }
 
@@ -515,6 +515,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                     if (AuthType.EXTERNAL == authType) {
                         clientCertificateAlias = mClientCertificateSpinner.getAlias();
                     } else {
+                    	clientCertificateAlias = mClientCertificateSpinner.getAlias();
                         password = mPasswordView.getText().toString();
                     }
 
@@ -549,6 +550,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
             if (authType == AuthType.EXTERNAL) {
                 clientCertificateAlias = mClientCertificateSpinner.getAlias();
             } else {
+            	clientCertificateAlias = mClientCertificateSpinner.getAlias();
                 password = mPasswordView.getText().toString();
             }
             String host = mServerView.getText().toString();

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -343,8 +343,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
             // show password fields, hide client certificate fields
             mPasswordView.setVisibility(View.VISIBLE);
             mPasswordLabelView.setVisibility(View.VISIBLE);
-            mClientCertificateLabelView.setVisibility(View.GONE);
-            mClientCertificateSpinner.setVisibility(View.GONE);
+            mClientCertificateLabelView.setVisibility(View.VISIBLE);
+            mClientCertificateSpinner.setVisibility(View.VISIBLE);
         }
     }
 
@@ -460,6 +460,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
             if (AuthType.EXTERNAL == authType) {
                 clientCertificateAlias = mClientCertificateSpinner.getAlias();
             } else {
+            	clientCertificateAlias = mClientCertificateSpinner.getAlias();
                 password = mPasswordView.getText().toString();
             }
         }


### PR DESCRIPTION
Changes seems harmless to me except userInfo pack and unpack.

    widget for client certificate is always visible

    all auth type ( I've tested only plain) sends cliantCertificateAlias
    for me works both with certificate ( my server)
    and without cert ( gmail)

    userInfo pack and unpack seems weak, but I lack skills to fix