### PR TITLE
ensure that multipart/* parts always have a non-null boundary field

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMultipart.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMultipart.java
@@ -32,7 +32,7 @@ public class MimeMultipart extends Multipart {
         this.boundary = boundary;
     }
 
-    public String generateBoundary() {
+    public static String generateBoundary() {
         Random random = new Random();
         StringBuilder sb = new StringBuilder();
         sb.append("----");

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -54,10 +54,10 @@ import com.fsck.k9.mail.message.MessageHeaderParser;
 import com.fsck.k9.mailstore.LockableDatabase.DbCallback;
 import com.fsck.k9.mailstore.LockableDatabase.WrappedException;
 import com.fsck.k9.message.extractors.AttachmentInfoExtractor;
+import com.fsck.k9.message.extractors.MessageFulltextCreator;
 import com.fsck.k9.message.extractors.MessagePreviewCreator;
 import com.fsck.k9.message.extractors.PreviewResult;
 import com.fsck.k9.message.extractors.PreviewResult.PreviewType;
-import com.fsck.k9.message.extractors.MessageFulltextCreator;
 import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
 import org.apache.commons.io.IOUtils;
@@ -1405,6 +1405,10 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         cv.put("display_name", attachment.displayName);
         cv.put("data_location", DataLocation.MISSING);
         cv.put("decoded_body_size", attachment.size);
+
+        if (MimeUtility.isMultipart(part.getMimeType())) {
+            cv.put("boundary", MimeMultipart.generateBoundary());
+        }
     }
 
     private void messageMarkerToContentValues(ContentValues cv) throws MessagingException {


### PR DESCRIPTION
See #1333. This makes sure that multipart fields always have a boundary field set in the database by generating a new one if the body of such part is null.