### PR TITLE
Support "binary" encoding

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
@@ -1019,7 +1019,8 @@ public class MimeUtility {
             RawDataBody rawDataBody = (RawDataBody) body;
             String encoding = rawDataBody.getEncoding();
             final InputStream rawInputStream = rawDataBody.getInputStream();
-            if (MimeUtil.ENC_7BIT.equalsIgnoreCase(encoding) || MimeUtil.ENC_8BIT.equalsIgnoreCase(encoding)) {
+            if (MimeUtil.ENC_7BIT.equalsIgnoreCase(encoding) || MimeUtil.ENC_8BIT.equalsIgnoreCase(encoding)
+                    || MimeUtil.ENC_BINARY.equalsIgnoreCase(encoding)) {
                 inputStream = rawInputStream;
             } else if (MimeUtil.ENC_BASE64.equalsIgnoreCase(encoding)) {
                 inputStream = new Base64InputStream(rawInputStream, false) {


### PR DESCRIPTION
Per RFC 1341: https://www.w3.org/Protocols/rfc1341/5_Content-Transfer-Encoding.html

The values "8bit", "7bit", and "binary" all imply that NO encoding has been performed.

This produces the expected output for #1146 