### PR TITLE
hide keyboard when message is displayed

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -211,8 +211,6 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
     public void onPendingIntentResult(int requestCode, int resultCode, Intent data) {
         if ((requestCode & REQUEST_MASK_LOADER_HELPER) == REQUEST_MASK_LOADER_HELPER) {
-            hideKeyboard();
-
             requestCode ^= REQUEST_MASK_LOADER_HELPER;
             messageLoaderHelper.onActivityResult(requestCode, resultCode, data);
             return;
@@ -242,6 +240,8 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     private void showMessage(MessageViewInfo messageViewInfo) {
+        hideKeyboard();
+
         boolean handledByCryptoPresenter = messageCryptoPresenter.maybeHandleShowMessage(
                 mMessageView, mAccount, messageViewInfo);
         if (!handledByCryptoPresenter) {


### PR DESCRIPTION
...and not only after interaction pending intent. because it never makes sense to have a keyboard on screen when a message is displayed to the user.