### PR TITLE
Add the ability to mark read on delete

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -223,6 +223,7 @@ public class Account implements BaseAccount, StoreConfig {
     private String mCryptoApp;
     private long mCryptoKey;
     private boolean mMarkMessageAsReadOnView;
+    private boolean mMarkMessageAsReadOnDelete;
     private boolean mAlwaysShowCcBcc;
     private boolean mAllowRemoteSearch;
     private boolean mRemoteSearchFullText;
@@ -473,6 +474,7 @@ public class Account implements BaseAccount, StoreConfig {
 
         mEnabled = storage.getBoolean(mUuid + ".enabled", true);
         mMarkMessageAsReadOnView = storage.getBoolean(mUuid + ".markMessageAsReadOnView", true);
+        mMarkMessageAsReadOnDelete = storage.getBoolean(mUuid + ".markMessageAsReadOnDelete", false);
         mAlwaysShowCcBcc = storage.getBoolean(mUuid + ".alwaysShowCcBcc", false);
 
         cacheChips();
@@ -558,6 +560,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.remove(mUuid + ".cryptoAutoEncrypt");
         editor.remove(mUuid + ".enabled");
         editor.remove(mUuid + ".markMessageAsReadOnView");
+        editor.remove(mUuid + ".markMessageAsReadOnDelete");
         editor.remove(mUuid + ".alwaysShowCcBcc");
         editor.remove(mUuid + ".allowRemoteSearch");
         editor.remove(mUuid + ".remoteSearchFullText");
@@ -734,6 +737,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putInt(mUuid + ".remoteSearchNumResults", mRemoteSearchNumResults);
         editor.putBoolean(mUuid + ".enabled", mEnabled);
         editor.putBoolean(mUuid + ".markMessageAsReadOnView", mMarkMessageAsReadOnView);
+        editor.putBoolean(mUuid + ".markMessageAsReadOnDelete", mMarkMessageAsReadOnDelete);
         editor.putBoolean(mUuid + ".alwaysShowCcBcc", mAlwaysShowCcBcc);
 
         editor.putBoolean(mUuid + ".vibrate", mNotificationSetting.shouldVibrate());
@@ -1699,6 +1703,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public synchronized void setMarkMessageAsReadOnView(boolean value) {
         mMarkMessageAsReadOnView = value;
+    }
+
+    public synchronized boolean isMarkMessageAsReadOnDelete() {
+        return mMarkMessageAsReadOnDelete;
+    }
+
+    public synchronized void setMarkMessageAsReadOnDelete(boolean value) {
+        mMarkMessageAsReadOnDelete = value;
     }
 
     public synchronized boolean isAlwaysShowCcBcc() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -69,6 +69,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
     private static final String PREFERENCE_DESCRIPTION = "account_description";
     private static final String PREFERENCE_MARK_MESSAGE_AS_READ_ON_VIEW = "mark_message_as_read_on_view";
+    private static final String PREFERENCE_MARK_MESSAGE_AS_READ_ON_DELETE = "mark_message_as_read_on_delete";
     private static final String PREFERENCE_COMPOSITION = "composition";
     private static final String PREFERENCE_MANAGE_IDENTITIES = "manage_identities";
     private static final String PREFERENCE_FREQUENCY = "account_check_frequency";
@@ -138,6 +139,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
     private EditTextPreference mAccountDescription;
     private CheckBoxPreference mMarkMessageAsReadOnView;
+    private CheckBoxPreference mMarkMessageAsReadOnDelete;
     private ListPreference mCheckFrequency;
     private ListPreference mDisplayCount;
     private ListPreference mMessageAge;
@@ -239,6 +241,9 @@ public class AccountSettings extends K9PreferenceActivity {
 
         mMarkMessageAsReadOnView = (CheckBoxPreference) findPreference(PREFERENCE_MARK_MESSAGE_AS_READ_ON_VIEW);
         mMarkMessageAsReadOnView.setChecked(mAccount.isMarkMessageAsReadOnView());
+
+        mMarkMessageAsReadOnDelete = (CheckBoxPreference) findPreference(PREFERENCE_MARK_MESSAGE_AS_READ_ON_DELETE);
+        mMarkMessageAsReadOnDelete.setChecked(mAccount.isMarkMessageAsReadOnDelete());
 
         mMessageFormat = (ListPreference) findPreference(PREFERENCE_MESSAGE_FORMAT);
         mMessageFormat.setValue(mAccount.getMessageFormat().name());
@@ -750,6 +755,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
         mAccount.setDescription(mAccountDescription.getText());
         mAccount.setMarkMessageAsReadOnView(mMarkMessageAsReadOnView.isChecked());
+        mAccount.setMarkMessageAsReadOnDelete(mMarkMessageAsReadOnDelete.isChecked());
         mAccount.setNotifyNewMail(mAccountNotify.isChecked());
         mAccount.setFolderNotifyNewMailMode(FolderMode.valueOf(mAccountNotifyNewMailMode.getValue()));
         mAccount.setNotifySelfNewMail(mAccountNotifySelf.isChecked());
@@ -992,7 +998,8 @@ public class AccountSettings extends K9PreferenceActivity {
                 maxResults = getString(R.string.account_settings_remote_search_num_results_entries_all);
             }
 
-            mRemoteSearchNumResults.setSummary(String.format(getString(R.string.account_settings_remote_search_num_summary), maxResults));
+            mRemoteSearchNumResults.setSummary(
+                    String.format(getString(R.string.account_settings_remote_search_num_summary), maxResults));
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2536,6 +2536,8 @@ public class MessagingController implements Runnable {
             return;
         }
 
+        Log.v(K9.LOG_TAG, "Updating flags for "+folderMap.size()+ " folders");
+
         // Loop over all folders
         for (Entry<String, List<String>> entry : folderMap.entrySet()) {
             String folderName = entry.getKey();
@@ -3570,12 +3572,13 @@ public class MessagingController implements Runnable {
     }
 
     public void deleteThreads(final List<LocalMessage> messages) {
+
+        markThreadsAsReadOnDelete(messages);
         actOnMessages(messages, new MessageActor() {
 
             @Override
             public void act(final Account account, final Folder folder,
-                    final List<Message> accountMessages) {
-
+                    final List<LocalMessage> accountMessages) {
                 suppressMessages(account, messages);
 
                 putBackground("deleteThreads", null, new Runnable() {
@@ -3589,8 +3592,7 @@ public class MessagingController implements Runnable {
     }
 
     public void deleteThreadsSynchronous(Account account, String folderName,
-            List<Message> messages) {
-
+            List<LocalMessage> messages) {
         try {
             List<Message> messagesToDelete = collectMessagesInThreads(account, messages);
 
@@ -3621,11 +3623,11 @@ public class MessagingController implements Runnable {
     }
 
     public void deleteMessages(final List<LocalMessage> messages, final MessagingListener listener) {
+        markMessageAsReadOnDelete(messages);
         actOnMessages(messages, new MessageActor() {
-
             @Override
             public void act(final Account account, final Folder folder,
-                    final List<Message> accountMessages) {
+                    final List<LocalMessage> accountMessages) {
                 suppressMessages(account, messages);
 
                 putBackground("deleteMessages", null, new Runnable() {
@@ -3636,9 +3638,44 @@ public class MessagingController implements Runnable {
                     }
                 });
             }
+        });
+    }
 
+    private void markThreadsAsReadOnDelete(final List<LocalMessage> messages) {
+        actOnMessages(messages, new MessageActor() {
+            @Override
+            public void act ( final Account account, final Folder folder,
+                              final List<LocalMessage> accountMessages) {
+                if(account.isMarkMessageAsReadOnDelete()) {
+                    try {
+                        List<Message> threadMessages = collectMessagesInThreads(account, accountMessages);
+                        String[] uids = new String[threadMessages.size()];
+                        for (int i = 0; i < threadMessages.size(); i++)
+                            uids[i] = threadMessages.get(0).getUid();
+                        queueSetFlag(account, folder.getName(), Boolean.toString(true),
+                                Flag.SEEN.name(), uids);
+                    } catch (MessagingException e) {
+                    }
+                }
+            }
         });
 
+    }
+
+    private void markMessageAsReadOnDelete(final List<LocalMessage> messages) {
+        actOnMessages(messages, new MessageActor() {
+            @Override
+            public void act ( final Account account, final Folder folder,
+                              final List<LocalMessage> accountMessages) {
+                if(account.isMarkMessageAsReadOnDelete()) {
+                    String[] uids = new String[accountMessages.size()];
+                    for (int i = 0; i < accountMessages.size(); i++)
+                        uids[i] = accountMessages.get(0).getUid();
+                    queueSetFlag(account, folder.getName(), Boolean.toString(true),
+                            Flag.SEEN.name(), new String[]{messages.get(0).getUid()});
+                }
+            }
+        });
     }
 
     private void deleteMessagesSynchronous(final Account account, final String folder, final List<? extends Message> messages,
@@ -4825,7 +4862,7 @@ public class MessagingController implements Runnable {
     }
 
     private void actOnMessages(List<LocalMessage> messages, MessageActor actor) {
-        Map<Account, Map<Folder, List<Message>>> accountMap = new HashMap<Account, Map<Folder, List<Message>>>();
+        Map<Account, Map<Folder, List<LocalMessage>>> accountMap = new HashMap<>();
 
         for (LocalMessage message : messages) {
             if ( message == null) {
@@ -4834,33 +4871,33 @@ public class MessagingController implements Runnable {
             Folder folder = message.getFolder();
             Account account = message.getAccount();
 
-            Map<Folder, List<Message>> folderMap = accountMap.get(account);
+            Map<Folder, List<LocalMessage>> folderMap = accountMap.get(account);
             if (folderMap == null) {
-                folderMap = new HashMap<Folder, List<Message>>();
+                folderMap = new HashMap<Folder, List<LocalMessage>>();
                 accountMap.put(account, folderMap);
             }
-            List<Message> messageList = folderMap.get(folder);
+            List<LocalMessage> messageList = folderMap.get(folder);
             if (messageList == null) {
-                messageList = new LinkedList<Message>();
+                messageList = new LinkedList<LocalMessage>();
                 folderMap.put(folder, messageList);
             }
 
             messageList.add(message);
         }
-        for (Map.Entry<Account, Map<Folder, List<Message>>> entry : accountMap.entrySet()) {
+        for (Map.Entry<Account, Map<Folder, List<LocalMessage>>> entry : accountMap.entrySet()) {
             Account account = entry.getKey();
 
             //account.refresh(Preferences.getPreferences(K9.app));
-            Map<Folder, List<Message>> folderMap = entry.getValue();
-            for (Map.Entry<Folder, List<Message>> folderEntry : folderMap.entrySet()) {
+            Map<Folder, List<LocalMessage>> folderMap = entry.getValue();
+            for (Map.Entry<Folder, List<LocalMessage>> folderEntry : folderMap.entrySet()) {
                 Folder folder = folderEntry.getKey();
-                List<Message> messageList = folderEntry.getValue();
+                List<LocalMessage> messageList = folderEntry.getValue();
                 actor.act(account, folder, messageList);
             }
         }
     }
 
     interface MessageActor {
-        public void act(final Account account, final Folder folder, final List<Message> messages);
+        public void act(final Account account, final Folder folder, final List<LocalMessage> messages);
     }
 }

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -532,6 +532,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_notification_opens_unread_summary">Searches for unread messages when Notification is opened</string>
     <string name="account_settings_mark_message_as_read_on_view_label">Mark as read when opened</string>
     <string name="account_settings_mark_message_as_read_on_view_summary">Mark a message as read when it is opened for viewing</string>
+    <string name="account_settings_mark_message_as_read_on_delete_label">Mark as read when deleted</string>
+    <string name="account_settings_mark_message_as_read_on_delete_summary">Mark a message as read when it is deleted</string>
 
     <string name="account_settings_show_pictures_label">Always show images</string>
     <string name="account_settings_show_pictures_never">No</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -72,6 +72,12 @@
             android:title="@string/account_settings_mark_message_as_read_on_view_label"
             android:summary="@string/account_settings_mark_message_as_read_on_view_summary" />
 
+        <CheckBoxPreference
+            android:persistent="false"
+            android:key="mark_message_as_read_on_delete"
+            android:title="@string/account_settings_mark_message_as_read_on_delete_label"
+            android:summary="@string/account_settings_mark_message_as_read_on_delete_summary" />
+
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
This provides the functionality for #591 as a reimplementation of #579 fixing the issues that were mentioned.

I'm not too sure I understand or entirely get the threading and MessageActor model in this class (which I consider overly long and complex - a bit God-like for a single controller. 

I had some trouble initially with the message being moved before the actual server command to apply the flag was ran meaning it wasn't actually updated. Hence the current design.
