### PR TITLE
ditch crypto status icon animation

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -4,8 +4,6 @@ package com.fsck.k9.activity.compose;
 import java.util.Arrays;
 import java.util.List;
 
-import android.animation.Animator;
-import android.animation.AnimatorListenerAdapter;
 import android.app.PendingIntent;
 import android.text.TextWatcher;
 import android.view.View;
@@ -270,46 +268,13 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
     public void showCryptoStatus(final CryptoStatusDisplayType cryptoStatusDisplayType) {
         boolean shouldBeHidden = cryptoStatusDisplayType.childToDisplay == VIEW_INDEX_HIDDEN;
         if (shouldBeHidden) {
-            hideCryptoStatus();
+            cryptoStatusView.setVisibility(View.GONE);
             return;
         }
 
-        boolean alreadyVisible = cryptoStatusView.getVisibility() == View.VISIBLE;
-        if (alreadyVisible) {
-            switchCryptoStatus(cryptoStatusDisplayType);
-            return;
-        }
-
-        cryptoStatusView.setTranslationX(100);
         cryptoStatusView.setVisibility(View.VISIBLE);
-        cryptoStatusView.animate().translationX(0).setDuration(300).setListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationEnd(Animator animation) {
-                switchCryptoStatus(cryptoStatusDisplayType);
-            }
-        }).start();
-    }
-
-
-    private void hideCryptoStatus() {
-        if (cryptoStatusView.getVisibility() == View.GONE) {
-            return;
-        }
-
-        cryptoStatusView.animate().translationX(100).setDuration(300).setListener(new AnimatorListenerAdapter() {
-            @Override
-            public void onAnimationEnd(Animator animation) {
-                super.onAnimationEnd(animation);
-                cryptoStatusView.setVisibility(View.GONE);
-            }
-        }).start();
-    }
-
-    private void switchCryptoStatus(CryptoStatusDisplayType cryptoStatus) {
-        int childToDisplay = cryptoStatus.childToDisplay;
-        if (cryptoStatusView.getDisplayedChild() != childToDisplay) {
-            cryptoStatusView.setDisplayedChild(childToDisplay);
-        }
+        int childToDisplay = cryptoStatusDisplayType.childToDisplay;
+        cryptoStatusView.setDisplayedChild(childToDisplay);
     }
 
     public void showContactPicker(int requestCode) {

--- a/k9mail/src/main/java/com/fsck/k9/view/ToolableViewAnimator.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/ToolableViewAnimator.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2015 Vincent Breitmoser <look@my.amazin.horse>
+ * 
+ * The MIT License (MIT)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ * 
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ * 
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.fsck.k9.view;
+
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.support.annotation.NonNull;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewGroup;
+import android.view.animation.Animation;
+import android.widget.ViewAnimator;
+
+import com.fsck.k9.R;
+
+
+/** This view is essentially identical to ViewAnimator, but allows specifying the initial view
+ * for preview as an xml attribute. */
+public class ToolableViewAnimator extends ViewAnimator {
+    private int mInitChild = -1;
+
+
+    public ToolableViewAnimator(Context context) {
+        super(context);
+    }
+
+    public ToolableViewAnimator(Context context, AttributeSet attrs) {
+        super(context, attrs);
+
+        if (isInEditMode()) {
+            TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.ToolableViewAnimator);
+            mInitChild = a.getInt(R.styleable.ToolableViewAnimator_previewInitialChild, -1);
+            a.recycle();
+        }
+    }
+
+    public ToolableViewAnimator(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs);
+
+        if (isInEditMode()) {
+            TypedArray a = context.obtainStyledAttributes(attrs, R.styleable.ToolableViewAnimator, defStyleAttr, 0);
+            mInitChild = a.getInt(R.styleable.ToolableViewAnimator_previewInitialChild, -1);
+            a.recycle();
+        }
+    }
+
+    @Override
+    public void addView(@NonNull View child, int index, ViewGroup.LayoutParams params) {
+        if (isInEditMode() && mInitChild-- > 0) {
+            return;
+        }
+        super.addView(child, index, params);
+    }
+
+    @Override
+    public void setDisplayedChild(int whichChild) {
+        if (whichChild != getDisplayedChild()) {
+            super.setDisplayedChild(whichChild);
+        }
+    }
+
+    public void setDisplayedChild(int whichChild, boolean animate) {
+        if (animate) {
+            setDisplayedChild(whichChild);
+            return;
+        }
+
+        Animation savedInAnim = getInAnimation();
+        Animation savedOutAnim = getOutAnimation();
+        setInAnimation(null);
+        setOutAnimation(null);
+
+        setDisplayedChild(whichChild);
+
+        setInAnimation(savedInAnim);
+        setOutAnimation(savedOutAnim);
+    }
+}

--- a/k9mail/src/main/res/layout/message_compose_recipients.xml
+++ b/k9mail/src/main/res/layout/message_compose_recipients.xml
@@ -5,6 +5,7 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="fill_parent"
     android:layout_height="wrap_content"
+    xmlns:custom="http://schemas.android.com/apk/res-auto"
     android:layout_marginBottom="4dp"
     android:orientation="vertical"
     tools:showIn="@layout/message_compose">
@@ -45,7 +46,7 @@
             style="@style/ComposeEditText"
             />
 
-        <ViewAnimator
+        <com.fsck.k9.view.ToolableViewAnimator
             android:layout_width="36dp"
             android:layout_height="32dp"
             android:layout_alignParentRight="true"
@@ -55,6 +56,7 @@
             android:visibility="gone"
             android:inAnimation="@anim/fade_in"
             android:outAnimation="@anim/fade_out"
+            custom:previewInitialChild="2"
             tools:visibility="visible">
 
             <ImageView
@@ -199,7 +201,7 @@
                 android:tint="@color/openpgp_blue"
                 />
 
-        </ViewAnimator>
+        </com.fsck.k9.view.ToolableViewAnimator>
 
     </RelativeLayout>
 

--- a/k9mail/src/main/res/values/attrs.xml
+++ b/k9mail/src/main/res/values/attrs.xml
@@ -71,4 +71,9 @@
         <attr name="upOutAnimation" format="reference" />
     </declare-styleable>
 
+    <declare-styleable name="ToolableViewAnimator">
+        <attr name="previewInitialChild" format="integer" />
+    </declare-styleable>
+
+
 </resources>


### PR DESCRIPTION
The animation of the crypto status icon is not used anymore because the visibility of the icon is static depending on the availability of a crypto provider. It also led problems when the animation was cancelled (#1224). So this PR simply ditches that animation to fix that.

(I also added my ToolableViewAnimator for easier previewing)