### PR TITLE
compose: try performing recipient completion on send (fixes #1495)

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -258,6 +258,18 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
         return bccView.hasUncompletedText();
     }
 
+    public boolean recipientToTryPerformCompletion() {
+        return toView.tryPerformCompletion();
+    }
+
+    public boolean recipientCcTryPerformCompletion() {
+        return ccView.tryPerformCompletion();
+    }
+
+    public boolean recipientBccTryPerformCompletion() {
+        return bccView.tryPerformCompletion();
+    }
+
     public void showToUncompletedError() {
         toView.setError(toView.getContext().getString(R.string.compose_error_incomplete_recipient));
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -116,6 +116,13 @@ public class RecipientPresenter implements PermissionPingCallback {
     }
 
     public boolean checkRecipientsOkForSending() {
+        boolean performedAnyCompletion = recipientMvpView.recipientToTryPerformCompletion() ||
+                recipientMvpView.recipientCcTryPerformCompletion() ||
+                recipientMvpView.recipientBccTryPerformCompletion();
+        if (performedAnyCompletion) {
+            return true;
+        }
+
         if (recipientMvpView.recipientToHasUncompletedText()) {
             recipientMvpView.showToUncompletedError();
             return true;

--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -364,6 +364,21 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         }
     }
 
+    public boolean tryPerformCompletion() {
+        if (!hasUncompletedText()) {
+            return false;
+        }
+        int previousNumRecipients = getTokenCount();
+        performCompletion();
+        int numRecipients = getTokenCount();
+
+        return previousNumRecipients != numRecipients;
+    }
+
+    private int getTokenCount() {
+        return getObjects().size();
+    }
+
     public boolean hasUncompletedText() {
         String currentCompletionText = currentCompletionText();
         return !TextUtils.isEmpty(currentCompletionText) && !isPlaceholderText(currentCompletionText);


### PR DESCRIPTION
This commit performs completion on recipient fields when the send button
is clicked (uncompleted text is usually present if the cursor is on the
recipient field at that time).

If any completion was performed, sending is quietly aborted. This avoids
sending mail to the wrong recipient if the uncompleted text doesn't
resolve to what the user thought.