### PR TITLE
show archive & spam actions when all accounts are copy capable

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -257,6 +257,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     private boolean mSingleAccountMode;
     private boolean mSingleFolderMode;
     private boolean mAllAccounts;
+    private boolean mAllAccountsCopyCapable;
 
     private MessageListHandler mHandler = new MessageListHandler(this);
 
@@ -828,6 +829,15 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 }
             } else {
                 mAccountUuids = accountUuids;
+            }
+        }
+
+        mAllAccountsCopyCapable = true;
+        for (String uuid : mAccountUuids) {
+            Account account = mPreferences.getAccount(uuid);
+            if (account == null || !mController.isCopyCapable(account)) {
+                mAllAccountsCopyCapable = false;
+                break;
             }
         }
     }
@@ -2669,11 +2679,10 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 menu.findItem(R.id.move).setVisible(false);
                 menu.findItem(R.id.copy).setVisible(false);
 
-                //TODO: we could support the archive and spam operations if all selected messages
-                // belong to non-POP3 accounts
-                menu.findItem(R.id.archive).setVisible(false);
-                menu.findItem(R.id.spam).setVisible(false);
-
+                if (!mAllAccountsCopyCapable) {
+                    menu.findItem(R.id.archive).setVisible(false);
+                    menu.findItem(R.id.spam).setVisible(false);
+                }
             } else {
                 // hide unsupported
                 if (!mController.isCopyCapable(account)) {


### PR DESCRIPTION
When viewing a message list, added a check to determine if all accounts included in the list are 'copy capable'. This check is then used in the multiple account scenario to determine whether or not to enable the archive and spam operations when multiple items are selected.

This solves a big pain point for me because I use both delete and archive extensively and the lack of the ability to archive multiple items at once in the unified mail list resulted in a poor workflow.

I hope this pull request is up to your standards. I am new to both android and this project, and any feedback on this request would be welcome.

Thanks for your all your hard work on this project!