### PR TITLE
Compose fixes

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -13,6 +13,7 @@ import android.app.LoaderManager;
 import android.app.LoaderManager.LoaderCallbacks;
 import android.content.Context;
 import android.content.Loader;
+import android.graphics.Rect;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
@@ -193,6 +194,22 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
     protected void onDetachedFromWindow() {
         super.onDetachedFromWindow();
         attachedToWindow = false;
+    }
+
+    @Override
+    public void onFocusChanged(boolean hasFocus, int direction, Rect previous) {
+        super.onFocusChanged(hasFocus, direction, previous);
+        if (hasFocus) {
+            displayKeyboard();
+        }
+    }
+
+    private void displayKeyboard() {
+        InputMethodManager imm = (InputMethodManager) getContext().getSystemService(Context.INPUT_METHOD_SERVICE);
+        if (imm == null) {
+            return;
+        }
+        imm.showSoftInput(this, InputMethodManager.SHOW_IMPLICIT);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -343,7 +343,13 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
     }
 
     public boolean hasUncompletedText() {
-        return !TextUtils.isEmpty(currentCompletionText());
+        String currentCompletionText = currentCompletionText();
+        return !TextUtils.isEmpty(currentCompletionText) && !isPlaceholderText(currentCompletionText);
+    }
+
+    static private boolean isPlaceholderText(String currentCompletionText) {
+        // TODO string matching here is sort of a hack, but it's somewhat reliable and the info isn't easily available
+        return currentCompletionText.startsWith("+") && currentCompletionText.substring(1).matches("[0-9]+");
     }
 
     @Override


### PR DESCRIPTION
two small fixes for recipient view: firstly, fix "send" button when the recipient view is collapsed with sort of a hack, and secondly show the keyboard when a recipient view gains focus from a `requestFocus()` call.