### PR TITLE
Decrypted reply

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -133,7 +133,6 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
     private static final int MSG_PROGRESS_ON = 1;
     private static final int MSG_PROGRESS_OFF = 2;
-    private static final int MSG_SKIPPED_ATTACHMENTS = 3;
     public static final int MSG_SAVED_DRAFT = 4;
     private static final int MSG_DISCARDED_DRAFT = 5;
 
@@ -277,12 +276,6 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                     break;
                 case MSG_PROGRESS_OFF:
                     setProgressBarIndeterminateVisibility(false);
-                    break;
-                case MSG_SKIPPED_ATTACHMENTS:
-                    Toast.makeText(
-                        MessageCompose.this,
-                        getString(R.string.message_compose_attachments_skipped_toast),
-                        Toast.LENGTH_LONG).show();
                     break;
                 case MSG_SAVED_DRAFT:
                     mDraftId = (Long) msg.obj;
@@ -1260,12 +1253,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
         // Quote the message and setup the UI.
         quotedMessagePresenter.processMessageToForward(messageViewInfo);
-
-        if (!mSourceMessageProcessed) {
-            if (message.isSet(Flag.X_DOWNLOADED_PARTIAL) || !attachmentPresenter.loadAttachments(message, 0)) {
-                mHandler.sendEmptyMessage(MSG_SKIPPED_ATTACHMENTS);
-            }
-        }
+        attachmentPresenter.processMessageToForward(messageViewInfo);
     }
 
     private void processDraftMessage(MessageViewInfo messageViewInfo) throws MessagingException {
@@ -1737,6 +1725,12 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         @Override
         public void performSaveAfterChecks() {
             MessageCompose.this.performSaveAfterChecks();
+        }
+
+        @Override
+        public void showMissingAttachmentsPartialMessageWarning() {
+            Toast.makeText(MessageCompose.this,
+                    getString(R.string.message_compose_attachments_skipped_toast), Toast.LENGTH_LONG).show();
         }
     };
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -113,8 +113,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     public static final String ACTION_EDIT_DRAFT = "com.fsck.k9.intent.action.EDIT_DRAFT";
 
     public static final String EXTRA_ACCOUNT = "account";
-    public static final String EXTRA_MESSAGE_BODY  = "messageBody";
     public static final String EXTRA_MESSAGE_REFERENCE = "message_reference";
+    public static final String EXTRA_MESSAGE_DECRYPTION_RESULT  = "message_decryption_result";
 
     private static final String STATE_KEY_SOURCE_MESSAGE_PROCED =
         "com.fsck.k9.activity.MessageCompose.stateKeySourceMessageProced";
@@ -366,10 +366,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         EolConvertingEditText upperSignature = (EolConvertingEditText)findViewById(R.id.upper_signature);
         EolConvertingEditText lowerSignature = (EolConvertingEditText)findViewById(R.id.lower_signature);
 
-        String sourceMessageBody = intent.getStringExtra(EXTRA_MESSAGE_BODY);
-
         QuotedMessageMvpView quotedMessageMvpView = new QuotedMessageMvpView(this);
-        quotedMessagePresenter = new QuotedMessagePresenter(this, quotedMessageMvpView, mAccount, sourceMessageBody);
+        quotedMessagePresenter = new QuotedMessagePresenter(this, quotedMessageMvpView, mAccount);
         attachmentPresenter = new AttachmentPresenter(getApplicationContext(), attachmentMvpView, getLoaderManager());
 
         mMessageContentView = (EolConvertingEditText)findViewById(R.id.message_content);
@@ -467,7 +465,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 messageLoaderHelper = new MessageLoaderHelper(this, getLoaderManager(), getFragmentManager(),
                         messageLoaderCallbacks);
                 mHandler.sendEmptyMessage(MSG_PROGRESS_ON);
-                messageLoaderHelper.asyncStartOrResumeLoadingMessage(mMessageReference);
+
+                Parcelable cachedDecryptionResult = intent.getParcelableExtra(EXTRA_MESSAGE_DECRYPTION_RESULT);
+                messageLoaderHelper.asyncStartOrResumeLoadingMessage(mMessageReference, cachedDecryptionResult);
             }
 
             if (mAction != Action.EDIT_DRAFT) {
@@ -1132,7 +1132,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             throw new IllegalStateException("tried to edit quoted message with no referenced message");
         }
 
-        messageLoaderHelper.asyncStartOrResumeLoadingMessage(mMessageReference);
+        messageLoaderHelper.asyncStartOrResumeLoadingMessage(mMessageReference, null);
     }
 
     /**

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -18,6 +18,7 @@ import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -53,7 +54,6 @@ import com.fsck.k9.search.SearchSpecification;
 import com.fsck.k9.search.SearchSpecification.Attribute;
 import com.fsck.k9.search.SearchSpecification.SearchCondition;
 import com.fsck.k9.search.SearchSpecification.SearchField;
-import com.fsck.k9.ui.messageview.CryptoInfoDialog.OnClickShowCryptoKeyListener;
 import com.fsck.k9.ui.messageview.MessageViewFragment;
 import com.fsck.k9.ui.messageview.MessageViewFragment.MessageViewFragmentListener;
 import com.fsck.k9.view.MessageHeader;
@@ -1210,17 +1210,32 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
     @Override
     public void onForward(LocalMessage message) {
-        MessageActions.actionForward(this, message, null);
+        onForward(message, null);
+    }
+
+    @Override
+    public void onForward(LocalMessage message, Parcelable decryptionResultForReply) {
+        MessageActions.actionForward(this, message, decryptionResultForReply);
     }
 
     @Override
     public void onReply(LocalMessage message) {
-        MessageActions.actionReply(this, message, false, null);
+        onReply(message, null);
+    }
+
+    @Override
+    public void onReply(LocalMessage message, Parcelable decryptionResultForReply) {
+        MessageActions.actionReply(this, message, false, decryptionResultForReply);
     }
 
     @Override
     public void onReplyAll(LocalMessage message) {
-        MessageActions.actionReply(this, message, true, null);
+        onReplyAll(message, null);
+    }
+
+    @Override
+    public void onReplyAll(LocalMessage message, Parcelable decryptionResultForReply) {
+        MessageActions.actionReply(this, message, true, decryptionResultForReply);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/MessageActions.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/MessageActions.java
@@ -2,6 +2,7 @@ package com.fsck.k9.activity.compose;
 
 import android.content.Context;
 import android.content.Intent;
+import android.os.Parcelable;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Preferences;
@@ -28,15 +29,11 @@ public class MessageActions {
     /**
      * Get intent for composing a new message as a reply to the given message. If replyAll is true
      * the function is reply all instead of simply reply.
-     * @param messageBody optional, for decrypted messages, null if it should be grabbed from the given message
      */
     public static Intent getActionReplyIntent(
-            Context context,
-            LocalMessage message,
-            boolean replyAll,
-            String messageBody) {
+            Context context, LocalMessage message, boolean replyAll, Parcelable decryptionResult) {
         Intent i = new Intent(context, MessageCompose.class);
-        i.putExtra(MessageCompose.EXTRA_MESSAGE_BODY, messageBody);
+        i.putExtra(MessageCompose.EXTRA_MESSAGE_DECRYPTION_RESULT, decryptionResult);
         i.putExtra(MessageCompose.EXTRA_MESSAGE_REFERENCE, message.makeMessageReference());
         if (replyAll) {
             i.setAction(MessageCompose.ACTION_REPLY_ALL);
@@ -58,27 +55,19 @@ public class MessageActions {
     /**
      * Compose a new message as a reply to the given message. If replyAll is true the function
      * is reply all instead of simply reply.
-     * @param messageBody optional, for decrypted messages, null if it should be grabbed from the given message
      */
     public static void actionReply(
-            Context context,
-            LocalMessage message,
-            boolean replyAll,
-            String messageBody) {
-        context.startActivity(getActionReplyIntent(context, message, replyAll, messageBody));
+            Context context, LocalMessage message, boolean replyAll, Parcelable decryptionResult) {
+        context.startActivity(getActionReplyIntent(context, message, replyAll, decryptionResult));
     }
 
     /**
      * Compose a new message as a forward of the given message.
-     * @param messageBody optional, for decrypted messages, null if it should be grabbed from the given message
      */
-    public static void actionForward(
-            Context context,
-            LocalMessage message,
-            String messageBody) {
+    public static void actionForward(Context context, LocalMessage message, Parcelable decryptionResult) {
         Intent i = new Intent(context, MessageCompose.class);
-        i.putExtra(MessageCompose.EXTRA_MESSAGE_BODY, messageBody);
         i.putExtra(MessageCompose.EXTRA_MESSAGE_REFERENCE, message.makeMessageReference());
+        i.putExtra(MessageCompose.EXTRA_MESSAGE_DECRYPTION_RESULT, decryptionResult);
         i.setAction(MessageCompose.ACTION_FORWARD);
         context.startActivity(i);
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -191,12 +191,12 @@ public class RecipientPresenter implements PermissionPingCallback {
         outState.putBoolean(STATE_KEY_CRYPTO_ENABLE_PGP_INLINE, cryptoEnablePgpInline);
     }
 
-    public void initFromDraftMessage(LocalMessage message) {
+    public void initFromDraftMessage(Message message) {
         initRecipientsFromDraftMessage(message);
         initPgpInlineFromDraftMessage(message);
     }
 
-    private void initRecipientsFromDraftMessage(LocalMessage message) {
+    private void initRecipientsFromDraftMessage(Message message) {
         addToAddresses(message.getRecipients(RecipientType.TO));
 
         Address[] ccRecipients = message.getRecipients(RecipientType.CC);
@@ -206,7 +206,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         addBccAddresses(bccRecipients);
     }
 
-    private void initPgpInlineFromDraftMessage(LocalMessage message) {
+    private void initPgpInlineFromDraftMessage(Message message) {
         cryptoEnablePgpInline = message.isSet(Flag.X_DRAFT_OPENPGP_INLINE);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/helper/QuotedMessageHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/QuotedMessageHelper.java
@@ -75,19 +75,17 @@ public class QuotedMessageHelper {
         InsertableHtmlContent insertable = findInsertionPoints(messageBody);
 
         String sentDate = getSentDateText(resources, originalMessage);
+        String fromAddress = Address.toString(originalMessage.getFrom());
         if (quoteStyle == QuoteStyle.PREFIX) {
             StringBuilder header = new StringBuilder(QUOTE_BUFFER_LENGTH);
             header.append("<div class=\"gmail_quote\">");
             if (sentDate.length() != 0) {
                 header.append(HtmlConverter.textToHtmlFragment(String.format(
-                        resources.getString(R.string.message_compose_reply_header_fmt_with_date),
-                        sentDate,
-                        Address.toString(originalMessage.getFrom()))
+                        resources.getString(R.string.message_compose_reply_header_fmt_with_date), sentDate, fromAddress)
                 ));
             } else {
                 header.append(HtmlConverter.textToHtmlFragment(String.format(
-                        resources.getString(R.string.message_compose_reply_header_fmt),
-                        Address.toString(originalMessage.getFrom()))
+                        resources.getString(R.string.message_compose_reply_header_fmt), fromAddress)
                 ));
             }
             header.append("<blockquote class=\"gmail_quote\" " +
@@ -102,9 +100,9 @@ public class QuotedMessageHelper {
             StringBuilder header = new StringBuilder();
             header.append("<div style='font-size:10.0pt;font-family:\"Tahoma\",\"sans-serif\";padding:3.0pt 0in 0in 0in'>\r\n");
             header.append("<hr style='border:none;border-top:solid #E1E1E1 1.0pt'>\r\n"); // This gets converted into a horizontal line during html to text conversion.
-            if (originalMessage.getFrom() != null && Address.toString(originalMessage.getFrom()).length() != 0) {
+            if (originalMessage.getFrom() != null && fromAddress.length() != 0) {
                 header.append("<b>").append(resources.getString(R.string.message_compose_quote_header_from)).append("</b> ")
-                        .append(HtmlConverter.textToHtmlFragment(Address.toString(originalMessage.getFrom())))
+                        .append(HtmlConverter.textToHtmlFragment(fromAddress))
                         .append("<br>\r\n");
             }
             if (sentDate.length() != 0) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import android.content.Context;
 import android.support.annotation.VisibleForTesting;
+import android.support.annotation.WorkerThread;
 
 import com.fsck.k9.R;
 import com.fsck.k9.helper.HtmlConverter;
@@ -44,6 +45,7 @@ public class MessageViewInfoExtractor {
 
     private MessageViewInfoExtractor() { }
 
+    @WorkerThread
     public static MessageViewInfo extractMessageForView(Context context,
             Message message, MessageCryptoAnnotations annotations) throws MessagingException {
 

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -11,6 +11,7 @@ import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.util.Log;
+import android.support.annotation.WorkerThread;
 
 import com.fsck.k9.Globals;
 import com.fsck.k9.K9;
@@ -40,7 +41,9 @@ public class AttachmentInfoExtractor {
         this.context = context;
     }
 
-    public List<AttachmentViewInfo> extractAttachmentInfos(List<Part> attachmentParts) throws MessagingException {
+    @WorkerThread
+    public List<AttachmentViewInfo> extractAttachmentInfos(List<Part> attachmentParts)
+            throws MessagingException {
 
         List<AttachmentViewInfo> attachments = new ArrayList<>();
         for (Part part : attachmentParts) {
@@ -50,6 +53,7 @@ public class AttachmentInfoExtractor {
         return attachments;
     }
 
+    @WorkerThread
     public AttachmentViewInfo extractAttachmentInfo(Part part) throws MessagingException {
         Uri uri;
         long size;
@@ -93,6 +97,7 @@ public class AttachmentInfoExtractor {
         return extractAttachmentInfo(part, Uri.EMPTY, AttachmentViewInfo.UNKNOWN_SIZE);
     }
 
+    @WorkerThread
     private AttachmentViewInfo extractAttachmentInfo(Part part, Uri uri, long size) throws MessagingException {
         boolean firstClassAttachment = true;
 
@@ -128,6 +133,7 @@ public class AttachmentInfoExtractor {
         return new AttachmentViewInfo(mimeType, name, attachmentSize, uri, firstClassAttachment, part);
     }
 
+    @WorkerThread
     private long extractAttachmentSize(String contentDisposition, long size) {
         if (size != AttachmentViewInfo.UNKNOWN_SIZE) {
             return size;

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -46,33 +46,17 @@ public class QuotedMessagePresenter {
     private QuoteStyle quoteStyle;
     private boolean forcePlainText;
 
-    /**
-     * "Original" message body
-     *
-     * <p>
-     * The contents of this string will be used instead of the body of a referenced message when
-     * replying to or forwarding a message.<br>
-     * Right now this is only used when replying to a signed or encrypted message. It then contains
-     * the stripped/decrypted body of that message.
-     * </p>
-     * <p><strong>Note:</strong>
-     * When this field is not {@code null} we assume that the message we are composing right now
-     * should be encrypted.
-     * </p>
-     */
-    private String sourceMessageBody;
 
     private SimpleMessageFormat quotedTextFormat;
     private InsertableHtmlContent quotedHtmlContent;
     private Account account;
 
 
-    public QuotedMessagePresenter(MessageCompose messageCompose, QuotedMessageMvpView quotedMessageMvpView,
-            Account account, String sourceMessageBody) {
+    public QuotedMessagePresenter(
+            MessageCompose messageCompose, QuotedMessageMvpView quotedMessageMvpView, Account account) {
         this.messageCompose = messageCompose;
         this.resources = messageCompose.getResources();
         this.view = quotedMessageMvpView;
-        this.sourceMessageBody = sourceMessageBody;
         onSwitchAccount(account);
 
         quotedTextMode = QuotedTextMode.NONE;
@@ -113,12 +97,9 @@ public class QuotedMessagePresenter {
             quotedTextFormat = SimpleMessageFormat.HTML;
         }
 
-        // TODO -- I am assuming that sourceMessageBody will always be a text part.  Is this a safe assumption?
-
         // Handle the original message in the reply
         // If we already have sourceMessageBody, use that.  It's pre-populated if we've got crypto going on.
-        String content = sourceMessageBody != null ? sourceMessageBody :
-                QuotedMessageHelper.getBodyTextFromMessage(messageViewInfo.message, quotedTextFormat);
+        String content = QuotedMessageHelper.getBodyTextFromMessage(messageViewInfo.message, quotedTextFormat);
 
         if (quotedTextFormat == SimpleMessageFormat.HTML) {
             // Strip signature.

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -15,7 +15,6 @@ import com.fsck.k9.activity.MessageCompose;
 import com.fsck.k9.activity.MessageCompose.Action;
 import com.fsck.k9.helper.HtmlConverter;
 import com.fsck.k9.helper.QuotedMessageHelper;
-import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MessageExtractor;

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -91,7 +91,7 @@ public class QuotedMessagePresenter {
             // Figure out which message format to use for the quoted text by looking if the source
             // message contains a text/html part. If it does, we use that.
             quotedTextFormat =
-                    (MimeUtility.findFirstPartByMimeType(messageViewInfo.message, "text/html") == null) ?
+                    (MimeUtility.findFirstPartByMimeType(messageViewInfo.rootPart, "text/html") == null) ?
                             SimpleMessageFormat.TEXT : SimpleMessageFormat.HTML;
         } else {
             quotedTextFormat = SimpleMessageFormat.HTML;
@@ -99,7 +99,7 @@ public class QuotedMessagePresenter {
 
         // Handle the original message in the reply
         // If we already have sourceMessageBody, use that.  It's pre-populated if we've got crypto going on.
-        String content = QuotedMessageHelper.getBodyTextFromMessage(messageViewInfo.message, quotedTextFormat);
+        String content = QuotedMessageHelper.getBodyTextFromMessage(messageViewInfo.rootPart, quotedTextFormat);
 
         if (quotedTextFormat == SimpleMessageFormat.HTML) {
             // Strip signature.
@@ -118,7 +118,7 @@ public class QuotedMessagePresenter {
 
             // TODO: Also strip the signature from the text/plain part
             view.setQuotedText(QuotedMessageHelper.quoteOriginalTextMessage(resources, messageViewInfo.message,
-                    QuotedMessageHelper.getBodyTextFromMessage(messageViewInfo.message, SimpleMessageFormat.TEXT),
+                    QuotedMessageHelper.getBodyTextFromMessage(messageViewInfo.rootPart, SimpleMessageFormat.TEXT),
                     quoteStyle, account.getQuotePrefix()));
 
         } else if (quotedTextFormat == SimpleMessageFormat.TEXT) {
@@ -283,11 +283,11 @@ public class QuotedMessagePresenter {
                 }
             }
             if (bodyPlainOffset != null && bodyPlainLength != null) {
-                processSourceMessageText(messageViewInfo.message, bodyPlainOffset, bodyPlainLength, false);
+                processSourceMessageText(messageViewInfo.rootPart, bodyPlainOffset, bodyPlainLength, false);
             }
         } else if (messageFormat == MessageFormat.TEXT) {
             quotedTextFormat = SimpleMessageFormat.TEXT;
-            processSourceMessageText(messageViewInfo.message, bodyOffset, bodyLength, true);
+            processSourceMessageText(messageViewInfo.rootPart, bodyOffset, bodyLength, true);
         } else {
             Log.e(K9.LOG_TAG, "Unhandled message format.");
         }
@@ -305,14 +305,13 @@ public class QuotedMessagePresenter {
     /**
      * Pull out the parts of the now loaded source message and apply them to the new message
      * depending on the type of message being composed.
-     * @param message Source message
      * @param bodyOffset Insertion point for reply.
      * @param bodyLength Length of reply.
      * @param viewMessageContent Update mMessageContentView or not.
      */
-    private void processSourceMessageText(Message message, int bodyOffset, int bodyLength, boolean viewMessageContent)
+    private void processSourceMessageText(Part rootMessagePart, int bodyOffset, int bodyLength, boolean viewMessageContent)
             throws MessagingException {
-        Part textPart = MimeUtility.findFirstPartByMimeType(message, "text/plain");
+        Part textPart = MimeUtility.findFirstPartByMimeType(rootMessagePart, "text/plain");
         if (textPart == null) {
             return;
         }

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -21,7 +21,6 @@ import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MessageExtractor;
 import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mailstore.AttachmentResolver;
-import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.message.IdentityField;
 import com.fsck.k9.message.InsertableHtmlContent;
@@ -134,7 +133,7 @@ public class QuotedMessagePresenter {
 
             // Load the message with the reply header. TODO replace with MessageViewInfo data
             view.setQuotedHtml(quotedHtmlContent.getQuotedContent(),
-                    AttachmentResolver.createFromPart(sourceMessage));
+                    AttachmentResolver.createFromPart(messageViewInfo.rootPart));
 
             // TODO: Also strip the signature from the text/plain part
             view.setQuotedText(QuotedMessageHelper.quoteOriginalTextMessage(resources, messageViewInfo.message,
@@ -299,7 +298,7 @@ public class QuotedMessagePresenter {
                     }
                     // TODO replace with MessageViewInfo data
                     view.setQuotedHtml(quotedHtmlContent.getQuotedContent(),
-                            AttachmentResolver.createFromPart(message));
+                            AttachmentResolver.createFromPart(messageViewInfo.rootPart));
                 }
             }
             if (bodyPlainOffset != null && bodyPlainLength != null) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
@@ -13,6 +13,7 @@ import android.app.Activity;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.WorkerThread;
 import android.util.Log;
@@ -69,6 +70,7 @@ public class MessageCryptoHelper {
     private MessageCryptoCallback callback;
 
     private LocalMessage currentMessage;
+    private OpenPgpDecryptionResult cachedDecryptionResult;
     private MessageCryptoAnnotations queuedResult;
     private PendingIntent queuedPendingIntent;
 
@@ -95,7 +97,8 @@ public class MessageCryptoHelper {
         }
     }
 
-    public void asyncStartOrResumeProcessingMessage(LocalMessage message, MessageCryptoCallback callback) {
+    public void asyncStartOrResumeProcessingMessage(LocalMessage message, MessageCryptoCallback callback,
+            OpenPgpDecryptionResult cachedDecryptionResult) {
         if (this.currentMessage != null) {
             reattachCallback(message, callback);
             return;
@@ -103,6 +106,7 @@ public class MessageCryptoHelper {
 
         this.messageAnnotations = new MessageCryptoAnnotations();
         this.currentMessage = message;
+        this.cachedDecryptionResult = cachedDecryptionResult;
         this.callback = callback;
 
         runFirstPass();
@@ -229,18 +233,26 @@ public class MessageCryptoHelper {
         Intent decryptIntent = userInteractionResultIntent;
         userInteractionResultIntent = null;
         if (decryptIntent == null) {
-            decryptIntent = new Intent();
+            decryptIntent = getDecryptionIntent();
         }
         decryptVerify(decryptIntent);
     }
 
-    private void decryptVerify(Intent intent) {
-        intent.setAction(OpenPgpApi.ACTION_DECRYPT_VERIFY);
+    @NonNull
+    private Intent getDecryptionIntent() {
+        Intent decryptIntent = new Intent(OpenPgpApi.ACTION_DECRYPT_VERIFY);
+
         Address[] from = currentMessage.getFrom();
         if (from.length > 0) {
-            intent.putExtra(OpenPgpApi.EXTRA_SENDER_ADDRESS, from[0].getAddress());
+            decryptIntent.putExtra(OpenPgpApi.EXTRA_SENDER_ADDRESS, from[0].getAddress());
         }
 
+        decryptIntent.putExtra(OpenPgpApi.EXTRA_DECRYPTION_RESULT, cachedDecryptionResult);
+
+        return decryptIntent;
+    }
+
+    private void decryptVerify(Intent intent) {
         try {
             CryptoPartType cryptoPartType = currentCryptoPart.type;
             switch (cryptoPartType) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageExtractorLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageExtractorLoader.java
@@ -4,6 +4,7 @@ package com.fsck.k9.ui.message;
 import android.content.AsyncTaskLoader;
 import android.content.Context;
 import android.support.annotation.Nullable;
+import android.support.annotation.WorkerThread;
 import android.util.Log;
 
 import com.fsck.k9.K9;
@@ -45,6 +46,7 @@ public class LocalMessageExtractorLoader extends AsyncTaskLoader<MessageViewInfo
     }
 
     @Override
+    @WorkerThread
     public MessageViewInfo loadInBackground() {
         try {
             return MessageViewInfoExtractor.extractMessageForView(getContext(), message, annotations);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -9,6 +9,7 @@ import android.content.IntentSender;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.util.Log;
@@ -199,6 +200,13 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
     public void onClickShowMessageOverrideWarning() {
         overrideCryptoWarning = true;
         messageCryptoMvpView.redisplayMessage();
+    }
+
+    public Parcelable getDecryptionResultForReply() {
+        if (cryptoResultAnnotation != null && cryptoResultAnnotation.isOpenPgpResult()) {
+            return cryptoResultAnnotation.getOpenPgpDecryptionResult();
+        }
+        return null;
     }
 
     @Nullable

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -16,6 +16,7 @@ import android.content.IntentSender.SendIntentException;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
+import android.os.Parcelable;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.ContextThemeWrapper;
@@ -203,7 +204,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         }
 
         mAccount = Preferences.getPreferences(getApplicationContext()).getAccount(mMessageReference.getAccountUuid());
-        messageLoaderHelper.asyncStartOrResumeLoadingMessage(messageReference);
+        messageLoaderHelper.asyncStartOrResumeLoadingMessage(messageReference, null);
 
         mFragmentListener.updateMenu();
     }
@@ -319,19 +320,19 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
     public void onReply() {
         if (mMessage != null) {
-            mFragmentListener.onReply(mMessage);
+            mFragmentListener.onReply(mMessage, messageCryptoPresenter.getDecryptionResultForReply());
         }
     }
 
     public void onReplyAll() {
         if (mMessage != null) {
-            mFragmentListener.onReplyAll(mMessage);
+            mFragmentListener.onReplyAll(mMessage, messageCryptoPresenter.getDecryptionResultForReply());
         }
     }
 
     public void onForward() {
         if (mMessage != null) {
-            mFragmentListener.onForward(mMessage);
+            mFragmentListener.onForward(mMessage, messageCryptoPresenter.getDecryptionResultForReply());
         }
     }
 
@@ -690,15 +691,15 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     public interface MessageViewFragmentListener {
-        public void onForward(LocalMessage mMessage);
-        public void disableDeleteAction();
-        public void onReplyAll(LocalMessage mMessage);
-        public void onReply(LocalMessage mMessage);
-        public void displayMessageSubject(String title);
-        public void setProgress(boolean b);
-        public void showNextMessageOrReturn();
-        public void messageHeaderViewAvailable(MessageHeader messageHeaderView);
-        public void updateMenu();
+        void onForward(LocalMessage mMessage, Parcelable decryptionResultForReply);
+        void disableDeleteAction();
+        void onReplyAll(LocalMessage mMessage, Parcelable decryptionResultForReply);
+        void onReply(LocalMessage mMessage, Parcelable decryptionResultForReply);
+        void displayMessageSubject(String title);
+        void setProgress(boolean b);
+        void showNextMessageOrReturn();
+        void messageHeaderViewAvailable(MessageHeader messageHeaderView);
+        void updateMenu();
     }
 
     public boolean isInitialized() {

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
@@ -258,6 +258,7 @@ public class OpenPgpApi {
     public static final String RESULT_INTENT = "intent";
 
     // DECRYPT_VERIFY
+    public static final String EXTRA_DECRYPTION_RESULT = "decryption_result";
     public static final String EXTRA_DETACHED_SIGNATURE = "detached_signature";
     public static final String EXTRA_PROGRESS_MESSENGER = "progress_messenger";
     public static final String EXTRA_DATA_LENGTH = "data_length";


### PR DESCRIPTION
(based on #1484, only the last six or so commits are actually relevant)

This PR introduces a couple of changes to make reply and forward pgp/mime aware:
* decryption info from message view is passed to the compose dialog, to avoid user interaction (passphrase/yubikey) for decryption
* extraction logic uses the decrypted message root part