### PR TITLE
Close underlying streams

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/filter/PeekableInputStream.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/filter/PeekableInputStream.java
@@ -1,6 +1,7 @@
 
 package com.fsck.k9.mail.filter;
 
+import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Locale;
@@ -10,19 +11,18 @@ import java.util.Locale;
  * client of this stream can call peek() to see the next available byte in the stream
  * and a subsequent read will still return the peeked byte.
  */
-public class PeekableInputStream extends InputStream {
-    private InputStream mIn;
+public class PeekableInputStream extends FilterInputStream {
     private boolean mPeeked;
     private int mPeekedByte;
 
     public PeekableInputStream(InputStream in) {
-        this.mIn = in;
+        super(in);
     }
 
     @Override
     public int read() throws IOException {
         if (!mPeeked) {
-            return mIn.read();
+            return in.read();
         } else {
             mPeeked = false;
             return mPeekedByte;
@@ -31,7 +31,7 @@ public class PeekableInputStream extends InputStream {
 
     public int peek() throws IOException {
         if (!mPeeked) {
-            mPeekedByte = mIn.read();
+            mPeekedByte = in.read();
             mPeeked = true;
         }
         return mPeekedByte;
@@ -40,11 +40,11 @@ public class PeekableInputStream extends InputStream {
     @Override
     public int read(byte[] b, int offset, int length) throws IOException {
         if (!mPeeked) {
-            return mIn.read(b, offset, length);
+            return in.read(b, offset, length);
         } else {
             b[offset] = (byte)mPeekedByte;
             mPeeked = false;
-            int r = mIn.read(b, offset + 1, length - 1);
+            int r = in.read(b, offset + 1, length - 1);
             if (r == -1) {
                 return 1;
             } else {
@@ -61,15 +61,6 @@ public class PeekableInputStream extends InputStream {
     @Override
     public String toString() {
         return String.format(Locale.US, "PeekableInputStream(in=%s, peeked=%b, peekedByte=%d)",
-                             mIn.toString(), mPeeked, mPeekedByte);
-    }
-
-    @Override
-    public void close() throws IOException {
-        InputStream localIn = mIn;
-        mIn = null;
-        if (localIn != null) {
-            localIn.close();
-        }
+                             in.toString(), mPeeked, mPeekedByte);
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/filter/PeekableInputStream.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/filter/PeekableInputStream.java
@@ -63,4 +63,13 @@ public class PeekableInputStream extends InputStream {
         return String.format(Locale.US, "PeekableInputStream(in=%s, peeked=%b, peekedByte=%d)",
                              mIn.toString(), mPeeked, mPeekedByte);
     }
+
+    @Override
+    public void close() throws IOException {
+        InputStream localIn = mIn;
+        mIn = null;
+        if (localIn != null) {
+            localIn.close();
+        }
+    }
 }


### PR DESCRIPTION
We wrap our InputStreams in a custom PeekableInputStream which extends InputStream

Unfortunately it does not currently implement a close method and the default from InputStream is a no-op

So even though we call close correctly, we don't actually close the underlying stream. So you get this:

```
04-16 19:23:28.848 21614-21622/? E/StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
                                               java.lang.Throwable: Explicit termination method 'close' not called
                                                   at dalvik.system.CloseGuard.open(CloseGuard.java:180)
                                                   at com.android.org.conscrypt.OpenSSLSocketImpl.startHandshake(OpenSSLSocketImpl.java:288)
                                                   at com.android.org.conscrypt.OpenSSLSocketImpl.waitForHandshake(OpenSSLSocketImpl.java:629)
                                                   at com.android.org.conscrypt.OpenSSLSocketImpl.getInputStream(OpenSSLSocketImpl.java:591)
                                                   at com.fsck.k9.mail.transport.SmtpTransport.open(SmtpTransport.java:237)
                                                   at com.fsck.k9.mail.transport.SmtpTransport.sendMessageTo(SmtpTransport.java:503)
                                                   at com.fsck.k9.mail.transport.SmtpTransport.sendMessage(SmtpTransport.java:495)
                                                   at com.fsck.k9.controller.MessagingController.sendPendingMessagesSynchronous(MessagingController.java:3131)
                                                   at com.fsck.k9.controller.MessagingController$20.run(MessagingController.java:3011)
                                                   at com.fsck.k9.controller.MessagingController.run(MessagingController.java:268)
                                                   at java.lang.Thread.run(Thread.java:818)
```

This PR fixes that by closing the underlying/passed InputStream the same way a BufferedInputStream does.