### PR TITLE
An interrupted POP3 connection attempt to the server yields an SSLException

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
@@ -33,7 +33,7 @@ public abstract class Folder<T extends Message> {
      *
      * @param mode READ_ONLY or READ_WRITE
      */
-    public abstract void open(int mode) throws MessagingException, IOException;
+    public abstract void open(int mode) throws MessagingException;
 
     /**
      * Forces a close of the MailProvider. Any further access will attempt to

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
@@ -33,7 +33,7 @@ public abstract class Folder<T extends Message> {
      *
      * @param mode READ_ONLY or READ_WRITE
      */
-    public abstract void open(int mode) throws MessagingException;
+    public abstract void open(int mode) throws MessagingException, IOException;
 
     /**
      * Forces a close of the MailProvider. Any further access will attempt to

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -252,10 +252,9 @@ public class Pop3Store extends RemoteStore {
 
     @Override
     public void checkSettings() throws MessagingException {
-        try {
-            Pop3Folder folder = new Pop3Folder(mStoreConfig.getInboxFolderName());
-            folder.open(Folder.OPEN_MODE_RW);
-            if (!mCapabilities.uidl) {
+        Pop3Folder folder = new Pop3Folder(mStoreConfig.getInboxFolderName());
+        folder.open(Folder.OPEN_MODE_RW);
+        if (!mCapabilities.uidl) {
             /*
              * Run an additional test to see if UIDL is supported on the server. If it's not we
              * can't service this account.
@@ -265,13 +264,10 @@ public class Pop3Store extends RemoteStore {
              * If the server doesn't support UIDL it will return a - response, which causes
              * executeSimpleCommand to throw a MessagingException, exiting this method.
              */
-                folder.executeSimpleCommand(UIDL_COMMAND);
+            folder.executeSimpleCommand(UIDL_COMMAND);
 
-            }
-            folder.close();
-        } catch (IOException ioe) {
-            throw new MessagingException("Unable to connect", ioe);
         }
+        folder.close();
     }
 
     @Override
@@ -300,7 +296,7 @@ public class Pop3Store extends RemoteStore {
         }
 
         @Override
-        public synchronized void open(int mode) throws MessagingException, IOException {
+        public synchronized void open(int mode) throws MessagingException {
             if (isOpen()) {
                 return;
             }
@@ -393,7 +389,7 @@ public class Pop3Store extends RemoteStore {
                 if (e.getCause() instanceof CertificateException) {
                     throw new CertificateValidationException(e.getMessage(), e);
                 } else {
-                    throw e;
+                    throw new MessagingException("Unable to connect", e);
                 }
             } catch (GeneralSecurityException gse) {
                 throw new MessagingException(

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1860,7 +1860,9 @@ public class MessagingController implements Runnable {
                     return;
                 }
             }
+
             remoteFolder.open(Folder.OPEN_MODE_RW);
+
             if (remoteFolder.getMode() != Folder.OPEN_MODE_RW) {
                 return;
             }
@@ -1951,6 +1953,8 @@ public class MessagingController implements Runnable {
                     }
                 }
             }
+        } catch (IOException ioe) {
+            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
             closeFolder(localFolder);
@@ -2093,7 +2097,13 @@ public class MessagingController implements Runnable {
             if (!remoteSrcFolder.exists()) {
                 throw new MessagingException("processingPendingMoveOrCopy: remoteFolder " + srcFolder + " does not exist", true);
             }
-            remoteSrcFolder.open(Folder.OPEN_MODE_RW);
+
+            try {
+                remoteSrcFolder.open(Folder.OPEN_MODE_RW);
+            } catch (IOException ioe) {
+                throw new MessagingException("Unable to connect", ioe);
+            }
+
             if (remoteSrcFolder.getMode() != Folder.OPEN_MODE_RW) {
                 throw new MessagingException("processingPendingMoveOrCopy: could not open remoteSrcFolder " + srcFolder + " read/write", true);
             }
@@ -2213,6 +2223,8 @@ public class MessagingController implements Runnable {
                 return;
             }
             remoteFolder.setFlags(messages, Collections.singleton(flag), newState);
+        } catch (IOException ioe) {
+            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
         }
@@ -2253,6 +2265,8 @@ public class MessagingController implements Runnable {
                 return;
             }
             remoteMessage.setFlag(flag, newState);
+        } catch (IOException ioe) {
+            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
         }
@@ -2295,6 +2309,8 @@ public class MessagingController implements Runnable {
             remoteFolder.expunge();
             if (K9.DEBUG)
                 Log.d(K9.LOG_TAG, "processPendingExpunge: complete for folder = " + folder);
+        } catch (IOException ioe) {
+            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
         }
@@ -2326,7 +2342,13 @@ public class MessagingController implements Runnable {
         if (!remoteSrcFolder.exists()) {
             throw new MessagingException("processPendingMoveOrCopyOld: remoteFolder " + srcFolder + " does not exist", true);
         }
-        remoteSrcFolder.open(Folder.OPEN_MODE_RW);
+
+        try {
+            remoteSrcFolder.open(Folder.OPEN_MODE_RW);
+        } catch (IOException ioe) {
+            throw new MessagingException("Unable to connect", ioe);
+        }
+
         if (remoteSrcFolder.getMode() != Folder.OPEN_MODE_RW) {
             throw new MessagingException("processPendingMoveOrCopyOld: could not open remoteSrcFolder " + srcFolder + " read/write", true);
         }
@@ -2352,7 +2374,12 @@ public class MessagingController implements Runnable {
             return;
         }
 
-        remoteDestFolder.open(Folder.OPEN_MODE_RW);
+        try {
+            remoteDestFolder.open(Folder.OPEN_MODE_RW);
+        } catch (IOException ioe) {
+            throw new MessagingException("Unable to connect", ioe);
+        }
+
         if (remoteDestFolder.getMode() != Folder.OPEN_MODE_RW) {
             throw new MessagingException("processPendingMoveOrCopyOld: could not open remoteDestFolder " + srcFolder + " read/write", true);
         }
@@ -2408,6 +2435,8 @@ public class MessagingController implements Runnable {
             remoteFolder.close();
         } catch (UnsupportedOperationException uoe) {
             Log.w(K9.LOG_TAG, "Could not mark all server-side as read because store doesn't support operation", uoe);
+        } catch (IOException ioe) {
+            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(localFolder);
             closeFolder(remoteFolder);
@@ -2613,7 +2642,12 @@ public class MessagingController implements Runnable {
         try {
             Store localStore = account.getLocalStore();
             localFolder = localStore.getFolder(folderName);
-            localFolder.open(Folder.OPEN_MODE_RW);
+
+            try {
+                localFolder.open(Folder.OPEN_MODE_RW);
+            } catch (IOException ioe) {
+                throw new MessagingException("Unable to connect", ioe);
+            }
 
             // Allows for re-allowing sending of messages that could not be sent
             if (flag == Flag.FLAGGED && !newState &&
@@ -2680,7 +2714,12 @@ public class MessagingController implements Runnable {
         try {
             LocalStore localStore = account.getLocalStore();
             localFolder = localStore.getFolder(folderName);
-            localFolder.open(Folder.OPEN_MODE_RW);
+
+            try {
+                localFolder.open(Folder.OPEN_MODE_RW);
+            } catch (IOException ioe) {
+                throw new MessagingException("Unable to connect", ioe);
+            }
 
             Message message = localFolder.getMessage(uid);
             if (message != null) {
@@ -2833,7 +2872,7 @@ public class MessagingController implements Runnable {
 
                     LocalMessage message = localFolder.getMessage(uid);
                     if (message == null
-                    || message.getId() == 0) {
+                            || message.getId() == 0) {
                         throw new IllegalArgumentException("Message not found: folder=" + folder + ", uid=" + uid);
                     }
                     // IMAP search results will usually need to be downloaded before viewing.
@@ -2926,7 +2965,11 @@ public class MessagingController implements Runnable {
 
                     Store remoteStore = account.getRemoteStore();
                     remoteFolder = remoteStore.getFolder(folderName);
-                    remoteFolder.open(Folder.OPEN_MODE_RW);
+                    try {
+                        remoteFolder.open(Folder.OPEN_MODE_RW);
+                    } catch (IOException ioe) {
+                        throw new MessagingException("Unable to connect", ioe);
+                    }
 
                     Message remoteMessage = remoteFolder.getMessage(message.getUid());
                     remoteFolder.fetchPart(remoteMessage, part, null);
@@ -2945,7 +2988,6 @@ public class MessagingController implements Runnable {
                     }
                     notifyUserIfCertificateProblem(account, me, true);
                     addErrorMessage(account, null, me);
-
                 } finally {
                     closeFolder(localFolder);
                     closeFolder(remoteFolder);
@@ -3778,6 +3820,8 @@ public class MessagingController implements Runnable {
 
 
             }
+        } catch (IOException ioe) {
+            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
         }
@@ -4008,7 +4052,11 @@ public class MessagingController implements Runnable {
 
             Store localStore = account.getLocalStore();
             for (final Folder folder : localStore.getPersonalNamespaces(false)) {
-                folder.open(Folder.OPEN_MODE_RW);
+                try {
+                    folder.open(Folder.OPEN_MODE_RW);
+                } catch (IOException ioe) {
+                    throw new MessagingException("Unable to connect", ioe);
+                }
 
                 Folder.FolderClass fDisplayClass = folder.getDisplayClass();
                 Folder.FolderClass fSyncClass = folder.getSyncClass();

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1860,9 +1860,7 @@ public class MessagingController implements Runnable {
                     return;
                 }
             }
-
             remoteFolder.open(Folder.OPEN_MODE_RW);
-
             if (remoteFolder.getMode() != Folder.OPEN_MODE_RW) {
                 return;
             }
@@ -1953,8 +1951,6 @@ public class MessagingController implements Runnable {
                     }
                 }
             }
-        } catch (IOException ioe) {
-            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
             closeFolder(localFolder);
@@ -2097,13 +2093,7 @@ public class MessagingController implements Runnable {
             if (!remoteSrcFolder.exists()) {
                 throw new MessagingException("processingPendingMoveOrCopy: remoteFolder " + srcFolder + " does not exist", true);
             }
-
-            try {
-                remoteSrcFolder.open(Folder.OPEN_MODE_RW);
-            } catch (IOException ioe) {
-                throw new MessagingException("Unable to connect", ioe);
-            }
-
+            remoteSrcFolder.open(Folder.OPEN_MODE_RW);
             if (remoteSrcFolder.getMode() != Folder.OPEN_MODE_RW) {
                 throw new MessagingException("processingPendingMoveOrCopy: could not open remoteSrcFolder " + srcFolder + " read/write", true);
             }
@@ -2223,8 +2213,6 @@ public class MessagingController implements Runnable {
                 return;
             }
             remoteFolder.setFlags(messages, Collections.singleton(flag), newState);
-        } catch (IOException ioe) {
-            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
         }
@@ -2265,8 +2253,6 @@ public class MessagingController implements Runnable {
                 return;
             }
             remoteMessage.setFlag(flag, newState);
-        } catch (IOException ioe) {
-            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
         }
@@ -2309,8 +2295,6 @@ public class MessagingController implements Runnable {
             remoteFolder.expunge();
             if (K9.DEBUG)
                 Log.d(K9.LOG_TAG, "processPendingExpunge: complete for folder = " + folder);
-        } catch (IOException ioe) {
-            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
         }
@@ -2342,13 +2326,7 @@ public class MessagingController implements Runnable {
         if (!remoteSrcFolder.exists()) {
             throw new MessagingException("processPendingMoveOrCopyOld: remoteFolder " + srcFolder + " does not exist", true);
         }
-
-        try {
-            remoteSrcFolder.open(Folder.OPEN_MODE_RW);
-        } catch (IOException ioe) {
-            throw new MessagingException("Unable to connect", ioe);
-        }
-
+        remoteSrcFolder.open(Folder.OPEN_MODE_RW);
         if (remoteSrcFolder.getMode() != Folder.OPEN_MODE_RW) {
             throw new MessagingException("processPendingMoveOrCopyOld: could not open remoteSrcFolder " + srcFolder + " read/write", true);
         }
@@ -2374,12 +2352,7 @@ public class MessagingController implements Runnable {
             return;
         }
 
-        try {
-            remoteDestFolder.open(Folder.OPEN_MODE_RW);
-        } catch (IOException ioe) {
-            throw new MessagingException("Unable to connect", ioe);
-        }
-
+        remoteDestFolder.open(Folder.OPEN_MODE_RW);
         if (remoteDestFolder.getMode() != Folder.OPEN_MODE_RW) {
             throw new MessagingException("processPendingMoveOrCopyOld: could not open remoteDestFolder " + srcFolder + " read/write", true);
         }
@@ -2435,8 +2408,6 @@ public class MessagingController implements Runnable {
             remoteFolder.close();
         } catch (UnsupportedOperationException uoe) {
             Log.w(K9.LOG_TAG, "Could not mark all server-side as read because store doesn't support operation", uoe);
-        } catch (IOException ioe) {
-            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(localFolder);
             closeFolder(remoteFolder);
@@ -2642,12 +2613,7 @@ public class MessagingController implements Runnable {
         try {
             Store localStore = account.getLocalStore();
             localFolder = localStore.getFolder(folderName);
-
-            try {
-                localFolder.open(Folder.OPEN_MODE_RW);
-            } catch (IOException ioe) {
-                throw new MessagingException("Unable to connect", ioe);
-            }
+            localFolder.open(Folder.OPEN_MODE_RW);
 
             // Allows for re-allowing sending of messages that could not be sent
             if (flag == Flag.FLAGGED && !newState &&
@@ -2714,12 +2680,7 @@ public class MessagingController implements Runnable {
         try {
             LocalStore localStore = account.getLocalStore();
             localFolder = localStore.getFolder(folderName);
-
-            try {
-                localFolder.open(Folder.OPEN_MODE_RW);
-            } catch (IOException ioe) {
-                throw new MessagingException("Unable to connect", ioe);
-            }
+            localFolder.open(Folder.OPEN_MODE_RW);
 
             Message message = localFolder.getMessage(uid);
             if (message != null) {
@@ -2872,7 +2833,7 @@ public class MessagingController implements Runnable {
 
                     LocalMessage message = localFolder.getMessage(uid);
                     if (message == null
-                            || message.getId() == 0) {
+                    || message.getId() == 0) {
                         throw new IllegalArgumentException("Message not found: folder=" + folder + ", uid=" + uid);
                     }
                     // IMAP search results will usually need to be downloaded before viewing.
@@ -2965,11 +2926,7 @@ public class MessagingController implements Runnable {
 
                     Store remoteStore = account.getRemoteStore();
                     remoteFolder = remoteStore.getFolder(folderName);
-                    try {
-                        remoteFolder.open(Folder.OPEN_MODE_RW);
-                    } catch (IOException ioe) {
-                        throw new MessagingException("Unable to connect", ioe);
-                    }
+                    remoteFolder.open(Folder.OPEN_MODE_RW);
 
                     Message remoteMessage = remoteFolder.getMessage(message.getUid());
                     remoteFolder.fetchPart(remoteMessage, part, null);
@@ -2988,6 +2945,7 @@ public class MessagingController implements Runnable {
                     }
                     notifyUserIfCertificateProblem(account, me, true);
                     addErrorMessage(account, null, me);
+
                 } finally {
                     closeFolder(localFolder);
                     closeFolder(remoteFolder);
@@ -3820,8 +3778,6 @@ public class MessagingController implements Runnable {
 
 
             }
-        } catch (IOException ioe) {
-            throw new MessagingException("Unable to connect", ioe);
         } finally {
             closeFolder(remoteFolder);
         }
@@ -4052,11 +4008,7 @@ public class MessagingController implements Runnable {
 
             Store localStore = account.getLocalStore();
             for (final Folder folder : localStore.getPersonalNamespaces(false)) {
-                try {
-                    folder.open(Folder.OPEN_MODE_RW);
-                } catch (IOException ioe) {
-                    throw new MessagingException("Unable to connect", ioe);
-                }
+                folder.open(Folder.OPEN_MODE_RW);
 
                 Folder.FolderClass fDisplayClass = folder.getDisplayClass();
                 Folder.FolderClass fSyncClass = folder.getSyncClass();


### PR DESCRIPTION
This has already been fixed for IMAP connections. 

An interrupted POP3 connection attempt to the server yields an SSLException as well, like this:

E/k9 ( 6937): Caused by: javax.net.ssl.SSLHandshakeException: Connection closed by peer
E/k9 ( 6937): at com.android.org.conscrypt.NativeCrypto.SSL_do_handshake(Native Method)
E/k9 ( 6937): at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:302)
E/k9 ( 6937): at com.android.org.conscrypt.OpenSSLSocketImpl.waitForHandshake(OpenSSLSocketImpl.java:598)
E/k9 ( 6937): at com.android.org.conscrypt.OpenSSLSocketImpl.getInputStream(OpenSSLSocketImpl.java:560)
E/k9 ( 6937): at com.fsck.k9.mail.store.ImapStore$ImapConnection.open(ImapStore.java:2459)

We don't want the user to notify of 'certificate problems' in that case.
Fix it by checking whether the SSLException was actually triggered by a
CertificateException.