### PR TITLE
Fix ImapFolderPusher connection reuse behaviour

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -74,7 +74,7 @@ class ImapConnection {
     private ImapSettings settings;
     private Exception stacktraceForClose;
     private boolean open = false;
-
+    private boolean closed = false;
 
     public ImapConnection(ImapSettings settings, TrustedSocketFactory socketFactory,
             ConnectivityManager connectivityManager) {
@@ -588,7 +588,6 @@ class ImapConnection {
     }
 
     public void close() {
-        open = false;
         stacktraceForClose = new Exception();
 
         IOUtils.closeQuietly(inputStream);
@@ -598,6 +597,12 @@ class ImapConnection {
         inputStream = null;
         outputStream = null;
         socket = null;
+        open = false;
+        closed = true;
+    }
+
+    public boolean hasBeenClosed() {
+        return closed;
     }
 
     public OutputStream getOutputStream() {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -122,11 +122,12 @@ class ImapFolder extends Folder<ImapMessage> {
         if (isOpen() && this.mode == mode) {
             // Make sure the connection is valid. If it's not we'll close it down and continue
             // on to get a new one.
-            try {
-                return executeSimpleCommand(Commands.NOOP);
-            } catch (IOException ioe) {
-                /* don't throw */ ioExceptionHandler(connection, ioe);
-            }
+            if (connection != null && !connection.hasBeenClosed())
+                try {
+                    return executeSimpleCommand(Commands.NOOP);
+                } catch (IOException ioe) {
+                    /* don't throw */ ioExceptionHandler(connection, ioe);
+                }
         }
 
         store.releaseConnection(connection);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
@@ -325,8 +325,10 @@ class ImapFolderPusher extends ImapFolder {
 
         private boolean openConnectionIfNecessary() throws MessagingException {
             ImapConnection oldConnection = connection;
-            internalOpen(OPEN_MODE_RO);
-
+            if (connection == null
+                    || (connection.isConnected() && !connection.hasBeenClosed())) {
+                internalOpen(OPEN_MODE_RO);
+            }
             ImapConnection conn = connection;
 
             checkConnectionNotNull(conn);


### PR DESCRIPTION
Should fix stacktrace seen in #1297 following the work done in #1300 

 

