### PR TITLE
Add support for SOCKS proxy

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ProxySettings.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ProxySettings.java
@@ -1,0 +1,13 @@
+package com.fsck.k9.mail;
+
+public class ProxySettings {
+    public boolean enabled;
+    public String host;
+    public int port;
+
+    public ProxySettings(boolean enabled, String host, int port) {
+        this.enabled = enabled;
+        this.host = host;
+        this.port = port;
+    }
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ProxySettings.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ProxySettings.java
@@ -1,9 +1,11 @@
 package com.fsck.k9.mail;
 
+
 public class ProxySettings {
-    public boolean enabled;
-    public String host;
-    public int port;
+    public final boolean enabled;
+    public final String host;
+    public final int port;
+
 
     public ProxySettings(boolean enabled, String host, int port) {
         this.enabled = enabled;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Transport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Transport.java
@@ -19,10 +19,12 @@ public abstract class Transport {
     // RFC 1047
     protected static final int SOCKET_READ_TIMEOUT = 300000;
 
-    public synchronized static Transport getInstance(Context context, StoreConfig storeConfig) throws MessagingException {
+    public synchronized static Transport getInstance(Context context,
+                                                     StoreConfig storeConfig,
+                                                     ProxySettings proxy) throws MessagingException {
         String uri = storeConfig.getTransportUri();
         if (uri.startsWith("smtp")) {
-            return new SmtpTransport(storeConfig, new DefaultTrustedSocketFactory(context));
+            return new SmtpTransport(storeConfig, new DefaultTrustedSocketFactory(context, proxy));
         } else if (uri.startsWith("webdav")) {
             return new WebDavTransport(storeConfig);
         } else {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Transport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Transport.java
@@ -19,9 +19,8 @@ public abstract class Transport {
     // RFC 1047
     protected static final int SOCKET_READ_TIMEOUT = 300000;
 
-    public synchronized static Transport getInstance(Context context,
-                                                     StoreConfig storeConfig,
-                                                     ProxySettings proxy) throws MessagingException {
+    public static synchronized Transport getInstance(Context context, StoreConfig storeConfig, ProxySettings proxy)
+            throws MessagingException {
         String uri = storeConfig.getTransportUri();
         if (uri.startsWith("smtp")) {
             return new SmtpTransport(storeConfig, new DefaultTrustedSocketFactory(context, proxy));

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/RemoteStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/RemoteStore.java
@@ -39,9 +39,8 @@ public abstract class RemoteStore extends Store {
     /**
      * Get an instance of a remote mail store.
      */
-    public synchronized static Store getInstance(Context context,
-                                                 StoreConfig storeConfig,
-                                                 ProxySettings proxySettings) throws MessagingException {
+    public static synchronized Store getInstance(Context context, StoreConfig storeConfig, ProxySettings proxySettings)
+            throws MessagingException {
         String uri = storeConfig.getStoreUri();
 
         if (uri.startsWith("local")) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/RemoteStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/RemoteStore.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.ConnectivityManager;
 
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.ProxySettings;
 import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mail.ServerSettings.Type;
 import com.fsck.k9.mail.Store;
@@ -39,7 +40,8 @@ public abstract class RemoteStore extends Store {
      * Get an instance of a remote mail store.
      */
     public synchronized static Store getInstance(Context context,
-                                                 StoreConfig storeConfig) throws MessagingException {
+                                                 StoreConfig storeConfig,
+                                                 ProxySettings proxySettings) throws MessagingException {
         String uri = storeConfig.getStoreUri();
 
         if (uri.startsWith("local")) {
@@ -50,11 +52,11 @@ public abstract class RemoteStore extends Store {
         if (store == null) {
             if (uri.startsWith("imap")) {
                 store = new ImapStore(storeConfig,
-                        new DefaultTrustedSocketFactory(context),
+                        new DefaultTrustedSocketFactory(context, proxySettings),
                         (ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
             } else if (uri.startsWith("pop3")) {
                 store = new Pop3Store(storeConfig,
-                        new DefaultTrustedSocketFactory(context));
+                        new DefaultTrustedSocketFactory(context, proxySettings));
             } else if (uri.startsWith("webdav")) {
                 store = new WebDavStore(storeConfig, new WebDavHttpClient.WebDavHttpClientFactory());
             }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -207,9 +207,8 @@ class ImapConnection {
             socket = socketFactory.createSocket(null, host, port, clientCertificateAlias);
         } else {
             socket = new Socket();
+            socket.connect(socketAddress, socketConnectTimeout);
         }
-
-        socket.connect(socketAddress, socketConnectTimeout);
 
         return socket;
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -314,9 +314,9 @@ public class Pop3Store extends RemoteStore {
                     mSocket = mTrustedSocketFactory.createSocket(null, mHost, mPort, mClientCertificateAlias);
                 } else {
                     mSocket = new Socket();
+                    mSocket.connect(socketAddress, SOCKET_CONNECT_TIMEOUT);
                 }
 
-                mSocket.connect(socketAddress, SOCKET_CONNECT_TIMEOUT);
                 mIn = new BufferedInputStream(mSocket.getInputStream(), 1024);
                 mOut = new BufferedOutputStream(mSocket.getOutputStream(), 512);
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -215,7 +215,6 @@ public class SmtpTransport extends Transport {
                     SocketAddress socketAddress = new InetSocketAddress(addresses[i], mPort);
                     if (mConnectionSecurity == ConnectionSecurity.SSL_TLS_REQUIRED) {
                         mSocket = mTrustedSocketFactory.createSocket(null, mHost, mPort, mClientCertificateAlias);
-                        mSocket.connect(socketAddress, SOCKET_CONNECT_TIMEOUT);
                         secureConnection = true;
                     } else {
                         mSocket = new Socket();

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -68,6 +68,8 @@ android {
             }
 
             buildConfigField "boolean", "DEVELOPER_MODE", "false"
+
+            buildConfigField "boolean", "FEATURE_SOCKS_PROXY", "false"
         }
 
         debug {
@@ -75,6 +77,8 @@ android {
             testCoverageEnabled rootProject.testCoverage
 
             buildConfigField "boolean", "DEVELOPER_MODE", "true"
+
+            buildConfigField "boolean", "FEATURE_SOCKS_PROXY", "true"
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -19,7 +19,6 @@ import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.net.Uri;
-import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
@@ -1282,7 +1281,8 @@ public class Account implements BaseAccount, StoreConfig {
     }
 
     public ProxySettings getProxySettings() {
-        return new ProxySettings(K9.isSocksProxyEnabled(), K9.getSocksProxyHost(), K9.getSocksProxyPort());
+        boolean enabled = Features.isSocksProxySupportEnabled() && K9.isSocksProxyEnabled();
+        return new ProxySettings(enabled, K9.getSocksProxyHost(), K9.getSocksProxyPort());
     }
 
     // It'd be great if this actually went into the store implementation

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -19,6 +19,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.graphics.Color;
 import android.net.Uri;
+import android.support.annotation.NonNull;
 import android.util.Log;
 
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
@@ -1276,12 +1277,12 @@ public class Account implements BaseAccount, StoreConfig {
     }
 
     public Store getRemoteStore() throws MessagingException {
-        return RemoteStore.getInstance(K9.app,
-                                       this,
-                                       new ProxySettings(
-                                            K9.isSocksProxyEnabled(),
-                                            K9.getSocksProxyHost(),
-                                            K9.getSocksProxyPort()));
+        ProxySettings proxySettings = getProxySettings();
+        return RemoteStore.getInstance(K9.app, this, proxySettings);
+    }
+
+    public ProxySettings getProxySettings() {
+        return new ProxySettings(K9.isSocksProxyEnabled(), K9.getSocksProxyHost(), K9.getSocksProxyPort());
     }
 
     // It'd be great if this actually went into the store implementation

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -26,6 +26,7 @@ import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.NetworkType;
+import com.fsck.k9.mail.ProxySettings;
 import com.fsck.k9.mail.Store;
 import com.fsck.k9.mail.Folder.FolderClass;
 import com.fsck.k9.mail.filter.Base64;
@@ -1275,7 +1276,12 @@ public class Account implements BaseAccount, StoreConfig {
     }
 
     public Store getRemoteStore() throws MessagingException {
-        return RemoteStore.getInstance(K9.app, this);
+        return RemoteStore.getInstance(K9.app,
+                                       this,
+                                       new ProxySettings(
+                                            K9.isSocksProxyEnabled(),
+                                            K9.getSocksProxyHost(),
+                                            K9.getSocksProxyPort()));
     }
 
     // It'd be great if this actually went into the store implementation

--- a/k9mail/src/main/java/com/fsck/k9/Features.java
+++ b/k9mail/src/main/java/com/fsck/k9/Features.java
@@ -1,0 +1,8 @@
+package com.fsck.k9;
+
+
+public class Features {
+    public static boolean isSocksProxySupportEnabled() {
+        return BuildConfig.FEATURE_SOCKS_PROXY;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -1,6 +1,7 @@
 
 package com.fsck.k9;
 
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -35,11 +36,11 @@ import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.BinaryTempFileBody;
+import com.fsck.k9.mail.ssl.LocalKeyStore;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
 import com.fsck.k9.provider.UnreadWidgetProvider;
-import com.fsck.k9.mail.ssl.LocalKeyStore;
 import com.fsck.k9.service.BootReceiver;
 import com.fsck.k9.service.MailService;
 import com.fsck.k9.service.ShutdownReceiver;
@@ -1335,19 +1336,25 @@ public class K9 extends Application {
         sMessageViewSpamActionVisible = visible;
     }
 
-    public static boolean isSocksProxyEnabled() { return sUseSocksProxy; }
+    public static boolean isSocksProxyEnabled() {
+        return sUseSocksProxy;
+    }
 
     public static void setUseSocksProxy(boolean useSocksProxy) {
         sUseSocksProxy = useSocksProxy;
     }
 
-    public static String getSocksProxyHost() { return sSocksProxyHost; }
+    public static String getSocksProxyHost() {
+        return sSocksProxyHost;
+    }
 
     public static void setSocksProxyHost(String socksProxyHost) {
         sSocksProxyHost = socksProxyHost;
     }
 
-    public static int getSocksProxyPort() { return sSocksProxyPort; }
+    public static int getSocksProxyPort() {
+        return sSocksProxyPort;
+    }
 
     public static void setSocksProxyPort(int socksProxyPort) {
         sSocksProxyPort = socksProxyPort;

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -255,6 +255,9 @@ public class K9 extends Application {
     private static boolean sMessageViewCopyActionVisible = false;
     private static boolean sMessageViewSpamActionVisible = false;
 
+    private static boolean sUseSocksProxy = false;
+    private static String sSocksProxyHost = "";
+    private static int sSocksProxyPort = 0;
 
     /**
      * @see #areDatabasesUpToDate()
@@ -491,6 +494,10 @@ public class K9 extends Application {
         editor.putBoolean("messageViewMoveActionVisible", sMessageViewMoveActionVisible);
         editor.putBoolean("messageViewCopyActionVisible", sMessageViewCopyActionVisible);
         editor.putBoolean("messageViewSpamActionVisible", sMessageViewSpamActionVisible);
+
+        editor.putBoolean("useSocksProxy", sUseSocksProxy);
+        editor.putString("socksProxyHost", sSocksProxyHost);
+        editor.putInt("useSocksPort", sSocksProxyPort);
 
         fontSizes.save(editor);
     }
@@ -745,6 +752,10 @@ public class K9 extends Application {
         sMessageViewMoveActionVisible = storage.getBoolean("messageViewMoveActionVisible", false);
         sMessageViewCopyActionVisible = storage.getBoolean("messageViewCopyActionVisible", false);
         sMessageViewSpamActionVisible = storage.getBoolean("messageViewSpamActionVisible", false);
+
+        sUseSocksProxy = storage.getBoolean("useSocksProxy", false);
+        sSocksProxyHost = storage.getString("socksProxyHost", "127.0.0.1");
+        sSocksProxyPort = storage.getInt("socksProxyPort", 12345);
 
 
         K9.setK9Language(storage.getString("language", ""));
@@ -1322,6 +1333,24 @@ public class K9 extends Application {
 
     public static void setMessageViewSpamActionVisible(boolean visible) {
         sMessageViewSpamActionVisible = visible;
+    }
+
+    public static boolean isSocksProxyEnabled() { return sUseSocksProxy; }
+
+    public static void setUseSocksProxy(boolean useSocksProxy) {
+        sUseSocksProxy = useSocksProxy;
+    }
+
+    public static String getSocksProxyHost() { return sSocksProxyHost; }
+
+    public static void setSocksProxyHost(String socksProxyHost) {
+        sSocksProxyHost = socksProxyHost;
+    }
+
+    public static int getSocksProxyPort() { return sSocksProxyPort; }
+
+    public static void setSocksProxyPort(int socksProxyPort) {
+        sSocksProxyPort = socksProxyPort;
     }
 
     /**

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -25,7 +25,6 @@ import com.fsck.k9.fragment.ConfirmationDialogFragment.ConfirmationDialogFragmen
 import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.MessagingException;
-import com.fsck.k9.mail.ProxySettings;
 import com.fsck.k9.mail.Store;
 import com.fsck.k9.mail.Transport;
 import com.fsck.k9.mail.store.webdav.WebDavStore;
@@ -477,12 +476,7 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
             if (!(account.getRemoteStore() instanceof WebDavStore)) {
                 publishProgress(R.string.account_setup_check_settings_check_outgoing_msg);
             }
-            Transport transport = Transport.getInstance(K9.app,
-                                                        account,
-                                                        new ProxySettings(
-                                                            K9.isSocksProxyEnabled(),
-                                                            K9.getSocksProxyHost(),
-                                                            K9.getSocksProxyPort()));
+            Transport transport = Transport.getInstance(K9.app, account, account.getProxySettings());
             transport.close();
             transport.open();
             transport.close();

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -25,6 +25,7 @@ import com.fsck.k9.fragment.ConfirmationDialogFragment.ConfirmationDialogFragmen
 import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.ProxySettings;
 import com.fsck.k9.mail.Store;
 import com.fsck.k9.mail.Transport;
 import com.fsck.k9.mail.store.webdav.WebDavStore;
@@ -476,7 +477,12 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
             if (!(account.getRemoteStore() instanceof WebDavStore)) {
                 publishProgress(R.string.account_setup_check_settings_check_outgoing_msg);
             }
-            Transport transport = Transport.getInstance(K9.app, account);
+            Transport transport = Transport.getInstance(K9.app,
+                                                        account,
+                                                        new ProxySettings(
+                                                            K9.isSocksProxyEnabled(),
+                                                            K9.getSocksProxyHost(),
+                                                            K9.getSocksProxyPort()));
             transport.close();
             transport.open();
             transport.close();

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -430,14 +430,14 @@ public class Prefs extends K9PreferenceActivity {
         initListPreference(mSplitViewMode, K9.getSplitViewMode().name(),
                 mSplitViewMode.getEntries(), mSplitViewMode.getEntryValues());
 
-        mUseSocksProxy = (CheckBoxPreference)findPreference(PREFERENCE_SOCKS_PROXY);
+        mUseSocksProxy = (CheckBoxPreference) findPreference(PREFERENCE_SOCKS_PROXY);
         mUseSocksProxy.setChecked(K9.isSocksProxyEnabled());
 
-        mSocksProxyHost = (EditTextPreference)findPreference(PREFERENCE_SOCKS_PROXY_HOST);
+        mSocksProxyHost = (EditTextPreference) findPreference(PREFERENCE_SOCKS_PROXY_HOST);
         mSocksProxyHost.setText(K9.getSocksProxyHost());
 
-        mSocksProxyPort = (EditTextPreference)findPreference(PREFERENCE_SOCKS_PROXY_PORT);
-        mSocksProxyPort.setText(K9.getSocksProxyPort()+"");
+        mSocksProxyPort = (EditTextPreference) findPreference(PREFERENCE_SOCKS_PROXY_PORT);
+        mSocksProxyPort.setText(Integer.toString(K9.getSocksProxyPort()));
     }
 
     private static String themeIdToName(K9.Theme theme) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -20,6 +20,7 @@ import android.preference.PreferenceScreen;
 import android.text.TextUtils;
 import android.widget.Toast;
 
+import com.fsck.k9.Features;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationHideSubject;
 import com.fsck.k9.K9.NotificationQuickDelete;
@@ -430,14 +431,24 @@ public class Prefs extends K9PreferenceActivity {
         initListPreference(mSplitViewMode, K9.getSplitViewMode().name(),
                 mSplitViewMode.getEntries(), mSplitViewMode.getEntryValues());
 
-        mUseSocksProxy = (CheckBoxPreference) findPreference(PREFERENCE_SOCKS_PROXY);
-        mUseSocksProxy.setChecked(K9.isSocksProxyEnabled());
+        CheckBoxPreference useSocksProxy = (CheckBoxPreference) findPreference(PREFERENCE_SOCKS_PROXY);
+        EditTextPreference socksProxyHost = (EditTextPreference) findPreference(PREFERENCE_SOCKS_PROXY_HOST);
+        EditTextPreference socksProxyPort = (EditTextPreference) findPreference(PREFERENCE_SOCKS_PROXY_PORT);
 
-        mSocksProxyHost = (EditTextPreference) findPreference(PREFERENCE_SOCKS_PROXY_HOST);
-        mSocksProxyHost.setText(K9.getSocksProxyHost());
+        if (Features.isSocksProxySupportEnabled()) {
+            mUseSocksProxy = useSocksProxy;
+            mSocksProxyHost = socksProxyHost;
+            mSocksProxyPort = socksProxyPort;
 
-        mSocksProxyPort = (EditTextPreference) findPreference(PREFERENCE_SOCKS_PROXY_PORT);
-        mSocksProxyPort.setText(Integer.toString(K9.getSocksProxyPort()));
+            useSocksProxy.setChecked(K9.isSocksProxyEnabled());
+            socksProxyHost.setText(K9.getSocksProxyHost());
+            socksProxyPort.setText(Integer.toString(K9.getSocksProxyPort()));
+        } else {
+            PreferenceScreen networkPreferences = (PreferenceScreen) findPreference("network_preferences");
+            networkPreferences.removePreference(useSocksProxy);
+            networkPreferences.removePreference(socksProxyHost);
+            networkPreferences.removePreference(socksProxyPort);
+        }
     }
 
     private static String themeIdToName(K9.Theme theme) {
@@ -538,9 +549,11 @@ public class Prefs extends K9PreferenceActivity {
         K9.setHideUserAgent(mHideUserAgent.isChecked());
         K9.setHideTimeZone(mHideTimeZone.isChecked());
 
-        K9.setUseSocksProxy(mUseSocksProxy.isChecked());
-        K9.setSocksProxyHost(mSocksProxyHost.getText());
-        K9.setSocksProxyPort(Integer.parseInt(mSocksProxyPort.getText()));
+        if (Features.isSocksProxySupportEnabled()) {
+            K9.setUseSocksProxy(mUseSocksProxy.isChecked());
+            K9.setSocksProxyHost(mSocksProxyHost.getText());
+            K9.setSocksProxyPort(Integer.parseInt(mSocksProxyPort.getText()));
+        }
 
         StorageEditor editor = storage.edit();
         K9.save(editor);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -15,6 +15,7 @@ import android.preference.CheckBoxPreference;
 import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
+import android.preference.Preference.OnPreferenceChangeListener;
 import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceScreen;
 import android.text.TextUtils;
@@ -436,13 +437,32 @@ public class Prefs extends K9PreferenceActivity {
         EditTextPreference socksProxyPort = (EditTextPreference) findPreference(PREFERENCE_SOCKS_PROXY_PORT);
 
         if (Features.isSocksProxySupportEnabled()) {
+            //TODO: Add input validation for hostname and port
+
             mUseSocksProxy = useSocksProxy;
             mSocksProxyHost = socksProxyHost;
             mSocksProxyPort = socksProxyPort;
 
             useSocksProxy.setChecked(K9.isSocksProxyEnabled());
-            socksProxyHost.setText(K9.getSocksProxyHost());
-            socksProxyPort.setText(Integer.toString(K9.getSocksProxyPort()));
+
+            String currentSockProxyHost = K9.getSocksProxyHost();
+            socksProxyHost.setText(currentSockProxyHost);
+            socksProxyHost.setSummary(currentSockProxyHost);
+
+            String currentSocksProxyPort = Integer.toString(K9.getSocksProxyPort());
+            socksProxyPort.setText(currentSocksProxyPort);
+            socksProxyPort.setSummary(currentSocksProxyPort);
+
+            OnPreferenceChangeListener changeListener = new OnPreferenceChangeListener() {
+                @Override
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    preference.setSummary(newValue.toString());
+                    return true;
+                }
+            };
+
+            socksProxyHost.setOnPreferenceChangeListener(changeListener);
+            socksProxyPort.setOnPreferenceChangeListener(changeListener);
         } else {
             PreferenceScreen networkPreferences = (PreferenceScreen) findPreference("network_preferences");
             networkPreferences.removePreference(useSocksProxy);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -12,6 +12,7 @@ import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 import android.preference.CheckBoxPreference;
+import android.preference.EditTextPreference;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.Preference.OnPreferenceClickListener;
@@ -99,6 +100,10 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_FOLDERLIST_WRAP_NAME = "folderlist_wrap_folder_name";
     private static final String PREFERENCE_SPLITVIEW_MODE = "splitview_mode";
 
+    private static final String PREFERENCE_SOCKS_PROXY = "socks_proxy";
+    private static final String PREFERENCE_SOCKS_PROXY_HOST = "socks_proxy_host";
+    private static final String PREFERENCE_SOCKS_PROXY_PORT = "socks_proxy_port";
+
     private static final int ACTIVITY_CHOOSE_FOLDER = 1;
 
     // Named indices for the mVisibleRefileActions field
@@ -155,6 +160,9 @@ public class Prefs extends K9PreferenceActivity {
     private CheckBoxPreference mThreadedView;
     private ListPreference mSplitViewMode;
 
+    private CheckBoxPreference mUseSocksProxy;
+    private EditTextPreference mSocksProxyHost;
+    private EditTextPreference mSocksProxyPort;
 
     public static void actionPrefs(Context context) {
         Intent i = new Intent(context, Prefs.class);
@@ -421,6 +429,15 @@ public class Prefs extends K9PreferenceActivity {
         mSplitViewMode = (ListPreference) findPreference(PREFERENCE_SPLITVIEW_MODE);
         initListPreference(mSplitViewMode, K9.getSplitViewMode().name(),
                 mSplitViewMode.getEntries(), mSplitViewMode.getEntryValues());
+
+        mUseSocksProxy = (CheckBoxPreference)findPreference(PREFERENCE_SOCKS_PROXY);
+        mUseSocksProxy.setChecked(K9.isSocksProxyEnabled());
+
+        mSocksProxyHost = (EditTextPreference)findPreference(PREFERENCE_SOCKS_PROXY_HOST);
+        mSocksProxyHost.setText(K9.getSocksProxyHost());
+
+        mSocksProxyPort = (EditTextPreference)findPreference(PREFERENCE_SOCKS_PROXY_PORT);
+        mSocksProxyPort.setText(K9.getSocksProxyPort()+"");
     }
 
     private static String themeIdToName(K9.Theme theme) {
@@ -520,6 +537,10 @@ public class Prefs extends K9PreferenceActivity {
         K9.DEBUG_SENSITIVE = mSensitiveLogging.isChecked();
         K9.setHideUserAgent(mHideUserAgent.isChecked());
         K9.setHideTimeZone(mHideTimeZone.isChecked());
+
+        K9.setUseSocksProxy(mUseSocksProxy.isChecked());
+        K9.setSocksProxyHost(mSocksProxyHost.getText());
+        K9.setSocksProxyPort(Integer.parseInt(mSocksProxyPort.getText()));
 
         StorageEditor editor = storage.edit();
         K9.save(editor);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -3071,10 +3071,7 @@ public class MessagingController implements Runnable {
             if (K9.DEBUG)
                 Log.i(K9.LOG_TAG, "Scanning folder '" + account.getOutboxFolderName() + "' (" + localFolder.getId() + ") for messages to send");
 
-            Transport transport = Transport.getInstance(K9.app, account, new ProxySettings(
-                    K9.isSocksProxyEnabled(),
-                    K9.getSocksProxyHost(),
-                    K9.getSocksProxyPort()));
+            Transport transport = Transport.getInstance(K9.app, account, account.getProxySettings());
             for (LocalMessage message : localMessages) {
                 if (message.isSet(Flag.DELETED)) {
                     message.destroy();

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -44,6 +44,7 @@ import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
 import com.fsck.k9.cache.EmailProviderCache;
 import com.fsck.k9.mail.CertificateValidationException;
+import com.fsck.k9.mail.ProxySettings;
 import com.fsck.k9.mail.power.TracingPowerManager;
 import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
 import com.fsck.k9.mail.Address;
@@ -3070,7 +3071,10 @@ public class MessagingController implements Runnable {
             if (K9.DEBUG)
                 Log.i(K9.LOG_TAG, "Scanning folder '" + account.getOutboxFolderName() + "' (" + localFolder.getId() + ") for messages to send");
 
-            Transport transport = Transport.getInstance(K9.app, account);
+            Transport transport = Transport.getInstance(K9.app, account, new ProxySettings(
+                    K9.isSocksProxyEnabled(),
+                    K9.getSocksProxyHost(),
+                    K9.getSocksProxyPort()));
             for (LocalMessage message : localMessages) {
                 if (message.isSet(Flag.DELETED)) {
                     message.destroy();

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -273,6 +273,15 @@ public class GlobalSettings {
         s.put("confirmDiscardMessage", Settings.versions(
                 new V(40, new BooleanSetting(true))
             ));
+        s.put("useSocksProxy", Settings.versions(
+                new V(41, new BooleanSetting(true))
+        ));
+        s.put("socksProxyHost", Settings.versions(
+                new V(41, new StringSetting("127.0.0.1"))
+        ));
+        s.put("socksProxyPort", Settings.versions(
+                new V(41, new IntegerRangeSetting(0, 65535, 12345))
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -818,6 +818,13 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="background_ops_always">Always</string>
     <string name="background_ops_auto_sync_only">When \'Auto-sync\' is checked</string>
 
+    <string name="socks_proxy_label">SOCKS Proxy</string>
+    <string name="socks_proxy_description">Enable SOCKS Proxy</string>
+    <string name="socks_proxy_host_label">SOCKS Host</string>
+    <string name="socks_proxy_host_description">SOCKS Host</string>
+    <string name="socks_proxy_port_label">SOCKS Port</string>
+    <string name="socks_proxy_port_description">SOCKS Port number</string>
+
     <string name="batch_select_all">Select all</string>
 
     <string name="account_setup_push_limit_label">Max folders to check with push</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -818,12 +818,12 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="background_ops_always">Always</string>
     <string name="background_ops_auto_sync_only">When \'Auto-sync\' is checked</string>
 
-    <string name="socks_proxy_label">SOCKS Proxy</string>
-    <string name="socks_proxy_description">Enable SOCKS Proxy</string>
-    <string name="socks_proxy_host_label">SOCKS Host</string>
-    <string name="socks_proxy_host_description">SOCKS Host</string>
-    <string name="socks_proxy_port_label">SOCKS Port</string>
-    <string name="socks_proxy_port_description">SOCKS Port number</string>
+    <string name="socks_proxy_label">SOCKS proxy</string>
+    <string name="socks_proxy_description">Enable SOCKS proxy</string>
+    <string name="socks_proxy_host_label">SOCKS host</string>
+    <string name="socks_proxy_host_description">SOCKS host</string>
+    <string name="socks_proxy_port_label">SOCKS port</string>
+    <string name="socks_proxy_port_description">SOCKS port number</string>
 
     <string name="batch_select_all">Select all</string>
 

--- a/k9mail/src/main/res/xml/global_preferences.xml
+++ b/k9mail/src/main/res/xml/global_preferences.xml
@@ -367,6 +367,7 @@
         <EditTextPreference
             android:persistent="false"
             android:key="socks_proxy_host"
+            android:dependency="socks_proxy"
             android:singleLine="true"
             android:title="@string/socks_proxy_host_label"
             android:summary=""
@@ -375,6 +376,7 @@
         <EditTextPreference
             android:persistent="false"
             android:key="socks_proxy_port"
+            android:dependency="socks_proxy"
             android:singleLine="true"
             android:title="@string/socks_proxy_port_label"
             android:summary=""

--- a/k9mail/src/main/res/xml/global_preferences.xml
+++ b/k9mail/src/main/res/xml/global_preferences.xml
@@ -357,6 +357,28 @@
             android:entryValues="@array/background_ops_values"
             android:dialogTitle="@string/background_ops_label" />
 
+        <CheckBoxPreference
+            android:key="socks_proxy"
+            android:persistent="false"
+            android:title="@string/socks_proxy_label"
+            android:summary="@string/socks_proxy_description"
+            />
+
+        <EditTextPreference
+            android:persistent="false"
+            android:key="socks_proxy_host"
+            android:singleLine="true"
+            android:title="@string/socks_proxy_host_label"
+            android:summary=""
+            android:dialogTitle="@string/socks_proxy_host_description" />
+
+        <EditTextPreference
+            android:persistent="false"
+            android:key="socks_proxy_port"
+            android:singleLine="true"
+            android:title="@string/socks_proxy_port_label"
+            android:summary=""
+            android:dialogTitle="@string/socks_proxy_port_description" />
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
Rebased pull request #861 on top of current `master`.
Made some additional changes.

The feature is currently disabled for release builds. We don't want to ship with incomplete proxy support because this might have privacy implications for our users.
