### PR TITLE
Added GNU email provider

### DIFF
--- a/k9mail/src/main/res/xml/providers.xml
+++ b/k9mail/src/main/res/xml/providers.xml
@@ -133,6 +133,10 @@
     	<incoming uri="imap+ssl+://imap.zoho.com" username="$email" />
     	<outgoing uri="smtp+tls+://smtp.zoho.com" username="$email" />
     </provider>
+    <provider id="gnu" label="GNU" domain="gnu.org">
+    	<incoming uri="pop3+ssl+://fencepost.gnu.org" username="$user" />
+    	<outgoing uri="smtp+tls+://fencepost.gnu.org" username="$user" />
+    </provider>
 
     <!-- Yahoo! Mail Variants -->
     <provider id="yahoo" label="Yahoo" domain="yahoo.com">


### PR DESCRIPTION
Provider information: https://www.fsf.org/about/systems/sending-mail-via-fencepost
Don't know how to specify it, but only "encrypted" passwords are supported.