### PR TITLE
extract AttachmentPresenter from MessageCompose

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Part.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Part.java
@@ -18,7 +18,7 @@ public interface Part {
 
     String getContentType();
 
-    String getDisposition() throws MessagingException;
+    String getDisposition();
 
     String getContentId();
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/DecoderUtil.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/DecoderUtil.java
@@ -91,7 +91,7 @@ class DecoderUtil {
 
         // ANDROID:  Most strings will not include "=?" so a quick test can prevent unneeded
         // object creation.  This could also be handled via lazy creation of the StringBuilder.
-        if (body.indexOf("=?") == -1) {
+        if (!body.contains("=?")) {
             return body;
         }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
@@ -440,12 +440,10 @@ public class MessageExtractor {
     }
 
     private static String getContentDisposition(Part part) {
-        try {
-            String disposition = part.getDisposition();
-            if (disposition != null) {
-                return MimeUtility.getHeaderParameter(disposition, null);
-            }
-        } catch (MessagingException e) { /* ignore */ }
+        String disposition = part.getDisposition();
+        if (disposition != null) {
+            return MimeUtility.getHeaderParameter(disposition, null);
+        }
         return null;
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
@@ -92,11 +92,11 @@ public class MimeBodyPart extends BodyPart {
     @Override
     public String getContentType() {
         String contentType = getFirstHeader(MimeHeader.HEADER_CONTENT_TYPE);
-        return (contentType == null) ? "text/plain" : contentType;
+        return (contentType == null) ? "text/plain" : MimeUtility.unfoldAndDecode(contentType);
     }
 
     @Override
-    public String getDisposition() throws MessagingException {
+    public String getDisposition() {
         return getFirstHeader(MimeHeader.HEADER_CONTENT_DISPOSITION);
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -164,12 +164,12 @@ public class MimeMessage extends Message {
     @Override
     public String getContentType() {
         String contentType = getFirstHeader(MimeHeader.HEADER_CONTENT_TYPE);
-        return (contentType == null) ? "text/plain" : contentType;
+        return (contentType == null) ? "text/plain" : MimeUtility.unfoldAndDecode(contentType);
     }
 
     @Override
-    public String getDisposition() throws MessagingException {
-        return getFirstHeader(MimeHeader.HEADER_CONTENT_DISPOSITION);
+    public String getDisposition() {
+        return MimeUtility.unfoldAndDecode(getFirstHeader(MimeHeader.HEADER_CONTENT_DISPOSITION));
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -1,0 +1,371 @@
+package com.fsck.k9.activity.compose;
+
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.app.LoaderManager;
+import android.content.ClipData;
+import android.content.Context;
+import android.content.Intent;
+import android.content.Loader;
+import android.net.Uri;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+
+import com.fsck.k9.activity.compose.ComposeCryptoStatus.AttachErrorState;
+import com.fsck.k9.activity.loader.AttachmentContentLoader;
+import com.fsck.k9.activity.loader.AttachmentInfoLoader;
+import com.fsck.k9.activity.misc.Attachment;
+import com.fsck.k9.activity.misc.Attachment.LoadingState;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.Multipart;
+import com.fsck.k9.mail.Part;
+import com.fsck.k9.mail.internet.MimeUtility;
+import com.fsck.k9.mailstore.LocalBodyPart;
+import com.fsck.k9.provider.AttachmentProvider;
+
+
+public class AttachmentPresenter {
+    private static final String STATE_KEY_ATTACHMENTS = "com.fsck.k9.activity.MessageCompose.attachments";
+    private static final String STATE_KEY_WAITING_FOR_ATTACHMENTS = "waitingForAttachments";
+    private static final String STATE_KEY_NEXT_LOADER_ID = "nextLoaderId";
+
+    private static final String LOADER_ARG_ATTACHMENT = "attachment";
+    private static final int LOADER_ID_MASK = 1 << 6;
+    public static final int MAX_TOTAL_LOADERS = LOADER_ID_MASK -1;
+    public static final int REQUEST_CODE_ATTACHMENT_URI = 1;
+
+
+    // injected state
+    private final Context context;
+    private final AttachmentMvpView attachmentMvpView;
+    private final LoaderManager loaderManager;
+
+    // persistent state
+    private LinkedHashMap<Uri, Attachment> attachments;
+    private int nextLoaderId = 0;
+    private WaitingAction actionToPerformAfterWaiting = WaitingAction.NONE;
+
+
+    public AttachmentPresenter(Context context, AttachmentMvpView attachmentMvpView, LoaderManager loaderManager) {
+        this.context = context;
+        this.attachmentMvpView = attachmentMvpView;
+        this.loaderManager = loaderManager;
+
+        attachments = new LinkedHashMap<>();
+    }
+
+    public void onSaveInstanceState(Bundle outState) {
+        outState.putString(STATE_KEY_WAITING_FOR_ATTACHMENTS, actionToPerformAfterWaiting.name());
+        outState.putParcelableArrayList(STATE_KEY_ATTACHMENTS, createAttachmentList());
+        outState.putInt(STATE_KEY_NEXT_LOADER_ID, nextLoaderId);
+    }
+
+    public void onRestoreInstanceState(Bundle savedInstanceState) {
+        actionToPerformAfterWaiting = WaitingAction.valueOf(
+                savedInstanceState.getString(STATE_KEY_WAITING_FOR_ATTACHMENTS));
+        nextLoaderId = savedInstanceState.getInt(STATE_KEY_NEXT_LOADER_ID);
+
+        ArrayList<Attachment> attachmentList = savedInstanceState.getParcelableArrayList(STATE_KEY_ATTACHMENTS);
+        // noinspection ConstantConditions, we know this is set in onSaveInstanceState
+        for (Attachment attachment : attachmentList) {
+            attachments.put(attachment.uri, attachment);
+            attachmentMvpView.addAttachmentView(attachment);
+
+            if (attachment.state == LoadingState.URI_ONLY) {
+                initAttachmentInfoLoader(attachment);
+            } else if (attachment.state == LoadingState.METADATA) {
+                initAttachmentContentLoader(attachment);
+            }
+        }
+    }
+
+    public boolean checkOkForSendingOrDraftSaving() {
+        if (actionToPerformAfterWaiting != WaitingAction.NONE) {
+            return true;
+        }
+
+        if (hasLoadingAttachments()) {
+            actionToPerformAfterWaiting = WaitingAction.SEND;
+            attachmentMvpView.showWaitingForAttachmentDialog(actionToPerformAfterWaiting);
+            return true;
+        }
+
+        return false;
+    }
+
+    private boolean hasLoadingAttachments() {
+        for (Attachment attachment : attachments.values()) {
+            Loader loader = loaderManager.getLoader(attachment.loaderId);
+            if (loader != null && loader.isStarted()) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public ArrayList<Attachment> createAttachmentList() {
+        ArrayList<Attachment> result = new ArrayList<>();
+        for (Attachment attachment : attachments.values()) {
+            result.add(attachment);
+        }
+        return result;
+    }
+
+    public void onClickAddAttachment(RecipientPresenter recipientPresenter) {
+        AttachErrorState maybeAttachErrorState = recipientPresenter.getCurrentCryptoStatus().getAttachErrorStateOrNull();
+        if (maybeAttachErrorState != null) {
+            recipientPresenter.showPgpAttachError(maybeAttachErrorState);
+            return;
+        }
+
+        attachmentMvpView.showPickAttachmentDialog(REQUEST_CODE_ATTACHMENT_URI);
+    }
+
+    private void addAttachment(Uri uri) {
+        addAttachment(uri, null);
+    }
+
+    public void addAttachment(Uri uri, String contentType) {
+        Attachment attachment = new Attachment();
+        attachment.uri = uri;
+        attachment.state = Attachment.LoadingState.URI_ONLY;
+        attachment.contentType = contentType;
+        attachment.loaderId = getNextFreeLoaderId();
+
+        if (attachments.containsKey(uri)) {
+            return;
+        }
+
+        attachments.put(uri, attachment);
+        attachmentMvpView.addAttachmentView(attachment);
+
+        initAttachmentInfoLoader(attachment);
+    }
+
+    private void initAttachmentInfoLoader(Attachment attachment) {
+        Bundle bundle = new Bundle();
+        bundle.putParcelable(LOADER_ARG_ATTACHMENT, attachment.uri);
+
+        loaderManager.initLoader(attachment.loaderId, bundle, mAttachmentInfoLoaderCallback);
+    }
+
+    private void initAttachmentContentLoader(Attachment attachment) {
+        Bundle bundle = new Bundle();
+        bundle.putParcelable(LOADER_ARG_ATTACHMENT, attachment.uri);
+
+        loaderManager.initLoader(attachment.loaderId, bundle, mAttachmentContentLoaderCallback);
+    }
+
+    private int getNextFreeLoaderId() {
+        if (nextLoaderId >= MAX_TOTAL_LOADERS) {
+            throw new AssertionError("more than " + MAX_TOTAL_LOADERS + " attachments? hum.");
+        }
+        return LOADER_ID_MASK | nextLoaderId++;
+    }
+
+    private LoaderManager.LoaderCallbacks<Attachment> mAttachmentInfoLoaderCallback =
+            new LoaderManager.LoaderCallbacks<Attachment>() {
+                @Override
+                public Loader<Attachment> onCreateLoader(int id, Bundle args) {
+                    Uri uri = args.getParcelable(LOADER_ARG_ATTACHMENT);
+                    return new AttachmentInfoLoader(context, attachments.get(uri));
+                }
+
+                @Override
+                public void onLoadFinished(Loader<Attachment> loader, Attachment attachment) {
+                    int loaderId = loader.getId();
+                    loaderManager.destroyLoader(loaderId);
+
+                    if (!attachments.containsKey(attachment.uri)) {
+                        return;
+                    }
+
+                    attachmentMvpView.updateAttachmentView(attachment);
+                    attachments.put(attachment.uri, attachment);
+                    initAttachmentContentLoader(attachment);
+                }
+
+                @Override
+                public void onLoaderReset(Loader<Attachment> loader) {
+                    // nothing to do
+                }
+            };
+
+    private LoaderManager.LoaderCallbacks<Attachment> mAttachmentContentLoaderCallback =
+            new LoaderManager.LoaderCallbacks<Attachment>() {
+                @Override
+                public Loader<Attachment> onCreateLoader(int id, Bundle args) {
+                    Uri uri = args.getParcelable(LOADER_ARG_ATTACHMENT);
+                    return new AttachmentContentLoader(context, attachments.get(uri));
+                }
+
+                @Override
+                public void onLoadFinished(Loader<Attachment> loader, Attachment attachment) {
+                    int loaderId = loader.getId();
+                    loaderManager.destroyLoader(loaderId);
+
+                    if (!attachments.containsKey(attachment.uri)) {
+                        return;
+                    }
+
+                    if (attachment.state == Attachment.LoadingState.COMPLETE) {
+                        attachmentMvpView.updateAttachmentView(attachment);
+                        attachments.put(attachment.uri, attachment);
+                    } else {
+                        attachments.remove(attachment.uri);
+                        attachmentMvpView.removeAttachmentView(attachment);
+                    }
+
+                    postPerformStalledAction();
+                }
+
+                @Override
+                public void onLoaderReset(Loader<Attachment> loader) {
+                    // nothing to do
+                }
+            };
+
+    private void postPerformStalledAction() {
+        new Handler().post(new Runnable() {
+            @Override
+            public void run() {
+                performStalledAction();
+            }
+        });
+    }
+
+    void performStalledAction() {
+        attachmentMvpView.dismissWaitingForAttachmentDialog();
+
+        WaitingAction waitingFor = actionToPerformAfterWaiting;
+        actionToPerformAfterWaiting = WaitingAction.NONE;
+
+        switch (waitingFor) {
+            case SEND: {
+                attachmentMvpView.performSendAfterChecks();
+                break;
+            }
+            case SAVE: {
+                attachmentMvpView.performSaveAfterChecks();
+                break;
+            }
+        }
+    }
+
+    /**
+     * Add all attachments of an existing message as if they were added by hand.
+     *
+     * @param part
+     *         The message part to check for being an attachment. This method will recurse if it's
+     *         a multipart part.
+     * @param depth
+     *         The recursion depth. Currently unused.
+     *
+     * @return {@code true} if all attachments were able to be attached, {@code false} otherwise.
+     *
+     * @throws MessagingException
+     *          In case of an error
+     */
+    public boolean loadAttachments(Part part, int depth) throws MessagingException {
+        if (part.getBody() instanceof Multipart) {
+            Multipart mp = (Multipart) part.getBody();
+            boolean ret = true;
+            for (int i = 0, count = mp.getCount(); i < count; i++) {
+                if (!loadAttachments(mp.getBodyPart(i), depth + 1)) {
+                    ret = false;
+                }
+            }
+            return ret;
+        }
+
+        String contentType = MimeUtility.unfoldAndDecode(part.getContentType());
+        String name = MimeUtility.getHeaderParameter(contentType, "name");
+        if (name != null) {
+            if (part instanceof LocalBodyPart) {
+                LocalBodyPart localBodyPart = (LocalBodyPart) part;
+                String accountUuid = localBodyPart.getAccountUuid();
+                long attachmentId = localBodyPart.getId();
+                Uri uri = AttachmentProvider.getAttachmentUri(accountUuid, attachmentId);
+                addAttachment(uri);
+                return true;
+            }
+            return false;
+        }
+        return true;
+    }
+
+    @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+    void addAttachmentsFromResultIntent(Intent data) {
+        // TODO draftNeedsSaving = true
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            ClipData clipData = data.getClipData();
+            if (clipData != null) {
+                for (int i = 0, end = clipData.getItemCount(); i < end; i++) {
+                    Uri uri = clipData.getItemAt(i).getUri();
+                    if (uri != null) {
+                        addAttachment(uri);
+                    }
+                }
+                return;
+            }
+        }
+
+        Uri uri = data.getData();
+        if (uri != null) {
+            addAttachment(uri);
+        }
+    }
+
+    public void attachmentProgressDialogCancelled() {
+        actionToPerformAfterWaiting = WaitingAction.NONE;
+    }
+
+    public void onClickRemoveAttachment(Uri uri) {
+        Attachment attachment = attachments.get(uri);
+
+        loaderManager.destroyLoader(attachment.loaderId);
+
+        attachmentMvpView.removeAttachmentView(attachment);
+        attachments.remove(uri);
+    }
+
+    public void onActivityResult(int resultCode, int requestCode, Intent data) {
+        if (requestCode != REQUEST_CODE_ATTACHMENT_URI) {
+            throw new AssertionError("onActivityResult must only be called for our request code");
+        }
+        if (resultCode != Activity.RESULT_OK) {
+            return;
+        }
+
+        if (data == null) {
+            return;
+        }
+        addAttachmentsFromResultIntent(data);
+    }
+
+    public enum WaitingAction {
+        NONE,
+        SEND,
+        SAVE
+    }
+
+    public interface AttachmentMvpView {
+        void showWaitingForAttachmentDialog(WaitingAction waitingAction);
+        void dismissWaitingForAttachmentDialog();
+        void showPickAttachmentDialog(int requestCode);
+
+        void addAttachmentView(Attachment attachment);
+        void removeAttachmentView(Attachment attachment);
+        void updateAttachmentView(Attachment attachment);
+
+        // TODO these should not really be here :\
+        void performSendAfterChecks();
+        void performSaveAfterChecks();
+
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -131,11 +131,8 @@ public class AttachmentPresenter {
     }
 
     public void addAttachment(Uri uri, String contentType) {
-        Attachment attachment = new Attachment();
-        attachment.uri = uri;
-        attachment.state = Attachment.LoadingState.URI_ONLY;
-        attachment.contentType = contentType;
-        attachment.loaderId = getNextFreeLoaderId();
+        int loaderId = getNextFreeLoaderId();
+        Attachment attachment = Attachment.createAttachment(uri, loaderId, contentType);
 
         if (attachments.containsKey(uri)) {
             return;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -280,7 +280,7 @@ public class AttachmentPresenter {
             return ret;
         }
 
-        String contentType = MimeUtility.unfoldAndDecode(part.getContentType());
+        String contentType = part.getContentType();
         String name = MimeUtility.getHeaderParameter(contentType, "name");
         if (name != null) {
             if (part instanceof LocalBodyPart) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -24,6 +24,7 @@ import com.fsck.k9.R;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.AttachErrorState;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.ComposeCryptoStatusBuilder;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.SendErrorState;
+import com.fsck.k9.activity.misc.Attachment;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.helper.MailTo;
 import com.fsck.k9.helper.ReplyToParser;

--- a/k9mail/src/main/java/com/fsck/k9/activity/misc/Attachment.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/misc/Attachment.java
@@ -61,7 +61,7 @@ public class Attachment implements Parcelable {
 
     public Attachment() {}
 
-    public static enum LoadingState {
+    public enum LoadingState {
         /**
          * The only thing we know about this attachment is {@link #uri}.
          */
@@ -84,7 +84,6 @@ public class Attachment implements Parcelable {
          */
         CANCELLED
     }
-
 
     // === Parcelable ===
 

--- a/k9mail/src/main/java/com/fsck/k9/fragment/ProgressDialogFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/ProgressDialogFragment.java
@@ -43,14 +43,13 @@ public class ProgressDialogFragment extends DialogFragment {
         Activity activity = getActivity();
         if (activity != null && activity instanceof CancelListener) {
             CancelListener listener = (CancelListener) activity;
-            listener.onCancel(this);
+            listener.onProgressCancel(this);
         }
 
         super.onCancel(dialog);
     }
 
-
     public interface CancelListener {
-        void onCancel(ProgressDialogFragment fragment);
+        void onProgressCancel(ProgressDialogFragment fragment);
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -280,14 +280,11 @@ public class MessageViewInfoExtractor {
      * @return The (file)name of the part if available. An empty string, otherwise.
      */
     private static String getPartName(Part part) {
-        try {
-            String disposition = part.getDisposition();
-            if (disposition != null) {
-                String name = getHeaderParameter(disposition, "filename");
-                return (name == null) ? "" : name;
-            }
+        String disposition = part.getDisposition();
+        if (disposition != null) {
+            String name = getHeaderParameter(disposition, "filename");
+            return (name == null) ? "" : name;
         }
-        catch (MessagingException e) { /* ignore */ }
 
         return "";
     }

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -376,7 +376,7 @@ public class PgpMessageBuilderTest {
                 .setEnablePgpInline(true)
                 .build();
         pgpMessageBuilder.setCryptoStatus(cryptoStatus);
-        pgpMessageBuilder.setAttachments(Collections.singletonList(new Attachment()));
+        pgpMessageBuilder.setAttachments(Collections.singletonList(Attachment.createAttachment(null, 0, null)));
 
         Callback mockCallback = mock(Callback.class);
         pgpMessageBuilder.buildAsync(mockCallback);
@@ -393,7 +393,7 @@ public class PgpMessageBuilderTest {
                 .setEnablePgpInline(true)
                 .build();
         pgpMessageBuilder.setCryptoStatus(cryptoStatus);
-        pgpMessageBuilder.setAttachments(Collections.singletonList(new Attachment()));
+        pgpMessageBuilder.setAttachments(Collections.singletonList(Attachment.createAttachment(null, 0, null)));
 
         Callback mockCallback = mock(Callback.class);
         pgpMessageBuilder.buildAsync(mockCallback);


### PR DESCRIPTION
What the title says: I extracted a presenter for managing attachments in MessageCompose.

I also changed some things with the loader structure, I think it's a lot more reliable and straightforward now. I tested configuration changes and "Don't keep activities" behavior in combination with the stalled action mechanism quite thoroughly on my device, everything works nicely.

One thing where I wasn't sure was where to place `performSendAfterChecks`, between keeping a reference to the activity and putting it in the mvp view, I put it in the view for now. If at some point the sending logic is handled by a presenter, handing that presenter to the attachmentPresenter would be a nicer option, but this is fairly minor for now.

(What I really wanted to work on was loadAttachments for #819, but I got a little sidetracked)