### PR TITLE
Ditch "hidden attachments"

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -165,7 +165,7 @@ public class AttachmentPresenter {
         }
 
         for (AttachmentViewInfo attachmentViewInfo : messageViewInfo.attachments) {
-            if (attachmentViewInfo.firstClassAttachment) {
+            if (!attachmentViewInfo.inlineAttachment) {
                 addAttachment(attachmentViewInfo);
             }
         }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
@@ -21,16 +21,16 @@ public class AttachmentViewInfo {
      * @see com.fsck.k9.ui.messageview.AttachmentController#getAttachmentUriForMimeType(AttachmentViewInfo, String)
      */
     public final Uri uri;
-    public final boolean firstClassAttachment;
+    public final boolean inlineAttachment;
     public final Part part;
 
-    public AttachmentViewInfo(String mimeType, String displayName, long size, Uri uri, boolean firstClassAttachment,
+    public AttachmentViewInfo(String mimeType, String displayName, long size, Uri uri, boolean inlineAttachment,
             Part part) {
         this.mimeType = mimeType;
         this.displayName = displayName;
         this.size = size;
         this.uri = uri;
-        this.firstClassAttachment = firstClassAttachment;
+        this.inlineAttachment = inlineAttachment;
         this.part = part;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -720,7 +720,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         // TODO might want to do that at a later point?
         // String displayName = cursor.getString(5);
         // int type = cursor.getInt(1);
-        // boolean firstClassAttachment = (type != MessagePartType.HIDDEN_ATTACHMENT);
+        // boolean inlineAttachment = (type == MessagePartType.HIDDEN_ATTACHMENT);
 
         final Part part;
         if (id == message.getMessagePartId()) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -107,7 +107,7 @@ public class MessageViewInfoExtractor {
             MessageExtractor.findViewablesAndAttachments(part, viewableParts, attachments);
         }
 
-        attachmentInfos.addAll(attachmentInfoExtractor.extractAttachmentInfos(attachments));
+        attachmentInfos.addAll(attachmentInfoExtractor.extractAttachmentInfoForView(attachments));
         return extractTextFromViewables(viewableParts);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -111,7 +111,6 @@ public class AttachmentInfoExtractor {
         }
 
         if (name == null) {
-            firstClassAttachment = false;
             String extension = null;
             if (mimeType != null) {
                 extension = MimeUtility.getExtensionByMimeType(mimeType);

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -48,7 +48,7 @@ public class AttachmentInfoExtractor {
         List<AttachmentViewInfo> attachments = new ArrayList<>();
         for (Part part : attachmentParts) {
             AttachmentViewInfo attachmentViewInfo = extractAttachmentInfo(part);
-            if (attachmentViewInfo.firstClassAttachment) {
+            if (!attachmentViewInfo.inlineAttachment) {
                 attachments.add(attachmentViewInfo);
             }
         }
@@ -102,7 +102,7 @@ public class AttachmentInfoExtractor {
 
     @WorkerThread
     private AttachmentViewInfo extractAttachmentInfo(Part part, Uri uri, long size) throws MessagingException {
-        boolean firstClassAttachment = true;
+        boolean inlineAttachment = false;
 
         String mimeType = part.getMimeType();
         String contentTypeHeader = MimeUtility.unfoldAndDecode(part.getContentType());
@@ -127,12 +127,12 @@ public class AttachmentInfoExtractor {
         if (contentDisposition != null &&
                 MimeUtility.getHeaderParameter(contentDisposition, null).matches("^(?i:inline)") &&
                 part.getHeader(MimeHeader.HEADER_CONTENT_ID).length > 0) {
-            firstClassAttachment = false;
+            inlineAttachment = true;
         }
 
         long attachmentSize = extractAttachmentSize(contentDisposition, size);
 
-        return new AttachmentViewInfo(mimeType, name, attachmentSize, uri, firstClassAttachment, part);
+        return new AttachmentViewInfo(mimeType, name, attachmentSize, uri, inlineAttachment, part);
     }
 
     @WorkerThread

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -42,12 +42,15 @@ public class AttachmentInfoExtractor {
     }
 
     @WorkerThread
-    public List<AttachmentViewInfo> extractAttachmentInfos(List<Part> attachmentParts)
+    public List<AttachmentViewInfo> extractAttachmentInfoForView(List<Part> attachmentParts)
             throws MessagingException {
 
         List<AttachmentViewInfo> attachments = new ArrayList<>();
         for (Part part : attachmentParts) {
-            attachments.add(extractAttachmentInfo(part));
+            AttachmentViewInfo attachmentViewInfo = extractAttachmentInfo(part);
+            if (attachmentViewInfo.firstClassAttachment) {
+                attachments.add(attachmentViewInfo);
+            }
         }
 
         return attachments;

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -412,8 +412,6 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
 
         renderAttachments(messageViewInfo);
 
-        mHiddenAttachments.setVisibility(View.GONE);
-
         if (mSavedState != null) {
             if (mSavedState.showingPictures) {
                 setLoadPictures(true);
@@ -477,9 +475,17 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
     }
 
     public void renderAttachments(MessageViewInfo messageViewInfo) {
+        boolean hasHiddenAttachments = false;
+
         if (messageViewInfo.attachments != null) {
             for (AttachmentViewInfo attachment : messageViewInfo.attachments) {
-                ViewGroup parent = attachment.firstClassAttachment ? mAttachments : mHiddenAttachments;
+                ViewGroup parent;
+                if (attachment.firstClassAttachment) {
+                    parent = mAttachments;
+                } else {
+                    parent = mHiddenAttachments;
+                    hasHiddenAttachments = true;
+                }
                 AttachmentView view =
                         (AttachmentView) mInflater.inflate(R.layout.message_view_attachment, parent, false);
                 view.setCallback(attachmentCallback);
@@ -492,7 +498,13 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
 
         if (messageViewInfo.extraAttachments != null) {
             for (AttachmentViewInfo attachment : messageViewInfo.extraAttachments) {
-                ViewGroup parent = attachment.firstClassAttachment ? mAttachments : mHiddenAttachments;
+                ViewGroup parent;
+                if (attachment.firstClassAttachment) {
+                    parent = mAttachments;
+                } else {
+                    parent = mHiddenAttachments;
+                    hasHiddenAttachments = true;
+                }
                 LockedAttachmentView view = (LockedAttachmentView) mInflater
                         .inflate(R.layout.message_view_attachment_locked, parent, false);
                 view.setCallback(attachmentCallback);
@@ -501,6 +513,10 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
                 // attachments.put(attachment, view);
                 parent.addView(view);
             }
+        }
+
+        if (hasHiddenAttachments) {
+            mShowHiddenAttachments.setVisibility(View.VISIBLE);
         }
     }
 
@@ -520,6 +536,7 @@ public class MessageContainerView extends LinearLayout implements OnClickListene
         setLoadPictures(false);
         mAttachments.removeAllViews();
         mHiddenAttachments.removeAllViews();
+        mHiddenAttachments.setVisibility(View.GONE);
 
         currentHtmlText = null;
         currentAttachmentResolver = null;

--- a/k9mail/src/main/res/layout/message_container.xml
+++ b/k9mail/src/main/res/layout/message_container.xml
@@ -77,20 +77,6 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             />
-
-        <Button
-            android:id="@+id/show_hidden_attachments"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:text="@string/message_view_show_more_attachments_action" />
-
-        <LinearLayout
-            android:id="@+id/hidden_attachments"
-            android:orientation="vertical"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            />
-
     </LinearLayout>
 
 </com.fsck.k9.ui.messageview.MessageContainerView>

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
@@ -85,9 +85,9 @@ public class AttachmentResolverTest {
         when(subPart2.getContentId()).thenReturn("cid-2");
 
         when(attachmentInfoExtractor.extractAttachmentInfo(subPart1)).thenReturn(
-                new AttachmentViewInfo(null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_1, true, subPart1));
+                new AttachmentViewInfo(null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_1, false, subPart1));
         when(attachmentInfoExtractor.extractAttachmentInfo(subPart2)).thenReturn(
-                new AttachmentViewInfo(null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_2, true, subPart2));
+                new AttachmentViewInfo(null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_2, false, subPart2));
 
 
         Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart);

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
@@ -79,7 +79,7 @@ public class AttachmentInfoExtractorTest {
         assertEquals(AttachmentViewInfo.UNKNOWN_SIZE, attachmentViewInfo.size);
         assertEquals("noname", attachmentViewInfo.displayName);
         assertNull(attachmentViewInfo.mimeType);
-        assertTrue(attachmentViewInfo.firstClassAttachment);
+        assertFalse(attachmentViewInfo.inlineAttachment);
     }
 
     @Test
@@ -95,7 +95,7 @@ public class AttachmentInfoExtractorTest {
     }
 
     @Test
-    public void extractInfoForDb__withContentTypeAndName__shouldReturnNamedFirstClassAttachment() throws Exception {
+    public void extractInfoForDb__withContentTypeAndName__shouldReturnNamedAttachment() throws Exception {
         Part part = mock(Part.class);
         when(part.getMimeType()).thenReturn(TEST_MIME_TYPE);
         when(part.getContentType()).thenReturn(TEST_MIME_TYPE + "; name=\"filename.ext\"");
@@ -105,7 +105,7 @@ public class AttachmentInfoExtractorTest {
         assertEquals(Uri.EMPTY, attachmentViewInfo.uri);
         assertEquals(TEST_MIME_TYPE, attachmentViewInfo.mimeType);
         assertEquals("filename.ext", attachmentViewInfo.displayName);
-        assertTrue(attachmentViewInfo.firstClassAttachment);
+        assertFalse(attachmentViewInfo.inlineAttachment);
     }
 
     @Test
@@ -119,7 +119,7 @@ public class AttachmentInfoExtractorTest {
     }
 
     @Test
-    public void extractInfoForDb__withDispositionAttach__shouldReturnNamedFirstClassAttachment() throws Exception {
+    public void extractInfoForDb__withDispositionAttach__shouldReturnNamedAttachment() throws Exception {
         Part part = mock(Part.class);
         when(part.getDisposition()).thenReturn("attachment" + "; filename=\"filename.ext\"; meaningless=\"dummy\"");
 
@@ -127,11 +127,11 @@ public class AttachmentInfoExtractorTest {
 
         assertEquals(Uri.EMPTY, attachmentViewInfo.uri);
         assertEquals("filename.ext", attachmentViewInfo.displayName);
-        assertTrue(attachmentViewInfo.firstClassAttachment);
+        assertFalse(attachmentViewInfo.inlineAttachment);
     }
 
     @Test
-    public void extractInfoForDb__withDispositionInlineAndContentId__shouldReturnNotFirstClassAttachment()
+    public void extractInfoForDb__withDispositionInlineAndContentId__shouldReturnInlineAttachment()
             throws Exception {
         Part part = mock(Part.class);
         when(part.getHeader(MimeHeader.HEADER_CONTENT_ID)).thenReturn(TEST_CONTENT_ID);
@@ -139,7 +139,7 @@ public class AttachmentInfoExtractorTest {
 
         AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfoForDatabase(part);
 
-        assertFalse(attachmentViewInfo.firstClassAttachment);
+        assertTrue(attachmentViewInfo.inlineAttachment);
     }
 
     @Test
@@ -186,6 +186,6 @@ public class AttachmentInfoExtractorTest {
         assertEquals(TEST_URI, attachmentViewInfo.uri);
         assertEquals(TEST_SIZE, attachmentViewInfo.size);
         assertEquals(TEST_MIME_TYPE, attachmentViewInfo.mimeType);
-        assertTrue(attachmentViewInfo.firstClassAttachment);
+        assertFalse(attachmentViewInfo.inlineAttachment);
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
@@ -79,7 +79,7 @@ public class AttachmentInfoExtractorTest {
         assertEquals(AttachmentViewInfo.UNKNOWN_SIZE, attachmentViewInfo.size);
         assertEquals("noname", attachmentViewInfo.displayName);
         assertNull(attachmentViewInfo.mimeType);
-        assertFalse(attachmentViewInfo.firstClassAttachment);
+        assertTrue(attachmentViewInfo.firstClassAttachment);
     }
 
     @Test
@@ -186,6 +186,6 @@ public class AttachmentInfoExtractorTest {
         assertEquals(TEST_URI, attachmentViewInfo.uri);
         assertEquals(TEST_SIZE, attachmentViewInfo.size);
         assertEquals(TEST_MIME_TYPE, attachmentViewInfo.mimeType);
-        assertFalse(attachmentViewInfo.firstClassAttachment);
+        assertTrue(attachmentViewInfo.firstClassAttachment);
     }
 }


### PR DESCRIPTION
* no "More" button anymore, attachments are either displayed or they aren't
* all attachments are first class, unless they have content-disposition "inline", and have a content-id (i.e. are displayed inline inside html)
* only first class attachments are displayed