### PR TITLE
Fetch message on view if body unavailable

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Store.java
@@ -13,7 +13,7 @@ import java.util.List;
  * making as few network connections as possible.
  */
 public abstract class Store {
-    public abstract Folder getFolder(String name);
+    public abstract Folder<? extends Message> getFolder(String name);
 
     public abstract List <? extends Folder > getPersonalNamespaces(boolean forceListAll) throws MessagingException;
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2691,6 +2691,16 @@ public class MessagingController implements Runnable {
         }
     }
 
+    public void loadMessagePartialForViewRemote(final Account account, final String folder,
+            final String uid, final MessagingListener listener) {
+        put("loadMessageForViewRemote", listener, new Runnable() {
+            @Override
+            public void run() {
+                loadMessageForViewRemoteSynchronous(account, folder, uid, listener, true);
+            }
+        });
+    }
+
     //TODO: Fix the callback mess. See GH-782
     public void loadMessageForViewRemote(final Account account, final String folder,
                                          final String uid, final MessagingListener listener) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1,6 +1,6 @@
 package com.fsck.k9.controller;
 
-import android.os.SystemClock;
+
 import java.io.CharArrayWriter;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -18,7 +18,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
-import java.util.concurrent.*;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -31,6 +38,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.PowerManager;
 import android.os.Process;
+import android.os.SystemClock;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
@@ -45,18 +53,16 @@ import com.fsck.k9.R;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
 import com.fsck.k9.cache.EmailProviderCache;
+import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.CertificateValidationException;
-import com.fsck.k9.mail.power.TracingPowerManager;
-import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
-import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.FetchProfile;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.Folder.FolderType;
-
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Message.RecipientType;
+import com.fsck.k9.mail.MessageRetrievalListener;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.PushReceiver;
@@ -68,14 +74,15 @@ import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.internet.MimeMessageHelper;
 import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mail.internet.TextBody;
-import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
-import com.fsck.k9.mailstore.MessageRemovalListener;
-import com.fsck.k9.mail.MessageRetrievalListener;
+import com.fsck.k9.mail.power.TracingPowerManager;
+import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
+import com.fsck.k9.mail.store.pop3.Pop3Store;
 import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.mailstore.LocalStore.PendingCommand;
-import com.fsck.k9.mail.store.pop3.Pop3Store;
+import com.fsck.k9.mailstore.MessageRemovalListener;
 import com.fsck.k9.mailstore.UnavailableStorageException;
 import com.fsck.k9.notification.NotificationController;
 import com.fsck.k9.provider.EmailProvider;
@@ -2690,14 +2697,13 @@ public class MessagingController implements Runnable {
         put("loadMessageForViewRemote", listener, new Runnable() {
             @Override
             public void run() {
-                loadMessageForViewRemoteSynchronous(account, folder, uid, listener, false, false);
+                loadMessageForViewRemoteSynchronous(account, folder, uid, listener, false);
             }
         });
     }
 
     public boolean loadMessageForViewRemoteSynchronous(final Account account, final String folder,
-            final String uid, final MessagingListener listener, final boolean force,
-            final boolean loadPartialFromSearch) {
+            final String uid, final MessagingListener listener, final boolean loadPartialFromSearch) {
         Folder remoteFolder = null;
         LocalFolder localFolder = null;
         try {
@@ -2826,9 +2832,7 @@ public class MessagingController implements Runnable {
                     // TODO: limit by account.getMaximumAutoDownloadMessageSize().
                     if (!message.isSet(Flag.X_DOWNLOADED_FULL) &&
                             !message.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
-                        if (loadMessageForViewRemoteSynchronous(account, folder, uid, listener,
-                                false, true)) {
-
+                        if (loadMessageForViewRemoteSynchronous(account, folder, uid, listener, true)) {
                             markMessageAsReadOnView(account, message);
                         }
                         return;

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2750,25 +2750,32 @@ public class MessagingController implements Runnable {
 
                 // Get the remote message and fully download it
                 Message remoteMessage = remoteFolder.getMessage(uid);
-                FetchProfile fp = new FetchProfile();
-                fp.add(FetchProfile.Item.BODY);
 
-                remoteFolder.fetch(Collections.singletonList(remoteMessage), fp, null);
-
-                // Store the message locally and load the stored message into memory
-                localFolder.appendMessages(Collections.singletonList(remoteMessage));
                 if (loadPartialFromSearch) {
+                    downloadMessages(account, remoteFolder, localFolder,
+                            Collections.singletonList(remoteMessage), false);
+                } else {
+                    FetchProfile fp = new FetchProfile();
                     fp.add(FetchProfile.Item.BODY);
+                    remoteFolder.fetch(Collections.singletonList(remoteMessage), fp, null);
+                    localFolder.appendMessages(Collections.singletonList(remoteMessage));
                 }
-                fp.add(FetchProfile.Item.ENVELOPE);
+
                 message = localFolder.getMessage(uid);
+
+                FetchProfile fp = new FetchProfile();
+                fp.add(FetchProfile.Item.ENVELOPE);
+                fp.add(FetchProfile.Item.BODY);
                 localFolder.fetch(Collections.singletonList(message), fp, null);
+
+                if (!loadPartialFromSearch) {
+                    message.setFlag(Flag.X_DOWNLOADED_FULL, true);
+                }
 
                 // Mark that this message is now fully synched
                 if (account.isMarkMessageAsReadOnView()) {
                     message.setFlag(Flag.SEEN, true);
                 }
-                message.setFlag(Flag.X_DOWNLOADED_FULL, true);
             }
 
             // now that we have the full message, refresh the headers

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -227,7 +227,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         displayMessageHeader(message);
 
         if (message.isBodyMissing()) {
-            startDownloadingMessageBody(message);
+            startDownloadingMessageBody();
         } else {
             messageCryptoHelper.decryptOrVerifyMessagePartsIfNecessary(message);
         }
@@ -237,8 +237,9 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         // mMessageView.showStatusMessage(mContext.getString(R.string.status_invalid_id_error));
     }
 
-    private void startDownloadingMessageBody(LocalMessage message) {
-        throw new RuntimeException("Not implemented yet");
+    private void startDownloadingMessageBody() {
+        mController.loadMessagePartialForViewRemote(
+                mAccount, mMessageReference.getFolderName(), mMessageReference.getUid(), downloadMessageListener);
     }
 
     private void onMessageDownloadFinished(LocalMessage message) {


### PR DESCRIPTION
Fix for #1384, getting rid of the not-implemented RuntimeException.

I assumed we don't want to download the entire message on view. The only critical commit in this PR is the first one: There was a `loadPartialForSearch` parameter in `loadMessageForView`, but that was a noop (unless I missed something) so I fixed it. I use `downloadMessages` to load messages, which takes care of the partial message download. 

I have no server to test server-side searching with and no insight about messagingcontroller behavior for that use case, so it would be helpful if someone could test behavior for that.