### PR TITLE
Allow import of "future" settings files

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -811,9 +811,8 @@ public class SettingsImporter {
                     versionString);
         }
 
-        if (version < 1 || version > Settings.VERSION) {
-            throw new SettingsImportExportException("Unsupported content version: " +
-                    versionString);
+        if (version < 1) {
+            throw new SettingsImportExportException("Unsupported content version: " + versionString);
         }
 
         return version;


### PR DESCRIPTION
We have strict input checking. So unknown/invalid settings will be ignored anyway.

This should make downgrades less painful.
