### PR TITLE
use mimeType and boundary values from BodyDescriptor over header values

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -1,6 +1,7 @@
 
 package com.fsck.k9.mail.internet;
 
+
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -9,14 +10,22 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.text.SimpleDateFormat;
 import java.util.Date;
-import java.util.TimeZone;
 import java.util.LinkedList;
 import java.util.Locale;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.UUID;
 
 import android.support.annotation.NonNull;
 
+import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.Body;
+import com.fsck.k9.mail.BodyPart;
+import com.fsck.k9.mail.CompositeBody;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.Multipart;
+import com.fsck.k9.mail.Part;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.dom.field.DateTimeField;
@@ -28,15 +37,6 @@ import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
 import org.apache.james.mime4j.util.MimeUtil;
-
-import com.fsck.k9.mail.Address;
-import com.fsck.k9.mail.Body;
-import com.fsck.k9.mail.BodyPart;
-import com.fsck.k9.mail.CompositeBody;
-import com.fsck.k9.mail.Message;
-import com.fsck.k9.mail.MessagingException;
-import com.fsck.k9.mail.Multipart;
-import com.fsck.k9.mail.Part;
 
 /**
  * An implementation of Message that stores all of it's metadata in RFC 822 and
@@ -530,9 +530,8 @@ public class MimeMessage extends Message {
 
             Part e = (Part)stack.peek();
             try {
-                String contentType = e.getContentType();
-                String mimeType = MimeUtility.getHeaderParameter(contentType, null);
-                String boundary = MimeUtility.getHeaderParameter(contentType, "boundary");
+                String mimeType = bd.getMimeType();
+                String boundary = bd.getBoundary();
                 MimeMultipart multiPart = new MimeMultipart(mimeType, boundary);
                 e.setBody(multiPart);
                 stack.addFirst(multiPart);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
@@ -15,7 +15,6 @@ import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MimeBodyPart;
 import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.internet.MimeMultipart;
-import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mailstore.util.FileFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.MimeException;
@@ -150,9 +149,8 @@ public class MimePartStreamParser {
         public void startMultipart(BodyDescriptor bd) throws MimeException {
             Part part = (Part) stack.peek();
             try {
-                String contentType = part.getContentType();
-                String mimeType = MimeUtility.getHeaderParameter(contentType, null);
-                String boundary = MimeUtility.getHeaderParameter(contentType, "boundary");
+                String mimeType = bd.getMimeType();
+                String boundary = bd.getBoundary();
 
                 MimeMultipart multipart = new MimeMultipart(mimeType, boundary);
                 part.setBody(multipart);


### PR DESCRIPTION
We get a BodyDescriptor in `startMultipart`, which gives better values for mimetype and boundary than our `MimeUtility.getHeaderParameter` values. One particular instance where it gives better values is a duplicate Content-Type header where the first one is empty and the second one is valid (see #1333).

We definitely want to use mime4j for all our parsing needs. However, this PR slightly reduces our parsing consistency, since there are other places (i.e. all places where `getContentType` + `MimeUtility.getHeaderParamet` is used to get the mimetype or boundary value) which use the old logic.  It's a little difficult to get that right since those header parsing methods aren't very exposed in mime4j... still, it's an improvement.