### PR TITLE
add global network option to fetch mails during Doze mode

### DIFF
--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion 21
+    compileSdkVersion 23
     buildToolsVersion '21.1.2'
 
     defaultConfig {

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -1,4 +1,3 @@
-
 package com.fsck.k9;
 
 import java.io.File;
@@ -260,6 +259,7 @@ public class K9 extends Application {
     private static boolean sMessageViewCopyActionVisible = false;
     private static boolean sMessageViewSpamActionVisible = false;
 
+    private static boolean checkMailDuringDoze = false;
 
     /**
      * @see #areDatabasesUpToDate()
@@ -505,6 +505,8 @@ public class K9 extends Application {
         editor.putBoolean("messageViewMoveActionVisible", sMessageViewMoveActionVisible);
         editor.putBoolean("messageViewCopyActionVisible", sMessageViewCopyActionVisible);
         editor.putBoolean("messageViewSpamActionVisible", sMessageViewSpamActionVisible);
+
+        editor.putBoolean("checkMailDuringDoze", checkMailDuringDoze);
 
         fontSizes.save(editor);
     }
@@ -765,6 +767,7 @@ public class K9 extends Application {
         sMessageViewCopyActionVisible = sprefs.getBoolean("messageViewCopyActionVisible", false);
         sMessageViewSpamActionVisible = sprefs.getBoolean("messageViewSpamActionVisible", false);
 
+        checkMailDuringDoze = sprefs.getBoolean("checkMailDuringDoze", false);
 
         K9.setK9Language(sprefs.getString("language", ""));
 
@@ -1341,6 +1344,14 @@ public class K9 extends Application {
 
     public static void setMessageViewSpamActionVisible(boolean visible) {
         sMessageViewSpamActionVisible = visible;
+    }
+
+    public static boolean isCheckMailDuringDoze() {
+        return checkMailDuringDoze;
+    }
+
+    public static void setCheckMailDuringDoze(boolean checkMailDuringDoze) {
+        K9.checkMailDuringDoze = checkMailDuringDoze;
     }
 
     /**

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -29,7 +29,6 @@ import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
 import com.fsck.k9.activity.ColorPickerDialog;
 import com.fsck.k9.activity.K9PreferenceActivity;
-import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.helper.FileBrowserHelper;
 import com.fsck.k9.helper.FileBrowserHelper.FileBrowserFailOverCallback;
 import com.fsck.k9.notification.NotificationController;
@@ -99,6 +98,7 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_THREADED_VIEW = "threaded_view";
     private static final String PREFERENCE_FOLDERLIST_WRAP_NAME = "folderlist_wrap_folder_name";
     private static final String PREFERENCE_SPLITVIEW_MODE = "splitview_mode";
+    private static final String PREFERENCE_CHECK_MAIL_DURING_DOZE = "check_mail_during_doze";
 
     private static final int ACTIVITY_CHOOSE_FOLDER = 1;
 
@@ -156,6 +156,7 @@ public class Prefs extends K9PreferenceActivity {
     private CheckBoxPreference mThreadedView;
     private ListPreference mSplitViewMode;
 
+    private CheckBoxPreference checkMailDuringDoze;
 
     public static void actionPrefs(Context context) {
         Intent i = new Intent(context, Prefs.class);
@@ -416,6 +417,9 @@ public class Prefs extends K9PreferenceActivity {
         visibleRefileActionsValues[VISIBLE_REFILE_ACTIONS_COPY] = K9.isMessageViewCopyActionVisible();
         visibleRefileActionsValues[VISIBLE_REFILE_ACTIONS_SPAM] = K9.isMessageViewSpamActionVisible();
 
+        checkMailDuringDoze = (CheckBoxPreference) findPreference(PREFERENCE_CHECK_MAIL_DURING_DOZE);
+        checkMailDuringDoze.setChecked(K9.isCheckMailDuringDoze());
+
         mVisibleRefileActions.setItems(visibleRefileActionsEntries);
         mVisibleRefileActions.setCheckedItems(visibleRefileActionsValues);
 
@@ -494,6 +498,8 @@ public class Prefs extends K9PreferenceActivity {
         K9.setMessageViewMoveActionVisible(enabledRefileActions[VISIBLE_REFILE_ACTIONS_MOVE]);
         K9.setMessageViewCopyActionVisible(enabledRefileActions[VISIBLE_REFILE_ACTIONS_COPY]);
         K9.setMessageViewSpamActionVisible(enabledRefileActions[VISIBLE_REFILE_ACTIONS_SPAM]);
+
+        K9.setCheckMailDuringDoze(checkMailDuringDoze.isChecked());
 
         K9.setNotificationDuringQuietTimeEnabled(!mDisableNotificationDuringQuietTime.isChecked());
         K9.setQuietTimeStarts(mQuietTimeStarts.getTime());

--- a/k9mail/src/main/java/com/fsck/k9/helper/MergeCursor.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/MergeCursor.java
@@ -214,6 +214,10 @@ public class MergeCursor implements Cursor {
     }
 
     @Override
+    public void setExtras(Bundle extras) {
+    }
+
+    @Override
     public boolean isAfterLast() {
         int count = getCount();
         if (count == 0) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -272,6 +272,9 @@ public class GlobalSettings {
         s.put("confirmDiscardMessage", Settings.versions(
                 new V(40, new BooleanSetting(true))
             ));
+        s.put("checkMailDuringDoze", Settings.versions(
+                new V(41, new BooleanSetting(false))
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 40;
+    public static final int VERSION = 41;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,

--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -716,6 +716,10 @@ public class MessageProvider extends ContentProvider {
         }
 
         @Override
+        public void setExtras(Bundle extras) {
+        }
+
+        @Override
         public boolean isAfterLast() {
             checkClosed();
             return mCursor.isAfterLast();

--- a/k9mail/src/main/res/values-de/strings.xml
+++ b/k9mail/src/main/res/values-de/strings.xml
@@ -896,6 +896,8 @@ Um Fehler zu melden, neue Funktionen vorzuschlagen oder Fragen zu stellen, besuc
   <string name="fetching_attachment_dialog_title_save">Entwurf speichern</string>
   <string name="fetching_attachment_dialog_message">Anhang wird heruntergeladen…</string>
   <string name="auth_external_error">Authentifizierung fehlgeschlagen. Der Server bietet nicht Simple Authentication and Security Layer, kurz SASL, an. Dies könnte durch ein Problem des Client Zertifikats (Zertifikat abgelaufen, unbekannte Zertifizierungsstelle) oder ein Konfigurationsproblem ausgelöst werden.</string>
+  <string name="check_mail_during_doze_label">Auf neue Mails während Doze prüfen</string>
+  <string name="check_mail_during_doze_summary">Auf neue Mails während Doze Modus prüfen (Android 6.0+), max. alle 15 Minuten</string>
   <!--=== OpenPGP specific ==================================================================-->
   <string name="openpgp_decrypting_verifying">Entschlüssle/Verifiziere…</string>
   <string name="openpgp_successful_decryption">Erfolgreiche Entschlüsselung</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1110,7 +1110,10 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="fetching_attachment_dialog_message">Fetching attachment…</string>
 
     <string name="auth_external_error">Unable to authenticate.  The server does not advertise the SASL EXTERNAL capability.  This could be due to a problem with the client certificate (expired, unknown certificate authority) or some other configuration problem.</string>
-    
+
+    <string name="check_mail_during_doze_label">Check for new mails during Doze</string>
+    <string name="check_mail_during_doze_summary">Check for new mails during Doze mode (Android 6.0+), max. every 15 minutes</string>
+
     <!-- === OpenPGP specific ================================================================== -->
     <string name="openpgp_decrypting_verifying">Decrypting/Verifying…</string>
     <string name="openpgp_successful_decryption">Successful decryption</string>

--- a/k9mail/src/main/res/xml/global_preferences.xml
+++ b/k9mail/src/main/res/xml/global_preferences.xml
@@ -357,6 +357,13 @@
             android:entryValues="@array/background_ops_values"
             android:dialogTitle="@string/background_ops_label" />
 
+        <CheckBoxPreference
+            android:persistent="false"
+            android:key="check_mail_during_doze"
+            android:title="@string/check_mail_during_doze_label"
+            android:defaultValue="false"
+            android:summary="@string/check_mail_during_doze_summary" />
+
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
This is the only way, K9 can fetch mails during Android 6.0 Doze mode. Adding K9 to the list of apps without battery optimization is not making "old" alarms working under Doze.