### PR TITLE
don't trust X_DOWNLOADED_FULL flag, consider messages with missing data incomplete (WIP)

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
@@ -114,6 +114,23 @@ public class MessageExtractor {
         }
     }
 
+    public static boolean hasMissingParts(Part part) {
+        Body body = part.getBody();
+        if (body == null) {
+            return true;
+        }
+        if (body instanceof Multipart) {
+            Multipart multipart = (Multipart) body;
+            for (Part subPart : multipart.getBodyParts()) {
+                if (hasMissingParts(subPart)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+
     /** Traverse the MIME tree of a message an extract viewable parts. */
     public static void findViewablesAndAttachments(Part part,
                 @Nullable List<Viewable> outputViewableParts, @Nullable List<Part> outputNonViewableParts)

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1558,7 +1558,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         @Override
-        public void onMessageViewInfoLoadFailed(LocalMessage localMessage) {
+        public void onMessageViewInfoLoadFailed(LocalMessage localMessage, MessageViewInfo messageViewInfo) {
             mHandler.sendEmptyMessage(MSG_PROGRESS_OFF);
             Toast.makeText(MessageCompose.this, R.string.status_invalid_id_error, Toast.LENGTH_LONG).show();
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1552,13 +1552,13 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         @Override
-        public void onMessageViewInfoLoadFinished(LocalMessage localMessage, MessageViewInfo messageViewInfo) {
+        public void onMessageViewInfoLoadFinished(MessageViewInfo messageViewInfo) {
             mHandler.sendEmptyMessage(MSG_PROGRESS_OFF);
             loadLocalMessageForDisplay(messageViewInfo, mAction);
         }
 
         @Override
-        public void onMessageViewInfoLoadFailed(LocalMessage localMessage, MessageViewInfo messageViewInfo) {
+        public void onMessageViewInfoLoadFailed(MessageViewInfo messageViewInfo) {
             mHandler.sendEmptyMessage(MSG_PROGRESS_OFF);
             Toast.makeText(MessageCompose.this, R.string.status_invalid_id_error, Toast.LENGTH_LONG).show();
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -333,11 +333,11 @@ public class MessageLoaderHelper {
 
         if (messageViewInfo == null) {
             messageViewInfo = createErrorStateMessageViewInfo();
-            callback.onMessageViewInfoLoadFailed(localMessage, messageViewInfo);
+            callback.onMessageViewInfoLoadFailed(messageViewInfo);
             return;
         }
 
-        callback.onMessageViewInfoLoadFinished(localMessage, messageViewInfo);
+        callback.onMessageViewInfoLoadFinished(messageViewInfo);
     }
 
     @NonNull
@@ -432,8 +432,8 @@ public class MessageLoaderHelper {
         void onMessageDataLoadFinished(LocalMessage message);
         void onMessageDataLoadFailed();
 
-        void onMessageViewInfoLoadFinished(LocalMessage localMessage, MessageViewInfo messageViewInfo);
-        void onMessageViewInfoLoadFailed(LocalMessage localMessage, MessageViewInfo messageViewInfo);
+        void onMessageViewInfoLoadFinished(MessageViewInfo messageViewInfo);
+        void onMessageViewInfoLoadFailed(MessageViewInfo messageViewInfo);
 
         void setLoadingProgress(int current, int max);
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2755,7 +2755,7 @@ public class MessagingController implements Runnable {
                 message.setFlag(Flag.X_DOWNLOADED_PARTIAL, false);
             }*/
 
-            if (!message.isSet(Flag.X_DOWNLOADED_FULL)) {
+            /*if (!message.isSet(Flag.X_DOWNLOADED_FULL)) */ {
                 /*
                  * At this point the message is not available, so we need to download it
                  * fully if possible.

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -768,8 +768,10 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
             String encoding = cursor.getString(7);
 
             File file = localStore.getAttachmentFile(Long.toString(id));
-            Body body = new FileBackedBody(file, encoding);
-            part.setBody(body);
+            if (file.exists()) {
+                Body body = new FileBackedBody(file, encoding);
+                part.setBody(body);
+            }
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
@@ -9,6 +9,7 @@ import com.fsck.k9.mail.Part;
 
 public class MessageViewInfo {
     public final Message message;
+    public final boolean isMessageIncomplete;
     public final Part rootPart;
     public final AttachmentResolver attachmentResolver;
     public final String text;
@@ -18,10 +19,14 @@ public class MessageViewInfo {
     public final List<AttachmentViewInfo> extraAttachments;
 
 
-    public MessageViewInfo(Message message, Part rootPart, String text, List<AttachmentViewInfo> attachments,
-            CryptoResultAnnotation cryptoResultAnnotation, AttachmentResolver attachmentResolver, String extraText,
-            List<AttachmentViewInfo> extraAttachments) {
+    public MessageViewInfo(
+            Message message, boolean isMessageIncomplete, Part rootPart,
+            String text, List<AttachmentViewInfo> attachments,
+            CryptoResultAnnotation cryptoResultAnnotation,
+            AttachmentResolver attachmentResolver,
+            String extraText, List<AttachmentViewInfo> extraAttachments) {
         this.message = message;
+        this.isMessageIncomplete = isMessageIncomplete;
         this.rootPart = rootPart;
         this.text = text;
         this.cryptoResultAnnotation = cryptoResultAnnotation;
@@ -31,15 +36,24 @@ public class MessageViewInfo {
         this.extraAttachments = extraAttachments;
     }
 
-    public static MessageViewInfo createWithExtractedContent(Message message, Part rootPart,
-            String text, List<AttachmentViewInfo> attachments, CryptoResultAnnotation cryptoResultAnnotation,
-            String extraText, List<AttachmentViewInfo> extraAttachments, AttachmentResolver attachmentResolver) {
-        return new MessageViewInfo(message, rootPart, text, attachments, cryptoResultAnnotation, attachmentResolver,
-                extraText, extraAttachments);
+    public static MessageViewInfo createWithExtractedContent(
+            Message message, boolean isMessageIncomplete, Part rootPart,
+            String text, List<AttachmentViewInfo> attachments,
+            CryptoResultAnnotation cryptoResultAnnotation,
+            AttachmentResolver attachmentResolver,
+            String extraText, List<AttachmentViewInfo> extraAttachments
+    ) {
+        return new MessageViewInfo(
+                message, isMessageIncomplete, rootPart,
+                text, attachments,
+                cryptoResultAnnotation,
+                attachmentResolver,
+                extraText, extraAttachments
+        );
     }
 
-    public static MessageViewInfo createWithErrorState(Message message) {
-        return new MessageViewInfo(message, null, null, null, null, null, null, null);
+    public static MessageViewInfo createWithErrorState(Message message, boolean isMessageIncomplete) {
+        return new MessageViewInfo(message, isMessageIncomplete, null, null, null, null, null, null, null);
     }
 
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -15,6 +15,7 @@ import com.fsck.k9.R;
 import com.fsck.k9.helper.HtmlConverter;
 import com.fsck.k9.helper.HtmlSanitizer;
 import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
@@ -94,8 +95,11 @@ public class MessageViewInfoExtractor {
 
         AttachmentResolver attachmentResolver = AttachmentResolver.createFromPart(rootPart);
 
-        return MessageViewInfo.createWithExtractedContent(message, rootPart, viewable.html,
-                attachmentInfos, cryptoResultAnnotation, extraViewableText, extraAttachmentInfos, attachmentResolver);
+        boolean isMessageIncomplete = !message.isSet(Flag.X_DOWNLOADED_FULL) ||
+                MessageExtractor.hasMissingParts(message);
+
+        return MessageViewInfo.createWithExtractedContent(message, isMessageIncomplete, rootPart, viewable.html,
+                attachmentInfos, cryptoResultAnnotation, attachmentResolver, extraViewableText, extraAttachmentInfos);
     }
 
     private ViewableExtractedText extractViewableAndAttachments(List<Part> parts,

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -22,7 +22,6 @@ import com.fsck.k9.Account.ShowPictures;
 import com.fsck.k9.R;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.Address;
-import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.ui.messageview.MessageContainerView.OnRenderingFinishedListener;
@@ -97,14 +96,14 @@ public class MessageTopView extends LinearLayout {
         hideShowPicturesButton();
     }
 
-    private void resetAndPrepareMessageView(Message message) {
+    private void resetAndPrepareMessageView(MessageViewInfo messageViewInfo) {
         mDownloadRemainder.setVisibility(View.GONE);
         containerView.removeAllViews();
-        setShowDownloadButton(message);
+        setShowDownloadButton(messageViewInfo);
     }
 
     public void showMessage(Account account, MessageViewInfo messageViewInfo) {
-        resetAndPrepareMessageView(messageViewInfo.message);
+        resetAndPrepareMessageView(messageViewInfo);
 
         ShowPictures showPicturesSetting = account.getShowPictures();
         boolean automaticallyLoadPictures =
@@ -128,7 +127,7 @@ public class MessageTopView extends LinearLayout {
 
     public void showMessageCryptoWarning(final MessageViewInfo messageViewInfo, Drawable providerIcon,
             @StringRes int warningTextRes) {
-        resetAndPrepareMessageView(messageViewInfo.message);
+        resetAndPrepareMessageView(messageViewInfo);
         View view = mInflater.inflate(R.layout.message_content_crypto_warning, containerView, false);
         setCryptoProviderIcon(providerIcon, view);
 
@@ -147,7 +146,7 @@ public class MessageTopView extends LinearLayout {
     }
 
     public void showMessageEncryptedButIncomplete(MessageViewInfo messageViewInfo, Drawable providerIcon) {
-        resetAndPrepareMessageView(messageViewInfo.message);
+        resetAndPrepareMessageView(messageViewInfo);
         View view = mInflater.inflate(R.layout.message_content_crypto_incomplete, containerView, false);
         setCryptoProviderIcon(providerIcon, view);
 
@@ -156,7 +155,7 @@ public class MessageTopView extends LinearLayout {
     }
 
     public void showMessageCryptoErrorView(MessageViewInfo messageViewInfo, Drawable providerIcon) {
-        resetAndPrepareMessageView(messageViewInfo.message);
+        resetAndPrepareMessageView(messageViewInfo);
         View view = mInflater.inflate(R.layout.message_content_crypto_error, containerView, false);
         setCryptoProviderIcon(providerIcon, view);
 
@@ -172,7 +171,7 @@ public class MessageTopView extends LinearLayout {
     }
 
     public void showMessageCryptoCancelledView(MessageViewInfo messageViewInfo, Drawable providerIcon) {
-        resetAndPrepareMessageView(messageViewInfo.message);
+        resetAndPrepareMessageView(messageViewInfo);
         View view = mInflater.inflate(R.layout.message_content_crypto_cancelled, containerView, false);
         setCryptoProviderIcon(providerIcon, view);
 
@@ -248,12 +247,12 @@ public class MessageTopView extends LinearLayout {
         mDownloadRemainder.setEnabled(false);
     }
 
-    private void setShowDownloadButton(Message message) {
-        if (message.isSet(Flag.X_DOWNLOADED_FULL)) {
-            mDownloadRemainder.setVisibility(View.GONE);
-        } else {
+    private void setShowDownloadButton(MessageViewInfo messageViewInfo) {
+        if (messageViewInfo.isMessageIncomplete) {
             mDownloadRemainder.setEnabled(true);
             mDownloadRemainder.setVisibility(View.VISIBLE);
+        } else {
+            mDownloadRemainder.setVisibility(View.GONE);
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -727,8 +727,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         }
 
         @Override
-        public void onMessageViewInfoLoadFailed(LocalMessage localMessage) {
-            MessageViewInfo messageViewInfo = MessageViewInfo.createWithErrorState(localMessage);
+        public void onMessageViewInfoLoadFailed(LocalMessage localMessage, MessageViewInfo messageViewInfo) {
             showMessage(messageViewInfo);
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -722,12 +722,12 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         }
 
         @Override
-        public void onMessageViewInfoLoadFinished(LocalMessage localMessage, MessageViewInfo messageViewInfo) {
+        public void onMessageViewInfoLoadFinished(MessageViewInfo messageViewInfo) {
             showMessage(messageViewInfo);
         }
 
         @Override
-        public void onMessageViewInfoLoadFailed(LocalMessage localMessage, MessageViewInfo messageViewInfo) {
+        public void onMessageViewInfoLoadFailed(MessageViewInfo messageViewInfo) {
             showMessage(messageViewInfo);
         }
 


### PR DESCRIPTION
This is an experimental fix for #1243 with the following changes, the overall idea is to allow recovery from a state where part files which should be on disk are missing.

* the flag which decides whether a message is complete, and whether the "Download Complete Message" button is shown, is moved into MessageViewInfo, the relevant logic into MessageViewInfoExtractor
* if a file-backed part is missing its related file, the `FileBackedBody` won't be created (leaving the part with a null body)
* a message is considered incomplete if either it doesn't have an X_DOWNLOADED_FULL flag, *or* it is missing the body of any message part
* automatic download of (partial) message content on view is triggered only if neither X_DOWNLOADED_PARTIAL nor X_DOWNLOADED_FULL flags is set, to avoid loops if a message can't be downloaded properly
* loadMessageRemoteSynchronous will always download a message. This is currently only called exactly if the user clicks the "Download Complete Message" button, so this seems reasonable?

Feedback welcome