### PR TITLE
enable syncing while idle on Android M devices

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ project.ext {
     preDexLibs = !project.hasProperty('disablePreDex')
     testCoverage = project.hasProperty('testCoverage')
 
-    compileSdkVersion = 22
+    compileSdkVersion = 23
     buildToolsVersion = '23.0.1'
 }
 

--- a/k9mail-library/build.gradle
+++ b/k9mail-library/build.gradle
@@ -31,6 +31,9 @@ android {
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
 
+    // for using Apache HTTP Client
+    useLibrary 'org.apache.http.legacy'
+
     buildTypes {
         debug {
             testCoverageEnabled rootProject.testCoverage

--- a/k9mail/src/main/java/com/fsck/k9/helper/K9AlarmManager.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/K9AlarmManager.java
@@ -1,0 +1,66 @@
+package com.fsck.k9.helper;
+
+import android.annotation.TargetApi;
+import android.app.AlarmManager;
+import android.app.PendingIntent;
+import android.content.Context;
+import android.os.Build;
+import android.os.PowerManager;
+
+public class K9AlarmManager {
+    private AlarmManager alarmManager;
+    private PowerManager powerManager;
+    private String packageName;
+
+    private K9AlarmManager(Context context) {
+        alarmManager = (AlarmManager) context.getSystemService(Context.ALARM_SERVICE);
+        powerManager = (PowerManager) context.getSystemService(Context.POWER_SERVICE);
+        packageName = context.getPackageName();
+    }
+
+    public static K9AlarmManager getAlarmManager(Context context) {
+        return new K9AlarmManager(context);
+    }
+
+    public void set(int type, long triggerAtMillis, PendingIntent operation) {
+        if (isDozeSupported() && isDozeWhiteListed()) {
+            setAndAllowWhileIdle(type, triggerAtMillis, operation);
+        } else {
+            alarmManager.set(type, triggerAtMillis, operation);
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    public void setAndAllowWhileIdle(int type, long triggerAtMillis, PendingIntent operation) {
+        alarmManager.setAndAllowWhileIdle(type, triggerAtMillis, operation);
+    }
+
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    public void setExact(int type, long triggerAtMillis, PendingIntent operation) {
+        if (isDozeSupported() && isDozeWhiteListed()) {
+            setExactAndAllowWhileIdle(type, triggerAtMillis, operation);
+        } else {
+            alarmManager.setExact(type, triggerAtMillis, operation);
+        }
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    public void setExactAndAllowWhileIdle(int type, long triggerAtMillis, PendingIntent operation) {
+        alarmManager.setExactAndAllowWhileIdle(type, triggerAtMillis, operation);
+    }
+
+
+    public void cancel(PendingIntent operation) {
+        alarmManager.cancel(operation);
+    }
+
+    private boolean isDozeSupported() {
+        return Build.VERSION.SDK_INT >= Build.VERSION_CODES.M;
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    private boolean isDozeWhiteListed() {
+        return powerManager.isIgnoringBatteryOptimizations(packageName);
+    }
+}
+

--- a/k9mail/src/main/java/com/fsck/k9/helper/MergeCursor.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/MergeCursor.java
@@ -19,12 +19,14 @@ package com.fsck.k9.helper;
 
 import java.util.Comparator;
 
+import android.annotation.TargetApi;
 import android.content.ContentResolver;
 import android.database.CharArrayBuffer;
 import android.database.ContentObserver;
 import android.database.Cursor;
 import android.database.DataSetObserver;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 
 
@@ -211,6 +213,12 @@ public class MergeCursor implements Cursor {
     @Override
     public boolean getWantsAllOnMoveCalls() {
         return mActiveCursor.getWantsAllOnMoveCalls();
+    }
+
+    @TargetApi(Build.VERSION_CODES.M)
+    @Override
+    public void setExtras(Bundle extras) {
+        mActiveCursor.setExtras(extras);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.provider;
 
+import android.annotation.TargetApi;
 import android.app.Application;
 import android.content.ContentProvider;
 import android.content.ContentResolver;
@@ -15,6 +16,7 @@ import android.database.DataSetObserver;
 import android.database.MatrixCursor;
 import android.net.Uri;
 import android.os.Binder;
+import android.os.Build;
 import android.os.Bundle;
 import android.provider.BaseColumns;
 import android.util.Log;
@@ -713,6 +715,12 @@ public class MessageProvider extends ContentProvider {
         public boolean getWantsAllOnMoveCalls() {
             checkClosed();
             return mCursor.getWantsAllOnMoveCalls();
+        }
+
+        @TargetApi(Build.VERSION_CODES.M)
+        @Override
+        public void setExtras(Bundle extras) {
+            mCursor.setExtras(extras);
         }
 
         @Override

--- a/k9mail/src/main/java/com/fsck/k9/service/BootReceiver.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/BootReceiver.java
@@ -12,6 +12,7 @@ import android.net.Uri;
 import android.util.Log;
 
 import com.fsck.k9.K9;
+import com.fsck.k9.helper.K9AlarmManager;
 
 public class BootReceiver extends CoreReceiver {
 
@@ -61,7 +62,7 @@ public class BootReceiver extends CoreReceiver {
                 Log.i(K9.LOG_TAG, "BootReceiver Scheduling intent " + alarmedIntent + " for " + new Date(atTime));
 
             PendingIntent pi = buildPendingIntent(context, intent);
-            AlarmManager alarmMgr = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
+            K9AlarmManager alarmMgr = K9AlarmManager.getAlarmManager(context);
 
             alarmMgr.set(AlarmManager.RTC_WAKEUP, atTime, pi);
         } else if (CANCEL_INTENT.equals(action)) {
@@ -71,7 +72,7 @@ public class BootReceiver extends CoreReceiver {
 
             PendingIntent pi = buildPendingIntent(context, intent);
 
-            AlarmManager alarmMgr = (AlarmManager)context.getSystemService(Context.ALARM_SERVICE);
+            K9AlarmManager alarmMgr = K9AlarmManager.getAlarmManager(context);
             alarmMgr.cancel(pi);
         }
 
@@ -119,8 +120,7 @@ public class BootReceiver extends CoreReceiver {
      * @param context
      */
     public static void purgeSchedule(final Context context) {
-        final AlarmManager alarmService = (AlarmManager) context
-                                          .getSystemService(Context.ALARM_SERVICE);
+        final K9AlarmManager alarmService = K9AlarmManager.getAlarmManager(context);
         alarmService.cancel(PendingIntent.getBroadcast(context, 0, new Intent() {
             @Override
             public boolean filterEquals(final Intent other) {

--- a/plugins/Android-PullToRefresh/library/src/com/handmark/pulltorefresh/library/PullToRefreshWebView.java
+++ b/plugins/Android-PullToRefresh/library/src/com/handmark/pulltorefresh/library/PullToRefreshWebView.java
@@ -112,7 +112,7 @@ public class PullToRefreshWebView extends PullToRefreshBase<WebView> {
 
 	@Override
 	protected boolean isReadyForPullEnd() {
-		float exactContentHeight = FloatMath.floor(mRefreshableView.getContentHeight() * mRefreshableView.getScale());
+		double exactContentHeight = Math.floor(mRefreshableView.getContentHeight() * mRefreshableView.getScale());
 		return mRefreshableView.getScrollY() >= (exactContentHeight - mRefreshableView.getHeight());
 	}
 
@@ -158,7 +158,7 @@ public class PullToRefreshWebView extends PullToRefreshBase<WebView> {
 		}
 
 		private int getScrollRange() {
-			return (int) Math.max(0, FloatMath.floor(mRefreshableView.getContentHeight() * mRefreshableView.getScale())
+			return (int) Math.max(0, Math.floor(mRefreshableView.getContentHeight() * mRefreshableView.getScale())
 					- (getHeight() - getPaddingBottom() - getPaddingTop()));
 		}
 	}


### PR DESCRIPTION
#970 #857
Change to use new AlarmManager API when it's available and whitelisted by user.
I think it's better to try fetching email as possible as frequent when user wanted.

I confirmed emails are fetched in this [test method](http://developer.android.com/training/monitoring-device-state/doze-standby.html#testing_doze_and_app_standby) and my daily use with N7(2013).

Sorry if my english is hard to understand.