### PR TITLE
new option: just show notification for contacts

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -181,6 +181,7 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean mNotifyNewMail;
     private FolderMode mFolderNotifyNewMailMode;
     private boolean mNotifySelfNewMail;
+    private boolean mNotifyContactsMailOnly;
     private String mInboxFolderName;
     private String mDraftsFolderName;
     private String mSentFolderName;
@@ -289,6 +290,7 @@ public class Account implements BaseAccount, StoreConfig {
         mFolderNotifyNewMailMode = FolderMode.ALL;
         mNotifySync = true;
         mNotifySelfNewMail = true;
+        mNotifyContactsMailOnly = false;
         mFolderDisplayMode = FolderMode.NOT_SECOND_CLASS;
         mFolderSyncMode = FolderMode.FIRST_CLASS;
         mFolderPushMode = FolderMode.FIRST_CLASS;
@@ -397,6 +399,7 @@ public class Account implements BaseAccount, StoreConfig {
 
         mFolderNotifyNewMailMode = getEnumStringPref(storage, mUuid + ".folderNotifyNewMailMode", FolderMode.ALL);
         mNotifySelfNewMail = storage.getBoolean(mUuid + ".notifySelfNewMail", true);
+        mNotifyContactsMailOnly = storage.getBoolean(mUuid + ".notifyContactsMailOnly", false);
         mNotifySync = storage.getBoolean(mUuid + ".notifyMailCheck", false);
         mDeletePolicy =  DeletePolicy.fromInt(storage.getInt(mUuid + ".deletePolicy", DeletePolicy.NEVER.setting));
         mInboxFolderName = storage.getString(mUuid  + ".inboxFolderName", INBOX);
@@ -684,6 +687,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(mUuid + ".notifyNewMail", mNotifyNewMail);
         editor.putString(mUuid + ".folderNotifyNewMailMode", mFolderNotifyNewMailMode.name());
         editor.putBoolean(mUuid + ".notifySelfNewMail", mNotifySelfNewMail);
+        editor.putBoolean(mUuid + ".notifyContactsMailOnly", mNotifyContactsMailOnly);
         editor.putBoolean(mUuid + ".notifyMailCheck", mNotifySync);
         editor.putInt(mUuid + ".deletePolicy", mDeletePolicy.setting);
         editor.putString(mUuid + ".inboxFolderName", mInboxFolderName);
@@ -1250,6 +1254,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public synchronized void setNotifySelfNewMail(boolean notifySelfNewMail) {
         mNotifySelfNewMail = notifySelfNewMail;
+    }
+
+    public synchronized boolean isNotifyContactsMailOnly() {
+        return mNotifyContactsMailOnly;
+    }
+
+    public synchronized void setNotifyContactsMailOnly(boolean notifyContactsMailOnly) {
+        this.mNotifyContactsMailOnly = notifyContactsMailOnly;
     }
 
     public synchronized Expunge getExpungePolicy() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -78,6 +78,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_NOTIFY = "account_notify";
     private static final String PREFERENCE_NOTIFY_NEW_MAIL_MODE = "folder_notify_new_mail_mode";
     private static final String PREFERENCE_NOTIFY_SELF = "account_notify_self";
+    private static final String PREFERENCE_NOTIFY_CONTACTS_MAIL_ONLY = "account_notify_contacts_mail_only";
     private static final String PREFERENCE_NOTIFY_SYNC = "account_notify_sync";
     private static final String PREFERENCE_VIBRATE = "account_vibrate";
     private static final String PREFERENCE_VIBRATE_PATTERN = "account_vibrate_pattern";
@@ -146,6 +147,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private CheckBoxPreference mAccountNotify;
     private ListPreference mAccountNotifyNewMailMode;
     private CheckBoxPreference mAccountNotifySelf;
+    private CheckBoxPreference mAccountNotifyContactsMailOnly;
     private ListPreference mAccountShowPictures;
     private CheckBoxPreference mAccountNotifySync;
     private CheckBoxPreference mAccountVibrate;
@@ -590,6 +592,9 @@ public class AccountSettings extends K9PreferenceActivity {
         mAccountNotifySelf = (CheckBoxPreference) findPreference(PREFERENCE_NOTIFY_SELF);
         mAccountNotifySelf.setChecked(mAccount.isNotifySelfNewMail());
 
+        mAccountNotifyContactsMailOnly = (CheckBoxPreference) findPreference(PREFERENCE_NOTIFY_CONTACTS_MAIL_ONLY);
+        mAccountNotifyContactsMailOnly.setChecked(mAccount.isNotifyContactsMailOnly());
+
         mAccountNotifySync = (CheckBoxPreference) findPreference(PREFERENCE_NOTIFY_SYNC);
         mAccountNotifySync.setChecked(mAccount.isShowOngoing());
 
@@ -753,6 +758,7 @@ public class AccountSettings extends K9PreferenceActivity {
         mAccount.setNotifyNewMail(mAccountNotify.isChecked());
         mAccount.setFolderNotifyNewMailMode(FolderMode.valueOf(mAccountNotifyNewMailMode.getValue()));
         mAccount.setNotifySelfNewMail(mAccountNotifySelf.isChecked());
+        mAccount.setNotifyContactsMailOnly(mAccountNotifyContactsMailOnly.isChecked());
         mAccount.setShowOngoing(mAccountNotifySync.isChecked());
         mAccount.setDisplayCount(Integer.parseInt(mDisplayCount.getValue()));
         mAccount.setMaximumAutoDownloadMessageSize(Integer.parseInt(mMessageSize.getValue()));

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -4314,15 +4314,8 @@ public class MessagingController implements Runnable {
             return false;
         }
 
-        if (account.isNotifyContactsMailOnly()) {
-            Cursor cursor = context.getContentResolver().query(ContactsContract.CommonDataKinds.Email.CONTENT_URI,
-                    new String[]{ContactsContract.Contacts.DISPLAY_NAME},
-                    ContactsContract.CommonDataKinds.Email.ADDRESS + " LIKE ? AND " +
-                            ContactsContract.Contacts.Data.MIMETYPE + " = '" + ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE+"'",
-                    new String[]{message.getFrom()[0].getAddress()}, "");
-            if (cursor.getCount() == 0) {
-                return false;
-            }
+        if (account.isNotifyContactsMailOnly() && !isContact(message.getFrom())) {
+            return false;
         }
 
         return true;
@@ -4400,6 +4393,25 @@ public class MessagingController implements Runnable {
         } else {
             return false;
         }
+    }
+
+    private boolean isContact(Address[] addrs) {
+        if (addrs == null) {
+            return false;
+        }
+
+        for (Address addr : addrs) {
+            Cursor cursor = context.getContentResolver().query(ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+                    new String[]{ContactsContract.Contacts.DISPLAY_NAME},
+                    ContactsContract.CommonDataKinds.Email.ADDRESS + " LIKE ? AND " +
+                            ContactsContract.Contacts.Data.MIMETYPE + " = '" + ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE+"'",
+                    new String[]{addr.getAddress()}, "");
+            if (cursor.getCount() != 0) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     static AtomicInteger sequencing = new AtomicInteger(0);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -40,6 +40,7 @@ import android.os.Build;
 import android.os.PowerManager;
 import android.os.Process;
 import android.os.SystemClock;
+import android.provider.ContactsContract;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
@@ -4311,6 +4312,17 @@ public class MessagingController implements Runnable {
         // to be notified for such messages.
         if (account.isAnIdentity(message.getFrom()) && !account.isNotifySelfNewMail()) {
             return false;
+        }
+
+        if (account.isNotifyContactsMailOnly()) {
+            Cursor cursor = context.getContentResolver().query(ContactsContract.CommonDataKinds.Email.CONTENT_URI,
+                    new String[]{ContactsContract.Contacts.DISPLAY_NAME},
+                    ContactsContract.CommonDataKinds.Email.ADDRESS + " LIKE ? AND " +
+                            ContactsContract.Contacts.Data.MIMETYPE + " = '" + ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE+"'",
+                    new String[]{message.getFrom()[0].getAddress()}, "");
+            if (cursor.getCount() == 0) {
+                return false;
+            }
         }
 
         return true;

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -56,6 +56,7 @@ import com.fsck.k9.R;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
 import com.fsck.k9.cache.EmailProviderCache;
+import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.CertificateValidationException;
@@ -4314,7 +4315,7 @@ public class MessagingController implements Runnable {
             return false;
         }
 
-        if (account.isNotifyContactsMailOnly() && !isContact(message.getFrom())) {
+        if (account.isNotifyContactsMailOnly() && !Contacts.getInstance(context).containsContact(message.getFrom())) {
             return false;
         }
 
@@ -4393,25 +4394,6 @@ public class MessagingController implements Runnable {
         } else {
             return false;
         }
-    }
-
-    private boolean isContact(Address[] addrs) {
-        if (addrs == null) {
-            return false;
-        }
-
-        for (Address addr : addrs) {
-            Cursor cursor = context.getContentResolver().query(ContactsContract.CommonDataKinds.Email.CONTENT_URI,
-                    new String[]{ContactsContract.Contacts.DISPLAY_NAME},
-                    ContactsContract.CommonDataKinds.Email.ADDRESS + " LIKE ? AND " +
-                            ContactsContract.Contacts.Data.MIMETYPE + " = '" + ContactsContract.CommonDataKinds.Email.CONTENT_ITEM_TYPE+"'",
-                    new String[]{addr.getAddress()}, "");
-            if (cursor.getCount() != 0) {
-                return true;
-            }
-        }
-
-        return false;
     }
 
     static AtomicInteger sequencing = new AtomicInteger(0);

--- a/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
@@ -142,6 +142,26 @@ public class Contacts {
     }
 
     /**
+     * Check whether one of the provided addresses belongs to one of the contacts.
+     *
+     * @param addresses The addresses to search in contacts
+     * @return <tt>true</tt>, if one address belongs to a contact.
+     *         <tt>false</tt>, otherwise.
+     */
+    public boolean containsContact(final Address[] addresses) {
+        if (addresses == null) {
+            return false;
+        }
+
+        for (Address addr : addresses) {
+            if (isInContacts(addr.getAddress())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Get the name of the contact an email address belongs to.
      *
      * @param address The email address to search for.

--- a/k9mail/src/main/res/values-de/strings.xml
+++ b/k9mail/src/main/res/values-de/strings.xml
@@ -438,6 +438,8 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="account_settings_notify_sync_summary">Benachrichtigung in der Statuszeile anzeigen, während nach neuen Nachrichten gesucht wird</string>
   <string name="account_settings_notify_self_label">Bei eigenen Nachrichten</string>
   <string name="account_settings_notify_self_summary">Benachrichtigungen für Nachrichten, die eine Ihrer eigenen E-Mail-Adressen als Absender tragen</string>
+  <string name="account_notify_contacts_mail_only_label">Nur für Kontakte</string>
+  <string name="account_notify_contacts_mail_only_summary">Benachrichtigungen nur für Nachrichten, die von eigenen Kontakten stammen</string>
   <string name="account_settings_notification_opens_unread_label">Ungelesene Nachrichten öffnen</string>
   <string name="account_settings_notification_opens_unread_summary">Beim Öffnen einer Benachrichtigung Liste der ungelesenen Nachrichten anzeigen</string>
   <string name="account_settings_mark_message_as_read_on_view_label">Beim Öffnen als gelesen markieren</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -532,6 +532,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_notify_sync_summary">Notify in status bar while mail is checked</string>
     <string name="account_settings_notify_self_label">Include outgoing mail</string>
     <string name="account_settings_notify_self_summary">Show a notification for messages I sent</string>
+    <string name="account_notify_contacts_mail_only_label">Contacts only</string>
+    <string name="account_notify_contacts_mail_only_summary">Show a notification only for messages of known contacts</string>
     <string name="account_settings_notification_opens_unread_label">Notification opens unread messages</string>
     <string name="account_settings_notification_opens_unread_summary">Searches for unread messages when Notification is opened</string>
     <string name="account_settings_mark_message_as_read_on_view_label">Mark as read when opened</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -360,6 +360,14 @@
             android:defaultValue="true"
             android:summary="@string/account_settings_notify_self_summary" />
 
+        <CheckBoxPreference
+            android:persistent="false"
+            android:key="account_notify_contacts_mail_only"
+            android:dependency="account_notify"
+            android:title="@string/account_notify_contacts_mail_only_label"
+            android:defaultValue="false"
+            android:summary="@string/account_notify_contacts_mail_only_summary" />
+
         <!--
           We can't disable persisting the ringtone value to SharedPreferences
           because it's needed to actually access the value.


### PR DESCRIPTION
A simplified approach for feature request #1144 and pull request #1188 .

Just a checkbox option to show notifications from contacts only. Thats my "fraction of the messages" which are worth notifying. I think its a reasonable limit for others, too.

I prefixed the option field with an "m", because it looked wrong in between the otther fields without...