### PR TITLE
Avoid ClassCastException in ImapResponseParser

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapResponseParser.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapResponseParser.java
@@ -127,12 +127,16 @@ class ImapResponseParser {
     private void readTokens(ImapResponse response) throws IOException {
         response.clear();
 
-        String firstToken = (String) readToken(response);
-        response.add(firstToken);
+        Object firstToken = readToken(response);
 
-        if (isStatusResponse(firstToken)) {
+        checkTokenIsString(firstToken);
+        String symbol = (String) firstToken;
+
+        response.add(symbol);
+
+        if (isStatusResponse(symbol)) {
             parseResponseText(response);
-        } else if (equalsIgnoreCase(firstToken, Responses.LIST) || equalsIgnoreCase(firstToken, Responses.LSUB)) {
+        } else if (equalsIgnoreCase(symbol, Responses.LIST) || equalsIgnoreCase(symbol, Responses.LSUB)) {
             parseListResponse(response);
         } else {
             Object token;
@@ -451,5 +455,11 @@ class ImapResponseParser {
         }
 
         return symbol.equalsIgnoreCase((String) token);
+    }
+
+    private void checkTokenIsString(Object token) throws IOException {
+        if (!(token instanceof String)) {
+            throw new IOException("Unexpected non-string token: " + token);
+        }
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.java
@@ -17,6 +17,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 
 @RunWith(RobolectricTestRunner.class)
@@ -310,6 +311,18 @@ public class ImapResponseParserTest {
         ImapResponse responseTwo = parser.readResponse();
 
         assertEquals("TAG", responseTwo.getTag());
+    }
+
+    @Test
+    public void readResponse_withListAsFirstToken_shouldThrow() throws Exception {
+        ImapResponseParser parser = createParser("* [1 2] 3\r\n");
+
+        try {
+            parser.readResponse();
+            fail("Expected exception");
+        } catch (IOException e) {
+            assertEquals("Unexpected non-string token: [1, 2]", e.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
Explicitly throw with a bit more information.

Fixes #811 