### PR TITLE
Crash app when migrations fail in debug build

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -434,11 +434,10 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
                         afe.getMessage() == null ? "" : afe.getMessage());
             } catch (CertificateValidationException cve) {
                 handleCertificateValidationException(cve);
-            } catch (Throwable t) {
-                Log.e(K9.LOG_TAG, "Error while testing settings", t);
-                showErrorDialog(
-                        R.string.account_setup_failed_dlg_server_message_fmt,
-                        (t.getMessage() == null ? "" : t.getMessage()));
+            } catch (Exception e) {
+                Log.e(K9.LOG_TAG, "Error while testing settings", e);
+                String message = e.getMessage() == null ? "" : e.getMessage();
+                showErrorDialog(R.string.account_setup_failed_dlg_server_message_fmt, message);
             }
             return null;
         }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -9,6 +9,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.util.Log;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mailstore.migrations.Migrations;
@@ -34,6 +35,10 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
         try {
             upgradeDatabase(db);
         } catch (Exception e) {
+            if (BuildConfig.DEBUG) {
+                throw new Error("Exception while upgrading database", e);
+            }
+
             Log.e(K9.LOG_TAG, "Exception while upgrading database. Resetting the DB to v0", e);
             db.setVersion(0);
             upgradeDatabase(db);


### PR DESCRIPTION
I don't want to change the current behavior of recreating the database in case of an unexpected exception during migration (see #1228).

However, when using debug builds we rather want the app to crash than our database containing the data to trigger the error wiped away.