### PR TITLE
Updated tap_hint message: s/envelope/circle/

### DIFF
--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -859,7 +859,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="integrated_inbox_title">Unified Inbox</string>
     <string name="integrated_inbox_detail">All messages in unified folders</string>
 
-    <string name="tap_hint">Tap envelope or star for unread or starred messages</string>
+    <string name="tap_hint">Tap circle or star for unread or starred messages</string>
 
     <string name="folder_settings_include_in_integrated_inbox_label">Unify</string>
     <string name="folder_settings_include_in_integrated_inbox_summary">All messages are shown in Unified Inbox</string>


### PR DESCRIPTION
The envelope icon was replaced with a circle icon a long time ago.  This
change updates the message to reflect this.