### PR TITLE
Fix failing com.fsck.k9.mail.MessageTest

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMultipart.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMultipart.java
@@ -32,7 +32,7 @@ public class MimeMultipart extends Multipart {
         this.boundary = boundary;
     }
 
-    public static String generateBoundary() {
+    public String generateBoundary() {
         Random random = new Random();
         StringBuilder sb = new StringBuilder();
         sb.append("----");

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -1407,7 +1407,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         cv.put("decoded_body_size", attachment.size);
 
         if (MimeUtility.isMultipart(part.getMimeType())) {
-            cv.put("boundary", MimeMultipart.generateBoundary());
+            cv.put("boundary", new MimeMultipart().generateBoundary());
         }
     }
 


### PR DESCRIPTION
I've just started looking at the K-9 source, and it looks like a recent commit (e3593a1) breaks the class `com.fsck.k9.mail.MessageTest` in k9mail-library/src/androidTest.

Here's my fix, to remove the static modifier on `MimeMultipart.generateBoundary()` that was added in that commit.