### PR TITLE
Handle preview extraction failures

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/DatabasePreviewType.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/DatabasePreviewType.java
@@ -7,7 +7,8 @@ import com.fsck.k9.message.preview.PreviewResult.PreviewType;
 public enum DatabasePreviewType {
     NONE("none", PreviewType.NONE),
     TEXT("text", PreviewType.TEXT),
-    ENCRYPTED("encrypted", PreviewType.ENCRYPTED);
+    ENCRYPTED("encrypted", PreviewType.ENCRYPTED),
+    ERROR("error", PreviewType.ERROR);
 
 
     private final String databaseValue;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -129,7 +129,7 @@ public class LocalStore extends Store implements Serializable {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 54;
+    public static final int DB_VERSION = 55;
 
 
     public static String getColumnNameForFlag(Flag flag) {

--- a/k9mail/src/main/java/com/fsck/k9/message/preview/MessagePreviewCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/preview/MessagePreviewCreator.java
@@ -41,8 +41,12 @@ public class MessagePreviewCreator {
             return PreviewResult.none();
         }
 
-        String previewText = previewTextExtractor.extractPreview(textPart);
-        return PreviewResult.text(previewText);
+        try {
+            String previewText = previewTextExtractor.extractPreview(textPart);
+            return PreviewResult.text(previewText);
+        } catch (PreviewExtractionException e) {
+            return PreviewResult.none();
+        }
     }
 
     private boolean hasEmptyBody(Part textPart) {

--- a/k9mail/src/main/java/com/fsck/k9/message/preview/MessagePreviewCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/preview/MessagePreviewCreator.java
@@ -45,7 +45,7 @@ public class MessagePreviewCreator {
             String previewText = previewTextExtractor.extractPreview(textPart);
             return PreviewResult.text(previewText);
         } catch (PreviewExtractionException e) {
-            return PreviewResult.none();
+            return PreviewResult.error();
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/message/preview/PreviewExtractionException.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/preview/PreviewExtractionException.java
@@ -1,0 +1,8 @@
+package com.fsck.k9.message.preview;
+
+
+class PreviewExtractionException extends Exception {
+    public PreviewExtractionException(String detailMessage) {
+        super(detailMessage);
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/message/preview/PreviewResult.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/preview/PreviewResult.java
@@ -26,6 +26,10 @@ public class PreviewResult {
         return new PreviewResult(PreviewType.NONE, null);
     }
 
+    public static PreviewResult error() {
+        return new PreviewResult(PreviewType.ERROR, null);
+    }
+
     public PreviewType getPreviewType() {
         return previewType;
     }
@@ -46,6 +50,7 @@ public class PreviewResult {
     public enum PreviewType {
         NONE,
         TEXT,
-        ENCRYPTED
+        ENCRYPTED,
+        ERROR
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/message/preview/PreviewTextExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/preview/PreviewTextExtractor.java
@@ -15,8 +15,13 @@ class PreviewTextExtractor {
     private static final int MAX_CHARACTERS_CHECKED_FOR_PREVIEW = 8192;
 
 
-    public String extractPreview(@NonNull Part textPart) {
+    @NonNull
+    public String extractPreview(@NonNull Part textPart) throws PreviewExtractionException {
         String text = MessageExtractor.getTextFromPart(textPart);
+        if (text == null) {
+            throw new PreviewExtractionException("Couldn't get text from part");
+        }
+
         String plainText = convertFromHtmlIfNecessary(textPart, text);
 
         return stripTextForPreview(plainText);
@@ -32,10 +37,6 @@ class PreviewTextExtractor {
     }
 
     private String stripTextForPreview(String text) {
-        if (text == null) {
-            return "";
-        }
-
         // Only look at the first 8k of a message when calculating
         // the preview.  This should avoid unnecessary
         // memory usage on large messages

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationContentCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationContentCreator.java
@@ -47,7 +47,7 @@ class NotificationContentCreator {
         String snippet = getPreview(message);
 
         boolean isSubjectEmpty = TextUtils.isEmpty(subject);
-        boolean isSnippetPresent = message.getPreviewType() != PreviewType.NONE;
+        boolean isSnippetPresent = snippet != null;
         if (isSubjectEmpty && isSnippetPresent) {
             return snippet;
         }
@@ -70,6 +70,7 @@ class NotificationContentCreator {
         PreviewType previewType = message.getPreviewType();
         switch (previewType) {
             case NONE:
+            case ERROR:
                 return null;
             case TEXT:
                 return message.getPreview();

--- a/k9mail/src/test/java/com/fsck/k9/message/preview/MessagePreviewCreatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/preview/MessagePreviewCreatorTest.java
@@ -88,6 +88,20 @@ public class MessagePreviewCreatorTest {
         assertEquals("expected", result.getPreviewText());
     }
 
+    @Test
+    public void createPreview_withPreviewTextExtractorThrowing() throws Exception {
+        Message message = createDummyMessage();
+        Part textPart = createTextPart("text/plain");
+        when(encryptionDetector.isEncrypted(message)).thenReturn(false);
+        when(textPartFinder.findFirstTextPart(message)).thenReturn(textPart);
+        when(previewTextExtractor.extractPreview(textPart)).thenThrow(new PreviewExtractionException(""));
+
+        PreviewResult result = previewCreator.createPreview(message);
+
+        assertFalse(result.isPreviewTextAvailable());
+        assertEquals(PreviewType.ERROR, result.getPreviewType());
+    }
+
     private Message createDummyMessage() {
         return new MimeMessage();
     }

--- a/k9mail/src/test/java/com/fsck/k9/message/preview/PreviewTextExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/preview/PreviewTextExtractorTest.java
@@ -24,14 +24,11 @@ public class PreviewTextExtractorTest {
         previewTextExtractor = new PreviewTextExtractor();
     }
 
-    @Test
-    public void extractPreview_withEmptyBody() throws Exception {
+    @Test(expected = PreviewExtractionException.class)
+    public void extractPreview_withEmptyBody_shouldThrow() throws Exception {
         Part part = new MimeBodyPart(null, "text/plain");
 
-        //TODO: throw exception
-        String preview = previewTextExtractor.extractPreview(part);
-
-        assertEquals("", preview);
+        previewTextExtractor.extractPreview(part);
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.java
@@ -87,6 +87,17 @@ public class NotificationContentCreatorTest {
     }
 
     @Test
+    public void createFromMessage_withErrorPreview() throws Exception {
+        when(message.getPreviewType()).thenReturn(PreviewType.ERROR);
+        when(message.getPreview()).thenReturn(null);
+
+        NotificationContent content = contentCreator.createFromMessage(account, message);
+
+        assertEquals(SUBJECT, content.subject);
+        assertEquals(SUBJECT, content.preview.toString());
+    }
+
+    @Test
     public void createFromMessage_withEncryptedMessage() throws Exception {
         when(message.getPreviewType()).thenReturn(PreviewType.ENCRYPTED);
         when(message.getPreview()).thenReturn(null);


### PR DESCRIPTION
This is a partial replacement for pull request #1173 which is trying to do too much at once. This PR only fixes `PreviewTextExtractor` and adds the notion of preview extraction errors to `MessagePreviewCreator`.

Failures to extract a message preview are saved in the database. This allows us to later add code to retry the preview extraction after an app update that fixed a preview-related bug.

`MessageExtractor` which definitely needs some love, is left untouched.
