### PR TITLE
Add debugging for when file I/O fails

### DIFF
--- a/k9mail-library/src/androidTest/java/com/fsck/k9/mail/ssl/TrustManagerFactoryTest.java
+++ b/k9mail-library/src/androidTest/java/com/fsck/k9/mail/ssl/TrustManagerFactoryTest.java
@@ -217,7 +217,9 @@ public class TrustManagerFactoryTest {
 
     @After
     public void tearDown() {
-        mKeyStoreFile.delete();
+        if(mKeyStoreFile.exists() && !mKeyStoreFile.delete()) {
+            throw new RuntimeException("Unable to delete key store file: " + mKeyStoreFile.getAbsolutePath());
+        }
     }
 
     /**
@@ -342,7 +344,10 @@ public class TrustManagerFactoryTest {
         assertTrue(mKeyStore.isValidCertificate(mCert2, NOT_MATCHING_HOST, PORT2));
 
         // reload store from empty file
-        mKeyStoreFile.delete();
+        if(mKeyStoreFile.exists() && !mKeyStoreFile.delete()) {
+            throw new RuntimeException("Unable to delete key store file: "
+                    + mKeyStoreFile.getAbsolutePath());
+        }
         mKeyStore.setKeyStoreFile(mKeyStoreFile);
         assertFalse(mKeyStore.isValidCertificate(mCert1, MATCHING_HOST, PORT1));
         assertFalse(mKeyStore.isValidCertificate(mCert2, NOT_MATCHING_HOST, PORT2));

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/LocalKeyStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/ssl/LocalKeyStore.java
@@ -76,7 +76,9 @@ public class LocalKeyStore {
              * File.createTempFile). We can't pass an empty file to
              * Keystore.load. Instead, we let it be created anew.
              */
-            file.delete();
+            if(file.exists() && !file.delete()) {
+                Log.d(LOG_TAG, "Failed to delete empty keystore file: " + file.getAbsolutePath());
+            }
         }
 
         FileInputStream fis = null;
@@ -176,7 +178,10 @@ public class LocalKeyStore {
     private void upgradeKeyStoreFile() throws CertificateException {
         if (KEY_STORE_FILE_VERSION > 0) {
             // Blow away version "0" because certificate aliases have changed.
-            new File(getKeyStoreFilePath(0)).delete();
+            File v0 = new File(getKeyStoreFilePath(0));
+            if (v0.exists() && !v0.delete()) {
+                Log.d(LOG_TAG, "Failed to delete old key-store file: " + v0.getAbsolutePath());
+            }
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -159,7 +159,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
             }
 
             String operation = mListener.getOperation(Accounts.this);
-            operation.trim();
+            operation = operation.trim();
             if (operation.length() < 1) {
                 mActionBarSubTitle.setVisibility(View.GONE);
             } else {

--- a/k9mail/src/main/java/com/fsck/k9/helper/FileHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/FileHelper.java
@@ -70,9 +70,13 @@ public class FileHelper {
         final File file = new File(parentDir, name);
         try {
             if (!file.exists()) {
-                file.createNewFile();
+                if(!file.createNewFile()) {
+                    Log.d(K9.LOG_TAG, "Unable to create file: " + file.getAbsolutePath());
+                }
             } else {
-                file.setLastModified(System.currentTimeMillis());
+                if(!file.setLastModified(System.currentTimeMillis())) {
+                    Log.d(K9.LOG_TAG, "Unable to change last modification date: " + file.getAbsolutePath());
+                }
             }
         } catch (Exception e) {
             Log.d(K9.LOG_TAG, "Unable to touch file: " + file.getAbsolutePath(), e);
@@ -81,9 +85,14 @@ public class FileHelper {
 
     public static boolean move(final File from, final File to) {
         if (to.exists()) {
-            to.delete();
+            if(!to.delete()) {
+                Log.d(K9.LOG_TAG, "Unable to delete file: " + to.getAbsolutePath());
+            }
         }
-        to.getParentFile().mkdirs();
+        if(!to.getParentFile().mkdirs()) {
+            Log.d(K9.LOG_TAG, "Unable to make directories: "
+                    + to.getParentFile().getAbsolutePath());
+        }
 
         try {
             FileInputStream in = new FileInputStream(from);
@@ -101,7 +110,9 @@ public class FileHelper {
             } finally {
                 try { in.close(); } catch (Throwable ignore) {}
             }
-            from.delete();
+            if(!from.delete()) {
+                Log.d(K9.LOG_TAG, "Unable to delete file: " + from.getAbsolutePath());
+            }
             return true;
         } catch (Exception e) {
             Log.w(K9.LOG_TAG, "cannot move " + from.getAbsolutePath() + " to " + to.getAbsolutePath(), e);
@@ -128,7 +139,9 @@ public class FileHelper {
         }
         if (!toDir.exists() || !toDir.isDirectory()) {
             if (toDir.exists()) {
-                toDir.delete();
+                if(!toDir.delete()) {
+                    Log.d(K9.LOG_TAG, "Unable to delete file: " + toDir.getAbsolutePath());
+                }
             }
             if (!toDir.mkdirs()) {
                 Log.w(K9.LOG_TAG, "cannot create directory " + toDir.getAbsolutePath());
@@ -138,7 +151,8 @@ public class FileHelper {
         for (File file : files) {
             if (file.isDirectory()) {
                 moveRecursive(file, new File(toDir, file.getName()));
-                file.delete();
+                if(!file.delete())
+                    Log.d(K9.LOG_TAG, "Unable to delete file: " + toDir.getAbsolutePath());
             } else {
                 File target = new File(toDir, file.getName());
                 if (!file.renameTo(target)) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LockableDatabase.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LockableDatabase.java
@@ -372,7 +372,9 @@ public class LockableDatabase {
             } catch (SQLiteException e) {
                 // TODO handle this error in a better way!
                 Log.w(K9.LOG_TAG, "Unable to open DB " + databaseFile + " - removing file and retrying", e);
-                databaseFile.delete();
+                if(databaseFile.exists() && !databaseFile.delete()) {
+                    Log.d(K9.LOG_TAG, "Failed to remove "+ databaseFile + " that couldn't be opened");
+                }
                 doOpenOrCreateDb(databaseFile);
             }
             if (mDb.getVersion() != mSchemaDefinition.getVersion()) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo51.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo51.java
@@ -164,10 +164,15 @@ class MigrationTo51 {
     private static void cleanUpOldAttachmentDirectory(File attachmentDirOld) {
         for (File file : attachmentDirOld.listFiles()) {
             Log.d(K9.LOG_TAG, "deleting stale attachment file: " + file.getName());
-            file.delete();
+            if(file.exists() && !file.delete()) {
+                Log.d(K9.LOG_TAG, "Failed to delete stale attachement file: "+file.getAbsolutePath());
+            }
         }
         Log.d(K9.LOG_TAG, "deleting old attachment directory");
-        attachmentDirOld.delete();
+        if(attachmentDirOld.exists() && !attachmentDirOld.delete()) {
+            Log.d(K9.LOG_TAG, "Failed to delete old attachement directory: "
+                    +attachmentDirOld.getAbsolutePath());
+        }
     }
 
     private static void copyMessageMetadataToNewTable(SQLiteDatabase db) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -86,7 +86,9 @@ public class SettingsExporter {
         {
             File dir = new File(Environment.getExternalStorageDirectory() + File.separator
                                 + context.getPackageName());
-            dir.mkdirs();
+            if(!dir.mkdirs()) {
+                Log.d(K9.LOG_TAG, "Unable to create directory: " + dir.getAbsolutePath());
+            }
             File file = FileHelper.createUniqueFile(dir, EXPORT_FILENAME);
             filename = file.getAbsolutePath();
             os = new FileOutputStream(filename);

--- a/k9mail/src/test/java/com/fsck/k9/helper/HtmlConverterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/HtmlConverterTest.java
@@ -142,10 +142,10 @@ public class HtmlConverterTest {
         FileWriter fstream = null;
 
         try {
-            System.err.println(content);
-
             File f = new File(OUTPUT_FILE);
-            f.delete();
+            if (f.exists() && !f.delete()) {
+                throw new RuntimeException("Unable to delete existing output");
+            }
 
             fstream = new FileWriter(OUTPUT_FILE);
             BufferedWriter out = new BufferedWriter(fstream);


### PR DESCRIPTION
The Java File I/O libraries love to return false on failure rather than throw an Exception. Hence, adding debug logging for when we were ignoring return values from File I/O.

Probably will help to debug issues like #1164 