### PR TITLE
Size extension parameter is optional - ignore null/empty value

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -308,11 +308,19 @@ public class SmtpTransport extends Transport {
                 authExternalSupported = saslMech.contains("EXTERNAL");
             }
             if (extensions.containsKey("SIZE")) {
-                try {
-                    mLargestAcceptableMessage = Integer.parseInt(extensions.get("SIZE"));
-                } catch (Exception e) {
-                    if (K9MailLib.isDebug() && DEBUG_PROTOCOL_SMTP) {
-                        Log.d(LOG_TAG, "Tried to parse " + extensions.get("SIZE") + " and get an int", e);
+                String sizeValue = extensions.get("SIZE");
+                /*
+                    An empty value is valid and indicates no limit :
+
+                    "**If** a numeric parameter..." - RFC 1870 4.
+                 */
+                if (sizeValue != null && sizeValue != "") {
+                    try {
+                        mLargestAcceptableMessage = Integer.parseInt(extensions.get("SIZE"));
+                    } catch (Exception e) {
+                        if (K9MailLib.isDebug() && DEBUG_PROTOCOL_SMTP) {
+                            Log.d(LOG_TAG, "Tried to parse " + extensions.get("SIZE") + " and get an int", e);
+                        }
                     }
                 }
             }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -307,23 +307,7 @@ public class SmtpTransport extends Transport {
                 authCramMD5Supported = saslMech.contains("CRAM-MD5");
                 authExternalSupported = saslMech.contains("EXTERNAL");
             }
-            if (extensions.containsKey("SIZE")) {
-                String sizeValue = extensions.get("SIZE");
-                /*
-                    An empty value is valid and indicates no limit :
-
-                    "**If** a numeric parameter..." - RFC 1870 4.
-                 */
-                if (sizeValue != null && sizeValue != "") {
-                    try {
-                        mLargestAcceptableMessage = Integer.parseInt(extensions.get("SIZE"));
-                    } catch (Exception e) {
-                        if (K9MailLib.isDebug() && DEBUG_PROTOCOL_SMTP) {
-                            Log.d(LOG_TAG, "Tried to parse " + extensions.get("SIZE") + " and get an int", e);
-                        }
-                    }
-                }
-            }
+            parseOptionalSizeValue(extensions);
 
             if (mUsername != null
                     && mUsername.length() > 0
@@ -418,6 +402,21 @@ public class SmtpTransport extends Transport {
                 "Unable to open connection to SMTP server due to security error.", gse);
         } catch (IOException ioe) {
             throw new MessagingException("Unable to open connection to SMTP server.", ioe);
+        }
+    }
+
+    private void parseOptionalSizeValue(Map<String, String> extensions) {
+        if (extensions.containsKey("SIZE")) {
+            String optionalsizeValue = extensions.get("SIZE");
+            if (optionalsizeValue != null && optionalsizeValue != "") {
+                try {
+                    mLargestAcceptableMessage = Integer.parseInt(optionalsizeValue);
+                } catch (NumberFormatException e) {
+                    if (K9MailLib.isDebug() && DEBUG_PROTOCOL_SMTP) {
+                        Log.d(LOG_TAG, "Tried to parse " + optionalsizeValue + " and get an int", e);
+                    }
+                }
+            }
         }
     }
 


### PR DESCRIPTION
Per the RFC it's perfectly fine to advertise the SIZE capability without giving a value. So just ignore it if it's empty.