### PR TITLE
Allow translation and formatting on common errors

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
@@ -102,6 +102,9 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
                 return context.getString(R.string.folder_error_hostname_lookup_failed);
             } else if (mess.startsWith("ErrnoException: open failed: ENOENT")) {
                 return context.getString(R.string.folder_error_open_failed_enoent);
+            } else if (mess.contains("Connection timed out")) {
+                //SSLException: Read error: ssl=0x7f7392e200: I/O error during system call, Connection timed out
+                return context.getString(R.string.folder_error_connnection_timed_out);
             }
 
             if (mess.length() > 27) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
@@ -4,6 +4,7 @@ import android.content.Context;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.R;
+import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mailstore.LocalFolder;
 
@@ -44,13 +45,6 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
 
     }
 
-    private String truncateStatus(String mess) {
-        if (mess != null && mess.length() > 27) {
-            mess = mess.substring(0, 27);
-        }
-        return mess;
-    }
-
     // constructor for an empty object for comparisons
     public FolderInfoHolder() {
     }
@@ -79,10 +73,42 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
         this.name = folder.getName();
         this.lastChecked = folder.getLastUpdate();
 
-        this.status = truncateStatus(folder.getStatus());
+        this.status = formatStatus(context, folder.getStatus());
 
         this.displayName = getDisplayName(context, account, name);
         setMoreMessagesFromFolder(folder);
+    }
+
+    /**
+     * Translate a folder status (which can be an opaque exception in error cases) into a
+     * user-friendly, translated string where possible.
+     *
+     * Truncate non-translated strings to 27 characters.
+     *
+     * @return formatted status
+     */
+    private String formatStatus(Context context, String mess) {
+        if (mess != null) {
+            if (mess.startsWith(MessagingController.PUSH_FAILED_ERROR_PREFIX)) {
+                String remainder = formatStatus(context, mess.substring(
+                        MessagingController.PUSH_FAILED_ERROR_PREFIX.length()));
+                String.format(context.getString(R.string.folder_error_push_failed), remainder);
+            }
+
+            if (mess.equals("SocketException: Socket is closed")) {
+                return context.getString(R.string.folder_error_remote_socket_closed);
+            } else if (mess.startsWith("GaiException: android_getaddrinfo failed:") ||
+                    mess.startsWith("UnknownHostException: Unable to resolve host")) {
+                return context.getString(R.string.folder_error_hostname_lookup_failed);
+            } else if (mess.startsWith("ErrnoException: open failed: ENOENT")) {
+                return context.getString(R.string.folder_error_open_failed_enoent);
+            }
+
+            if (mess.length() > 27) {
+                mess = mess.substring(0, 27);
+            }
+        }
+        return mess;
     }
 
     /**

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
@@ -100,6 +100,8 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
             } else if (mess.startsWith("GaiException: android_getaddrinfo failed:") ||
                     mess.startsWith("UnknownHostException: Unable to resolve host")) {
                 return context.getString(R.string.folder_error_hostname_lookup_failed);
+            } else if (mess.startsWith("SocketTimeoutException: SSL handshake timed out")) {
+                return context.getString(R.string.folder_error_connection_attempt_failed);
             } else if (mess.startsWith("ErrnoException: open failed: ENOENT")) {
                 return context.getString(R.string.folder_error_open_failed_enoent);
             } else if (mess.contains("Connection timed out")) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -137,6 +137,7 @@ public class MessagingController implements Runnable {
      * Maximum number of unsynced messages to store at once
      */
     private static final int UNSYNC_CHUNK_SIZE = 5;
+    public static final String PUSH_FAILED_ERROR_PREFIX = "Push failed: ";
 
     private static MessagingController inst = null;
     private BlockingQueue<Command> mCommands = new PriorityBlockingQueue<Command>();
@@ -4532,7 +4533,7 @@ public class MessagingController implements Runnable {
 
                 } catch (Exception e) {
                     String rootMessage = getRootCauseMessage(e);
-                    String errorMessage = "Push failed: " + rootMessage;
+                    String errorMessage = PUSH_FAILED_ERROR_PREFIX + rootMessage;
                     try {
                         // Oddly enough, using a local variable gets rid of a
                         // potential null pointer access warning with Eclipse.

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1145,4 +1145,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="error_crypto_provider_connect">Cannot connect to crypto provider, check your settings or click crypto icon to retry!</string>
     <string name="error_crypto_provider_ui_required">Crypto provider access denied, click crypto icon to retry!</string>
 
+    <!-- Better explanations for errors that are displayed in the folder list -->
+    <string name="folder_error_push_failed">Push failed: %s</string>
+    <string name="folder_error_remote_socket_closed">Remote socket closed</string>
+    <string name="folder_error_hostname_lookup_failed">Hostname resolution failed</string>
+    <string name="folder_error_open_failed_enoent">Opening email failed</string>
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1150,4 +1150,5 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="folder_error_remote_socket_closed">Remote socket closed</string>
     <string name="folder_error_hostname_lookup_failed">Hostname resolution failed</string>
     <string name="folder_error_open_failed_enoent">Opening email failed</string>
+    <string name="folder_error_connnection_timed_out">Connection timed out</string>
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1149,6 +1149,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="folder_error_push_failed">Push failed: %s</string>
     <string name="folder_error_remote_socket_closed">Remote socket closed</string>
     <string name="folder_error_hostname_lookup_failed">Hostname resolution failed</string>
+    <string name="folder_error_connection_attempt_failed">Connection attempt failed</string>
     <string name="folder_error_open_failed_enoent">Opening email failed</string>
     <string name="folder_error_connnection_timed_out">Connection timed out</string>
 </resources>


### PR DESCRIPTION
These are just the errors I've seen in common scenarios (one might be a bug, the others are expected - e.g. attempting to sync when there's no network connection/the server not playing ball).

This doesn't affect what you see in the K-9 errors folder, only the behaviour of the status line below the folder name.