### PR TITLE
Handle synchronizing empty folders

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1177,7 +1177,6 @@ public class MessagingController implements Runnable {
             if (K9.DEBUG)
                 Log.d(K9.LOG_TAG, "SYNC: About to fetch " + unsyncedMessages.size() + " unsynced messages for folder " + folder);
 
-
             fetchUnsyncedMessages(account, remoteFolder, unsyncedMessages, smallMessages, largeMessages, progress, todo, fp);
 
             String updatedPushState = localFolder.getPushState();
@@ -1192,10 +1191,7 @@ public class MessagingController implements Runnable {
             if (K9.DEBUG) {
                 Log.d(K9.LOG_TAG, "SYNC: Synced unsynced messages for folder " + folder);
             }
-
-
         }
-
         if (K9.DEBUG)
             Log.d(K9.LOG_TAG, "SYNC: Have "
                   + largeMessages.size() + " large messages and "
@@ -1203,26 +1199,24 @@ public class MessagingController implements Runnable {
                   + unsyncedMessages.size() + " unsynced messages");
 
         unsyncedMessages.clear();
-
         /*
          * Grab the content of the small messages first. This is going to
          * be very fast and at very worst will be a single up of a few bytes and a single
          * download of 625k.
          */
         FetchProfile fp = new FetchProfile();
+        //TODO: Only fetch small and large messages if we have some
         fp.add(FetchProfile.Item.BODY);
         //        fp.add(FetchProfile.Item.FLAGS);
         //        fp.add(FetchProfile.Item.ENVELOPE);
-
         downloadSmallMessages(account, remoteFolder, localFolder, smallMessages, progress, unreadBeforeStart, newMessages, todo, fp);
         smallMessages.clear();
-
         /*
          * Now do the large messages that require more round trips.
          */
-        fp.clear();
+        fp = new FetchProfile();
         fp.add(FetchProfile.Item.STRUCTURE);
-        downloadLargeMessages(account, remoteFolder, localFolder, largeMessages, progress, unreadBeforeStart,  newMessages, todo, fp);
+        downloadLargeMessages(account, remoteFolder, localFolder, largeMessages, progress, unreadBeforeStart, newMessages, todo, fp);
         largeMessages.clear();
 
         /*
@@ -1335,7 +1329,6 @@ public class MessagingController implements Runnable {
         final String folder = remoteFolder.getName();
 
         final Date earliestDate = account.getEarliestPollDate();
-
         remoteFolder.fetch(unsyncedMessages, fp,
         new MessageRetrievalListener<T>() {
             @Override
@@ -1353,6 +1346,7 @@ public class MessagingController implements Runnable {
                         }
                         progress.incrementAndGet();
                         for (MessagingListener l : getListeners()) {
+                            //TODO: This might be the source of poll count errors in the UI. Is todo always the same as ofTotal
                             l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
                         }
                         return;
@@ -1502,7 +1496,7 @@ public class MessagingController implements Runnable {
                  * incomplete so the entire thing can be downloaded later if the user
                  * wishes to download it.
                  */
-                fp.clear();
+                fp = new FetchProfile();
                 fp.add(FetchProfile.Item.BODY_SANE);
                 /*
                  *  TODO a good optimization here would be to make sure that all Stores set
@@ -1920,7 +1914,6 @@ public class MessagingController implements Runnable {
                     /*
                      * Otherwise we'll upload our message and then delete the remote message.
                      */
-                    fp.clear();
                     fp = new FetchProfile();
                     fp.add(FetchProfile.Item.BODY);
                     localFolder.fetch(Collections.singletonList(localMessage), fp, null);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -765,7 +765,9 @@ public class MessagingController implements Runnable {
      * TODO Break this method up into smaller chunks.
      * @param providedRemoteFolder TODO
      */
-    private void synchronizeMailboxSynchronous(final Account account, final String folder, final MessagingListener listener, Folder providedRemoteFolder) {
+    private void synchronizeMailboxSynchronous(
+            final Account account, final String folder, final MessagingListener listener,
+            Folder providedRemoteFolder) {
         Folder remoteFolder = null;
         LocalFolder tLocalFolder = null;
 
@@ -886,7 +888,7 @@ public class MessagingController implements Runnable {
             final Date earliestDate = account.getEarliestPollDate();
 
 
-            int remoteStart;
+            int remoteStart = 1;
             if (remoteMessageCount > 0) {
                 /* Message numbers start at 1.  */
                 if (visibleLimit > 0) {
@@ -927,7 +929,7 @@ public class MessagingController implements Runnable {
                     l.synchronizeMailboxHeadersFinished(account, folder, headerProgress.get(), remoteUidMap.size());
                 }
 
-            } else {
+            } else if(remoteMessageCount < 0) {
                 throw new Exception("Message count " + remoteMessageCount + " for folder " + folder);
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -775,7 +775,8 @@ public class MessagingController implements Runnable {
      * TODO Break this method up into smaller chunks.
      * @param providedRemoteFolder TODO
      */
-    private void synchronizeMailboxSynchronous(
+    @VisibleForTesting
+    void synchronizeMailboxSynchronous(
             final Account account, final String folder, final MessagingListener listener,
             Folder providedRemoteFolder) {
         Folder remoteFolder = null;

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -1,0 +1,150 @@
+package com.fsck.k9.controller;
+
+import android.content.Context;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.AccountStats;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalStore;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowApplication;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+public class MessagingControllerTest {
+
+    private MessagingController controller;
+    @Mock
+    private Account account;
+    @Mock
+    private AccountStats accountStats;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private Folder remoteFolder;
+    @Mock
+    private LocalStore localStore;
+
+    @Before
+    public void before() throws MessagingException {
+        MockitoAnnotations.initMocks(this);
+        controller = MessagingController.getInstance(
+                ShadowApplication.getInstance().getApplicationContext());
+        when(account.getLocalStore()).thenReturn(localStore);
+        when(account.getStats(any(Context.class))).thenReturn(accountStats);
+        when(localStore.getFolder("Folder")).thenReturn(localFolder);
+    }
+
+    @Test
+    public void can_synchronize_folder_with_message() throws InterruptedException, MessagingException {
+        final CountDownLatch commandStarted = new CountDownLatch(1);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                System.out.println("answer");
+                commandStarted.countDown();
+                return null;
+            }
+        }).when(listener).synchronizeMailboxStarted(account, "Folder");
+
+        final CountDownLatch commandFinished = new CountDownLatch(1);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                commandFinished.countDown();
+                return null;
+            }
+        }).when(listener).synchronizeMailboxFinished(account, "Folder", 1, 0);
+        when(remoteFolder.getMessageCount()).thenReturn(1);
+        Thread thread = new Thread(controller);
+        thread.start();
+        controller.synchronizeMailbox(account, "Folder", listener, remoteFolder);
+        assertTrue(commandStarted.await(1, TimeUnit.SECONDS));
+        assertTrue(commandFinished.await(1, TimeUnit.SECONDS));
+        verify(localFolder).setStatus(null);
+    }
+
+    @Test
+    public void can_synchronize_empty_folder() throws InterruptedException, MessagingException {
+        final CountDownLatch commandStarted = new CountDownLatch(1);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                commandStarted.countDown();
+                return null;
+            }
+        }).when(listener).synchronizeMailboxStarted(account, "Folder");
+
+        final CountDownLatch commandFinished = new CountDownLatch(1);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                commandFinished.countDown();
+                return null;
+            }
+        }).when(listener).synchronizeMailboxFinished(account, "Folder", 0, 0);
+        when(remoteFolder.getMessageCount()).thenReturn(0);
+
+        Thread thread = new Thread(controller);
+        thread.start();
+        controller.synchronizeMailbox(account, "Folder", listener, remoteFolder);
+        assertTrue(commandStarted.await(1, TimeUnit.SECONDS));
+        assertTrue(commandFinished.await(1, TimeUnit.SECONDS));
+        verify(localFolder).setStatus(null);
+    }
+
+    @Test
+    public void cant_synchronize_folder_with_negative_message_count() throws InterruptedException, MessagingException {
+        final CountDownLatch commandStarted = new CountDownLatch(1);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                commandStarted.countDown();
+                return null;
+            }
+        }).when(listener).synchronizeMailboxStarted(account, "Folder");
+
+        final CountDownLatch commandFinished = new CountDownLatch(1);
+        doAnswer(new Answer<Void>() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                commandFinished.countDown();
+                return null;
+            }
+        }).when(listener).synchronizeMailboxFailed(eq(account), eq("Folder"), anyString());
+        when(remoteFolder.getMessageCount()).thenReturn(-1);
+
+        Thread thread = new Thread(controller);
+        thread.start();
+        controller.synchronizeMailbox(account, "Folder", listener, remoteFolder);
+        assertTrue(commandStarted.await(1, TimeUnit.SECONDS));
+        assertTrue(commandFinished.await(1, TimeUnit.SECONDS));
+        verify(localFolder).setStatus("Exception: Message count -1 for folder Folder");
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -5,32 +5,53 @@ import android.content.Context;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.AccountStats;
+import com.fsck.k9.mail.FetchProfile;
 import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessageRetrievalListener;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Store;
 import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.notification.NotificationController;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.mockito.cglib.core.Local;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-
+@SuppressWarnings("unchecked")
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
 public class MessagingControllerTest {
     private static final String FOLDER_NAME = "Folder";
+    private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;
 
 
     private MessagingController controller;
@@ -48,9 +69,12 @@ public class MessagingControllerTest {
     private LocalStore localStore;
     @Mock
     private Store remoteStore;
-
     @Mock
     private NotificationController notificationController;
+    @Captor
+    private ArgumentCaptor<List<Message>> messageListCaptor;
+    @Captor
+    private ArgumentCaptor<FetchProfile> fetchProfileCaptor;
 
 
     @Before
@@ -143,13 +167,186 @@ public class MessagingControllerTest {
         verify(remoteFolder, never()).expunge();
     }
 
+    @Test
+    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfDeletedMessages() throws Exception {
+        messageCountInRemoteFolder(0);
+        LocalMessage localCopyOfRemoteDeletedMessage = mock(LocalMessage.class);
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(localCopyOfRemoteDeletedMessage));
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        verify(localFolder).destroyMessages(messageListCaptor.capture());
+        assertEquals(localCopyOfRemoteDeletedMessage, messageListCaptor.getValue().get(0));
+    }
+
+    @Test
+    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfExistingMessagesAfterEarliestPollDate() throws Exception {
+        messageCountInRemoteFolder(1);
+        Date dateOfEarliestPoll = new Date();
+        LocalMessage localMessage = localMessageWithCopyOnServer();
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(account.getEarliestPollDate()).thenReturn(dateOfEarliestPoll);
+        when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(false);
+        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(localMessage));
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
+    }
+
+
+    @Test
+    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfExistingMessagesBeforeEarliestPollDate() throws Exception {
+        messageCountInRemoteFolder(1);
+        LocalMessage localMessage = localMessageWithCopyOnServer();
+        Date dateOfEarliestPoll = new Date();
+
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(account.getEarliestPollDate()).thenReturn(dateOfEarliestPoll);
+        when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(true);
+        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(localMessage));
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        verify(localFolder).destroyMessages(messageListCaptor.capture());
+        assertEquals(localMessage, messageListCaptor.getValue().get(0));
+    }
+
+    @Test
+    public void synchronizeMailboxSynchronous_withAccountSetNotToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfMessages() throws Exception {
+        messageCountInRemoteFolder(0);
+        LocalMessage remoteDeletedMessage = mock(LocalMessage.class);
+        when(account.syncRemoteDeletions()).thenReturn(false);
+        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(remoteDeletedMessage));
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
+    }
+
+    @Test
+    public void synchronizeMailboxSynchronous_withAccountSupportingFetchingFlags_shouldFetchUnsychronizedMessagesListAndFlags() throws Exception {
+        messageCountInRemoteFolder(1);
+        hasUnsychedRemoteMessage();
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(), any(MessageRetrievalListener.class));
+        assertEquals(2, fetchProfileCaptor.getAllValues().get(0).size());
+        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.FLAGS));
+        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
+    }
+
+    @Test
+    public void synchronizeMailboxSynchronous_withAccountNotSupportingFetchingFlags_shouldFetchUnsychronizedMessages() throws Exception {
+        messageCountInRemoteFolder(1);
+        hasUnsychedRemoteMessage();
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(), any(MessageRetrievalListener.class));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(0).size());
+        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
+    }
+
+    @Test
+    public void synchronizeMailboxSynchronous_withUnsyncedNewSmallMessage_shouldFetchBodyOfSmallMessage() throws Exception {
+        final Message smallMessageEnvelope = mock(Message.class);
+        when(smallMessageEnvelope.olderThan(any(Date.class))).thenReturn(false);
+        when(smallMessageEnvelope.getSize()).thenReturn(MAXIMUM_SMALL_MESSAGE_SIZE);
+
+        messageCountInRemoteFolder(1);
+        hasUnsychedRemoteMessage();
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+        doAnswer(new Answer() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                FetchProfile fp = (FetchProfile) invocation.getArguments()[1];
+                MessageRetrievalListener l = (MessageRetrievalListener) invocation.getArguments()[2];
+                if(fp.contains(FetchProfile.Item.ENVELOPE)) {
+                    l.messageStarted("UID", 1, 1);
+                    l.messageFinished(smallMessageEnvelope, 1, 1);
+                    l.messagesFinished(1);
+                }
+                return null;
+            }
+        }).when(remoteFolder).fetch(any(List.class), any(FetchProfile.class), any(MessageRetrievalListener.class));
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        verify(remoteFolder, atLeast(2)).fetch(any(List.class), fetchProfileCaptor.capture(), any(MessageRetrievalListener.class));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(1).size());
+        assertTrue(fetchProfileCaptor.getAllValues().get(1).contains(FetchProfile.Item.BODY));
+    }
+
+    @Test
+    public void synchronizeMailboxSynchronous_withUnsyncedNewSmallMessage_shouldOnlyFetchStructureOfLargeMessage() throws Exception {
+        final Message largeMessageEnvelope = mock(Message.class);
+        when(largeMessageEnvelope.olderThan(any(Date.class))).thenReturn(false);
+        when(largeMessageEnvelope.getSize()).thenReturn(MAXIMUM_SMALL_MESSAGE_SIZE+1);
+
+        messageCountInRemoteFolder(1);
+        hasUnsychedRemoteMessage();
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+        doAnswer(new Answer() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                FetchProfile fp = (FetchProfile) invocation.getArguments()[1];
+                System.out.println(fp);
+                if(invocation.getArguments()[2] != null) {
+                    MessageRetrievalListener l = (MessageRetrievalListener) invocation.getArguments()[2];
+                    if (fp.contains(FetchProfile.Item.ENVELOPE)) {
+                        l.messageStarted("UID", 1, 1);
+                        l.messageFinished(largeMessageEnvelope, 1, 1);
+                        l.messagesFinished(1);
+                    }
+                }
+                return null;
+            }
+        }).when(remoteFolder).fetch(any(List.class), any(FetchProfile.class), any(MessageRetrievalListener.class));
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        //TODO: Don't bother fetching messages of a size we don't have
+        verify(remoteFolder, atLeast(4)).fetch(any(List.class), fetchProfileCaptor.capture(), any(MessageRetrievalListener.class));
+
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(2).size());
+        assertEquals(FetchProfile.Item.STRUCTURE, fetchProfileCaptor.getAllValues().get(2).get(0));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(3).size());
+        assertEquals(FetchProfile.Item.BODY_SANE, fetchProfileCaptor.getAllValues().get(3).get(0));
+    }
+
     private void messageCountInRemoteFolder(int value) throws MessagingException {
         when(remoteFolder.getMessageCount()).thenReturn(value);
+    }
+
+    private LocalMessage localMessageWithCopyOnServer() throws MessagingException {
+        String messageUid = "UID";
+        Message remoteMessage = mock(Message.class);
+        LocalMessage localMessage = mock(LocalMessage.class);
+
+        when(remoteMessage.getUid()).thenReturn(messageUid);
+        when(localMessage.getUid()).thenReturn(messageUid);
+        when(remoteFolder.getMessages(anyInt(), anyInt(), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(Collections.singletonList(remoteMessage));
+        return localMessage;
+    }
+
+    private void hasUnsychedRemoteMessage() throws MessagingException {
+        String messageUid = "UID";
+        Message remoteMessage = mock(Message.class);
+        when(remoteMessage.getUid()).thenReturn(messageUid);
+        when(remoteFolder.getMessages(anyInt(), anyInt(), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(Collections.singletonList(remoteMessage));
     }
 
     private void configureAccount() throws MessagingException {
         when(account.getLocalStore()).thenReturn(localStore);
         when(account.getStats(any(Context.class))).thenReturn(accountStats);
+        when(account.getMaximumAutoDownloadMessageSize()).thenReturn(MAXIMUM_SMALL_MESSAGE_SIZE);
     }
 
     private void configureLocalStore() {

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -23,7 +23,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.mockito.cglib.core.Local;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.RobolectricTestRunner;
@@ -94,7 +93,8 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withOneMessageInRemoteFolder_shouldFinishWithoutError() throws Exception {
+    public void synchronizeMailboxSynchronous_withOneMessageInRemoteFolder_shouldFinishWithoutError()
+            throws Exception {
         messageCountInRemoteFolder(1);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
@@ -103,7 +103,8 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withEmptyRemoteFolder_shouldFinishWithoutError() throws Exception {
+    public void synchronizeMailboxSynchronous_withEmptyRemoteFolder_shouldFinishWithoutError()
+            throws Exception {
         messageCountInRemoteFolder(0);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
@@ -123,7 +124,8 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withRemoteFolderProvided_shouldNotOpenRemoteFolder() throws Exception {
+    public void synchronizeMailboxSynchronous_withRemoteFolderProvided_shouldNotOpenRemoteFolder()
+            throws Exception {
         messageCountInRemoteFolder(1);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
@@ -133,10 +135,11 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withNoRemoteFolderProvided_shouldOpenRemoteFolderFromStore() throws Exception {
+    public void synchronizeMailboxSynchronous_withNoRemoteFolderProvided_shouldOpenRemoteFolderFromStore()
+            throws Exception {
         messageCountInRemoteFolder(1);
-        when(account.getRemoteStore()).thenReturn(remoteStore);
-        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
+        configureRemoteStoreWithFolder();
+
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
 
@@ -145,7 +148,8 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withRemoteFolderProvided_shouldNotCloseRemoteFolder() throws Exception {
+    public void synchronizeMailboxSynchronous_withRemoteFolderProvided_shouldNotCloseRemoteFolder()
+            throws Exception {
         messageCountInRemoteFolder(1);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
@@ -155,10 +159,10 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withNoRemoteFolderProvided_shouldCloseRemoteFolderFromStore() throws Exception {
+    public void synchronizeMailboxSynchronous_withNoRemoteFolderProvided_shouldCloseRemoteFolderFromStore()
+            throws Exception {
         messageCountInRemoteFolder(1);
-        when(account.getRemoteStore()).thenReturn(remoteStore);
-        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
+        configureRemoteStoreWithFolder();
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
 
@@ -167,11 +171,11 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withAccountPolicySetToExpungeOnPoll_shouldExpungeRemoteFolder() throws Exception {
+    public void synchronizeMailboxSynchronous_withAccountPolicySetToExpungeOnPoll_shouldExpungeRemoteFolder()
+            throws Exception {
         messageCountInRemoteFolder(1);
         when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_ON_POLL);
-        when(account.getRemoteStore()).thenReturn(remoteStore);
-        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
+        configureRemoteStoreWithFolder();
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
 
@@ -179,7 +183,8 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withAccountPolicySetToExpungeManually_shouldNotExpungeRemoteFolder() throws Exception {
+    public void synchronizeMailboxSynchronous_withAccountPolicySetToExpungeManually_shouldNotExpungeRemoteFolder()
+            throws Exception {
         messageCountInRemoteFolder(1);
         when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_MANUALLY);
 
@@ -189,7 +194,8 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfDeletedMessages() throws Exception {
+    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfDeletedMessages()
+            throws Exception {
         messageCountInRemoteFolder(0);
         LocalMessage localCopyOfRemoteDeletedMessage = mock(LocalMessage.class);
         when(account.syncRemoteDeletions()).thenReturn(true);
@@ -202,7 +208,8 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfExistingMessagesAfterEarliestPollDate() throws Exception {
+    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfExistingMessagesAfterEarliestPollDate()
+            throws Exception {
         messageCountInRemoteFolder(1);
         Date dateOfEarliestPoll = new Date();
         LocalMessage localMessage = localMessageWithCopyOnServer();
@@ -218,7 +225,8 @@ public class MessagingControllerTest {
 
 
     @Test
-    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfExistingMessagesBeforeEarliestPollDate() throws Exception {
+    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfExistingMessagesBeforeEarliestPollDate()
+            throws Exception {
         messageCountInRemoteFolder(1);
         LocalMessage localMessage = localMessageWithCopyOnServer();
         Date dateOfEarliestPoll = new Date();
@@ -235,7 +243,8 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withAccountSetNotToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfMessages() throws Exception {
+    public void synchronizeMailboxSynchronous_withAccountSetNotToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfMessages()
+            throws Exception {
         messageCountInRemoteFolder(0);
         LocalMessage remoteDeletedMessage = mock(LocalMessage.class);
         when(account.syncRemoteDeletions()).thenReturn(false);
@@ -247,61 +256,69 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withAccountSupportingFetchingFlags_shouldFetchUnsychronizedMessagesListAndFlags() throws Exception {
+    public void synchronizeMailboxSynchronous_withAccountSupportingFetchingFlags_shouldFetchUnsychronizedMessagesListAndFlags()
+            throws Exception {
         messageCountInRemoteFolder(1);
-        hasUnsychedRemoteMessage();
+        hasUnsyncedRemoteMessage();
         when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
 
-        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(), any(MessageRetrievalListener.class));
+        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
         assertEquals(2, fetchProfileCaptor.getAllValues().get(0).size());
         assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.FLAGS));
         assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withAccountNotSupportingFetchingFlags_shouldFetchUnsychronizedMessages() throws Exception {
+    public void synchronizeMailboxSynchronous_withAccountNotSupportingFetchingFlags_shouldFetchUnsychronizedMessages()
+            throws Exception {
         messageCountInRemoteFolder(1);
-        hasUnsychedRemoteMessage();
+        hasUnsyncedRemoteMessage();
         when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
 
-        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(), any(MessageRetrievalListener.class));
+        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
         assertEquals(1, fetchProfileCaptor.getAllValues().get(0).size());
         assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withUnsyncedNewSmallMessage_shouldFetchBodyOfSmallMessage() throws Exception {
+    public void synchronizeMailboxSynchronous_withUnsyncedNewSmallMessage_shouldFetchBodyOfSmallMessage()
+            throws Exception {
         final Message smallMessage = buildSmallNewMessage();
 
         messageCountInRemoteFolder(1);
-        hasUnsychedRemoteMessage();
+        hasUnsyncedRemoteMessage();
         when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
         respondToFetchEnvelopesWithMessage(smallMessage);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
 
-        verify(remoteFolder, atLeast(2)).fetch(any(List.class), fetchProfileCaptor.capture(), any(MessageRetrievalListener.class));
+        verify(remoteFolder, atLeast(2)).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
         assertEquals(1, fetchProfileCaptor.getAllValues().get(1).size());
         assertTrue(fetchProfileCaptor.getAllValues().get(1).contains(FetchProfile.Item.BODY));
     }
 
     @Test
-    public void synchronizeMailboxSynchronous_withUnsyncedNewSmallMessage_shouldFetchStructureAndLimitedBodyOfLargeMessage() throws Exception {
+    public void synchronizeMailboxSynchronous_withUnsyncedNewSmallMessage_shouldFetchStructureAndLimitedBodyOfLargeMessage()
+            throws Exception {
         final Message largeMessage = buildLargeNewMessage();
 
         messageCountInRemoteFolder(1);
-        hasUnsychedRemoteMessage();
+        hasUnsyncedRemoteMessage();
         when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
         respondToFetchEnvelopesWithMessage(largeMessage);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
 
         //TODO: Don't bother fetching messages of a size we don't have
-        verify(remoteFolder, atLeast(4)).fetch(any(List.class), fetchProfileCaptor.capture(), any(MessageRetrievalListener.class));
+        verify(remoteFolder, atLeast(4)).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
         assertEquals(1, fetchProfileCaptor.getAllValues().get(2).size());
         assertEquals(FetchProfile.Item.STRUCTURE, fetchProfileCaptor.getAllValues().get(2).get(0));
         assertEquals(1, fetchProfileCaptor.getAllValues().get(3).size());
@@ -325,7 +342,8 @@ public class MessagingControllerTest {
                 }
                 return null;
             }
-        }).when(remoteFolder).fetch(any(List.class), any(FetchProfile.class), any(MessageRetrievalListener.class));
+        }).when(remoteFolder).fetch(any(List.class), any(FetchProfile.class),
+                any(MessageRetrievalListener.class));
 
     }
 
@@ -339,7 +357,7 @@ public class MessagingControllerTest {
     private Message buildLargeNewMessage() {
         Message message = mock(Message.class);
         when(message.olderThan(any(Date.class))).thenReturn(false);
-        when(message.getSize()).thenReturn(MAXIMUM_SMALL_MESSAGE_SIZE+1);
+        when(message.getSize()).thenReturn(MAXIMUM_SMALL_MESSAGE_SIZE + 1);
         return message;
     }
 
@@ -359,7 +377,7 @@ public class MessagingControllerTest {
         return localMessage;
     }
 
-    private void hasUnsychedRemoteMessage() throws MessagingException {
+    private void hasUnsyncedRemoteMessage() throws MessagingException {
         String messageUid = "UID";
         Message remoteMessage = mock(Message.class);
         when(remoteMessage.getUid()).thenReturn(messageUid);
@@ -375,5 +393,10 @@ public class MessagingControllerTest {
 
     private void configureLocalStore() {
         when(localStore.getFolder(FOLDER_NAME)).thenReturn(localFolder);
+    }
+
+    private void configureRemoteStoreWithFolder() throws MessagingException {
+        when(account.getRemoteStore()).thenReturn(remoteStore);
+        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -135,12 +135,34 @@ public class MessagingControllerTest {
     @Test
     public void synchronizeMailboxSynchronous_withNoRemoteFolderProvided_shouldOpenRemoteFolderFromStore() throws Exception {
         messageCountInRemoteFolder(1);
-        when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_ON_POLL);
         when(account.getRemoteStore()).thenReturn(remoteStore);
+        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
 
         verify(remoteFolder).open(Folder.OPEN_MODE_RW);
+
+    }
+
+    @Test
+    public void synchronizeMailboxSynchronous_withRemoteFolderProvided_shouldNotCloseRemoteFolder() throws Exception {
+        messageCountInRemoteFolder(1);
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        verify(remoteFolder, never()).close();
+
+    }
+
+    @Test
+    public void synchronizeMailboxSynchronous_withNoRemoteFolderProvided_shouldCloseRemoteFolderFromStore() throws Exception {
+        messageCountInRemoteFolder(1);
+        when(account.getRemoteStore()).thenReturn(remoteStore);
+        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
+
+        verify(remoteFolder).close();
 
     }
 
@@ -285,6 +307,8 @@ public class MessagingControllerTest {
         assertEquals(1, fetchProfileCaptor.getAllValues().get(3).size());
         assertEquals(FetchProfile.Item.BODY_SANE, fetchProfileCaptor.getAllValues().get(3).get(0));
     }
+
+
 
     private void respondToFetchEnvelopesWithMessage(final Message message) throws MessagingException {
         doAnswer(new Answer() {


### PR DESCRIPTION
Tested fix for #1139 

Retains the current behaviour for folders with negative message counts.