### PR TITLE
Fix openpgp decrypt loop 864

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
@@ -63,6 +63,7 @@ public class MessageCryptoHelper {
     private Intent currentCryptoResult;
 
     private MessageCryptoAnnotations messageAnnotations;
+    private Intent userInteractionResultIntent;
 
 
     public MessageCryptoHelper(Activity activity, Account account, MessageCryptoCallback callback) {
@@ -163,7 +164,12 @@ public class MessageCryptoHelper {
 
     private void decryptOrVerifyPart(CryptoPart cryptoPart) {
         currentCryptoPart = cryptoPart;
-        decryptVerify(new Intent());
+        Intent decryptIntent = userInteractionResultIntent;
+        userInteractionResultIntent = null;
+        if (decryptIntent == null) {
+            decryptIntent = new Intent();
+        }
+        decryptVerify(decryptIntent);
     }
 
     private void decryptVerify(Intent intent) {
@@ -419,6 +425,7 @@ public class MessageCryptoHelper {
         }
 
         if (resultCode == Activity.RESULT_OK) {
+            userInteractionResultIntent = data;
             decryptOrVerifyNextPart();
         } else {
             onCryptoFailed(new OpenPgpError(OpenPgpError.CLIENT_SIDE_ERROR, context.getString(R.string.openpgp_canceled_by_user)));


### PR DESCRIPTION
The problem in #864 is caused because K-9 behaves slightly incorrectly regarding openpgp user interaction. After a pending intent returns, it expects the original call to be repeated with the returned intent as its new data.

I fixed this behavior in this PR in a simple way. I will probably change the way this is done when I work on pgp/mime reading support, but this will do for now.