### PR TITLE
When in AccountSettings, clear the cryptography settings if none are available.

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -783,6 +783,9 @@ public class AccountSettings extends K9PreferenceActivity {
         if (mHasCrypto) {
             mAccount.setCryptoApp(mCryptoApp.getValue());
             mAccount.setCryptoKey(mCryptoKey.getValue());
+        } else {
+            mAccount.setCryptoApp(Account.NO_OPENPGP_PROVIDER);
+            mAccount.setCryptoKey(Account.NO_OPENPGP_KEY);
         }
 
         // In webdav account we use the exact folder name also for inbox,


### PR DESCRIPTION
Allows the user to fix #1153 and #1160 by just visiting the AccountSettings to clear the status.