### PR TITLE
support for PGP/MIME

### DIFF
--- a/k9mail-library/src/androidTest/java/com/fsck/k9/mail/MessageTest.java
+++ b/k9mail-library/src/androidTest/java/com/fsck/k9/mail/MessageTest.java
@@ -276,6 +276,120 @@ public class MessageTest {
             + "\r\n"
             + "------Boundary103--\r\n";
 
+    private static final String TO_BODY_PART_RESULT =
+                    "Content-Type: multipart/mixed; boundary=\"----Boundary103\"\r\n"
+                    + "Content-Transfer-Encoding: 8bit\r\n"
+                    + "\r\n"
+                    + "------Boundary103\r\n"
+                    + "Content-Type: text/plain;\r\n"
+                    + " charset=utf-8\r\n"
+                    + "Content-Transfer-Encoding: 8bit\r\n"
+                    + "\r\n"
+                    + "Testing.\r\n"
+                    + "This is a text body with some greek characters.\r\n"
+                    + "αβγδεζηθ\r\n"
+                    + "End of test.\r\n"
+                    + "\r\n"
+                    + "------Boundary103\r\n"
+                    + "Content-Type: text/plain;\r\n"
+                    + " charset=utf-8\r\n"
+                    + "Content-Transfer-Encoding: quoted-printable\r\n"
+                    + "\r\n"
+                    + "Testing=2E\r\n"
+                    + "This is a text body with some greek characters=2E\r\n"
+                    + "=CE=B1=CE=B2=CE=B3=CE=B4=CE=B5=CE=B6=CE=B7=CE=B8\r\n"
+                    + "End of test=2E\r\n"
+                    + "\r\n"
+                    + "------Boundary103\r\n"
+                    + "Content-Type: application/octet-stream\r\n"
+                    + "Content-Transfer-Encoding: base64\r\n"
+                    + "\r\n"
+                    + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\r\n"
+                    + "\r\n"
+                    + "------Boundary103\r\n"
+                    + "Content-Type: message/rfc822\r\n"
+                    + "Content-Disposition: attachment\r\n"
+                    + "Content-Transfer-Encoding: 8bit\r\n"
+                    + "\r\n"
+                    + "From: from@example.com\r\n"
+                    + "To: to@example.com\r\n"
+                    + "Subject: Test Message\r\n"
+                    + "Date: Wed, 28 Aug 2013 08:51:09 -0400\r\n"
+                    + "MIME-Version: 1.0\r\n"
+                    + "Content-Type: multipart/mixed; boundary=\"----Boundary102\"\r\n"
+                    + "Content-Transfer-Encoding: 8bit\r\n"
+                    + "\r\n"
+                    + "------Boundary102\r\n"
+                    + "Content-Type: text/plain;\r\n"
+                    + " charset=utf-8\r\n"
+                    + "Content-Transfer-Encoding: 8bit\r\n"
+                    + "\r\n"
+                    + "Testing.\r\n"
+                    + "This is a text body with some greek characters.\r\n"
+                    + "αβγδεζηθ\r\n"
+                    + "End of test.\r\n"
+                    + "\r\n"
+                    + "------Boundary102\r\n"
+                    + "Content-Type: text/plain;\r\n"
+                    + " charset=utf-8\r\n"
+                    + "Content-Transfer-Encoding: quoted-printable\r\n"
+                    + "\r\n"
+                    + "Testing=2E\r\n"
+                    + "This is a text body with some greek characters=2E\r\n"
+                    + "=CE=B1=CE=B2=CE=B3=CE=B4=CE=B5=CE=B6=CE=B7=CE=B8\r\n"
+                    + "End of test=2E\r\n"
+                    + "\r\n"
+                    + "------Boundary102\r\n"
+                    + "Content-Type: application/octet-stream\r\n"
+                    + "Content-Transfer-Encoding: base64\r\n"
+                    + "\r\n"
+                    + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\r\n"
+                    + "\r\n"
+                    + "------Boundary102\r\n"
+                    + "Content-Type: message/rfc822\r\n"
+                    + "Content-Disposition: attachment\r\n"
+                    + "Content-Transfer-Encoding: 8bit\r\n"
+                    + "\r\n"
+                    + "From: from@example.com\r\n"
+                    + "To: to@example.com\r\n"
+                    + "Subject: Test Message\r\n"
+                    + "Date: Wed, 28 Aug 2013 08:51:09 -0400\r\n"
+                    + "MIME-Version: 1.0\r\n"
+                    + "Content-Type: multipart/mixed; boundary=\"----Boundary101\"\r\n"
+                    + "Content-Transfer-Encoding: 8bit\r\n"
+                    + "\r\n"
+                    + "------Boundary101\r\n"
+                    + "Content-Type: text/plain;\r\n"
+                    + " charset=utf-8\r\n"
+                    + "Content-Transfer-Encoding: 8bit\r\n"
+                    + "\r\n"
+                    + "Testing.\r\n"
+                    + "This is a text body with some greek characters.\r\n"
+                    + "αβγδεζηθ\r\n"
+                    + "End of test.\r\n"
+                    + "\r\n"
+                    + "------Boundary101\r\n"
+                    + "Content-Type: text/plain;\r\n"
+                    + " charset=utf-8\r\n"
+                    + "Content-Transfer-Encoding: quoted-printable\r\n"
+                    + "\r\n"
+                    + "Testing=2E\r\n"
+                    + "This is a text body with some greek characters=2E\r\n"
+                    + "=CE=B1=CE=B2=CE=B3=CE=B4=CE=B5=CE=B6=CE=B7=CE=B8\r\n"
+                    + "End of test=2E\r\n"
+                    + "\r\n"
+                    + "------Boundary101\r\n"
+                    + "Content-Type: application/octet-stream\r\n"
+                    + "Content-Transfer-Encoding: base64\r\n"
+                    + "\r\n"
+                    + "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/\r\n"
+                    + "\r\n"
+                    + "------Boundary101--\r\n"
+                    + "\r\n"
+                    + "------Boundary102--\r\n"
+                    + "\r\n"
+                    + "------Boundary103--\r\n";
+
     private int mMimeBoundary;
 
     @Test
@@ -414,5 +528,20 @@ public class MessageTest {
             sb.append(Integer.toString(mMimeBoundary++));
             return sb.toString();
         }
+    }
+
+    @Test
+    public void testToBodyPart() throws MessagingException, IOException {
+        MimeMessage message;
+        ByteArrayOutputStream out;
+
+        BinaryTempFileBody.setTempDirectory(InstrumentationRegistry.getTargetContext().getCacheDir());
+
+        mMimeBoundary = 101;
+        message = nestedMessage(nestedMessage(sampleMessage()));
+        out = new ByteArrayOutputStream();
+        MimeBodyPart bodyPart = message.toBodyPart();
+        bodyPart.writeTo(out);
+        assertEquals(TO_BODY_PART_RESULT, out.toString());
     }
 }

--- a/k9mail-library/src/androidTest/java/com/fsck/k9/mail/filter/SignSafeOutputStreamTest.java
+++ b/k9mail-library/src/androidTest/java/com/fsck/k9/mail/filter/SignSafeOutputStreamTest.java
@@ -1,0 +1,36 @@
+package com.fsck.k9.mail.filter;
+
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Created by alexandre on 11/10/15.
+ */
+public class SignSafeOutputStreamTest {
+    private static final String INPUT_STRING = "It's generally a good idea to encode lines that begin with\r\n"
+            + "From because some mail transport agents will insert a greater-\r\n"
+            + "than (>) sign, thus invalidating the signature.\r\n\r\n"
+            + "Also, in some cases it might be desirable to encode any    \r\n"
+            + "trailing whitespace that occurs on lines in order to ensure   \r\n"
+            + "that the message signature is not invalidated when passing  \r\n"
+            + "a gateway that modifies such whitespace (like BITNET).  \r\n\r\n";
+
+    private static final String EXPECTED = "It's generally a good idea to encode lines that begin with\r\n"
+            + "From=20because some mail transport agents will insert a greater-\r\n"
+            + "than (>) sign, thus invalidating the signature.\r\n\r\n"
+            + "Also, in some cases it might be desirable to encode any   =20\r\n"
+            + "trailing whitespace that occurs on lines in order to ensure  =20\r\n"
+            + "that the message signature is not invalidated when passing =20\r\n"
+            + "a gateway that modifies such whitespace (like BITNET). =20\r\n\r\n";
+
+    @Test
+    public void testWrite() throws IOException {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new SignSafeOutputStream(output).write(INPUT_STRING.getBytes("US-ASCII"));
+        assertEquals(EXPECTED, new String(output.toByteArray(), "US-ASCII"));
+    }
+}

--- a/k9mail-library/src/androidTest/java/com/fsck/k9/mail/internet/MimeHeaderTest.java
+++ b/k9mail-library/src/androidTest/java/com/fsck/k9/mail/internet/MimeHeaderTest.java
@@ -1,0 +1,57 @@
+package com.fsck.k9.mail.internet;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+/**
+ * Created by alexandre on 11/5/15.
+ */
+@RunWith(AndroidJUnit4.class)
+public class MimeHeaderTest {
+    private static final String TEST_WRITE_WITH_CONTENT_PARAMETERS =
+            "Content-Type: multipart/signed; protocol=\"application-pgp\"; micalg=md5\r\n"
+            + "  ; boundary=\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\r\n";
+
+    private static final String TEST_WRITE_WITH_CONTENT_PARAMETERS2 =
+            "Content-Type: multipart/signed; protocol=\"application-pgp\"; micalg=md5\r\n"
+                    + "  ; boundary=\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"\r\n"
+            + "  ; param=\"sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss\"\r\n";
+
+    @Test
+    public void testWriteToWithContentTypeParameters() throws IOException {
+        MimeHeader header = new MimeHeader();
+        header.setHeader("Content-Type", "multipart/signed");
+        header.addContentTypeParameter("protocol", "\"application-pgp\"");
+        header.addContentTypeParameter("micalg", "md5");
+        header.addContentTypeParameter("boundary", "\"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\"");
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        header.writeTo(output);
+        String strOutput = new String(output.toByteArray(), "US-ASCII");
+        assertEquals(TEST_WRITE_WITH_CONTENT_PARAMETERS, strOutput);
+
+        header.addContentTypeParameter("param", "\"sssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssssss\"");
+        output = new ByteArrayOutputStream();
+        header.writeTo(output);
+        strOutput = new String(output.toByteArray(), "US-ASCII");
+        assertEquals(TEST_WRITE_WITH_CONTENT_PARAMETERS2, strOutput);
+
+        for (int i = 0; i < 20 ; i++){
+            header.addContentTypeParameter("anotherparam" + i, "value");
+        }
+        output = new ByteArrayOutputStream();
+        header.writeTo(output);
+        strOutput = new String(output.toByteArray(), "US-ASCII");
+        String[] splited = strOutput.split("\r\n");
+        for (String line : splited) {
+            assertTrue(line.length() <= 128);
+        }
+    }
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/EncryptionType.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/EncryptionType.java
@@ -7,7 +7,7 @@ public enum EncryptionType {
 
     NONE,
 
-    INLINE,
+    PGP_INLINE,
 
     PGP_MIME,
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/EncryptionType.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/EncryptionType.java
@@ -1,0 +1,15 @@
+package com.fsck.k9.mail;
+
+/**
+ * Enumeration of the different possible encryption protocol that can be used.
+ */
+public enum EncryptionType {
+
+    NONE,
+
+    INLINE,
+
+    PGP_MIME,
+
+    S_MIME
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
@@ -9,6 +9,7 @@ import java.util.Set;
 
 import android.util.Log;
 
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.filter.CountingOutputStream;
 import com.fsck.k9.mail.filter.EOLConvertingOutputStream;
 
@@ -239,4 +240,9 @@ public abstract class Message implements Part, CompositeBody {
     @Override
     public abstract Message clone();
 
+    /**
+     * Returns message encryption type
+     * @return encrytion type
+     */
+    public abstract EncryptionType getEncryptionType();
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Part.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Part.java
@@ -54,4 +54,6 @@ public interface Part {
     String getServerExtra();
 
     void setServerExtra(String serverExtra);
+
+    String getContentTypeParameter(String attribute);
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/filter/SignSafeOutputStream.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/filter/SignSafeOutputStream.java
@@ -1,0 +1,219 @@
+package com.fsck.k9.mail.filter;
+
+import org.apache.james.mime4j.codec.QuotedPrintableOutputStream;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * Further encode a quoted-printable stream into a safer format for signed email.
+ * @see <a href="http://tools.ietf.org/html/rfc2015">RFC-2015</a>
+ */
+public class SignSafeOutputStream extends FilterOutputStream {
+    private ByteBuffer buffer = ByteBuffer.allocate(1);
+
+    private State state = State.cr_FROM;
+
+    public SignSafeOutputStream(OutputStream out){
+        super(out);
+    }
+
+    public static FilterOutputStream newInstance(OutputStream out){
+        return new QuotedPrintableOutputStream(new SignSafeOutputStream(out), false);
+    }
+
+    private static final byte[] ESCAPE = new byte[]{'=','2','0'};
+
+    @Override
+    public void write(int oneByte) throws IOException {
+        State nextState = state.nextState(oneByte);
+        if (nextState == State.SPACE_FROM){
+            state = State.INIT;
+            out.write(ESCAPE);
+        } else if (nextState == State.lf_SPACE){
+            buffer.clear();
+            state = State.lf_FROM;
+            out.write(ESCAPE);
+            out.write(oneByte);
+        } else if (nextState == State.SPACE) {
+            writeBuffer();
+            buffer.put((byte)32);
+            state = nextState;
+        } else {
+            writeBuffer();
+            state = nextState;
+            out.write(oneByte);
+        }
+    }
+
+    private void writeBuffer() throws IOException {
+        buffer.flip();
+        if (buffer.hasRemaining()) {
+            out.write(buffer.get());
+        }
+        buffer.clear();
+    }
+
+    @Override
+    public void close() throws IOException {
+        writeBuffer();
+        out.close();
+    }
+
+    enum State {
+        INIT {
+            @Override
+            public State nextState(int b) {
+                switch (b) {
+                    case '\r':
+                        return lf_FROM;
+                    case ' ':
+                        return SPACE;
+                    default:
+                        return INIT;
+
+                }
+            }
+        },
+        lf_FROM {
+            @Override
+            public State nextState(int b) {
+                switch (b) {
+                    case '\n':
+                        return cr_FROM;
+                    case ' ':
+                        return SPACE;
+                    case '\r':
+                        return lf_FROM;
+                    default:
+                        return INIT;
+
+                }
+            }
+        },
+        cr_FROM {
+            @Override
+            public State nextState(int b) {
+                switch (b) {
+                    case 'F':
+                        return F_FROM;
+                    case ' ':
+                        return SPACE;
+                    case '\r':
+                        return lf_FROM;
+                    default:
+                        return INIT;
+
+                }
+            }
+        },
+        F_FROM {
+            @Override
+            public State nextState(int b) {
+                switch (b) {
+                    case 'r':
+                        return R_FROM;
+                    case ' ':
+                        return SPACE;
+                    case '\r':
+                        return lf_FROM;
+                    default:
+                        return INIT;
+
+                }
+            }
+        },
+        R_FROM {
+            @Override
+            public State nextState(int b) {
+                switch (b) {
+                    case 'o':
+                        return O_FROM;
+                    case ' ':
+                        return SPACE;
+                    case '\r':
+                        return lf_FROM;
+                    default:
+                        return INIT;
+
+                }
+            }
+        },
+        O_FROM {
+            @Override
+            public State nextState(int b) {
+                switch (b) {
+                    case 'm':
+                        return M_FROM;
+                    case ' ':
+                        return SPACE;
+                    case '\r':
+                        return lf_FROM;
+                    default:
+                        return INIT;
+
+                }
+            }
+        },
+        M_FROM {
+            @Override
+            public State nextState(int b) {
+                switch (b) {
+                    case ' ':
+                        return SPACE_FROM;
+                    case '\r':
+                        return lf_FROM;
+                    default:
+                        return INIT;
+
+                }
+            }
+
+        },
+        SPACE_FROM {
+            @Override
+            public State nextState(int b) {
+                switch (b) {
+                    case '\r':
+                        return lf_SPACE;
+                    case 'F':
+                        return F_FROM;
+                    case ' ':
+                        return SPACE;
+                    default:
+                        return INIT;
+
+                }
+            }
+
+        },
+        SPACE {
+            @Override
+            public State nextState(int b) {
+                switch (b) {
+                    case '\r':
+                        return lf_SPACE;
+                    case 'F':
+                        return F_FROM;
+                    case ' ':
+                        return SPACE;
+                    default:
+                        return INIT;
+
+                }
+            }
+        },
+        lf_SPACE {
+            @Override
+            public State nextState(int b) {
+                return INIT;
+            }
+        };
+
+        public abstract State nextState(int b);
+    }
+}
+
+

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
@@ -185,4 +185,15 @@ public class MimeBodyPart extends BodyPart {
         }
     }
 
+
+    /**
+     * Returns the value of content-type given parameter.
+     * To allow comparison, the returned string isn't quoted.
+     * @param attribute
+     * @return the unquoted parameter value
+     */
+    public String getContentTypeParameter(String attribute){
+        return mHeader.getContentTypeParameter(attribute);
+    }
+
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
@@ -10,6 +10,7 @@ import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.util.Collection;
 
 import org.apache.james.mime4j.util.MimeUtil;
 
@@ -18,7 +19,7 @@ import org.apache.james.mime4j.util.MimeUtil;
  * Message.
  */
 public class MimeBodyPart extends BodyPart {
-    private final MimeHeader mHeader = new MimeHeader();
+    private MimeHeader mHeader = new MimeHeader();
     private Body mBody;
 
     public MimeBodyPart() throws MessagingException {
@@ -34,6 +35,11 @@ public class MimeBodyPart extends BodyPart {
             addHeader(MimeHeader.HEADER_CONTENT_TYPE, mimeType);
         }
         MimeMessageHelper.setBody(this, body);
+    }
+
+    MimeBodyPart(MimeHeader header, Body body)  throws MessagingException {
+        this(body);
+        mHeader = header;
     }
 
     private String getFirstHeader(String name) {
@@ -177,4 +183,5 @@ public class MimeBodyPart extends BodyPart {
             setEncoding(MimeUtil.ENC_QUOTED_PRINTABLE);
         }
     }
+
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
@@ -19,7 +19,7 @@ import org.apache.james.mime4j.util.MimeUtil;
  * Message.
  */
 public class MimeBodyPart extends BodyPart {
-    private MimeHeader mHeader = new MimeHeader();
+    final private MimeHeader mHeader;
     private Body mBody;
 
     public MimeBodyPart() throws MessagingException {
@@ -31,15 +31,19 @@ public class MimeBodyPart extends BodyPart {
     }
 
     public MimeBodyPart(Body body, String mimeType) throws MessagingException {
+        this(body, mimeType, new MimeHeader());
+    }
+
+    MimeBodyPart(MimeHeader header, Body body)  throws MessagingException {
+        this(body, null, header);
+    }
+
+    private MimeBodyPart(Body body, String mimeType, MimeHeader header) throws MessagingException {
+        mHeader = header;
         if (mimeType != null) {
             addHeader(MimeHeader.HEADER_CONTENT_TYPE, mimeType);
         }
         MimeMessageHelper.setBody(this, body);
-    }
-
-    MimeBodyPart(MimeHeader header, Body body)  throws MessagingException {
-        this(body);
-        mHeader = header;
     }
 
     private String getFirstHeader(String name) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
@@ -147,6 +147,7 @@ public class MimeBodyPart extends BodyPart {
     @Override
     public void setUsing7bitTransport() throws MessagingException {
         String type = getFirstHeader(MimeHeader.HEADER_CONTENT_TYPE);
+        String transferEncoding = getFirstHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING);
         /*
          * We don't trust that a multipart/* will properly have an 8bit encoding
          * header if any of its subparts are 8bit, so we automatically recurse
@@ -156,8 +157,8 @@ public class MimeBodyPart extends BodyPart {
             setEncoding(MimeUtil.ENC_7BIT);
             // recurse
             ((CompositeBody) mBody).setUsing7bitTransport();
-        } else if (!MimeUtil.ENC_8BIT
-                .equalsIgnoreCase(getFirstHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING))) {
+        } else if (!MimeUtil.ENC_8BIT.equalsIgnoreCase(transferEncoding)
+                && !MimeUtil.isSameMimeType(transferEncoding, MimeUtil.ENC_BINARY)) {
             return;
         } else if (type != null &&
                 (MimeUtility.isSameMimeType(type, "multipart/signed") || MimeUtility.isMessage(type))) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeHeader.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeHeader.java
@@ -283,6 +283,7 @@ class ContentType {
         contentTypeParameters.put(attribute, value);
     }
 
+    @Override
     public String toString() {
         if (type == null){
             return null;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -146,7 +146,7 @@ public class MimeMessage extends Message {
                 if (data != null) {
                     Matcher matcher = PGP_MESSAGE.matcher(data);
                     if (matcher.matches()) {
-                        encryptionType = EncryptionType.INLINE;
+                        encryptionType = EncryptionType.PGP_INLINE;
                     }
                 }
             }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -717,5 +717,32 @@ public class MimeMessage extends Message {
         this.serverExtra = serverExtra;
     }
 
+    /**
+     * Convert a top level message into a bodypart.
+     * Returned body part shouldn't contain inappropriate headers such as smtp
+     * headers or MIME-VERSION.
+     * Both Message and MimeBodyPart might share structures.
+     * @return the body part
+     * @throws MessagingException
+     */
+    public MimeBodyPart toBodyPart() throws MessagingException {
+        MimeHeader headerClone = mHeader.clone();
+        for (String header : headerClone.getHeaderNames()){
+            if (!header.toLowerCase().startsWith("content-")){
+                headerClone.removeHeader(header);
+            }
+        }
+        MimeBodyPart result = new MimeBodyPart(headerClone, getBody());
+        return result;
+    }
 
+    /**
+     * Add a parameter to the content-type header.
+     * Content-Type=type/subtype; parameter.
+     * @param attribute the attribute to add
+     * @param value value of the attribute, quoted or not
+     */
+    public void addContentTypeParameter(String attribute, String value){
+        mHeader.addContentTypeParameter(attribute, value);
+    }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -14,6 +14,8 @@ import java.util.LinkedList;
 import java.util.Locale;
 import java.util.Set;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.MimeException;
@@ -31,6 +33,7 @@ import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.CompositeBody;
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Multipart;
@@ -41,6 +44,9 @@ import com.fsck.k9.mail.Part;
  * RFC 2045 style headers.
  */
 public class MimeMessage extends Message {
+    public static final Pattern PGP_MESSAGE =
+            Pattern.compile(".*?(-----BEGIN PGP MESSAGE-----.*?-----END PGP MESSAGE-----).*",
+                    Pattern.DOTALL);
     private MimeHeader mHeader = new MimeHeader();
     protected Address[] mFrom;
     protected Address[] mTo;
@@ -58,6 +64,8 @@ public class MimeMessage extends Message {
     private Body mBody;
     protected int mSize;
     private String serverExtra;
+
+    private EncryptionType encryptionType = EncryptionType.NONE;
 
     public MimeMessage() {
     }
@@ -114,6 +122,34 @@ public class MimeMessage extends Message {
         } catch (MimeException me) {
             //TODO wouldn't a MessagingException be better?
             throw new Error(me);
+        }
+
+        inspectEncryption();
+    }
+
+    private void inspectEncryption() throws MessagingException  {
+        encryptionType = EncryptionType.NONE;
+        String[] headers = getHeader("Content-Type");
+        if (headers.length > 0
+                && headers[0].contains("multipart/encrypted")) {
+            encryptionType = EncryptionType.PGP_MIME;
+        } else if (headers.length > 0
+                && headers[0].toLowerCase().startsWith("application/pkcs7-mime")) {
+            encryptionType = EncryptionType.S_MIME;
+        } else {
+            Part part = MimeUtility.findFirstPartByMimeType(this, "text/plain");
+            if (part == null) {
+                part = MimeUtility.findFirstPartByMimeType(this, "text/html");
+            }
+            if (part != null) {
+                String data = MessageExtractor.getTextFromPart(part);
+                if (data != null) {
+                    Matcher matcher = PGP_MESSAGE.matcher(data);
+                    if (matcher.matches()) {
+                        encryptionType = EncryptionType.INLINE;
+                    }
+                }
+            }
         }
     }
 
@@ -642,6 +678,7 @@ public class MimeMessage extends Message {
         destination.mReplyTo = mReplyTo;
         destination.mReferences = mReferences;
         destination.mInReplyTo = mInReplyTo;
+        destination.encryptionType = encryptionType;
     }
 
     @Override
@@ -734,6 +771,15 @@ public class MimeMessage extends Message {
         }
         MimeBodyPart result = new MimeBodyPart(headerClone, getBody());
         return result;
+    }
+    
+    @Override
+    public EncryptionType getEncryptionType(){
+        return encryptionType;
+    }
+
+    public void setEncryptionType(EncryptionType encryptionType) {
+        this.encryptionType = encryptionType;
     }
 
     /**

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -745,4 +745,14 @@ public class MimeMessage extends Message {
     public void addContentTypeParameter(String attribute, String value){
         mHeader.addContentTypeParameter(attribute, value);
     }
+
+    /**
+     * Returns the value of content-type given parameter.
+     * To allow comparison, the returned string isn't quoted.
+     * @param attribute
+     * @return the unquoted parameter value
+     */
+    public String getContentTypeParameter(String attribute){
+        return mHeader.getContentTypeParameter(attribute);
+    }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessageHelper.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessageHelper.java
@@ -26,7 +26,7 @@ public class MimeMessageHelper {
             String mimeType = multipart.getMimeType();
             String contentType = String.format("%s; boundary=\"%s\"", mimeType, multipart.getBoundary());
             part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType);
-            if (MimeUtility.isSameMimeType(mimeType, "multipart/signed")) {
+            if (MimeUtility.isSameMimeType(mimeType, "multipart/signed") || MimeUtility.isSameMimeType(mimeType, "multipart/encrypted")) {
                 setEncoding(part, MimeUtil.ENC_7BIT);
             } else {
                 setEncoding(part, MimeUtil.ENC_8BIT);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
@@ -1115,6 +1115,8 @@ public class MimeUtility {
             return (MimeUtil.ENC_7BIT);
         } else if (isMultipart(type)) {
             return (MimeUtil.ENC_8BIT);
+        } else if (MimeUtil.isSameMimeType(type, "application/pgp-keys")) {
+            return MimeUtil.ENC_7BIT;
         } else {
             return (MimeUtil.ENC_BASE64);
         }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/TextBody.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/TextBody.java
@@ -11,6 +11,8 @@ import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 
 import com.fsck.k9.mail.filter.CountingOutputStream;
+import com.fsck.k9.mail.filter.SignSafeOutputStream;
+
 import org.apache.james.mime4j.codec.QuotedPrintableOutputStream;
 import org.apache.james.mime4j.util.MimeUtil;
 
@@ -34,6 +36,12 @@ public class TextBody implements Body, SizeAware {
         this.mBody = body;
     }
 
+    private static boolean signSafe = false;
+
+    public static void setSignSafe(boolean signable){
+        signSafe = signable;
+    }
+
     @Override
     public void writeTo(OutputStream out) throws IOException, MessagingException {
         if (mBody != null) {
@@ -41,6 +49,9 @@ public class TextBody implements Body, SizeAware {
             if (MimeUtil.ENC_8BIT.equalsIgnoreCase(mEncoding)) {
                 out.write(bytes);
             } else {
+                if (signSafe){
+                    out = new SignSafeOutputStream(out);
+                }
                 QuotedPrintableOutputStream qp = new QuotedPrintableOutputStream(out, false);
                 qp.write(bytes);
                 qp.flush();

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -115,6 +115,8 @@ public class Account implements BaseAccount, StoreConfig {
     public static final String IDENTITY_EMAIL_KEY = "email";
     public static final String IDENTITY_DESCRIPTION_KEY = "description";
 
+    private static final String USE_PGP_MIME = ".usePgpMime";
+
     /*
      * http://developer.android.com/design/style/color.html
      * Note: Order does matter, it's the order in which they will be picked.
@@ -222,6 +224,7 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean mSyncRemoteDeletions;
     private String mCryptoApp;
     private long mCryptoKey;
+    private boolean usePgpMime;
     private boolean mMarkMessageAsReadOnView;
     private boolean mAlwaysShowCcBcc;
     private boolean mAllowRemoteSearch;
@@ -474,6 +477,7 @@ public class Account implements BaseAccount, StoreConfig {
         mEnabled = prefs.getBoolean(mUuid + ".enabled", true);
         mMarkMessageAsReadOnView = prefs.getBoolean(mUuid + ".markMessageAsReadOnView", true);
         mAlwaysShowCcBcc = prefs.getBoolean(mUuid + ".alwaysShowCcBcc", false);
+        usePgpMime = prefs.getBoolean(mUuid + USE_PGP_MIME, false);
 
         cacheChips();
 
@@ -569,6 +573,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.remove(mUuid + ".messageFormat");
         editor.remove(mUuid + ".messageReadReceipt");
         editor.remove(mUuid + ".notifyMailCheck");
+        editor.remove(mUuid + USE_PGP_MIME);
         for (NetworkType type : NetworkType.values()) {
             editor.remove(mUuid + ".useCompression." + type.name());
         }
@@ -729,6 +734,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(mUuid + ".stripSignature", mStripSignature);
         editor.putString(mUuid + ".cryptoApp", mCryptoApp);
         editor.putLong(mUuid + ".cryptoKey", mCryptoKey);
+        editor.putBoolean(mUuid + USE_PGP_MIME, usePgpMime);
         editor.putBoolean(mUuid + ".allowRemoteSearch", mAllowRemoteSearch);
         editor.putBoolean(mUuid + ".remoteSearchFullText", mRemoteSearchFullText);
         editor.putInt(mUuid + ".remoteSearchNumResults", mRemoteSearchNumResults);
@@ -1885,5 +1891,21 @@ public class Account implements BaseAccount, StoreConfig {
             Uri uri = Uri.parse(transportUri);
             localKeyStore.deleteCertificate(uri.getHost(), uri.getPort());
         }
+    }
+
+    /**
+     * Returns true if PGP/MIME should be used ro encrypt/sign emails sent with this account.
+     * @return true if PGP/MIME should be used ro encrypt/sign emails sent with this account.
+     */
+    public boolean isUsePgpMime(){
+        return usePgpMime;
+    }
+
+    /**
+     * Sets wether emails sent with this account
+     * @param usePgpMime true if PGP/MIME should be used ro encrypt/sign emails sent with this account.
+     */
+    public void setUsePgpMime(boolean usePgpMime){
+        this.usePgpMime = usePgpMime;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1,9 +1,14 @@
 package com.fsck.k9.activity;
 
 
+import java.io.BufferedOutputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.text.DateFormat;
@@ -30,6 +35,7 @@ import android.content.ClipData;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
 import android.content.Loader;
 import android.content.pm.ActivityInfo;
@@ -82,6 +88,7 @@ import com.fsck.k9.activity.loader.AttachmentInfoLoader;
 import com.fsck.k9.activity.misc.Attachment;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.crypto.OpenPgpApiException;
 import com.fsck.k9.crypto.PgpData;
 import com.fsck.k9.fragment.ProgressDialogFragment;
 import com.fsck.k9.helper.ContactItem;
@@ -98,6 +105,7 @@ import com.fsck.k9.mail.Message.RecipientType;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Multipart;
 import com.fsck.k9.mail.Part;
+import com.fsck.k9.mail.filter.EOLConvertingOutputStream;
 import com.fsck.k9.mail.internet.MessageExtractor;
 import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.internet.MimeUtility;
@@ -111,6 +119,9 @@ import com.fsck.k9.message.QuotedTextMode;
 import com.fsck.k9.message.SimpleMessageFormat;
 import com.fsck.k9.ui.EolConvertingEditText;
 import com.fsck.k9.view.MessageWebView;
+
+import org.apache.commons.io.output.CountingOutputStream;
+import org.apache.james.mime4j.codec.QuotedPrintableOutputStream;
 import org.htmlcleaner.CleanerProperties;
 import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.SimpleHtmlSerializer;
@@ -188,6 +199,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private static final int CONTACT_PICKER_BCC2 = 9;
 
     private static final int REQUEST_CODE_SIGN_ENCRYPT = 12;
+    private static final int REQUEST_CODE_SIGN=13;
+    private static final int REQUEST_CODE_ENCRYPT=14;
 
     /**
      * Regular expression to remove the first localized "Re:" prefix in subjects.
@@ -245,6 +258,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
      */
     private boolean mSourceMessageProcessed = false;
     private int mMaxLoaderId = 0;
+    private Attachment myPublicKey;
 
     enum Action {
         COMPOSE,
@@ -294,6 +308,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private CheckBox mEncryptCheckbox;
     private TextView mCryptoSignatureUserId;
     private TextView mCryptoSignatureUserIdRest;
+    private CheckBox attachKeyCheckBox;
 
     private PgpData mPgpData = null;
     private String mOpenPgpProvider;
@@ -760,6 +775,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             mCryptoSignatureUserIdRest = (TextView)findViewById(R.id.userIdRest);
             mEncryptCheckbox = (CheckBox)findViewById(R.id.cb_encrypt);
             mEncryptCheckbox.setOnCheckedChangeListener(updateListener);
+            attachKeyCheckBox = (CheckBox) findViewById(R.id.cb_attach_key);
+            attachKeyCheckBox.setEnabled(mAccount.getCryptoKey() != 0);
 
             if (mSourceMessageBody != null) {
                 // mSourceMessageBody is set to something when replying to and forwarding decrypted
@@ -1176,15 +1193,19 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         return createMessageBuilder(isDraft).buildText();
     }
 
-    private MimeMessage createDraftMessage() throws MessagingException {
+    private MimeMessage createDraftMessage() throws MessagingException, OpenPgpApiException {
         return createMessageBuilder(true).build();
     }
 
-    private MimeMessage createMessage() throws MessagingException {
+    private MimeMessage createMessage() throws MessagingException, OpenPgpApiException {
         return createMessageBuilder(false).build();
     }
 
     private MessageBuilder createMessageBuilder(boolean isDraft) {
+        OpenPgpApi api = null;
+        if (mAccount.isUsePgpMime() && (shouldEncrypt() || shouldSign())) {
+            api = new OpenPgpApi(this, mOpenPgpServiceConnection.getService());
+        }
         return new MessageBuilder(getApplicationContext())
                 .setSubject(mSubjectView.getText().toString())
                 .setTo(getAddresses(mToView))
@@ -1209,7 +1230,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 .setSignatureChanged(mSignatureChanged)
                 .setCursorPosition(mMessageContentView.getSelectionStart())
                 .setMessageReference(mMessageReference)
-                .setDraft(isDraft);
+                .setDraft(isDraft)
+                .setPgpMimeEncryption(shouldEncrypt() && mAccount.isUsePgpMime(), encryptIntent, api)
+                .setPgpMimeSignature(shouldSign() && mAccount.isUsePgpMime(), signIntent, api);
     }
 
     private ArrayList<Attachment> createAttachmentList() {
@@ -1219,8 +1242,46 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             Attachment attachment = (Attachment) view.getTag();
             attachments.add(attachment);
         }
-
+        if (myPublicKey != null){
+            attachments.add(myPublicKey);
+        }
         return attachments;
+    }
+
+    private Attachment attachedPublicKey() throws OpenPgpApiException {
+        try {
+            Attachment publicKey = new Attachment();
+            publicKey.contentType = "application/pgp-keys";
+
+            String keyName = "0x" +  Long.toString(mAccount.getCryptoKey(), 16).substring(8);
+            publicKey.name = keyName + ".asc";
+            Intent intent = new Intent(OpenPgpApi.ACTION_GET_KEY);
+            intent.putExtra(OpenPgpApi.EXTRA_KEY_ID, mAccount.getCryptoKey());
+            intent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
+            OpenPgpApi api = new OpenPgpApi(this, mOpenPgpServiceConnection.getService());
+            File keyTempFile = File.createTempFile("key", ".asc", getCacheDir());
+            keyTempFile.deleteOnExit();
+            try {
+                CountingOutputStream keyFileStream = new CountingOutputStream(new BufferedOutputStream(
+                        new FileOutputStream(keyTempFile)));
+                Intent res = api.executeApi(intent, null, new EOLConvertingOutputStream(keyFileStream));
+                if (res.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR) != OpenPgpApi.RESULT_CODE_SUCCESS
+                        || keyFileStream.getByteCount() == 0) {
+                    keyTempFile.delete();
+                    throw new OpenPgpApiException(String.format(getString(R.string.openpgp_no_public_key_returned),
+                            getString(R.string.btn_attach_key)));
+                }
+                publicKey.filename = keyTempFile.getAbsolutePath();
+                publicKey.state = Attachment.LoadingState.COMPLETE;
+                publicKey.size = keyFileStream.getByteCount();
+                return publicKey;
+            } catch(RuntimeException e){
+                keyTempFile.delete();
+                throw e;
+            }
+        } catch(IOException e){
+            throw new RuntimeException(getString(R.string.error_cant_create_temporary_file), e);
+        }
     }
 
     private void sendMessage() {
@@ -1257,27 +1318,145 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
     }
 
+    private volatile Intent signIntent;
+    private volatile Intent encryptIntent;
+
     private void onSend() {
-        if (getAddresses(mToView).length == 0 && getAddresses(mCcView).length == 0 && getAddresses(mBccView).length == 0) {
-            mToView.setError(getString(R.string.message_compose_error_no_recipients));
-            Toast.makeText(this, getString(R.string.message_compose_error_no_recipients), Toast.LENGTH_LONG).show();
-            return;
-        }
+        try {
+            if (getAddresses(mToView).length == 0 && getAddresses(mCcView).length == 0 && getAddresses(mBccView).length == 0) {
+                mToView.setError(getString(R.string.message_compose_error_no_recipients));
+                Toast.makeText(this, getString(R.string.message_compose_error_no_recipients), Toast.LENGTH_LONG).show();
+                return;
+            }
 
-        if (mWaitingForAttachments != WaitingAction.NONE) {
-            return;
-        }
+            if (mWaitingForAttachments != WaitingAction.NONE) {
+                return;
+            }
 
-        if (mNumAttachmentsLoading > 0) {
-            mWaitingForAttachments = WaitingAction.SEND;
-            showWaitingForAttachmentDialog();
-        } else {
-            performSend();
+            if (mNumAttachmentsLoading > 0) {
+                mWaitingForAttachments = WaitingAction.SEND;
+                showWaitingForAttachmentDialog();
+            } else {
+                if (isCryptoProviderEnabled() && attachKeyCheckBox.isChecked()){
+                    myPublicKey = attachedPublicKey();
+                }
+
+                boolean canProceed = true;
+                encryptIntent = signIntent = null;
+                if (shouldEncrypt() && mAccount.isUsePgpMime()) {
+                    if (!buildAndTestEncryptIntent()) {
+                        canProceed = false;
+                    }
+
+                }
+                if (shouldSign() && mAccount.isUsePgpMime()) {
+                    if (!buildAndTestSignIntent()) {
+                        canProceed = false;
+                    }
+                }
+                if (canProceed) {
+                    performSend();
+                }
+            }
+        } catch(OpenPgpApiException e){
+            Log.e(K9.LOG_TAG, "OpenPgp error while sending message", e);
+            Toast.makeText(MessageCompose.this,
+                    getString(R.string.openpgp_error, e.getLocalizedMessage()),
+                    Toast.LENGTH_LONG).show();
+        } catch(RuntimeException e){
+            Log.e(K9.LOG_TAG, "Error sending message", e);
+            Toast.makeText(MessageCompose.this,
+                    getString(R.string.send_aborted, e.getLocalizedMessage()),
+                    Toast.LENGTH_LONG).show();
         }
     }
 
+    private boolean buildAndTestSignIntent()  throws OpenPgpApiException {
+        signIntent = new Intent(OpenPgpApi.ACTION_DETACHED_SIGN);
+        if (mAccount.getCryptoKey() != 0) {
+            signIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, mAccount.getCryptoKey());
+        }
+        boolean result = testSignIntent(signIntent);
+        if (!result){
+            signIntent = null;
+        }
+        return result;
+    }
+
+    private boolean testSignIntent(Intent signIntent) throws OpenPgpApiException {
+        OpenPgpApi api = new OpenPgpApi(this, mOpenPgpServiceConnection.getService());
+        OutputStream nullOutput = new OutputStream(){
+            public void write(int b){}
+
+        };
+        Intent res = api.executeApi(signIntent, new ByteArrayInputStream("dummy".getBytes()), nullOutput);
+        switch (res.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
+            case OpenPgpApi.RESULT_CODE_SUCCESS:
+                return true;
+
+            case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
+                PendingIntent pi = res.getParcelableExtra(OpenPgpApi.RESULT_INTENT);
+                try {
+                    startIntentSenderForResult(pi.getIntentSender(), REQUEST_CODE_SIGN, null, 0, 0, 0);
+                } catch (IntentSender.SendIntentException e) {
+                    throw new RuntimeException(e.getLocalizedMessage(), e);
+                }
+                return false;
+            case OpenPgpApi.RESULT_CODE_ERROR:
+                OpenPgpError error = res.getParcelableExtra(OpenPgpApi.RESULT_ERROR);
+                throw new OpenPgpApiException(error);
+            default:
+                throw new RuntimeException("Unexpected result from OpenPgpApi :"+ res.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR));
+        }
+    }
+
+    private boolean testEncryptIntent(Intent encryptIntent) throws OpenPgpApiException {
+        OpenPgpApi api = new OpenPgpApi(this, mOpenPgpServiceConnection.getService());
+        OutputStream nullOutput = new OutputStream(){
+            public void write(int b){}
+
+        };
+        Intent res = api.executeApi(encryptIntent, new ByteArrayInputStream("dummy".getBytes()), nullOutput);
+        switch (res.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
+            case OpenPgpApi.RESULT_CODE_SUCCESS:
+                return true;
+
+            case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED: {
+                PendingIntent pi = res.getParcelableExtra(OpenPgpApi.RESULT_INTENT);
+                try {
+                    startIntentSenderForResult(pi.getIntentSender(), REQUEST_CODE_ENCRYPT, null, 0, 0, 0);
+                } catch (IntentSender.SendIntentException e) {
+                    throw new RuntimeException("Internal error", e);
+                }
+                return false;
+            }
+            case OpenPgpApi.RESULT_CODE_ERROR: {
+                OpenPgpError error = res.getParcelableExtra(OpenPgpApi.RESULT_ERROR);
+                throw new OpenPgpApiException(error);
+            }
+            default:
+                throw new RuntimeException("Unexpected result from OpenPgpApi :"+ res.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR));
+        }
+    }
+
+    private boolean buildAndTestEncryptIntent() throws OpenPgpApiException {
+        List<String> emails = new ArrayList<String>();
+
+        for (Address address : getRecipientAddresses()) {
+            emails.add(address.getAddress());
+        }
+        encryptIntent = new Intent(OpenPgpApi.ACTION_ENCRYPT);
+        encryptIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, emails.toArray(new String[emails.size()]));
+        encryptIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
+        boolean result = testEncryptIntent(encryptIntent);
+        if (!result){
+            encryptIntent = null;
+        }
+        return result;
+    }
+
     private void performSend() {
-        if (isCryptoProviderEnabled()) {
+        if (isCryptoProviderEnabled() && ! mAccount.isUsePgpMime()) {
             // OpenPGP Provider API
 
             // If not already encrypted but user wants to encrypt...
@@ -1487,7 +1666,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
      */
     @SuppressLint("InlinedApi")
     private void onAddAttachment2(final String mime_type) {
-        if (isCryptoProviderEnabled()) {
+        if (isCryptoProviderEnabled() && !mAccount.isUsePgpMime()) {
             Toast.makeText(this, R.string.attachment_encryption_unsupported, Toast.LENGTH_LONG).show();
         }
         Intent i = new Intent(Intent.ACTION_GET_CONTENT);
@@ -1752,7 +1931,47 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                     addAddress(mBccView, new Address(emailAddr, ""));
                 }
                 break;
+            case REQUEST_CODE_ENCRYPT:
+                onActivityResultCodeEncrypt(requestCode, resultCode, data);
+                break;
+
+            case REQUEST_CODE_SIGN:
+                onActivityResultCodeSign(requestCode, resultCode, data);
+                break;
         }
+    }
+
+    protected void onActivityResultCodeEncrypt(int requestCode, int resultCode, Intent data) {
+        long[] keyIds = data.getLongArrayExtra(OpenPgpApi.EXTRA_KEY_IDS);
+        if (keyIds.length == 0) {
+            Toast.makeText(this,
+                    R.string.openpgp_dialog_select_a_key,
+                    Toast.LENGTH_LONG).show();
+        } else {
+            encryptIntent = data;
+            if (canPerformSend()) {
+                performSend();
+            }
+        }
+    }
+
+    protected void onActivityResultCodeSign(int requestCode, int resultCode, Intent data) {
+        try {
+            boolean success = testSignIntent(data);
+            if (success) {
+                signIntent = data;
+                if (canPerformSend()) {
+                    performSend();
+                }
+            }
+        } catch(OpenPgpApiException e){
+            Toast.makeText(this, getString(R.string.openpgp_unable_to_sign)+ " : " + e.getLocalizedMessage(), Toast.LENGTH_LONG).show();
+        }
+    }
+
+    private boolean canPerformSend(){
+        return (encryptIntent != null || !shouldEncrypt())
+                && (signIntent != null || !shouldSign());
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
@@ -3120,6 +3339,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             MimeMessage message;
             try {
                 message = createMessage();
+            } catch (OpenPgpApiException e){
+                Log.e(K9.LOG_TAG, "Failed to create new message for send or save.", e);
+                throw new RuntimeException("Failed to create a new message for send or save.", e);
             } catch (MessagingException me) {
                 Log.e(K9.LOG_TAG, "Failed to create new message for send or save.", me);
                 throw new RuntimeException("Failed to create a new message for send or save.", me);
@@ -3153,6 +3375,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             MimeMessage message;
             try {
                 message = createDraftMessage();
+            } catch (OpenPgpApiException e){
+                Log.e(K9.LOG_TAG, "Failed to create new message for send or save.", e);
+                throw new RuntimeException("Failed to create a new message for send or save.", e);
             } catch (MessagingException me) {
                 Log.e(K9.LOG_TAG, "Failed to create new message for send or save.", me);
                 throw new RuntimeException("Failed to create a new message for send or save.", me);
@@ -3471,9 +3696,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             // Right now we send a text/plain-only message when the quoted text was edited, no
             // matter what the user selected for the message format.
             messageFormat = SimpleMessageFormat.TEXT;
-        } else if (shouldEncrypt() || shouldSign()) {
-            // Right now we only support PGP inline which doesn't play well with HTML. So force
-            // plain text in those cases.
+        } else if ((shouldEncrypt() || shouldSign()) && !mAccount.isUsePgpMime()) {
+            // PGP inline doesn't play well with HTML. So force plain text in those cases.
             messageFormat = SimpleMessageFormat.TEXT;
         } else if (origMessageFormat == MessageFormat.AUTO) {
             if (mAction == Action.COMPOSE || mQuotedTextFormat == SimpleMessageFormat.TEXT ||

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -20,6 +20,7 @@ import android.preference.Preference;
 import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.PreferenceScreen;
 import android.preference.RingtonePreference;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.fsck.k9.Account;
@@ -113,6 +114,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_CRYPTO = "crypto";
     private static final String PREFERENCE_CRYPTO_APP = "crypto_app";
     private static final String PREFERENCE_CRYPTO_KEY = "crypto_key";
+    private static final String PREFERENCE_CRYPTO_PGPMIME = "pgp_mime_default";
     private static final String PREFERENCE_CLOUD_SEARCH_ENABLED = "remote_search_enabled";
     private static final String PREFERENCE_REMOTE_SEARCH_NUM_RESULTS = "account_remote_search_num_results";
     private static final String PREFERENCE_REMOTE_SEARCH_FULL_TEXT = "account_remote_search_full_text";
@@ -179,6 +181,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private boolean mHasCrypto = false;
     private OpenPgpAppPreference mCryptoApp;
     private OpenPgpKeyPreference mCryptoKey;
+    private CheckBoxPreference cryptoPgpMime;
 
     private PreferenceScreen mSearchScreen;
     private CheckBoxPreference mCloudSearchEnabled;
@@ -695,12 +698,16 @@ public class AccountSettings extends K9PreferenceActivity {
             mCryptoKey = (OpenPgpKeyPreference) findPreference(PREFERENCE_CRYPTO_KEY);
 
             mCryptoApp.setValue(String.valueOf(mAccount.getCryptoApp()));
+            cryptoPgpMime = (CheckBoxPreference) findPreference(PREFERENCE_CRYPTO_PGPMIME);
+            cryptoPgpMime.setEnabled(!TextUtils.isEmpty(mCryptoApp.getValue()));
+
             mCryptoApp.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
                     String value = newValue.toString();
                     mCryptoApp.setValue(value);
 
                     mCryptoKey.setOpenPgpProvider(value);
+                    cryptoPgpMime.setEnabled(!TextUtils.isEmpty(value));
                     return false;
                 }
             });
@@ -716,6 +723,7 @@ public class AccountSettings extends K9PreferenceActivity {
                     return false;
                 }
             });
+            cryptoPgpMime.setChecked(mAccount.isUsePgpMime());
         } else {
             final Preference mCryptoMenu = findPreference(PREFERENCE_CRYPTO);
             mCryptoMenu.setEnabled(false);
@@ -783,6 +791,7 @@ public class AccountSettings extends K9PreferenceActivity {
         if (mHasCrypto) {
             mAccount.setCryptoApp(mCryptoApp.getValue());
             mAccount.setCryptoKey(mCryptoKey.getValue());
+            mAccount.setUsePgpMime(cryptoPgpMime.isChecked());
         }
 
         // In webdav account we use the exact folder name also for inbox,

--- a/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
@@ -61,7 +61,8 @@ public class MessageDecryptVerifier {
             String mimeType = part.getMimeType();
             Body body = part.getBody();
 
-            if (isSameMimeType(mimeType, MULTIPART_SIGNED)) {
+            if (isSameMimeType(mimeType, MULTIPART_SIGNED)
+                    && APPLICATION_PGP_SIGNATURE.equalsIgnoreCase(part.getContentTypeParameter(PROTOCOL_PARAMETER))) {
                 signedParts.add(part);
             } else if (body instanceof Multipart) {
                 Multipart multipart = (Multipart) body;

--- a/k9mail/src/main/java/com/fsck/k9/crypto/OpenPgpApiException.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/OpenPgpApiException.java
@@ -1,0 +1,27 @@
+package com.fsck.k9.crypto;
+
+import org.openintents.openpgp.OpenPgpError;
+
+/**
+ * Created by alexandre on 11/9/15.
+ */
+public class OpenPgpApiException extends Exception {
+    public OpenPgpApiException() {
+    }
+
+    public OpenPgpApiException(String detailMessage) {
+        super(detailMessage);
+    }
+
+    public OpenPgpApiException(String detailMessage, Throwable throwable) {
+        super(detailMessage, throwable);
+    }
+
+    public OpenPgpApiException(Throwable throwable) {
+        super(throwable);
+    }
+
+    public OpenPgpApiException(OpenPgpError error){
+        super(error.getMessage());
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -84,6 +84,7 @@ import com.fsck.k9.helper.MergeCursorWithUniqueId;
 import com.fsck.k9.helper.MessageHelper;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.Message;
@@ -126,11 +127,13 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         MessageColumns.ATTACHMENT_COUNT,
         MessageColumns.FOLDER_ID,
         MessageColumns.PREVIEW,
+        MessageColumns.ENCRYPTION,
         ThreadColumns.ROOT,
         SpecialColumns.ACCOUNT_UUID,
         SpecialColumns.FOLDER_NAME,
 
-        SpecialColumns.THREAD_COUNT,
+        SpecialColumns.THREAD_COUNT
+
     };
 
     private static final int ID_COLUMN = 0;
@@ -148,10 +151,11 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     private static final int ATTACHMENT_COUNT_COLUMN = 12;
     private static final int FOLDER_ID_COLUMN = 13;
     private static final int PREVIEW_COLUMN = 14;
-    private static final int THREAD_ROOT_COLUMN = 15;
-    private static final int ACCOUNT_UUID_COLUMN = 16;
-    private static final int FOLDER_NAME_COLUMN = 17;
-    private static final int THREAD_COUNT_COLUMN = 18;
+    private static final int ENCRYPTION_COLUMN = 15;
+    private static final int THREAD_ROOT_COLUMN = 16;
+    private static final int ACCOUNT_UUID_COLUMN = 17;
+    private static final int FOLDER_NAME_COLUMN = 18;
+    private static final int THREAD_COUNT_COLUMN = 19;
 
     private static final String[] PROJECTION = Arrays.copyOf(THREADED_PROJECTION,
             THREAD_COUNT_COLUMN);
@@ -2029,9 +2033,15 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                     .append(beforePreviewText);
 
             if (mPreviewLines > 0) {
-                String preview = cursor.getString(PREVIEW_COLUMN);
-                if (preview != null) {
-                    messageStringBuilder.append(" ").append(preview);
+                if (EncryptionType.values()[cursor.getInt(ENCRYPTION_COLUMN)] != EncryptionType.NONE) {
+                    messageStringBuilder.append(" *");
+                    messageStringBuilder.append(context.getString(R.string.openpgp_result_encrypted));
+                    messageStringBuilder.append('*');
+                } else {
+                    String preview = cursor.getString(PREVIEW_COLUMN);
+                    if (preview != null) {
+                        messageStringBuilder.append(" ").append(preview);
+                    }
                 }
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -1262,6 +1262,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                     ? System.currentTimeMillis() : message.getInternalDate().getTime());
             cv.put("mime_type", message.getMimeType());
             cv.put("empty", 0);
+            cv.put("encryption_type", message.getEncryptionType().ordinal());
 
             String messageId = message.getMessageId();
             if (messageId != null) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -14,6 +14,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.MessagingException;
@@ -113,6 +114,7 @@ public class LocalMessage extends MimeMessage {
 
         messagePartId = cursor.getLong(22);
         mimeType = cursor.getString(23);
+        setEncryptionType(EncryptionType.values()[cursor.getInt(24)]);
     }
 
     long getMessagePartId() {
@@ -317,7 +319,7 @@ public class LocalMessage extends MimeMessage {
             this.localStore.database.execute(true, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException,
-                    UnavailableStorageException {
+                        UnavailableStorageException {
                     try {
                         LocalFolder localFolder = (LocalFolder) mFolder;
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -555,4 +555,26 @@ public class LocalMessage extends MimeMessage {
     public boolean isBodyMissing() {
         return getBody() == null;
     }
+
+
+    /**
+     * Returns the value of content-type given parameter.
+     * To allow comparison, the returned string isn't quoted.
+     * @param attribute
+     * @return the unquoted parameter value
+     */
+    public String getContentTypeParameter(String attribute){
+        loadHeaderIfNecessary();
+        return super.getContentTypeParameter(attribute);
+    }
+
+    synchronized protected void loadHeaderIfNecessary() {
+        try {
+            if (!mHeadersLoaded) {
+                loadHeaders();
+            }
+        } catch(MessagingException e){
+            throw new RuntimeException("Couldn't parse header", e);
+        }
+    }
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -80,12 +80,13 @@ public class LocalStore extends Store implements Serializable {
     /*
      * a String containing the columns getMessages expects to work with
      * in the correct order.
+     * - encryption_type : see {@link EncryptionType} for possible values
      */
     static String GET_MESSAGES_COLS =
         "subject, sender_list, date, uid, flags, messages.id, to_list, cc_list, " +
         "bcc_list, reply_to_list, attachment_count, internal_date, messages.message_id, " +
         "folder_id, preview, threads.id, threads.root, deleted, read, flagged, answered, " +
-        "forwarded, message_part_id, mime_type ";
+        "forwarded, message_part_id, mime_type, encryption_type ";
 
     static final String GET_FOLDER_COLS =
         "folders.id, name, visible_limit, last_updated, status, push_state, last_pushed, " +
@@ -129,8 +130,7 @@ public class LocalStore extends Store implements Serializable {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 52;
-
+    public static final int DB_VERSION = 53;
 
     public static String getColumnNameForFlag(Flag flag) {
         switch (flag) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageInfoExtractor.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import android.content.Context;
 
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
@@ -25,8 +26,12 @@ class MessageInfoExtractor {
     }
 
     public String getMessageTextPreview() throws MessagingException {
-        getViewablesIfNecessary();
-        return MessagePreviewExtractor.extractPreview(context, viewables);
+        if (message.getEncryptionType() == EncryptionType.NONE) {
+            getViewablesIfNecessary();
+            return MessagePreviewExtractor.extractPreview(context, viewables);
+        } else {
+            return ""; // cant preview encrypted emails
+        }
     }
 
     public int getAttachmentCount() throws MessagingException {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -104,7 +104,8 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
                         "flagged INTEGER default 0, " +
                         "answered INTEGER default 0, " +
                         "forwarded INTEGER default 0, " +
-                        "message_part_id INTEGER" +
+                        "message_part_id INTEGER, " +
+                        "encryption_type INTEGER" +
                         ")");
 
                 db.execSQL("CREATE TABLE message_parts (" +
@@ -576,6 +577,12 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
                 }
                 if (db.getVersion() < 52) {
                     addMoreMessagesColumnToFoldersTable(db);
+                }
+                if (db.getVersion() < 53) {
+                    /*
+                     * All messages are initialized to "no encrypted" even if encrypted.
+                     */
+                    db.execSQL("ALTER TABLE messages ADD COLUMN encryption_type INTEGER default 0");
                 }
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
@@ -512,6 +512,14 @@ public class MessageBuilder {
      * @throws MessagingException
      */
     private void encapsulateMimeInMultipartSigned(MimeMessage mime) throws MessagingException, OpenPgpApiException {
+        /*
+         * Once set to true, text messages will be sign safe (RFC-3156 §3) until K9Mail is stopped.
+         * This "global parameter" is made to avoid a double generation (regular/sign safe) on the
+         * whole Part/Body hierarchy and still limit the scope of this extra encoding to pgp/mime users
+         * Downside it that even unsigned messages will contain extra-encoding once a message has
+         * been signed. But it will be transparent if the recipient decodes properly quoted-printable.
+         */
+        TextBody.setSignSafe(true);
         MimeBodyPart bodyPart = mime.toBodyPart();
         bodyPart.setUsing7bitTransport();
         ByteArrayOutputStream messageToSign = new ByteArrayOutputStream();

--- a/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
@@ -141,7 +141,7 @@ public class MessageBuilder {
         if (pgpData.getEncryptedData() != null) {
             String text = pgpData.getEncryptedData();
             body = new TextBody(text);
-            message.setEncryptionType(EncryptionType.INLINE);
+            message.setEncryptionType(EncryptionType.PGP_INLINE);
         } else {
             body = buildText(isDraft);
         }

--- a/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
@@ -1,11 +1,17 @@
 package com.fsck.k9.message;
 
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 
 import android.content.Context;
+import android.content.Intent;
+import android.util.Log;
 
 import com.fsck.k9.Account.QuoteStyle;
 import com.fsck.k9.Identity;
@@ -13,6 +19,7 @@ import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.activity.misc.Attachment;
+import com.fsck.k9.crypto.OpenPgpApiException;
 import com.fsck.k9.crypto.PgpData;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Body;
@@ -25,10 +32,13 @@ import com.fsck.k9.mail.internet.MimeMessageHelper;
 import com.fsck.k9.mail.internet.MimeMultipart;
 import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mail.internet.TextBody;
+import com.fsck.k9.mailstore.BinaryMemoryBody;
 import com.fsck.k9.mailstore.TempFileBody;
 import com.fsck.k9.mailstore.TempFileMessageBody;
 import org.apache.james.mime4j.codec.EncoderUtil;
 import org.apache.james.mime4j.util.MimeUtil;
+import org.openintents.openpgp.OpenPgpError;
+import org.openintents.openpgp.util.OpenPgpApi;
 
 
 public class MessageBuilder {
@@ -59,6 +69,9 @@ public class MessageBuilder {
     private MessageReference messageReference;
     private boolean isDraft;
 
+    private Intent pgpMimeSignIntent = null;
+    private Intent pgpMimeEncryptIntent = null;
+    private OpenPgpApi openPgpApi;
 
     public MessageBuilder(Context context) {
         this.context = context;
@@ -68,7 +81,7 @@ public class MessageBuilder {
      * Build the final message to be sent (or saved). If there is another message quoted in this one, it will be baked
      * into the final message here.
      */
-    public MimeMessage build() throws MessagingException {
+    public MimeMessage build() throws MessagingException, OpenPgpApiException {
         //FIXME: check arguments
 
         MimeMessage message = new MimeMessage();
@@ -76,6 +89,12 @@ public class MessageBuilder {
         buildHeader(message);
         buildBody(message);
 
+        if (pgpMimeSignIntent != null){
+            encapsulateMimeInMultipartSigned(message);
+        }
+        if (pgpMimeEncryptIntent != null){
+            encapsulateMimeInMultipartEncrypted(message);
+        }
         return message;
     }
 
@@ -446,5 +465,108 @@ public class MessageBuilder {
     public MessageBuilder setDraft(boolean isDraft) {
         this.isDraft = isDraft;
         return this;
+    }
+
+    /**
+     * Turns PGP/MIME encryption on.
+     * @param encrypt turn encryption on, if false other parameters will be ignored
+     * @param encryptIntent Intent to use to perform the encryption. This Intent must be
+     *                      fully functional and mustn't requires further interaction. If it isn't the case,
+     *                      message building will fail.
+     * @param api Link to an initialized OpenPgpApi
+     * @return this
+     */
+    public MessageBuilder setPgpMimeEncryption(boolean encrypt, Intent encryptIntent, OpenPgpApi api){
+        if (encrypt) {
+            this.pgpMimeEncryptIntent = encryptIntent;
+            this.openPgpApi = api;
+        } else {
+            pgpMimeEncryptIntent = null;
+        }
+        return this;
+    }
+
+    /**
+     * Turns PGP/MIME signature on.
+     * @param sign turn on signature, if false other parameters will be ignored
+     * @param signIntent Intent to use to sign the message. This Intent must be
+     *                      fully functional and mustn't requires further interaction. If it isn't the case,
+     *                      message building will fail.
+     * @param api Link to an initialized OpenPgpApi
+     * @return this
+     */
+    public MessageBuilder setPgpMimeSignature(boolean sign, Intent signIntent, OpenPgpApi api){
+        if (sign) {
+            this.pgpMimeSignIntent = signIntent;
+            this.openPgpApi = api;
+        } else {
+            this.pgpMimeSignIntent = null;
+        }
+        return this;
+    }
+
+    /**
+     * Process the message in order to encapsulate it in a multipart/signed message.
+     * @see <a href="http://tools.ietf.org/html/rfc2015">RFC-2015</a>
+     * @param mime messsage to process
+     * @throws MessagingException
+     */
+    private void encapsulateMimeInMultipartSigned(MimeMessage mime) throws MessagingException, OpenPgpApiException {
+        MimeBodyPart bodyPart = mime.toBodyPart();
+        bodyPart.setUsing7bitTransport();
+        ByteArrayOutputStream messageToSign = new ByteArrayOutputStream();
+        try {
+            bodyPart.writeTo(messageToSign);
+            Intent result = openPgpApi.executeApi(pgpMimeSignIntent, new ByteArrayInputStream(messageToSign.toByteArray()), null);
+            if (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR) != OpenPgpApi.RESULT_CODE_SUCCESS) {
+                OpenPgpError error = result.getParcelableExtra(OpenPgpApi.RESULT_ERROR);
+                Log.e(OpenPgpApi.TAG, error.getMessage());
+                throw new OpenPgpApiException(error);
+            }
+            byte[] signedData = result.getByteArrayExtra(OpenPgpApi.RESULT_DETACHED_SIGNATURE);
+
+            MimeMultipart multipartSigned = new MimeMultipart();
+            multipartSigned.setSubType("signed");
+            multipartSigned.addBodyPart(bodyPart);
+            multipartSigned.addBodyPart(new MimeBodyPart(new BinaryMemoryBody(signedData, MimeUtil.ENC_7BIT), "application/pgp-signature"));
+
+            MimeMessageHelper.setBody(mime, multipartSigned);
+            mime.addContentTypeParameter("protocol", "\"application/pgp-signature\"");
+            mime.addContentTypeParameter("micalg", "pgp-sha256");
+        } catch(IOException e){
+            throw new RuntimeException(e.getLocalizedMessage(), e);
+        }
+    }
+
+    /**
+     * Process the message in order to encapsulate it in a multipart/encrypted mime entity
+     * @see <a href="http://tools.ietf.org/html/rfc2015">RFC-2015</a>
+     * @param mime message to encrypt and process
+     * @throws MessagingException
+     */
+    private void encapsulateMimeInMultipartEncrypted(MimeMessage mime) throws MessagingException, OpenPgpApiException {
+        ByteArrayOutputStream mimeMessageToEncrypt = new ByteArrayOutputStream();
+        try {
+            mime.toBodyPart().writeTo(mimeMessageToEncrypt);
+
+            final ByteArrayOutputStream encryptedData = new ByteArrayOutputStream();
+            Intent result = openPgpApi.executeApi(pgpMimeEncryptIntent, new ByteArrayInputStream(mimeMessageToEncrypt.toByteArray()), encryptedData);
+            if (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR) == OpenPgpApi.RESULT_CODE_ERROR) {
+                OpenPgpError error = result.getParcelableExtra(OpenPgpApi.RESULT_ERROR);
+                Log.e(OpenPgpApi.TAG, error.getMessage());
+                throw new OpenPgpApiException(error);
+            }
+
+            MimeMultipart multipartEncrypted = new MimeMultipart();
+            multipartEncrypted.setSubType("encrypted");
+            multipartEncrypted.addBodyPart(new MimeBodyPart(new BinaryMemoryBody("Version: 1".getBytes("US-ASCII"), MimeUtil.ENC_7BIT), "application/pgp-encrypted"));
+
+            multipartEncrypted.addBodyPart(new MimeBodyPart(
+                    new BinaryMemoryBody(encryptedData.toByteArray(), MimeUtil.ENC_7BIT), "application/octet-stream"));
+            MimeMessageHelper.setBody(mime, multipartEncrypted);
+            mime.addContentTypeParameter("protocol", "\"application/pgp-encrypted\"");
+        } catch (IOException e) {
+            throw new RuntimeException(e.getLocalizedMessage(), e);
+        }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
@@ -4,7 +4,6 @@ package com.fsck.k9.message;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.UnsupportedEncodingException;
 import java.util.Date;
 import java.util.List;
 import java.util.Locale;
@@ -23,6 +22,7 @@ import com.fsck.k9.crypto.OpenPgpApiException;
 import com.fsck.k9.crypto.PgpData;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Body;
+import com.fsck.k9.mail.EncryptionType;
 import com.fsck.k9.mail.Message.RecipientType;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.MimeBodyPart;
@@ -141,6 +141,7 @@ public class MessageBuilder {
         if (pgpData.getEncryptedData() != null) {
             String text = pgpData.getEncryptedData();
             body = new TextBody(text);
+            message.setEncryptionType(EncryptionType.INLINE);
         } else {
             body = buildText(isDraft);
         }
@@ -573,6 +574,7 @@ public class MessageBuilder {
                     new BinaryMemoryBody(encryptedData.toByteArray(), MimeUtil.ENC_7BIT), "application/octet-stream"));
             MimeMessageHelper.setBody(mime, multipartEncrypted);
             mime.addContentTypeParameter("protocol", "\"application/pgp-encrypted\"");
+            mime.setEncryptionType(EncryptionType.PGP_MIME);
         } catch (IOException e) {
             throw new RuntimeException(e.getLocalizedMessage(), e);
         }

--- a/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
@@ -148,6 +148,7 @@ public class EmailProvider extends ContentProvider {
         public static final String FLAGGED = "flagged";
         public static final String ANSWERED = "answered";
         public static final String FORWARDED = "forwarded";
+        public static final String ENCRYPTION = "encryption_type";
     }
 
     private interface InternalMessageColumns extends MessageColumns {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/OpenPgpHeaderView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/OpenPgpHeaderView.java
@@ -140,7 +140,7 @@ public class OpenPgpHeaderView extends LinearLayout {
         if (error == null) {
             text = context.getString(R.string.openpgp_unknown_error);
         } else {
-            text = context.getString(R.string.openpgp_error, error.getMessage());
+            text = context.getString(R.string.openpgp_decryption_failed, error.getMessage());
         }
         resultEncryptionText.setText(text);
     }
@@ -160,6 +160,9 @@ public class OpenPgpHeaderView extends LinearLayout {
 
         switch (cryptoAnnotation.getErrorType()) {
             case CRYPTO_API_RETURNED_ERROR:
+                displayEncryptionError();
+                dontDisplayVerification();
+                break;
             case NONE: {
                 displayVerificationResult();
                 break;
@@ -170,6 +173,11 @@ public class OpenPgpHeaderView extends LinearLayout {
                 break;
             }
         }
+    }
+    private void dontDisplayVerification(){
+        hideSignatureLayout();
+        resultSignatureText.setVisibility(View.GONE);
+        resultSignatureIcon.setVisibility(View.GONE);
     }
 
     private void displayIncompleteSignedPart() {

--- a/k9mail/src/main/res/layout/message_compose.xml
+++ b/k9mail/src/main/res/layout/message_compose.xml
@@ -182,6 +182,13 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:layout_weight="1"/>
+                    <CheckBox
+                        android:text="@string/btn_attach_key"
+                        android:id="@+id/cb_attach_key"
+                        android:layout_gravity="center_vertical"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1"/>
 
                 </LinearLayout>
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -576,6 +576,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_crypto">Cryptography</string>
     <string name="account_settings_crypto_app">OpenPGP app</string>
     <string name="account_settings_crypto_key">My Key</string>
+    <string name="account_settings_crypto_pgp_mime">Use PGP/MIME by default</string>
+    <string name="account_settings_crypto_pgp_mime_summary">If checked, will use PGP/MIME to sign/encrypt.</string>
     <string name="account_settings_no_openpgp_provider_installed">No OpenPGP app installed</string>
 
     <string name="account_settings_mail_check_frequency_label">Folder poll frequency</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -921,9 +921,10 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="error_activity_not_found">No suitable application for this action found.</string>
     <string name="btn_crypto_sign">Sign</string>
     <string name="btn_encrypt">Encrypt</string>
+    <string name="btn_attach_key">Attach my public key</string>
     <string name="unknown_crypto_signature_user_id">&lt;unknown&gt;</string>
     <string name="pgp_mime_unsupported">PGP/MIME messages are not supported yet.</string>
-    <string name="attachment_encryption_unsupported">Warning: attachments are NOT signed or encrypted yet.</string>
+    <string name="attachment_use_pgpmime">Warning: use PGP/MIME if you want to encrypt/sign attachments.</string>
     <string name="send_aborted">Send aborted.</string>
 
     <string name="save_or_discard_draft_message_dlg_title">Save draft message?</string>
@@ -1126,6 +1127,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="openpgp_unknown_error">Unknown OpenPGP Error</string>
     <string name="openpgp_user_id">User Id</string>
     <string name="openpgp_canceled_by_user">Canceled by user</string>
+    <string name="openpgp_unable_to_sign">"Can't sign"</string>
     
     <string name="openpgp_result_no_signature">"Not Signed"</string>
     <string name="openpgp_result_invalid_signature">"Invalid signature!"</string>
@@ -1142,6 +1144,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="openpgp_result_action_lookup">"Lookup"</string>
     <string name="openpgp_result_no_name">"No name"</string>
     <string name="openpgp_result_no_email">"No email"</string>
+    <string name="openpgp_dialog_cant_encrypt">Unable to encrypt message</string>
+    <string name="openpgp_dialog_select_a_key">Select at least a recipient\'s key to proceed.</string>
+    <string name="openpgp_no_public_key_returned">Your OpenPgp provider didn\'t return any key on ACTION_GET_KEY, contact them.\nUncheck \"%1$s\" to proceed.</string>
 
     <!-- === Client certificates specific ================================================================== -->
     <string name="account_setup_basics_client_certificate">Use client certificate</string>
@@ -1158,4 +1163,5 @@ Please submit bug reports, contribute new features and ask questions at
     <!-- Note: This references message_view_download_remainder -->
     <string name="crypto_download_complete_message_to_decrypt">Click \'Download complete message\' to allow decryption.</string>
 
+    <string name="error_cant_create_temporary_file">Couldn\'t create temporary file, memory full?</string>
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1123,7 +1123,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="openpgp_successful_decryption_valid_signature_uncertified">Successful decryption and valid signature but uncertified</string>
     <string name="openpgp_successful_decryption_unknown_signature">Successful decryption but missing public key</string>
     <string name="openpgp_get_key">Lookup missing key</string>
-    <string name="openpgp_error">OpenPGP Error: %s</string>
+    <string name="openpgp_decryption_failed">Decryption failed: %s</string>
     <string name="openpgp_unknown_error">Unknown OpenPGP Error</string>
     <string name="openpgp_user_id">User Id</string>
     <string name="openpgp_canceled_by_user">Canceled by user</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -476,6 +476,12 @@
             android:key="crypto_key"
             android:title="@string/account_settings_crypto_key" />
 
+        <CheckBoxPreference
+            android:key="pgp_mime_default"
+            android:title="@string/account_settings_crypto_pgp_mime"
+            android:summary="@string/account_settings_crypto_pgp_mime_summary"
+            android:persistent="false"/>
+
     </PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
Hi,
This pull request was at first dedicated to #572. I am now piling up issues from PGP/MIME milestone because it simplifies testing and integration of linked issues scattered on multiple branches. I'll start a new branch once this one will be merged on mainstream unless said otherwise.

## Done
- [x] fixes #571 K9Mail no longer crash when opening a S/MIME signed message ;
- [x] fixes #572 Add support for PGP/MIME composing (Preference Account->Cryptography->Use PGP/MIME) ;
- [x] fixes #575 Display *Encrypted* in message preview ;
- [x] partially fixes #576 Composing of RFC-1847 message ;
- [x] fixes #588 Crash when cancelling passphrase input.

## What doesn't work/not tested/TODO
- [ ] #576 RFC-1847 messages are shown as "Not Signed"
- [ ] #575 Initialize `message.encryption_type` on db migration. I am not sure how messages were stored in the previous schema, so can't parse them. Any document describing the old schema?

## Design notes
1. `MessageCompose.onSend` attempts a dummy encrypt/sign in order to ensure further crypto operation (on the WorkerThread) will succeed. If interactions with PGP provider are required it launches them. If no further interaction were required,  it invokes `performSend` which continue on a worker thread and close the window. 
2. `MessageCompose.onActivityResult` fetches working Intents and invokes `performSend` if activity interactions were successful
3. `MessageCompose.createMessage` creates a *regular* message but then process the `MimeMessage` according to PGP/MIME specifications if cryptography was required

I'm waiting for your questions/advices. Don't hesitate.

Regards,
Alexandre