### PR TITLE
Don't add additional CR LF to the end of a message when sending

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/transport/SmtpTransport.java
@@ -527,12 +527,10 @@ public class SmtpTransport extends Transport {
                     new LineWrapOutputStream(new SmtpDataStuffing(mOut), 1000));
 
             message.writeTo(msgOut);
-
-            // We use BufferedOutputStream. So make sure to call flush() !
-            msgOut.flush();
+            msgOut.endWithCrLfAndFlush();
 
             entireMessageSent = true; // After the "\r\n." is attempted, we may have sent the message
-            executeSimpleCommand("\r\n.");
+            executeSimpleCommand(".");
         } catch (NegativeSmtpReplyException e) {
             throw e;
         } catch (Exception e) {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/filter/EOLConvertingOutputStreamTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/filter/EOLConvertingOutputStreamTest.java
@@ -78,4 +78,48 @@ public class EOLConvertingOutputStreamTest {
         subject.write("\n".getBytes());
         assertEquals("Flush\r\n\r\n", out.toString());
     }
+
+    @Test
+    public void testFlushWithCrFollowedByLf() throws Exception {
+        subject.write("Flush\r".getBytes());
+        subject.flush();
+        subject.write("\n".getBytes());
+        assertEquals("Flush\r\n", out.toString());
+    }
+
+    @Test
+    public void endWithCrLfAndFlush_withoutNewline_shouldAddNewline() throws Exception {
+        subject.write("The end".getBytes());
+        
+        subject.endWithCrLfAndFlush();
+        
+        assertEquals("The end\r\n", out.toString());
+    }
+
+    @Test
+    public void endWithCrLfAndFlush_endingWithNewline_shouldNotAddAdditionalNewline() throws Exception {
+        subject.write("The end\r\n".getBytes());
+        
+        subject.endWithCrLfAndFlush();
+        
+        assertEquals("The end\r\n", out.toString());
+    }
+
+    @Test
+    public void endWithCrLfAndFlush_endingWithCr_shouldCompleteNewline() throws Exception {
+        subject.write("The end\r".getBytes());
+        
+        subject.endWithCrLfAndFlush();
+        
+        assertEquals("The end\r\n", out.toString());
+    }
+
+    @Test
+    public void endWithCrLfAndFlush_endingWithLf_shouldCompleteNewline() throws Exception {
+        subject.write("The end\n".getBytes());
+        
+        subject.endWithCrLfAndFlush();
+        
+        assertEquals("The end\r\n", out.toString());
+    }
 }


### PR DESCRIPTION
This is an alternative version of PR #1371