### PR TITLE
make UidReverseComparator transitive, order null elements to right

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -136,23 +136,29 @@ public class MessagingController implements Runnable {
 
     public static class UidReverseComparator implements Comparator<Message> {
         @Override
-        public int compare(Message o1, Message o2) {
-            if (o1 == null || o2 == null || o1.getUid() == null || o2.getUid() == null) {
-                return 0;
-            }
-            int id1, id2;
+        public int compare(Message messageLeft, Message messageRight) {
+            Integer uidLeft, uidRight;
             try {
-                id1 = Integer.parseInt(o1.getUid());
-                id2 = Integer.parseInt(o2.getUid());
-            } catch (NumberFormatException e) {
-                return 0;
+                uidLeft = Integer.parseInt(messageLeft.getUid());
+            } catch (NullPointerException | NumberFormatException e) {
+                uidLeft = null;
             }
-            //reversed intentionally.
-            if (id1 < id2)
+            try {
+                uidRight = Integer.parseInt(messageRight.getUid());
+            } catch (NullPointerException | NumberFormatException e) {
+                uidRight = null;
+            }
+
+            if (uidLeft == null && uidRight == null) {
+                return 0;
+            } else if (uidLeft == null) {
                 return 1;
-            if (id1 > id2)
+            } else if (uidRight == null) {
                 return -1;
-            return 0;
+            }
+
+            // reverse order
+            return uidRight.compareTo(uidLeft);
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -133,34 +132,6 @@ public class MessagingController implements Runnable {
     private static final String PENDING_COMMAND_APPEND = "com.fsck.k9.MessagingController.append";
     private static final String PENDING_COMMAND_MARK_ALL_AS_READ = "com.fsck.k9.MessagingController.markAllAsRead";
     private static final String PENDING_COMMAND_EXPUNGE = "com.fsck.k9.MessagingController.expunge";
-
-    public static class UidReverseComparator implements Comparator<Message> {
-        @Override
-        public int compare(Message messageLeft, Message messageRight) {
-            Integer uidLeft, uidRight;
-            try {
-                uidLeft = Integer.parseInt(messageLeft.getUid());
-            } catch (NullPointerException | NumberFormatException e) {
-                uidLeft = null;
-            }
-            try {
-                uidRight = Integer.parseInt(messageRight.getUid());
-            } catch (NullPointerException | NumberFormatException e) {
-                uidRight = null;
-            }
-
-            if (uidLeft == null && uidRight == null) {
-                return 0;
-            } else if (uidLeft == null) {
-                return 1;
-            } else if (uidRight == null) {
-                return -1;
-            }
-
-            // reverse order
-            return uidRight.compareTo(uidLeft);
-        }
-    }
 
     /**
      * Maximum number of unsynced messages to store at once

--- a/k9mail/src/main/java/com/fsck/k9/controller/UidReverseComparator.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/UidReverseComparator.java
@@ -1,0 +1,35 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Comparator;
+
+import com.fsck.k9.mail.Message;
+
+
+class UidReverseComparator implements Comparator<Message> {
+    @Override
+    public int compare(Message messageLeft, Message messageRight) {
+        Integer uidLeft, uidRight;
+        try {
+            uidLeft = Integer.parseInt(messageLeft.getUid());
+        } catch (NullPointerException | NumberFormatException e) {
+            uidLeft = null;
+        }
+        try {
+            uidRight = Integer.parseInt(messageRight.getUid());
+        } catch (NullPointerException | NumberFormatException e) {
+            uidRight = null;
+        }
+
+        if (uidLeft == null && uidRight == null) {
+            return 0;
+        } else if (uidLeft == null) {
+            return 1;
+        } else if (uidRight == null) {
+            return -1;
+        }
+
+        // reverse order
+        return uidRight.compareTo(uidLeft);
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/UidReverseComparator.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/UidReverseComparator.java
@@ -9,17 +9,8 @@ import com.fsck.k9.mail.Message;
 class UidReverseComparator implements Comparator<Message> {
     @Override
     public int compare(Message messageLeft, Message messageRight) {
-        Integer uidLeft, uidRight;
-        try {
-            uidLeft = Integer.parseInt(messageLeft.getUid());
-        } catch (NullPointerException | NumberFormatException e) {
-            uidLeft = null;
-        }
-        try {
-            uidRight = Integer.parseInt(messageRight.getUid());
-        } catch (NullPointerException | NumberFormatException e) {
-            uidRight = null;
-        }
+        Integer uidLeft = getUidForMessage(messageLeft);
+        Integer uidRight = getUidForMessage(messageRight);
 
         if (uidLeft == null && uidRight == null) {
             return 0;
@@ -31,5 +22,13 @@ class UidReverseComparator implements Comparator<Message> {
 
         // reverse order
         return uidRight.compareTo(uidLeft);
+    }
+
+    private Integer getUidForMessage(Message message) {
+        try {
+            return Integer.parseInt(message.getUid());
+        } catch (NullPointerException | NumberFormatException e) {
+            return null;
+        }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/controller/UidReverseComparator.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/UidReverseComparator.java
@@ -9,8 +9,8 @@ import com.fsck.k9.mail.Message;
 class UidReverseComparator implements Comparator<Message> {
     @Override
     public int compare(Message messageLeft, Message messageRight) {
-        Integer uidLeft = getUidForMessage(messageLeft);
-        Integer uidRight = getUidForMessage(messageRight);
+        Long uidLeft = getUidForMessage(messageLeft);
+        Long uidRight = getUidForMessage(messageRight);
 
         if (uidLeft == null && uidRight == null) {
             return 0;
@@ -24,9 +24,9 @@ class UidReverseComparator implements Comparator<Message> {
         return uidRight.compareTo(uidLeft);
     }
 
-    private Integer getUidForMessage(Message message) {
+    private Long getUidForMessage(Message message) {
         try {
-            return Integer.parseInt(message.getUid());
+            return Long.parseLong(message.getUid());
         } catch (NullPointerException | NumberFormatException e) {
             return null;
         }

--- a/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
@@ -1,0 +1,136 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Arrays;
+import java.util.Random;
+
+import android.support.annotation.NonNull;
+
+import com.fsck.k9.controller.MessagingController.UidReverseComparator;
+import com.fsck.k9.mail.Message;
+import org.hamcrest.Matcher;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.mockito.verification.VerificationMode;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("ConstantConditions")
+public class UidReverseComparatorTest {
+
+    private UidReverseComparator comparator;
+    private Random random;
+
+    @Before
+    public void onBefore() {
+        comparator = new UidReverseComparator();
+        random = new Random();
+    }
+
+    @Test
+    public void compare_withTwoNullArguments_shouldReturnZero() throws Exception {
+        Message messageLeft = null;
+        Message messageRight = null;
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 0 when both arguments are null", 0, result);
+    }
+
+    @Test
+    public void compare_withLeftNullArgument_shouldReturnPositive() throws Exception {
+        Message messageLeft = null;
+        Message messageRight = mockMessage(1);
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 1 when both arguments are null", 1, result);
+    }
+
+    @Test
+    public void compare_withRightNullArgument_shouldReturnNegative() throws Exception {
+        Message messageLeft = mockMessage(1);
+        Message messageRight = null;
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be -1 when both arguments are null", -1, result);
+    }
+
+    @Test
+    public void compare_twoMessages_shouldReturnOrderByUid() throws Exception {
+        Message messageLeft = mockMessage(5);
+        Message messageRight = mockMessage(15);
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 1 when right message has larger uid than left message", 1, result);
+    }
+
+    @Test
+    public void testRandomCompare() throws Exception {
+
+        Message[] msgs = new Message[500];
+        for (int i = 1; i < msgs.length; i++) {
+            if (random.nextInt(10) < 2) {
+                msgs[i] = null;
+
+                continue;
+            }
+            if (random.nextInt(10) < 2) {
+                Message numberFormatExceptionMessage = mock(Message.class);
+                when(numberFormatExceptionMessage.getUid()).thenReturn("xyz" + i);
+
+                msgs[i] = numberFormatExceptionMessage;
+                continue;
+            }
+            int uid = random.nextInt(200) -100;
+            msgs[i] = mockMessage(uid);
+        }
+
+        Arrays.sort(msgs, comparator);
+
+        // all objects which are null or unparsable must appear in a contiguous segment at the end
+        boolean isNullRange = false;
+        for (int i = 1; i < msgs.length; i++) {
+            if (msgs[i] == null) {
+                isNullRange = true;
+                continue;
+            }
+            verify(msgs[i], atLeastOnce()).getUid();
+            if (!isIntParseable(msgs[i].getUid())) {
+                isNullRange = true;
+                continue;
+            }
+            assertFalse(isNullRange);
+            int id1 = Integer.parseInt(msgs[i-1].getUid());
+            int id2 = Integer.parseInt(msgs[i].getUid());
+            assertTrue(id1 >= id2);
+        }
+
+    }
+
+    private static boolean isIntParseable(String str) {
+        try {
+            // noinspection ResultOfMethodCallIgnored
+            Integer.parseInt(str);
+            return true;
+        } catch (NullPointerException | NumberFormatException e) {
+            return false;
+        }
+    }
+
+    @NonNull
+    private static Message mockMessage(int uid1) {
+        Message msg1 = mock(Message.class);
+        when(msg1.getUid()).thenReturn(Integer.toString(uid1));
+        return msg1;
+    }
+
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
@@ -3,7 +3,6 @@ package com.fsck.k9.controller;
 
 import android.support.annotation.NonNull;
 
-import com.fsck.k9.controller.MessagingController.UidReverseComparator;
 import com.fsck.k9.mail.Message;
 import org.junit.Before;
 import org.junit.Test;

--- a/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
@@ -37,7 +37,7 @@ public class UidReverseComparatorTest {
     @Test
     public void compare_withLeftNullArgument_shouldReturnPositive() throws Exception {
         Message messageLeft = null;
-        Message messageRight = mockMessage(1);
+        Message messageRight = createMessageWithUid(1);
 
         int result = comparator.compare(messageLeft, messageRight);
 
@@ -46,7 +46,7 @@ public class UidReverseComparatorTest {
 
     @Test
     public void compare_withRightNullArgument_shouldReturnNegative() throws Exception {
-        Message messageLeft = mockMessage(1);
+        Message messageLeft = createMessageWithUid(1);
         Message messageRight = null;
 
         int result = comparator.compare(messageLeft, messageRight);
@@ -56,8 +56,8 @@ public class UidReverseComparatorTest {
 
     @Test
     public void compare_twoMessages_shouldReturnOrderByUid() throws Exception {
-        Message messageLeft = mockMessage(5);
-        Message messageRight = mockMessage(15);
+        Message messageLeft = createMessageWithUid(5);
+        Message messageRight = createMessageWithUid(15);
 
         int result = comparator.compare(messageLeft, messageRight);
 
@@ -65,9 +65,10 @@ public class UidReverseComparatorTest {
     }
 
     @NonNull
-    private static Message mockMessage(int uid1) {
-        Message msg1 = mock(Message.class);
-        when(msg1.getUid()).thenReturn(Integer.toString(uid1));
-        return msg1;
+    private Message createMessageWithUid(int uid) {
+        Message message = mock(Message.class);
+        when(message.getUid()).thenReturn(Integer.toString(uid));
+
+        return message;
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
@@ -1,36 +1,26 @@
 package com.fsck.k9.controller;
 
 
-import java.util.Arrays;
-import java.util.Random;
-
 import android.support.annotation.NonNull;
 
 import com.fsck.k9.controller.MessagingController.UidReverseComparator;
 import com.fsck.k9.mail.Message;
-import org.hamcrest.Matcher;
 import org.junit.Before;
 import org.junit.Test;
-import org.mockito.Mockito;
-import org.mockito.verification.VerificationMode;
 
-import static org.junit.Assert.*;
-import static org.mockito.Mockito.atLeastOnce;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("ConstantConditions")
 public class UidReverseComparatorTest {
-
     private UidReverseComparator comparator;
-    private Random random;
+
 
     @Before
     public void onBefore() {
         comparator = new UidReverseComparator();
-        random = new Random();
     }
 
     @Test
@@ -73,64 +63,10 @@ public class UidReverseComparatorTest {
         assertEquals("result must be 1 when right message has larger uid than left message", 1, result);
     }
 
-    @Test
-    public void testRandomCompare() throws Exception {
-
-        Message[] msgs = new Message[500];
-        for (int i = 1; i < msgs.length; i++) {
-            if (random.nextInt(10) < 2) {
-                msgs[i] = null;
-
-                continue;
-            }
-            if (random.nextInt(10) < 2) {
-                Message numberFormatExceptionMessage = mock(Message.class);
-                when(numberFormatExceptionMessage.getUid()).thenReturn("xyz" + i);
-
-                msgs[i] = numberFormatExceptionMessage;
-                continue;
-            }
-            int uid = random.nextInt(200) -100;
-            msgs[i] = mockMessage(uid);
-        }
-
-        Arrays.sort(msgs, comparator);
-
-        // all objects which are null or unparsable must appear in a contiguous segment at the end
-        boolean isNullRange = false;
-        for (int i = 1; i < msgs.length; i++) {
-            if (msgs[i] == null) {
-                isNullRange = true;
-                continue;
-            }
-            verify(msgs[i], atLeastOnce()).getUid();
-            if (!isIntParseable(msgs[i].getUid())) {
-                isNullRange = true;
-                continue;
-            }
-            assertFalse(isNullRange);
-            int id1 = Integer.parseInt(msgs[i-1].getUid());
-            int id2 = Integer.parseInt(msgs[i].getUid());
-            assertTrue(id1 >= id2);
-        }
-
-    }
-
-    private static boolean isIntParseable(String str) {
-        try {
-            // noinspection ResultOfMethodCallIgnored
-            Integer.parseInt(str);
-            return true;
-        } catch (NullPointerException | NumberFormatException e) {
-            return false;
-        }
-    }
-
     @NonNull
     private static Message mockMessage(int uid1) {
         Message msg1 = mock(Message.class);
         when(msg1.getUid()).thenReturn(Integer.toString(uid1));
         return msg1;
     }
-
 }

--- a/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -40,7 +41,7 @@ public class UidReverseComparatorTest {
 
         int result = comparator.compare(messageLeft, messageRight);
 
-        assertEquals("result must be 1 when both arguments are null", 1, result);
+        assertTrue("result must be > 0 when left argument is null", result > 0);
     }
 
     @Test
@@ -50,7 +51,7 @@ public class UidReverseComparatorTest {
 
         int result = comparator.compare(messageLeft, messageRight);
 
-        assertEquals("result must be -1 when both arguments are null", -1, result);
+        assertTrue("result must be < 0 when right argument is null", result < 0);
     }
 
     @Test
@@ -60,7 +61,7 @@ public class UidReverseComparatorTest {
 
         int result = comparator.compare(messageLeft, messageRight);
 
-        assertEquals("result must be 1 when right message has larger uid than left message", 1, result);
+        assertTrue("result must be > 0 when right message has larger UID than left message", result > 0);
     }
 
     @NonNull

--- a/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/UidReverseComparatorTest.java
@@ -35,6 +35,86 @@ public class UidReverseComparatorTest {
     }
 
     @Test
+    public void compare_withNullArgumentAndMessageWithNullUid_shouldReturnZero() throws Exception {
+        Message messageLeft = null;
+        Message messageRight = createMessageWithNullUid();
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 0 when both arguments are not a message with valid UID", 0, result);
+    }
+
+    @Test
+    public void compare_withMessageWithNullUidAndNullArgument_shouldReturnZero() throws Exception {
+        Message messageLeft = createMessageWithNullUid();
+        Message messageRight = null;
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 0 when both arguments are not a message with valid UID", 0, result);
+    }
+
+    @Test
+    public void compare_withTwoMessagesWithNullUid_shouldReturnZero() throws Exception {
+        Message messageLeft = createMessageWithNullUid();
+        Message messageRight = createMessageWithNullUid();
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 0 when both arguments are a message with a null UID", 0, result);
+    }
+
+    @Test
+    public void compare_withNullArgumentAndMessageWithInvalidUid_shouldReturnZero() throws Exception {
+        Message messageLeft = null;
+        Message messageRight = createMessageWithInvalidUid();
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 0 when both arguments are not a message with valid UID", 0, result);
+    }
+
+    @Test
+    public void compare_withMessageWithInvalidUidAndNullArgument_shouldReturnZero() throws Exception {
+        Message messageLeft = createMessageWithInvalidUid();
+        Message messageRight = null;
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 0 when both arguments are not a message with valid UID", 0, result);
+    }
+
+    @Test
+    public void compare_withTwoMessagesWithInvalidUid_shouldReturnZero() throws Exception {
+        Message messageLeft = createMessageWithInvalidUid();
+        Message messageRight = createMessageWithInvalidUid();
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 0 when both arguments are a message with an invalid UID", 0, result);
+    }
+
+    @Test
+    public void compare_withMessageWithNullUidAndMessageWithInvalidUid_shouldReturnZero() throws Exception {
+        Message messageLeft = createMessageWithNullUid();
+        Message messageRight = createMessageWithInvalidUid();
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 0 when both arguments are not a message with valid UID", 0, result);
+    }
+
+    @Test
+    public void compare_withMessageWithInvalidUidAndMessageWithNullUid_shouldReturnZero() throws Exception {
+        Message messageLeft = createMessageWithInvalidUid();
+        Message messageRight = createMessageWithNullUid();
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertEquals("result must be 0 when both arguments are not a message with valid UID", 0, result);
+    }
+
+    @Test
     public void compare_withLeftNullArgument_shouldReturnPositive() throws Exception {
         Message messageLeft = null;
         Message messageRight = createMessageWithUid(1);
@@ -42,6 +122,26 @@ public class UidReverseComparatorTest {
         int result = comparator.compare(messageLeft, messageRight);
 
         assertTrue("result must be > 0 when left argument is null", result > 0);
+    }
+
+    @Test
+    public void compare_withLeftMessageWithNullUid_shouldReturnPositive() throws Exception {
+        Message messageLeft = createMessageWithNullUid();
+        Message messageRight = createMessageWithUid(1);
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertTrue("result must be > 0 when left argument is message with null UID", result > 0);
+    }
+
+    @Test
+    public void compare_withLeftMessageWithInvalidUid_shouldReturnPositive() throws Exception {
+        Message messageLeft = createMessageWithInvalidUid();
+        Message messageRight = createMessageWithUid(1);
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertTrue("result must be > 0 when left argument is message with invalid UID", result > 0);
     }
 
     @Test
@@ -55,19 +155,55 @@ public class UidReverseComparatorTest {
     }
 
     @Test
-    public void compare_twoMessages_shouldReturnOrderByUid() throws Exception {
-        Message messageLeft = createMessageWithUid(5);
-        Message messageRight = createMessageWithUid(15);
+    public void compare_withRightMessageWithNullUid_shouldReturnNegative() throws Exception {
+        Message messageLeft = createMessageWithUid(1);
+        Message messageRight = createMessageWithNullUid();
 
         int result = comparator.compare(messageLeft, messageRight);
 
-        assertTrue("result must be > 0 when right message has larger UID than left message", result > 0);
+        assertTrue("result must be < 0 when right argument is message with null UID", result < 0);
+    }
+
+    @Test
+    public void compare_withRightMessageWithInvalidUid_shouldReturnNegative() throws Exception {
+        Message messageLeft = createMessageWithUid(1);
+        Message messageRight = createMessageWithInvalidUid();
+
+        int result = comparator.compare(messageLeft, messageRight);
+
+        assertTrue("result must be < 0 when right argument is message with invalid UID", result < 0);
+    }
+
+    @Test
+    public void compare_twoMessages_shouldReturnOrderByUid() throws Exception {
+        Message messageSmall = createMessageWithUid(5);
+        Message messageLarge = createMessageWithUid(15);
+
+        int resultOne = comparator.compare(messageSmall, messageLarge);
+        int resultTwo = comparator.compare(messageLarge, messageSmall);
+
+        assertTrue("result must be > 0 when right message has larger UID than left message", resultOne > 0);
+        assertTrue("result must be < 0 when left message has larger UID than right message", resultTwo < 0);
     }
 
     @NonNull
     private Message createMessageWithUid(int uid) {
+        return createMessageWithUidString(Integer.toString(uid));
+    }
+
+    @NonNull
+    private Message createMessageWithNullUid() {
+        return createMessageWithUidString(null);
+    }
+
+    @NonNull
+    private Message createMessageWithInvalidUid() {
+        return createMessageWithUidString("invalid");
+    }
+
+    private Message createMessageWithUidString(String uid) {
         Message message = mock(Message.class);
-        when(message.getUid()).thenReturn(Integer.toString(uid));
+        when(message.getUid()).thenReturn(uid);
 
         return message;
     }


### PR DESCRIPTION
this makes the comparator transitive by sorting null elements to the end. I'm not really sure about the assumptions made on the `uid` strings, so they might be better sorted to the start of the array? changing that should be trivial either way.