### PR TITLE
Fix an issue when passphrase is canceled

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/OpenPgpHeaderView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/OpenPgpHeaderView.java
@@ -180,6 +180,11 @@ public class OpenPgpHeaderView extends LinearLayout {
 
     private void displayVerificationResult() {
         OpenPgpSignatureResult signatureResult = cryptoAnnotation.getSignatureResult();
+        if (signatureResult == null) {
+            hideSignatureLayout();
+            hideSignatureIconAndText();
+            return;
+        }
 
         switch (signatureResult.getResult()) {
             case OpenPgpSignatureResult.RESULT_NO_SIGNATURE: {
@@ -253,6 +258,11 @@ public class OpenPgpHeaderView extends LinearLayout {
             resultSignatureButton.setVisibility(View.VISIBLE);
             resultSignatureButton.setText(stringId);
         }
+    }
+
+    private void hideSignatureIconAndText() {
+        resultSignatureIcon.setVisibility(View.GONE);
+        resultSignatureText.setVisibility(View.GONE);
     }
 
     private void displayNotSigned() {


### PR DESCRIPTION
Cancel the window asking passphrase crash the app because OpenPgpSignatureResult signatureResult is null when the decrypt fails.
Issue from commit be18d06afd0db49b4c111f5091ca3d12f3ace357