### PR TITLE
couple of broken message fixes

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
@@ -50,8 +50,8 @@ public class MessageExtractor {
                     return ((TextBody)body).getText();
                 }
                 final String mimeType = part.getMimeType();
-                if (mimeType != null && MimeUtility.mimeTypeMatches(mimeType, "text/*") ||
-                        part.isMimeType("application/pgp")) {
+                if (mimeType != null && isSameMimeType(mimeType, "text") ||
+                        MimeUtility.mimeTypeMatches(mimeType, "text/*") || part.isMimeType("application/pgp")) {
                     return getTextFromTextPart(part, body, mimeType, textSizeLimit);
                 } else {
                     throw new MessagingException("Provided non-text part: " + part);
@@ -171,7 +171,8 @@ public class MessageExtractor {
                 return;
             }
             String mimeType = part.getMimeType();
-            if (isSameMimeType(mimeType, "text/plain")) {
+            // TODO we default to html handling here, does that make sense?
+            if (isSameMimeType(mimeType, "text/plain") || isSameMimeType(mimeType, "text")) {
                 Text text = new Text(part);
                 outputViewableParts.add(text);
             } else {
@@ -281,7 +282,8 @@ public class MessageExtractor {
                         break;
                     }
                 }
-            } else if (isPartTextualBody(part) && isSameMimeType(part.getMimeType(), "text/plain")) {
+            } else if (isPartTextualBody(part) && (isSameMimeType(part.getMimeType(), "text/plain") ||
+                    isSameMimeType(part.getMimeType(), "text"))) {
                 Text text = new Text(part);
                 viewables.add(text);
                 if (directChild) {
@@ -429,6 +431,11 @@ public class MessageExtractor {
         }
 
         if (part.isMimeType("text/plain")) {
+            return true;
+        }
+
+        if (part.isMimeType("text")) {
+            // Thunderbird does this, so we do too
             return true;
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -124,7 +124,7 @@ public class LocalMessage extends MimeMessage {
         mimeType = cursor.getString(23);
     }
 
-    long getMessagePartId() {
+    public long getMessagePartId() {
         return messagePartId;
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -7,6 +7,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
+import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.util.Log;
 import com.fsck.k9.Account;
@@ -678,6 +679,7 @@ public class LocalStore extends Store implements Serializable {
         });
     }
 
+    @Nullable
     public InputStream getAttachmentInputStream(final String attachmentId) throws MessagingException {
         return database.execute(false, new DbCallback<InputStream>() {
             @Override
@@ -704,6 +706,7 @@ public class LocalStore extends Store implements Serializable {
         });
     }
 
+    @Nullable
     private InputStream getRawAttachmentInputStream(Cursor cursor, int location, String attachmentId) {
         switch (location) {
             case DataLocation.IN_DATABASE: {
@@ -715,7 +718,7 @@ public class LocalStore extends Store implements Serializable {
                 try {
                     return new FileInputStream(file);
                 } catch (FileNotFoundException e) {
-                    throw new WrappedException(e);
+                    return null;
                 }
             }
             default: {
@@ -724,7 +727,12 @@ public class LocalStore extends Store implements Serializable {
         }
     }
 
-    InputStream getDecodingInputStream(final InputStream rawInputStream, String encoding) {
+    @Nullable
+    InputStream getDecodingInputStream(@Nullable final InputStream rawInputStream, @Nullable String encoding) {
+        if (rawInputStream == null) {
+            return null;
+        }
+
         if (MimeUtil.ENC_BASE64.equals(encoding)) {
             return new Base64InputStream(rawInputStream) {
                 @Override

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -20,8 +20,9 @@ import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MimeHeader;
 import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mailstore.AttachmentViewInfo;
-import com.fsck.k9.mailstore.LocalPart;
 import com.fsck.k9.mailstore.DeferredFileBody;
+import com.fsck.k9.mailstore.LocalMessage;
+import com.fsck.k9.mailstore.LocalPart;
 import com.fsck.k9.provider.AttachmentProvider;
 import com.fsck.k9.provider.DecryptedFileProvider;
 
@@ -58,6 +59,12 @@ public class AttachmentInfoExtractor {
             String accountUuid = localPart.getAccountUuid();
             long messagePartId = localPart.getId();
             size = localPart.getSize();
+            uri = AttachmentProvider.getAttachmentUri(accountUuid, messagePartId);
+        } else if (part instanceof LocalMessage) {
+            LocalMessage localMessage = (LocalMessage) part;
+            String accountUuid = localMessage.getAccount().getUuid();
+            long messagePartId = localMessage.getMessagePartId();
+            size = localMessage.getSize();
             uri = AttachmentProvider.getAttachmentUri(accountUuid, messagePartId);
         } else {
             Body body = part.getBody();


### PR DESCRIPTION
This PR contains three fixes, for the related but separate problems mentioned in #1201:

* the "text" mimeType is treated the same as "text/plain" in our message parsing
* AttachmetInfoExtractor can now handle LocalMessage parts, which can happen if the message Content-Type isn't something we can display inline and is instead treated as an attachment
* fix delayed crash in AttachmentProvider on missing part

I only noticed #1246 as I was writing this message, which introduced the `text` fix, too. I would argue that [if Thunderbird handles this content-type, who are we to disagree?](https://github.com/mozilla/releases-comm-central/blob/644b5a1487f60d73010dee11fcc6631cf7cc897f/mailnews/mime/src/mimei.cpp#L500)  If we really don't want it, feel free to rebase out the relevant commit.