### PR TITLE
Add debug operation to clear a message locally

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -29,6 +29,7 @@ import java.util.concurrent.PriorityBlockingQueue;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import android.annotation.SuppressLint;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
@@ -46,6 +47,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.Account.DeletePolicy;
 import com.fsck.k9.Account.Expunge;
 import com.fsck.k9.AccountStats;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.Intents;
 import com.fsck.k9.Preferences;
@@ -3664,6 +3666,27 @@ public class MessagingController implements Runnable {
                 });
             }
 
+        });
+
+    }
+
+    @SuppressLint("NewApi") // used for debugging only
+    public void debugClearMessagesLocally(final List<LocalMessage> messages) {
+        if (!BuildConfig.DEBUG) {
+            throw new AssertionError("method must only be used in debug build!");
+        }
+
+        putBackground("debugClearLocalMessages", null, new Runnable() {
+            @Override
+            public void run() {
+                for (LocalMessage message : messages) {
+                    try {
+                        message.debugClearLocalData();
+                    } catch (MessagingException e) {
+                        throw new AssertionError("clearing local message content failed!", e);
+                    }
+                }
+            }
         });
 
     }

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.fragment;
 
+
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -67,6 +68,7 @@ import android.widget.Toast;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.SortType;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.FontSizes;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
@@ -79,7 +81,16 @@ import com.fsck.k9.activity.misc.ContactPictureLoader;
 import com.fsck.k9.cache.EmailProviderCache;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.fragment.ConfirmationDialogFragment.ConfirmationDialogFragmentListener;
-import com.fsck.k9.fragment.MessageListFragmentComparators.*;
+import com.fsck.k9.fragment.MessageListFragmentComparators.ArrivalComparator;
+import com.fsck.k9.fragment.MessageListFragmentComparators.AttachmentComparator;
+import com.fsck.k9.fragment.MessageListFragmentComparators.ComparatorChain;
+import com.fsck.k9.fragment.MessageListFragmentComparators.DateComparator;
+import com.fsck.k9.fragment.MessageListFragmentComparators.FlaggedComparator;
+import com.fsck.k9.fragment.MessageListFragmentComparators.ReverseComparator;
+import com.fsck.k9.fragment.MessageListFragmentComparators.ReverseIdComparator;
+import com.fsck.k9.fragment.MessageListFragmentComparators.SenderComparator;
+import com.fsck.k9.fragment.MessageListFragmentComparators.SubjectComparator;
+import com.fsck.k9.fragment.MessageListFragmentComparators.UnreadComparator;
 import com.fsck.k9.helper.ContactPicture;
 import com.fsck.k9.helper.MergeCursorWithUniqueId;
 import com.fsck.k9.helper.MessageHelper;
@@ -104,7 +115,6 @@ import com.fsck.k9.search.SearchSpecification;
 import com.fsck.k9.search.SearchSpecification.SearchCondition;
 import com.fsck.k9.search.SearchSpecification.SearchField;
 import com.fsck.k9.search.SqlQueryBuilder;
-
 import com.handmark.pulltorefresh.library.ILoadingLayout;
 import com.handmark.pulltorefresh.library.PullToRefreshBase;
 import com.handmark.pulltorefresh.library.PullToRefreshListView;
@@ -1410,6 +1420,12 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 onCopy(getMessageAtPosition(adapterPosition));
                 break;
             }
+
+            // debug options
+            case R.id.debug_delete_locally: {
+                onDebugClearLocally(getMessageAtPosition(adapterPosition));
+                break;
+            }
         }
 
         mContextMenuUniqueId = 0;
@@ -1435,6 +1451,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         }
 
         getActivity().getMenuInflater().inflate(R.menu.message_list_item_context, menu);
+        menu.findItem(R.id.debug_delete_locally).setVisible(BuildConfig.DEBUG);
 
         mContextMenuUniqueId = cursor.getLong(mUniqueIdColumn);
         Account account = getAccountFromCursor(cursor);
@@ -2316,6 +2333,10 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 messages.get(0).getFolder().getAccountUuid(),
                 null,
                 messages);
+    }
+
+    private void onDebugClearLocally(LocalMessage message) {
+        mController.debugClearMessagesLocally(Collections.singletonList(message));
     }
 
     /**

--- a/k9mail/src/main/res/menu/message_list_item_context.xml
+++ b/k9mail/src/main/res/menu/message_list_item_context.xml
@@ -56,4 +56,8 @@
     <item
         android:id="@+id/same_sender"
         android:title="@string/from_same_sender" />
+    <item
+        android:id="@+id/debug_delete_locally"
+        android:title="Debug / Clear message body"
+        />
 </menu>


### PR DESCRIPTION
While working on #1386 I needed a way to clear messages easily. This adds a menu item to the messagelist context menu which does just that, and which is only shown if `K9.DEBUG`.

I'm not sure if we merge that sort of thing, but thought I'd put it here anyways. Having those options available makes it more easy to test corner cases, increasing the probability that people test them.