### PR TITLE
Use themable colour for emphasized notifications - fixes #746

### DIFF
--- a/k9mail/src/main/res/values-v21/styles.xml
+++ b/k9mail/src/main/res/values-v21/styles.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <style name="TextAppearance.StatusBar.EventContent.Emphasized" parent="@android:style/TextAppearance.StatusBar.EventContent">
-        <item name="android:textColor">#000000</item>
+        <item name="android:textColor">?android:textColorPrimaryInverse</item>
     </style>
 </resources>


### PR DESCRIPTION
My previous comment on the ticket was somewhat wrong (I was looking at the wrong bit). And I don't think referencing material is useful when our entire app is still built round Holo.

This seems to still work for my device and affects the right text.