### PR TITLE
Encapsulate attachment resource handling into AttachmentResolver

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
@@ -1,0 +1,81 @@
+package com.fsck.k9.mailstore;
+
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Stack;
+
+import android.content.Context;
+import android.net.Uri;
+import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
+import android.util.Log;
+
+import com.fsck.k9.K9;
+import com.fsck.k9.mail.Body;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.Multipart;
+import com.fsck.k9.mail.Part;
+import com.fsck.k9.message.extractors.AttachmentInfoExtractor;
+
+
+/**
+ * This class is used to encapsulate a message part, providing an interface to
+ * get relevant info for a given Content-ID URI.
+ *
+ * The point of this class is to keep the Content-ID loading code agnostic of
+ * the underlying part structure.
+ */
+public class AttachmentResolver {
+    Map<String,Uri> contentIdToAttachmentUriMap;
+
+
+    private AttachmentResolver(Map<String, Uri> contentIdToAttachmentUriMap) {
+        this.contentIdToAttachmentUriMap = contentIdToAttachmentUriMap;
+    }
+
+    @Nullable
+    public Uri getAttachmentUriForContentId(String cid) {
+        return contentIdToAttachmentUriMap.get(cid);
+    }
+
+    @WorkerThread
+    public static AttachmentResolver createFromPart(Context context, Part part) {
+        Map<String,Uri> contentIdToAttachmentUriMap = buildCidToAttachmentUriMap(context, part);
+
+        return new AttachmentResolver(contentIdToAttachmentUriMap);
+    }
+
+    private static Map<String,Uri> buildCidToAttachmentUriMap(Context context, Part rootPart) {
+        HashMap<String,Uri> result = new HashMap<>();
+
+        Stack<Part> partsToCheck = new Stack<>();
+        partsToCheck.push(rootPart);
+
+        while (!partsToCheck.isEmpty()) {
+            Part part = partsToCheck.pop();
+
+            Body body = part.getBody();
+            if (body instanceof Multipart) {
+                Multipart multipart = (Multipart) body;
+                for (Part bodyPart : multipart.getBodyParts()) {
+                    partsToCheck.push(bodyPart);
+                }
+            } else {
+                try {
+                    String contentId = part.getContentId();
+                    if (contentId != null) {
+                        AttachmentViewInfo attachmentInfo = AttachmentInfoExtractor.extractAttachmentInfo(context, part);
+                        result.put(contentId, attachmentInfo.uri);
+                    }
+                } catch (MessagingException e) {
+                    Log.e(K9.LOG_TAG, "Error extracting attachment info", e);
+                }
+            }
+        }
+
+        return Collections.unmodifiableMap(result);
+    }
+
+}

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
@@ -20,17 +20,19 @@ public class MessageViewInfo {
 
     public static class MessageViewContainer {
         public final String text;
+        public final AttachmentResolver attachmentResolver;
         public final Part rootPart;
         public final List<AttachmentViewInfo> attachments;
         public final CryptoResultAnnotation cryptoAnnotation;
 
 
-        MessageViewContainer(String text, Part rootPart, List<AttachmentViewInfo> attachments,
-                CryptoResultAnnotation cryptoAnnotation) {
+        MessageViewContainer(String text, AttachmentResolver attachmentResolver, Part rootPart,
+                List<AttachmentViewInfo> attachments, CryptoResultAnnotation cryptoAnnotation) {
             this.text = text;
             this.rootPart = rootPart;
             this.attachments = attachments;
             this.cryptoAnnotation = cryptoAnnotation;
+            this.attachmentResolver = attachmentResolver;
         }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -68,8 +68,12 @@ public class MessageViewInfoExtractor {
             ViewableExtractedText viewable = MessageViewInfoExtractor.extractTextFromViewables(context, viewableParts);
             List<AttachmentViewInfo> attachmentInfos = AttachmentInfoExtractor.extractAttachmentInfos(context, attachments);
 
+            AttachmentResolver attachmentResolver =
+                    AttachmentResolver.createFromPart(context, part);
+
             MessageViewContainer messageViewContainer =
-                    new MessageViewContainer(viewable.html, part, attachmentInfos, pgpAnnotation);
+                    new MessageViewContainer(viewable.html, attachmentResolver,
+                            part, attachmentInfos, pgpAnnotation);
 
             containers.add(messageViewContainer);
         }

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessageMvpView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessageMvpView.java
@@ -12,6 +12,7 @@ import android.widget.ImageButton;
 import com.fsck.k9.FontSizes;
 import com.fsck.k9.R;
 import com.fsck.k9.activity.MessageCompose;
+import com.fsck.k9.mailstore.AttachmentResolver;
 import com.fsck.k9.message.QuotedTextMode;
 import com.fsck.k9.message.SimpleMessageFormat;
 import com.fsck.k9.ui.EolConvertingEditText;
@@ -117,8 +118,8 @@ public class QuotedMessageMvpView {
         mFontSizes.setViewTextSize(mQuotedText, fontSize);
     }
 
-    public void setQuotedHtml(String quotedContent) {
-        mQuotedHTML.setText(quotedContent);
+    public void setQuotedHtml(String quotedContent, AttachmentResolver attachmentResolver) {
+        mQuotedHTML.displayHtmlContentWithInlineAttachments(quotedContent, attachmentResolver);
     }
 
     public void setQuotedText(String quotedText) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -20,6 +20,7 @@ import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MessageExtractor;
 import com.fsck.k9.mail.internet.MimeUtility;
+import com.fsck.k9.mailstore.AttachmentResolver;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.message.IdentityField;
 import com.fsck.k9.message.InsertableHtmlContent;
@@ -130,8 +131,9 @@ public class QuotedMessagePresenter {
             quotedHtmlContent = QuotedMessageHelper.quoteOriginalHtmlMessage(
                     resources, sourceMessage, content, quoteStyle);
 
-            // Load the message with the reply header.
-            view.setQuotedHtml(quotedHtmlContent.getQuotedContent());
+            // Load the message with the reply header. TODO replace with MessageViewInfo data
+            view.setQuotedHtml(quotedHtmlContent.getQuotedContent(), AttachmentResolver
+                    .createFromPart(messageCompose, sourceMessage));
 
             // TODO: Also strip the signature from the text/plain part
             view.setQuotedText(QuotedMessageHelper.quoteOriginalTextMessage(resources, sourceMessage,
@@ -173,7 +175,8 @@ public class QuotedMessagePresenter {
     public void onRestoreInstanceState(Bundle savedInstanceState) {
         quotedHtmlContent = (InsertableHtmlContent) savedInstanceState.getSerializable(STATE_KEY_HTML_QUOTE);
         if (quotedHtmlContent != null && quotedHtmlContent.getQuotedContent() != null) {
-            view.setQuotedHtml(quotedHtmlContent.getQuotedContent());
+            // we don't have the part here, but inline-displayed images are cached by the webview
+            view.setQuotedHtml(quotedHtmlContent.getQuotedContent(), null);
         }
         quotedTextFormat = (SimpleMessageFormat) savedInstanceState.getSerializable(
                 STATE_KEY_QUOTED_TEXT_FORMAT);
@@ -293,7 +296,9 @@ public class QuotedMessagePresenter {
                     } else {
                         quotedHtmlContent.setFooterInsertionPoint(bodyOffset);
                     }
-                    view.setQuotedHtml(quotedHtmlContent.getQuotedContent());
+                    // TODO replace with MessageViewInfo data
+                    view.setQuotedHtml(quotedHtmlContent.getQuotedContent(),
+                            AttachmentResolver.createFromPart(messageCompose, message));
                 }
             }
             if (bodyPlainOffset != null && bodyPlainLength != null) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.ui.messageview;
 
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,7 +25,6 @@ import android.view.ViewGroup;
 import android.view.ViewStub;
 import android.webkit.WebView;
 import android.webkit.WebView.HitTestResult;
-import android.webkit.WebViewClient;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.Toast;
@@ -35,12 +35,11 @@ import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.AttachmentResolver;
 import com.fsck.k9.mailstore.AttachmentViewInfo;
-import com.fsck.k9.mailstore.MessageViewInfo.MessageViewContainer;
-
 import com.fsck.k9.mailstore.CryptoResultAnnotation;
 import com.fsck.k9.mailstore.CryptoResultAnnotation.CryptoError;
-import com.fsck.k9.view.K9WebViewClient;
+import com.fsck.k9.mailstore.MessageViewInfo.MessageViewContainer;
 import com.fsck.k9.view.MessageHeader.OnLayoutChangedListener;
 import com.fsck.k9.view.MessageWebView;
 
@@ -380,7 +379,7 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
 
     public void showPictures() {
         setLoadPictures(true);
-        loadBodyFromText(mText);
+        displayHtmlContentWithInlineAttachments(mText, null);
     }
 
     public void enableAttachmentButtons() {
@@ -403,9 +402,6 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
         this.attachmentCallback = attachmentCallback;
 
         resetView();
-
-        WebViewClient webViewClient = K9WebViewClient.newInstance(messageViewContainer.rootPart);
-        mMessageContentView.setWebViewClient(webViewClient);
 
         boolean hasAttachments = !messageViewContainer.attachments.isEmpty();
         if (hasAttachments) {
@@ -458,7 +454,7 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
             text = wrapStatusMessage(getContext().getString(R.string.webview_empty_message));
         }
 
-        loadBodyFromText(text);
+        displayHtmlContentWithInlineAttachments(text, messageViewContainer.attachmentResolver);
     }
 
     private String getTextToDisplay(MessageViewContainer messageViewContainer) {
@@ -489,8 +485,8 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
         return "<div style=\"text-align:center; color: grey;\">" + status + "</div>";
     }
 
-    private void loadBodyFromText(String emailText) {
-        mMessageContentView.setText(emailText);
+    private void displayHtmlContentWithInlineAttachments(String htmlText, AttachmentResolver attachmentResolver) {
+        mMessageContentView.displayHtmlContentWithInlineAttachments(htmlText, attachmentResolver);
     }
 
     public void renderAttachments(MessageViewContainer messageContainer) throws MessagingException {
@@ -529,7 +525,7 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
          * its size because the button to download the complete message was previously shown and
          * is now hidden.
          */
-        loadBodyFromText("");
+        displayHtmlContentWithInlineAttachments("", null);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/view/K9WebViewClient.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/K9WebViewClient.java
@@ -12,6 +12,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Build.VERSION_CODES;
 import android.provider.Browser;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.webkit.WebResourceRequest;
@@ -32,10 +33,11 @@ abstract class K9WebViewClient extends WebViewClient {
     private static final WebResourceResponse RESULT_DUMMY_RESPONSE = new WebResourceResponse(null, null, null);
 
 
+    @Nullable
     private final AttachmentResolver attachmentResolver;
 
 
-    public static K9WebViewClient newInstance(AttachmentResolver attachmentResolver) {
+    public static K9WebViewClient newInstance(@Nullable AttachmentResolver attachmentResolver) {
         if (Build.VERSION.SDK_INT < 21) {
             return new PreLollipopWebViewClient(attachmentResolver);
         }
@@ -44,7 +46,7 @@ abstract class K9WebViewClient extends WebViewClient {
     }
 
 
-    private K9WebViewClient(AttachmentResolver attachmentResolver) {
+    private K9WebViewClient(@Nullable AttachmentResolver attachmentResolver) {
         this.attachmentResolver = attachmentResolver;
     }
 
@@ -83,6 +85,10 @@ abstract class K9WebViewClient extends WebViewClient {
     protected WebResourceResponse shouldInterceptRequest(WebView webView, Uri uri) {
         if (!CID_SCHEME.equals(uri.getScheme())) {
             return RESULT_DO_NOT_INTERCEPT;
+        }
+
+        if (attachmentResolver == null) {
+            return RESULT_DUMMY_RESPONSE;
         }
 
         String cid = uri.getSchemeSpecificPart();

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageWebView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageWebView.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.view;
 
+
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.util.AttributeSet;
@@ -12,6 +13,7 @@ import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.helper.HtmlConverter;
 import com.fsck.k9.helper.HtmlSanitizer;
+import com.fsck.k9.mailstore.AttachmentResolver;
 
 
 public class MessageWebView extends RigidWebView {
@@ -102,19 +104,18 @@ public class MessageWebView extends RigidWebView {
         getSettings().setDisplayZoomControls(!supportsMultiTouch);
     }
 
-    /**
-     * Load a message body into a {@code MessageWebView}
-     *
-     * <p>
-     * Before loading, the text is wrapped in an HTML header and footer
-     * so that it displays properly.
-     * </p>
-     *
-     * @param text
-     *      The message body to display.  Assumed to be MIME type text/html.
-     */
-    public void setText(String text) {
-     // Include a meta tag so the WebView will not use a fixed viewport width of 980 px
+    public void displayHtmlContentWithInlineAttachments(String htmlText, AttachmentResolver attachmentResolver) {
+        setAttachmentResolverWebViewClient(attachmentResolver);
+        setHtmlContent(htmlText);
+    }
+
+    private void setAttachmentResolverWebViewClient(AttachmentResolver attachmentResolver) {
+        K9WebViewClient webViewClient = K9WebViewClient.newInstance(attachmentResolver);
+        setWebViewClient(webViewClient);
+    }
+
+    private void setHtmlContent(String htmlText) {
+        // Include a meta tag so the WebView will not use a fixed viewport width of 980 px
         String content = "<html><head><meta name=\"viewport\" content=\"width=device-width\"/>";
         if (K9.getK9MessageViewTheme() == K9.Theme.DARK)  {
             content += "<style type=\"text/css\">" +
@@ -123,7 +124,7 @@ public class MessageWebView extends RigidWebView {
                    ":visited, :visited * { color: #551A8B !important }</style> ";
         }
         content += HtmlConverter.cssStylePre();
-        content += "</head><body>" + text + "</body></html>";
+        content += "</head><body>" + htmlText + "</body></html>";
         //TODO: Do this in the background
         String sanitizedContent = HtmlSanitizer.sanitize(content);
         loadDataWithBaseURL("about:blank", sanitizedContent, "text/html", "utf-8", null);

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageWebView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageWebView.java
@@ -3,6 +3,8 @@ package com.fsck.k9.view;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.KeyEvent;
@@ -104,17 +106,18 @@ public class MessageWebView extends RigidWebView {
         getSettings().setDisplayZoomControls(!supportsMultiTouch);
     }
 
-    public void displayHtmlContentWithInlineAttachments(String htmlText, AttachmentResolver attachmentResolver) {
+    public void displayHtmlContentWithInlineAttachments(@NonNull String htmlText,
+            @Nullable AttachmentResolver attachmentResolver) {
         setAttachmentResolverWebViewClient(attachmentResolver);
         setHtmlContent(htmlText);
     }
 
-    private void setAttachmentResolverWebViewClient(AttachmentResolver attachmentResolver) {
+    private void setAttachmentResolverWebViewClient(@Nullable AttachmentResolver attachmentResolver) {
         K9WebViewClient webViewClient = K9WebViewClient.newInstance(attachmentResolver);
         setWebViewClient(webViewClient);
     }
 
-    private void setHtmlContent(String htmlText) {
+    private void setHtmlContent(@NonNull String htmlText) {
         // Include a meta tag so the WebView will not use a fixed viewport width of 980 px
         String content = "<html><head><meta name=\"viewport\" content=\"width=device-width\"/>";
         if (K9.getK9MessageViewTheme() == K9.Theme.DARK)  {


### PR DESCRIPTION
This commit introduces the AttachmentResourceProvider as a layer of
abstraction between K9WebViewClient and the message Part structure,
which allows getting rid of all "Part" logic in it and moves all
K9WebViewClient-related handling into MessageWebView itself (making
the class package-local).

It also fixes display of uncached inline attachments, e.g. in a Forward
operation called from the context menu.