### PR TITLE
Different fix for decrpyed part double decode problem

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/DecryptStreamParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/DecryptStreamParser.java
@@ -12,7 +12,6 @@ import android.content.Context;
 import android.util.Log;
 
 import com.fsck.k9.K9;
-import com.fsck.k9.crypto.DecryptedTempFileBody;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.Message;
@@ -67,7 +66,7 @@ public class DecryptStreamParser {
 
     private static Body createBody(InputStream inputStream, String transferEncoding, File decryptedTempDirectory)
             throws IOException {
-        DecryptedTempFileBody body = new DecryptedTempFileBody(transferEncoding, decryptedTempDirectory);
+        DecryptedTempFileBody body = new DecryptedTempFileBody(decryptedTempDirectory, transferEncoding);
         OutputStream outputStream = body.getOutputStream();
         try {
             InputStream decodingInputStream;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/DecryptStreamParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/DecryptStreamParser.java
@@ -70,7 +70,26 @@ public class DecryptStreamParser {
         DecryptedTempFileBody body = new DecryptedTempFileBody(transferEncoding, decryptedTempDirectory);
         OutputStream outputStream = body.getOutputStream();
         try {
-            IOUtils.copy(inputStream, outputStream);
+            InputStream decodingInputStream;
+            boolean closeStream;
+            if (MimeUtil.ENC_QUOTED_PRINTABLE.equals(transferEncoding)) {
+                decodingInputStream = new QuotedPrintableInputStream(inputStream, false);
+                closeStream = true;
+            } else if (MimeUtil.ENC_BASE64.equals(transferEncoding)) {
+                decodingInputStream = new Base64InputStream(inputStream);
+                closeStream = true;
+            } else {
+                decodingInputStream = inputStream;
+                closeStream = false;
+            }
+
+            try {
+                IOUtils.copy(decodingInputStream, outputStream);
+            } finally {
+                if (closeStream) {
+                    decodingInputStream.close();
+                }
+            }
         } finally {
             outputStream.close();
         }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/DecryptedTempFileBody.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/DecryptedTempFileBody.java
@@ -1,4 +1,4 @@
-package com.fsck.k9.crypto;
+package com.fsck.k9.mailstore;
 
 
 import java.io.File;
@@ -8,31 +8,27 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import android.annotation.TargetApi;
+import android.os.Build.VERSION_CODES;
+
+import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.MessagingException;
-import com.fsck.k9.mail.internet.RawDataBody;
 import com.fsck.k9.mail.internet.SizeAware;
 import org.apache.commons.io.IOUtils;
 
 
-public class DecryptedTempFileBody implements RawDataBody, SizeAware {
+public class DecryptedTempFileBody extends BinaryAttachmentBody implements SizeAware {
     private final File tempDirectory;
-    private final String encoding;
     private File file;
 
 
-    public DecryptedTempFileBody(String encoding, File tempDirectory) {
-        this.encoding = encoding;
+    public DecryptedTempFileBody(File tempDirectory, String transferEncoding) {
         this.tempDirectory = tempDirectory;
-    }
-
-    @Override
-    public String getEncoding() {
-        return encoding;
-    }
-
-    @Override
-    public void setEncoding(String encoding) throws MessagingException {
-        throw new RuntimeException("Not supported");
+        try {
+            setEncoding(transferEncoding);
+        } catch (MessagingException e) {
+            throw new AssertionError("setEncoding() must succeed");
+        }
     }
 
     public OutputStream getOutputStream() throws IOException {
@@ -46,16 +42,6 @@ public class DecryptedTempFileBody implements RawDataBody, SizeAware {
             return new FileInputStream(file);
         } catch (IOException ioe) {
             throw new MessagingException("Unable to open body", ioe);
-        }
-    }
-
-    @Override
-    public void writeTo(OutputStream out) throws IOException, MessagingException {
-        InputStream in = getInputStream();
-        try {
-            IOUtils.copy(in, out);
-        } finally {
-            in.close();
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessageExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessageExtractor.java
@@ -4,7 +4,6 @@ import android.content.Context;
 import android.net.Uri;
 
 import com.fsck.k9.R;
-import com.fsck.k9.crypto.DecryptedTempFileBody;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;


### PR DESCRIPTION
See #1252. This PR simply changes from RawDataBody to a regular Body, implicitly fixing the misbehavior in `MimeUtility.decodeBody`