### PR TITLE
Rework WebDavSocketFactory to use DefaultTrustedSocketFactory

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
@@ -6,6 +6,7 @@ import java.net.Socket;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -15,6 +16,10 @@ import android.text.TextUtils;
 import android.util.Log;
 
 import com.fsck.k9.mail.MessagingException;
+
+import org.apache.http.conn.scheme.SocketFactory;
+import org.apache.http.conn.ssl.StrictHostnameVerifier;
+
 import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLSocket;
@@ -170,6 +175,21 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
         setSniHost(socketFactory, sslSocket, host);
 
         return trustedSocket;
+    }
+
+    /**
+     * This isn't bulletproof but it's much better than other implementations.
+     */
+    @Override
+    public boolean isSecure(Socket socket) {
+        if(!(socket instanceof SSLSocket))
+            return false;
+        SSLSocket sslSocket = (SSLSocket) socket;
+        if(Arrays.asList(BLACKLISTED_PROTOCOLS).contains(sslSocket.getSession().getProtocol()))
+            return false;
+        if(Arrays.asList(BLACKLISTED_CIPHERS).contains(sslSocket.getSession().getCipherSuite()))
+            return false;
+        return true;
     }
 
     private static void hardenSocket(SSLSocket sock) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/TrustedSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/TrustedSocketFactory.java
@@ -10,4 +10,6 @@ import java.security.NoSuchAlgorithmException;
 public interface TrustedSocketFactory {
     Socket createSocket(Socket socket, String host, int port, String clientCertificateAlias)
             throws NoSuchAlgorithmException, KeyManagementException, MessagingException, IOException;
+
+    boolean isSecure(Socket socket);
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
@@ -10,6 +10,8 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 
+import javax.net.ssl.SSLSocketFactory;
+
 /**
  * Provides a factory for creating WebDAV capable sockets.
  *
@@ -68,12 +70,12 @@ public class WebDavSocketFactory implements LayeredSocketFactory {
      * Create a new socket factory, using the given trusted socket factory and alias.
      */
     public WebDavSocketFactory(TrustedSocketFactory trustedSocketFactory,
+                               org.apache.http.conn.ssl.SSLSocketFactory internalSocketFactory,
                                String defaultHost,
                                int defaultPort,
                                String certificateAlias) {
         mTrustedSocketFactory = trustedSocketFactory;
-
-        mSchemeSocketFactory = org.apache.http.conn.ssl.SSLSocketFactory.getSocketFactory();
+        mSchemeSocketFactory = internalSocketFactory;
         mSchemeSocketFactory.setHostnameVerifier(
                 org.apache.http.conn.ssl.SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
@@ -10,8 +10,6 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
 
-import javax.net.ssl.SSLSocketFactory;
-
 /**
  * Provides a factory for creating WebDAV capable sockets.
  *

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
@@ -1,72 +1,128 @@
 package com.fsck.k9.mail.store.webdav;
 
-import com.fsck.k9.mail.ssl.DefaultTrustedSocketFactory;
 import org.apache.http.conn.ConnectTimeoutException;
 import org.apache.http.conn.scheme.LayeredSocketFactory;
 import org.apache.http.params.HttpParams;
 
-import com.fsck.k9.mail.ssl.TrustManagerFactory;
+import com.fsck.k9.mail.ssl.TrustedSocketFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.Socket;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
 
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
-import javax.net.ssl.TrustManager;
-
-
-/*
- * TODO: find out what's going on here and document it.
- * Using two socket factories looks suspicious.
+/**
+ * Provides a factory for creating WebDAV capable sockets.
+ *
+ * <h3>Design Goals</h3>
+ * The WebDAV SocketFactory has two objectives:
+ *
+ * 1. Implement the (deprecated) SocketFactory API
+ * 2. Use our TrustedSocketFactory implementation
+ *
+ * To do this we implemented a layered socket factory. In this approach we need two socket factories.
+ * We can't just use SchemeSocketFactory as we want to be able to use custom self-trusted
+ * certificates on the fly.
+ *
+ * When asked to create a socket, we call the TrustedSocketFactory to provide us with a socket
+ * that uses the SSLContext we want. We do the hostname and certificate verification here.
+ *
+ * When asked to connect a socket using the API we use the Apache SSLSocketFactory.
+ * We don't need to do any hostname verification here because we'll be using a socket that
+ * has already been created by us. If we do strict verification here,
+ * we can't use our self-trusted certificates.
+ *
+ * <h4>Developer Notes</h4>
+ *
+ * The Apache SSLSocketFactory we create internally must NEVER be used to create a Socket,
+ * otherwise we can leak sockets that do no hostname verification at all.
+ *
+ * We thus have the following layering model:
+ *
+ * org.apache.http.conn.ssl.SSLSocketFactory
+ * TrustedSocketFactory.SSLSocketFactory
+ *
+ * Which produces an SSLSocket (with accepted self-signed alias if necessary)
+ * that has the relevant connection timeouts, is bound locally and has HTTP params
+ * associated with it.
+ *
+ * <h4>Deprecated API Usage</h4>
+ *
+ * We are using the deprecated API because the alternative is hand-rolling the
+ * entire HTTP stack support plus WebDAV. While this would be nicer it's an awful lot of work.
+ *
+ * The DefaultHttpClient and associated API is only really deprecated for use as a normal HTTP GET/POST
+ * stack (the {@link java.net.HttpURLConnection}/{@link javax.net.ssl.HttpsURLConnection} classes
+ * are designed for that).
  */
 public class WebDavSocketFactory implements LayeredSocketFactory {
-    private SSLSocketFactory mSocketFactory;
+    //Optional alias for referencing user-trusted certificate.
+    private final String mCertificateAlias;
+    private final String mDefaultHost;
+    private final int mDefaultPort;
+    // For creating secure sockets (with optional user-trusted certificate)
+    private TrustedSocketFactory mTrustedSocketFactory;
+    // For connecting existing sockets with the correct HTTP params and local binding
     private org.apache.http.conn.ssl.SSLSocketFactory mSchemeSocketFactory;
 
-    public WebDavSocketFactory(String host, int port) throws NoSuchAlgorithmException, KeyManagementException {
-        SSLContext sslContext = SSLContext.getInstance("TLS");
-        sslContext.init(null, new TrustManager[] {
-                TrustManagerFactory.get(host, port)
-        }, null);
-        mSocketFactory = sslContext.getSocketFactory();
+    /**
+     * Create a new socket factory, using the given trusted socket factory and alias.
+     */
+    public WebDavSocketFactory(TrustedSocketFactory trustedSocketFactory,
+                               String defaultHost,
+                               int defaultPort,
+                               String certificateAlias) {
+        mTrustedSocketFactory = trustedSocketFactory;
+
         mSchemeSocketFactory = org.apache.http.conn.ssl.SSLSocketFactory.getSocketFactory();
         mSchemeSocketFactory.setHostnameVerifier(
-                org.apache.http.conn.ssl.SSLSocketFactory.STRICT_HOSTNAME_VERIFIER);
-    }
+                org.apache.http.conn.ssl.SSLSocketFactory.ALLOW_ALL_HOSTNAME_VERIFIER);
 
-    public Socket connectSocket(Socket sock, String host, int port,
-            InetAddress localAddress, int localPort, HttpParams params)
-            throws IOException, ConnectTimeoutException {
-        return mSchemeSocketFactory.connectSocket(sock, host, port, localAddress, localPort, params);
+        mCertificateAlias = certificateAlias;
+        mDefaultHost = defaultHost;
+        mDefaultPort = defaultPort;
     }
 
     @Override
     public Socket createSocket() throws IOException {
-        return mSocketFactory.createSocket();
+        return createSocket(null, mDefaultHost, mDefaultPort);
     }
 
-    public boolean isSecure(Socket sock) throws IllegalArgumentException {
-        return mSchemeSocketFactory.isSecure(sock);
+    @Override
+    public Socket createSocket(final Socket socket, final String host, final int port,
+                               final boolean autoClose) throws IOException {
+        if (!autoClose)
+            throw new IOException("We don't support non-auto close sockets");
+        return createSocket(socket, host, port);
     }
-    public Socket createSocket(
+
+    private Socket createSocket(
             final Socket socket,
             final String host,
-            final int port,
-            final boolean autoClose
-    ) throws IOException {
-        SSLSocket sslSocket = (SSLSocket) mSocketFactory.createSocket(
-                socket,
-                host,
-                port,
-                autoClose
-        );
-        DefaultTrustedSocketFactory.setSniHost(mSocketFactory, sslSocket, host);
-        //hostnameVerifier.verify(host, sslSocket);
-        // verifyHostName() didn't blowup - good!
-        return sslSocket;
+            final int port) throws IOException {
+        try {
+            return mTrustedSocketFactory.createSocket(
+                    socket,
+                    host,
+                    port,
+                    mCertificateAlias);
+        } catch (Exception e) {
+            throw new IOException("Exception creating trusted socket", e);
+        }
+    }
+
+    @Override
+    public Socket connectSocket(Socket sock, String host, int port,
+                                InetAddress localAddress, int localPort, HttpParams params)
+            throws IOException, ConnectTimeoutException {
+        if (sock == null) {
+            //We don't want to delegate creation - we just want the Scheme to wrap a secure socket.
+            sock = createSocket(null, host, port);
+        }
+        return mSchemeSocketFactory.connectSocket(sock, host, port, localAddress, localPort, params);
+    }
+
+    @Override
+    public boolean isSecure(Socket sock) throws IllegalArgumentException {
+        return mSchemeSocketFactory.isSecure(sock) && mTrustedSocketFactory.isSecure(sock);
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -15,6 +15,7 @@ import org.apache.http.client.entity.UrlEncodedFormEntity;
 import org.apache.http.client.protocol.ClientContext;
 import org.apache.http.conn.scheme.Scheme;
 import org.apache.http.conn.scheme.SchemeRegistry;
+import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.BasicCookieStore;
 import org.apache.http.message.BasicNameValuePair;
@@ -970,7 +971,10 @@ public class WebDavStore extends RemoteStore {
             // For HTTPS based WebDAV we want to replace the default
             // SSLSocketFactory with one that allows us to inject our own certificates.
             SchemeRegistry reg = mHttpClient.getConnectionManager().getSchemeRegistry();
-            Scheme s = new Scheme("https", new WebDavSocketFactory(mTrustedSocketFactory, mHost, 443, mCertificateAlias), 443);
+            WebDavSocketFactory webDavSocketFactory =
+                    new WebDavSocketFactory(mTrustedSocketFactory,
+                            SSLSocketFactory.getSocketFactory(), mHost, 443, mCertificateAlias);
+            Scheme s = new Scheme("https", webDavSocketFactory, 443);
             reg.register(s);
         }
         return mHttpClient;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -150,7 +150,7 @@ public class WebDavStore extends RemoteStore {
             }
         }
 
-        //TODO: decode clientCertAlias
+        //TODO: Support client-side certificates
 
         return new WebDavStoreSettings(host, port, connectionSecurity, null, username, password,
                 clientCertificateAlias, alias, path, authPath, mailboxPath);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactoryTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactoryTest.java
@@ -1,0 +1,70 @@
+package com.fsck.k9.mail.ssl;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowApplication;
+
+import java.net.Socket;
+
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 21)
+public class DefaultTrustedSocketFactoryTest {
+
+    private DefaultTrustedSocketFactory defaultTrustedSocketFactory;
+
+    @Before
+    public void setUp() throws Exception {
+        defaultTrustedSocketFactory = new DefaultTrustedSocketFactory(
+                ShadowApplication.getInstance().getApplicationContext());
+    }
+
+    @Test
+    public void isSecure_withSocket_isFalse() {
+        Socket socket = mock(Socket.class);
+
+        assertFalse(defaultTrustedSocketFactory.isSecure(socket));
+    }
+
+    @Test
+    public void isSecure_withSSLSocketWithSSLv3_isFalse() {
+        SSLSocket socket = mock(SSLSocket.class);
+        SSLSession sslSession = mock(SSLSession.class);
+        when(socket.getSession()).thenReturn(sslSession);
+        when(sslSession.getProtocol()).thenReturn("SSLv3");
+
+        assertFalse(defaultTrustedSocketFactory.isSecure(socket));
+    }
+
+    @Test
+    public void isSecure_withSSLSocketWithBadCipher_isFalse() {
+        SSLSocket socket = mock(SSLSocket.class);
+        SSLSession sslSession = mock(SSLSession.class);
+        when(socket.getSession()).thenReturn(sslSession);
+        when(sslSession.getProtocol()).thenReturn("TLSv1.2");
+        when(sslSession.getCipherSuite()).thenReturn("TLS_ECDHE_RSA_WITH_RC4_128_SHA");
+
+        assertFalse(defaultTrustedSocketFactory.isSecure(socket));
+    }
+
+    @Test
+    public void isSecure_withSSLSocketWithTLSandGoodCipher_isTrue() {
+        SSLSocket socket = mock(SSLSocket.class);
+        SSLSession sslSession = mock(SSLSession.class);
+        when(socket.getSession()).thenReturn(sslSession);
+        when(sslSession.getProtocol()).thenReturn("TLSv1.2");
+        when(sslSession.getProtocol()).thenReturn("TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384");
+
+        assertTrue(defaultTrustedSocketFactory.isSecure(socket));
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -687,6 +687,11 @@ public class ImapConnectionTest {
                     socket.getPort(),
                     true);
         }
+
+        @Override
+        public boolean isSecure(Socket socket) {
+            return true;
+        }
     }
 
     @SuppressLint("TrustAllX509TrustManager")

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactoryTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactoryTest.java
@@ -1,0 +1,165 @@
+package com.fsck.k9.mail.store.webdav;
+
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.ssl.TrustedSocketFactory;
+
+import org.apache.http.conn.ssl.SSLSocketFactory;
+import org.apache.http.params.CoreConnectionPNames;
+import org.apache.http.params.HttpParams;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.SocketAddress;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+
+import javax.net.ssl.SSLSession;
+import javax.net.ssl.SSLSocket;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 21)
+public class WebDavSocketFactoryTest {
+    private static final String DEFAULT_HOST = "defaultHost.com";
+    private static final int DEFAULT_PORT = 1000;
+    private static final String CERTIFICATE_ALIAS = "certificateAlias";
+    private WebDavSocketFactory webDavSocketFactory;
+    @Mock
+    private TrustedSocketFactory trustedSocketFactory;
+    @Mock
+    private SSLSocket trustedSocket;
+    @Mock
+    private SSLSocket customAddressTrustedSocket;
+    @Mock
+    private SSLSocket wrappedTrustedSocket;
+    @Mock
+    private Socket unknownSocket;
+    @Mock
+    private SSLSession sslSession = mock(SSLSession.class);
+    @Mock
+    private HttpParams params;
+
+    private ArgumentCaptor<InetSocketAddress> inetSocketAddressCaptor;
+    private SSLSocketFactory apacheSocketFactory;
+
+    private String otherHost = "otherHost.com";
+    private int port = 10001;
+    private InetAddress localAddress = mock(InetAddress.class);
+    private int localPort = 10001;
+    private int connectionTimeout = 1030;
+
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        webDavSocketFactory = new WebDavSocketFactory(trustedSocketFactory, apacheSocketFactory,
+                DEFAULT_HOST, DEFAULT_PORT, CERTIFICATE_ALIAS);
+        when(trustedSocketFactory.createSocket(null, DEFAULT_HOST, DEFAULT_PORT, CERTIFICATE_ALIAS))
+                .thenReturn(trustedSocket);
+
+        when(trustedSocketFactory.createSocket(null, otherHost, port, CERTIFICATE_ALIAS))
+                .thenReturn(customAddressTrustedSocket);
+        when(apacheSocketFactory.connectSocket(trustedSocket, otherHost, port, localAddress, localPort, params))
+                .thenReturn(wrappedTrustedSocket);
+        when(params.getIntParameter(eq(CoreConnectionPNames.CONNECTION_TIMEOUT), anyInt()))
+                .thenReturn(connectionTimeout);
+        when(customAddressTrustedSocket.getSession()).thenReturn(sslSession);
+    }
+
+    @Test
+    public void createSocket_usesTrustedSocketFactoryToCreateSocket() throws IOException {
+        Socket socket = webDavSocketFactory.createSocket();
+
+        assertSame(trustedSocket, socket);
+    }
+
+    @Test
+    public void createSocket_withCustomHostPort_usesTrustedSocketFactoryToCreateSocket()
+            throws IOException, NoSuchAlgorithmException, MessagingException, KeyManagementException {
+        Socket customAddressTrustedSocket = mock(Socket.class);
+        String host = "otherHost.com";
+        int port = 10001;
+        when(trustedSocketFactory.createSocket(null, host, port, CERTIFICATE_ALIAS)).thenReturn(customAddressTrustedSocket);
+
+        Socket socket = webDavSocketFactory.createSocket(null, host, port, true);
+
+        assertSame(customAddressTrustedSocket, socket);
+    }
+
+
+    @Test
+    public void connectSocket_withNoSocket_usesTrustedSocketFactoryToCreateSocket()
+            throws IOException, NoSuchAlgorithmException, MessagingException, KeyManagementException {
+        Socket socket = webDavSocketFactory.connectSocket(null, otherHost, port,
+                localAddress, localPort, params);
+
+        assertSame(customAddressTrustedSocket, socket);
+    }
+
+
+    @Test
+    public void connectSocket_bindsTrustedSocketToLocalAddressAndUsesHttpParams()
+            throws IOException, NoSuchAlgorithmException, MessagingException, KeyManagementException {
+        webDavSocketFactory.connectSocket(null, otherHost, port, localAddress, localPort, params);
+
+        verify(apacheSocketFactory).connectSocket(customAddressTrustedSocket, otherHost, port,
+                localAddress, localPort, params);
+    }
+
+    @Test
+    public void connectSocket_bindsProvidedSocketToLocalAddressAndUsesHttpParams()
+            throws IOException, NoSuchAlgorithmException, MessagingException, KeyManagementException {
+        webDavSocketFactory.connectSocket(unknownSocket, otherHost, port, localAddress, localPort, params);
+
+        verify(apacheSocketFactory).connectSocket(unknownSocket, otherHost, port,
+                localAddress, localPort, params);
+    }
+
+    @Test
+    public void isSecure_whenApacheSaysNo_isFalse()
+            throws IOException, NoSuchAlgorithmException, MessagingException, KeyManagementException {
+        when(apacheSocketFactory.isSecure(unknownSocket)).thenReturn(false);
+        when(trustedSocketFactory.isSecure(unknownSocket)).thenReturn(true);
+
+        assertFalse(webDavSocketFactory.isSecure(unknownSocket));
+    }
+
+    @Test
+    public void isSecure_whenTrustedSaysNo_isFalse()
+            throws IOException, NoSuchAlgorithmException, MessagingException, KeyManagementException {
+        when(apacheSocketFactory.isSecure(unknownSocket)).thenReturn(true);
+        when(trustedSocketFactory.isSecure(unknownSocket)).thenReturn(false);
+
+        assertFalse(webDavSocketFactory.isSecure(unknownSocket));
+    }
+
+    @Test
+    public void isSecure_whenBothSaySecure_isTrue()
+            throws IOException, NoSuchAlgorithmException, MessagingException, KeyManagementException {
+        when(apacheSocketFactory.isSecure(unknownSocket)).thenReturn(true);
+        when(trustedSocketFactory.isSecure(unknownSocket)).thenReturn(true);
+
+        assertTrue(webDavSocketFactory.isSecure(unknownSocket));
+    }
+
+}


### PR DESCRIPTION
Here we go. I've unpicked the chaos, documented the odd behaviour and reverted the change I made for the reasons I've documented.

I've moved to using the DefaultTrustedSocketFactory directly, which means it's less prone to error. I've also added tests for the expected behaviour.