### PR TITLE
Add UK variants of Hotmail addresses to providers

### DIFF
--- a/k9mail/src/main/res/xml/providers.xml
+++ b/k9mail/src/main/res/xml/providers.xml
@@ -185,6 +185,14 @@
         <incoming uri="pop3+ssl+://pop.mail.yahoo.co.uk" username="$user" />
         <outgoing uri="smtp+ssl+://smtp.mail.yahoo.co.uk" username="$user" />
     </provider>
+    <provider id="live-uk" label="Windows Live Hotmail" domain="live.co.uk">
+        <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
+    </provider>
+    <provider id="hotmail-uk" label="Hotmail" domain="hotmail.co.uk">
+        <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
+    </provider>
     
     <!-- Germany -->
     <provider id="mailbox.org" label="mailbox.org" domain="mailbox.org">


### PR DESCRIPTION
Recognises `@hotmail.co.uk` and `@live.co.uk` as Outlook.com addresses.

I suspect there are other countries too, but these are the only ones I've really come across.