### PR TITLE
Make the migration more resilient

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LockableDatabase.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LockableDatabase.java
@@ -16,6 +16,7 @@ import com.fsck.k9.K9;
 import com.fsck.k9.helper.FileHelper;
 import com.fsck.k9.mail.MessagingException;
 
+
 public class LockableDatabase {
 
     /**

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/DatabaseUpgradeException.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/DatabaseUpgradeException.java
@@ -1,0 +1,15 @@
+
+package com.fsck.k9.mailstore.migrations;
+
+public class DatabaseUpgradeException extends Exception {
+    public static final long serialVersionUID = -1;
+
+    public DatabaseUpgradeException(String message) {
+        super(message);
+    }
+
+    public DatabaseUpgradeException(String message, Throwable throwable) {
+        super(message, throwable);
+    }
+
+}

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo51.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo51.java
@@ -36,6 +36,7 @@ class MigrationTo51 {
     private static final int DATA_LOCATION__MISSING = 0;
     private static final int DATA_LOCATION__IN_DATABASE = 1;
     private static final int DATA_LOCATION__ON_DISK = 2;
+    private static final int MAX_FAILED_MIGRATIONS = 100;
 
     /**
      * This method converts from the old message table structure to the new one.
@@ -58,7 +59,8 @@ class MigrationTo51 {
      *    + otherwise, use multipart/mixed, adding attachments after textual content
      *    + revert content:// URIs in htmlContent to original cid: URIs.
      */
-    public static void db51MigrateMessageFormat(SQLiteDatabase db, MigrationsHelper migrationsHelper) {
+    public static void db51MigrateMessageFormat(SQLiteDatabase db, MigrationsHelper migrationsHelper)
+            throws DatabaseUpgradeException {
         renameOldMessagesTableAndCreateNew(db);
 
         copyMessageMetadataToNewTable(db);
@@ -74,6 +76,8 @@ class MigrationTo51 {
                 null, null, null, null, null);
         try {
             Log.d(K9.LOG_TAG, "migrating " + msgCursor.getCount() + " messages");
+            int failedMigrations = 0;
+
             ContentValues cv = new ContentValues();
             while (msgCursor.moveToNext()) {
                 long messageId = msgCursor.getLong(0);
@@ -126,6 +130,11 @@ class MigrationTo51 {
                         db.delete("", "root_part_id=?", new String[] { Long.toString(structureState.rootPartId) });
                     }
                     structureState = null;
+                    failedMigrations += 1;
+
+                    if (failedMigrations > MAX_FAILED_MIGRATIONS) {
+                        throw new DatabaseUpgradeException("Too many failed migrations - giving up!", e);
+                    }
                 }
 
                 if (structureState != null) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
@@ -6,7 +6,8 @@ import android.database.sqlite.SQLiteDatabase;
 
 public class Migrations {
     @SuppressWarnings("fallthrough")
-    public static void upgradeDatabase(SQLiteDatabase db, MigrationsHelper migrationsHelper) {
+    public static void upgradeDatabase(SQLiteDatabase db, MigrationsHelper migrationsHelper)
+            throws DatabaseUpgradeException {
         switch (db.getVersion()) {
             case 29:
                 MigrationTo30.addDeletedColumn(db);


### PR DESCRIPTION
If a single mail migration fails, that's no reason to reset the entire database. I added a catch-all, and an upper limit of failed mails before the migration routine gives up.

A fixed limit might not be the best option here, but it's simple and I couldn't think of a very good less-simple solution.