### PR TITLE
inject loader manager to RecipientSelectView via presenter

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -364,8 +364,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
         RecipientMvpView recipientMvpView = new RecipientMvpView(this);
         ComposePgpInlineDecider composePgpInlineDecider = new ComposePgpInlineDecider();
-        recipientPresenter = new RecipientPresenter(this, recipientMvpView, mAccount,
-                composePgpInlineDecider, new ReplyToParser());
+        recipientPresenter = new RecipientPresenter(getApplicationContext(), getLoaderManager(), recipientMvpView,
+                mAccount, composePgpInlineDecider, new ReplyToParser());
 
         mSubjectView = (EditText) findViewById(R.id.subject);
         mSubjectView.getInputExtras(true).putBoolean("allowEmoji", true);

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -4,6 +4,7 @@ package com.fsck.k9.activity.compose;
 import java.util.Arrays;
 import java.util.List;
 
+import android.app.LoaderManager;
 import android.app.PendingIntent;
 import android.text.TextWatcher;
 import android.view.View;
@@ -377,6 +378,12 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
 
     public void launchUserInteractionPendingIntent(PendingIntent pendingIntent, int requestCode) {
         activity.launchUserInteractionPendingIntent(pendingIntent, requestCode);
+    }
+
+    public void setLoaderManager(LoaderManager loaderManager) {
+        toView.setLoaderManager(loaderManager);
+        ccView.setLoaderManager(loaderManager);
+        bccView.setLoaderManager(loaderManager);
     }
 
     public enum CryptoStatusDisplayType {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 
 import android.app.Activity;
+import android.app.LoaderManager;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
@@ -21,6 +22,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.Identity;
 import com.fsck.k9.K9;
 import com.fsck.k9.R;
+import com.fsck.k9.activity.MessageCompose;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.AttachErrorState;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.ComposeCryptoStatusBuilder;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.SendErrorState;
@@ -78,14 +80,15 @@ public class RecipientPresenter implements PermissionPingCallback {
     private boolean cryptoEnablePgpInline = false;
 
 
-    public RecipientPresenter(Context context, RecipientMvpView recipientMvpView, Account account,
-            ComposePgpInlineDecider composePgpInlineDecider, ReplyToParser replyToParser) {
+    public RecipientPresenter(Context context, LoaderManager loaderManager, RecipientMvpView recipientMvpView,
+            Account account, ComposePgpInlineDecider composePgpInlineDecider, ReplyToParser replyToParser) {
         this.recipientMvpView = recipientMvpView;
         this.context = context;
         this.composePgpInlineDecider = composePgpInlineDecider;
         this.replyToParser = replyToParser;
 
         recipientMvpView.setPresenter(this);
+        recipientMvpView.setLoaderManager(loaderManager);
         onSwitchAccount(account);
         updateCryptoStatus();
     }

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
@@ -4,6 +4,7 @@ package com.fsck.k9.activity.compose;
 import java.util.Arrays;
 import java.util.List;
 
+import android.app.LoaderManager;
 import android.content.Context;
 
 import com.fsck.k9.Account;
@@ -41,6 +42,7 @@ public class RecipientPresenterTest {
     private ComposePgpInlineDecider composePgpInlineDecider;
     private Account account;
     private RecipientMvpView recipientMvpView;
+    private LoaderManager loaderManager;
 
 
     @Before
@@ -51,9 +53,10 @@ public class RecipientPresenterTest {
         account = mock(Account.class);
         composePgpInlineDecider = mock(ComposePgpInlineDecider.class);
         replyToParser = mock(ReplyToParser.class);
+        loaderManager = mock(LoaderManager.class);
 
         recipientPresenter = new RecipientPresenter(
-                context, recipientMvpView, account, composePgpInlineDecider, replyToParser);
+                context, loaderManager, recipientMvpView, account, composePgpInlineDecider, replyToParser);
     }
 
     @Test


### PR DESCRIPTION
This PR changes RecipientSelectView to retrieve its the loader manager from the RecipientPresenter on initialization, rather than implicitly acquiring it from the context under the assumption that it's an activity.

After that, it will silently ignore all recipient popup callbacks when loader manager is null. This should fix the crashes from #1251, and there should theoretically be no scenario where a callback is lost when the view is actually displayed.