### PR TITLE
Added provider settings for Ziggo and Virgin Media

### DIFF
--- a/k9mail/src/main/res/xml/providers.xml
+++ b/k9mail/src/main/res/xml/providers.xml
@@ -193,6 +193,23 @@
         <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
         <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
     </provider>
+    <!-- Virgin Media variants -->
+    <provider id="virginmedia.com" label="Virgin Media" domain="virginmedia.com">
+        <incoming uri="imap+ssl+://imap.virginmedia.com" username="$email" />
+        <outgoing uri="smtp+ssl+://smtp.virginmedia.com" username="$email" />
+    </provider>
+    <provider id="virgin.net" label="Virgin Media" domain="virgin.net">
+        <incoming uri="imap+ssl+://imap4.virgin.net" username="$email" />
+        <outgoing uri="smtp+ssl+://smtp.virgin.net" username="$email" />
+    </provider>
+    <provider id="blueyonder.co.uk" label="Virgin Media" domain="blueyonder.co.uk">
+        <incoming uri="imap+ssl+://imap4.blueyonder.co.uk" username="$email" />
+        <outgoing uri="smtp+ssl+://smtp.blueyonder.co.uk" username="$email" />
+    </provider>
+    <provider id="ntlworld.com" label="Virgin Media" domain="ntlworld.com">
+        <incoming uri="imap+ssl+://imap.ntlworld.com" username="$email" />
+        <outgoing uri="smtp+ssl+://smtp.ntlworld.com" username="$email" />
+    </provider>
     
     <!-- Germany -->
     <provider id="mailbox.org" label="mailbox.org" domain="mailbox.org">
@@ -544,6 +561,65 @@
     <provider id="outlook.sk" label="Outlook.sk" domain="outlook.sk">
         <incoming uri="imap+ssl+://imap-mail.outlook.com"  username="$email" />
         <outgoing uri="smtp+tls+://smtp-mail.outlook.com" username="$email" />
+    </provider>
+    
+    <!-- The Netherlands -->
+    <!-- Ziggo variants -->
+    <provider id="casema.nl" label="Ziggo" domain="casema.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="chello.nl" label="Ziggo" domain="chello.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="hahah.nl" label="Ziggo" domain="hahah.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="home.nl" label="Ziggo" domain="home.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="multiweb.nl" label="Ziggo" domain="multiweb.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="quicknet.nl" label="Ziggo" domain="quicknet.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="razcall.com" label="Ziggo" domain="razcall.com">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="razcall.nl" label="Ziggo" domain="razcall.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="upcmail.nl" label="Ziggo" domain="upcmail.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="zeggis.com" label="Ziggo" domain="zeggis.com">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="zeggis.nl" label="Ziggo" domain="zeggis.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="ziggomail.com" label="Ziggo" domain="ziggomail.com">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="ziggo.nl" label="Ziggo" domain="ziggo.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
+    </provider>
+    <provider id="zinders.nl" label="Ziggo" domain="zinders.nl">
+        <incoming uri="imap+ssl+://imap.ziggo.nl"  username="$email" />
+        <outgoing uri="smtp+tls+://smtp.ziggo.nl" username="$email" />
     </provider>
 
     <!-- Developers' vanity providers -->


### PR DESCRIPTION
We (Liberty Global) would like to extend the automatic configuration support with settings for Ziggo (The Netherlands) and Virgin Media (UK). You can validate these settings at:

https://www.ziggo.nl/klantenservice/internet/e-mail/imap/

http://help.virginmedia.com/system/selfservice.controller?CONFIGURATION=1001&PARTITION_ID=1&TIMEZONE_OFFSET=&USERTYPE=1&VM_CUSTOMER_TYPE=Cable&CMD=VIEW_ARTICLE&ARTICLE_ID=2743

Thanks in advance!