### PR TITLE
New option: bundle replies and forwards together with original messages

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -105,6 +105,7 @@ public class Account implements BaseAccount, StoreConfig {
     public static final boolean DEFAULT_QUOTED_TEXT_SHOWN = true;
     public static final boolean DEFAULT_REPLY_AFTER_QUOTE = false;
     public static final boolean DEFAULT_STRIP_SIGNATURE = true;
+    public static final boolean DEFAULT_BUNDLE_MESSAGE_FOLLOWINGS = false;
     public static final int DEFAULT_REMOTE_SEARCH_NUM_RESULTS = 25;
 
     public static final String ACCOUNT_DESCRIPTION_KEY = "description";
@@ -219,6 +220,7 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean mDefaultQuotedTextShown;
     private boolean mReplyAfterQuote;
     private boolean mStripSignature;
+    private boolean bundleMessageFollowings;
     private boolean mSyncRemoteDeletions;
     private String mCryptoApp;
     private long mCryptoKey;
@@ -314,6 +316,7 @@ public class Account implements BaseAccount, StoreConfig {
         mDefaultQuotedTextShown = DEFAULT_QUOTED_TEXT_SHOWN;
         mReplyAfterQuote = DEFAULT_REPLY_AFTER_QUOTE;
         mStripSignature = DEFAULT_STRIP_SIGNATURE;
+        bundleMessageFollowings = DEFAULT_BUNDLE_MESSAGE_FOLLOWINGS;
         mSyncRemoteDeletions = true;
         mCryptoApp = NO_OPENPGP_PROVIDER;
         mCryptoKey = NO_OPENPGP_KEY;
@@ -424,6 +427,7 @@ public class Account implements BaseAccount, StoreConfig {
         mDefaultQuotedTextShown = storage.getBoolean(mUuid + ".defaultQuotedTextShown", DEFAULT_QUOTED_TEXT_SHOWN);
         mReplyAfterQuote = storage.getBoolean(mUuid + ".replyAfterQuote", DEFAULT_REPLY_AFTER_QUOTE);
         mStripSignature = storage.getBoolean(mUuid + ".stripSignature", DEFAULT_STRIP_SIGNATURE);
+        bundleMessageFollowings = storage.getBoolean(mUuid + ".bundleMessageFollowings", DEFAULT_BUNDLE_MESSAGE_FOLLOWINGS);
         for (NetworkType type : NetworkType.values()) {
             Boolean useCompression = storage.getBoolean(mUuid + ".useCompression." + type,
                                      true);
@@ -553,6 +557,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.remove(mUuid + ".showPicturesEnum");
         editor.remove(mUuid + ".replyAfterQuote");
         editor.remove(mUuid + ".stripSignature");
+        editor.remove(mUuid + ".bundleMessageFollowings");
         editor.remove(mUuid + ".cryptoApp");
         editor.remove(mUuid + ".cryptoAutoSignature");
         editor.remove(mUuid + ".cryptoAutoEncrypt");
@@ -727,6 +732,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(mUuid + ".defaultQuotedTextShown", mDefaultQuotedTextShown);
         editor.putBoolean(mUuid + ".replyAfterQuote", mReplyAfterQuote);
         editor.putBoolean(mUuid + ".stripSignature", mStripSignature);
+        editor.putBoolean(mUuid + ".bundleMessageFollowings", bundleMessageFollowings);
         editor.putString(mUuid + ".cryptoApp", mCryptoApp);
         editor.putLong(mUuid + ".cryptoKey", mCryptoKey);
         editor.putBoolean(mUuid + ".allowRemoteSearch", mAllowRemoteSearch);
@@ -1596,6 +1602,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public synchronized void setStripSignature(boolean stripSignature) {
         mStripSignature = stripSignature;
+    }
+
+    public synchronized boolean isBundleMessageFollowings() {
+        return bundleMessageFollowings;
+    }
+
+    public synchronized void setBundleMessageFollowings(boolean bundleMessageFollowings) {
+        this.bundleMessageFollowings = bundleMessageFollowings;
     }
 
     public String getCryptoApp() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1769,7 +1769,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 Log.e(K9.LOG_TAG, "Failed to mark contact as contacted.", e);
             }
 
-            MessagingController.getInstance(context).sendMessage(account, message, null);
+            MessagingController.getInstance(context).sendMessage(account, message, messageReference, null);
             if (draftId != null) {
                 // TODO set draft id to invalid in MessageCompose!
                 MessagingController.getInstance(context).deleteDraft(account, draftId);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -109,6 +109,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_DEFAULT_QUOTED_TEXT_SHOWN = "default_quoted_text_shown";
     private static final String PREFERENCE_REPLY_AFTER_QUOTE = "reply_after_quote";
     private static final String PREFERENCE_STRIP_SIGNATURE = "strip_signature";
+    private static final String PREFERENCE_BUNDLE_MESSAGE_FOLLOWINGS = "bundle_message_followings";
     private static final String PREFERENCE_SYNC_REMOTE_DELETIONS = "account_sync_remote_deletetions";
     private static final String PREFERENCE_CRYPTO = "crypto";
     private static final String PREFERENCE_CRYPTO_APP = "crypto_app";
@@ -172,6 +173,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private CheckBoxPreference mAccountDefaultQuotedTextShown;
     private CheckBoxPreference mReplyAfterQuote;
     private CheckBoxPreference mStripSignature;
+    private CheckBoxPreference bundleMessageFollowings;
     private CheckBoxPreference mSyncRemoteDeletions;
     private CheckBoxPreference mPushPollOnConnect;
     private ListPreference mIdleRefreshPeriod;
@@ -280,6 +282,9 @@ public class AccountSettings extends K9PreferenceActivity {
 
         mStripSignature = (CheckBoxPreference) findPreference(PREFERENCE_STRIP_SIGNATURE);
         mStripSignature.setChecked(mAccount.isStripSignature());
+
+        bundleMessageFollowings = (CheckBoxPreference) findPreference(PREFERENCE_BUNDLE_MESSAGE_FOLLOWINGS);
+        bundleMessageFollowings.setChecked(mAccount.isBundleMessageFollowings());
 
         mComposingScreen = (PreferenceScreen) findPreference(PREFERENCE_SCREEN_COMPOSING);
 
@@ -779,6 +784,7 @@ public class AccountSettings extends K9PreferenceActivity {
         mAccount.setDefaultQuotedTextShown(mAccountDefaultQuotedTextShown.isChecked());
         mAccount.setReplyAfterQuote(mReplyAfterQuote.isChecked());
         mAccount.setStripSignature(mStripSignature.isChecked());
+        mAccount.setBundleMessageFollowings(bundleMessageFollowings.isChecked());
         mAccount.setLocalStorageProviderId(mLocalStorageProvider.getValue());
         if (mHasCrypto) {
             mAccount.setCryptoApp(mCryptoApp.getValue());

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -185,6 +185,9 @@ public class AccountSettings {
         s.put("stripSignature", Settings.versions(
                 new V(2, new BooleanSetting(Account.DEFAULT_STRIP_SIGNATURE))
             ));
+        s.put("bundleMessageFollowings", Settings.versions(
+                new V(42, new BooleanSetting(Account.DEFAULT_BUNDLE_MESSAGE_FOLLOWINGS))
+            ));
         s.put("subscribedFoldersOnly", Settings.versions(
                 new V(1, new BooleanSetting(false))
             ));

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 41;
+    public static final int VERSION = 42;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,

--- a/k9mail/src/main/res/values-pt-rBR/strings.xml
+++ b/k9mail/src/main/res/values-pt-rBR/strings.xml
@@ -413,8 +413,6 @@
   <string name="account_settings_reply_after_quote_summary">Quando respondendo mensagens, o texto original deverá aparecer acima da minha resposta.</string>
   <string name="account_settings_strip_signature_label">Tirar assinaturas em respostas</string>
   <string name="account_settings_strip_signature_summary">Assinaturas serão removidas em mensagens com citação</string>
-  <string name="account_settings_bundle_message_followings_label">Agrupar sequências a mensagens</string>
-  <string name="account_settings_bundle_message_followings_summary">Respostas e encaminhamentos serão guardados na mesma pasta que a mensagem original</string>
   <string name="account_settings_message_format_label">Formato da Mensagem</string>
   <string name="account_settings_message_format_text">Texto (imagens e formatação serão removidas)</string>
   <string name="account_settings_message_format_html">HTML (imagens e formatação serão preservadas)</string>

--- a/k9mail/src/main/res/values-pt-rBR/strings.xml
+++ b/k9mail/src/main/res/values-pt-rBR/strings.xml
@@ -413,6 +413,8 @@
   <string name="account_settings_reply_after_quote_summary">Quando respondendo mensagens, o texto original deverá aparecer acima da minha resposta.</string>
   <string name="account_settings_strip_signature_label">Tirar assinaturas em respostas</string>
   <string name="account_settings_strip_signature_summary">Assinaturas serão removidas em mensagens com citação</string>
+  <string name="account_settings_bundle_message_followings_label">Agrupar sequências a mensagens</string>
+  <string name="account_settings_bundle_message_followings_summary">Respostas e encaminhamentos serão guardados na mesma pasta que a mensagem original</string>
   <string name="account_settings_message_format_label">Formato da Mensagem</string>
   <string name="account_settings_message_format_text">Texto (imagens e formatação serão removidas)</string>
   <string name="account_settings_message_format_html">HTML (imagens e formatação serão preservadas)</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -553,6 +553,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_strip_signature_label">Strip signatures on reply</string>
     <string name="account_settings_strip_signature_summary">Signatures will be removed from quoted messages</string>
 
+    <string name="account_settings_bundle_message_followings_label">Bundle message followings</string>
+    <string name="account_settings_bundle_message_followings_summary">Replies and forwarded messages will be saved to the folder containing the original message</string>
+
     <string name="account_settings_message_format_label">Message Format</string>
     <string name="account_settings_message_format_text">Plain Text (remove images and formatting)</string>
     <string name="account_settings_message_format_html">HTML (keep images and formatting)</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -241,6 +241,13 @@
             android:defaultValue="true"
             android:summary="@string/account_settings_strip_signature_summary" />
 
+        <CheckBoxPreference
+            android:persistent="false"
+            android:key="bundle_message_followings"
+            android:title="@string/account_settings_bundle_message_followings_label"
+            android:defaultValue="false"
+            android:summary="@string/account_settings_bundle_message_followings_summary" />
+
         <EditTextPreference
             android:persistent="false"
             android:key="account_quote_prefix"


### PR DESCRIPTION
Add new per-account flag for optionally saving replies and forwarded messages to the same folder as the original message, similar to [Thunderbird's behaviour](http://forums.mozillazine.org/viewtopic.php?f=39&t=1870275), allowing for consistent actions between desktop and mobile for those who fancy this particular flow (me included.)

In order to keep it simple, this particular implementation is a best effort - it won't have any effect if a message is sent on an application run other than the one under which it was created, nor if sending using an account different than the one through which we received the original message.

Making it persist between application runs would be nice but, from I was able to gather from the code, it would require significant changes to the way messages are persisted in local folders, as well as mixing in some semantic weirdness: a complexity increase to cover something that will happen rarely in the first place. As for making it work between separate accounts: the potential edge cases made my head hurt, and this is a per-account setting anyway.
