### PR TITLE
Sanitize HTML in MessageViewExtractor instead of MessageWebView

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Globals.java
+++ b/k9mail/src/main/java/com/fsck/k9/Globals.java
@@ -8,8 +8,7 @@ import android.support.annotation.VisibleForTesting;
 public class Globals {
     private static Context context;
 
-    @VisibleForTesting
-    public static void setContext(Context context) {
+    static void setContext(Context context) {
         Globals.context = context;
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/Globals.java
+++ b/k9mail/src/main/java/com/fsck/k9/Globals.java
@@ -2,12 +2,14 @@ package com.fsck.k9;
 
 
 import android.content.Context;
+import android.support.annotation.VisibleForTesting;
 
 
 public class Globals {
     private static Context context;
 
-    static void setContext(Context context) {
+    @VisibleForTesting
+    public static void setContext(Context context) {
         Globals.context = context;
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/helper/HtmlConverter.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HtmlConverter.java
@@ -1323,6 +1323,31 @@ public class HtmlConverter {
         return "</pre>";
     }
 
+    public static String wrapStatusMessage(CharSequence status) {
+        return wrapMessageContent("<div style=\"text-align:center; color: grey;\">" + status + "</div>");
+    }
+
+    public static String wrapMessageContent(CharSequence messageContent) {
+        // Include a meta tag so the WebView will not use a fixed viewport width of 980 px
+        return "<html><head><meta name=\"viewport\" content=\"width=device-width\"/>" +
+                HtmlConverter.cssStyleTheme() +
+                HtmlConverter.cssStylePre() +
+                "</head><body>" +
+                messageContent +
+                "</body></html>";
+    }
+
+    private static String cssStyleTheme() {
+        if (K9.getK9MessageViewTheme() == K9.Theme.DARK)  {
+            return "<style type=\"text/css\">" +
+                    "* { background: black ! important; color: #F3F3F3 !important }" +
+                    ":link, :link * { color: #CCFF33 !important }" +
+                    ":visited, :visited * { color: #551A8B !important }</style> ";
+        } else {
+            return "";
+        }
+    }
+
     /**
      * Dynamically generate a CSS style for {@code <pre>} elements.
      *
@@ -1335,7 +1360,7 @@ public class HtmlConverter {
      *      A {@code <style>} element that can be dynamically included in the HTML
      *      {@code <head>} element when messages are displayed.
      */
-    public static String cssStylePre() {
+    private static String cssStylePre() {
         final String font = K9.messageViewFixedWidthFont()
                 ? "monospace"
                 : "sans-serif";

--- a/k9mail/src/main/java/com/fsck/k9/helper/HtmlSanitizer.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HtmlSanitizer.java
@@ -1,6 +1,8 @@
 package com.fsck.k9.helper;
 
 
+import android.support.annotation.VisibleForTesting;
+
 import org.htmlcleaner.CleanerProperties;
 import org.htmlcleaner.HtmlCleaner;
 import org.htmlcleaner.HtmlSerializer;
@@ -19,9 +21,15 @@ public class HtmlSanitizer {
     }
 
 
-    private HtmlSanitizer() {}
+    public static HtmlSanitizer getInstance() {
+        return new HtmlSanitizer();
+    }
 
-    public static String sanitize(String html) {
+    @VisibleForTesting
+    HtmlSanitizer() {}
+
+
+    public String sanitize(String html) {
         TagNode rootNode = HTML_CLEANER.clean(html);
 
         removeMetaRefresh(rootNode);
@@ -43,7 +51,7 @@ public class HtmlSanitizer {
         return properties;
     }
 
-    private static void removeMetaRefresh(TagNode rootNode) {
+    private void removeMetaRefresh(TagNode rootNode) {
         for (TagNode element : rootNode.getElementListByName("meta", true)) {
             String httpEquiv = element.getAttributeByName("http-equiv");
             if (httpEquiv != null && httpEquiv.trim().equalsIgnoreCase("refresh")) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageExtractorLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageExtractorLoader.java
@@ -16,6 +16,9 @@ import com.fsck.k9.ui.crypto.MessageCryptoAnnotations;
 
 
 public class LocalMessageExtractorLoader extends AsyncTaskLoader<MessageViewInfo> {
+    private static final MessageViewInfoExtractor messageViewInfoExtractor = MessageViewInfoExtractor.getInstance();
+
+
     private final Message message;
     private MessageViewInfo messageViewInfo;
     @Nullable
@@ -49,7 +52,7 @@ public class LocalMessageExtractorLoader extends AsyncTaskLoader<MessageViewInfo
     @WorkerThread
     public MessageViewInfo loadInBackground() {
         try {
-            return MessageViewInfoExtractor.extractMessageForView(getContext(), message, annotations);
+            return messageViewInfoExtractor.extractMessageForView(message, annotations);
         } catch (Exception e) {
             Log.e(K9.LOG_TAG, "Error while decoding message", e);
             return null;

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -33,6 +33,7 @@ import android.widget.Toast;
 import com.fsck.k9.R;
 import com.fsck.k9.helper.ClipboardManager;
 import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.helper.HtmlConverter;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mailstore.AttachmentResolver;
@@ -437,7 +438,7 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
         }
 
         if (textToDisplay == null) {
-            textToDisplay = wrapStatusMessage(getContext().getString(R.string.webview_empty_message));
+            textToDisplay = HtmlConverter.wrapStatusMessage(getContext().getString(R.string.webview_empty_message));
         }
 
         OnPageFinishedListener onPageFinishedListener = new OnPageFinishedListener() {
@@ -458,10 +459,6 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
 
     public boolean hasHiddenExternalImages() {
         return hasHiddenExternalImages;
-    }
-
-    public String wrapStatusMessage(String status) {
-        return "<div style=\"text-align:center; color: grey;\">" + status + "</div>";
     }
 
     private void displayHtmlContentWithInlineAttachments(String htmlText, AttachmentResolver attachmentResolver,

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageWebView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageWebView.java
@@ -17,8 +17,6 @@ import android.widget.Toast;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.Theme;
 import com.fsck.k9.R;
-import com.fsck.k9.helper.HtmlConverter;
-import com.fsck.k9.helper.HtmlSanitizer;
 import com.fsck.k9.mailstore.AttachmentResolver;
 
 
@@ -132,19 +130,7 @@ public class MessageWebView extends RigidWebView {
     }
 
     private void setHtmlContent(@NonNull String htmlText) {
-        // Include a meta tag so the WebView will not use a fixed viewport width of 980 px
-        String content = "<html><head><meta name=\"viewport\" content=\"width=device-width\"/>";
-        if (K9.getK9MessageViewTheme() == K9.Theme.DARK)  {
-            content += "<style type=\"text/css\">" +
-                   "* { background: black ! important; color: #F3F3F3 !important }" +
-                   ":link, :link * { color: #CCFF33 !important }" +
-                   ":visited, :visited * { color: #551A8B !important }</style> ";
-        }
-        content += HtmlConverter.cssStylePre();
-        content += "</head><body>" + htmlText + "</body></html>";
-        //TODO: Do this in the background
-        String sanitizedContent = HtmlSanitizer.sanitize(content);
-        loadDataWithBaseURL("about:blank", sanitizedContent, "text/html", "utf-8", null);
+        loadDataWithBaseURL("about:blank", htmlText, "text/html", "utf-8", null);
         resumeTimers();
     }
 

--- a/k9mail/src/test/java/com/fsck/k9/GlobalsHelper.java
+++ b/k9mail/src/test/java/com/fsck/k9/GlobalsHelper.java
@@ -1,0 +1,11 @@
+package com.fsck.k9;
+
+
+import android.content.Context;
+
+
+public class GlobalsHelper {
+    public static void setContext(Context context) {
+        Globals.setContext(context);
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/helper/HtmlSanitizerHelper.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/HtmlSanitizerHelper.java
@@ -1,0 +1,13 @@
+package com.fsck.k9.helper;
+
+
+public class HtmlSanitizerHelper {
+    public static HtmlSanitizer getDummyHtmlSanitizer() {
+        return new HtmlSanitizer() {
+            @Override
+            public String sanitize(String html) {
+                return html;
+            }
+        };
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/helper/HtmlSanitizerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/HtmlSanitizerTest.java
@@ -1,19 +1,27 @@
 package com.fsck.k9.helper;
 
 
+import org.junit.Before;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
 
 public class HtmlSanitizerTest {
+    private HtmlSanitizer htmlSanitizer;
+
+    @Before
+    public void setUp() throws Exception {
+        htmlSanitizer = HtmlSanitizer.getInstance();
+    }
+
     @Test
     public void shouldRemoveMetaRefreshInHead() {
         String html = "<html>" +
                 "<head><meta http-equiv=\"refresh\" content=\"1; URL=http://example.com/\"></head>" +
                 "<body>Message</body>" +
                 "</html>";
-        assertEquals("<html><head></head><body>Message</body></html>", HtmlSanitizer.sanitize(html));
+        assertEquals("<html><head></head><body>Message</body></html>", htmlSanitizer.sanitize(html));
     }
 
     @Test
@@ -22,7 +30,7 @@ public class HtmlSanitizerTest {
                 "<head></head><meta http-equiv=\"refresh\" content=\"1; URL=http://example.com/\">" +
                 "<body>Message</body>" +
                 "</html>";
-        assertEquals("<html><head></head><body>Message</body></html>", HtmlSanitizer.sanitize(html));
+        assertEquals("<html><head></head><body>Message</body></html>", htmlSanitizer.sanitize(html));
     }
 
     @Test
@@ -31,7 +39,7 @@ public class HtmlSanitizerTest {
                 "<head></head>" +
                 "<body><meta http-equiv=\"refresh\" content=\"1; URL=http://example.com/\">Message</body>" +
                 "</html>";
-        assertEquals("<html><head></head><body>Message</body></html>", HtmlSanitizer.sanitize(html));
+        assertEquals("<html><head></head><body>Message</body></html>", htmlSanitizer.sanitize(html));
     }
 
     @Test
@@ -40,7 +48,7 @@ public class HtmlSanitizerTest {
                 "<head><meta http-equiv=\"REFRESH\" content=\"1; URL=http://example.com/\"></head>" +
                 "<body>Message</body>" +
                 "</html>";
-        assertEquals("<html><head></head><body>Message</body></html>", HtmlSanitizer.sanitize(html));
+        assertEquals("<html><head></head><body>Message</body></html>", htmlSanitizer.sanitize(html));
     }
 
     @Test
@@ -49,7 +57,7 @@ public class HtmlSanitizerTest {
                 "<head><meta http-equiv=\"Refresh\" content=\"1; URL=http://example.com/\"></head>" +
                 "<body>Message</body>" +
                 "</html>";
-        assertEquals("<html><head></head><body>Message</body></html>", HtmlSanitizer.sanitize(html));
+        assertEquals("<html><head></head><body>Message</body></html>", htmlSanitizer.sanitize(html));
     }
 
     @Test
@@ -58,7 +66,7 @@ public class HtmlSanitizerTest {
                 "<head><meta http-equiv=refresh content=\"1; URL=http://example.com/\"></head>" +
                 "<body>Message</body>" +
                 "</html>";
-        assertEquals("<html><head></head><body>Message</body></html>", HtmlSanitizer.sanitize(html));
+        assertEquals("<html><head></head><body>Message</body></html>", htmlSanitizer.sanitize(html));
     }
 
     @Test
@@ -67,7 +75,7 @@ public class HtmlSanitizerTest {
                 "<head><meta http-equiv=\"refresh \" content=\"1; URL=http://example.com/\"></head>" +
                 "<body>Message</body>" +
                 "</html>";
-        assertEquals("<html><head></head><body>Message</body></html>", HtmlSanitizer.sanitize(html));
+        assertEquals("<html><head></head><body>Message</body></html>", htmlSanitizer.sanitize(html));
     }
 
     @Test
@@ -76,7 +84,7 @@ public class HtmlSanitizerTest {
                 "<head><meta http-equiv=\"refresh\" content=\"1; URL=http://example.com/\"></head>" +
                 "<body><meta http-equiv=\"refresh\" content=\"1; URL=http://example.com/\">Message</body>" +
                 "</html>";
-        assertEquals("<html><head></head><body>Message</body></html>", HtmlSanitizer.sanitize(html));
+        assertEquals("<html><head></head><body>Message</body></html>", htmlSanitizer.sanitize(html));
     }
 
     @Test
@@ -89,6 +97,6 @@ public class HtmlSanitizerTest {
                 "<body>Message</body>" +
                 "</html>";
         assertEquals("<html><head><meta http-equiv=\"content-type\" content=\"text/html; charset=UTF-8\" /></head>" +
-                "<body>Message</body></html>", HtmlSanitizer.sanitize(html));
+                "<body>Message</body></html>", htmlSanitizer.sanitize(html));
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -9,6 +9,8 @@ import java.util.TimeZone;
 
 import com.fsck.k9.Globals;
 import com.fsck.k9.activity.K9ActivityCommon;
+import com.fsck.k9.helper.HtmlSanitizer;
+import com.fsck.k9.helper.HtmlSanitizerHelper;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message.RecipientType;
 import com.fsck.k9.mail.MessagingException;
@@ -24,30 +26,67 @@ import com.fsck.k9.mailstore.MessageViewInfoExtractor.ViewableExtractedText;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricGradleTestRunner;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import static com.fsck.k9.mailstore.MessageViewInfoExtractor.extractTextFromViewables;
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertSame;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
 public class MessageViewInfoExtractorTest {
+    public static final String BODY_TEXT = "K-9 Mail rocks :>";
+    public static final String BODY_TEXT_HTML = "K-9 Mail rocks :&gt;";
+
+
+    private MessageViewInfoExtractor messageViewInfoExtractor;
+
 
     @Before
     public void setUp() throws Exception {
         Globals.setContext(RuntimeEnvironment.application);
+
+        HtmlSanitizer dummyHtmlSanitizer = HtmlSanitizerHelper.getDummyHtmlSanitizer();
+
+        messageViewInfoExtractor = new MessageViewInfoExtractor(RuntimeEnvironment.application,
+                null, dummyHtmlSanitizer);
+    }
+
+    @Test
+    public void testShouldSanitizeOutputHtml() throws MessagingException {
+        // Create text/plain body
+        TextBody body = new TextBody(BODY_TEXT);
+
+        // Create message
+        MimeMessage message = new MimeMessage();
+        MimeMessageHelper.setBody(message, body);
+
+        // Prepare fixture
+        HtmlSanitizer htmlSanitizer = mock(HtmlSanitizer.class);
+        MessageViewInfoExtractor messageViewInfoExtractor =
+                new MessageViewInfoExtractor(RuntimeEnvironment.application, null, htmlSanitizer);
+        String value = "--sanitized html--";
+        when(htmlSanitizer.sanitize(any(String.class))).thenReturn(value);
+
+        // Extract text
+        List<Part> outputNonViewableParts = new ArrayList<>();
+        ArrayList<Viewable> outputViewableParts = new ArrayList<>();
+        MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
+        ViewableExtractedText viewableExtractedText =
+                messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
+
+        assertSame(value, viewableExtractedText.html);
     }
 
     @Test
     public void testSimplePlainTextMessage() throws MessagingException {
-        String bodyText = "K-9 Mail rocks :>";
-
         // Create text/plain body
-        TextBody body = new TextBody(bodyText);
+        TextBody body = new TextBody(BODY_TEXT);
 
         // Create message
         MimeMessage message = new MimeMessage();
@@ -57,16 +96,16 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<Part>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = extractTextFromViewables(RuntimeEnvironment.application, outputViewableParts);
+        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
 
-        String expectedText = bodyText;
+        String expectedText = BODY_TEXT;
         String expectedHtml =
                 "<pre class=\"k9mail\">" +
                 "K-9 Mail rocks :&gt;" +
                 "</pre>";
 
         assertEquals(expectedText, container.text);
-        assertEquals(expectedHtml, container.html);
+        assertEquals(expectedHtml, getHtmlBodyText(container.html));
     }
 
     @Test
@@ -85,14 +124,14 @@ public class MessageViewInfoExtractorTest {
         List<Part> attachments = new ArrayList<Part>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, attachments);
-        ViewableExtractedText container = extractTextFromViewables(RuntimeEnvironment.application, outputViewableParts);
+        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
 
-        String expectedText = "K-9 Mail rocks :>";
+        String expectedText = BODY_TEXT;
         String expectedHtml =
                 bodyText;
 
         assertEquals(expectedText, container.text);
-        assertEquals(expectedHtml, container.html);
+        assertEquals(expectedHtml, getHtmlBodyText(container.html));
     }
 
     @Test
@@ -119,7 +158,7 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<Part>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = extractTextFromViewables(RuntimeEnvironment.application, outputViewableParts);
+        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
 
         String expectedText =
                 bodyText1 + "\r\n\r\n" +
@@ -137,7 +176,7 @@ public class MessageViewInfoExtractorTest {
 
 
         assertEquals(expectedText, container.text);
-        assertEquals(expectedHtml, container.html);
+        assertEquals(expectedHtml, getHtmlBodyText(container.html));
     }
 
     @Test
@@ -146,11 +185,10 @@ public class MessageViewInfoExtractorTest {
         Locale.setDefault(Locale.US);
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+01:00"));
 
-        String bodyText = "Some text here";
         String innerBodyText = "Hey there. I'm inside a message/rfc822 (inline) attachment.";
 
         // Create text/plain body
-        TextBody textBody = new TextBody(bodyText);
+        TextBody textBody = new TextBody(BODY_TEXT);
 
         // Create inner text/plain body
         TextBody innerBody = new TextBody(innerBodyText);
@@ -179,11 +217,10 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<Part>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = extractTextFromViewables(RuntimeEnvironment.application,
-                outputViewableParts);
+        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
 
         String expectedText =
-                bodyText +
+                BODY_TEXT +
                 "\r\n\r\n" +
                 "----- message.eml ------------------------------------------------------" +
                 "\r\n\r\n" +
@@ -195,7 +232,7 @@ public class MessageViewInfoExtractorTest {
                 innerBodyText;
         String expectedHtml =
                 "<pre class=\"k9mail\">" +
-                bodyText +
+                        BODY_TEXT_HTML +
                 "</pre>" +
                 "<p style=\"margin-top: 2.5em; margin-bottom: 1em; border-bottom: " +
                         "1px solid #000\">message.eml</p>" +
@@ -219,6 +256,13 @@ public class MessageViewInfoExtractorTest {
                 "</pre>";
 
         assertEquals(expectedText, container.text);
-        assertEquals(expectedHtml, container.html);
+        assertEquals(expectedHtml, getHtmlBodyText(container.html));
     }
+
+    private static String getHtmlBodyText(String htmlText) {
+        htmlText = htmlText.substring(htmlText.indexOf("<body>") +6);
+        htmlText = htmlText.substring(0, htmlText.indexOf("</body>"));
+        return htmlText;
+    }
+
 }

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -7,9 +7,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import android.support.test.InstrumentationRegistry;
-import android.support.test.runner.AndroidJUnit4;
-
+import com.fsck.k9.Globals;
 import com.fsck.k9.activity.K9ActivityCommon;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message.RecipientType;
@@ -23,15 +21,26 @@ import com.fsck.k9.mail.internet.MimeMultipart;
 import com.fsck.k9.mail.internet.TextBody;
 import com.fsck.k9.mail.internet.Viewable;
 import com.fsck.k9.mailstore.MessageViewInfoExtractor.ViewableExtractedText;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
 
 import static com.fsck.k9.mailstore.MessageViewInfoExtractor.extractTextFromViewables;
 import static junit.framework.Assert.assertEquals;
 
 
-@RunWith(AndroidJUnit4.class)
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
 public class MessageViewInfoExtractorTest {
+
+    @Before
+    public void setUp() throws Exception {
+        Globals.setContext(RuntimeEnvironment.application);
+    }
 
     @Test
     public void testSimplePlainTextMessage() throws MessagingException {
@@ -48,8 +57,7 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<Part>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = extractTextFromViewables(InstrumentationRegistry.getTargetContext(),
-                outputViewableParts);
+        ViewableExtractedText container = extractTextFromViewables(RuntimeEnvironment.application, outputViewableParts);
 
         String expectedText = bodyText;
         String expectedHtml =
@@ -77,8 +85,7 @@ public class MessageViewInfoExtractorTest {
         List<Part> attachments = new ArrayList<Part>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, attachments);
-        ViewableExtractedText container = extractTextFromViewables(InstrumentationRegistry.getTargetContext(),
-                outputViewableParts);
+        ViewableExtractedText container = extractTextFromViewables(RuntimeEnvironment.application, outputViewableParts);
 
         String expectedText = "K-9 Mail rocks :>";
         String expectedHtml =
@@ -112,8 +119,7 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<Part>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = extractTextFromViewables(InstrumentationRegistry.getTargetContext(),
-                outputViewableParts);
+        ViewableExtractedText container = extractTextFromViewables(RuntimeEnvironment.application, outputViewableParts);
 
         String expectedText =
                 bodyText1 + "\r\n\r\n" +
@@ -136,7 +142,7 @@ public class MessageViewInfoExtractorTest {
 
     @Test
     public void testTextPlusRfc822Message() throws MessagingException {
-        K9ActivityCommon.setLanguage(InstrumentationRegistry.getTargetContext(), "en");
+        K9ActivityCommon.setLanguage(RuntimeEnvironment.application, "en");
         Locale.setDefault(Locale.US);
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+01:00"));
 
@@ -173,7 +179,7 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<Part>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = extractTextFromViewables(InstrumentationRegistry.getTargetContext(),
+        ViewableExtractedText container = extractTextFromViewables(RuntimeEnvironment.application,
                 outputViewableParts);
 
         String expectedText =

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -7,7 +7,9 @@ import java.util.List;
 import java.util.Locale;
 import java.util.TimeZone;
 
-import com.fsck.k9.Globals;
+import android.app.Application;
+
+import com.fsck.k9.GlobalsHelper;
 import com.fsck.k9.activity.K9ActivityCommon;
 import com.fsck.k9.helper.HtmlSanitizer;
 import com.fsck.k9.helper.HtmlSanitizerHelper;
@@ -45,15 +47,18 @@ public class MessageViewInfoExtractorTest {
 
 
     private MessageViewInfoExtractor messageViewInfoExtractor;
+    private Application context;
 
 
     @Before
     public void setUp() throws Exception {
-        Globals.setContext(RuntimeEnvironment.application);
+        context = RuntimeEnvironment.application;
+
+        GlobalsHelper.setContext(context);
 
         HtmlSanitizer dummyHtmlSanitizer = HtmlSanitizerHelper.getDummyHtmlSanitizer();
 
-        messageViewInfoExtractor = new MessageViewInfoExtractor(RuntimeEnvironment.application,
+        messageViewInfoExtractor = new MessageViewInfoExtractor(context,
                 null, dummyHtmlSanitizer);
     }
 
@@ -69,7 +74,7 @@ public class MessageViewInfoExtractorTest {
         // Prepare fixture
         HtmlSanitizer htmlSanitizer = mock(HtmlSanitizer.class);
         MessageViewInfoExtractor messageViewInfoExtractor =
-                new MessageViewInfoExtractor(RuntimeEnvironment.application, null, htmlSanitizer);
+                new MessageViewInfoExtractor(context, null, htmlSanitizer);
         String value = "--sanitized html--";
         when(htmlSanitizer.sanitize(any(String.class))).thenReturn(value);
 
@@ -181,7 +186,7 @@ public class MessageViewInfoExtractorTest {
 
     @Test
     public void testTextPlusRfc822Message() throws MessagingException {
-        K9ActivityCommon.setLanguage(RuntimeEnvironment.application, "en");
+        K9ActivityCommon.setLanguage(context, "en");
         Locale.setDefault(Locale.US);
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+01:00"));
 


### PR DESCRIPTION
This PR moves more data processing, namely the html header construction and sanitization, into extractor classes, saving a bunch of processing time on the ui thread.

It is arguable if addition of the viewport meta tag shouldn't be kept in the MessageWebView, since that bit is about a specific behavior of the WebView. However, if we do that we seperate it from other header pieces like theming and fonts, ripping apart the header creation. So I decided to move all of that into HtmlConverter. I suppose HtmlConverter is slowly approaching a point where it does too much, but we can always split it apart later. 