### PR TITLE
Update SafeContentResolver to 0.9.0

### DIFF
--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     compile 'de.cketti.library.changelog:ckchangelog:1.2.1'
     compile 'com.github.bumptech.glide:glide:3.6.1'
     compile 'com.splitwise:tokenautocomplete:2.0.7'
-    compile 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.0.1'
+    compile 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.9.0'
     compile 'com.github.amlcurran.showcaseview:library:5.4.1'
 
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'

--- a/k9mail/src/main/AndroidManifest.xml
+++ b/k9mail/src/main/AndroidManifest.xml
@@ -391,7 +391,13 @@
             android:exported="true"
             android:grantUriPermissions="true"
             android:multiprocess="true"
-            android:readPermission="${applicationId}.permission.READ_ATTACHMENT"/>
+            android:readPermission="${applicationId}.permission.READ_ATTACHMENT">
+            
+            <meta-data
+                android:name="de.cketti.safecontentresolver.ALLOW_INTERNAL_ACCESS"
+                android:value="true" />
+        
+        </provider>
 
         <provider
             android:name=".provider.MessageProvider"


### PR DESCRIPTION
This version of SafeContentResolver uses [ReLinker](https://github.com/KeepSafe/ReLinker) to avoid running into `UnsatisfiedLinkError`.

Fixes #1394