### PR TITLE
pass MessageReference instead of LocalMessage to MessagingController operations

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -45,7 +45,6 @@ import com.fsck.k9.activity.setup.FolderSettings;
 import com.fsck.k9.activity.setup.Prefs;
 import com.fsck.k9.fragment.MessageListFragment;
 import com.fsck.k9.fragment.MessageListFragment.MessageListFragmentListener;
-import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.StorageManager;
 import com.fsck.k9.preferences.StorageEditor;
 import com.fsck.k9.search.LocalSearch;
@@ -1204,38 +1203,38 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     }
 
     @Override
-    public void onResendMessage(LocalMessage message) {
-        MessageActions.actionEditDraft(this, message.makeMessageReference());
+    public void onResendMessage(MessageReference messageReference) {
+        MessageActions.actionEditDraft(this, messageReference);
     }
 
     @Override
-    public void onForward(LocalMessage message) {
-        onForward(message, null);
+    public void onForward(MessageReference messageReference) {
+        onForward(messageReference, null);
     }
 
     @Override
-    public void onForward(LocalMessage message, Parcelable decryptionResultForReply) {
-        MessageActions.actionForward(this, message, decryptionResultForReply);
+    public void onForward(MessageReference messageReference, Parcelable decryptionResultForReply) {
+        MessageActions.actionForward(this, messageReference, decryptionResultForReply);
     }
 
     @Override
-    public void onReply(LocalMessage message) {
-        onReply(message, null);
+    public void onReply(MessageReference messageReference) {
+        onReply(messageReference, null);
     }
 
     @Override
-    public void onReply(LocalMessage message, Parcelable decryptionResultForReply) {
-        MessageActions.actionReply(this, message, false, decryptionResultForReply);
+    public void onReply(MessageReference messageReference, Parcelable decryptionResultForReply) {
+        MessageActions.actionReply(this, messageReference, false, decryptionResultForReply);
     }
 
     @Override
-    public void onReplyAll(LocalMessage message) {
-        onReplyAll(message, null);
+    public void onReplyAll(MessageReference messageReference) {
+        onReplyAll(messageReference, null);
     }
 
     @Override
-    public void onReplyAll(LocalMessage message, Parcelable decryptionResultForReply) {
-        MessageActions.actionReply(this, message, true, decryptionResultForReply);
+    public void onReplyAll(MessageReference messageReference, Parcelable decryptionResultForReply) {
+        MessageActions.actionReply(this, messageReference, true, decryptionResultForReply);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/MessageActions.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/MessageActions.java
@@ -8,7 +8,6 @@ import com.fsck.k9.Account;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.MessageCompose;
 import com.fsck.k9.activity.MessageReference;
-import com.fsck.k9.mailstore.LocalMessage;
 
 public class MessageActions {
     /**
@@ -31,10 +30,10 @@ public class MessageActions {
      * the function is reply all instead of simply reply.
      */
     public static Intent getActionReplyIntent(
-            Context context, LocalMessage message, boolean replyAll, Parcelable decryptionResult) {
+            Context context, MessageReference messageReference, boolean replyAll, Parcelable decryptionResult) {
         Intent i = new Intent(context, MessageCompose.class);
         i.putExtra(MessageCompose.EXTRA_MESSAGE_DECRYPTION_RESULT, decryptionResult);
-        i.putExtra(MessageCompose.EXTRA_MESSAGE_REFERENCE, message.makeMessageReference());
+        i.putExtra(MessageCompose.EXTRA_MESSAGE_REFERENCE, messageReference);
         if (replyAll) {
             i.setAction(MessageCompose.ACTION_REPLY_ALL);
         } else {
@@ -57,16 +56,16 @@ public class MessageActions {
      * is reply all instead of simply reply.
      */
     public static void actionReply(
-            Context context, LocalMessage message, boolean replyAll, Parcelable decryptionResult) {
-        context.startActivity(getActionReplyIntent(context, message, replyAll, decryptionResult));
+            Context context, MessageReference messageReference, boolean replyAll, Parcelable decryptionResult) {
+        context.startActivity(getActionReplyIntent(context, messageReference, replyAll, decryptionResult));
     }
 
     /**
      * Compose a new message as a forward of the given message.
      */
-    public static void actionForward(Context context, LocalMessage message, Parcelable decryptionResult) {
+    public static void actionForward(Context context, MessageReference messageReference, Parcelable decryptionResult) {
         Intent i = new Intent(context, MessageCompose.class);
-        i.putExtra(MessageCompose.EXTRA_MESSAGE_REFERENCE, message.makeMessageReference());
+        i.putExtra(MessageCompose.EXTRA_MESSAGE_REFERENCE, messageReference);
         i.putExtra(MessageCompose.EXTRA_MESSAGE_DECRYPTION_RESULT, decryptionResult);
         i.setAction(MessageCompose.ACTION_FORWARD);
         context.startActivity(i);

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -102,7 +102,6 @@ import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.DatabasePreviewType;
 import com.fsck.k9.mailstore.LocalFolder;
-import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.preferences.StorageEditor;
 import com.fsck.k9.provider.EmailProvider;
@@ -206,7 +205,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         // fill the mapping at class time loading
 
         final Map<SortType, Comparator<Cursor>> map =
-                new EnumMap<SortType, Comparator<Cursor>>(SortType.class);
+                new EnumMap<>(SortType.class);
         map.put(SortType.SORT_ATTACHMENT, new AttachmentComparator());
         map.put(SortType.SORT_DATE, new DateComparator());
         map.put(SortType.SORT_ARRIVAL, new ArrivalComparator());
@@ -268,7 +267,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     private boolean mStars = true;
 
     private int mSelectedCount = 0;
-    private Set<Long> mSelected = new HashSet<Long>();
+    private Set<Long> mSelected = new HashSet<>();
 
     private FontSizes mFontSizes = K9.getFontSizes();
 
@@ -280,7 +279,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      * Relevant messages for the current context when we have to remember the chosen messages
      * between user interactions (e.g. selecting a folder for move operation).
      */
-    private List<LocalMessage> mActiveMessages;
+    private List<MessageReference> mActiveMessages;
 
     /* package visibility for faster inner class access */
     MessageHelper mMessageHelper;
@@ -349,7 +348,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         private WeakReference<MessageListFragment> mFragment;
 
         public MessageListHandler(MessageListFragment fragment) {
-            mFragment = new WeakReference<MessageListFragment>(fragment);
+            mFragment = new WeakReference<>(fragment);
         }
         public void folderLoading(String folder, boolean loading) {
             android.os.Message msg = android.os.Message.obtain(this, ACTION_FOLDER_LOADING,
@@ -466,14 +465,14 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      */
     protected Comparator<Cursor> getComparator() {
         final List<Comparator<Cursor>> chain =
-                new ArrayList<Comparator<Cursor>>(3 /* we add 3 comparators at most */);
+                new ArrayList<>(3 /* we add 3 comparators at most */);
 
         // Add the specified comparator
         final Comparator<Cursor> comparator = SORT_COMPARATORS.get(mSortType);
         if (mSortAscending) {
             chain.add(comparator);
         } else {
-            chain.add(new ReverseComparator<Cursor>(comparator));
+            chain.add(new ReverseComparator<>(comparator));
         }
 
         // Add the date comparator if not already specified
@@ -482,7 +481,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             if (mSortDateAscending) {
                 chain.add(dateComparator);
             } else {
-                chain.add(new ReverseComparator<Cursor>(dateComparator));
+                chain.add(new ReverseComparator<>(dateComparator));
             }
         }
 
@@ -490,7 +489,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         chain.add(new ReverseIdComparator());
 
         // Build the comparator chain
-        return new ComparatorChain<Cursor>(chain);
+        return new ComparatorChain<>(chain);
     }
 
     private void folderLoading(String folder, boolean loading) {
@@ -617,8 +616,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         } else {
             if (mThreadedList && cursor.getInt(THREAD_COUNT_COLUMN) > 1) {
                 Account account = getAccountFromCursor(cursor);
-                long folderId = cursor.getLong(FOLDER_ID_COLUMN);
-                String folderName = getFolderNameById(account, folderId);
+                String folderName = cursor.getString(FOLDER_NAME_COLUMN);
 
                 // If threading is enabled and this item represents a thread, display the thread contents.
                 long rootId = cursor.getLong(THREAD_ROOT_COLUMN);
@@ -876,25 +874,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         return localFolder;
     }
 
-    private String getFolderNameById(Account account, long folderId) {
-        Folder folder = getFolderById(account, folderId);
-        if (folder != null) {
-            return folder.getName();
-        }
-        return null;
-    }
-
-    private LocalFolder getFolderById(Account account, long folderId) {
-        try {
-            LocalStore localStore = account.getLocalStore();
-            LocalFolder localFolder = localStore.getFolderById(folderId);
-            localFolder.open(Folder.OPEN_MODE_RO);
-            return localFolder;
-        } catch (MessagingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
     @Override
     public void onPause() {
         super.onPause();
@@ -1037,20 +1016,20 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         }
     }
 
-    public void onReply(LocalMessage message) {
-        mFragmentListener.onReply(message);
+    public void onReply(MessageReference messageReference) {
+        mFragmentListener.onReply(messageReference);
     }
 
-    public void onReplyAll(LocalMessage message) {
-        mFragmentListener.onReplyAll(message);
+    public void onReplyAll(MessageReference messageReference) {
+        mFragmentListener.onReplyAll(messageReference);
     }
 
-    public void onForward(LocalMessage message) {
-        mFragmentListener.onForward(message);
+    public void onForward(MessageReference messageReference) {
+        mFragmentListener.onForward(messageReference);
     }
 
-    public void onResendMessage(LocalMessage message) {
-        mFragmentListener.onResendMessage(message);
+    public void onResendMessage(MessageReference messageReference) {
+        mFragmentListener.onResendMessage(messageReference);
     }
 
     public void changeSort(SortType sortType) {
@@ -1157,11 +1136,11 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         changeSort(sorts[curIndex]);
     }
 
-    private void onDelete(LocalMessage message) {
+    private void onDelete(MessageReference message) {
         onDelete(Collections.singletonList(message));
     }
 
-    private void onDelete(List<LocalMessage> messages) {
+    private void onDelete(List<MessageReference> messages) {
         if (K9.confirmDelete()) {
             // remember the message selection for #onCreateDialog(int)
             mActiveMessages = messages;
@@ -1171,7 +1150,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         }
     }
 
-    private void onDeleteConfirmed(List<LocalMessage> messages) {
+    private void onDeleteConfirmed(List<MessageReference> messages) {
         if (mThreadedList) {
             mController.deleteThreads(messages);
         } else {
@@ -1193,14 +1172,21 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             }
 
             final String destFolderName = data.getStringExtra(ChooseFolder.EXTRA_NEW_FOLDER);
-            final List<LocalMessage> messages = mActiveMessages;
+            final List<MessageReference> messages = mActiveMessages;
 
             if (destFolderName != null) {
 
                 mActiveMessages = null; // don't need it any more
 
                 if (messages.size() > 0) {
-                    messages.get(0).getFolder().setLastSelectedFolderName(destFolderName);
+                    try {
+                        MessageReference firstMsg = messages.get(0);
+                        Account account = mPreferences.getAccount(firstMsg.getAccountUuid());
+                        LocalFolder firstMsgFolder = getFolder(firstMsg.getFolderName(), account);
+                        firstMsgFolder.setLastSelectedFolderName(destFolderName);
+                    } catch (MessagingException e) {
+                        Log.e(K9.LOG_TAG, "Error getting folder for setLastSelectedFolderName()", e);
+                    }
                 }
 
                 switch (requestCode) {
@@ -1392,7 +1378,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 break;
             }
             case R.id.delete: {
-                LocalMessage message = getMessageAtPosition(adapterPosition);
+                MessageReference message = getMessageAtPosition(adapterPosition);
                 onDelete(message);
                 break;
             }
@@ -2236,9 +2222,9 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             return;
         }
 
-        Map<Account, List<Long>> messageMap = new HashMap<Account, List<Long>>();
-        Map<Account, List<Long>> threadMap = new HashMap<Account, List<Long>>();
-        Set<Account> accounts = new HashSet<Account>();
+        Map<Account, List<Long>> messageMap = new HashMap<>();
+        Map<Account, List<Long>> threadMap = new HashMap<>();
+        Set<Account> accounts = new HashSet<>();
 
         for (int position = 0, end = mAdapter.getCount(); position < end; position++) {
             Cursor cursor = (Cursor) mAdapter.getItem(position);
@@ -2252,7 +2238,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 if (mThreadedList && cursor.getInt(THREAD_COUNT_COLUMN) > 1) {
                     List<Long> threadRootIdList = threadMap.get(account);
                     if (threadRootIdList == null) {
-                        threadRootIdList = new ArrayList<Long>();
+                        threadRootIdList = new ArrayList<>();
                         threadMap.put(account, threadRootIdList);
                     }
 
@@ -2260,7 +2246,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 } else {
                     List<Long> messageIdList = messageMap.get(account);
                     if (messageIdList == null) {
-                        messageIdList = new ArrayList<Long>();
+                        messageIdList = new ArrayList<>();
                         messageMap.put(account, messageIdList);
                     }
 
@@ -2285,7 +2271,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         computeBatchDirection();
     }
 
-    private void onMove(LocalMessage message) {
+    private void onMove(MessageReference message) {
         onMove(Collections.singletonList(message));
     }
 
@@ -2295,27 +2281,27 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      * @param messages
      *         Never {@code null}.
      */
-    private void onMove(List<LocalMessage> messages) {
+    private void onMove(List<MessageReference> messages) {
         if (!checkCopyOrMovePossible(messages, FolderOperation.MOVE)) {
             return;
         }
 
-        final Folder folder;
+        String folderName;
         if (mIsThreadDisplay) {
-            folder = messages.get(0).getFolder();
+            folderName = messages.get(0).getFolderName();
         } else if (mSingleFolderMode) {
-            folder = mCurrentFolder.folder;
+            folderName = mCurrentFolder.folder.getName();
         } else {
-            folder = null;
+            folderName = null;
         }
 
 
-        displayFolderChoice(ACTIVITY_CHOOSE_FOLDER_MOVE, folder,
-                messages.get(0).getFolder().getAccountUuid(), null,
+        displayFolderChoice(ACTIVITY_CHOOSE_FOLDER_MOVE, folderName,
+                messages.get(0).getAccountUuid(), null,
                 messages);
     }
 
-    private void onCopy(LocalMessage message) {
+    private void onCopy(MessageReference message) {
         onCopy(Collections.singletonList(message));
     }
 
@@ -2325,27 +2311,27 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      * @param messages
      *         Never {@code null}.
      */
-    private void onCopy(List<LocalMessage> messages) {
+    private void onCopy(List<MessageReference> messages) {
         if (!checkCopyOrMovePossible(messages, FolderOperation.COPY)) {
             return;
         }
 
-        final Folder folder;
+        String folderName;
         if (mIsThreadDisplay) {
-            folder = messages.get(0).getFolder();
+            folderName = messages.get(0).getFolderName();
         } else if (mSingleFolderMode) {
-            folder = mCurrentFolder.folder;
+            folderName = mCurrentFolder.folder.getName();
         } else {
-            folder = null;
+            folderName = null;
         }
 
-        displayFolderChoice(ACTIVITY_CHOOSE_FOLDER_COPY, folder,
-                messages.get(0).getFolder().getAccountUuid(),
+        displayFolderChoice(ACTIVITY_CHOOSE_FOLDER_COPY, folderName,
+                messages.get(0).getAccountUuid(),
                 null,
                 messages);
     }
 
-    private void onDebugClearLocally(LocalMessage message) {
+    private void onDebugClearLocally(MessageReference message) {
         mController.debugClearMessagesLocally(Collections.singletonList(message));
     }
 
@@ -2356,25 +2342,20 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      * @param requestCode
      *         If {@code >= 0}, this code will be returned in {@code onActivityResult()} when the
      *         activity exits.
-     * @param folder
-     *         The source folder. Never {@code null}.
-     * @param messages
-     *         Messages to be affected by the folder operation. Never {@code null}.
      *
      * @see #startActivityForResult(Intent, int)
      */
-    private void displayFolderChoice(int requestCode, Folder folder,
+    private void displayFolderChoice(int requestCode, String sourceFolderName,
             String accountUuid, String lastSelectedFolderName,
-            List<LocalMessage> messages) {
-
+            List<MessageReference> messages) {
         Intent intent = new Intent(getActivity(), ChooseFolder.class);
         intent.putExtra(ChooseFolder.EXTRA_ACCOUNT, accountUuid);
         intent.putExtra(ChooseFolder.EXTRA_SEL_FOLDER, lastSelectedFolderName);
 
-        if (folder == null) {
+        if (sourceFolderName == null) {
             intent.putExtra(ChooseFolder.EXTRA_SHOW_CURRENT, "yes");
         } else {
-            intent.putExtra(ChooseFolder.EXTRA_CUR_FOLDER, folder.getName());
+            intent.putExtra(ChooseFolder.EXTRA_CUR_FOLDER, sourceFolderName);
         }
 
         // remember the selected messages for #onActivityResult
@@ -2382,14 +2363,14 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         startActivityForResult(intent, requestCode);
     }
 
-    private void onArchive(final LocalMessage message) {
+    private void onArchive(MessageReference message) {
         onArchive(Collections.singletonList(message));
     }
 
-    private void onArchive(final List<LocalMessage> messages) {
-        Map<Account, List<LocalMessage>> messagesByAccount = groupMessagesByAccount(messages);
+    private void onArchive(final List<MessageReference> messages) {
+        Map<Account, List<MessageReference>> messagesByAccount = groupMessagesByAccount(messages);
 
-        for (Entry<Account, List<LocalMessage>> entry : messagesByAccount.entrySet()) {
+        for (Entry<Account, List<MessageReference>> entry : messagesByAccount.entrySet()) {
             Account account = entry.getKey();
             String archiveFolder = account.getArchiveFolderName();
 
@@ -2399,14 +2380,14 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         }
     }
 
-    private Map<Account, List<LocalMessage>> groupMessagesByAccount(final List<LocalMessage> messages) {
-        Map<Account, List<LocalMessage>> messagesByAccount = new HashMap<Account, List<LocalMessage>>();
-        for (LocalMessage message : messages) {
-            Account account = message.getAccount();
+    private Map<Account, List<MessageReference>> groupMessagesByAccount(final List<MessageReference> messages) {
+        Map<Account, List<MessageReference>> messagesByAccount = new HashMap<>();
+        for (MessageReference message : messages) {
+            Account account = mPreferences.getAccount(message.getAccountUuid());
 
-            List<LocalMessage> msgList = messagesByAccount.get(account);
+            List<MessageReference> msgList = messagesByAccount.get(account);
             if (msgList == null) {
-                msgList = new ArrayList<LocalMessage>();
+                msgList = new ArrayList<>();
                 messagesByAccount.put(account, msgList);
             }
 
@@ -2415,7 +2396,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         return messagesByAccount;
     }
 
-    private void onSpam(LocalMessage message) {
+    private void onSpam(MessageReference message) {
         onSpam(Collections.singletonList(message));
     }
 
@@ -2425,7 +2406,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      * @param messages
      *         The messages to move to the spam folder. Never {@code null}.
      */
-    private void onSpam(List<LocalMessage> messages) {
+    private void onSpam(List<MessageReference> messages) {
         if (K9.confirmSpam()) {
             // remember the message selection for #onCreateDialog(int)
             mActiveMessages = messages;
@@ -2435,10 +2416,10 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         }
     }
 
-    private void onSpamConfirmed(List<LocalMessage> messages) {
-        Map<Account, List<LocalMessage>> messagesByAccount = groupMessagesByAccount(messages);
+    private void onSpamConfirmed(List<MessageReference> messages) {
+        Map<Account, List<MessageReference>> messagesByAccount = groupMessagesByAccount(messages);
 
-        for (Entry<Account, List<LocalMessage>> entry : messagesByAccount.entrySet()) {
+        for (Entry<Account, List<MessageReference>> entry : messagesByAccount.entrySet()) {
             Account account = entry.getKey();
             String spamFolder = account.getSpamFolderName();
 
@@ -2462,7 +2443,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      *
      * @return {@code true}, if operation is possible.
      */
-    private boolean checkCopyOrMovePossible(final List<LocalMessage> messages,
+    private boolean checkCopyOrMovePossible(final List<MessageReference> messages,
             final FolderOperation operation) {
 
         if (messages.isEmpty()) {
@@ -2470,11 +2451,10 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         }
 
         boolean first = true;
-        for (final LocalMessage message : messages) {
+        for (MessageReference message : messages) {
             if (first) {
                 first = false;
-                // account check
-                final Account account = message.getAccount();
+                Account account = mPreferences.getAccount(message.getAccountUuid());
                 if ((operation == FolderOperation.MOVE && !mController.isMoveCapable(account)) ||
                         (operation == FolderOperation.COPY && !mController.isCopyCapable(account))) {
                     return false;
@@ -2500,7 +2480,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      * @param destination
      *         The name of the destination folder. Never {@code null}.
      */
-    private void copy(List<LocalMessage> messages, final String destination) {
+    private void copy(List<MessageReference> messages, final String destination) {
         copyOrMove(messages, destination, FolderOperation.COPY);
     }
 
@@ -2512,7 +2492,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      * @param destination
      *         The name of the destination folder. Never {@code null}.
      */
-    private void move(List<LocalMessage> messages, final String destination) {
+    private void move(List<MessageReference> messages, final String destination) {
         copyOrMove(messages, destination, FolderOperation.MOVE);
     }
 
@@ -2528,12 +2508,12 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      * @param operation
      *         Specifies what operation to perform. Never {@code null}.
      */
-    private void copyOrMove(List<LocalMessage> messages, final String destination,
+    private void copyOrMove(List<MessageReference> messages, final String destination,
             final FolderOperation operation) {
 
-        Map<String, List<LocalMessage>> folderMap = new HashMap<String, List<LocalMessage>>();
+        Map<String, List<MessageReference>> folderMap = new HashMap<>();
 
-        for (LocalMessage message : messages) {
+        for (MessageReference message : messages) {
             if ((operation == FolderOperation.MOVE && !mController.isMoveCapable(message)) ||
                     (operation == FolderOperation.COPY && !mController.isCopyCapable(message))) {
 
@@ -2546,37 +2526,37 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 return;
             }
 
-            String folderName = message.getFolder().getName();
+            String folderName = message.getFolderName();
             if (folderName.equals(destination)) {
                 // Skip messages already in the destination folder
                 continue;
             }
 
-            List<LocalMessage> outMessages = folderMap.get(folderName);
+            List<MessageReference> outMessages = folderMap.get(folderName);
             if (outMessages == null) {
-                outMessages = new ArrayList<LocalMessage>();
+                outMessages = new ArrayList<>();
                 folderMap.put(folderName, outMessages);
             }
 
             outMessages.add(message);
         }
 
-        for (Map.Entry<String, List<LocalMessage>> entry : folderMap.entrySet()) {
+        for (Map.Entry<String, List<MessageReference>> entry : folderMap.entrySet()) {
             String folderName = entry.getKey();
-            List<LocalMessage> outMessages = entry.getValue();
-            Account account = outMessages.get(0).getAccount();
+            List<MessageReference> outMessages = entry.getValue();
+            Account account = mPreferences.getAccount(outMessages.get(0).getAccountUuid());
 
             if (operation == FolderOperation.MOVE) {
                 if (mThreadedList) {
                     mController.moveMessagesInThread(account, folderName, outMessages, destination);
                 } else {
-                    mController.moveMessages(account, folderName, outMessages, destination, null);
+                    mController.moveMessages(account, folderName, outMessages, destination);
                 }
             } else {
                 if (mThreadedList) {
                     mController.copyMessagesInThread(account, folderName, outMessages, destination);
                 } else {
-                    mController.copyMessages(account, folderName, outMessages, destination, null);
+                    mController.copyMessages(account, folderName, outMessages, destination);
                 }
             }
         }
@@ -2624,7 +2604,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
          */
         private Set<String> getAccountUuidsForSelected() {
             int maxAccounts = mAccountUuids.length;
-            Set<String> accountUuids = new HashSet<String>(maxAccounts);
+            Set<String> accountUuids = new HashSet<>(maxAccounts);
 
             for (int position = 0, end = mAdapter.getCount(); position < end; position++) {
                 Cursor cursor = (Cursor) mAdapter.getItem(position);
@@ -2737,7 +2717,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
              */
             switch (item.getItemId()) {
             case R.id.delete: {
-                List<LocalMessage> messages = getCheckedMessages();
+                List<MessageReference> messages = getCheckedMessages();
                 onDelete(messages);
                 mSelectedCount = 0;
                 break;
@@ -2874,23 +2854,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         super.onStop();
     }
 
-    public List<MessageReference> getMessageReferences() {
-        List<MessageReference> messageRefs = new ArrayList<MessageReference>();
-
-        for (int i = 0, len = mAdapter.getCount(); i < len; i++) {
-            Cursor cursor = (Cursor) mAdapter.getItem(i);
-
-            String accountUuid = cursor.getString(ACCOUNT_UUID_COLUMN);
-            String folderName = cursor.getString(FOLDER_NAME_COLUMN);
-            String messageUid = cursor.getString(UID_COLUMN);
-            MessageReference ref = new MessageReference(accountUuid, folderName, messageUid, null);
-
-            messageRefs.add(ref);
-        }
-
-        return messageRefs;
-    }
-
     public void selectAll() {
         setSelectionState(true);
     }
@@ -2993,10 +2956,10 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         void setMessageListProgress(int level);
         void showThread(Account account, String folderName, long rootId);
         void showMoreFromSameSender(String senderAddress);
-        void onResendMessage(LocalMessage message);
-        void onForward(LocalMessage message);
-        void onReply(LocalMessage message);
-        void onReplyAll(LocalMessage message);
+        void onResendMessage(MessageReference message);
+        void onForward(MessageReference message);
+        void onReply(MessageReference message);
+        void onReplyAll(MessageReference message);
         void openMessage(MessageReference messageReference);
         void setMessageListTitle(String title);
         void setMessageListSubTitle(String subTitle);
@@ -3012,7 +2975,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         changeSort(mSortType);
     }
 
-    private LocalMessage getSelectedMessage() {
+    private MessageReference getSelectedMessage() {
         int listViewPosition = mListView.getSelectedItemPosition();
         int adapterPosition = listViewToAdapterPosition(listViewPosition);
 
@@ -3035,33 +2998,28 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         return AdapterView.INVALID_POSITION;
     }
 
-    private LocalMessage getMessageAtPosition(int adapterPosition) {
+    private MessageReference getMessageAtPosition(int adapterPosition) {
         if (adapterPosition == AdapterView.INVALID_POSITION) {
             return null;
         }
 
         Cursor cursor = (Cursor) mAdapter.getItem(adapterPosition);
-        String uid = cursor.getString(UID_COLUMN);
 
-        Account account = getAccountFromCursor(cursor);
-        long folderId = cursor.getLong(FOLDER_ID_COLUMN);
-        LocalFolder folder = getFolderById(account, folderId);
+        String accountUuid = cursor.getString(ACCOUNT_UUID_COLUMN);
+        String folderName = cursor.getString(FOLDER_NAME_COLUMN);
+        String messageUid = cursor.getString(UID_COLUMN);
 
-        try {
-            return folder.getMessage(uid);
-        } catch (MessagingException e) {
-            throw new RuntimeException(e);
-        }
+        return new MessageReference(accountUuid, folderName, messageUid, null);
     }
 
-    private List<LocalMessage> getCheckedMessages() {
-        List<LocalMessage> messages = new ArrayList<LocalMessage>(mSelected.size());
+    private List<MessageReference> getCheckedMessages() {
+        List<MessageReference> messages = new ArrayList<>(mSelected.size());
         for (int position = 0, end = mAdapter.getCount(); position < end; position++) {
             Cursor cursor = (Cursor) mAdapter.getItem(position);
             long uniqueId = cursor.getLong(mUniqueIdColumn);
 
             if (mSelected.contains(uniqueId)) {
-                LocalMessage message = getMessageAtPosition(position);
+                MessageReference message = getMessageAtPosition(position);
                 if (message != null) {
                     messages.add(message);
                 }
@@ -3072,7 +3030,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     public void onDelete() {
-        LocalMessage message = getSelectedMessage();
+        MessageReference message = getSelectedMessage();
         if (message != null) {
             onDelete(Collections.singletonList(message));
         }
@@ -3102,21 +3060,21 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     public void onMove() {
-        LocalMessage message = getSelectedMessage();
+        MessageReference message = getSelectedMessage();
         if (message != null) {
             onMove(message);
         }
     }
 
     public void onArchive() {
-        LocalMessage message = getSelectedMessage();
+        MessageReference message = getSelectedMessage();
         if (message != null) {
             onArchive(message);
         }
     }
 
     public void onCopy() {
-        LocalMessage message = getSelectedMessage();
+        MessageReference message = getSelectedMessage();
         if (message != null) {
             onCopy(message);
         }
@@ -3213,7 +3171,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         }
 
         StringBuilder query = new StringBuilder();
-        List<String> queryArgs = new ArrayList<String>();
+        List<String> queryArgs = new ArrayList<>();
         if (needConditions) {
             boolean selectActive = mActiveMessage != null && mActiveMessage.getAccountUuid().equals(accountUuid);
 
@@ -3251,7 +3209,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     private String buildSortOrder() {
-        String sortColumn = MessageColumns.ID;
+        String sortColumn;
         switch (mSortType) {
             case SORT_ARRIVAL: {
                 sortColumn = MessageColumns.INTERNAL_DATE;
@@ -3292,9 +3250,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             secondarySort = MessageColumns.DATE + ((mSortDateAscending) ? " ASC, " : " DESC, ");
         }
 
-        String sortOrder = sortColumn + sortDirection + ", " + secondarySort +
-                MessageColumns.ID + " DESC";
-        return sortOrder;
+        return sortColumn + sortDirection + ", " + secondarySort + MessageColumns.ID + " DESC";
     }
 
     @Override
@@ -3406,7 +3362,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             return;
         }
 
-        Set<Long> selected = new HashSet<Long>();
+        Set<Long> selected = new HashSet<>();
         for (cursor.moveToFirst(); !cursor.isAfterLast(); cursor.moveToNext()) {
             long uniqueId = cursor.getLong(mUniqueIdColumn);
             if (mSelected.contains(uniqueId)) {

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionService.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionService.java
@@ -173,9 +173,7 @@ public class NotificationActionService extends CoreService {
         }
 
         List<MessageReference> messageReferences = intent.getParcelableArrayListExtra(EXTRA_MESSAGE_REFERENCES);
-        List<LocalMessage> messages = getLocalMessages(messageReferences);
-
-        controller.deleteMessages(messages, null);
+        controller.deleteMessages(messageReferences, null);
     }
 
     private void archiveMessages(Intent intent, Account account, MessagingController controller) {
@@ -193,10 +191,9 @@ public class NotificationActionService extends CoreService {
 
         List<MessageReference> messageReferences = intent.getParcelableArrayListExtra(EXTRA_MESSAGE_REFERENCES);
         for (MessageReference messageReference : messageReferences) {
-            LocalMessage message = messageReference.restoreToLocalMessage(this);
-            if (controller.isMoveCapable(message)) {
-                String sourceFolderName = message.getFolder().getName();
-                controller.moveMessage(account, sourceFolderName, message, archiveFolderName, null);
+            if (controller.isMoveCapable(messageReference)) {
+                String sourceFolderName = messageReference.getFolderName();
+                controller.moveMessage(account, sourceFolderName, messageReference, archiveFolderName);
             }
         }
     }
@@ -207,13 +204,12 @@ public class NotificationActionService extends CoreService {
         }
 
         MessageReference messageReference = intent.getParcelableExtra(EXTRA_MESSAGE_REFERENCE);
-        LocalMessage message = messageReference.restoreToLocalMessage(this);
 
         String spamFolderName = account.getSpamFolderName();
         if (spamFolderName != null && !K9.confirmSpam() &&
                 isMovePossible(controller, account, spamFolderName)) {
-            String sourceFolderName = message.getFolder().getName();
-            controller.moveMessage(account, sourceFolderName, message, spamFolderName, null);
+            String sourceFolderName = messageReference.getFolderName();
+            controller.moveMessage(account, sourceFolderName, messageReference, spamFolderName);
         }
     }
 
@@ -229,18 +225,6 @@ public class NotificationActionService extends CoreService {
         } else {
             controller.cancelNotificationsForAccount(account);
         }
-    }
-
-    private List<LocalMessage> getLocalMessages(List<MessageReference> messageReferences) {
-        List<LocalMessage> messages = new ArrayList<LocalMessage>(messageReferences.size());
-
-        for (MessageReference messageReference : messageReferences) {
-            LocalMessage message = messageReference.restoreToLocalMessage(this);
-            if (message != null) {
-                messages.add(message);
-            }
-        }
-        return messages;
     }
 
     private boolean isMovePossible(MessagingController controller, Account account,

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -285,7 +285,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
             mFragmentListener.disableDeleteAction();
             LocalMessage messageToDelete = mMessage;
             mFragmentListener.showNextMessageOrReturn();
-            mController.deleteMessages(Collections.singletonList(messageToDelete), null);
+            mController.deleteMessage(mMessageReference, null);
         }
     }
 
@@ -293,7 +293,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         if (!mController.isMoveCapable(mAccount)) {
             return;
         }
-        if (!mController.isMoveCapable(mMessage)) {
+        if (!mController.isMoveCapable(mMessageReference)) {
             Toast toast = Toast.makeText(getActivity(), R.string.move_copy_cannot_copy_unsynced_message, Toast.LENGTH_LONG);
             toast.show();
             return;
@@ -313,26 +313,26 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
     private void refileMessage(String dstFolder) {
         String srcFolder = mMessageReference.getFolderName();
-        LocalMessage messageToMove = mMessage;
+        MessageReference messageToMove = mMessageReference;
         mFragmentListener.showNextMessageOrReturn();
-        mController.moveMessage(mAccount, srcFolder, messageToMove, dstFolder, null);
+        mController.moveMessage(mAccount, srcFolder, messageToMove, dstFolder);
     }
 
     public void onReply() {
         if (mMessage != null) {
-            mFragmentListener.onReply(mMessage, messageCryptoPresenter.getDecryptionResultForReply());
+            mFragmentListener.onReply(mMessage.makeMessageReference(), messageCryptoPresenter.getDecryptionResultForReply());
         }
     }
 
     public void onReplyAll() {
         if (mMessage != null) {
-            mFragmentListener.onReplyAll(mMessage, messageCryptoPresenter.getDecryptionResultForReply());
+            mFragmentListener.onReplyAll(mMessage.makeMessageReference(), messageCryptoPresenter.getDecryptionResultForReply());
         }
     }
 
     public void onForward() {
         if (mMessage != null) {
-            mFragmentListener.onForward(mMessage, messageCryptoPresenter.getDecryptionResultForReply());
+            mFragmentListener.onForward(mMessage.makeMessageReference(), messageCryptoPresenter.getDecryptionResultForReply());
         }
     }
 
@@ -350,7 +350,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                 || (mMessage == null)) {
             return;
         }
-        if (!mController.isMoveCapable(mMessage)) {
+        if (!mController.isMoveCapable(mMessageReference)) {
             Toast toast = Toast.makeText(getActivity(), R.string.move_copy_cannot_copy_unsynced_message, Toast.LENGTH_LONG);
             toast.show();
             return;
@@ -365,7 +365,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                 || (mMessage == null)) {
             return;
         }
-        if (!mController.isCopyCapable(mMessage)) {
+        if (!mController.isCopyCapable(mMessageReference)) {
             Toast toast = Toast.makeText(getActivity(), R.string.move_copy_cannot_copy_unsynced_message, Toast.LENGTH_LONG);
             toast.show();
             return;
@@ -484,13 +484,11 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     public void moveMessage(MessageReference reference, String destFolderName) {
-        mController.moveMessage(mAccount, mMessageReference.getFolderName(), mMessage,
-                destFolderName, null);
+        mController.moveMessage(mAccount, mMessageReference.getFolderName(), reference, destFolderName);
     }
 
     public void copyMessage(MessageReference reference, String destFolderName) {
-        mController.copyMessage(mAccount, mMessageReference.getFolderName(), mMessage,
-                destFolderName, null);
+        mController.copyMessage(mAccount, mMessageReference.getFolderName(), reference, destFolderName);
     }
 
     private void showDialog(int dialogId) {
@@ -691,10 +689,10 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     public interface MessageViewFragmentListener {
-        void onForward(LocalMessage mMessage, Parcelable decryptionResultForReply);
+        void onForward(MessageReference messageReference, Parcelable decryptionResultForReply);
         void disableDeleteAction();
-        void onReplyAll(LocalMessage mMessage, Parcelable decryptionResultForReply);
-        void onReply(LocalMessage mMessage, Parcelable decryptionResultForReply);
+        void onReplyAll(MessageReference messageReference, Parcelable decryptionResultForReply);
+        void onReply(MessageReference messageReference, Parcelable decryptionResultForReply);
         void displayMessageSubject(String title);
         void setProgress(boolean b);
         void showNextMessageOrReturn();


### PR DESCRIPTION
Ideally, the UI code should only ever deal with extracted data for display (like MessageViewInfo) and refer to messages by `MessageReference`s otherwise to trigger actions on these messages.

This PR is a first step in that direction, changing the parameters of move, copy and delete operations in `MessagingController` to take `List<MessageReference>` instead of `List<LocalMessage>`. I started changing only one of these methods, but they are all implemented very analogously so doing all of them wasn't much more work.

This is mostly untested, waiting for feedback on the general direction before I proceed.