### PR TITLE
fixes #575 : Display *Encrypted* for encrypted messages in message preview

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/EncryptionType.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/EncryptionType.java
@@ -1,0 +1,15 @@
+package com.fsck.k9.mail;
+
+/**
+ * Enumeration of the different possible encryption protocol that can be used.
+ */
+public enum EncryptionType {
+
+    NONE,
+
+    INLINE,
+
+    PGP_MIME,
+
+    S_MIME
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import android.util.Log;
 
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.filter.CountingOutputStream;
 import com.fsck.k9.mail.filter.EOLConvertingOutputStream;
 
@@ -239,4 +240,9 @@ public abstract class Message implements Part, CompositeBody {
     @Override
     public abstract Message clone();
 
+    /**
+     * Returns message encryption type
+     * @return encrytion type
+     */
+    public abstract EncryptionType getEncryptionType();
 }

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -84,6 +84,7 @@ import com.fsck.k9.helper.MergeCursorWithUniqueId;
 import com.fsck.k9.helper.MessageHelper;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.Message;
@@ -131,6 +132,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         SpecialColumns.FOLDER_NAME,
 
         SpecialColumns.THREAD_COUNT,
+        MessageColumns.ENCRYPTION
     };
 
     private static final int ID_COLUMN = 0;
@@ -152,6 +154,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     private static final int ACCOUNT_UUID_COLUMN = 16;
     private static final int FOLDER_NAME_COLUMN = 17;
     private static final int THREAD_COUNT_COLUMN = 18;
+    private static final int ENCRYPTION_COLUMN = 19;
 
     private static final String[] PROJECTION = Arrays.copyOf(THREADED_PROJECTION,
             THREAD_COUNT_COLUMN);
@@ -2029,9 +2032,15 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                     .append(beforePreviewText);
 
             if (mPreviewLines > 0) {
-                String preview = cursor.getString(PREVIEW_COLUMN);
-                if (preview != null) {
-                    messageStringBuilder.append(" ").append(preview);
+                if (EncryptionType.valueOf(cursor.getString(ENCRYPTION_COLUMN)) != EncryptionType.NONE) {
+                    messageStringBuilder.append(" *");
+                    messageStringBuilder.append(context.getString(R.string.openpgp_result_encrypted));
+                    messageStringBuilder.append('*');
+                } else {
+                    String preview = cursor.getString(PREVIEW_COLUMN);
+                    if (preview != null) {
+                        messageStringBuilder.append(" ").append(preview);
+                    }
                 }
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -1263,6 +1263,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                     ? System.currentTimeMillis() : message.getInternalDate().getTime());
             cv.put("mime_type", message.getMimeType());
             cv.put("empty", 0);
+            cv.put("encryption_type", message.getEncryptionType().name());
 
             String messageId = message.getMessageId();
             if (messageId != null) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -14,6 +14,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.MessagingException;
@@ -110,6 +111,7 @@ public class LocalMessage extends MimeMessage {
 
         messagePartId = cursor.getLong(22);
         mimeType = cursor.getString(23);
+        setEncryptionType(EncryptionType.valueOf(cursor.getString(24)));
     }
 
     long getMessagePartId() {
@@ -314,7 +316,7 @@ public class LocalMessage extends MimeMessage {
             this.localStore.database.execute(true, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException,
-                    UnavailableStorageException {
+                        UnavailableStorageException {
                     try {
                         LocalFolder localFolder = (LocalFolder) mFolder;
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -80,12 +80,13 @@ public class LocalStore extends Store implements Serializable {
     /*
      * a String containing the columns getMessages expects to work with
      * in the correct order.
+     * - encryption_type : see {@link EncryptionType} for possible values
      */
     static String GET_MESSAGES_COLS =
         "subject, sender_list, date, uid, flags, messages.id, to_list, cc_list, " +
         "bcc_list, reply_to_list, attachment_count, internal_date, messages.message_id, " +
         "folder_id, preview, threads.id, threads.root, deleted, read, flagged, answered, " +
-        "forwarded, message_part_id, mime_type ";
+        "forwarded, message_part_id, mime_type, encryption_type ";
 
     static final String GET_FOLDER_COLS =
         "folders.id, name, visible_limit, last_updated, status, push_state, last_pushed, " +
@@ -129,7 +130,7 @@ public class LocalStore extends Store implements Serializable {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 53;
+    public static final int DB_VERSION = 54;
 
 
     public static String getColumnNameForFlag(Flag flag) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageInfoExtractor.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import android.content.Context;
 
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
@@ -25,8 +26,12 @@ class MessageInfoExtractor {
     }
 
     public String getMessageTextPreview() throws MessagingException {
-        getViewablesIfNecessary();
-        return MessagePreviewExtractor.extractPreview(context, viewables);
+        if (message.getEncryptionType() == EncryptionType.NONE) {
+            getViewablesIfNecessary();
+            return MessagePreviewExtractor.extractPreview(context, viewables);
+        } else {
+            return ""; // cant preview encrypted emails
+        }
     }
 
     public int getAttachmentCount() throws MessagingException {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -98,7 +98,8 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
                         "flagged INTEGER default 0, " +
                         "answered INTEGER default 0, " +
                         "forwarded INTEGER default 0, " +
-                        "message_part_id INTEGER" +
+                        "message_part_id INTEGER, " +
+                        "encryption_type TEXT" +
                         ")");
 
                 db.execSQL("CREATE TABLE message_parts (" +
@@ -574,6 +575,12 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
                 }
                 if (db.getVersion() < 53) {
                     removeNullValuesFromEmptyColumnInMessagesTable(db);
+                }
+                if (db.getVersion() < 54) {
+                    /*
+                     * All messages are initialized to "no encrypted" even if encrypted.
+                     */
+                    db.execSQL("ALTER TABLE messages ADD COLUMN encryption_type TEXT default 'NONE'");
                 }
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
@@ -148,6 +148,7 @@ public class EmailProvider extends ContentProvider {
         public static final String FLAGGED = "flagged";
         public static final String ANSWERED = "answered";
         public static final String FORWARDED = "forwarded";
+        public static final String ENCRYPTION = "encryption_type";
     }
 
     private interface InternalMessageColumns extends MessageColumns {


### PR DESCRIPTION
Hi, I wish I could read PGPMIME encrypted emails on k9 so I am attempting to help. Here is an attempt to fixes #575 .
This is my first time contributing to any opensource project so feel free to tell me if I forgot to fill something else somewhere before this pull request.

Description : 
- Added column encryption_type in message table
- all previously stored message have their encryption_type set to 0. So previously stored email will still display their previously computed preview. Sounds a bit too much work and computing to migrate the database properly.
- On reception, encryption_type is set to a value > 0 when emails are encrypted
- Display "*encrypted*" instead of column preview when encryption_type > 0

-Alexandre