### PR TITLE
Fix ImapConnection reuse in ImapFolderPusher

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
@@ -253,6 +253,8 @@ class ImapFolderPusher extends ImapFolder {
             } catch (Exception me) {
                 Log.e(LOG_TAG, "Got exception while closing for exception for " + getLogId(), me);
             }
+
+            connection = null;
         }
 
         private long getNewUidNext() throws MessagingException {


### PR DESCRIPTION
Make sure `ImapConnection` is not reused after it has been closed due to an exception. Alternative to #1339 