### PR TITLE
compose: enable long click on recipient select view

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -97,6 +97,8 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
 
         adapter = new RecipientAdapter(context);
         setAdapter(adapter);
+
+        setLongClickable(true);
     }
 
     @Override


### PR DESCRIPTION
This PR enables long-click on RecipientSelectView, to allow pasting.

This leads to some problems: Copying is still broken, and if more than one token is actually parsed. However, for the common use case of parsing a single address, it seems to work just fine, so this hopefully does more good than harm.

see also https://github.com/splitwise/TokenAutoComplete/issues/95