### PR TITLE
Use json for serializing pending commands

### DIFF
--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -33,6 +33,7 @@ dependencies {
     compile 'com.splitwise:tokenautocomplete:2.0.7'
     compile 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.9.0'
     compile 'com.github.amlcurran.showcaseview:library:5.4.1'
+    compile 'com.squareup.moshi:moshi:1.2.0'
 
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -56,6 +56,13 @@ import com.fsck.k9.R;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
 import com.fsck.k9.cache.EmailProviderCache;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingCommand;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingEmptyTrash;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingExpunge;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingMarkAllAsRead;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingMoveOrCopy;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingSetFlag;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.AuthenticationFailedException;
@@ -86,7 +93,6 @@ import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
-import com.fsck.k9.mailstore.LocalStore.PendingCommand;
 import com.fsck.k9.mailstore.MessageRemovalListener;
 import com.fsck.k9.mailstore.UnavailableStorageException;
 import com.fsck.k9.notification.NotificationController;
@@ -115,18 +121,7 @@ import com.fsck.k9.search.SqlQueryBuilder;
 public class MessagingController {
     public static final long INVALID_MESSAGE_ID = -1;
 
-    private static final String[] EMPTY_STRING_ARRAY = new String[0];
     private static final Set<Flag> SYNC_FLAGS = EnumSet.of(Flag.SEEN, Flag.FLAGGED, Flag.ANSWERED, Flag.FORWARDED);
-
-    private static final String PENDING_COMMAND_MOVE_OR_COPY = "com.fsck.k9.MessagingController.moveOrCopy";
-    private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK = "com.fsck.k9.MessagingController.moveOrCopyBulk";
-    private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW = "com.fsck.k9.MessagingController.moveOrCopyBulkNew";
-    private static final String PENDING_COMMAND_EMPTY_TRASH = "com.fsck.k9.MessagingController.emptyTrash";
-    private static final String PENDING_COMMAND_SET_FLAG_BULK = "com.fsck.k9.MessagingController.setFlagBulk";
-    private static final String PENDING_COMMAND_SET_FLAG = "com.fsck.k9.MessagingController.setFlag";
-    private static final String PENDING_COMMAND_APPEND = "com.fsck.k9.MessagingController.append";
-    private static final String PENDING_COMMAND_MARK_ALL_AS_READ = "com.fsck.k9.MessagingController.markAllAsRead";
-    private static final String PENDING_COMMAND_EXPUNGE = "com.fsck.k9.MessagingController.expunge";
 
 
     private static MessagingController inst = null;
@@ -1726,13 +1721,11 @@ public class MessagingController {
         try {
             for (PendingCommand command : commands) {
                 processingCommand = command;
-                if (K9.DEBUG)
+                if (K9.DEBUG) {
                     Log.d(K9.LOG_TAG, "Processing pending command '" + command + "'");
-
-                String[] components = command.command.split("\\.");
-                String commandTitle = components[components.length - 1];
+                }
                 for (MessagingListener l : getListeners()) {
-                    l.pendingCommandStarted(account, commandTitle);
+                    l.pendingCommandStarted(account, command.getCommandName());
                 }
                 /*
                  * We specifically do not catch any exceptions here. If a command fails it is
@@ -1740,28 +1733,23 @@ public class MessagingController {
                  * other command processes. This maintains the order of the commands.
                  */
                 try {
-                    if (PENDING_COMMAND_APPEND.equals(command.command)) {
-                        processPendingAppend(command, account);
-                    } else if (PENDING_COMMAND_SET_FLAG_BULK.equals(command.command)) {
-                        processPendingSetFlag(command, account);
-                    } else if (PENDING_COMMAND_SET_FLAG.equals(command.command)) {
-                        processPendingSetFlagOld(command, account);
-                    } else if (PENDING_COMMAND_MARK_ALL_AS_READ.equals(command.command)) {
-                        processPendingMarkAllAsRead(command, account);
-                    } else if (PENDING_COMMAND_MOVE_OR_COPY_BULK.equals(command.command)) {
-                        processPendingMoveOrCopyOld2(command, account);
-                    } else if (PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW.equals(command.command)) {
-                        processPendingMoveOrCopy(command, account);
-                    } else if (PENDING_COMMAND_MOVE_OR_COPY.equals(command.command)) {
-                        processPendingMoveOrCopyOld(command, account);
-                    } else if (PENDING_COMMAND_EMPTY_TRASH.equals(command.command)) {
-                        processPendingEmptyTrash(command, account);
-                    } else if (PENDING_COMMAND_EXPUNGE.equals(command.command)) {
-                        processPendingExpunge(command, account);
+                    if (command instanceof PendingAppend) {
+                        processPendingAppend((PendingAppend) command, account);
+                    } else if (command instanceof PendingSetFlag) {
+                        processPendingSetFlag((PendingSetFlag) command, account);
+                    } else if (command instanceof PendingMarkAllAsRead) {
+                        processPendingMarkAllAsRead((PendingMarkAllAsRead) command, account);
+                    } else if (command instanceof PendingMoveOrCopy) {
+                        processPendingMoveOrCopy((PendingMoveOrCopy) command, account);
+                    } else if (command instanceof PendingEmptyTrash) {
+                        processPendingEmptyTrash((PendingEmptyTrash) command, account);
+                    } else if (command instanceof PendingExpunge) {
+                        processPendingExpunge((PendingExpunge) command, account);
                     }
                     localStore.removePendingCommand(command);
-                    if (K9.DEBUG)
+                    if (K9.DEBUG) {
                         Log.d(K9.LOG_TAG, "Done processing pending command '" + command + "'");
+                    }
                 } catch (MessagingException me) {
                     if (me.isPermanentFailure()) {
                         addErrorMessage(account, null, me);
@@ -1774,7 +1762,7 @@ public class MessagingController {
                     progress++;
                     for (MessagingListener l : getListeners()) {
                         l.synchronizeMailboxProgress(account, null, progress, todo);
-                        l.pendingCommandCompleted(account, commandTitle);
+                        l.pendingCommandCompleted(account, command.getCommandName());
                     }
                 }
             }
@@ -1798,13 +1786,13 @@ public class MessagingController {
      * created.
      * TODO update the local message UID instead of deleteing it
      */
-    private void processPendingAppend(PendingCommand command, Account account) throws MessagingException {
+    private void processPendingAppend(PendingAppend command, Account account) throws MessagingException {
         Folder remoteFolder = null;
         LocalFolder localFolder = null;
         try {
 
-            String folder = command.arguments[0];
-            String uid = command.arguments[1];
+            String folder = command.folder;
+            String uid = command.uid;
 
             if (account.getErrorFolderName().equals(folder)) {
                 return;
@@ -1924,16 +1912,7 @@ public class MessagingController {
         if (account.getErrorFolderName().equals(srcFolder)) {
             return;
         }
-        PendingCommand command = new PendingCommand();
-        command.command = PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW;
-
-        int length = 4 + uids.length;
-        command.arguments = new String[length];
-        command.arguments[0] = srcFolder;
-        command.arguments[1] = destFolder;
-        command.arguments[2] = Boolean.toString(isCopy);
-        command.arguments[3] = Boolean.toString(false);
-        System.arraycopy(uids, 0, command.arguments, 4, uids.length);
+        PendingCommand command = MessagingControllerCommands.createMoveOrCopyBulk(srcFolder, destFolder, isCopy, uids);
         queuePendingCommand(account, command);
     }
 
@@ -1945,72 +1924,22 @@ public class MessagingController {
             if (account.getErrorFolderName().equals(srcFolder)) {
                 return;
             }
-            PendingCommand command = new PendingCommand();
-            command.command = PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW;
-
-            int length = 4 + uidMap.keySet().size() + uidMap.values().size();
-            command.arguments = new String[length];
-            command.arguments[0] = srcFolder;
-            command.arguments[1] = destFolder;
-            command.arguments[2] = Boolean.toString(isCopy);
-            command.arguments[3] = Boolean.toString(true);
-            System.arraycopy(uidMap.keySet().toArray(EMPTY_STRING_ARRAY), 0, command.arguments, 4, uidMap.keySet().size());
-            System.arraycopy(uidMap.values().toArray(EMPTY_STRING_ARRAY), 0, command.arguments, 4 + uidMap.keySet().size(), uidMap.values().size());
+            PendingCommand command = MessagingControllerCommands.createMoveOrCopyBulk(srcFolder, destFolder, isCopy, uidMap);
             queuePendingCommand(account, command);
         }
     }
 
-    /**
-     * Convert pending command to new format and call
-     * {@link #processPendingMoveOrCopy(PendingCommand, Account)}.
-     *
-     * <p>
-     * TODO: This method is obsolete and is only for transition from K-9 4.0 to K-9 4.2
-     * Eventually, it should be removed.
-     * </p>
-     *
-     * @param command
-     *         Pending move/copy command in old format.
-     * @param account
-     *         The account the pending command belongs to.
-     *
-     * @throws MessagingException
-     *         In case of an error.
-     */
-    private void processPendingMoveOrCopyOld2(PendingCommand command, Account account) throws MessagingException {
-        PendingCommand newCommand = new PendingCommand();
-        int len = command.arguments.length;
-        newCommand.command = PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW;
-        newCommand.arguments = new String[len + 1];
-        newCommand.arguments[0] = command.arguments[0];
-        newCommand.arguments[1] = command.arguments[1];
-        newCommand.arguments[2] = command.arguments[2];
-        newCommand.arguments[3] = Boolean.toString(false);
-        System.arraycopy(command.arguments, 3, newCommand.arguments, 4, len - 3);
-
-        processPendingMoveOrCopy(newCommand, account);
-    }
-
-    /**
-     * Process a pending trash message command.
-     */
-    private void processPendingMoveOrCopy(PendingCommand command, Account account) throws MessagingException {
+    private void processPendingMoveOrCopy(PendingMoveOrCopy command, Account account) throws MessagingException {
         Folder remoteSrcFolder = null;
         Folder remoteDestFolder = null;
         LocalFolder localDestFolder;
         try {
-            String srcFolder = command.arguments[0];
+            String srcFolder = command.srcFolder;
             if (account.getErrorFolderName().equals(srcFolder)) {
                 return;
             }
-            String destFolder = command.arguments[1];
-            String isCopyS = command.arguments[2];
-            String hasNewUidsS = command.arguments[3];
-
-            boolean hasNewUids = false;
-            if (hasNewUidsS != null) {
-                hasNewUids = Boolean.parseBoolean(hasNewUidsS);
-            }
+            String destFolder = command.destFolder;
+            boolean isCopy = command.isCopy;
 
             Store remoteStore = account.getRemoteStore();
             remoteSrcFolder = remoteStore.getFolder(srcFolder);
@@ -2019,34 +1948,11 @@ public class MessagingController {
             localDestFolder = (LocalFolder) localStore.getFolder(destFolder);
             List<Message> messages = new ArrayList<>();
 
-            /*
-             * We split up the localUidMap into two parts while sending the command, here we assemble it back.
-             */
-            Map<String, String> localUidMap = new HashMap<>();
-            if (hasNewUids) {
-                int offset = (command.arguments.length - 4) / 2;
-
-                for (int i = 4; i < 4 + offset; i++) {
-                    localUidMap.put(command.arguments[i], command.arguments[i + offset]);
-
-                    String uid = command.arguments[i];
-                    if (!uid.startsWith(K9.LOCAL_UID_PREFIX)) {
-                        messages.add(remoteSrcFolder.getMessage(uid));
-                    }
+            Collection<String> uids = command.newUidMap != null ? command.newUidMap.keySet() : Arrays.asList(command.uids);
+            for (String uid : uids) {
+                if (!uid.startsWith(K9.LOCAL_UID_PREFIX)) {
+                    messages.add(remoteSrcFolder.getMessage(uid));
                 }
-
-            } else {
-                for (int i = 4; i < command.arguments.length; i++) {
-                    String uid = command.arguments[i];
-                    if (!uid.startsWith(K9.LOCAL_UID_PREFIX)) {
-                        messages.add(remoteSrcFolder.getMessage(uid));
-                    }
-                }
-            }
-
-            boolean isCopy = false;
-            if (isCopyS != null) {
-                isCopy = Boolean.parseBoolean(isCopyS);
             }
 
             if (!remoteSrcFolder.exists()) {
@@ -2092,11 +1998,14 @@ public class MessagingController {
              * This next part is used to bring the local UIDs of the local destination folder
              * upto speed with the remote UIDs of remote destination folder.
              */
-            if (!localUidMap.isEmpty() && remoteUidMap != null && !remoteUidMap.isEmpty()) {
+            if (command.newUidMap != null && remoteUidMap != null && !remoteUidMap.isEmpty()) {
                 for (Map.Entry<String, String> entry : remoteUidMap.entrySet()) {
                     String remoteSrcUid = entry.getKey();
-                    String localDestUid = localUidMap.get(remoteSrcUid);
                     String newUid = entry.getValue();
+                    String localDestUid = command.newUidMap.get(remoteSrcUid);
+                    if (localDestUid == null) {
+                        continue;
+                    }
 
                     Message localDestMessage = localDestFolder.getMessage(localDestUid);
                     if (localDestMessage != null) {
@@ -2115,18 +2024,11 @@ public class MessagingController {
     }
 
     private void queueSetFlag(final Account account, final String folderName,
-            final String newState, final String flag, final String[] uids) {
+            final boolean newState, final Flag flag, final String[] uids) {
         putBackground("queueSetFlag " + account.getDescription() + ":" + folderName, null, new Runnable() {
             @Override
             public void run() {
-                PendingCommand command = new PendingCommand();
-                command.command = PENDING_COMMAND_SET_FLAG_BULK;
-                int length = 3 + uids.length;
-                command.arguments = new String[length];
-                command.arguments[0] = folderName;
-                command.arguments[1] = newState;
-                command.arguments[2] = flag;
-                System.arraycopy(uids, 0, command.arguments, 3, uids.length);
+                PendingCommand command = MessagingControllerCommands.createSetFlag(folderName, newState, flag, uids);
                 queuePendingCommand(account, command);
                 processPendingCommands(account);
             }
@@ -2135,16 +2037,15 @@ public class MessagingController {
     /**
      * Processes a pending mark read or unread command.
      */
-    private void processPendingSetFlag(PendingCommand command, Account account) throws MessagingException {
-        String folder = command.arguments[0];
+    private void processPendingSetFlag(PendingSetFlag command, Account account) throws MessagingException {
+        String folder = command.folder;
 
         if (account.getErrorFolderName().equals(folder) || account.getOutboxFolderName().equals(folder)) {
             return;
         }
 
-        boolean newState = Boolean.parseBoolean(command.arguments[1]);
-
-        Flag flag = Flag.valueOf(command.arguments[2]);
+        boolean newState = command.newState;
+        Flag flag = command.flag;
 
         Store remoteStore = account.getRemoteStore();
         Folder remoteFolder = remoteStore.getFolder(folder);
@@ -2158,8 +2059,7 @@ public class MessagingController {
                 return;
             }
             List<Message> messages = new ArrayList<>();
-            for (int i = 3; i < command.arguments.length; i++) {
-                String uid = command.arguments[i];
+            for (String uid : command.uids) {
                 if (!uid.startsWith(K9.LOCAL_UID_PREFIX)) {
                     messages.add(remoteFolder.getMessage(uid));
                 }
@@ -2174,61 +2074,18 @@ public class MessagingController {
         }
     }
 
-    // TODO: This method is obsolete and is only for transition from K-9 2.0 to K-9 2.1
-    // Eventually, it should be removed
-    private void processPendingSetFlagOld(PendingCommand command, Account account) throws MessagingException {
-        String folder = command.arguments[0];
-        String uid = command.arguments[1];
-
-        if (account.getErrorFolderName().equals(folder) || account.getOutboxFolderName().equals(folder)) {
-            return;
-        }
-        if (K9.DEBUG)
-            Log.d(K9.LOG_TAG, "processPendingSetFlagOld: folder = " + folder + ", uid = " + uid);
-
-        boolean newState = Boolean.parseBoolean(command.arguments[2]);
-
-        Flag flag = Flag.valueOf(command.arguments[3]);
-        Folder remoteFolder = null;
-        try {
-            Store remoteStore = account.getRemoteStore();
-            remoteFolder = remoteStore.getFolder(folder);
-            if (!remoteFolder.exists()) {
-                return;
-            }
-            remoteFolder.open(Folder.OPEN_MODE_RW);
-            if (remoteFolder.getMode() != Folder.OPEN_MODE_RW) {
-                return;
-            }
-            Message remoteMessage = null;
-            if (!uid.startsWith(K9.LOCAL_UID_PREFIX)) {
-                remoteMessage = remoteFolder.getMessage(uid);
-            }
-            if (remoteMessage == null) {
-                return;
-            }
-            remoteMessage.setFlag(flag, newState);
-        } finally {
-            closeFolder(remoteFolder);
-        }
-    }
     private void queueExpunge(final Account account, final String folderName) {
         putBackground("queueExpunge " + account.getDescription() + ":" + folderName, null, new Runnable() {
             @Override
             public void run() {
-                PendingCommand command = new PendingCommand();
-                command.command = PENDING_COMMAND_EXPUNGE;
-
-                command.arguments = new String[1];
-
-                command.arguments[0] = folderName;
+                PendingCommand command = MessagingControllerCommands.createExpunge(folderName);
                 queuePendingCommand(account, command);
                 processPendingCommands(account);
             }
         });
     }
-    private void processPendingExpunge(PendingCommand command, Account account) throws MessagingException {
-        String folder = command.arguments[0];
+    private void processPendingExpunge(PendingExpunge command, Account account) throws MessagingException {
+        String folder = command.folder;
 
         if (account.getErrorFolderName().equals(folder)) {
             return;
@@ -2254,73 +2111,8 @@ public class MessagingController {
         }
     }
 
-
-    // TODO: This method is obsolete and is only for transition from K-9 2.0 to K-9 2.1
-    // Eventually, it should be removed
-    private void processPendingMoveOrCopyOld(PendingCommand command, Account account) throws MessagingException {
-        String srcFolder = command.arguments[0];
-        String uid = command.arguments[1];
-        String destFolder = command.arguments[2];
-        String isCopyS = command.arguments[3];
-
-        boolean isCopy = false;
-        if (isCopyS != null) {
-            isCopy = Boolean.parseBoolean(isCopyS);
-        }
-
-        if (account.getErrorFolderName().equals(srcFolder)) {
-            return;
-        }
-
-        Store remoteStore = account.getRemoteStore();
-        Folder remoteSrcFolder = remoteStore.getFolder(srcFolder);
-        Folder remoteDestFolder = remoteStore.getFolder(destFolder);
-
-        if (!remoteSrcFolder.exists()) {
-            throw new MessagingException("processPendingMoveOrCopyOld: remoteFolder " + srcFolder + " does not exist", true);
-        }
-        remoteSrcFolder.open(Folder.OPEN_MODE_RW);
-        if (remoteSrcFolder.getMode() != Folder.OPEN_MODE_RW) {
-            throw new MessagingException("processPendingMoveOrCopyOld: could not open remoteSrcFolder " + srcFolder + " read/write", true);
-        }
-
-        Message remoteMessage = null;
-        if (!uid.startsWith(K9.LOCAL_UID_PREFIX)) {
-            remoteMessage = remoteSrcFolder.getMessage(uid);
-        }
-        if (remoteMessage == null) {
-            throw new MessagingException("processPendingMoveOrCopyOld: remoteMessage " + uid + " does not exist", true);
-        }
-
-        if (K9.DEBUG)
-            Log.d(K9.LOG_TAG, "processPendingMoveOrCopyOld: source folder = " + srcFolder
-                  + ", uid = " + uid + ", destination folder = " + destFolder + ", isCopy = " + isCopy);
-
-        if (!isCopy && destFolder.equals(account.getTrashFolderName())) {
-            if (K9.DEBUG)
-                Log.d(K9.LOG_TAG, "processPendingMoveOrCopyOld doing special case for deleting message");
-
-            remoteMessage.delete(account.getTrashFolderName());
-            remoteSrcFolder.close();
-            return;
-        }
-
-        remoteDestFolder.open(Folder.OPEN_MODE_RW);
-        if (remoteDestFolder.getMode() != Folder.OPEN_MODE_RW) {
-            throw new MessagingException("processPendingMoveOrCopyOld: could not open remoteDestFolder " + srcFolder + " read/write", true);
-        }
-
-        if (isCopy) {
-            remoteSrcFolder.copyMessages(Collections.singletonList(remoteMessage), remoteDestFolder);
-        } else {
-            remoteSrcFolder.moveMessages(Collections.singletonList(remoteMessage), remoteDestFolder);
-        }
-        remoteSrcFolder.close();
-        remoteDestFolder.close();
-    }
-
-    private void processPendingMarkAllAsRead(PendingCommand command, Account account) throws MessagingException {
-        String folder = command.arguments[0];
+    private void processPendingMarkAllAsRead(PendingMarkAllAsRead command, Account account) throws MessagingException {
+        String folder = command.folder;
         Folder remoteFolder = null;
         LocalFolder localFolder = null;
         try {
@@ -2443,9 +2235,7 @@ public class MessagingController {
         if (K9.DEBUG) {
             Log.i(K9.LOG_TAG, "Marking all messages in " + account.getDescription() + ":" + folder + " as read");
         }
-        PendingCommand command = new PendingCommand();
-        command.command = PENDING_COMMAND_MARK_ALL_AS_READ;
-        command.arguments = new String[] { folder };
+        PendingCommand command = MessagingControllerCommands.createMarkAllAsRead(folder);
         queuePendingCommand(account, command);
         processPendingCommands(account);
     }
@@ -2534,7 +2324,7 @@ public class MessagingController {
             // Send flag change to server
             List<String> value = entry.getValue();
             String[] uids = value.toArray(new String[value.size()]);
-            queueSetFlag(account, folderName, Boolean.toString(newState), flag.toString(), uids);
+            queueSetFlag(account, folderName, newState, flag, uids);
             processPendingCommands(account);
         }
     }
@@ -2602,7 +2392,7 @@ public class MessagingController {
                 uids[i] = messages.get(i).getUid();
             }
 
-            queueSetFlag(account, folderName, Boolean.toString(newState), flag.toString(), uids);
+            queueSetFlag(account, folderName, newState, flag, uids);
             processPendingCommands(account);
         } catch (MessagingException me) {
             addErrorMessage(account, null, me);
@@ -3034,9 +2824,7 @@ public class MessagingController {
                             if (K9.DEBUG)
                                 Log.i(K9.LOG_TAG, "Moved sent message to folder '" + account.getSentFolderName() + "' (" + localSentFolder.getId() + ") ");
 
-                            PendingCommand command = new PendingCommand();
-                            command.command = PENDING_COMMAND_APPEND;
-                            command.arguments = new String[] { localSentFolder.getName(), message.getUid() };
+                            PendingCommand command = MessagingControllerCommands.createAppend(localSentFolder.getName(), message.getUid());
                             queuePendingCommand(account, command);
                             processPendingCommands(account);
                         }
@@ -3635,25 +3423,19 @@ public class MessagingController {
                 for (Message message : messages) {
                     // If the message was in the Outbox, then it has been copied to local Trash, and has
                     // to be copied to remote trash
-                    PendingCommand command = new PendingCommand();
-                    command.command = PENDING_COMMAND_APPEND;
-                    command.arguments =
-                        new String[] {
-                        account.getTrashFolderName(),
-                        message.getUid()
-                    };
+                    PendingCommand command = MessagingControllerCommands.createAppend(account.getTrashFolderName(), message.getUid());
                     queuePendingCommand(account, command);
                 }
                 processPendingCommands(account);
             } else if (account.getDeletePolicy() == DeletePolicy.ON_DELETE) {
                 if (folder.equals(account.getTrashFolderName())) {
-                    queueSetFlag(account, folder, Boolean.toString(true), Flag.DELETED.toString(), uids);
+                    queueSetFlag(account, folder, true, Flag.DELETED, uids);
                 } else {
                     queueMoveOrCopy(account, folder, account.getTrashFolderName(), false, uids, uidMap);
                 }
                 processPendingCommands(account);
             } else if (account.getDeletePolicy() == DeletePolicy.MARK_AS_READ) {
-                queueSetFlag(account, folder, Boolean.toString(true), Flag.SEEN.toString(), uids);
+                queueSetFlag(account, folder, true, Flag.SEEN, uids);
                 processPendingCommands(account);
             } else {
                 if (K9.DEBUG)
@@ -3683,7 +3465,7 @@ public class MessagingController {
     }
 
     @SuppressWarnings("UnusedParameters") // for consistency with other PendingCommand methods
-    private void processPendingEmptyTrash(PendingCommand command, Account account) throws MessagingException {
+    private void processPendingEmptyTrash(PendingEmptyTrash command, Account account) throws MessagingException {
         Store remoteStore = account.getRemoteStore();
 
         Folder remoteFolder = remoteStore.getFolder(account.getTrashFolderName());
@@ -3729,9 +3511,7 @@ public class MessagingController {
                     }
 
                     if (!isTrashLocalOnly) {
-                        PendingCommand command = new PendingCommand();
-                        command.command = PENDING_COMMAND_EMPTY_TRASH;
-                        command.arguments = EMPTY_STRING_ARRAY;
+                        PendingCommand command = MessagingControllerCommands.createEmptyTrash();
                         queuePendingCommand(account, command);
                         processPendingCommands(account);
                     }
@@ -4224,12 +4004,7 @@ public class MessagingController {
             localMessage.setFlag(Flag.X_DOWNLOADED_FULL, true);
 
             if (saveRemotely) {
-                PendingCommand command = new PendingCommand();
-                command.command = PENDING_COMMAND_APPEND;
-                command.arguments = new String[] {
-                        localFolder.getName(),
-                        localMessage.getUid()
-                };
+                PendingCommand command = MessagingControllerCommands.createAppend(localFolder.getName(), localMessage.getUid());
                 queuePendingCommand(account, command);
                 processPendingCommands(account);
             }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -1,0 +1,137 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Map;
+
+import com.fsck.k9.mail.Flag;
+
+
+public class MessagingControllerCommands {
+    static final String COMMAND_APPEND = "append";
+    static final String COMMAND_MARK_ALL_AS_READ = "mark_all_as_read";
+    static final String COMMAND_SET_FLAG = "set_flag";
+    static final String COMMAND_EXPUNGE = "expunge";
+    static final String COMMAND_MOVE_OR_COPY = "move_or_copy";
+    static final String COMMAND_EMPTY_TRASH = "empty_trash";
+
+
+    public static PendingSetFlag createSetFlag(String folder, boolean newState, Flag flag, String[] uids) {
+        return new PendingSetFlag(folder, newState, flag, uids);
+    }
+
+    public static PendingExpunge createExpunge(String folderName) {
+        return new PendingExpunge(folderName);
+    }
+
+    public static PendingMarkAllAsRead createMarkAllAsRead(String folder) {
+        return new PendingMarkAllAsRead(folder);
+    }
+
+    public static PendingAppend createAppend(String folderName, String uid) {
+        return new PendingAppend(folderName, uid);
+    }
+
+    public static PendingEmptyTrash createEmptyTrash() {
+        return new PendingEmptyTrash();
+    }
+
+    public static PendingMoveOrCopy createMoveOrCopyBulk(String srcFolder, String destFolder, boolean isCopy, Map<String, String> uidMap) {
+        return new PendingMoveOrCopy(srcFolder, destFolder, isCopy, null, uidMap);
+    }
+
+    public static PendingMoveOrCopy createMoveOrCopyBulk(String srcFolder, String destFolder, boolean isCopy, String[] uids) {
+        return new PendingMoveOrCopy(srcFolder, destFolder, isCopy, uids, null);
+    }
+
+
+    public static abstract class PendingCommand {
+        public transient long databaseId;
+
+        public abstract String getCommandName();
+
+        private PendingCommand() { }
+    }
+
+    public static class PendingMoveOrCopy extends PendingCommand {
+        public final String srcFolder;
+        public final String destFolder;
+        public final boolean isCopy;
+        public final String[] uids;
+        public final Map<String, String> newUidMap;
+
+        public PendingMoveOrCopy(
+                String srcFolder, String destFolder, boolean isCopy, String[] uids, Map<String, String> newUidMap) {
+            this.srcFolder = srcFolder;
+            this.destFolder = destFolder;
+            this.isCopy = isCopy;
+            this.uids = uids;
+            this.newUidMap = newUidMap;
+        }
+
+        public String getCommandName() {
+            return COMMAND_MOVE_OR_COPY;
+        }
+    }
+
+    public static class PendingEmptyTrash extends PendingCommand {
+        public String getCommandName() {
+            return COMMAND_EMPTY_TRASH;
+        }
+    }
+
+    public static class PendingSetFlag extends PendingCommand {
+        public final String folder;
+        public final boolean newState;
+        public final Flag flag;
+        public final String[] uids;
+
+        public PendingSetFlag(String folder, boolean newState, Flag flag, String[] uids) {
+            this.folder = folder;
+            this.newState = newState;
+            this.flag = flag;
+            this.uids = uids;
+        }
+
+        public String getCommandName() {
+            return COMMAND_SET_FLAG;
+        }
+    }
+
+    public static class PendingAppend extends PendingCommand {
+        public final String folder;
+        public final String uid;
+
+        public PendingAppend(String folder, String uid) {
+            this.folder = folder;
+            this.uid = uid;
+        }
+
+        public String getCommandName() {
+            return COMMAND_APPEND;
+        }
+    }
+
+    public static class PendingMarkAllAsRead extends PendingCommand {
+        public final String folder;
+
+        public PendingMarkAllAsRead(String folder) {
+            this.folder = folder;
+        }
+
+        public String getCommandName() {
+            return COMMAND_MARK_ALL_AS_READ;
+        }
+    }
+
+    public static class PendingExpunge extends PendingCommand {
+        public final String folder;
+
+        public PendingExpunge(String folder) {
+            this.folder = folder;
+        }
+
+        public String getCommandName() {
+            return COMMAND_EXPUNGE;
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.controller;
 
 
+import java.util.List;
 import java.util.Map;
 
 import com.fsck.k9.mail.Flag;
@@ -15,7 +16,7 @@ public class MessagingControllerCommands {
     static final String COMMAND_EMPTY_TRASH = "empty_trash";
 
 
-    public static PendingSetFlag createSetFlag(String folder, boolean newState, Flag flag, String[] uids) {
+    public static PendingSetFlag createSetFlag(String folder, boolean newState, Flag flag, List<String> uids) {
         return new PendingSetFlag(folder, newState, flag, uids);
     }
 
@@ -39,7 +40,7 @@ public class MessagingControllerCommands {
         return new PendingMoveOrCopy(srcFolder, destFolder, isCopy, null, uidMap);
     }
 
-    public static PendingMoveOrCopy createMoveOrCopyBulk(String srcFolder, String destFolder, boolean isCopy, String[] uids) {
+    public static PendingMoveOrCopy createMoveOrCopyBulk(String srcFolder, String destFolder, boolean isCopy, List<String> uids) {
         return new PendingMoveOrCopy(srcFolder, destFolder, isCopy, uids, null);
     }
 
@@ -56,11 +57,11 @@ public class MessagingControllerCommands {
         public final String srcFolder;
         public final String destFolder;
         public final boolean isCopy;
-        public final String[] uids;
+        public final List<String> uids;
         public final Map<String, String> newUidMap;
 
         public PendingMoveOrCopy(
-                String srcFolder, String destFolder, boolean isCopy, String[] uids, Map<String, String> newUidMap) {
+                String srcFolder, String destFolder, boolean isCopy, List<String> uids, Map<String, String> newUidMap) {
             this.srcFolder = srcFolder;
             this.destFolder = destFolder;
             this.isCopy = isCopy;
@@ -83,9 +84,9 @@ public class MessagingControllerCommands {
         public final String folder;
         public final boolean newState;
         public final Flag flag;
-        public final String[] uids;
+        public final List<String> uids;
 
-        public PendingSetFlag(String folder, boolean newState, Flag flag, String[] uids) {
+        public PendingSetFlag(String folder, boolean newState, Flag flag, List<String> uids) {
             this.folder = folder;
             this.newState = newState;
             this.flag = flag;

--- a/k9mail/src/main/java/com/fsck/k9/controller/PendingCommandSerializer.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/PendingCommandSerializer.java
@@ -1,0 +1,70 @@
+package com.fsck.k9.controller;
+
+
+import java.io.IOError;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingCommand;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingEmptyTrash;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingExpunge;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingMarkAllAsRead;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingMoveOrCopy;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingSetFlag;
+import com.squareup.moshi.JsonAdapter;
+import com.squareup.moshi.Moshi;
+
+
+public class PendingCommandSerializer {
+    private static final PendingCommandSerializer INSTANCE = new PendingCommandSerializer();
+
+
+    private final Map<String, JsonAdapter<? extends PendingCommand>> adapters;
+
+
+    private PendingCommandSerializer() {
+        Moshi moshi = new Moshi.Builder().build();
+        HashMap<String, JsonAdapter<? extends PendingCommand>> adapters = new HashMap<>();
+
+        adapters.put(MessagingControllerCommands.COMMAND_MOVE_OR_COPY, moshi.adapter(PendingMoveOrCopy.class));
+        adapters.put(MessagingControllerCommands.COMMAND_APPEND, moshi.adapter(PendingAppend.class));
+        adapters.put(MessagingControllerCommands.COMMAND_EMPTY_TRASH, moshi.adapter(PendingEmptyTrash.class));
+        adapters.put(MessagingControllerCommands.COMMAND_EXPUNGE, moshi.adapter(PendingExpunge.class));
+        adapters.put(MessagingControllerCommands.COMMAND_MARK_ALL_AS_READ, moshi.adapter(PendingMarkAllAsRead.class));
+        adapters.put(MessagingControllerCommands.COMMAND_SET_FLAG, moshi.adapter(PendingSetFlag.class));
+
+        this.adapters = Collections.unmodifiableMap(adapters);
+    }
+
+
+    public static PendingCommandSerializer getInstance() {
+        return INSTANCE;
+    }
+
+
+    public <T extends PendingCommand> String serialize(T command) {
+        // noinspection unchecked, we know the map has correctly matching adapters
+        JsonAdapter<T> adapter = (JsonAdapter<T>) adapters.get(command.getCommandName());
+        if (adapter == null) {
+            throw new IllegalArgumentException("Unsupported pending command type!");
+        }
+        return adapter.toJson(command);
+    }
+
+    public PendingCommand unserialize(long databaseId, String commandName, String data) {
+        JsonAdapter<? extends PendingCommand> adapter = adapters.get(commandName);
+        if (adapter == null) {
+            throw new IllegalArgumentException("Unsupported pending command type!");
+        }
+        try {
+            PendingCommand command = adapter.fromJson(data);
+            command.databaseId = databaseId;
+            return command;
+        } catch (IOException e) {
+            throw new IOError(e);
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/helper/Utility.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/Utility.java
@@ -128,40 +128,6 @@ public class Utility {
         return false;
     }
 
-    /**
-     * A fast version of  URLDecoder.decode() that works only with UTF-8 and does only two
-     * allocations. This version is around 3x as fast as the standard one and I'm using it
-     * hundreds of times in places that slow down the UI, so it helps.
-     */
-    public static String fastUrlDecode(String s) {
-
-            byte[] bytes = s.getBytes(Charset.forName("UTF-8"));
-            byte ch;
-            int length = 0;
-            for (int i = 0, count = bytes.length; i < count; i++) {
-                ch = bytes[i];
-                if (ch == '%') {
-                    int h = (bytes[i + 1] - '0');
-                    int l = (bytes[i + 2] - '0');
-                    if (h > 9) {
-                        h -= 7;
-                    }
-                    if (l > 9) {
-                        l -= 7;
-                    }
-                    bytes[length] = (byte)((h << 4) | l);
-                    i += 2;
-                } else if (ch == '+') {
-                    bytes[length] = ' ';
-                } else {
-                    bytes[length] = bytes[i];
-                }
-                length++;
-            }
-            return new String(bytes, 0, length, Charset.forName("UTF-8"));
-
-    }
-
     /*
      * TODO disabled this method globally. It is used in all the settings screens but I just
      * noticed that an unrelated icon was dimmed. Android must share drawables internally.

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -34,7 +34,8 @@ import android.util.Log;
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
-import com.fsck.k9.helper.UrlEncodingHelper;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingCommand;
+import com.fsck.k9.controller.PendingCommandSerializer;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;
@@ -47,8 +48,6 @@ import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Multipart;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.Store;
-import com.fsck.k9.mail.internet.MimeMessage;
-import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mailstore.LocalFolder.DataLocation;
 import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
 import com.fsck.k9.mailstore.LockableDatabase.DbCallback;
@@ -153,7 +152,7 @@ public class LocalStore extends Store implements Serializable {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 57;
+    public static final int DB_VERSION = 58;
 
 
     public static String getColumnNameForFlag(Flag flag) {
@@ -188,6 +187,7 @@ public class LocalStore extends Store implements Serializable {
     private final MessagePreviewCreator messagePreviewCreator;
     private final MessageFulltextCreator messageFulltextCreator;
     private final AttachmentCounter attachmentCounter;
+    private final PendingCommandSerializer pendingCommandSerializer;
 
     /**
      * local://localhost/path/to/database/uuid.db
@@ -206,6 +206,7 @@ public class LocalStore extends Store implements Serializable {
         messagePreviewCreator = MessagePreviewCreator.newInstance();
         messageFulltextCreator = MessageFulltextCreator.newInstance();
         attachmentCounter = AttachmentCounter.newInstance();
+        pendingCommandSerializer = PendingCommandSerializer.getInstance();
 
         database.open();
     }
@@ -487,7 +488,7 @@ public class LocalStore extends Store implements Serializable {
                 Cursor cursor = null;
                 try {
                     cursor = db.query("pending_commands",
-                                      new String[] { "id", "command", "arguments" },
+                                      new String[] { "id", "command", "data" },
                                       null,
                                       null,
                                       null,
@@ -495,14 +496,11 @@ public class LocalStore extends Store implements Serializable {
                                       "id ASC");
                     List<PendingCommand> commands = new ArrayList<>();
                     while (cursor.moveToNext()) {
-                        PendingCommand command = new PendingCommand();
-                        command.mId = cursor.getLong(0);
-                        command.command = cursor.getString(1);
-                        String arguments = cursor.getString(2);
-                        command.arguments = arguments.split(",");
-                        for (int i = 0; i < command.arguments.length; i++) {
-                            command.arguments[i] = Utility.fastUrlDecode(command.arguments[i]);
-                        }
+                        long databaseId = cursor.getLong(0);
+                        String commandName = cursor.getString(1);
+                        String data = cursor.getString(2);
+                        PendingCommand command = pendingCommandSerializer.unserialize(
+                                databaseId, commandName, data);
                         commands.add(command);
                     }
                     return commands;
@@ -514,12 +512,9 @@ public class LocalStore extends Store implements Serializable {
     }
 
     public void addPendingCommand(PendingCommand command) throws MessagingException {
-        for (int i = 0; i < command.arguments.length; i++) {
-            command.arguments[i] = UrlEncodingHelper.encodeUtf8(command.arguments[i]);
-        }
         final ContentValues cv = new ContentValues();
-        cv.put("command", command.command);
-        cv.put("arguments", Utility.combine(command.arguments, ','));
+        cv.put("command", command.getCommandName());
+        cv.put("data", pendingCommandSerializer.serialize(command));
         database.execute(false, new DbCallback<Void>() {
             @Override
             public Void doDbWork(final SQLiteDatabase db) throws WrappedException {
@@ -533,7 +528,7 @@ public class LocalStore extends Store implements Serializable {
         database.execute(false, new DbCallback<Void>() {
             @Override
             public Void doDbWork(final SQLiteDatabase db) throws WrappedException {
-                db.delete("pending_commands", "id = ?", new String[] { Long.toString(command.mId) });
+                db.delete("pending_commands", "id = ?", new String[] { Long.toString(command.databaseId) });
                 return null;
             }
         });
@@ -547,25 +542,6 @@ public class LocalStore extends Store implements Serializable {
                 return null;
             }
         });
-    }
-
-    public static class PendingCommand {
-        private long mId;
-        public String command;
-        public String[] arguments;
-
-        @Override
-        public String toString() {
-            StringBuilder sb = new StringBuilder();
-            sb.append(command);
-            sb.append(": ");
-            for (String argument : arguments) {
-                sb.append(", ");
-                sb.append(argument);
-                //sb.append("\n");
-            }
-            return sb.toString();
-        }
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -195,7 +195,7 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
 
         db.execSQL("DROP TABLE IF EXISTS pending_commands");
         db.execSQL("CREATE TABLE pending_commands " +
-                "(id INTEGER PRIMARY KEY, command TEXT, arguments TEXT)");
+                "(id INTEGER PRIMARY KEY, command TEXT, data TEXT)");
 
         db.execSQL("DROP TRIGGER IF EXISTS delete_folder");
         db.execSQL("CREATE TRIGGER delete_folder BEFORE DELETE ON folders BEGIN DELETE FROM messages WHERE old.id = folder_id; END;");

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -20,7 +20,6 @@ import com.fsck.k9.preferences.Storage;
 class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
     private final LocalStore localStore;
 
-
     StoreSchemaDefinition(LocalStore localStore) {
         this.localStore = localStore;
     }
@@ -49,6 +48,7 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
         Log.i(K9.LOG_TAG, String.format(Locale.US, "Upgrading database from version %d to version %d",
                 db.getVersion(), LocalStore.DB_VERSION));
 
+
         db.beginTransaction();
         try {
             // schema version 29 was when we moved to incremental updates
@@ -63,6 +63,8 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
             db.setVersion(LocalStore.DB_VERSION);
 
             db.setTransactionSuccessful();
+            Log.i(K9.LOG_TAG, String.format(Locale.US, "Upgraded database to version %d",
+                    db.getVersion()));
         } finally {
             db.endTransaction();
         }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
@@ -187,6 +187,7 @@ class MigrationTo58 {
         }
     }
 
+    @VisibleForTesting
     static class OldPendingCommand {
         public String command;
         public String[] arguments;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
@@ -1,0 +1,14 @@
+package com.fsck.k9.mailstore.migrations;
+
+
+import android.database.sqlite.SQLiteDatabase;
+
+
+class MigrationTo58 {
+    static void migratePendingCommands(SQLiteDatabase db) {
+        // TODO actually migrate
+        db.execSQL("DROP TABLE IF EXISTS pending_commands");
+        db.execSQL("CREATE TABLE pending_commands " +
+                "(id INTEGER PRIMARY KEY, command TEXT, data TEXT)");
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
@@ -1,14 +1,194 @@
 package com.fsck.k9.mailstore.migrations;
 
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import android.content.ContentValues;
+import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.VisibleForTesting;
+
+import com.fsck.k9.controller.MessagingControllerCommands;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingCommand;
+import com.fsck.k9.controller.PendingCommandSerializer;
+import com.fsck.k9.helper.Utility;
+import com.fsck.k9.mail.Flag;
 
 
 class MigrationTo58 {
+    private static final String PENDING_COMMAND_MOVE_OR_COPY = "com.fsck.k9.MessagingController.moveOrCopy";
+    private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK = "com.fsck.k9.MessagingController.moveOrCopyBulk";
+    private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW = "com.fsck.k9.MessagingController.moveOrCopyBulkNew";
+    private static final String PENDING_COMMAND_EMPTY_TRASH = "com.fsck.k9.MessagingController.emptyTrash";
+    private static final String PENDING_COMMAND_SET_FLAG_BULK = "com.fsck.k9.MessagingController.setFlagBulk";
+    private static final String PENDING_COMMAND_SET_FLAG = "com.fsck.k9.MessagingController.setFlag";
+    private static final String PENDING_COMMAND_APPEND = "com.fsck.k9.MessagingController.append";
+    private static final String PENDING_COMMAND_MARK_ALL_AS_READ = "com.fsck.k9.MessagingController.markAllAsRead";
+    private static final String PENDING_COMMAND_EXPUNGE = "com.fsck.k9.MessagingController.expunge";
+
+
     static void migratePendingCommands(SQLiteDatabase db) {
-        // TODO actually migrate
+        List<PendingCommand> pendingCommmands = new ArrayList<>();
+        for (OldPendingCommand oldPendingCommand : getPendingCommands(db)) {
+            PendingCommand newPendingCommand = migratePendingCommand(oldPendingCommand);
+            pendingCommmands.add(newPendingCommand);
+        }
+
         db.execSQL("DROP TABLE IF EXISTS pending_commands");
         db.execSQL("CREATE TABLE pending_commands " +
                 "(id INTEGER PRIMARY KEY, command TEXT, data TEXT)");
+
+        PendingCommandSerializer pendingCommandSerializer = PendingCommandSerializer.getInstance();
+        for (PendingCommand pendingCommand : pendingCommmands) {
+            final ContentValues cv = new ContentValues();
+            cv.put("command", pendingCommand.getCommandName());
+            cv.put("data", pendingCommandSerializer.serialize(pendingCommand));
+            db.insert("pending_commands", "command", cv);
+        }
+    }
+
+    @VisibleForTesting
+    static PendingCommand migratePendingCommand(OldPendingCommand oldPendingCommand) {
+        switch (oldPendingCommand.command) {
+            case PENDING_COMMAND_APPEND:
+                return migrateCommandAppend(oldPendingCommand);
+            case PENDING_COMMAND_SET_FLAG_BULK:
+                return migrateCommandSetFlagBulk(oldPendingCommand);
+            case PENDING_COMMAND_SET_FLAG:
+                return migrateCommandSetFlag(oldPendingCommand);
+            case PENDING_COMMAND_MARK_ALL_AS_READ:
+                return migrateCommandMarkAllAsRead(oldPendingCommand);
+            case PENDING_COMMAND_MOVE_OR_COPY_BULK:
+                return migrateCommandMoveOrCopyBulk(oldPendingCommand);
+            case PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW:
+                return migrateCommandMoveOrCopyBulkNew(oldPendingCommand);
+            case PENDING_COMMAND_MOVE_OR_COPY:
+                return migrateCommandMoveOrCopy(oldPendingCommand);
+            case PENDING_COMMAND_EMPTY_TRASH:
+                return migrateCommandEmptyTrash();
+            case PENDING_COMMAND_EXPUNGE:
+                return migrateCommandExpunge(oldPendingCommand);
+            default:
+                throw new IllegalArgumentException("Tried to migrate unknown pending command!");
+        }
+    }
+
+    private static PendingCommand migrateCommandExpunge(OldPendingCommand command) {
+        String folder = command.arguments[0];
+        return MessagingControllerCommands.createExpunge(folder);
+    }
+
+    private static PendingCommand migrateCommandEmptyTrash() {
+        return MessagingControllerCommands.createEmptyTrash();
+    }
+
+    private static PendingCommand migrateCommandMoveOrCopy(OldPendingCommand command) {
+        String srcFolder = command.arguments[0];
+        String uid = command.arguments[1];
+        String destFolder = command.arguments[2];
+        boolean isCopy = Boolean.parseBoolean(command.arguments[3]);
+
+        return MessagingControllerCommands.createMoveOrCopyBulk(srcFolder, destFolder, isCopy,
+                Collections.singletonList(uid));
+    }
+
+    private static PendingCommand migrateCommandMoveOrCopyBulkNew(OldPendingCommand command) {
+        String srcFolder = command.arguments[0];
+        String destFolder = command.arguments[1];
+        boolean isCopy = Boolean.parseBoolean(command.arguments[2]);
+        boolean hasNewUids = Boolean.parseBoolean(command.arguments[3]);
+
+        if (hasNewUids) {
+            Map<String, String> uidMap = new HashMap<>();
+            int offset = (command.arguments.length - 4) / 2;
+            for (int i = 4; i < 4 + offset; i++) {
+                uidMap.put(command.arguments[i], command.arguments[i + offset]);
+            }
+
+            return MessagingControllerCommands.createMoveOrCopyBulk(srcFolder, destFolder, isCopy, uidMap);
+        } else {
+            List<String> uids = new ArrayList<>(command.arguments.length -4);
+            uids.addAll(Arrays.asList(command.arguments).subList(4, command.arguments.length));
+
+            return MessagingControllerCommands.createMoveOrCopyBulk(srcFolder, destFolder, isCopy, uids);
+        }
+
+    }
+
+    private static PendingCommand migrateCommandMoveOrCopyBulk(OldPendingCommand command) {
+        int len = command.arguments.length;
+
+        OldPendingCommand newCommand = new OldPendingCommand();
+        newCommand.command = PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW;
+        newCommand.arguments = new String[len + 1];
+        newCommand.arguments[0] = command.arguments[0];
+        newCommand.arguments[1] = command.arguments[1];
+        newCommand.arguments[2] = command.arguments[2];
+        newCommand.arguments[3] = Boolean.toString(false);
+        System.arraycopy(command.arguments, 3, newCommand.arguments, 4, len - 3);
+
+        return migratePendingCommand(newCommand);
+    }
+
+    private static PendingCommand migrateCommandMarkAllAsRead(OldPendingCommand command) {
+        return MessagingControllerCommands.createMarkAllAsRead(command.arguments[0]);
+    }
+
+    private static PendingCommand migrateCommandSetFlag(OldPendingCommand command) {
+        String folder = command.arguments[0];
+        String uid = command.arguments[1];
+        boolean newState = Boolean.parseBoolean(command.arguments[2]);
+        Flag flag = Flag.valueOf(command.arguments[3]);
+
+        return MessagingControllerCommands.createSetFlag(folder, newState, flag, Collections.singletonList(uid));
+    }
+
+    private static PendingCommand migrateCommandSetFlagBulk(OldPendingCommand command) {
+        String folder = command.arguments[0];
+        boolean newState = Boolean.parseBoolean(command.arguments[1]);
+        Flag flag = Flag.valueOf(command.arguments[2]);
+
+        List<String> uids = new ArrayList<>(command.arguments.length -3);
+        uids.addAll(Arrays.asList(command.arguments).subList(3, command.arguments.length));
+
+        return MessagingControllerCommands.createSetFlag(folder, newState, flag, uids);
+    }
+
+    private static PendingCommand migrateCommandAppend(OldPendingCommand command) {
+        String folder = command.arguments[0];
+        String uid = command.arguments[1];
+        return MessagingControllerCommands.createAppend(folder, uid);
+    }
+
+    private static List<OldPendingCommand> getPendingCommands(SQLiteDatabase db) {
+        Cursor cursor = null;
+        try {
+            cursor = db.query("pending_commands",
+                    new String[] { "id", "command", "arguments" }, null, null, null, null, "id ASC");
+            List<OldPendingCommand> commands = new ArrayList<>();
+            while (cursor.moveToNext()) {
+                OldPendingCommand command = new OldPendingCommand();
+                command.command = cursor.getString(1);
+                String arguments = cursor.getString(2);
+                command.arguments = arguments.split(",");
+                for (int i = 0; i < command.arguments.length; i++) {
+                    command.arguments[i] = Utility.fastUrlDecode(command.arguments[i]);
+                }
+                commands.add(command);
+            }
+            return commands;
+        } finally {
+            Utility.closeQuietly(cursor);
+        }
+    }
+
+    static class OldPendingCommand {
+        public String command;
+        public String[] arguments;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
@@ -35,22 +35,40 @@ class MigrationTo58 {
 
     static void migratePendingCommands(SQLiteDatabase db) {
         List<PendingCommand> pendingCommmands = new ArrayList<>();
-        for (OldPendingCommand oldPendingCommand : getPendingCommands(db)) {
-            PendingCommand newPendingCommand = migratePendingCommand(oldPendingCommand);
-            pendingCommmands.add(newPendingCommand);
-        }
 
-        db.execSQL("DROP TABLE IF EXISTS pending_commands");
-        db.execSQL("CREATE TABLE pending_commands " +
-                "(id INTEGER PRIMARY KEY, command TEXT, data TEXT)");
+        if (columnExists(db, "pending_commands", "arguments")) {
+            for (OldPendingCommand oldPendingCommand : getPendingCommands(db)) {
+                PendingCommand newPendingCommand = migratePendingCommand(oldPendingCommand);
+                pendingCommmands.add(newPendingCommand);
+            }
 
-        PendingCommandSerializer pendingCommandSerializer = PendingCommandSerializer.getInstance();
-        for (PendingCommand pendingCommand : pendingCommmands) {
-            final ContentValues cv = new ContentValues();
-            cv.put("command", pendingCommand.getCommandName());
-            cv.put("data", pendingCommandSerializer.serialize(pendingCommand));
-            db.insert("pending_commands", "command", cv);
+            db.execSQL("DROP TABLE IF EXISTS pending_commands");
+            db.execSQL("CREATE TABLE pending_commands " +
+                    "(id INTEGER PRIMARY KEY, command TEXT, data TEXT)");
+
+            PendingCommandSerializer pendingCommandSerializer = PendingCommandSerializer.getInstance();
+            for (PendingCommand pendingCommand : pendingCommmands) {
+                final ContentValues cv = new ContentValues();
+                cv.put("command", pendingCommand.getCommandName());
+                cv.put("data", pendingCommandSerializer.serialize(pendingCommand));
+                db.insert("pending_commands", "command", cv);
+            }
         }
+    }
+
+    private static boolean columnExists(SQLiteDatabase db, String table, String columnName) {
+        Cursor columnCursor  = db.rawQuery("PRAGMA table_info("+table+")", null);
+        columnCursor.moveToFirst();
+        boolean foundColumn = false;
+        while (!columnCursor.isAfterLast()) {
+            if(columnCursor.getString(1).equals(columnName)) {
+                foundColumn = true;
+                break;
+            }
+            columnCursor.moveToNext();
+        }
+        columnCursor.close();
+        return foundColumn;
     }
 
     @VisibleForTesting
@@ -118,7 +136,6 @@ class MigrationTo58 {
 
             return MessagingControllerCommands.createMoveOrCopyBulk(srcFolder, destFolder, isCopy, uids);
         }
-
     }
 
     private static PendingCommand migrateCommandMoveOrCopyBulk(OldPendingCommand command) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
@@ -68,6 +68,8 @@ public class Migrations {
                 MigrationTo56.cleanUpFtsTable(db);
             case 56:
                 MigrationTo57.fixDataLocationForMultipartParts(db);
+            case 57:
+                MigrationTo58.migratePendingCommands(db);
         }
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/controller/PendingCommandSerializerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/PendingCommandSerializerTest.java
@@ -1,0 +1,81 @@
+package com.fsck.k9.controller;
+
+
+import java.util.HashMap;
+
+import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingCommand;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingEmptyTrash;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingMoveOrCopy;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+
+@SuppressWarnings("WeakerAccess")
+public class PendingCommandSerializerTest {
+    static final int DATABASE_ID = 123;
+    static final String UID = "uid";
+    static final String SOURCE_FOLDER = "source_folder";
+    static final String DEST_FOLDER = "dest_folder";
+    static final HashMap<String, String> UID_MAP = new HashMap<>();
+    public static final boolean IS_COPY = true;
+
+    static {
+        UID_MAP.put("uid_1", "uid_other_1");
+        UID_MAP.put("uid_2", "uid_other_2");
+    }
+
+
+    PendingCommandSerializer pendingCommandSerializer = PendingCommandSerializer.getInstance();
+
+
+    @Test
+    public void testSerializeDeserialize__withoutArguments() {
+        PendingCommand pendingCommand = MessagingControllerCommands.createEmptyTrash();
+
+        String serializedCommand = pendingCommandSerializer.serialize(pendingCommand);
+        PendingEmptyTrash unserializedCommand = (PendingEmptyTrash) pendingCommandSerializer.unserialize(
+                DATABASE_ID, pendingCommand.getCommandName(), serializedCommand);
+
+        assertEquals(DATABASE_ID, unserializedCommand.databaseId);
+    }
+
+    @Test
+    public void testSerializeDeserialize__withArguments() {
+        PendingCommand pendingCommand = MessagingControllerCommands.createAppend(SOURCE_FOLDER, UID);
+
+        String serializedCommand = pendingCommandSerializer.serialize(pendingCommand);
+        PendingAppend unserializedCommand = (PendingAppend) pendingCommandSerializer.unserialize(
+                DATABASE_ID, pendingCommand.getCommandName(), serializedCommand);
+
+        assertEquals(DATABASE_ID, unserializedCommand.databaseId);
+        assertEquals(SOURCE_FOLDER, unserializedCommand.folder);
+        assertEquals(UID, unserializedCommand.uid);
+    }
+
+    @Test
+    public void testSerializeDeserialize__withComplexArguments() {
+        PendingCommand pendingCommand = MessagingControllerCommands.createMoveOrCopyBulk(
+                SOURCE_FOLDER, DEST_FOLDER, IS_COPY, UID_MAP);
+
+        String serializedCommand = pendingCommandSerializer.serialize(pendingCommand);
+        PendingMoveOrCopy unserializedCommand = (PendingMoveOrCopy) pendingCommandSerializer.unserialize(
+                DATABASE_ID, pendingCommand.getCommandName(), serializedCommand);
+
+        assertEquals(DATABASE_ID, unserializedCommand.databaseId);
+        assertEquals(SOURCE_FOLDER, unserializedCommand.srcFolder);
+        assertEquals(DEST_FOLDER, unserializedCommand.destFolder);
+        assertEquals(UID_MAP, unserializedCommand.newUidMap);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testDeserialize__withUnknownCommandName__shouldFail() {
+        PendingCommand pendingCommand = MessagingControllerCommands.createEmptyTrash();
+
+        String serializedCommand = pendingCommandSerializer.serialize(pendingCommand);
+        pendingCommandSerializer.unserialize(DATABASE_ID,  "BAD_COMMAND_NAME", serializedCommand);
+    }
+
+}

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationTo58Test.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationTo58Test.java
@@ -1,0 +1,284 @@
+package com.fsck.k9.mailstore.migrations;
+
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingCommand;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingEmptyTrash;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingExpunge;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingMarkAllAsRead;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingMoveOrCopy;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingSetFlag;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mailstore.migrations.MigrationTo58.OldPendingCommand;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+
+@SuppressWarnings("WeakerAccess")
+public class MigrationTo58Test {
+    static final String PENDING_COMMAND_MOVE_OR_COPY = "com.fsck.k9.MessagingController.moveOrCopy";
+    static final String PENDING_COMMAND_MOVE_OR_COPY_BULK = "com.fsck.k9.MessagingController.moveOrCopyBulk";
+    static final String PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW = "com.fsck.k9.MessagingController.moveOrCopyBulkNew";
+    static final String PENDING_COMMAND_EMPTY_TRASH = "com.fsck.k9.MessagingController.emptyTrash";
+    static final String PENDING_COMMAND_SET_FLAG_BULK = "com.fsck.k9.MessagingController.setFlagBulk";
+    static final String PENDING_COMMAND_SET_FLAG = "com.fsck.k9.MessagingController.setFlag";
+    static final String PENDING_COMMAND_APPEND = "com.fsck.k9.MessagingController.append";
+    static final String PENDING_COMMAND_MARK_ALL_AS_READ = "com.fsck.k9.MessagingController.markAllAsRead";
+    static final String PENDING_COMMAND_EXPUNGE = "com.fsck.k9.MessagingController.expunge";
+
+    static final String SOURCE_FOLDER = "source_folder";
+    static final String DEST_FOLDER = "dest_folder";
+    static final boolean IS_COPY = true;
+    static final String[] UID_ARRAY = new String[] { "uid_1", "uid_2" };
+    static final boolean FLAG_STATE = true;
+    static final Flag FLAG = Flag.X_DESTROYED;
+    static final String UID = "uid";
+    static final HashMap<String, String> UID_MAP = new HashMap<>();
+    static {
+        UID_MAP.put("uid_1", "uid_other_1");
+        UID_MAP.put("uid_2", "uid_other_2");
+    }
+
+
+    @Test
+    public void testMigrateMoveOrCopy__withUidArray() {
+        OldPendingCommand command = queueMoveOrCopy(SOURCE_FOLDER, DEST_FOLDER, IS_COPY, UID_ARRAY);
+
+        PendingMoveOrCopy pendingCommand = (PendingMoveOrCopy) MigrationTo58.migratePendingCommand(command);
+
+        assertEquals(SOURCE_FOLDER, pendingCommand.srcFolder);
+        assertEquals(DEST_FOLDER, pendingCommand.destFolder);
+        assertEquals(IS_COPY, pendingCommand.isCopy);
+        assertEquals(Arrays.asList(UID_ARRAY), pendingCommand.uids);
+        assertNull(pendingCommand.newUidMap);
+    }
+
+    OldPendingCommand queueMoveOrCopy(String srcFolder, String destFolder, boolean isCopy, String uids[]) {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW;
+
+        int length = 4 + uids.length;
+        command.arguments = new String[length];
+        command.arguments[0] = srcFolder;
+        command.arguments[1] = destFolder;
+        command.arguments[2] = Boolean.toString(isCopy);
+        command.arguments[3] = Boolean.toString(false);
+        System.arraycopy(uids, 0, command.arguments, 4, uids.length);
+        return command;
+    }
+
+
+    @Test
+    public void testMigrateMoveOrCopy__withUidMap() {
+        OldPendingCommand command = queueMoveOrCopy(SOURCE_FOLDER, DEST_FOLDER, IS_COPY, UID_MAP);
+
+        PendingMoveOrCopy pendingCommand = (PendingMoveOrCopy) MigrationTo58.migratePendingCommand(command);
+
+        assertEquals(SOURCE_FOLDER, pendingCommand.srcFolder);
+        assertEquals(DEST_FOLDER, pendingCommand.destFolder);
+        assertEquals(IS_COPY, pendingCommand.isCopy);
+        assertEquals(UID_MAP, pendingCommand.newUidMap);
+        assertNull(pendingCommand.uids);
+    }
+
+    OldPendingCommand queueMoveOrCopy(
+            String srcFolder, String destFolder, boolean isCopy, Map<String, String> uidMap) {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW;
+
+        int length = 4 + uidMap.keySet().size() + uidMap.values().size();
+        command.arguments = new String[length];
+        command.arguments[0] = srcFolder;
+        command.arguments[1] = destFolder;
+        command.arguments[2] = Boolean.toString(isCopy);
+        command.arguments[3] = Boolean.toString(true);
+        Set<String> strings = uidMap.keySet();
+        System.arraycopy(strings.toArray(new String[strings.size()]), 0, command.arguments, 4, uidMap.keySet().size());
+        Collection<String> values = uidMap.values();
+        System.arraycopy(values.toArray(new String[values.size()]), 0, command.arguments, 4 + uidMap.keySet().size(), uidMap.values().size());
+        return command;
+    }
+
+
+    @Test
+    public void testMigrateMoveOrCopy__withOldFormat() {
+        OldPendingCommand command = queueMoveOrCopyOld(SOURCE_FOLDER, DEST_FOLDER, IS_COPY, UID_ARRAY);
+
+        PendingMoveOrCopy pendingCommand = (PendingMoveOrCopy) MigrationTo58.migratePendingCommand(command);
+
+        assertEquals(SOURCE_FOLDER, pendingCommand.srcFolder);
+        assertEquals(DEST_FOLDER, pendingCommand.destFolder);
+        assertEquals(IS_COPY, pendingCommand.isCopy);
+        assertEquals(Arrays.asList(UID_ARRAY), pendingCommand.uids);
+        assertNull(pendingCommand.newUidMap);
+    }
+
+    OldPendingCommand queueMoveOrCopyOld(String srcFolder, String destFolder, boolean isCopy, String uids[]) {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_MOVE_OR_COPY_BULK;
+
+        int length = 3 + uids.length;
+        command.arguments = new String[length];
+        command.arguments[0] = srcFolder;
+        command.arguments[1] = destFolder;
+        command.arguments[2] = Boolean.toString(isCopy);
+        System.arraycopy(uids, 0, command.arguments, 3, uids.length);
+        return command;
+    }
+
+
+    @Test
+    public void testMigrateMoveOrCopy__withEvenOlderFormat() {
+        OldPendingCommand command = queueMoveOrCopyEvenOlder(SOURCE_FOLDER, DEST_FOLDER, UID, IS_COPY);
+
+        PendingMoveOrCopy pendingCommand = (PendingMoveOrCopy) MigrationTo58.migratePendingCommand(command);
+
+        assertEquals(SOURCE_FOLDER, pendingCommand.srcFolder);
+        assertEquals(DEST_FOLDER, pendingCommand.destFolder);
+        assertEquals(IS_COPY, pendingCommand.isCopy);
+        assertEquals(Collections.singletonList(UID), pendingCommand.uids);
+        assertNull(pendingCommand.newUidMap);
+    }
+
+    OldPendingCommand queueMoveOrCopyEvenOlder(String srcFolder, String destFolder, String uid, boolean isCopy) {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_MOVE_OR_COPY;
+
+        command.arguments = new String[4];
+        command.arguments[0] = srcFolder;
+        command.arguments[1] = uid;
+        command.arguments[2] = destFolder;
+        command.arguments[3] = Boolean.toString(isCopy);
+        return command;
+    }
+
+
+    @Test
+    public void testMigrateSetFlag() {
+        OldPendingCommand command = queueSetFlagBulk(SOURCE_FOLDER, FLAG_STATE, FLAG, UID_ARRAY);
+
+        PendingSetFlag pendingCommand = (PendingSetFlag) MigrationTo58.migratePendingCommand(command);
+
+        assertEquals(SOURCE_FOLDER, pendingCommand.folder);
+        assertEquals(FLAG_STATE, pendingCommand.newState);
+        assertEquals(FLAG, pendingCommand.flag);
+        assertEquals(Arrays.asList(UID_ARRAY), pendingCommand.uids);
+    }
+
+    OldPendingCommand queueSetFlagBulk(String folderName, boolean newState, Flag flag, String[] uids) {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_SET_FLAG_BULK;
+        int length = 3 + uids.length;
+        command.arguments = new String[length];
+        command.arguments[0] = folderName;
+        command.arguments[1] = Boolean.toString(newState);
+        command.arguments[2] = flag.toString();
+        System.arraycopy(uids, 0, command.arguments, 3, uids.length);
+        return command;
+    }
+
+
+    @Test
+    public void testMigrateSetFlag__oldFormat() {
+        OldPendingCommand command = queueSetFlagOld(SOURCE_FOLDER, FLAG_STATE, FLAG, UID);
+
+        PendingSetFlag pendingCommand = (PendingSetFlag) MigrationTo58.migratePendingCommand(command);
+
+        assertEquals(SOURCE_FOLDER, pendingCommand.folder);
+        assertEquals(FLAG_STATE, pendingCommand.newState);
+        assertEquals(FLAG, pendingCommand.flag);
+        assertEquals(Collections.singletonList(UID), pendingCommand.uids);
+    }
+
+    OldPendingCommand queueSetFlagOld(String folderName, boolean newState, Flag flag, String uid) {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_SET_FLAG;
+        command.arguments = new String[4];
+        command.arguments[0] = folderName;
+        command.arguments[1] = uid;
+        command.arguments[2] = Boolean.toString(newState);
+        command.arguments[3] = flag.toString();
+        return command;
+    }
+
+
+    @Test
+    public void testMigrateExpunge() {
+        OldPendingCommand command = queueExpunge(SOURCE_FOLDER);
+
+        PendingExpunge pendingCommand = (PendingExpunge) MigrationTo58.migratePendingCommand(command);
+
+        assertEquals(SOURCE_FOLDER, pendingCommand.folder);
+    }
+
+    OldPendingCommand queueExpunge(String folderName) {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_EXPUNGE;
+        command.arguments = new String[1];
+        command.arguments[0] = folderName;
+        return command;
+    }
+
+
+    @Test
+    public void testMigrateEmptyTrash() {
+        OldPendingCommand command = queueEmptyTrash();
+
+        PendingCommand pendingCommand = MigrationTo58.migratePendingCommand(command);
+
+        assertTrue(pendingCommand instanceof PendingEmptyTrash);
+    }
+
+    OldPendingCommand queueEmptyTrash() {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_EMPTY_TRASH;
+        command.arguments = new String[0];
+        return command;
+    }
+
+
+    @Test
+    public void testMigrateMarkAllMessagesRead() {
+        OldPendingCommand command = queueMarkAllMessagesRead(SOURCE_FOLDER);
+
+        PendingMarkAllAsRead pendingCommand = (PendingMarkAllAsRead) MigrationTo58.migratePendingCommand(command);
+
+        assertEquals(SOURCE_FOLDER, pendingCommand.folder);
+    }
+
+    OldPendingCommand queueMarkAllMessagesRead(final String folder) {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_MARK_ALL_AS_READ;
+        command.arguments = new String[] { folder };
+        return command;
+    }
+
+
+    @Test
+    public void testMigrateAppend() {
+        OldPendingCommand command = queueAppend(SOURCE_FOLDER, UID);
+
+        PendingAppend pendingCommand = (PendingAppend) MigrationTo58.migratePendingCommand(command);
+
+        assertEquals(SOURCE_FOLDER, pendingCommand.folder);
+        assertEquals(UID, pendingCommand.uid);
+    }
+
+    OldPendingCommand queueAppend(String srcFolder, String uid) {
+        OldPendingCommand command = new OldPendingCommand();
+        command.command = PENDING_COMMAND_APPEND;
+        command.arguments = new String[] { srcFolder, uid };
+        return command;
+    }
+
+}


### PR DESCRIPTION
This PR moves all pending commands from MessagingController, which were previously stored as `String[]`, into strongly typed data structures and extracts the serialization mechanism into its own `PendingCommandSerializer` which is then implemented using moshi to serialize the data into JSON objects.

Comes with with tests for serialization, a migration layer, tests for the migration, and a total of -300/+70 lines for MessagingController. Such a beauty.
