### PR TITLE
anchor pgp inline message matching to beginning of message

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
@@ -91,7 +91,7 @@ public class MessageDecryptVerifier {
                 if (TextUtils.isEmpty(text)) {
                     continue;
                 }
-                switch (OpenPgpUtils.parseMessage(text)) {
+                switch (OpenPgpUtils.parseMessage(text, true)) {
                     case OpenPgpUtils.PARSE_RESULT_MESSAGE:
                     case OpenPgpUtils.PARSE_RESULT_SIGNED_MESSAGE:
                         inlineParts.add(part);

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpUtils.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpUtils.java
@@ -29,11 +29,11 @@ import android.text.TextUtils;
 public class OpenPgpUtils {
 
     public static final Pattern PGP_MESSAGE = Pattern.compile(
-            ".*?(-----BEGIN PGP MESSAGE-----.*?-----END PGP MESSAGE-----).*",
+            "(-----BEGIN PGP MESSAGE-----.*?-----END PGP MESSAGE-----).*",
             Pattern.DOTALL);
 
     public static final Pattern PGP_SIGNED_MESSAGE = Pattern.compile(
-            ".*?(-----BEGIN PGP SIGNED MESSAGE-----.*?-----BEGIN PGP SIGNATURE-----.*?-----END PGP SIGNATURE-----).*",
+            "(-----BEGIN PGP SIGNED MESSAGE-----.*?-----BEGIN PGP SIGNATURE-----.*?-----END PGP SIGNATURE-----).*",
             Pattern.DOTALL);
 
     public static final int PARSE_RESULT_NO_PGP = -1;
@@ -41,12 +41,16 @@ public class OpenPgpUtils {
     public static final int PARSE_RESULT_SIGNED_MESSAGE = 1;
 
     public static int parseMessage(String message) {
+        return parseMessage(message, false);
+    }
+
+    public static int parseMessage(String message, boolean anchorToStart) {
         Matcher matcherSigned = PGP_SIGNED_MESSAGE.matcher(message);
         Matcher matcherMessage = PGP_MESSAGE.matcher(message);
 
-        if (matcherMessage.matches()) {
+        if (anchorToStart ? matcherMessage.matches() : matcherMessage.find()) {
             return PARSE_RESULT_MESSAGE;
-        } else if (matcherSigned.matches()) {
+        } else if (anchorToStart ? matcherSigned.matches() : matcherSigned.find()) {
             return PARSE_RESULT_SIGNED_MESSAGE;
         } else {
             return PARSE_RESULT_NO_PGP;


### PR DESCRIPTION
simple workaround fix for #807. this behavior will be redone sooner or later so I just fixed the method in OpenPgpUtils.