### PR TITLE
If account isn't setup properly, show email address instead of account description (fix for #922)

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -1056,10 +1056,15 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 return null;
             }
 
+            String accountDescription = mSelectedContextAccount.getDescription();
+            if (accountDescription == null || accountDescription.isEmpty() ) {
+                accountDescription = mSelectedContextAccount.getEmail();
+            }
+
             return ConfirmationDialog.create(this, id,
                                              R.string.account_delete_dlg_title,
                                              getString(R.string.account_delete_dlg_instructions_fmt,
-                                                     mSelectedContextAccount.getDescription()),
+                                                     accountDescription),
                                              R.string.okay_action,
                                              R.string.cancel_action,
             new Runnable() {
@@ -1154,20 +1159,26 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
     @Override
     public void onPrepareDialog(int id, Dialog d) {
         AlertDialog alert = (AlertDialog) d;
+
+        String accountDescription = mSelectedContextAccount.getDescription();
+        if (accountDescription == null || accountDescription.isEmpty() ) {
+            accountDescription = mSelectedContextAccount.getEmail();
+        }
+
         switch (id) {
         case DIALOG_REMOVE_ACCOUNT: {
             alert.setMessage(getString(R.string.account_delete_dlg_instructions_fmt,
-                                       mSelectedContextAccount.getDescription()));
+                    accountDescription));
             break;
         }
         case DIALOG_CLEAR_ACCOUNT: {
             alert.setMessage(getString(R.string.account_clear_dlg_instructions_fmt,
-                                       mSelectedContextAccount.getDescription()));
+                    accountDescription));
             break;
         }
         case DIALOG_RECREATE_ACCOUNT: {
             alert.setMessage(getString(R.string.account_recreate_dlg_instructions_fmt,
-                                       mSelectedContextAccount.getDescription()));
+                    accountDescription));
             break;
         }
         }


### PR DESCRIPTION
Fix for #922 