### PR TITLE
disable search in message bodies with a warning

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -405,7 +405,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
                 mSearch.or(new SearchCondition(SearchField.SENDER, Attribute.CONTAINS, query));
                 mSearch.or(new SearchCondition(SearchField.SUBJECT, Attribute.CONTAINS, query));
-                mSearch.or(new SearchCondition(SearchField.MESSAGE_CONTENTS, Attribute.CONTAINS, query));
+                // TODO re-enable search in message contents
+                // mSearch.or(new SearchCondition(SearchField.MESSAGE_CONTENTS, Attribute.CONTAINS, query));
+                Toast.makeText(this, R.string.warn_search_disabled, Toast.LENGTH_LONG).show();
 
                 Bundle appData = intent.getBundleExtra(SearchManager.APP_DATA);
                 if (appData != null) {

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1170,5 +1170,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="address_type_work">Work</string>
     <string name="address_type_other">Other</string>
     <string name="address_type_mobile">Mobile</string>
+    <string name="warn_search_disabled">Search in message bodies is disabled in this development version!</string>
 
 </resources>


### PR DESCRIPTION
#1005 related. conveniently, there is only a single place where `SearchField.MESSAGE_CONTENTS` is used.