### PR TITLE
Ensure we close transport when checking settings to avoid leak

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -478,8 +478,11 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
             }
             Transport transport = Transport.getInstance(K9.app, account);
             transport.close();
-            transport.open();
-            transport.close();
+            try {
+                transport.open();
+            } finally {
+                transport.close();
+            }
         }
 
         private void checkIncoming() throws MessagingException {


### PR DESCRIPTION
If this happens:

```
03-22 09:14:40.158 2993-3040/com.fsck.k9.debug E/k9: Error while testing settings
com.fsck.k9.mail.transport.SmtpTransport$NegativeSmtpReplyException: Negative SMTP reply: 451 4.3.2 Internal server error (6530)
    at com.fsck.k9.mail.transport.SmtpTransport.checkLine(SmtpTransport.java:633)
    at com.fsck.k9.mail.transport.SmtpTransport.executeSimpleCommand(SmtpTransport.java:674)
    at com.fsck.k9.mail.transport.SmtpTransport.saslAuthPlain(SmtpTransport.java:718)
    at com.fsck.k9.mail.transport.SmtpTransport.open(SmtpTransport.java:335)
    at com.fsck.k9.activity.setup.AccountSetupCheckSettings$CheckAccountTask.checkOutgoing(AccountSetupCheckSettings.java:481)
    at com.fsck.k9.activity.setup.AccountSetupCheckSettings$CheckAccountTask.checkServerSettings(AccountSetupCheckSettings.java:469)
    at com.fsck.k9.activity.setup.AccountSetupCheckSettings$CheckAccountTask.doInBackground(AccountSetupCheckSettings.java:421)
    at com.fsck.k9.activity.setup.AccountSetupCheckSettings$CheckAccountTask.doInBackground(AccountSetupCheckSettings.java:399)
    at android.os.AsyncTask$2.call(AsyncTask.java:295)
    at java.util.concurrent.FutureTask.run(FutureTask.java:237)
    at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:234)
    at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
    at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
    at java.lang.Thread.run(Thread.java:818)
```

then without this fix, this follows:

```
03-22 09:14:59.113 2993-3002/com.fsck.k9.debug E/StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
        java.lang.Throwable: Explicit termination method 'close' not called
            at dalvik.system.CloseGuard.open(CloseGuard.java:180)
            at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:288)
            at com.android.org.conscrypt.OpenSSLSocketImpl.waitForHandshake(OpenSSLSocketImpl.java:629)
            at com.android.org.conscrypt.OpenSSLSocketImpl.getInputStream(OpenSSLSocketImpl.java:591)
            at com.fsck.k9.mail.transport.SmtpTransport.open(SmtpTransport.java:237)
            at com.fsck.k9.activity.setup.AccountSetupCheckSettings$CheckAccountTask.checkOutgoing(AccountSetupCheckSettings.java:481)
            at com.fsck.k9.activity.setup.AccountSetupCheckSettings$CheckAccountTask.checkServerSettings(AccountSetupCheckSettings.java:469)
            at com.fsck.k9.activity.setup.AccountSetupCheckSettings$CheckAccountTask.doInBackground(AccountSetupCheckSettings.java:421)
            at com.fsck.k9.activity.setup.AccountSetupCheckSettings$CheckAccountTask.doInBackground(AccountSetupCheckSettings.java:399)
            at android.os.AsyncTask$2.call(AsyncTask.java:295)
            at java.util.concurrent.FutureTask.run(FutureTask.java:237)
            at android.os.AsyncTask$SerialExecutor$1.run(AsyncTask.java:234)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1113)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:588)
            at java.lang.Thread.run(Thread.java:818)
```