### PR TITLE
Clean up database to simplify queries

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -277,7 +277,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                     try {
                         cursor = db.rawQuery(
                                 "SELECT COUNT(id) FROM messages " +
-                                "WHERE (empty IS NULL OR empty != 1) AND deleted = 0 and folder_id = ?",
+                                "WHERE empty = 0 AND deleted = 0 and folder_id = ?",
                                 new String[] { Long.toString(mFolderId) });
                         cursor.moveToFirst();
                         return cursor.getInt(0);   //messagecount
@@ -303,7 +303,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                 public Integer doDbWork(final SQLiteDatabase db) throws WrappedException {
                     int unreadMessageCount = 0;
                     Cursor cursor = db.query("messages", new String[] { "COUNT(id)" },
-                            "folder_id = ? AND (empty IS NULL OR empty != 1) AND deleted = 0 AND read=0",
+                            "folder_id = ? AND empty = 0 AND deleted = 0 AND read=0",
                             new String[] { Long.toString(mFolderId) }, null, null, null);
 
                     try {
@@ -334,7 +334,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                 public Integer doDbWork(final SQLiteDatabase db) throws WrappedException {
                     int flaggedMessageCount = 0;
                     Cursor cursor = db.query("messages", new String[] { "COUNT(id)" },
-                            "folder_id = ? AND (empty IS NULL OR empty != 1) AND deleted = 0 AND flagged = 1",
+                            "folder_id = ? AND empty = 0 AND deleted = 0 AND flagged = 1",
                             new String[] { Long.toString(mFolderId) }, null, null, null);
 
                     try {
@@ -885,7 +885,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                                 "SELECT " + LocalStore.GET_MESSAGES_COLS +
                                 "FROM messages " +
                                 "LEFT JOIN threads ON (threads.message_id = messages.id) " +
-                                "WHERE (empty IS NULL OR empty != 1) AND " +
+                                "WHERE empty = 0 AND " +
                                 (includeDeleted ? "" : "deleted = 0 AND ") +
                                 "folder_id = ? ORDER BY date DESC",
                                 new String[] { Long.toString(mFolderId) });
@@ -1630,7 +1630,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                 "SELECT " + LocalStore.GET_MESSAGES_COLS +
                 "FROM messages " +
                 "LEFT JOIN threads ON (threads.message_id = messages.id) " +
-                "WHERE (empty IS NULL OR empty != 1) AND (folder_id = ? and date < ?)",
+                "WHERE empty = 0 AND (folder_id = ? and date < ?)",
                 new String[] { Long.toString(mFolderId), Long.toString(cutoff) });
 
         for (Message message : messages) {
@@ -1651,7 +1651,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException {
                     try {
                         Cursor cursor = db.query("messages", new String[] { "message_part_id" },
-                                "folder_id = ? AND (empty IS NULL OR empty != 1)",
+                                "folder_id = ? AND empty = 0",
                                 folderIdArg, null, null, null);
                         try {
                             while (cursor.moveToNext()) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -568,7 +568,7 @@ public class LocalStore extends Store implements Serializable {
         String sqlQuery = "SELECT " + GET_MESSAGES_COLS + "FROM messages " +
                 "LEFT JOIN threads ON (threads.message_id = messages.id) " +
                 "LEFT JOIN folders ON (folders.id = messages.folder_id) WHERE " +
-                "((empty IS NULL OR empty != 1) AND deleted = 0)" +
+                "(empty = 0 AND deleted = 0)" +
                 ((!TextUtils.isEmpty(where)) ? " AND (" + where + ")" : "") +
                 " ORDER BY date DESC";
 
@@ -981,7 +981,7 @@ public class LocalStore extends Store implements Serializable {
             public void doDbWork(SQLiteDatabase db, String selectionSet, String[] selectionArgs)
                     throws UnavailableStorageException {
 
-                db.update("messages", cv, "(empty IS NULL OR empty != 1) AND id" + selectionSet,
+                db.update("messages", cv, "empty = 0 AND id" + selectionSet,
                         selectionArgs);
             }
 
@@ -1033,7 +1033,7 @@ public class LocalStore extends Store implements Serializable {
                         " WHERE id IN (" +
                         "SELECT m.id FROM threads t " +
                         "LEFT JOIN messages m ON (t.message_id = m.id) " +
-                        "WHERE (m.empty IS NULL OR m.empty != 1) AND m.deleted = 0 " +
+                        "WHERE m.empty = 0 AND m.deleted = 0 " +
                         "AND t.root" + selectionSet + ")",
                         selectionArgs);
             }
@@ -1086,7 +1086,7 @@ public class LocalStore extends Store implements Serializable {
                             "FROM threads t " +
                             "LEFT JOIN messages m ON (t.message_id = m.id) " +
                             "LEFT JOIN folders f ON (m.folder_id = f.id) " +
-                            "WHERE (m.empty IS NULL OR m.empty != 1) AND m.deleted = 0 " +
+                            "WHERE m.empty = 0 AND m.deleted = 0 " +
                             "AND t.root" + selectionSet;
 
                     getDataFromCursor(db.rawQuery(sql, selectionArgs));
@@ -1096,7 +1096,7 @@ public class LocalStore extends Store implements Serializable {
                             "SELECT m.uid, f.name " +
                             "FROM messages m " +
                             "LEFT JOIN folders f ON (m.folder_id = f.id) " +
-                            "WHERE (m.empty IS NULL OR m.empty != 1) AND m.id" + selectionSet;
+                            "WHERE m.empty = 0 AND m.id" + selectionSet;
 
                     getDataFromCursor(db.rawQuery(sql, selectionArgs));
                 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -129,7 +129,7 @@ public class LocalStore extends Store implements Serializable {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 52;
+    public static final int DB_VERSION = 53;
 
 
     public static String getColumnNameForFlag(Flag flag) {

--- a/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
@@ -303,14 +303,12 @@ public class EmailProvider extends ContentProvider {
 
                     String where;
                     if (TextUtils.isEmpty(selection)) {
-                        where = InternalMessageColumns.DELETED + "=0 AND (" +
-                                InternalMessageColumns.EMPTY + " IS NULL OR " +
-                                InternalMessageColumns.EMPTY + "!=1)";
+                        where = InternalMessageColumns.DELETED + " = 0 AND " +
+                                InternalMessageColumns.EMPTY + " = 0";
                     } else {
                         where = "(" + selection + ") AND " +
-                                InternalMessageColumns.DELETED + "=0 AND (" +
-                                InternalMessageColumns.EMPTY + " IS NULL OR " +
-                                InternalMessageColumns.EMPTY + "!=1)";
+                                InternalMessageColumns.DELETED + " = 0 AND " +
+                                InternalMessageColumns.EMPTY + " = 0";
                     }
 
                     final Cursor cursor;
@@ -466,10 +464,10 @@ public class EmailProvider extends ContentProvider {
                     ")");
         }
 
-        query.append(" WHERE " +
-                "(" + InternalMessageColumns.DELETED + " = 0 AND " +
-                "(" + InternalMessageColumns.EMPTY + " IS NULL OR " +
-                InternalMessageColumns.EMPTY + " != 1))");
+        query.append(" WHERE (" +
+                InternalMessageColumns.DELETED + " = 0 AND " +
+                InternalMessageColumns.EMPTY + " = 0" +
+                ")");
 
 
         if (!TextUtils.isEmpty(selection)) {
@@ -522,9 +520,8 @@ public class EmailProvider extends ContentProvider {
 
                     query.append("WHERE " +
                             ThreadColumns.ROOT + " = ? AND " +
-                            InternalMessageColumns.DELETED + " = 0 AND (" +
-                            InternalMessageColumns.EMPTY + " IS NULL OR " +
-                            InternalMessageColumns.EMPTY + " != 1)");
+                            InternalMessageColumns.DELETED + " = 0 AND " +
+                            InternalMessageColumns.EMPTY + " = 0");
 
                     query.append(" ORDER BY ");
                     query.append(SqlQueryBuilder.addPrefixToSelection(FIXUP_MESSAGES_COLUMNS,
@@ -581,7 +578,7 @@ public class EmailProvider extends ContentProvider {
         }
 
         // WHERE clause
-        sql.append(" WHERE (deleted=0 AND (empty IS NULL OR empty!=1))");
+        sql.append(" WHERE (deleted = 0 AND empty = 0)");
         if (!TextUtils.isEmpty(selection)) {
             sql.append(" AND (");
             sql.append(selection);


### PR DESCRIPTION
I was lazy when adding support for message threading. The database migration code only added new columns but didn't touch existing data. That lead to rather ugly conditions in SQL statements, e.g. `(empty IS NULL OR empty != 1)`.

This PR adds code to get rid of potentially left over NULL values in the `empty` column and simplifies SQL queries.