### PR TITLE
compose: show parse error for non-ascii characters in address

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -41,6 +41,7 @@ import com.fsck.k9.activity.compose.RecipientLoader;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
 import com.tokenautocomplete.TokenCompleteTextView;
+import org.apache.james.mime4j.util.CharsetUtil;
 
 
 public class RecipientSelectView extends TokenCompleteTextView<Recipient> implements LoaderCallbacks<List<Recipient>>,
@@ -169,7 +170,12 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
     @Override
     protected Recipient defaultObject(String completionText) {
         Address[] parsedAddresses = Address.parse(completionText);
+        if (!CharsetUtil.isASCII(completionText)) {
+            setError(getContext().getString(R.string.recipient_error_non_ascii));
+            return null;
+        }
         if (parsedAddresses.length == 0 || parsedAddresses[0].getAddress() == null) {
+            setError(getContext().getString(R.string.recipient_error_parse_failed));
             return null;
         }
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1215,5 +1215,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="messageview_crypto_warning_expired">This message was signed by an <b>expired key!</b></string>
     <string name="messageview_crypto_warning_insecure">This message was signed by an <b>insecure key!</b></string>
     <string name="messageview_crypto_warning_error">There was an <b>error in this message\'s signature!</b></string>
+    <string name="recipient_error_non_ascii">Special characters are currently not supported!</string>
+    <string name="recipient_error_parse_failed">Error parsing address!</string>
 
 </resources>


### PR DESCRIPTION
This doesn't fix #1328, but it improves error handling a bit.