### PR TITLE
preload WebView widget in K9.onCreate() to avoid loading time later on

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -1,6 +1,7 @@
 
 package com.fsck.k9;
 
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -24,6 +25,7 @@ import android.os.Looper;
 import android.os.StrictMode;
 import android.text.format.Time;
 import android.util.Log;
+import android.webkit.WebView;
 
 import com.fsck.k9.Account.SortType;
 import com.fsck.k9.activity.MessageCompose;
@@ -33,13 +35,12 @@ import com.fsck.k9.controller.MessagingListener;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.Message;
-import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.BinaryTempFileBody;
+import com.fsck.k9.mail.ssl.LocalKeyStore;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
 import com.fsck.k9.provider.UnreadWidgetProvider;
-import com.fsck.k9.mail.ssl.LocalKeyStore;
 import com.fsck.k9.service.BootReceiver;
 import com.fsck.k9.service.MailService;
 import com.fsck.k9.service.ShutdownReceiver;
@@ -602,7 +603,18 @@ public class K9 extends Application {
 
         });
 
+        preloadWebViewWidget();
+
         notifyObservers();
+    }
+
+    /**
+     * This method preloads the WebView widget, which takes some 200ms to load native libraries, avoiding this
+     * time on the UI thread when we first display a message. To this end, an instance of WebView is constructed
+     * and then immediately destroyed.
+     */
+    private void preloadWebViewWidget() {
+        new WebView(this).destroy();
     }
 
     /**


### PR DESCRIPTION
During profiling of MessageViewFragment, I noticed there is a long delay when the first message is displayed since the WebView widget needs to load some native libraries. This must be done on the UI thread and takes more than 250ms on my Nexus 5, which is a quite noticable delay, especially since it interferes with the transition animation.

The rationale here is that when K9 is opened, the user will sooner rather than later view a message, so the time to load the library will be spent on the UI thread somewhere regardless. 250ms of app startup time are some more black screen time, which feels a lot less laggy to me than the same time spent in the transition when first viewing a message.

I realize that `Application.onCreate` is not a great position to introduce this delay either, so if anyone has a nicer idea where to place this I'd be happy to hear it. Maybe in `MessageList`?

It might also be a bad idea to do this in the first place, not sure. Either way the fix is simple so I thought I'd bring it up for discussion.