### PR TITLE
Add reply-to-SIP and reply-to-XMPP calling

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -1193,6 +1193,14 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         mFragmentListener.onReplyAll(message);
     }
 
+    public void onCallSIP(LocalMessage message) {
+        mFragmentListener.onCallSIP(message);
+    }
+
+    public void onCallXMPP(LocalMessage message) {
+        mFragmentListener.onCallXMPP(message);
+    }
+
     public void onForward(LocalMessage message) {
         mFragmentListener.onForward(message);
     }
@@ -1510,6 +1518,14 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             }
             case R.id.reply_all: {
                 onReplyAll(getMessageAtPosition(adapterPosition));
+                break;
+            }
+            case R.id.call_sip: {
+                onCallSIP(getMessageAtPosition(adapterPosition));
+                break;
+            }
+            case R.id.call_xmpp: {
+                onCallXMPP(getMessageAtPosition(adapterPosition));
                 break;
             }
             case R.id.forward: {
@@ -3104,6 +3120,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         void onForward(LocalMessage message);
         void onReply(LocalMessage message);
         void onReplyAll(LocalMessage message);
+        void onCallSIP(LocalMessage message);
+        void onCallXMPP(LocalMessage message);
         void openMessage(MessageReference messageReference);
         void setMessageListTitle(String title);
         void setMessageListSubTitle(String subTitle);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -358,6 +358,18 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         }
     }
 
+    public void onCallSIP() {
+        if (mMessage != null) {
+            mFragmentListener.onCallSIP(mMessage, mPgpData);
+        }
+    }
+
+    public void onCallXMPP() {
+        if (mMessage != null) {
+            mFragmentListener.onCallXMPP(mMessage, mPgpData);
+        }
+    }
+
     public void onForward() {
         if (mMessage != null) {
             mFragmentListener.onForward(mMessage, mPgpData);
@@ -703,6 +715,8 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         public void disableDeleteAction();
         public void onReplyAll(LocalMessage mMessage, PgpData mPgpData);
         public void onReply(LocalMessage mMessage, PgpData mPgpData);
+        public void onCallSIP(LocalMessage mMessage, PgpData mPgpData);
+        public void onCallXMPP(LocalMessage mMessage, PgpData mPgpData);
         public void displayMessageSubject(String title);
         public void setProgress(boolean b);
         public void showNextMessageOrReturn();

--- a/k9mail/src/main/res/menu/message_list_item_context.xml
+++ b/k9mail/src/main/res/menu/message_list_item_context.xml
@@ -12,6 +12,12 @@
          android:id="@+id/reply"
          android:title="@string/reply_action"/>
      <item
+         android:id="@+id/call_sip"
+         android:title="@string/call_sip_action"/>
+     <item
+         android:id="@+id/call_xmpp"
+         android:title="@string/call_xmpp_action"/>
+     <item
          android:id="@+id/send_again"
          android:title="@string/send_again_action"/>
      <item

--- a/k9mail/src/main/res/menu/message_list_option.xml
+++ b/k9mail/src/main/res/menu/message_list_option.xml
@@ -100,6 +100,12 @@
             <item
                 android:id="@+id/share"
                 android:title="@string/send_alternate_action"/>
+            <item
+                android:id="@+id/call_sip"
+                android:title="@string/call_sip_action"/>
+            <item
+                android:id="@+id/call_xmpp"
+                android:title="@string/call_xmpp_action"/>
         </menu>
     </item>
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -122,6 +122,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="deselect_action">Deselect</string>
     <string name="reply_action">Reply</string>
     <string name="reply_all_action">Reply all</string>
+    <string name="call_sip_action">Call (SIP)</string>
+    <string name="call_xmpp_action">Call (XMPP)</string>
     <string name="delete_action">Delete</string>
     <string name="archive_action">Archive</string>
     <string name="spam_action">Spam</string>
@@ -1159,4 +1161,9 @@ Please submit bug reports, contribute new features and ask questions at
     <!-- Note: This references message_view_download_remainder -->
     <string name="crypto_download_complete_message_to_decrypt">Click \'Download complete message\' to allow decryption.</string>
 
+    <!-- === Invoking other apps specific ================================================================== -->
+    <string name="no_sender_to_call">No sender/from address found to call.</string>
+    <string name="no_sip_app">No app for SIP.  Please try installing Lumicall.</string>
+    <string name="no_xmpp_app">No app for XMPP.  Please try installing Conversations.</string>
+    <string name="no_app_for_scheme">No app installed for scheme \'%1%s\'.</string>
 </resources>


### PR DESCRIPTION
This adds the options "Call (SIP)" and "Call (XMPP)" in various menus that have other "Reply", "Reply All" and "Forward" options.

This doesn't add the complexity of SIP or XMPP to K-9 itself, rather, it sends an Intent to any other app that has registered support for the "sip" or "xmpp" URI schemes.  If the user doesn't have an appropriate app installed, a helpful alert appears.