### PR TITLE
Loader helper fixes

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -405,7 +405,7 @@ public class MessageLoaderHelper {
     MessagingListener downloadMessageListener = new MessagingListener() {
         @Override
         public void loadMessageRemoteFinished(Account account, String folder, String uid) {
-            if (messageReference.equals(account.getUuid(), folder, uid, null)) {
+            if (messageReference.equals(account.getUuid(), folder, uid)) {
                 return;
             }
             onMessageDownloadFinished();

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -399,6 +399,9 @@ public class MessageLoaderHelper {
     MessagingListener downloadMessageListener = new MessagingListener() {
         @Override
         public void loadMessageRemoteFinished(Account account, String folder, String uid) {
+            if (messageReference.equals(account.getUuid(), folder, uid, null)) {
+                return;
+            }
             onMessageDownloadFinished();
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -69,11 +69,11 @@ public class MessageLoaderHelper {
     private static final int DECODE_MESSAGE_LOADER_ID = 2;
 
 
-    // injected state
-    private final Context context;
-    private final FragmentManager fragmentManager;
-    private final LoaderManager loaderManager;
-    @Nullable // may be cleared
+    // injected state - all of this may be cleared to avoid data leakage!
+    private Context context;
+    private FragmentManager fragmentManager;
+    private LoaderManager loaderManager;
+    @Nullable // make this explicitly nullable, make sure to cancel/ignore any operation if this is null
     private MessageLoaderCallbacks callback;
 
 
@@ -126,6 +126,9 @@ public class MessageLoaderHelper {
         }
 
         callback = null;
+        context = null;
+        fragmentManager = null;
+        loaderManager = null;
     }
 
     /** Prevents future callbacks, but retains loading state to pick up from in a call to
@@ -137,6 +140,9 @@ public class MessageLoaderHelper {
         }
 
         callback = null;
+        context = null;
+        fragmentManager = null;
+        loaderManager = null;
     }
 
     @UiThread

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageReference.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageReference.java
@@ -113,11 +113,10 @@ public class MessageReference implements Parcelable {
             return false;
         }
         MessageReference other = (MessageReference) o;
-        return equals(other.accountUuid, other.folderName, other.uid, other.flag);
+        return equals(other.accountUuid, other.folderName, other.uid);
     }
 
-    @SuppressWarnings("UnusedParameters") // consistency with constructor
-    public boolean equals(String accountUuid, String folderName, String uid, Flag flag) {
+    public boolean equals(String accountUuid, String folderName, String uid) {
         // noinspection StringEquality, we check for null values here
         return ((accountUuid == this.accountUuid || (accountUuid != null && accountUuid.equals(this.accountUuid)))
                 && (folderName == this.folderName || (folderName != null && folderName.equals(this.folderName)))

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageReference.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageReference.java
@@ -109,16 +109,19 @@ public class MessageReference implements Parcelable {
 
     @Override
     public boolean equals(Object o) {
-        if (o instanceof MessageReference == false) {
+        if (!(o instanceof MessageReference)) {
             return false;
         }
         MessageReference other = (MessageReference) o;
-        if ((accountUuid == other.accountUuid || (accountUuid != null && accountUuid.equals(other.accountUuid)))
-                && (folderName == other.folderName || (folderName != null && folderName.equals(other.folderName)))
-                && (uid == other.uid || (uid != null && uid.equals(other.uid)))) {
-            return true;
-        }
-        return false;
+        return equals(other.accountUuid, other.folderName, other.uid, other.flag);
+    }
+
+    @SuppressWarnings("UnusedParameters") // consistency with constructor
+    public boolean equals(String accountUuid, String folderName, String uid, Flag flag) {
+        // noinspection StringEquality, we check for null values here
+        return ((accountUuid == this.accountUuid || (accountUuid != null && accountUuid.equals(this.accountUuid)))
+                && (folderName == this.folderName || (folderName != null && folderName.equals(this.folderName)))
+                && (uid == this.uid || (uid != null && uid.equals(this.uid))));
     }
 
     @Override


### PR DESCRIPTION
Just two small fixes for MessageLoaderHelper:
* don't leak Context, FragmentManager and LoaderManager after detach (see #782)
* check that callbacks we get actually relate to our MessageReference before processing them