### PR TITLE
don't cache decoded message over configurations

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -146,6 +146,8 @@ public class MessageLoaderHelper {
      * asyncStartOrResumeLoadingMessage in a new instance of this class. */
     @UiThread
     public void onDestroyChangingConfigurations() {
+        cancelAndClearDecodeLoader();
+
         if (messageCryptoHelper != null) {
             messageCryptoHelper.detachCallback();
         }


### PR DESCRIPTION
Since 773600c717f8bf79810b1a3ddd03e3c153a68fcb, the message decoding process might actually depend on theming parameters.  The MessageList activity assumes that the theme will be reapplied during a call to `recreate()`, so we better drop that cache on configuration changes.

This should fix #1666