### PR TITLE
switch from encapsulated to combined pgp/mime format

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessageHelper.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessageHelper.java
@@ -32,10 +32,15 @@ public class MimeMessageHelper {
                 setEncoding(part, MimeUtil.ENC_8BIT);
             }
         } else if (body instanceof TextBody) {
-            String contentType = String.format("%s;\r\n charset=utf-8", part.getMimeType());
-            String name = MimeUtility.getHeaderParameter(part.getContentType(), "name");
-            if (name != null) {
-                contentType += String.format(";\r\n name=\"%s\"", name);
+            String contentType;
+            if (MimeUtility.mimeTypeMatches(part.getMimeType(), "text/*")) {
+                contentType = String.format("%s;\r\n charset=utf-8", part.getMimeType());
+                String name = MimeUtility.getHeaderParameter(part.getContentType(), "name");
+                if (name != null) {
+                    contentType += String.format(";\r\n name=\"%s\"", name);
+                }
+            } else {
+                contentType = part.getMimeType();
             }
             part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType);
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/TextBody.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/TextBody.java
@@ -132,4 +132,8 @@ public class TextBody implements Body, SizeAware {
 
         return countingOutputStream.getCount();
     }
+
+    public String getEncoding() {
+        return mEncoding;
+    }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -107,6 +107,14 @@ public class ComposeCryptoStatus {
         return enablePgpInline;
     }
 
+    public boolean isCryptoDisabled() {
+        return cryptoMode == CryptoMode.DISABLE;
+    }
+
+    public boolean isProviderStateOk() {
+        return cryptoProviderState == CryptoProviderState.OK;
+    }
+
     public static class ComposeCryptoStatusBuilder {
 
         private CryptoProviderState cryptoProviderState;

--- a/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
@@ -72,7 +72,7 @@ public abstract class MessageBuilder {
      * Build the message to be sent (or saved). If there is another message quoted in this one, it will be baked
      * into the message here.
      */
-    public MimeMessage build() throws MessagingException {
+    protected MimeMessage build() throws MessagingException {
         //FIXME: check arguments
 
         MimeMessage message = new MimeMessage();

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -93,6 +93,12 @@ public class PgpMessageBuilder extends MessageBuilder {
                 return;
             }
 
+            boolean isSimpleTextMessage =
+                    MimeUtility.isSameMimeType("text/plain", currentProcessedMimeMessage.getMimeType());
+            if (isPgpInlineMode && !isSimpleTextMessage) {
+                throw new MessagingException("Attachments are not supported in PGP/INLINE format!");
+            }
+
             if (pgpApiIntent == null) {
                 pgpApiIntent = buildOpenPgpApiIntent(shouldSign, shouldEncrypt, isPgpInlineMode);
             }

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -2,6 +2,7 @@ package com.fsck.k9.message;
 
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 
 import android.app.PendingIntent;
@@ -22,8 +23,10 @@ import com.fsck.k9.mail.internet.MimeHeader;
 import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.internet.MimeMessageHelper;
 import com.fsck.k9.mail.internet.MimeMultipart;
+import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mail.internet.TextBody;
 import com.fsck.k9.mailstore.BinaryMemoryBody;
+import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.util.MimeUtil;
 import org.openintents.openpgp.OpenPgpError;
 import org.openintents.openpgp.util.OpenPgpApi;
@@ -94,8 +97,8 @@ public class PgpMessageBuilder extends MessageBuilder {
                 pgpApiIntent = buildOpenPgpApiIntent(shouldSign, shouldEncrypt, isPgpInlineMode);
             }
 
-            PendingIntent returnedPendingIntent =
-                    launchOpenPgpApiIntent(pgpApiIntent, shouldEncrypt || isPgpInlineMode, isPgpInlineMode);
+            PendingIntent returnedPendingIntent = launchOpenPgpApiIntent(
+                    pgpApiIntent, shouldEncrypt || isPgpInlineMode, shouldEncrypt || !isPgpInlineMode, isPgpInlineMode);
             if (returnedPendingIntent != null) {
                 queueMessageBuildPendingIntent(returnedPendingIntent, REQUEST_USER_INTERACTION);
                 return;
@@ -151,7 +154,7 @@ public class PgpMessageBuilder extends MessageBuilder {
     }
 
     private PendingIntent launchOpenPgpApiIntent(@NonNull Intent openPgpIntent,
-            boolean captureOutputPart, boolean writeBodyContentOnly) throws MessagingException {
+            boolean captureOutputPart, boolean capturedOutputPartIs7Bit, boolean writeBodyContentOnly) throws MessagingException {
         final MimeBodyPart bodyPart = currentProcessedMimeMessage.toBodyPart();
         String[] contentType = currentProcessedMimeMessage.getHeader(MimeHeader.HEADER_CONTENT_TYPE);
         if (contentType.length > 0) {
@@ -165,7 +168,8 @@ public class PgpMessageBuilder extends MessageBuilder {
         OutputStream outputStream = null;
         if (captureOutputPart) {
             try {
-                pgpResultTempBody = new BinaryTempFileBody(MimeUtil.ENC_7BIT);
+                pgpResultTempBody = new BinaryTempFileBody(
+                        capturedOutputPartIs7Bit ? MimeUtil.ENC_7BIT : MimeUtil.ENC_8BIT);
                 outputStream = pgpResultTempBody.getOutputStream();
             } catch (IOException e) {
                 throw new MessagingException("could not allocate temp file for storage!", e);
@@ -211,7 +215,9 @@ public class PgpMessageBuilder extends MessageBuilder {
             public void writeTo(OutputStream os) throws IOException {
                 try {
                     if (writeBodyContentOnly) {
-                        bodyPart.getBody().writeTo(os);
+                        Body body = bodyPart.getBody();
+                        InputStream inputStream = body.getInputStream();
+                        IOUtils.copy(inputStream, os);
                     } else {
                         bodyPart.writeTo(os);
                     }
@@ -295,6 +301,10 @@ public class PgpMessageBuilder extends MessageBuilder {
             throw new IllegalStateException("call to mimeBuildInlineMessage while pgp/inline isn't enabled!");
         }
 
+        boolean isCleartextSignature = !cryptoStatus.isEncryptionEnabled();
+        if (isCleartextSignature) {
+            inlineBodyPart.setEncoding(MimeUtil.ENC_QUOTED_PRINTABLE);
+        }
         MimeMessageHelper.setBody(currentProcessedMimeMessage, inlineBodyPart);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -48,7 +48,21 @@ public class PgpMessageBuilder extends MessageBuilder {
 
     @Override
     protected void buildMessageInternal() {
+        if (currentProcessedMimeMessage != null) {
+            throw new IllegalStateException("message can only be built once!");
+        }
+        if (cryptoStatus == null) {
+            throw new IllegalStateException("PgpMessageBuilder must have cryptoStatus set before building!");
+        }
+        if (cryptoStatus.isCryptoDisabled()) {
+            throw new AssertionError("PgpMessageBuilder must not be used if crypto is disabled!");
+        }
+
         try {
+            if (!cryptoStatus.isProviderStateOk()) {
+                throw new MessagingException("OpenPGP Provider is not ready!");
+            }
+
             currentProcessedMimeMessage = build();
         } catch (MessagingException me) {
             queueMessageBuildException(me);
@@ -59,7 +73,10 @@ public class PgpMessageBuilder extends MessageBuilder {
     }
 
     @Override
-    public void buildMessageOnActivityResult(int requestCode, Intent userInteractionResult) {
+    public void buildMessageOnActivityResult(int requestCode, @NonNull Intent userInteractionResult) {
+        if (currentProcessedMimeMessage == null) {
+            throw new AssertionError("build message from activity result must not be called individually");
+        }
         startOrContinueBuildMessage(userInteractionResult);
     }
 
@@ -116,7 +133,7 @@ public class PgpMessageBuilder extends MessageBuilder {
                 String[] encryptRecipientAddresses = cryptoStatus.getRecipientAddresses();
                 boolean hasRecipientAddresses = encryptRecipientAddresses != null && encryptRecipientAddresses.length > 0;
                 if (!hasRecipientAddresses) {
-                    throw new MessagingException("encryption is enabled, but no encryption key specified!");
+                    throw new MessagingException("encryption is enabled, but no recipient specified!");
                 }
                 pgpApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, encryptRecipientAddresses);
                 pgpApiIntent.putExtra(OpenPgpApi.EXTRA_ENCRYPT_OPPORTUNISTIC, cryptoStatus.isEncryptionOpportunistic());
@@ -228,7 +245,7 @@ public class PgpMessageBuilder extends MessageBuilder {
     }
 
     private void mimeBuildSignedMessage(@NonNull BodyPart signedBodyPart, Intent result) throws MessagingException {
-        if (!cryptoStatus.isEncryptionEnabled()) {
+        if (!cryptoStatus.isSigningEnabled()) {
             throw new IllegalStateException("call to mimeBuildSignedMessage while signing isn't enabled!");
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -7,6 +7,7 @@ import java.io.OutputStream;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
 
@@ -14,7 +15,6 @@ import com.fsck.k9.K9;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;
-import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.BinaryTempFileBody;
 import com.fsck.k9.mail.internet.MimeBodyPart;
@@ -32,49 +32,22 @@ import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
 
 public class PgpMessageBuilder extends MessageBuilder {
 
-    public static final int REQUEST_SIGN_INTERACTION = 1;
-    public static final int REQUEST_ENCRYPT_INTERACTION = 2;
-    public static final int REQUEST_INLINE_INTERACTION = 3;
+    public static final int REQUEST_USER_INTERACTION = 1;
 
     private final OpenPgpApi openPgpApi;
 
     private MimeMessage currentProcessedMimeMessage;
     private ComposeCryptoStatus cryptoStatus;
+    private boolean opportunisticSkipEncryption;
+    private boolean opportunisticSecondPass;
 
     public PgpMessageBuilder(Context context, OpenPgpApi openPgpApi) {
         super(context);
         this.openPgpApi = openPgpApi;
     }
 
-    /** This class keeps track of its internal state explicitly. */
-    private enum State {
-        IDLE, START, FAILURE,
-        OPENPGP_SIGN, OPENPGP_SIGN_UI, OPENPGP_SIGN_OK,
-        OPENPGP_ENCRYPT, OPENPGP_ENCRYPT_UI, OPENPGP_ENCRYPT_OK,
-        OPENPGP_INLINE, OPENPGP_INLINE_UI, OPENPGP_INLINE_OK;
-
-        public boolean isBreakState() {
-            return this == OPENPGP_SIGN_UI || this == OPENPGP_ENCRYPT_UI || this == OPENPGP_INLINE_UI || this == FAILURE;
-        }
-
-        public boolean isReentrantState() {
-            return this == OPENPGP_SIGN || this == OPENPGP_ENCRYPT || this == OPENPGP_INLINE;
-        }
-
-        public boolean isSignOk() {
-            return this == OPENPGP_SIGN_OK || this == OPENPGP_ENCRYPT
-                    || this == OPENPGP_ENCRYPT_UI || this == OPENPGP_ENCRYPT_OK;
-        }
-    }
-
-    State currentState = State.IDLE;
-
     @Override
     protected void buildMessageInternal() {
-        if (currentState != State.IDLE) {
-            throw new IllegalStateException("internal error, a PgpMessageBuilder can only be built once!");
-        }
-
         try {
             currentProcessedMimeMessage = build();
         } catch (MessagingException me) {
@@ -82,49 +55,38 @@ public class PgpMessageBuilder extends MessageBuilder {
             return;
         }
 
-        currentState = State.START;
         startOrContinueBuildMessage(null);
     }
 
     @Override
     public void buildMessageOnActivityResult(int requestCode, Intent userInteractionResult) {
-        if (requestCode == REQUEST_SIGN_INTERACTION && currentState == State.OPENPGP_SIGN_UI) {
-            currentState = State.OPENPGP_SIGN;
-            startOrContinueBuildMessage(userInteractionResult);
-        } else if (requestCode == REQUEST_ENCRYPT_INTERACTION && currentState == State.OPENPGP_ENCRYPT_UI) {
-            currentState = State.OPENPGP_ENCRYPT;
-            startOrContinueBuildMessage(userInteractionResult);
-        } else if (requestCode == REQUEST_INLINE_INTERACTION && currentState == State.OPENPGP_INLINE_UI) {
-            currentState = State.OPENPGP_INLINE;
-            startOrContinueBuildMessage(userInteractionResult);
-        } else {
-            throw new IllegalStateException("illegal state!");
-        }
+        startOrContinueBuildMessage(userInteractionResult);
     }
 
-    private void startOrContinueBuildMessage(@Nullable Intent userInteractionResult) {
-        if (currentState != State.START && !currentState.isReentrantState()) {
-            throw new IllegalStateException("bad state!");
-        }
-
-        if (cryptoStatus.isPgpInlineModeEnabled()) {
-            startOrContinueBuildPgpInlineMessage(userInteractionResult);
-        } else {
-            startOrContinueBuildPgpMimeMessage(userInteractionResult);
-        }
-    }
-
-    private void startOrContinueBuildPgpMimeMessage(@Nullable Intent userInteractionResult) {
+    private void startOrContinueBuildMessage(@Nullable Intent pgpApiIntent) {
         try {
-            startOrContinueSigningIfRequested(userInteractionResult);
+            boolean shouldSign = cryptoStatus.isSigningEnabled();
+            boolean shouldEncrypt = cryptoStatus.isEncryptionEnabled() && !opportunisticSkipEncryption;
+            boolean isPgpInlineMode = cryptoStatus.isPgpInlineModeEnabled();
 
-            if (currentState.isBreakState()) {
+            if (!shouldSign && !shouldEncrypt) {
                 return;
             }
 
-            startOrContinueEncryptionIfRequested(userInteractionResult);
+            if (pgpApiIntent == null) {
+                pgpApiIntent = buildOpenPgpApiIntent(shouldSign, shouldEncrypt, isPgpInlineMode);
+            }
 
-            if (currentState.isBreakState()) {
+            PendingIntent returnedPendingIntent =
+                    launchOpenPgpApiIntent(pgpApiIntent, shouldEncrypt || isPgpInlineMode, isPgpInlineMode);
+            if (returnedPendingIntent != null) {
+                queueMessageBuildPendingIntent(returnedPendingIntent, REQUEST_USER_INTERACTION);
+                return;
+            }
+
+            if (opportunisticSkipEncryption && !opportunisticSecondPass) {
+                opportunisticSecondPass = true;
+                startOrContinueBuildMessage(null);
                 return;
             }
 
@@ -134,40 +96,33 @@ public class PgpMessageBuilder extends MessageBuilder {
         }
     }
 
-    private void startOrContinueBuildPgpInlineMessage(@Nullable Intent userInteractionResult) {
-        try {
-            startOrContinueInlineSignCryptIfRequested(userInteractionResult);
-
-            if (currentState.isBreakState()) {
-                return;
-            }
-
-            queueMessageBuildSuccess(currentProcessedMimeMessage);
-        } catch (MessagingException me) {
-            queueMessageBuildException(me);
-        }
-    }
-
-    private void startOrContinueInlineSignCryptIfRequested(Intent userInteractionResult) throws MessagingException {
-        boolean reenterOperation = currentState == State.OPENPGP_INLINE;
-        if (reenterOperation) {
-            mimeIntentLaunch(userInteractionResult);
-            return;
-        }
-
-        boolean shouldSign = cryptoStatus.isSigningEnabled();
-        boolean shouldEncrypt = cryptoStatus.isEncryptionEnabled();
-
-        if (!shouldSign && !shouldEncrypt) {
-            return;
-        }
-
+    @NonNull
+    private Intent buildOpenPgpApiIntent(boolean shouldSign, boolean shouldEncrypt, boolean isPgpInlineMode)
+            throws MessagingException {
         Intent pgpApiIntent;
         if (shouldEncrypt) {
-            pgpApiIntent = new Intent(OpenPgpApi.ACTION_ENCRYPT);
-            putEncryptionIntentExtras(pgpApiIntent);
+            if (!shouldSign) {
+                throw new IllegalStateException("encrypt-only is not supported at this point and should never happen!");
+            }
+            // pgpApiIntent = new Intent(shouldSign ? OpenPgpApi.ACTION_SIGN_AND_ENCRYPT : OpenPgpApi.ACTION_ENCRYPT);
+            pgpApiIntent = new Intent(OpenPgpApi.ACTION_SIGN_AND_ENCRYPT);
+
+            long[] encryptKeyIds = cryptoStatus.getEncryptKeyIds();
+            if (encryptKeyIds != null) {
+                pgpApiIntent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, encryptKeyIds);
+            }
+
+            if(!isDraft()) {
+                String[] encryptRecipientAddresses = cryptoStatus.getRecipientAddresses();
+                boolean hasRecipientAddresses = encryptRecipientAddresses != null && encryptRecipientAddresses.length > 0;
+                if (!hasRecipientAddresses) {
+                    throw new MessagingException("encryption is enabled, but no encryption key specified!");
+                }
+                pgpApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, encryptRecipientAddresses);
+                pgpApiIntent.putExtra(OpenPgpApi.EXTRA_ENCRYPT_OPPORTUNISTIC, cryptoStatus.isEncryptionOpportunistic());
+            }
         } else {
-            pgpApiIntent = new Intent(OpenPgpApi.ACTION_SIGN);
+            pgpApiIntent = new Intent(isPgpInlineMode ? OpenPgpApi.ACTION_SIGN : OpenPgpApi.ACTION_DETACHED_SIGN);
         }
 
         if (shouldSign) {
@@ -175,87 +130,66 @@ public class PgpMessageBuilder extends MessageBuilder {
         }
 
         pgpApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
-
-        currentState = State.OPENPGP_INLINE;
-        mimeIntentLaunch(pgpApiIntent);
+        return pgpApiIntent;
     }
 
-    private void startOrContinueEncryptionIfRequested(Intent userInteractionResult) throws MessagingException {
-        boolean reenterOperation = currentState == State.OPENPGP_ENCRYPT;
-        if (reenterOperation) {
-            mimeIntentLaunch(userInteractionResult);
-            return;
-        }
-
-        if (!cryptoStatus.isEncryptionEnabled()) {
-            return;
-        }
-
-        Intent encryptIntent = new Intent(OpenPgpApi.ACTION_ENCRYPT);
-        encryptIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
-
-        putEncryptionIntentExtras(encryptIntent);
-
-        currentState = State.OPENPGP_ENCRYPT;
-        mimeIntentLaunch(encryptIntent);
-    }
-
-    private void startOrContinueSigningIfRequested(Intent userInteractionResult) throws MessagingException {
-        boolean reenterOperation = currentState == State.OPENPGP_SIGN;
-        if (reenterOperation) {
-            mimeIntentLaunch(userInteractionResult);
-            return;
-        }
-
-        boolean signingDisabled = !cryptoStatus.isSigningEnabled();
-        boolean alreadySigned = currentState.isSignOk();
-        boolean isDraft = isDraft();
-        if (signingDisabled || alreadySigned || isDraft) {
-            return;
-        }
-
-        Intent signIntent = new Intent(OpenPgpApi.ACTION_DETACHED_SIGN);
-        signIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, cryptoStatus.getSigningKeyId());
-
-        currentState = State.OPENPGP_SIGN;
-        mimeIntentLaunch(signIntent);
-    }
-
-    private void putEncryptionIntentExtras(Intent pgpApiIntent) throws MessagingException {
-        long[] encryptKeyIds = cryptoStatus.getEncryptKeyIds();
-        if (encryptKeyIds != null) {
-            pgpApiIntent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, encryptKeyIds);
-        }
-
-        if(!isDraft()) {
-            String[] encryptRecipientAddresses = cryptoStatus.getRecipientAddresses();
-            boolean hasRecipientAddresses = encryptRecipientAddresses != null && encryptRecipientAddresses.length > 0;
-            if (!hasRecipientAddresses) {
-                throw new MessagingException("Encryption is enabled, but no encryption key specified!");
-            }
-            pgpApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, encryptRecipientAddresses);
-            pgpApiIntent.putExtra(OpenPgpApi.EXTRA_ENCRYPT_OPPORTUNISTIC, cryptoStatus.isEncryptionOpportunistic());
-        }
-    }
-
-    /** This method executes the given Intent with the OpenPGP Api. It will pass the
-     * entire current message as input. On success, either mimeBuildSignedMessage() or
-     * mimeBuildEncryptedMessage() will be called with their appropriate inputs. If an
-     * error or PendingInput is returned, this will be passed as a result to the
-     * operation.
-     */
-    private void mimeIntentLaunch(Intent openPgpIntent) throws MessagingException {
+    private PendingIntent launchOpenPgpApiIntent(@NonNull Intent openPgpIntent,
+            boolean captureOutputPart, boolean writeBodyContentOnly) throws MessagingException {
         final MimeBodyPart bodyPart = currentProcessedMimeMessage.toBodyPart();
-
         String[] contentType = currentProcessedMimeMessage.getHeader(MimeHeader.HEADER_CONTENT_TYPE);
         if (contentType.length > 0) {
             bodyPart.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType[0]);
         }
         bodyPart.setUsing7bitTransport();
 
-        // This data will be read in a worker thread
-        final boolean writeBodyContentOnly = currentState == State.OPENPGP_INLINE;
-        OpenPgpDataSource dataSource = new OpenPgpDataSource() {
+        OpenPgpDataSource dataSource = createOpenPgpDataSourceFromBodyPart(bodyPart, writeBodyContentOnly);
+
+        BinaryTempFileBody pgpResultTempBody = null;
+        OutputStream outputStream = null;
+        if (captureOutputPart) {
+            try {
+                pgpResultTempBody = new BinaryTempFileBody(MimeUtil.ENC_7BIT);
+                outputStream = pgpResultTempBody.getOutputStream();
+            } catch (IOException e) {
+                throw new MessagingException("could not allocate temp file for storage!", e);
+            }
+        }
+
+        Intent result = openPgpApi.executeApi(openPgpIntent, dataSource, outputStream);
+
+        switch (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
+            case OpenPgpApi.RESULT_CODE_SUCCESS:
+                mimeBuildMessage(result, bodyPart, pgpResultTempBody);
+                return null;
+
+            case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
+                PendingIntent returnedPendingIntent = result.getParcelableExtra(OpenPgpApi.RESULT_INTENT);
+                if (returnedPendingIntent == null) {
+                    throw new MessagingException("openpgp api needs user interaction, but returned no pendingintent!");
+                }
+                return returnedPendingIntent;
+
+            case OpenPgpApi.RESULT_CODE_ERROR:
+                OpenPgpError error = result.getParcelableExtra(OpenPgpApi.RESULT_ERROR);
+                if (error == null) {
+                    throw new MessagingException("internal openpgp api error");
+                }
+                boolean isOpportunisticError = error.getErrorId() == OpenPgpError.OPPORTUNISTIC_MISSING_KEYS;
+                if (isOpportunisticError) {
+                    skipEncryptingMessage();
+                    return null;
+                }
+                throw new MessagingException(error.getMessage());
+        }
+
+        throw new IllegalStateException("unreachable code segment reached - this is a bug");
+    }
+
+    @NonNull
+    private OpenPgpDataSource createOpenPgpDataSourceFromBodyPart(final MimeBodyPart bodyPart,
+            final boolean writeBodyContentOnly)
+            throws MessagingException {
+        return new OpenPgpDataSource() {
             @Override
             public void writeTo(OutputStream os) throws IOException {
                 try {
@@ -269,77 +203,45 @@ public class PgpMessageBuilder extends MessageBuilder {
                 }
             }
         };
+    }
 
-        BinaryTempFileBody pgpResultTempBody = null;
-        OutputStream outputStream = null;
-        if (currentState == State.OPENPGP_ENCRYPT || currentState == State.OPENPGP_INLINE) {
-            try {
-                pgpResultTempBody = new BinaryTempFileBody(MimeUtil.ENC_7BIT);
-                outputStream = pgpResultTempBody.getOutputStream();
-            } catch (IOException e) {
-                throw new MessagingException("Could not allocate temp file for storage!", e);
+    private void mimeBuildMessage(
+            @NonNull Intent result, @NonNull MimeBodyPart bodyPart, @Nullable BinaryTempFileBody pgpResultTempBody)
+            throws MessagingException {
+        if (pgpResultTempBody == null) {
+            boolean shouldHaveResultPart = cryptoStatus.isPgpInlineModeEnabled() ||
+                    (cryptoStatus.isEncryptionEnabled() && !opportunisticSkipEncryption);
+            if (shouldHaveResultPart) {
+                throw new AssertionError("encryption or pgp/inline is enabled, but no output part - this is a bug!");
             }
+
+            mimeBuildSignedMessage(bodyPart, result);
+            return;
         }
 
-        Intent result = openPgpApi.executeApi(openPgpIntent, dataSource, outputStream);
-
-        switch (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR)) {
-            case OpenPgpApi.RESULT_CODE_SUCCESS:
-                if (currentState == State.OPENPGP_SIGN) {
-                    mimeBuildSignedMessage(bodyPart, result);
-                } else if (currentState == State.OPENPGP_ENCRYPT) {
-                    mimeBuildEncryptedMessage(pgpResultTempBody, result);
-                } else if (currentState == State.OPENPGP_INLINE) {
-                    mimeBuildInlineMessage(pgpResultTempBody, result);
-                } else {
-                    throw new IllegalStateException("state error!");
-                }
-                return;
-
-            case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
-                launchUserInteraction(result);
-                return;
-
-            case OpenPgpApi.RESULT_CODE_ERROR:
-                OpenPgpError error = result.getParcelableExtra(OpenPgpApi.RESULT_ERROR);
-                boolean isOpportunisticError = error.getErrorId() == OpenPgpError.OPPORTUNISTIC_MISSING_KEYS;
-                if (isOpportunisticError) {
-                    skipEncryptingMessage();
-                    return;
-                }
-                throw new MessagingException(error.getMessage());
-
-            default:
-                throw new IllegalStateException("unreachable code segment reached - this is a bug");
+        if (cryptoStatus.isPgpInlineModeEnabled()) {
+            mimeBuildInlineMessage(pgpResultTempBody);
+            return;
         }
+
+        mimeBuildEncryptedMessage(pgpResultTempBody);
     }
 
-    private void launchUserInteraction(Intent result) {
-        PendingIntent pendingIntent = result.getParcelableExtra(OpenPgpApi.RESULT_INTENT);
-
-        if (currentState == State.OPENPGP_ENCRYPT) {
-            currentState = State.OPENPGP_ENCRYPT_UI;
-            queueMessageBuildPendingIntent(pendingIntent, REQUEST_ENCRYPT_INTERACTION);
-        } else if (currentState == State.OPENPGP_SIGN) {
-            currentState = State.OPENPGP_SIGN_UI;
-            queueMessageBuildPendingIntent(pendingIntent, REQUEST_SIGN_INTERACTION);
-        } else if (currentState == State.OPENPGP_INLINE) {
-            currentState = State.OPENPGP_INLINE_UI;
-            queueMessageBuildPendingIntent(pendingIntent, REQUEST_INLINE_INTERACTION);
-        } else {
-            throw new IllegalStateException("illegal state!");
+    private void mimeBuildSignedMessage(@NonNull BodyPart signedBodyPart, Intent result) throws MessagingException {
+        if (!cryptoStatus.isEncryptionEnabled()) {
+            throw new IllegalStateException("call to mimeBuildSignedMessage while signing isn't enabled!");
         }
-    }
 
-    private void mimeBuildSignedMessage(BodyPart signedBodyPart, Intent result) throws MessagingException {
         byte[] signedData = result.getByteArrayExtra(OpenPgpApi.RESULT_DETACHED_SIGNATURE);
+        if (signedData == null) {
+            throw new MessagingException("didn't find expected RESULT_DETACHED_SIGNATURE in api call result");
+        }
 
         MimeMultipart multipartSigned = new MimeMultipart();
         multipartSigned.setSubType("signed");
         multipartSigned.addBodyPart(signedBodyPart);
         multipartSigned.addBodyPart(
                 new MimeBodyPart(new BinaryMemoryBody(signedData, MimeUtil.ENC_7BIT), "application/pgp-signature"));
-
         MimeMessageHelper.setBody(currentProcessedMimeMessage, multipartSigned);
 
         String contentType = String.format(
@@ -352,80 +254,42 @@ public class PgpMessageBuilder extends MessageBuilder {
             Log.e(K9.LOG_TAG, "missing micalg parameter for pgp multipart/signed!");
         }
         currentProcessedMimeMessage.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType);
-
-        currentState = State.OPENPGP_SIGN_OK;
     }
 
-    @SuppressWarnings("UnusedParameters")
-    private void mimeBuildEncryptedMessage(Body encryptedBodyPart, Intent result) throws MessagingException {
+    private void mimeBuildEncryptedMessage(@NonNull Body encryptedBodyPart) throws MessagingException {
+        if (!cryptoStatus.isEncryptionEnabled()) {
+            throw new IllegalStateException("call to mimeBuildEncryptedMessage while encryption isn't enabled!");
+        }
+
         MimeMultipart multipartEncrypted = new MimeMultipart();
         multipartEncrypted.setSubType("encrypted");
-
         multipartEncrypted.addBodyPart(new MimeBodyPart(new TextBody("Version: 1"), "application/pgp-encrypted"));
         multipartEncrypted.addBodyPart(new MimeBodyPart(encryptedBodyPart, "application/octet-stream"));
         MimeMessageHelper.setBody(currentProcessedMimeMessage, multipartEncrypted);
+
         String contentType = String.format(
                 "multipart/encrypted; boundary=\"%s\";\r\n  protocol=\"application/pgp-encrypted\"",
                 multipartEncrypted.getBoundary());
         currentProcessedMimeMessage.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType);
-
-        currentState = State.OPENPGP_ENCRYPT_OK;
     }
 
-    @SuppressWarnings("UnusedParameters")
-    private void mimeBuildInlineMessage(Body inlineBodyPart, Intent result) throws MessagingException {
-        MimeMessageHelper.setBody(currentProcessedMimeMessage, inlineBodyPart);
+    private void mimeBuildInlineMessage(@NonNull Body inlineBodyPart) throws MessagingException {
+        if (!cryptoStatus.isPgpInlineModeEnabled()) {
+            throw new IllegalStateException("call to mimeBuildInlineMessage while pgp/inline isn't enabled!");
+        }
 
-        currentState = State.OPENPGP_INLINE_OK;
+        MimeMessageHelper.setBody(currentProcessedMimeMessage, inlineBodyPart);
     }
 
     private void skipEncryptingMessage() throws MessagingException {
         if (!cryptoStatus.isEncryptionOpportunistic()) {
             throw new AssertionError("Got opportunistic error, but encryption wasn't supposed to be opportunistic!");
         }
-        currentState = State.OPENPGP_ENCRYPT_OK;
+        opportunisticSkipEncryption = true;
     }
 
     public void setCryptoStatus(ComposeCryptoStatus cryptoStatus) {
         this.cryptoStatus = cryptoStatus;
     }
-
-    /* TODO re-add attach public key
-    private Attachment attachedPublicKey() throws OpenPgpApiException {
-        try {
-            Attachment publicKey = new Attachment();
-            publicKey.contentType = "application/pgp-keys";
-
-            String keyName = "0x" +  Long.toString(mAccount.getCryptoKey(), 16).substring(8);
-            publicKey.name = keyName + ".asc";
-            Intent intent = new Intent(OpenPgpApi.ACTION_GET_KEY);
-            intent.putExtra(OpenPgpApi.EXTRA_KEY_ID, mAccount.getCryptoKey());
-            intent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
-            OpenPgpApi api = new OpenPgpApi(this, mOpenPgpServiceConnection.getService());
-            File keyTempFile = File.createTempFile("key", ".asc", getCacheDir());
-            keyTempFile.deleteOnExit();
-            try {
-                CountingOutputStream keyFileStream = new CountingOutputStream(new BufferedOutputStream(
-                        new FileOutputStream(keyTempFile)));
-                Intent res = api.executeApi(intent, null, new EOLConvertingOutputStream(keyFileStream));
-                if (res.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR) != OpenPgpApi.RESULT_CODE_SUCCESS
-                        || keyFileStream.getByteCount() == 0) {
-                    keyTempFile.delete();
-                    throw new OpenPgpApiException(String.format(getString(R.string.openpgp_no_public_key_returned),
-                            getString(R.string.btn_attach_key)));
-                }
-                publicKey.filename = keyTempFile.getAbsolutePath();
-                publicKey.state = Attachment.LoadingState.COMPLETE;
-                publicKey.size = keyFileStream.getByteCount();
-                return publicKey;
-            } catch(RuntimeException e){
-                keyTempFile.delete();
-                throw e;
-            }
-        } catch(IOException e){
-            throw new RuntimeException(getString(R.string.error_cant_create_temporary_file), e);
-        }
-    }
-     */
 
 }

--- a/k9mail/src/main/java/com/fsck/k9/message/TextBodyBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/TextBodyBuilder.java
@@ -1,12 +1,14 @@
 package com.fsck.k9.message;
 
+
 import android.text.TextUtils;
 import android.util.Log;
 
 import com.fsck.k9.K9;
-import com.fsck.k9.mail.Body;
 import com.fsck.k9.helper.HtmlConverter;
+import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.internet.TextBody;
+
 
 class TextBodyBuilder {
     private boolean mIncludeQuotedText = true;

--- a/k9mail/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
@@ -1,0 +1,182 @@
+package com.fsck.k9.message;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import com.fsck.k9.Account.QuoteStyle;
+import com.fsck.k9.Identity;
+import com.fsck.k9.activity.misc.Attachment;
+import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.Body;
+import com.fsck.k9.mail.Message.RecipientType;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.internet.MimeMessage;
+import com.fsck.k9.message.MessageBuilder.Callback;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+public class MessageBuilderTest {
+    public static final String TEST_MESSAGE_TEXT = "message text";
+    public static final String TEST_SUBJECT = "test_subject";
+    public static final Address TEST_IDENTITY_ADDRESS = new Address("test@example.org", "tester");
+    public static final Address[] TEST_TO = new Address[] {
+            new Address("to1@example.org", "recip 1"), new Address("to2@example.org", "recip 2")
+    };
+    public static final Address[] TEST_CC = new Address[] { new Address("cc@example.org", "cc recip") };
+    public static final Address[] TEST_BCC = new Address[] { new Address("bcc@example.org", "bcc recip") };
+
+
+    @Test
+    public void build__shouldSucceed() throws MessagingException {
+        MessageBuilder messageBuilder = createSimpleMessageBuilder();
+
+
+        Callback mockCallback = mock(Callback.class);
+        messageBuilder.buildAsync(mockCallback);
+
+
+        ArgumentCaptor<MimeMessage> mimeMessageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mockCallback).onMessageBuildSuccess(mimeMessageCaptor.capture(), eq(false));
+        verifyNoMoreInteractions(mockCallback);
+
+        MimeMessage mimeMessage = mimeMessageCaptor.getValue();
+        assertContentOfBodyEquals("message content must match", mimeMessage.getBody(), TEST_MESSAGE_TEXT);
+        assertEquals("text/plain", mimeMessage.getMimeType());
+        assertEquals(TEST_SUBJECT, mimeMessage.getSubject());
+        assertEquals(TEST_IDENTITY_ADDRESS, mimeMessage.getFrom()[0]);
+        assertArrayEquals(TEST_TO, mimeMessage.getRecipients(RecipientType.TO));
+        assertArrayEquals(TEST_CC, mimeMessage.getRecipients(RecipientType.CC));
+        assertArrayEquals(TEST_BCC, mimeMessage.getRecipients(RecipientType.BCC));
+    }
+
+    @Test
+    public void build__detachAndReattach__shouldSucceed() throws MessagingException {
+        MessageBuilder messageBuilder = createSimpleMessageBuilder();
+
+
+        Callback mockCallback = mock(Callback.class);
+        Robolectric.getBackgroundThreadScheduler().pause();
+        messageBuilder.buildAsync(mockCallback);
+        messageBuilder.detachCallback();
+        Robolectric.getBackgroundThreadScheduler().unPause();
+
+        verifyNoMoreInteractions(mockCallback);
+
+
+        mockCallback = mock(Callback.class);
+        messageBuilder.reattachCallback(mockCallback);
+
+        verify(mockCallback).onMessageBuildSuccess(any(MimeMessage.class), eq(false));
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void buildWithException__shouldThrow() throws MessagingException {
+        MessageBuilder messageBuilder = new SimpleMessageBuilder(RuntimeEnvironment.application) {
+            @Override
+            protected void buildMessageInternal() {
+                queueMessageBuildException(new MessagingException("expected error"));
+            }
+        };
+
+        Callback mockCallback = mock(Callback.class);
+        messageBuilder.buildAsync(mockCallback);
+
+        verify(mockCallback).onMessageBuildException(any(MessagingException.class));
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void buildWithException__detachAndReattach__shouldThrow() throws MessagingException {
+        MessageBuilder messageBuilder = new SimpleMessageBuilder(RuntimeEnvironment.application) {
+            @Override
+            protected void buildMessageInternal() {
+                queueMessageBuildException(new MessagingException("expected error"));
+            }
+        };
+
+
+        Callback mockCallback = mock(Callback.class);
+        Robolectric.getBackgroundThreadScheduler().pause();
+        messageBuilder.buildAsync(mockCallback);
+        messageBuilder.detachCallback();
+        Robolectric.getBackgroundThreadScheduler().unPause();
+
+        verifyNoMoreInteractions(mockCallback);
+
+
+        mockCallback = mock(Callback.class);
+        messageBuilder.reattachCallback(mockCallback);
+
+        verify(mockCallback).onMessageBuildException(any(MessagingException.class));
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    private static MessageBuilder createSimpleMessageBuilder() {
+        MessageBuilder b = new SimpleMessageBuilder(RuntimeEnvironment.application);
+
+        Identity identity = new Identity();
+        identity.setName(TEST_IDENTITY_ADDRESS.getPersonal());
+        identity.setEmail(TEST_IDENTITY_ADDRESS.getAddress());
+        identity.setDescription("test identity");
+        identity.setSignatureUse(false);
+
+        b.setSubject(TEST_SUBJECT)
+                .setTo(Arrays.asList(TEST_TO))
+                .setCc(Arrays.asList(TEST_CC))
+                .setBcc(Arrays.asList(TEST_BCC))
+                .setInReplyTo("inreplyto")
+                .setReferences("references")
+                .setRequestReadReceipt(false)
+                .setIdentity(identity)
+                .setMessageFormat(SimpleMessageFormat.TEXT)
+                .setText(TEST_MESSAGE_TEXT)
+                .setAttachments(new ArrayList<Attachment>())
+                .setSignature("signature")
+                .setQuoteStyle(QuoteStyle.PREFIX)
+                .setQuotedTextMode(QuotedTextMode.NONE)
+                .setQuotedText("quoted text")
+                .setQuotedHtmlContent(new InsertableHtmlContent())
+                .setReplyAfterQuote(false)
+                .setSignatureBeforeQuotedText(false)
+                .setIdentityChanged(false)
+                .setSignatureChanged(false)
+                .setCursorPosition(0)
+                .setMessageReference(null)
+                .setDraft(false);
+
+        return b;
+    }
+
+    private static void assertContentOfBodyEquals(String reason, Body bodyPart, String expected) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            bodyPart.writeTo(bos) ;
+            Assert.assertEquals(reason, expected, new String(bos.toByteArray()));
+        } catch (IOException | MessagingException e) {
+            fail();
+        }
+    }
+
+}

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -372,6 +372,40 @@ public class PgpMessageBuilderTest {
         Assert.assertEquals("message must be text/plain", "text/plain", message.getMimeType());
     }
 
+    @Test
+    public void buildSignWithAttach__withInlineEnabled__shouldThrow() throws MessagingException {
+        ComposeCryptoStatus cryptoStatus = cryptoStatusBuilder
+                .setCryptoMode(CryptoMode.SIGN_ONLY)
+                .setEnablePgpInline(true)
+                .build();
+        pgpMessageBuilder.setCryptoStatus(cryptoStatus);
+        pgpMessageBuilder.setAttachments(Collections.singletonList(new Attachment()));
+
+        Callback mockCallback = mock(Callback.class);
+        pgpMessageBuilder.buildAsync(mockCallback);
+
+        verify(mockCallback).onMessageBuildException(any(MessagingException.class));
+        verifyNoMoreInteractions(mockCallback);
+        verifyNoMoreInteractions(openPgpApi);
+    }
+
+    @Test
+    public void buildEncryptWithAttach__withInlineEnabled__shouldThrow() throws MessagingException {
+        ComposeCryptoStatus cryptoStatus = cryptoStatusBuilder
+                .setCryptoMode(CryptoMode.OPPORTUNISTIC)
+                .setEnablePgpInline(true)
+                .build();
+        pgpMessageBuilder.setCryptoStatus(cryptoStatus);
+        pgpMessageBuilder.setAttachments(Collections.singletonList(new Attachment()));
+
+        Callback mockCallback = mock(Callback.class);
+        pgpMessageBuilder.buildAsync(mockCallback);
+
+        verify(mockCallback).onMessageBuildException(any(MessagingException.class));
+        verifyNoMoreInteractions(mockCallback);
+        verifyNoMoreInteractions(openPgpApi);
+    }
+
     private ComposeCryptoStatusBuilder createDefaultComposeCryptoStatusBuilder() {
         return new ComposeCryptoStatusBuilder()
                 .setEnablePgpInline(false)

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -426,7 +426,7 @@ public class PgpMessageBuilderTest {
         }
     }
 
-    static void assertIntentEqualsActionAndExtras(Intent expected, Intent actual) {
+    private static void assertIntentEqualsActionAndExtras(Intent expected, Intent actual) {
         Assert.assertEquals(expected.getAction(), actual.getAction());
 
         Bundle expectedExtras = expected.getExtras();

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -1,0 +1,460 @@
+package com.fsck.k9.message;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.fsck.k9.Account.QuoteStyle;
+import com.fsck.k9.Identity;
+import com.fsck.k9.activity.compose.ComposeCryptoStatus;
+import com.fsck.k9.activity.compose.ComposeCryptoStatus.ComposeCryptoStatusBuilder;
+import com.fsck.k9.activity.compose.RecipientPresenter.CryptoMode;
+import com.fsck.k9.activity.compose.RecipientPresenter.CryptoProviderState;
+import com.fsck.k9.activity.misc.Attachment;
+import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.BodyPart;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.internet.MimeMessage;
+import com.fsck.k9.mail.internet.MimeMultipart;
+import com.fsck.k9.mail.internet.MimeUtility;
+import com.fsck.k9.message.MessageBuilder.Callback;
+import com.fsck.k9.view.RecipientSelectView.Recipient;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.openintents.openpgp.util.OpenPgpApi;
+import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.argThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+public class PgpMessageBuilderTest {
+    public static final long TEST_SIGN_KEY_ID = 123L;
+    public static final long TEST_SELF_ENCRYPT_KEY_ID = 234L;
+    public static final String TEST_MESSAGE_TEXT = "message text";
+
+
+    private ComposeCryptoStatusBuilder cryptoStatusBuilder = createDefaultComposeCryptoStatusBuilder();
+    private OpenPgpApi openPgpApi = mock(OpenPgpApi.class);
+    private PgpMessageBuilder pgpMessageBuilder = createDefaultPgpMessageBuilder(openPgpApi);
+
+
+    @Test(expected = AssertionError.class)
+    public void build__withDisabledCrypto__shouldError() throws MessagingException {
+        pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.setCryptoMode(CryptoMode.DISABLE).build());
+
+        pgpMessageBuilder.buildAsync(mock(Callback.class));
+    }
+
+    @Test
+    public void build__withCryptoProviderNotOk__shouldThrow() throws MessagingException {
+        cryptoStatusBuilder.setCryptoMode(CryptoMode.SIGN_ONLY);
+        CryptoProviderState[] cryptoProviderStates = {
+                CryptoProviderState.LOST_CONNECTION, CryptoProviderState.UNCONFIGURED,
+                CryptoProviderState.UNINITIALIZED, CryptoProviderState.ERROR
+        };
+
+        for (CryptoProviderState state : cryptoProviderStates) {
+            cryptoStatusBuilder.setCryptoProviderState(state);
+            pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
+
+            Callback mockCallback = mock(Callback.class);
+            pgpMessageBuilder.buildAsync(mockCallback);
+
+            verify(mockCallback).onMessageBuildException(any(MessagingException.class));
+            verifyNoMoreInteractions(mockCallback);
+        }
+    }
+
+    @Test
+    public void buildSign__withNoDetachedSignatureInResult__shouldThrow() throws MessagingException {
+        cryptoStatusBuilder.setCryptoMode(CryptoMode.SIGN_ONLY);
+        pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
+
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+        when(openPgpApi.executeApi(any(Intent.class), any(OpenPgpDataSource.class), any(OutputStream.class)))
+                .thenReturn(returnIntent);
+
+        Callback mockCallback = mock(Callback.class);
+        pgpMessageBuilder.buildAsync(mockCallback);
+
+        verify(mockCallback).onMessageBuildException(any(MessagingException.class));
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void buildSign__withDetachedSignatureInResult__shouldSucceed() throws MessagingException {
+        cryptoStatusBuilder.setCryptoMode(CryptoMode.SIGN_ONLY);
+        pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
+
+        ArgumentCaptor<Intent> capturedApiIntent = ArgumentCaptor.forClass(Intent.class);
+
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+        returnIntent.putExtra(OpenPgpApi.RESULT_DETACHED_SIGNATURE, new byte[] { 1, 2, 3 });
+        when(openPgpApi.executeApi(capturedApiIntent.capture(), any(OpenPgpDataSource.class), any(OutputStream.class)))
+                .thenReturn(returnIntent);
+
+        Callback mockCallback = mock(Callback.class);
+        pgpMessageBuilder.buildAsync(mockCallback);
+
+        Intent expectedIntent = new Intent(OpenPgpApi.ACTION_DETACHED_SIGN);
+        expectedIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
+        expectedIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
+        assertIntentEqualsActionAndExtras(expectedIntent, capturedApiIntent.getValue());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mockCallback).onMessageBuildSuccess(captor.capture(), eq(false));
+        verifyNoMoreInteractions(mockCallback);
+
+        MimeMessage message = captor.getValue();
+        Assert.assertEquals("message must be multipart/signed", "multipart/signed", message.getMimeType());
+
+        MimeMultipart multipart = (MimeMultipart) message.getBody();
+        Assert.assertEquals("multipart/signed must consist of two parts", 2, multipart.getCount());
+
+        BodyPart contentBodyPart = multipart.getBodyPart(0);
+        Assert.assertEquals("first part must be the text content",
+                "text/plain", MimeUtility.getHeaderParameter(contentBodyPart.getContentType(), null));
+        assertContentOfBodyPartEquals("content must match the supplied detached signature",
+                contentBodyPart, TEST_MESSAGE_TEXT);
+
+        BodyPart signatureBodyPart = multipart.getBodyPart(1);
+        Assert.assertEquals("second part must be pgp signature",
+                "application/pgp-signature", signatureBodyPart.getContentType());
+        assertContentOfBodyPartEquals("content must match the supplied detached signature",
+                signatureBodyPart, new byte[] { 1, 2, 3 });
+    }
+
+    @Test
+    public void buildSign__withUserInteractionResult__shouldReturnUserInteraction() throws MessagingException {
+        cryptoStatusBuilder.setCryptoMode(CryptoMode.SIGN_ONLY);
+        pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
+
+        Intent returnIntent = mock(Intent.class);
+        when(returnIntent.getIntExtra(eq(OpenPgpApi.RESULT_CODE), anyInt()))
+                .thenReturn(OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED);
+        final PendingIntent mockPendingIntent = mock(PendingIntent.class);
+        when(returnIntent.getParcelableExtra(eq(OpenPgpApi.RESULT_INTENT)))
+                .thenReturn(mockPendingIntent);
+
+        when(openPgpApi.executeApi(any(Intent.class), any(OpenPgpDataSource.class), any(OutputStream.class)))
+                .thenReturn(returnIntent);
+
+        Callback mockCallback = mock(Callback.class);
+        pgpMessageBuilder.buildAsync(mockCallback);
+
+        ArgumentCaptor<PendingIntent> captor = ArgumentCaptor.forClass(PendingIntent.class);
+        verify(mockCallback).onMessageBuildReturnPendingIntent(captor.capture(), anyInt());
+        verifyNoMoreInteractions(mockCallback);
+
+        PendingIntent pendingIntent = captor.getValue();
+        Assert.assertSame(pendingIntent, mockPendingIntent);
+    }
+
+    @Test
+    public void buildSign__withReturnAfterUserInteraction__shouldSucceed() throws MessagingException {
+        cryptoStatusBuilder.setCryptoMode(CryptoMode.SIGN_ONLY);
+        pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
+
+        int returnedRequestCode;
+        {
+            Intent returnIntent = spy(new Intent());
+            returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED);
+
+            PendingIntent mockPendingIntent = mock(PendingIntent.class);
+            when(returnIntent.getParcelableExtra(eq(OpenPgpApi.RESULT_INTENT)))
+                    .thenReturn(mockPendingIntent);
+
+            when(openPgpApi.executeApi(any(Intent.class), any(OpenPgpDataSource.class), any(OutputStream.class)))
+                    .thenReturn(returnIntent);
+
+            Callback mockCallback = mock(Callback.class);
+            pgpMessageBuilder.buildAsync(mockCallback);
+
+            verify(returnIntent).getIntExtra(eq(OpenPgpApi.RESULT_CODE), anyInt());
+            ArgumentCaptor<PendingIntent> piCaptor = ArgumentCaptor.forClass(PendingIntent.class);
+            ArgumentCaptor<Integer> rcCaptor = ArgumentCaptor.forClass(Integer.class);
+            verify(mockCallback).onMessageBuildReturnPendingIntent(piCaptor.capture(), rcCaptor.capture());
+            verifyNoMoreInteractions(mockCallback);
+
+            returnedRequestCode = rcCaptor.getValue();
+            Assert.assertSame(mockPendingIntent, piCaptor.getValue());
+        }
+
+        {
+            Intent returnIntent = spy(new Intent());
+            returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+
+            Intent mockReturnIntent = mock(Intent.class);
+            when(openPgpApi.executeApi(same(mockReturnIntent), any(OpenPgpDataSource.class), any(OutputStream.class)))
+                    .thenReturn(returnIntent);
+
+            Callback mockCallback = mock(Callback.class);
+            pgpMessageBuilder.onActivityResult(mockCallback, returnedRequestCode, Activity.RESULT_OK, mockReturnIntent);
+            verify(openPgpApi).executeApi(same(mockReturnIntent), any(OpenPgpDataSource.class), any(OutputStream.class));
+            verify(returnIntent).getIntExtra(eq(OpenPgpApi.RESULT_CODE), anyInt());
+        }
+    }
+
+    @Test
+    public void buildEncrypt__withoutRecipients__shouldThrow() throws MessagingException {
+        cryptoStatusBuilder
+                .setCryptoMode(CryptoMode.OPPORTUNISTIC)
+                .setRecipients(new ArrayList<Recipient>());
+        pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
+
+        Intent returnIntent = spy(new Intent());
+        returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+        when(openPgpApi.executeApi(any(Intent.class), any(OpenPgpDataSource.class), any(OutputStream.class)))
+                .thenReturn(returnIntent);
+
+        Callback mockCallback = mock(Callback.class);
+        pgpMessageBuilder.buildAsync(mockCallback);
+
+        verify(mockCallback).onMessageBuildException(any(MessagingException.class));
+        verifyNoMoreInteractions(mockCallback);
+    }
+
+    @Test
+    public void buildEncrypt__shouldSucceed() throws MessagingException {
+        ComposeCryptoStatus cryptoStatus = cryptoStatusBuilder
+                .setCryptoMode(CryptoMode.PRIVATE)
+                .setRecipients(Collections.singletonList(new Recipient("test", "test@example.org", "labru", -1, "key")))
+                .build();
+        pgpMessageBuilder.setCryptoStatus(cryptoStatus);
+
+        ArgumentCaptor<Intent> capturedApiIntent = ArgumentCaptor.forClass(Intent.class);
+
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+
+        when(openPgpApi.executeApi(capturedApiIntent.capture(),
+                any(OpenPgpDataSource.class), any(OutputStream.class))).thenReturn(returnIntent);
+
+        Callback mockCallback = mock(Callback.class);
+        pgpMessageBuilder.buildAsync(mockCallback);
+
+        Intent expectedApiIntent = new Intent(OpenPgpApi.ACTION_SIGN_AND_ENCRYPT);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, new long[] { TEST_SELF_ENCRYPT_KEY_ID });
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_ENCRYPT_OPPORTUNISTIC, false);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, cryptoStatus.getRecipientAddresses());
+        assertIntentEqualsActionAndExtras(expectedApiIntent, capturedApiIntent.getValue());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mockCallback).onMessageBuildSuccess(captor.capture(), eq(false));
+        verifyNoMoreInteractions(mockCallback);
+
+        MimeMessage message = captor.getValue();
+
+        Assert.assertEquals("message must be multipart/encrypted", "multipart/encrypted", message.getMimeType());
+
+        MimeMultipart multipart = (MimeMultipart) message.getBody();
+        Assert.assertEquals("multipart/encrypted must consist of two parts", 2, multipart.getCount());
+
+        BodyPart dummyBodyPart = multipart.getBodyPart(0);
+        Assert.assertEquals("second part must be pgp encrypted dummy part",
+                "application/pgp-encrypted", dummyBodyPart.getContentType());
+        assertContentOfBodyPartEquals("content must match the supplied detached signature",
+                dummyBodyPart, "Version: 1");
+
+        BodyPart signatureBodyPart = multipart.getBodyPart(1);
+        Assert.assertEquals("second part must be octet-stream",
+                "application/octet-stream", signatureBodyPart.getContentType());
+    }
+
+    @Test
+    public void buildEncrypt__withInlineEnabled__shouldSucceed() throws MessagingException {
+        ComposeCryptoStatus cryptoStatus = cryptoStatusBuilder
+                .setCryptoMode(CryptoMode.PRIVATE)
+                .setRecipients(Collections.singletonList(new Recipient("test", "test@example.org", "labru", -1, "key")))
+                .setEnablePgpInline(true)
+                .build();
+        pgpMessageBuilder.setCryptoStatus(cryptoStatus);
+
+        ArgumentCaptor<Intent> capturedApiIntent = ArgumentCaptor.forClass(Intent.class);
+
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+
+        when(openPgpApi.executeApi(capturedApiIntent.capture(), any(OpenPgpDataSource.class), any(OutputStream.class)))
+                .thenReturn(returnIntent);
+
+        Callback mockCallback = mock(Callback.class);
+        pgpMessageBuilder.buildAsync(mockCallback);
+
+        Intent expectedApiIntent = new Intent(OpenPgpApi.ACTION_SIGN_AND_ENCRYPT);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, new long[] { TEST_SELF_ENCRYPT_KEY_ID });
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_ENCRYPT_OPPORTUNISTIC, false);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, cryptoStatus.getRecipientAddresses());
+        assertIntentEqualsActionAndExtras(expectedApiIntent, capturedApiIntent.getValue());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mockCallback).onMessageBuildSuccess(captor.capture(), eq(false));
+        verifyNoMoreInteractions(mockCallback);
+
+        MimeMessage message = captor.getValue();
+        Assert.assertEquals("message must be text/plain", "text/plain", message.getMimeType());
+    }
+
+    @Test
+    public void buildSign__withInlineEnabled__shouldSucceed() throws MessagingException {
+        ComposeCryptoStatus cryptoStatus = cryptoStatusBuilder
+                .setCryptoMode(CryptoMode.SIGN_ONLY)
+                .setRecipients(Collections.singletonList(new Recipient("test", "test@example.org", "labru", -1, "key")))
+                .setEnablePgpInline(true)
+                .build();
+        pgpMessageBuilder.setCryptoStatus(cryptoStatus);
+
+        ArgumentCaptor<Intent> capturedApiIntent = ArgumentCaptor.forClass(Intent.class);
+
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+
+        when(openPgpApi.executeApi(capturedApiIntent.capture(), any(OpenPgpDataSource.class), any(OutputStream.class)))
+                .thenReturn(returnIntent);
+
+        Callback mockCallback = mock(Callback.class);
+        pgpMessageBuilder.buildAsync(mockCallback);
+
+        Intent expectedApiIntent = new Intent(OpenPgpApi.ACTION_SIGN);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
+        assertIntentEqualsActionAndExtras(expectedApiIntent, capturedApiIntent.getValue());
+
+        ArgumentCaptor<MimeMessage> captor = ArgumentCaptor.forClass(MimeMessage.class);
+        verify(mockCallback).onMessageBuildSuccess(captor.capture(), eq(false));
+        verifyNoMoreInteractions(mockCallback);
+
+        MimeMessage message = captor.getValue();
+        Assert.assertEquals("message must be text/plain", "text/plain", message.getMimeType());
+    }
+
+    private ComposeCryptoStatusBuilder createDefaultComposeCryptoStatusBuilder() {
+        return new ComposeCryptoStatusBuilder()
+                .setEnablePgpInline(false)
+                .setSigningKeyId(TEST_SIGN_KEY_ID)
+                .setSelfEncryptId(TEST_SELF_ENCRYPT_KEY_ID)
+                .setRecipients(new ArrayList<Recipient>())
+                .setCryptoProviderState(CryptoProviderState.OK);
+    }
+
+    private static PgpMessageBuilder createDefaultPgpMessageBuilder(OpenPgpApi openPgpApi) {
+        PgpMessageBuilder b = new PgpMessageBuilder(RuntimeEnvironment.application, openPgpApi);
+
+        Identity identity = new Identity();
+        identity.setName("tester");
+        identity.setEmail("test@example.org");
+        identity.setDescription("test identity");
+        identity.setSignatureUse(false);
+
+        b.setSubject("subject")
+                .setTo(new ArrayList<Address>())
+                .setCc(new ArrayList<Address>())
+                .setBcc(new ArrayList<Address>())
+                .setInReplyTo("inreplyto")
+                .setReferences("references")
+                .setRequestReadReceipt(false)
+                .setIdentity(identity)
+                .setMessageFormat(SimpleMessageFormat.TEXT)
+                .setText(TEST_MESSAGE_TEXT)
+                .setAttachments(new ArrayList<Attachment>())
+                .setSignature("signature")
+                .setQuoteStyle(QuoteStyle.PREFIX)
+                .setQuotedTextMode(QuotedTextMode.NONE)
+                .setQuotedText("quoted text")
+                .setQuotedHtmlContent(new InsertableHtmlContent())
+                .setReplyAfterQuote(false)
+                .setSignatureBeforeQuotedText(false)
+                .setIdentityChanged(false)
+                .setSignatureChanged(false)
+                .setCursorPosition(0)
+                .setMessageReference(null)
+                .setDraft(false);
+
+        return b;
+    }
+
+    private static void assertContentOfBodyPartEquals(String reason, BodyPart signatureBodyPart, byte[] expected) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            signatureBodyPart.getBody().writeTo(bos);
+            Assert.assertArrayEquals(reason, expected, bos.toByteArray());
+        } catch (IOException | MessagingException e) {
+            Assert.fail();
+        }
+    }
+
+    private static void assertContentOfBodyPartEquals(String reason, BodyPart signatureBodyPart, String expected) {
+        try {
+            ByteArrayOutputStream bos = new ByteArrayOutputStream();
+            signatureBodyPart.getBody().writeTo(bos);
+            Assert.assertEquals(reason, expected, new String(bos.toByteArray()));
+        } catch (IOException | MessagingException e) {
+            Assert.fail();
+        }
+    }
+
+    static void assertIntentEqualsActionAndExtras(Intent expected, Intent actual) {
+        Assert.assertEquals(expected.getAction(), actual.getAction());
+
+        Bundle expectedExtras = expected.getExtras();
+        Bundle intentExtras = actual.getExtras();
+
+        if (expectedExtras.size() != intentExtras.size()) {
+            Assert.assertEquals(expectedExtras.size(), intentExtras.size());
+        }
+
+        for (String key : expectedExtras.keySet()) {
+            Object intentExtra = intentExtras.get(key);
+            Object expectedExtra = expectedExtras.get(key);
+            if (intentExtra == null) {
+                if (expectedExtra == null) {
+                    continue;
+                }
+                Assert.fail("found null for an expected non-null extra: " + key);
+            }
+            if (intentExtra instanceof long[]) {
+                if (!Arrays.equals((long[]) intentExtra, (long[]) expectedExtra)) {
+                    Assert.assertArrayEquals((long[]) expectedExtra, (long[]) intentExtra);
+                }
+            } else {
+                if (!intentExtra.equals(expectedExtra)) {
+                    Assert.assertEquals(expectedExtra, intentExtra);
+                }
+            }
+        }
+    }
+
+}

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -3,6 +3,7 @@ package com.fsck.k9.message;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -23,11 +24,15 @@ import com.fsck.k9.activity.misc.Attachment;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.internet.BinaryTempFileBody;
 import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.internet.MimeMultipart;
 import com.fsck.k9.mail.internet.MimeUtility;
+import com.fsck.k9.mail.internet.TextBody;
 import com.fsck.k9.message.MessageBuilder.Callback;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
+import org.apache.commons.io.IOUtils;
+import org.apache.james.mime4j.util.MimeUtil;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.junit.Assert;
@@ -57,7 +62,7 @@ import static org.mockito.Mockito.when;
 public class PgpMessageBuilderTest {
     public static final long TEST_SIGN_KEY_ID = 123L;
     public static final long TEST_SELF_ENCRYPT_KEY_ID = 234L;
-    public static final String TEST_MESSAGE_TEXT = "message text";
+    public static final String TEST_MESSAGE_TEXT = "message text with a ☭ CCCP symbol";
 
 
     private ComposeCryptoStatusBuilder cryptoStatusBuilder = createDefaultComposeCryptoStatusBuilder();
@@ -141,10 +146,11 @@ public class PgpMessageBuilderTest {
         Assert.assertEquals("multipart/signed must consist of two parts", 2, multipart.getCount());
 
         BodyPart contentBodyPart = multipart.getBodyPart(0);
-        Assert.assertEquals("first part must be the text content",
+        Assert.assertEquals("first part must have content type text/plain",
                 "text/plain", MimeUtility.getHeaderParameter(contentBodyPart.getContentType(), null));
-        assertContentOfBodyPartEquals("content must match the supplied detached signature",
-                contentBodyPart, TEST_MESSAGE_TEXT);
+        Assert.assertTrue("signed message body must be TextBody", contentBodyPart.getBody() instanceof TextBody);
+        Assert.assertEquals(MimeUtil.ENC_QUOTED_PRINTABLE, ((TextBody) contentBodyPart.getBody()).getEncoding());
+        assertContentOfBodyPartEquals("content must match the message text", contentBodyPart, TEST_MESSAGE_TEXT);
 
         BodyPart signatureBodyPart = multipart.getBodyPart(1);
         Assert.assertEquals("second part must be pgp signature",
@@ -282,14 +288,17 @@ public class PgpMessageBuilderTest {
         Assert.assertEquals("multipart/encrypted must consist of two parts", 2, multipart.getCount());
 
         BodyPart dummyBodyPart = multipart.getBodyPart(0);
-        Assert.assertEquals("second part must be pgp encrypted dummy part",
+        Assert.assertEquals("first part must be pgp encrypted dummy part",
                 "application/pgp-encrypted", dummyBodyPart.getContentType());
         assertContentOfBodyPartEquals("content must match the supplied detached signature",
                 dummyBodyPart, "Version: 1");
 
-        BodyPart signatureBodyPart = multipart.getBodyPart(1);
-        Assert.assertEquals("second part must be octet-stream",
-                "application/octet-stream", signatureBodyPart.getContentType());
+        BodyPart encryptedBodyPart = multipart.getBodyPart(1);
+        Assert.assertEquals("second part must be octet-stream of encrypted data",
+                "application/octet-stream", encryptedBodyPart.getContentType());
+        Assert.assertTrue("message body must be BinaryTempFileBody",
+                encryptedBodyPart.getBody() instanceof BinaryTempFileBody);
+        Assert.assertEquals(MimeUtil.ENC_7BIT, ((BinaryTempFileBody) encryptedBodyPart.getBody()).getEncoding());
     }
 
     @Test
@@ -325,7 +334,9 @@ public class PgpMessageBuilderTest {
         verifyNoMoreInteractions(mockCallback);
 
         MimeMessage message = captor.getValue();
-        Assert.assertEquals("message must be text/plain", "text/plain", message.getMimeType());
+        Assert.assertEquals("text/plain", message.getMimeType());
+        Assert.assertTrue("message body must be BinaryTempFileBody", message.getBody() instanceof BinaryTempFileBody);
+        Assert.assertEquals(MimeUtil.ENC_7BIT, ((BinaryTempFileBody) message.getBody()).getEncoding());
     }
 
     @Test
@@ -419,7 +430,8 @@ public class PgpMessageBuilderTest {
     private static void assertContentOfBodyPartEquals(String reason, BodyPart signatureBodyPart, String expected) {
         try {
             ByteArrayOutputStream bos = new ByteArrayOutputStream();
-            signatureBodyPart.getBody().writeTo(bos);
+            InputStream inputStream = MimeUtility.decodeBody(signatureBodyPart.getBody());
+            IOUtils.copy(inputStream, bos);
             Assert.assertEquals(reason, expected, new String(bos.toByteArray()));
         } catch (IOException | MessagingException e) {
             Assert.fail();


### PR DESCRIPTION
...what the title says.

PgpMessageBuilder got a hundred lines lighter in the process and lost the state machine, the logic should now be a lot easier to read. Pretty happy with that.