### PR TITLE
fix flicker of subject line in MessageHeader

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -132,7 +132,6 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
 
         mMessageHelper = MessageHelper.getInstance(mContext);
 
-        mSubjectView.setVisibility(VISIBLE);
         hideAdditionalHeaders();
     }
 
@@ -267,15 +266,11 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
             counterpartyAddress = fromAddrs[0];
         }
 
-        /*
-         * Only reset visibility of the subject if populate() was called because a new
-         * message is shown. If it is the same, do not force the subject visible, because
-         * this breaks the MessageTitleView in the action bar, which may hide our subject
-         * if it fits in the action bar but is only called when a new message is shown
-         * or the device is rotated.
-         */
-        if (mMessage == null || mMessage.getId() != message.getId()) {
-            mSubjectView.setVisibility(VISIBLE);
+        /* We hide the subject by default for each new message, and MessageTitleView might show
+         * it later by calling showSubjectLine(). */
+        boolean newMessageShown = mMessage == null || mMessage.getId() != message.getId();
+        if (newMessageShown) {
+            mSubjectView.setVisibility(GONE);
         }
 
         mMessage = message;
@@ -484,7 +479,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         }
     }
 
-    public void hideSubjectLine() {
-        mSubjectView.setVisibility(GONE);
+    public void showSubjectLine() {
+        mSubjectView.setVisibility(VISIBLE);
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageTitleView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageTitleView.java
@@ -51,8 +51,7 @@ public class MessageTitleView extends TextView {
                 if (getLayout().getLineCount() > MAX_LINES) {
                     int lineEndIndex = getLayout().getLineEnd(MAX_LINES - 1);
                     setText(getText().subSequence(0, lineEndIndex - 2) + ELLIPSIS);
-                } else {
-                    mHeader.hideSubjectLine();
+                    mHeader.showSubjectLine();
                 }
                 mNeedEllipsizeCheck = false;
             }

--- a/k9mail/src/main/res/layout/message_view_header.xml
+++ b/k9mail/src/main/res/layout/message_view_header.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <com.fsck.k9.view.MessageHeader
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/header_container"
     android:layout_width="match_parent"
     android:orientation="vertical"
@@ -31,8 +32,11 @@
                 android:textStyle="bold"
                 android:textColor="?android:attr/textColorPrimary"
                 android:textAppearance="?android:attr/textAppearanceMedium"
-                android:text="@string/general_no_subject"
-                android:padding="8dp" />
+                android:padding="8dp"
+                android:visibility="gone"
+                tools:visibility="visible"
+                tools:text="(no subject)"
+                />
 
             <LinearLayout
                 android:layout_width="match_parent"


### PR DESCRIPTION
MessageHeader rendered the subject line by default, and only after
MessageTitleView decided it was large enough to display the entire
subject line, the subject line was hidden again. This caused a noticable
flicker in vertical size during message rendering while navigating with
next/previous message buttons.

This commit flips the logic, only displaying the subject view once the
title view finds it can't display it all.