### PR TITLE
fixes #588 crash when canceling decryption

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/OpenPgpHeaderView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/OpenPgpHeaderView.java
@@ -140,7 +140,7 @@ public class OpenPgpHeaderView extends LinearLayout {
         if (error == null) {
             text = context.getString(R.string.openpgp_unknown_error);
         } else {
-            text = context.getString(R.string.openpgp_error, error.getMessage());
+            text = context.getString(R.string.openpgp_decryption_failed, error.getMessage());
         }
         resultEncryptionText.setText(text);
     }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/OpenPgpHeaderView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/OpenPgpHeaderView.java
@@ -160,6 +160,9 @@ public class OpenPgpHeaderView extends LinearLayout {
 
         switch (cryptoAnnotation.getErrorType()) {
             case CRYPTO_API_RETURNED_ERROR:
+                displayEncryptionError();
+                dontDisplayVerification();
+                break;
             case NONE: {
                 displayVerificationResult();
                 break;
@@ -170,6 +173,11 @@ public class OpenPgpHeaderView extends LinearLayout {
                 break;
             }
         }
+    }
+    private void dontDisplayVerification(){
+        hideSignatureLayout();
+        resultSignatureText.setVisibility(View.GONE);
+        resultSignatureIcon.setVisibility(View.GONE);
     }
 
     private void displayIncompleteSignedPart() {

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1123,7 +1123,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="openpgp_successful_decryption_valid_signature_uncertified">Successful decryption and valid signature but uncertified</string>
     <string name="openpgp_successful_decryption_unknown_signature">Successful decryption but missing public key</string>
     <string name="openpgp_get_key">Lookup missing key</string>
-    <string name="openpgp_error">OpenPGP Error: %s</string>
+    <string name="openpgp_decryption_failed">Decryption failed: %s</string>
     <string name="openpgp_unknown_error">Unknown OpenPGP Error</string>
     <string name="openpgp_user_id">User Id</string>
     <string name="openpgp_canceled_by_user">Canceled by user</string>


### PR DESCRIPTION
fixes #588
- Decryption error was detected but not properly handled.
- I also changed the error message in a separate commit from "OpenPGP error" to "Decryption failed" as it better describe what is going on in my opinion.
Thanks for examining this pull request,
Alexandre