### PR TITLE
supress confirmation when closing totally empty new mail

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -634,6 +634,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             mSignatureView = lowerSignature;
             upperSignature.setVisibility(View.GONE);
         }
+        updateSignature();
         mSignatureView.addTextChangedListener(signTextWatcher);
 
         if (!mIdentity.getSignatureUse()) {
@@ -646,8 +647,6 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         updateFrom();
 
         if (!mSourceMessageProcessed) {
-            updateSignature();
-
             if (mAction == Action.REPLY || mAction == Action.REPLY_ALL ||
                     mAction == Action.FORWARD || mAction == Action.EDIT_DRAFT) {
                 /*


### PR DESCRIPTION
Call updateSignature() before adding TextChangeListener for signature to prevent setting draftNeedsSaving flag true.

Fixes #1027