### PR TITLE
WebDav polling fix

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -497,19 +497,12 @@ class WebDavFolder extends Folder<WebDavMessage> {
             }
             WebDavMessage wdMessage = (WebDavMessage) messages.get(i);
 
-            if (listener != null) {
-                listener.messageStarted(wdMessage.getUid(), i, count);
-            }
-
             try {
                 wdMessage.setFlagInternal(Flag.SEEN, uidToReadStatus.get(wdMessage.getUid()));
             } catch (NullPointerException e) {
                 Log.v(LOG_TAG, "Under some weird circumstances, setting the read status when syncing from webdav threw an NPE. Skipping.");
             }
 
-            if (listener != null) {
-                listener.messageFinished(wdMessage, i, count);
-            }
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -525,7 +525,6 @@ public class MessagingController implements Runnable {
                 @Override
                 public void messagesFinished(int number) {}
                 @Override
-
                 public void messageFinished(LocalMessage message, int number, int ofTotal) {
                     if (!isMessageSuppressed(message)) {
                         List<LocalMessage> messages = new ArrayList<LocalMessage>();
@@ -1396,7 +1395,7 @@ public class MessagingController implements Runnable {
         final Date earliestDate = account.getEarliestPollDate();
 
         if (K9.DEBUG)
-            Log.d(K9.LOG_TAG, "SYNC: Fetching small messages for folder " + folder);
+            Log.d(K9.LOG_TAG, "SYNC: Fetching " + smallMessages.size() + " small messages for folder " + folder);
 
         remoteFolder.fetch(smallMessages,
         fp, new MessageRetrievalListener<T>() {


### PR DESCRIPTION
Fixes an observed "50/25" polling bug - we were actually downloading messages twice as a result because we were adding each message twice to a list.