### PR TITLE
Load attachments from AttachmentViewInfo in AttachmentPresenter

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1276,7 +1276,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         if (!mSourceMessageProcessed) {
-            attachmentPresenter.loadAttachments(message, 0);
+            attachmentPresenter.loadNonInlineAttachments(messageViewInfo);
         }
 
         // Decode the identity header when loading a draft.

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
@@ -23,14 +23,16 @@ public class AttachmentViewInfo {
     public final Uri uri;
     public final boolean inlineAttachment;
     public final Part part;
+    public final boolean isContentAvailable;
 
     public AttachmentViewInfo(String mimeType, String displayName, long size, Uri uri, boolean inlineAttachment,
-            Part part) {
+            Part part, boolean isContentAvailable) {
         this.mimeType = mimeType;
         this.displayName = displayName;
         this.size = size;
         this.uri = uri;
         this.inlineAttachment = inlineAttachment;
         this.part = part;
+        this.isContentAvailable = isContentAvailable;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
@@ -55,7 +55,7 @@ public class AttachmentController {
     }
 
     public void viewAttachment() {
-        if (needsDownloading()) {
+        if (!attachment.isContentAvailable) {
             downloadAndViewAttachment((LocalPart) attachment.part);
         } else {
             viewLocalAttachment();
@@ -68,18 +68,6 @@ public class AttachmentController {
 
     public void saveAttachmentTo(String directory) {
         saveAttachmentTo(new File(directory));
-    }
-
-    private boolean needsDownloading() {
-        return isPartMissing() && isLocalPart();
-    }
-
-    private boolean isPartMissing() {
-        return attachment.part.getBody() == null;
-    }
-
-    private boolean isLocalPart() {
-        return attachment.part instanceof LocalPart;
     }
 
     private void downloadAndViewAttachment(LocalPart localPart) {
@@ -133,7 +121,7 @@ public class AttachmentController {
             return;
         }
 
-        if (needsDownloading()) {
+        if (!attachment.isContentAvailable) {
             downloadAndSaveAttachmentTo((LocalPart) attachment.part, directory);
         } else {
             saveLocalAttachmentTo(directory);

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
@@ -86,13 +86,14 @@ public class AttachmentResolverTest {
         subPart1.setHeader(MimeHeader.HEADER_CONTENT_ID, "cid-1");
         subPart2.setHeader(MimeHeader.HEADER_CONTENT_ID, "cid-2");
 
-        when(attachmentInfoExtractor.extractAttachmentInfo(subPart1)).thenReturn(
-                new AttachmentViewInfo(null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_1, false, subPart1));
-        when(attachmentInfoExtractor.extractAttachmentInfo(subPart2)).thenReturn(
-                new AttachmentViewInfo(null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_2, false, subPart2));
+        when(attachmentInfoExtractor.extractAttachmentInfo(subPart1)).thenReturn(new AttachmentViewInfo(
+                        null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_1, false, subPart1, true));
+        when(attachmentInfoExtractor.extractAttachmentInfo(subPart2)).thenReturn(new AttachmentViewInfo(
+                        null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_2, false, subPart2, true));
 
 
         Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart);
+
 
         assertEquals(2, result.size());
         assertEquals(ATTACHMENT_TEST_URI_1, result.get("cid-1"));

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
@@ -8,6 +8,7 @@ import android.support.annotation.Nullable;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MimeBodyPart;
 import com.fsck.k9.mail.internet.MimeHeader;
+import com.fsck.k9.mail.internet.TextBody;
 import com.fsck.k9.mailstore.AttachmentViewInfo;
 import com.fsck.k9.mailstore.LocalBodyPart;
 import com.fsck.k9.mailstore.DeferredFileBody;
@@ -163,6 +164,25 @@ public class AttachmentInfoExtractorTest {
     }
 
     @Test
+    public void extractInfoForDb__withNoBody__shouldReturnContentNotAvailable() throws Exception {
+        MimeBodyPart part = new MimeBodyPart();
+
+        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfoForDatabase(part);
+
+        assertFalse(attachmentViewInfo.isContentAvailable);
+    }
+
+    @Test
+    public void extractInfoForDb__withNoBody__shouldReturnContentAvailable() throws Exception {
+        MimeBodyPart part = new MimeBodyPart();
+        part.setBody(new TextBody("data"));
+
+        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfoForDatabase(part);
+
+        assertTrue(attachmentViewInfo.isContentAvailable);
+    }
+
+    @Test
     public void extractInfo__withDeferredFileBody() throws Exception {
         attachmentInfoExtractor = new AttachmentInfoExtractor(context) {
             @Nullable
@@ -187,5 +207,6 @@ public class AttachmentInfoExtractorTest {
         assertEquals(TEST_SIZE, attachmentViewInfo.size);
         assertEquals(TEST_MIME_TYPE, attachmentViewInfo.mimeType);
         assertFalse(attachmentViewInfo.inlineAttachment);
+        assertTrue(attachmentViewInfo.isContentAvailable);
     }
 }


### PR DESCRIPTION
Building on #1392, this PR gets rid of all the remaining part parsing logic in AttachmentPresenter. I also moved the "is attachment available" logic into AttachmentInfoExtractor so it can be used in both Compose and MessageView.

This PR should fix #819.