### PR TITLE
Handle unsupported message types - display a toast if we fail create the message

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/message/DecodeMessageLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/message/DecodeMessageLoader.java
@@ -4,12 +4,16 @@ package com.fsck.k9.ui.message;
 import android.content.AsyncTaskLoader;
 import android.content.Context;
 import android.util.Log;
+import android.widget.Toast;
 
 import com.fsck.k9.K9;
+import com.fsck.k9.R;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mailstore.LocalMessageExtractor;
 import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.ui.crypto.MessageCryptoAnnotations;
+
+import java.util.Collections;
 
 
 public class DecodeMessageLoader extends AsyncTaskLoader<MessageViewInfo> {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -272,6 +272,12 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     private void onDecodeMessageFinished(MessageViewInfo messageViewInfo) {
+        if(messageViewInfo == null) {
+            Toast.makeText(getActivity().getApplicationContext(),
+                    R.string.message_view_toast_unable_to_display_message, Toast.LENGTH_SHORT)
+                .show();
+            messageViewInfo = new MessageViewInfo(Collections.EMPTY_LIST, mMessage);
+        }
         this.messageViewInfo = messageViewInfo;
         showMessage(messageViewInfo);
     }

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -281,6 +281,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="message_view_show_more_attachments_action">More…</string>
     <string name="message_view_no_viewer">Unable to find viewer for <xliff:g id="mimetype">%s</xliff:g>.</string>
     <string name="message_view_download_remainder">Download complete message</string>
+    <string name="message_view_toast_unable_to_display_message">Unable to display message</string>
 
     <!-- NOTE: The following message refers to strings with id account_setup_incoming_save_all_headers_label and account_setup_incoming_title -->
     <string name="message_no_additional_headers_available">All headers have been downloaded, but there are no additional headers to show.</string>


### PR DESCRIPTION
If we get a null response from decoding a message, create an empty MessageViewInfo and display a Toast.

Improves #1201 
Fixes #916 