### PR TITLE
Add Globals class so we can avoid passing Context through layers of code

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Globals.java
+++ b/k9mail/src/main/java/com/fsck/k9/Globals.java
@@ -1,0 +1,21 @@
+package com.fsck.k9;
+
+
+import android.content.Context;
+
+
+public class Globals {
+    private static Context context;
+
+    static void setContext(Context context) {
+        Globals.context = context;
+    }
+
+    public static Context getContext() {
+        if (context == null) {
+            throw new IllegalStateException("No context provided");
+        }
+
+        return context;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -505,6 +505,7 @@ public class K9 extends Application {
 
         super.onCreate();
         app = this;
+        Globals.setContext(this);
 
         K9MailLib.setDebugStatus(new K9MailLib.DebugStatus() {
             @Override public boolean enabled() {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
@@ -6,7 +6,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
 
-import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -42,14 +41,14 @@ public class AttachmentResolver {
     }
 
     @WorkerThread
-    public static AttachmentResolver createFromPart(Context context, Part part) {
+    public static AttachmentResolver createFromPart(Part part) {
         AttachmentInfoExtractor attachmentInfoExtractor = AttachmentInfoExtractor.getInstance();
-        Map<String, Uri> contentIdToAttachmentUriMap = buildCidToAttachmentUriMap(context, attachmentInfoExtractor, part);
+        Map<String, Uri> contentIdToAttachmentUriMap = buildCidToAttachmentUriMap(attachmentInfoExtractor, part);
         return new AttachmentResolver(contentIdToAttachmentUriMap);
     }
 
     @VisibleForTesting
-    static Map<String,Uri> buildCidToAttachmentUriMap(Context context, AttachmentInfoExtractor attachmentInfoExtractor,
+    static Map<String,Uri> buildCidToAttachmentUriMap(AttachmentInfoExtractor attachmentInfoExtractor,
             Part rootPart) {
         HashMap<String,Uri> result = new HashMap<>();
 
@@ -69,7 +68,7 @@ public class AttachmentResolver {
                 try {
                     String contentId = part.getContentId();
                     if (contentId != null) {
-                        AttachmentViewInfo attachmentInfo = attachmentInfoExtractor.extractAttachmentInfo(context, part);
+                        AttachmentViewInfo attachmentInfo = attachmentInfoExtractor.extractAttachmentInfo(part);
                         result.put(contentId, attachmentInfo.uri);
                     }
                 } catch (MessagingException e) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -74,7 +74,7 @@ public class MessageViewInfoExtractor {
             extraViewableText = extraViewable.text;
         }
 
-        AttachmentResolver attachmentResolver = AttachmentResolver.createFromPart(context, rootPart);
+        AttachmentResolver attachmentResolver = AttachmentResolver.createFromPart(rootPart);
 
         return MessageViewInfo.createWithExtractedContent(message, rootPart, viewable.html,
                 attachmentInfos, cryptoResultAnnotation, extraViewableText, extraAttachmentInfos, attachmentResolver);
@@ -89,7 +89,7 @@ public class MessageViewInfoExtractor {
             MessageExtractor.findViewablesAndAttachments(part, viewableParts, attachments);
         }
 
-        attachmentInfos.addAll(attachmentInfoExtractor.extractAttachmentInfos(context, attachments));
+        attachmentInfos.addAll(attachmentInfoExtractor.extractAttachmentInfos(attachments));
         return MessageViewInfoExtractor.extractTextFromViewables(context, viewableParts);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -133,7 +133,7 @@ public class QuotedMessagePresenter {
 
             // Load the message with the reply header. TODO replace with MessageViewInfo data
             view.setQuotedHtml(quotedHtmlContent.getQuotedContent(),
-                    AttachmentResolver.createFromPart(messageCompose, sourceMessage));
+                    AttachmentResolver.createFromPart(sourceMessage));
 
             // TODO: Also strip the signature from the text/plain part
             view.setQuotedText(QuotedMessageHelper.quoteOriginalTextMessage(resources, sourceMessage,
@@ -298,7 +298,7 @@ public class QuotedMessagePresenter {
                     }
                     // TODO replace with MessageViewInfo data
                     view.setQuotedHtml(quotedHtmlContent.getQuotedContent(),
-                            AttachmentResolver.createFromPart(messageCompose, message));
+                            AttachmentResolver.createFromPart(message));
                 }
             }
             if (bodyPlainOffset != null && bodyPlainLength != null) {

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
@@ -1,8 +1,6 @@
 package com.fsck.k9.mailstore;
 
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.Map;
 
 import android.net.Uri;
@@ -17,7 +15,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.*;
@@ -46,8 +43,7 @@ public class AttachmentResolverTest {
     public void buildCidMap__onPartWithNoBody__shouldReturnEmptyMap() throws Exception {
         Part part = new MimeBodyPart();
 
-        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(
-                RuntimeEnvironment.application, attachmentInfoExtractor, part);
+        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, part);
 
         assertTrue(result.isEmpty());
     }
@@ -57,8 +53,7 @@ public class AttachmentResolverTest {
         Multipart multipartBody = new MimeMultipart();
         Part multipartPart = new MimeBodyPart(multipartBody);
 
-        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(
-                RuntimeEnvironment.application, attachmentInfoExtractor, multipartPart);
+        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart);
 
         assertTrue(result.isEmpty());
     }
@@ -70,10 +65,7 @@ public class AttachmentResolverTest {
         Part multipartPart = new MimeBodyPart(multipartBody);
         multipartBody.addBodyPart(bodyPart);
 
-
-        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(
-                RuntimeEnvironment.application, attachmentInfoExtractor, multipartPart);
-
+        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart);
 
         verify(bodyPart).getContentId();
         assertTrue(result.isEmpty());
@@ -92,19 +84,16 @@ public class AttachmentResolverTest {
         when(subPart1.getContentId()).thenReturn("cid-1");
         when(subPart2.getContentId()).thenReturn("cid-2");
 
-        when(attachmentInfoExtractor.extractAttachmentInfo(RuntimeEnvironment.application, subPart1)).thenReturn(
+        when(attachmentInfoExtractor.extractAttachmentInfo(subPart1)).thenReturn(
                 new AttachmentViewInfo(null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_1, true, subPart1));
-        when(attachmentInfoExtractor.extractAttachmentInfo(RuntimeEnvironment.application, subPart2)).thenReturn(
+        when(attachmentInfoExtractor.extractAttachmentInfo(subPart2)).thenReturn(
                 new AttachmentViewInfo(null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_2, true, subPart2));
 
 
-        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(RuntimeEnvironment.application,
-                attachmentInfoExtractor, multipartPart);
-
+        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart);
 
         assertEquals(2, result.size());
         assertEquals(ATTACHMENT_TEST_URI_1, result.get("cid-1"));
         assertEquals(ATTACHMENT_TEST_URI_2, result.get("cid-2"));
     }
-
 }

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
@@ -1,8 +1,6 @@
 package com.fsck.k9.message.extractors;
 
 
-import java.io.File;
-
 import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.Nullable;
@@ -40,18 +38,20 @@ public class AttachmentInfoExtractorTest {
 
 
     private AttachmentInfoExtractor attachmentInfoExtractor;
+    private Context context;
 
 
     @Before
     public void setUp() throws Exception {
-        attachmentInfoExtractor = AttachmentInfoExtractor.getInstance();
+        context = RuntimeEnvironment.application;
+        attachmentInfoExtractor = new AttachmentInfoExtractor(context);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void extractInfo__withGenericPart_shouldThrow() throws Exception {
         Part part = mock(Part.class);
 
-        attachmentInfoExtractor.extractAttachmentInfo(RuntimeEnvironment.application, part);
+        attachmentInfoExtractor.extractAttachmentInfo(part);
     }
 
     @Test
@@ -62,8 +62,7 @@ public class AttachmentInfoExtractorTest {
         when(part.getSize()).thenReturn(TEST_SIZE);
         when(part.getAccountUuid()).thenReturn(TEST_ACCOUNT_UUID);
 
-        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(
-                RuntimeEnvironment.application, part);
+        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(part);
 
         assertEquals(AttachmentProvider.getAttachmentUri(TEST_ACCOUNT_UUID, TEST_ID), attachmentViewInfo.uri);
         assertEquals(TEST_SIZE, attachmentViewInfo.size);
@@ -165,11 +164,10 @@ public class AttachmentInfoExtractorTest {
 
     @Test
     public void extractInfo__withDeferredFileBody() throws Exception {
-        attachmentInfoExtractor = new AttachmentInfoExtractor() {
+        attachmentInfoExtractor = new AttachmentInfoExtractor(context) {
             @Nullable
             @Override
-            protected Uri getDecryptedFileProviderUri(Context context, DeferredFileBody decryptedTempFileBody,
-                    String mimeType) {
+            protected Uri getDecryptedFileProviderUri(DeferredFileBody decryptedTempFileBody, String mimeType) {
                 return TEST_URI;
             }
         };
@@ -182,8 +180,7 @@ public class AttachmentInfoExtractorTest {
         when(body.getSize()).thenReturn(TEST_SIZE);
 
 
-        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(
-                RuntimeEnvironment.application, part);
+        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(part);
 
 
         assertEquals(TEST_URI, attachmentViewInfo.uri);


### PR DESCRIPTION
If your class requires a Context instance make it a constructor argument. Then create a static factory method that calls Globals.getContext(). The result can then be passed to the constructor.
This allows testing individual classes using test doubles by directly invoking the constructor and not having to deal with Globals. For integrated tests spanning multiple classes you might have to use Globals.setContext().