### PR TITLE
Add an options for viewing the plain text if available

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -198,6 +198,7 @@ public class Account implements BaseAccount, StoreConfig {
     private SortType mSortType;
     private Map<SortType, Boolean> mSortAscending = new HashMap<SortType, Boolean>();
     private ShowPictures mShowPictures;
+    private DisplayPreference mDisplayPreference;
     private boolean mIsSignatureBeforeQuotedText;
     private Expunge mExpungePolicy = Expunge.EXPUNGE_IMMEDIATELY;
     private int mMaxPushFolders;
@@ -265,6 +266,10 @@ public class Account implements BaseAccount, StoreConfig {
         NEVER, ALWAYS, ONLY_FROM_CONTACTS
     }
 
+    public enum DisplayPreference {
+        HTML_PREFERRED, TEXT_PREFERRED, TEXT_ALWAYS
+    }
+
     public enum Searchable {
         ALL, DISPLAYABLE, NONE
     }
@@ -295,6 +300,7 @@ public class Account implements BaseAccount, StoreConfig {
         mFolderTargetMode = FolderMode.NOT_SECOND_CLASS;
         mSortType = DEFAULT_SORT_TYPE;
         mSortAscending.put(DEFAULT_SORT_TYPE, DEFAULT_SORT_ASCENDING);
+        mDisplayPreference = DisplayPreference.HTML_PREFERRED;
         mShowPictures = ShowPictures.NEVER;
         mIsSignatureBeforeQuotedText = false;
         mExpungePolicy = Expunge.EXPUNGE_IMMEDIATELY;
@@ -439,6 +445,8 @@ public class Account implements BaseAccount, StoreConfig {
         mSortType = getEnumStringPref(storage, mUuid + ".sortTypeEnum", SortType.SORT_DATE);
 
         mSortAscending.put(mSortType, storage.getBoolean(mUuid + ".sortAscending", false));
+
+        mDisplayPreference = getEnumStringPref(storage, mUuid + ".displayPreferenceEnum", DisplayPreference.HTML_PREFERRED);
 
         mShowPictures = getEnumStringPref(storage, mUuid + ".showPicturesEnum", ShowPictures.NEVER);
 
@@ -1226,6 +1234,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public synchronized void setShowPictures(ShowPictures showPictures) {
         mShowPictures = showPictures;
+    }
+
+    public synchronized DisplayPreference getDisplayPreference() {
+        return mDisplayPreference;
+    }
+
+    public synchronized void setDisplayPreference(DisplayPreference displayPreference) {
+        mDisplayPreference = displayPreference;
     }
 
     public synchronized FolderMode getFolderTargetMode() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -110,10 +110,7 @@ import org.htmlcleaner.CleanerProperties;
 import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.SimpleHtmlSerializer;
 import org.htmlcleaner.TagNode;
-import org.openintents.openpgp.IOpenPgpService2;
 import org.openintents.openpgp.util.OpenPgpApi;
-import org.openintents.openpgp.util.OpenPgpServiceConnection;
-import org.openintents.openpgp.util.OpenPgpServiceConnection.OnBound;
 
 
 @SuppressWarnings("deprecation")
@@ -915,7 +912,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         mQuotedHtmlContent =
                 (InsertableHtmlContent) savedInstanceState.getSerializable(STATE_KEY_HTML_QUOTE);
         if (mQuotedHtmlContent != null && mQuotedHtmlContent.getQuotedContent() != null) {
-            mQuotedHTML.setText(mQuotedHtmlContent.getQuotedContent());
+            mQuotedHTML.setText(mQuotedHtmlContent.getQuotedContent(), true);
         }
 
         mDraftId = savedInstanceState.getLong(STATE_KEY_DRAFT_ID);
@@ -2053,7 +2050,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                     } else {
                         mQuotedHtmlContent.setFooterInsertionPoint(bodyOffset);
                     }
-                    mQuotedHTML.setText(mQuotedHtmlContent.getQuotedContent());
+                    mQuotedHTML.setText(mQuotedHtmlContent.getQuotedContent(), true);
                 }
             }
             if (bodyPlainOffset != null && bodyPlainLength != null) {
@@ -2245,7 +2242,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             mQuotedHtmlContent = quoteOriginalHtmlMessage(mSourceMessage, content, mQuoteStyle);
 
             // Load the message with the reply header.
-            mQuotedHTML.setText(mQuotedHtmlContent.getQuotedContent());
+            mQuotedHTML.setText(mQuotedHtmlContent.getQuotedContent(), true);
 
             // TODO: Also strip the signature from the text/plain part
             mQuotedText.setCharacters(quoteOriginalTextMessage(mSourceMessage,

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -74,6 +74,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_FREQUENCY = "account_check_frequency";
     private static final String PREFERENCE_DISPLAY_COUNT = "account_display_count";
     private static final String PREFERENCE_DEFAULT = "account_default";
+    private static final String PREFERENCE_DISPLAY_PREFERENCE = "display_preference_enum";
     private static final String PREFERENCE_SHOW_PICTURES = "show_pictures_enum";
     private static final String PREFERENCE_NOTIFY = "account_notify";
     private static final String PREFERENCE_NOTIFY_NEW_MAIL_MODE = "folder_notify_new_mail_mode";
@@ -146,6 +147,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private CheckBoxPreference mAccountNotify;
     private ListPreference mAccountNotifyNewMailMode;
     private CheckBoxPreference mAccountNotifySelf;
+    private ListPreference mAccountDisplayPreference;
     private ListPreference mAccountShowPictures;
     private CheckBoxPreference mAccountNotifySync;
     private CheckBoxPreference mAccountVibrate;
@@ -461,6 +463,20 @@ public class AccountSettings extends K9PreferenceActivity {
         mAccountDefault = (CheckBoxPreference) findPreference(PREFERENCE_DEFAULT);
         mAccountDefault.setChecked(
             mAccount.equals(Preferences.getPreferences(this).getDefaultAccount()));
+
+        mAccountDisplayPreference = (ListPreference) findPreference(PREFERENCE_DISPLAY_PREFERENCE);
+
+        mAccountDisplayPreference.setValue("" + mAccount.getDisplayPreference());
+        mAccountDisplayPreference.setSummary(mAccountDisplayPreference.getEntry());
+        mAccountDisplayPreference.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                final String summary = newValue.toString();
+                int index = mAccountDisplayPreference.findIndexOfValue(summary);
+                mAccountDisplayPreference.setSummary(mAccountDisplayPreference.getEntries()[index]);
+                mAccountDisplayPreference.setValue(summary);
+                return false;
+            }
+        });
 
         mAccountShowPictures = (ListPreference) findPreference(PREFERENCE_SHOW_PICTURES);
         mAccountShowPictures.setValue("" + mAccount.getShowPictures());
@@ -828,6 +844,8 @@ public class AccountSettings extends K9PreferenceActivity {
                 mAccount.getNotificationSetting().setRingtone(null);
             }
         }
+
+        mAccount.setDisplayPreference(Account.DisplayPreference.valueOf(mAccountDisplayPreference.getValue()));
 
         mAccount.setShowPictures(ShowPictures.valueOf(mAccountShowPictures.getValue()));
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessageExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessageExtractor.java
@@ -444,7 +444,7 @@ public class LocalMessageExtractor {
             List<AttachmentViewInfo> attachmentInfos = extractAttachmentInfos(context, attachments);
 
             MessageViewContainer messageViewContainer =
-                    new MessageViewContainer(viewable.html, part, attachmentInfos, pgpAnnotation);
+                    new MessageViewContainer(viewable, part, attachmentInfos, pgpAnnotation);
 
             containers.add(messageViewContainer);
         }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
@@ -19,15 +19,15 @@ public class MessageViewInfo {
 
 
     public static class MessageViewContainer {
-        public final String text;
+        public final ViewableContainer viewable;
         public final Part rootPart;
         public final List<AttachmentViewInfo> attachments;
         public final OpenPgpResultAnnotation cryptoAnnotation;
 
 
-        MessageViewContainer(String text, Part rootPart, List<AttachmentViewInfo> attachments,
+        MessageViewContainer(ViewableContainer viewable, Part rootPart, List<AttachmentViewInfo> attachments,
                 OpenPgpResultAnnotation cryptoAnnotation) {
-            this.text = text;
+            this.viewable = viewable;
             this.rootPart = rootPart;
             this.attachments = attachments;
             this.cryptoAnnotation = cryptoAnnotation;

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -95,7 +95,7 @@ public class MessageTopView extends LinearLayout implements ShowPicturesControll
                     containerViews, false);
             boolean displayPgpHeader = account.isOpenPgpProviderConfigured();
             view.displayMessageViewContainer(container, automaticallyLoadPictures, this, attachmentCallback,
-                    openPgpHeaderViewCallback, displayPgpHeader);
+                    openPgpHeaderViewCallback, displayPgpHeader, account.getDisplayPreference());
 
             containerViews.addView(view);
         }

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageWebView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageWebView.java
@@ -112,8 +112,9 @@ public class MessageWebView extends RigidWebView {
      *
      * @param text
      *      The message body to display.  Assumed to be MIME type text/html.
+     * @param isHtml
      */
-    public void setText(String text) {
+    public void setText(String text, boolean isHtml) {
      // Include a meta tag so the WebView will not use a fixed viewport width of 980 px
         String content = "<html><head><meta name=\"viewport\" content=\"width=device-width\"/>";
         if (K9.getK9MessageViewTheme() == K9.Theme.DARK)  {
@@ -121,6 +122,10 @@ public class MessageWebView extends RigidWebView {
                    "* { background: black ! important; color: #F3F3F3 !important }" +
                    ":link, :link * { color: #CCFF33 !important }" +
                    ":visited, :visited * { color: #551A8B !important }</style> ";
+        }
+        if (!isHtml) {
+            content += "<style type=\"text/css\"> body" +
+                    " {white-space: pre-wrap; word-wrap:break-word; }</style>";
         }
         content += HtmlConverter.cssStylePre();
         content += "</head><body>" + text + "</body></html>";

--- a/k9mail/src/main/res/values/arrays.xml
+++ b/k9mail/src/main/res/values/arrays.xml
@@ -155,6 +155,18 @@
         <item>NOT_SECOND_CLASS</item>
     </string-array>
 
+    <string-array name="account_settings_display_preference_entries">
+        <item>@string/account_settings_display_preference_html</item>
+        <item>@string/account_settings_display_preference_text</item>
+        <item>@string/account_settings_display_preference_text_only</item>
+    </string-array>
+
+    <string-array name="account_settings_display_preference_values" translatable="false">
+        <item>HTML_PREFERRED</item>
+        <item>TEXT_PREFERRED</item>
+        <item>TEXT_ALWAYS</item>
+    </string-array>
+
     <string-array name="account_settings_show_pictures_entries">
         <item>@string/account_settings_show_pictures_never</item>
         <item>@string/account_settings_show_pictures_only_from_contacts</item>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -533,6 +533,11 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_mark_message_as_read_on_view_label">Mark as read when opened</string>
     <string name="account_settings_mark_message_as_read_on_view_summary">Mark a message as read when it is opened for viewing</string>
 
+    <string name="account_settings_display_preference_label">Email display preference</string>
+    <string name="account_settings_display_preference_html">HTML preferred</string>
+    <string name="account_settings_display_preference_text">Plain text preferred</string>
+    <string name="account_settings_display_preference_text_only">Plain text only</string>
+
     <string name="account_settings_show_pictures_label">Always show images</string>
     <string name="account_settings_show_pictures_never">No</string>
     <string name="account_settings_show_pictures_only_from_contacts">From contacts</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -60,6 +60,14 @@
 
         <ListPreference
             android:persistent="false"
+            android:key="display_preference_enum"
+            android:title="@string/account_settings_display_preference_label"
+            android:entries="@array/account_settings_display_preference_entries"
+            android:entryValues="@array/account_settings_display_preference_values"
+            android:dialogTitle="@string/account_settings_display_preference_label" />
+
+        <ListPreference
+            android:persistent="false"
             android:key="show_pictures_enum"
             android:title="@string/account_settings_show_pictures_label"
             android:entries="@array/account_settings_show_pictures_entries"


### PR DESCRIPTION
Probably some bike-shedding to be done regarding the name of the preference in code (displayPreference is what I came up with at the time - there must be better). But at least it gets the ball rolling.

Defaults to HTML preferred because I don't want the default behaviour for new users be an email app that looks like it's only capable of plain text mail.

Will fix #906 