### PR TITLE
Fix extracting alert text from negative IMAP responses

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/AlertResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/AlertResponse.java
@@ -1,0 +1,26 @@
+package com.fsck.k9.mail.store.imap;
+
+
+import static com.fsck.k9.mail.store.imap.ImapResponseParser.equalsIgnoreCase;
+
+
+class AlertResponse {
+    private static final String ALERT_RESPONSE_CODE = "ALERT";
+
+
+    private AlertResponse() {
+    }
+
+    public static String getAlertText(ImapResponse response) {
+        if (response.size() < 3 || !response.isList(1)) {
+            return null;
+        }
+
+        ImapList responseTextCode = response.getList(1);
+        if (responseTextCode.size() != 1 || !equalsIgnoreCase(responseTextCode.get(0), ALERT_RESPONSE_CODE)) {
+            return null;
+        }
+
+        return response.getString(2);
+    }
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapResponse.java
@@ -55,19 +55,6 @@ class ImapResponse extends ImapList {
         this.callback = callback;
     }
 
-    public String getAlertText() {
-        if (size() > 1 && ImapResponseParser.equalsIgnoreCase(get(1), "[ALERT]")) {
-            StringBuilder sb = new StringBuilder();
-            for (int i = 2, count = size(); i < count; i++) {
-                sb.append(get(i).toString());
-                sb.append(' ');
-            }
-            return sb.toString();
-        } else {
-            return null;
-        }
-    }
-
     @Override
     public String toString() {
         return "#" + (commandContinuationRequested ? "+" : tag) + "# " + super.toString();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapResponseParser.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapResponseParser.java
@@ -117,8 +117,9 @@ class ImapResponseParser {
         } while (response == null || response.getTag() == null);
 
         if (response.size() < 1 || !equalsIgnoreCase(response.get(0), Responses.OK)) {
-            throw new NegativeImapResponseException("Command: " + commandToLog + "; response: " + response.toString(),
-                    response.getAlertText());
+            String message = "Command: " + commandToLog + "; response: " + response.toString();
+            String alertText = AlertResponse.getAlertText(response);
+            throw new NegativeImapResponseException(message, alertText);
         }
 
         return responses;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/NegativeImapResponseException.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/NegativeImapResponseException.java
@@ -13,4 +13,8 @@ class NegativeImapResponseException extends MessagingException {
         super(message, true);
         this.alertText = alertText;
     }
+
+    public String getAlertText() {
+        return alertText;
+    }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/AlertResponseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/AlertResponseTest.java
@@ -1,0 +1,66 @@
+package com.fsck.k9.mail.store.imap;
+
+
+import org.junit.Test;
+
+import static com.fsck.k9.mail.store.imap.ImapResponseHelper.createImapResponse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+public class AlertResponseTest {
+
+    @Test
+    public void getAlertText_withProperAlertResponse() throws Exception {
+        ImapResponse imapResponse = createImapResponse("x NO [ALERT] Please don't do that");
+
+        String result = AlertResponse.getAlertText(imapResponse);
+
+        assertEquals("Please don't do that", result);
+    }
+
+    @Test
+    public void getAlertText_withoutResponseCodeText_shouldReturnNull() throws Exception {
+        ImapResponse imapResponse = createImapResponse("x NO");
+
+        String result = AlertResponse.getAlertText(imapResponse);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getAlertText_withoutAlertText_shouldReturnNull() throws Exception {
+        ImapResponse imapResponse = createImapResponse("x NO [ALERT]");
+
+        String result = AlertResponse.getAlertText(imapResponse);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getAlertText_withoutResponseCodeTextList_shouldReturnNull() throws Exception {
+        ImapResponse imapResponse = createImapResponse("x NO ALERT ALARM!");
+
+        String result = AlertResponse.getAlertText(imapResponse);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getAlertText_withResponseCodeTextContainingTooManyItems_shouldReturnNull() throws Exception {
+        ImapResponse imapResponse = createImapResponse("x NO [ALERT SOMETHING] ALARM!");
+
+        String result = AlertResponse.getAlertText(imapResponse);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getAlertText_withWrongResponseCodeText_shouldReturnNull() throws Exception {
+        ImapResponse imapResponse = createImapResponse("x NO [ALARM] ALERT!");
+
+        String result = AlertResponse.getAlertText(imapResponse);
+
+        assertNull(result);
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.java
@@ -358,6 +358,30 @@ public class ImapResponseParserTest {
         assertEquals("\\Seen", response.getList(2).getList(10).getString(0));
     }
 
+    @Test
+    public void readStatusResponse_withNoResponse_shouldThrow() throws Exception {
+        ImapResponseParser parser = createParser("1 NO\r\n");
+
+        try {
+            parser.readStatusResponse("1", "COMMAND", "[logId]", null);
+            fail("Expected exception");
+        } catch (NegativeImapResponseException e) {
+            assertEquals("Command: COMMAND; response: #1# [NO]", e.getMessage());
+        }
+    }
+
+    @Test
+    public void readStatusResponse_withNoResponseAndAlertText_shouldThrowWithAlertText() throws Exception {
+        ImapResponseParser parser = createParser("1 NO [ALERT] Access denied\r\n");
+
+        try {
+            parser.readStatusResponse("1", "COMMAND", "[logId]", null);
+            fail("Expected exception");
+        } catch (NegativeImapResponseException e) {
+            assertEquals("Access denied", e.getAlertText());
+        }
+    }
+
     private ImapResponseParser createParser(String response) {
         ByteArrayInputStream byteArrayInputStream = new ByteArrayInputStream(response.getBytes());
         PeekableInputStream peekableInputStream = new PeekableInputStream(byteArrayInputStream);


### PR DESCRIPTION
We currently don't use the alert text. But especially for authentication errors we should show the alert text to the user.
This PR fixes the extraction of the alert text from the server response.