### PR TITLE
don't rely on cached metadata from database for attachment info

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalBodyPart.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalBodyPart.java
@@ -11,17 +11,15 @@ public class LocalBodyPart extends MimeBodyPart implements LocalPart {
     private final long messagePartId;
     private final String displayName;
     private final long size;
-    private final boolean firstClassAttachment;
 
-    public LocalBodyPart(String accountUuid, LocalMessage message, long messagePartId, String displayName, long size,
-            boolean firstClassAttachment) throws MessagingException {
+    public LocalBodyPart(String accountUuid, LocalMessage message, long messagePartId, String displayName, long size)
+            throws MessagingException {
         super();
         this.accountUuid = accountUuid;
         this.message = message;
         this.messagePartId = messagePartId;
         this.displayName = displayName;
         this.size = size;
-        this.firstClassAttachment = firstClassAttachment;
     }
 
     @Override
@@ -42,11 +40,6 @@ public class LocalBodyPart extends MimeBodyPart implements LocalPart {
     @Override
     public long getSize() {
         return size;
-    }
-
-    @Override
-    public boolean isFirstClassAttachment() {
-        return firstClassAttachment;
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -708,7 +708,6 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
             throws MessagingException {
 
         long id = cursor.getLong(0);
-        int type = cursor.getInt(1);
         long parentId = cursor.getLong(2);
         String mimeType = cursor.getString(3);
         long size = cursor.getLong(4);
@@ -716,7 +715,9 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         byte[] header = cursor.getBlob(6);
         int dataLocation = cursor.getInt(9);
         String serverExtra = cursor.getString(15);
-        boolean firstClassAttachment = (type != MessagePartType.HIDDEN_ATTACHMENT);
+        // TODO we don't currently cache the part types. might want to do that at a later point?
+        // int type = cursor.getInt(1);
+        // boolean firstClassAttachment = (type != MessagePartType.HIDDEN_ATTACHMENT);
 
         final Part part;
         if (id == message.getMessagePartId()) {
@@ -729,8 +730,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
             String parentMimeType = parentPart.getMimeType();
             if (MimeUtility.isMultipart(parentMimeType)) {
-                BodyPart bodyPart = new LocalBodyPart(getAccountUuid(), message, id, displayName, size,
-                        firstClassAttachment);
+                BodyPart bodyPart = new LocalBodyPart(getAccountUuid(), message, id, displayName, size);
                 ((Multipart) parentPart.getBody()).addBodyPart(bodyPart);
                 part = bodyPart;
             } else if (MimeUtility.isMessage(parentMimeType)) {
@@ -2054,6 +2054,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     }
 
     // Note: The contents of the 'message_parts' table depend on these values.
+    // TODO currently unused, might be for caching at a later point
     static class MessagePartType {
         static final int UNKNOWN = 0;
         static final int ALTERNATIVE_PLAIN = 1;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalPart.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalPart.java
@@ -6,6 +6,5 @@ public interface LocalPart {
     long getId();
     String getDisplayName();
     long getSize();
-    boolean isFirstClassAttachment();
     LocalMessage getMessage();
 }

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -33,29 +33,30 @@ public class AttachmentInfoExtractor {
     }
 
     public static AttachmentViewInfo extractAttachmentInfo(Context context, Part part) throws MessagingException {
+        Uri uri;
+        long size;
         if (part instanceof LocalPart) {
             LocalPart localPart = (LocalPart) part;
             String accountUuid = localPart.getAccountUuid();
             long messagePartId = localPart.getId();
-            String mimeType = part.getMimeType();
-            String displayName = localPart.getDisplayName();
-            long size = localPart.getSize();
-            boolean firstClassAttachment = localPart.isFirstClassAttachment();
-            Uri uri = AttachmentProvider.getAttachmentUri(accountUuid, messagePartId);
-
-            return new AttachmentViewInfo(mimeType, displayName, size, uri, firstClassAttachment, part);
+            size = localPart.getSize();
+            uri = AttachmentProvider.getAttachmentUri(accountUuid, messagePartId);
         } else {
             Body body = part.getBody();
             if (body instanceof DecryptedTempFileBody) {
                 DecryptedTempFileBody decryptedTempFileBody = (DecryptedTempFileBody) body;
+                size = decryptedTempFileBody.getSize();
+
                 File file = decryptedTempFileBody.getFile();
-                Uri uri = K9FileProvider.getUriForFile(context, file, part.getMimeType());
-                long size = file.length();
+                uri = K9FileProvider.getUriForFile(context, file, part.getMimeType());
+
                 return extractAttachmentInfo(part, uri, size);
             } else {
                 throw new RuntimeException("Not supported");
             }
         }
+
+        return extractAttachmentInfo(part, uri, size);
     }
 
     public static AttachmentViewInfo extractAttachmentInfo(Part part) throws MessagingException {

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MigrationTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MigrationTest.java
@@ -252,7 +252,6 @@ public class MigrationTest {
         Assert.assertEquals("attachment", MimeUtility.getHeaderParameter(attachmentPart.getDisposition(), null));
         Assert.assertEquals("k9small.png", MimeUtility.getHeaderParameter(attachmentPart.getDisposition(), "filename"));
         Assert.assertEquals("2250", MimeUtility.getHeaderParameter(attachmentPart.getDisposition(), "size"));
-        Assert.assertTrue(attachmentPart.isFirstClassAttachment());
 
         FileBackedBody attachmentBody = (FileBackedBody) attachmentPart.getBody();
         Assert.assertEquals(2250, attachmentBody.getSize());


### PR DESCRIPTION
This commit removes use of LocalFolder.MessagePartType as an indication
of part types in AttachmentInfoExtractor. The enum was intended as a
caching mechanism to skip loading unimportant parts from the database,
but only the reading side was implemented. As the expected performance
gain is negligible, I disabled the reading side for now (computing the
data instead) and more explicitly disabled the writing side as well.

What this actually fixes is display of multipart/related parts as both inline
content and attachments.