### PR TITLE
Prevent ImapConnection reuse

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -72,6 +72,7 @@ class ImapConnection {
     private int nextCommandTag;
     private Set<String> capabilities = new HashSet<String>();
     private ImapSettings settings;
+    private Exception stacktraceForClose;
 
 
     public ImapConnection(ImapSettings settings, TrustedSocketFactory socketFactory,
@@ -95,6 +96,9 @@ class ImapConnection {
     public void open() throws IOException, MessagingException {
         if (isOpen()) {
             return;
+        } else if (stacktraceForClose != null) {
+            throw new IllegalStateException("open() called after close(). " +
+                    "Check wrapped exception to see where close() was called.", stacktraceForClose);
         }
 
         boolean authSuccess = false;
@@ -582,6 +586,8 @@ class ImapConnection {
     }
 
     public void close() {
+        stacktraceForClose = new Exception();
+
         IOUtils.closeQuietly(inputStream);
         IOUtils.closeQuietly(outputStream);
         IOUtils.closeQuietly(socket);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -73,6 +73,7 @@ class ImapConnection {
     private Set<String> capabilities = new HashSet<String>();
     private ImapSettings settings;
     private Exception stacktraceForClose;
+    private boolean open = false;
 
 
     public ImapConnection(ImapSettings settings, TrustedSocketFactory socketFactory,
@@ -94,13 +95,14 @@ class ImapConnection {
     }
 
     public void open() throws IOException, MessagingException {
-        if (isOpen()) {
+        if (open) {
             return;
         } else if (stacktraceForClose != null) {
             throw new IllegalStateException("open() called after close(). " +
                     "Check wrapped exception to see where close() was called.", stacktraceForClose);
         }
 
+        open = true;
         boolean authSuccess = false;
         nextCommandTag = 1;
 
@@ -586,6 +588,7 @@ class ImapConnection {
     }
 
     public void close() {
+        open = false;
         stacktraceForClose = new Exception();
 
         IOUtils.closeQuietly(inputStream);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -160,7 +160,7 @@ class ImapConnection {
         }
     }
 
-    public boolean isOpen() {
+    public boolean isConnected() {
         return inputStream != null && outputStream != null && socket != null &&
                 socket.isConnected() && !socket.isClosed();
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -332,7 +332,7 @@ public class ImapStore extends RemoteStore {
     }
 
     void releaseConnection(ImapConnection connection) {
-        if (connection != null && connection.isOpen()) {
+        if (connection != null && connection.isConnected()) {
             synchronized (connections) {
                 connections.offer(connection);
             }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -373,7 +373,7 @@ public class ImapConnectionTest {
         } catch (UnknownHostException ignored) {
         }
 
-        assertFalse(imapConnection.isOpen());
+        assertFalse(imapConnection.isConnected());
     }
 
     @Test
@@ -532,20 +532,20 @@ public class ImapConnectionTest {
     }
 
     @Test
-    public void isOpen_withoutPreviousOpen_shouldReturnFalse() throws Exception {
+    public void isConnected_withoutPreviousOpen_shouldReturnFalse() throws Exception {
         ImapConnection imapConnection = createImapConnection(settings, socketFactory, connectivityManager);
 
-        boolean result = imapConnection.isOpen();
+        boolean result = imapConnection.isConnected();
 
         assertFalse(result);
     }
 
     @Test
-    public void isOpen_afterOpen_shouldReturnTrue() throws Exception {
+    public void isConnected_afterOpen_shouldReturnTrue() throws Exception {
         MockImapServer server = new MockImapServer();
         ImapConnection imapConnection = simpleOpen(server);
 
-        boolean result = imapConnection.isOpen();
+        boolean result = imapConnection.isConnected();
 
         assertTrue(result);
         server.verifyConnectionStillOpen();
@@ -554,12 +554,12 @@ public class ImapConnectionTest {
     }
 
     @Test
-    public void isOpen_afterOpenAndClose_shouldReturnFalse() throws Exception {
+    public void isConnected_afterOpenAndClose_shouldReturnFalse() throws Exception {
         MockImapServer server = new MockImapServer();
         ImapConnection imapConnection = simpleOpen(server);
         imapConnection.close();
 
-        boolean result = imapConnection.isOpen();
+        boolean result = imapConnection.isConnected();
 
         assertFalse(result);
         server.verifyConnectionClosed();

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -115,6 +115,27 @@ public class ImapConnectionTest {
     }
 
     @Test
+    public void open_afterCloseWasCalled_shouldThrow() throws Exception {
+        settings.setAuthType(AuthType.PLAIN);
+        MockImapServer server = new MockImapServer();
+        preAuthenticationDialog(server);
+        server.expect("2 LOGIN \"" + USERNAME + "\" \"" + PASSWORD + "\"");
+        server.output("2 OK LOGIN completed");
+        simplePostAuthenticationDialog(server);
+        ImapConnection imapConnection = startServerAndCreateImapConnection(server);
+        imapConnection.open();
+        imapConnection.close();
+
+        try {
+            imapConnection.open();
+            fail("Expected exception");
+        } catch (IllegalStateException e) {
+            assertEquals("open() called after close(). Check wrapped exception to see where close() was called.",
+                    e.getMessage());
+        }
+    }
+
+    @Test
     public void open_authPlainWithLoginDisabled_shouldThrow() throws Exception {
         settings.setAuthType(AuthType.PLAIN);
         MockImapServer server = new MockImapServer();

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
@@ -249,7 +249,7 @@ public class ImapStoreTest {
     @Test
     public void getConnection_calledAfterRelease_shouldReturnCachedImapConnection() throws Exception {
         ImapConnection imapConnection = mock(ImapConnection.class);
-        when(imapConnection.isOpen()).thenReturn(true);
+        when(imapConnection.isConnected()).thenReturn(true);
         imapStore.enqueueImapConnection(imapConnection);
         ImapConnection connection = imapStore.getConnection();
         imapStore.releaseConnection(connection);
@@ -267,7 +267,7 @@ public class ImapStoreTest {
         imapStore.enqueueImapConnection(imapConnectionOne);
         imapStore.enqueueImapConnection(imapConnectionTwo);
         imapStore.getConnection();
-        when(imapConnectionOne.isOpen()).thenReturn(false);
+        when(imapConnectionOne.isConnected()).thenReturn(false);
         imapStore.releaseConnection(imapConnectionOne);
 
         ImapConnection result = imapStore.getConnection();
@@ -282,7 +282,7 @@ public class ImapStoreTest {
         imapStore.enqueueImapConnection(imapConnectionOne);
         imapStore.enqueueImapConnection(imapConnectionTwo);
         imapStore.getConnection();
-        when(imapConnectionOne.isOpen()).thenReturn(true);
+        when(imapConnectionOne.isConnected()).thenReturn(true);
         doThrow(IOException.class).when(imapConnectionOne).executeSimpleCommand(Commands.NOOP);
         imapStore.releaseConnection(imapConnectionOne);
 


### PR DESCRIPTION
`ImapConnection` should not be reused after is was closed. So `open()` now throws an exception when it is called after `close()` has been called.
This should allow us to find out faster what caused issues like #1297.