### PR TITLE
Tests for MessagingController

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -107,25 +107,6 @@ public class MessagingController implements Runnable {
      */
     private static final String[] EMPTY_STRING_ARRAY = new String[0];
 
-    /**
-     * The maximum message size that we'll consider to be "small". A small message is downloaded
-     * in full immediately instead of in pieces. Anything over this size will be downloaded in
-     * pieces with attachments being left off completely and downloaded on demand.
-     *
-     *
-     * 25k for a "small" message was picked by educated trial and error.
-     * http://answers.google.com/answers/threadview?id=312463 claims that the
-     * average size of an email is 59k, which I feel is too large for our
-     * blind download. The following tests were performed on a download of
-     * 25 random messages.
-     * <pre>
-     * 5k - 61 seconds,
-     * 25k - 51 seconds,
-     * 55k - 53 seconds,
-     * </pre>
-     * So 25k gives good performance and a reasonable data footprint. Sounds good to me.
-     */
-
     private static final String PENDING_COMMAND_MOVE_OR_COPY = "com.fsck.k9.MessagingController.moveOrCopy";
     private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK = "com.fsck.k9.MessagingController.moveOrCopyBulk";
     private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW = "com.fsck.k9.MessagingController.moveOrCopyBulkNew";
@@ -459,6 +440,7 @@ public class MessagingController implements Runnable {
             for (Folder localFolder : localFolders) {
                 localFolderNames.add(localFolder.getName());
             }
+
             for (Folder remoteFolder : remoteFolders) {
                 if (localFolderNames.contains(remoteFolder.getName()) == false) {
                     LocalFolder localFolder = localStore.getFolder(remoteFolder.getName());


### PR DESCRIPTION
MessagingController is central to the app, massive (4900 LOC) and yet almost untested. We don't have a firm grasp on what it's supposed to do, so any changes could easily break stuff. Refactoring is dangerous as a result. 

To alleviate this I've started writing tests to verify existing functionality. In the Controller this means minimal changes to expose methods for testing. In the Test class this means lots and lots of new tests.

I've covered off most of the basic features for a couple of methods in this first commit. There's lots more to do. I suspect I already found a bug - refreshRemote doesn't call `listFoldersStarted` - I think it should be doing so.

NB: If you append ?w=1 you see the diff without whitespace changes, which makes the changes to the Controller easier to understand.