### PR TITLE
Improve Activity operation text

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 05 23:11:53 CEST 2016
+#Sun Oct 09 01:26:59 BST 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'
 
-    testCompile 'org.robolectric:robolectric:3.0'
+    testCompile 'org.robolectric:robolectric:3.1.1'
     testCompile 'junit:junit:4.12'
     testCompile 'org.mockito:mockito-core:1.10.19'
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -58,9 +58,9 @@ public class ActivityListener extends MessagingListener {
 
         if (mLoadingFolderName != null || mLoadingHeaderFolderName != null) {
             String displayName = null;
-            if(mLoadingHeaderFolderName != null) {
+            if (mLoadingHeaderFolderName != null) {
                 displayName = mLoadingHeaderFolderName;
-            } else if(mLoadingFolderName != null) {
+            } else if (mLoadingFolderName != null) {
                 displayName = mLoadingFolderName;
             }
             if ((mAccount != null) && (mAccount.getInboxFolderName() != null)

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -31,54 +31,64 @@ public class ActivityListener extends MessagingListener {
     };
 
     public String getOperation(Context context) {
-        String operation;
-        String progress = null;
         if (mLoadingAccountDescription  != null
                 || mSendingAccountDescription != null
                 || mLoadingHeaderFolderName != null
                 || mProcessingAccountDescription != null) {
-            progress = (mFolderTotal > 0 ?
-                        context.getString(R.string.folder_progress, mFolderCompleted, mFolderTotal) : "");
 
-            if (mLoadingFolderName != null || mLoadingHeaderFolderName != null) {
-                String displayName = mLoadingFolderName;
-                if ((mAccount != null) && (mAccount.getInboxFolderName() != null) && mAccount.getInboxFolderName().equalsIgnoreCase(displayName)) {
-                    displayName = context.getString(R.string.special_mailbox_name_inbox);
-                } else if ((mAccount != null) && mAccount.getOutboxFolderName().equals(displayName)) {
-                    displayName = context.getString(R.string.special_mailbox_name_outbox);
-                }
+            return getActionInProgressOperation(context);
 
-                if (mLoadingHeaderFolderName != null) {
-
-                    operation = context.getString(R.string.status_loading_account_folder_headers, mLoadingAccountDescription, displayName, progress);
-                } else {
-                    operation = context.getString(R.string.status_loading_account_folder, mLoadingAccountDescription, displayName, progress);
-                }
-            }
-
-            else if (mSendingAccountDescription != null) {
-                operation = context.getString(R.string.status_sending_account, mSendingAccountDescription, progress);
-            } else if (mProcessingAccountDescription != null) {
-                operation = context.getString(R.string.status_processing_account, mProcessingAccountDescription,
-                                              mProcessingCommandTitle != null ? mProcessingCommandTitle : "",
-                                              progress);
-            } else {
-                operation = "";
-            }
         } else {
             long nextPollTime = MailService.getNextPollTime();
             if (nextPollTime != -1) {
-                operation = context.getString(R.string.status_next_poll,
+                return context.getString(R.string.status_next_poll,
                         DateUtils.getRelativeTimeSpanString(nextPollTime, System.currentTimeMillis(),
                                 DateUtils.MINUTE_IN_MILLIS, 0));
             } else if (MailService.isSyncDisabled()) {
-                operation = context.getString(R.string.status_syncing_off);
+                return context.getString(R.string.status_syncing_off);
             } else {
-                operation = "";
+                return "";
+            }
+        }
+    }
+
+    private String getActionInProgressOperation(Context context) {
+        String progress = (mFolderTotal > 0 ?
+                context.getString(R.string.folder_progress, mFolderCompleted, mFolderTotal) : "");
+
+        if (mLoadingFolderName != null || mLoadingHeaderFolderName != null) {
+            String displayName = null;
+            if(mLoadingHeaderFolderName != null) {
+                displayName = mLoadingHeaderFolderName;
+            } else if(mLoadingFolderName != null) {
+                displayName = mLoadingFolderName;
+            }
+            if ((mAccount != null) && (mAccount.getInboxFolderName() != null)
+                    && mAccount.getInboxFolderName().equalsIgnoreCase(displayName)) {
+                displayName = context.getString(R.string.special_mailbox_name_inbox);
+            } else if ((mAccount != null) && (mAccount.getOutboxFolderName() != null)
+                    && mAccount.getOutboxFolderName().equals(displayName)) {
+                displayName = context.getString(R.string.special_mailbox_name_outbox);
+            }
+
+            if (mLoadingHeaderFolderName != null) {
+                return context.getString(R.string.status_loading_account_folder_headers,
+                        mLoadingAccountDescription, displayName, progress);
+            } else {
+                return context.getString(R.string.status_loading_account_folder,
+                        mLoadingAccountDescription, displayName, progress);
             }
         }
 
-        return operation;
+        else if (mSendingAccountDescription != null) {
+            return context.getString(R.string.status_sending_account, mSendingAccountDescription, progress);
+        } else if (mProcessingAccountDescription != null) {
+            return context.getString(R.string.status_processing_account, mProcessingAccountDescription,
+                    mProcessingCommandTitle != null ? mProcessingCommandTitle : "",
+                    progress);
+        } else {
+            return "";
+        }
     }
 
     public void onResume(Context context) {
@@ -117,6 +127,7 @@ public class ActivityListener extends MessagingListener {
 
     @Override
     public void synchronizeMailboxHeadersStarted(Account account, String folder) {
+        mLoadingAccountDescription = account.getDescription();
         mLoadingHeaderFolderName = folder;
         informUserOfStatus();
     }
@@ -209,6 +220,7 @@ public class ActivityListener extends MessagingListener {
     public void systemStatusChanged() {
         informUserOfStatus();
     }
+
     @Override
     public void folderStatusChanged(Account account, String folder, int unreadMessageCount) {
         informUserOfStatus();

--- a/k9mail/src/main/res/values-ca/strings.xml
+++ b/k9mail/src/main/res/values-ca/strings.xml
@@ -47,7 +47,7 @@
   <string name="status_loading_account_folder_headers">Recollint capçaleres <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Enviant <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Proc <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Propera comprovació <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Comprovació acabada</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> seleccionats</string>

--- a/k9mail/src/main/res/values-cs/strings.xml
+++ b/k9mail/src/main/res/values-cs/strings.xml
@@ -77,7 +77,7 @@ Chybová hlášení prosím posílejte, přispívejte novými funkcemi a ptejte 
   <string name="status_loading_account_folder_headers">Stahování záhlaví <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Odesílání <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Zpracování <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Příští dotaz <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Synchronizace vypnuta</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> vybraných</string>

--- a/k9mail/src/main/res/values-da/strings.xml
+++ b/k9mail/src/main/res/values-da/strings.xml
@@ -45,7 +45,7 @@
   <string name="status_loading_account_folder_headers">Henter headers <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Sender <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Behandler <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Næste synkronisering <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">synkronisering deaktiveret</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> valgt</string>

--- a/k9mail/src/main/res/values-de/strings.xml
+++ b/k9mail/src/main/res/values-de/strings.xml
@@ -78,7 +78,7 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="status_loading_account_folder_headers">Lade Kopfzeilen in <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Sende <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Verarbeite <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Nächster Abruf <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Synchronisation deaktiviert</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> ausgewählt</string>

--- a/k9mail/src/main/res/values-el/strings.xml
+++ b/k9mail/src/main/res/values-el/strings.xml
@@ -78,7 +78,7 @@
   <string name="status_loading_account_folder_headers">Ανάγνωση επικεφαλίδων <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Αποστολή <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Επεξεργασία <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Επόμενος έλεγχος στις <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Συγχρονισμός απενεργοποιημένος</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> επιλέχθηκαν</string>

--- a/k9mail/src/main/res/values-es/strings.xml
+++ b/k9mail/src/main/res/values-es/strings.xml
@@ -48,7 +48,7 @@
   <string name="status_loading_account_folder_headers">Recuperando cabeceras <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Enviando <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Proc <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Próxima sincronización <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Sincronización deshabilitada</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> seleccionados</string>

--- a/k9mail/src/main/res/values-et/strings.xml
+++ b/k9mail/src/main/res/values-et/strings.xml
@@ -48,7 +48,7 @@
   <string name="status_loading_account_folder_headers">Toob pealkirju <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Saadab <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Töötleb <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Järgmine pollimine <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Sünkroniseerimine mitteaktiivne</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> valitud</string>

--- a/k9mail/src/main/res/values-eu/strings.xml
+++ b/k9mail/src/main/res/values-eu/strings.xml
@@ -47,7 +47,7 @@
   <string name="status_loading_account_folder_headers"><xliff:g id="account">%s</xliff:g> goiburuak eskuratzen:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account"><xliff:g id="account">%s</xliff:g> bidaltzen<xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Prozesatzen <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Hurrengo azterketa <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Sinkronizazioa ezgaituta</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> hautatuta</string>

--- a/k9mail/src/main/res/values-fi/strings.xml
+++ b/k9mail/src/main/res/values-fi/strings.xml
@@ -77,7 +77,7 @@ Ilmoita virheistä, ota osaa sovelluskehitykseen ja esitä kysymyksiä osoittees
   <string name="status_loading_account_folder_headers">Haetaan otsikkotietoja <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Lähetetään <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Käsitellään <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Seuraava tarkistus <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Synkronointi pois päältä</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> valittu</string>

--- a/k9mail/src/main/res/values-fr/strings.xml
+++ b/k9mail/src/main/res/values-fr/strings.xml
@@ -78,7 +78,7 @@ Veuillez rapporter les bogues, recommander de nouvelles fonctions et poser vos q
   <string name="status_loading_account_folder_headers">Récup. entêtes <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Envoi <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Prép <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Prochaine récup. <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Synchronisation désactivée</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> sélectionné(s)</string>

--- a/k9mail/src/main/res/values-gl-rES/strings.xml
+++ b/k9mail/src/main/res/values-gl-rES/strings.xml
@@ -48,7 +48,7 @@
   <string name="status_loading_account_folder_headers">Obtendo cabeceiras <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Enviando <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Procesando <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Próxima comprobación ás <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Sincronización deshabilitada</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> seleccionada</string>

--- a/k9mail/src/main/res/values-gl/strings.xml
+++ b/k9mail/src/main/res/values-gl/strings.xml
@@ -45,7 +45,7 @@
   <string name="status_loading_account_folder_headers">Recuperando encabezados <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Enviando <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Proc <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Próxima comprobación <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Comprobación rematada</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> seleccionada</string>

--- a/k9mail/src/main/res/values-hr/strings.xml
+++ b/k9mail/src/main/res/values-hr/strings.xml
@@ -48,7 +48,7 @@
   <string name="status_loading_account_folder_headers">Dobavljanje zaglavlja <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Šaljem <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Obrađujem <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Slijedeća provjera <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Sinhroniziranje je onemogućeno</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> odabrano</string>

--- a/k9mail/src/main/res/values-hu/strings.xml
+++ b/k9mail/src/main/res/values-hu/strings.xml
@@ -78,7 +78,7 @@ Kérünk küldj hibajelentést, hozzájárulva az új verziókhoz, és tegyél f
   <string name="status_loading_account_folder_headers">Letöltés <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Küldés <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Feldolgozás <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Frissítés <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Szinkronizálás letiltva</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> kiválasztva</string>

--- a/k9mail/src/main/res/values-it/strings.xml
+++ b/k9mail/src/main/res/values-it/strings.xml
@@ -78,7 +78,7 @@ Invia segnalazioni di bug, contribuisci con nuove funzionalità e poni domande s
   <string name="status_loading_account_folder_headers">Recupero intestazioni <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Invio <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Elab <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Prossima verifica <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Sincronizzazione disabilitata</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> selezionati</string>

--- a/k9mail/src/main/res/values-iw/strings.xml
+++ b/k9mail/src/main/res/values-iw/strings.xml
@@ -34,7 +34,7 @@
   <string name="compose_title_compose">חבר</string>
   <string name="choose_folder_title">בחר תיקייה</string>
   <string name="status_sending_account">שולח… <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_syncing_off">הסנכרון מושבת</string>
   <string name="next_action">הבא</string>
   <string name="previous_action">הקודם</string>

--- a/k9mail/src/main/res/values-ja/strings.xml
+++ b/k9mail/src/main/res/values-ja/strings.xml
@@ -47,7 +47,7 @@
   <string name="status_loading_account_folder_headers">ヘッダ取込 <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">送信 <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">処理 <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">次回受信 <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">同期停止</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g>件選択しました</string>

--- a/k9mail/src/main/res/values-ko/strings.xml
+++ b/k9mail/src/main/res/values-ko/strings.xml
@@ -48,7 +48,7 @@
   <string name="status_loading_account_folder_headers"><xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g> 헤더 정보 가져 오는 중</string>
   <string name="status_sending_account"><xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g> 보내는 중</string>
   <string name="status_processing_account"><xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g> 처리 중</string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">다음 수신 <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">동기화 실패</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> 선택</string>

--- a/k9mail/src/main/res/values-lt/strings.xml
+++ b/k9mail/src/main/res/values-lt/strings.xml
@@ -47,7 +47,7 @@
   <string name="status_loading_account_folder_headers">Gaunamos antraštės <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Siunčiama <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Apdorojama <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress"> <xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress"> <xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Sekantis tikrinimas <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Sinchronizavimas išjungtas</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> pasirinkta</string>

--- a/k9mail/src/main/res/values-lv/strings.xml
+++ b/k9mail/src/main/res/values-lv/strings.xml
@@ -77,7 +77,7 @@ Lūdzu, iesniedziet kļūdu ziņojumus, ierosiniet jaunas iespējas un uzdodiet 
   <string name="status_loading_account_folder_headers">Saņem vēstuļu papildinformāciju <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Sūta <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Proc <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Nākošā pārbaude <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Sinhronizācija atslēgta</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> atzīmēts</string>

--- a/k9mail/src/main/res/values-nb/strings.xml
+++ b/k9mail/src/main/res/values-nb/strings.xml
@@ -47,7 +47,7 @@
   <string name="status_loading_account_folder_headers">Henter overskrifter <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Sender <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Proc <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Neste sjekk <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Synkronisering deaktivert</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> valgt</string>

--- a/k9mail/src/main/res/values-nl/strings.xml
+++ b/k9mail/src/main/res/values-nl/strings.xml
@@ -48,7 +48,7 @@
   <string name="status_loading_account_folder_headers">Het ophalen van headers <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Verzenden <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Proc <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Volgende poll <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Synchroniseren uitgeschakeld</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> geselecteerd</string>

--- a/k9mail/src/main/res/values-pl/strings.xml
+++ b/k9mail/src/main/res/values-pl/strings.xml
@@ -47,7 +47,7 @@
   <string name="status_loading_account_folder_headers">Nagłówki: <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Wysyłam: <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Przetwarzam: <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Sprawdzę <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Synchronizacja wyłączona</string>
   <string name="actionbar_selected">Wybrano <xliff:g id="selection_count">%d</xliff:g></string>

--- a/k9mail/src/main/res/values-pt-rBR/strings.xml
+++ b/k9mail/src/main/res/values-pt-rBR/strings.xml
@@ -48,7 +48,7 @@
   <string name="status_loading_account_folder_headers">Buscando cabeçalhos <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Enviando <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Proc <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Nova verif. <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Sincronização desabilitada</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> selecionadas</string>

--- a/k9mail/src/main/res/values-ru/strings.xml
+++ b/k9mail/src/main/res/values-ru/strings.xml
@@ -77,7 +77,7 @@ K-9 Mail — почтовый клиент для Android.
   <string name="status_loading_account_folder_headers">просмотр <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">отправка <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">обработка <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">проверка <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">ожидание</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> выбрано</string>

--- a/k9mail/src/main/res/values-sk/strings.xml
+++ b/k9mail/src/main/res/values-sk/strings.xml
@@ -78,7 +78,7 @@ Prosím, nahlasujte prípadné chyby, prispievajte novými funkciami a pýtajte 
   <string name="status_loading_account_folder_headers">Načítavanie hlavičiek <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Odosielanie <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Spracovávanie <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Ďalšia synchronizácia <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Synchronizovanie vypnuté</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> vybraných</string>

--- a/k9mail/src/main/res/values-sl/strings.xml
+++ b/k9mail/src/main/res/values-sl/strings.xml
@@ -78,7 +78,7 @@ Prosimo pošljite poročila o napakah, predloge za nove funkcije in vprašanja n
   <string name="status_loading_account_folder_headers">Prenašanje glav <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Pošiljanje <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Obdelava <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Naslednje izpraševanje <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">SInhronizacija onemogočena</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> izbranih</string>

--- a/k9mail/src/main/res/values-sr/strings.xml
+++ b/k9mail/src/main/res/values-sr/strings.xml
@@ -77,7 +77,7 @@
   <string name="status_loading_account_folder_headers">Добављам заглавља <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Шаљем <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Обрађујем <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Следећа провера <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Синхронизација онемогућена</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> изабрано</string>

--- a/k9mail/src/main/res/values-sv/strings.xml
+++ b/k9mail/src/main/res/values-sv/strings.xml
@@ -77,7 +77,7 @@ Skicka gärna in rapporter om buggar, eller bidra med nya funktioner eller stäl
   <string name="status_loading_account_folder_headers">Hämtar brevhuvud <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Skickar <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Behandlar <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Nästa kontroll <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Synk inaktiverat</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> valda</string>

--- a/k9mail/src/main/res/values-tr/strings.xml
+++ b/k9mail/src/main/res/values-tr/strings.xml
@@ -48,7 +48,7 @@
   <string name="status_loading_account_folder_headers">Başlıklar alınıyor <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Gönderiyor <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">İşlem <xliff:g id="account">%s</xliff:g><xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Sonraki alım <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Senk. kapalı</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> seçildi</string>

--- a/k9mail/src/main/res/values-uk/strings.xml
+++ b/k9mail/src/main/res/values-uk/strings.xml
@@ -47,7 +47,7 @@
   <string name="status_loading_account_folder_headers">Отримання заголовків <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">Надсилання <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">Опрацювання <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">Наступний запит <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">Синхронізація заборонена</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> вибраний</string>

--- a/k9mail/src/main/res/values-zh-rCN/strings.xml
+++ b/k9mail/src/main/res/values-zh-rCN/strings.xml
@@ -48,7 +48,7 @@
   <string name="status_loading_account_folder_headers">正在接收邮件头: <xliff:g id="folder">%s</xliff:g>: <xliff:g id="progress">%s</xliff:g>, <xliff:g id="account">%s</xliff:g></string>
   <string name="status_sending_account">正在发送 <xliff:g id="progress">%s</xliff:g>: <xliff:g id="account">%s</xliff:g></string>
   <string name="status_processing_account">正在处理 <xliff:g id="command">%s</xliff:g>: <xliff:g id="progress">%s</xliff:g>: <xliff:g id="account">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">下次接收 <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">同步已禁用</string>
   <string name="actionbar_selected">已选择 <xliff:g id="selection_count">%d</xliff:g> 个</string>

--- a/k9mail/src/main/res/values-zh-rTW/strings.xml
+++ b/k9mail/src/main/res/values-zh-rTW/strings.xml
@@ -47,7 +47,7 @@
   <string name="status_loading_account_folder_headers">正在接收郵件訊息<xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_sending_account">正在寄送<xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
   <string name="status_processing_account">正在處理<xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-  <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+  <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
   <string name="status_next_poll">下次接收時間 @ <xliff:g id="nexttime">%s</xliff:g></string>
   <string name="status_syncing_off">同步已停用</string>
   <string name="actionbar_selected"><xliff:g id="selection_count">%d</xliff:g> 已選擇</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -104,7 +104,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="status_loading_account_folder_headers">Fetching headers <xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
     <string name="status_sending_account">Sending <xliff:g id="account">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
     <string name="status_processing_account">Proc <xliff:g id="account">%s</xliff:g>:<xliff:g id="command">%s</xliff:g><xliff:g id="progress">%s</xliff:g></string>
-    <string name="folder_progress">\u0020<xliff:g id="completed">%s</xliff:g>/<xliff:g id="total">%s</xliff:g></string>
+    <string name="folder_progress">\u0020<xliff:g id="completed">%d</xliff:g>/<xliff:g id="total">%d</xliff:g></string>
 
     <string name="status_next_poll">Next poll <xliff:g id="nexttime">%s</xliff:g></string>
     <string name="status_syncing_off">Syncing disabled</string>

--- a/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
@@ -1,0 +1,140 @@
+package com.fsck.k9.activity;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.mail.Message;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+public class ActivityListenerTest {
+
+    private ActivityListener activityListener;
+    private Account account;
+    private String folder;
+    private String errorMessage;
+    private Message message;
+    private int count;
+
+    @Before
+    public void before() {
+        account = mock(Account.class);
+        when(account.getDescription()).thenReturn("account");
+        folder = "folder";
+        errorMessage = "errorMessage";
+        message = mock(Message.class);
+        count = 1;
+        activityListener = new ActivityListener();
+    }
+
+    @Test
+    public void folderStatusChanged__shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(account, folder);
+        activityListener.folderStatusChanged(account, folder, count);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertEquals("Poll account:folder", operation);
+    }
+
+    @Test
+    public void synchronizeMailboxStarted__shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(account, folder);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertEquals("Poll account:folder", operation);
+    }
+
+    @Test
+    public void synchronizeMailboxProgress_shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(account, folder);
+        activityListener.synchronizeMailboxProgress(account, folder, count, count);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertEquals("Poll account:folder"+"\\u0020"+"1/1", operation);
+    }
+
+    @Test
+    public void synchronizeMailboxFailed_shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(account, folder);
+        activityListener.synchronizeMailboxFailed(account, folder, errorMessage);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertNotEquals("Poll account:folder", operation);
+        assertNotNull(operation);
+    }
+
+    @Test
+    public void synchronizeMailboxFinished__shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(account, folder);
+        activityListener.synchronizeMailboxFinished(account, folder, count, count);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertNotNull(operation);
+    }
+
+    @Test
+    public void synchronizeMailboxHeadersStarted_shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxHeadersStarted(account, folder);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertEquals("Fetching headers account:folder", operation);
+    }
+
+    @Test
+    public void synchronizeMailboxHeadersProgress__shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxHeadersStarted(account, folder);
+        activityListener.synchronizeMailboxHeadersProgress(account, folder, count, count);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertEquals("Fetching headers account:folder"+"\\u0020"+"1/1", operation);
+    }
+
+    @Test
+    public void synchronizeMailboxHeadersFinished__shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxHeadersStarted(account, folder);
+        activityListener.synchronizeMailboxHeadersFinished(account, folder, count, count);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertEquals("", operation);
+    }
+
+    @Test
+    public void synchronizeMailboxAddOrUpdateMessage__shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(account, folder);
+        activityListener.synchronizeMailboxAddOrUpdateMessage(account, folder, message);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertEquals("Poll account:folder", operation);
+    }
+
+    @Test
+    public void synchronizeMailboxNewMessage__shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(account, folder);
+        activityListener.synchronizeMailboxNewMessage(account, folder, message);
+
+        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+
+        assertEquals("Poll account:folder", operation);
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
@@ -1,5 +1,7 @@
 package com.fsck.k9.activity;
 
+import android.content.Context;
+
 import com.fsck.k9.Account;
 import com.fsck.k9.mail.Message;
 
@@ -11,8 +13,6 @@ import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertNotNull;
-import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -21,119 +21,115 @@ import static org.mockito.Mockito.when;
 @Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
 public class ActivityListenerTest {
 
+    private static final Account ACCOUNT = mock(Account.class);
+    private static final String FOLDER = "folder";
+    private static final String ERROR_MESSAGE = "errorMessage";
+    private static final Message MESSAGE = mock(Message.class);
+    private static final int COUNT = 1;
     private ActivityListener activityListener;
-    private Account account;
-    private String folder;
-    private String errorMessage;
-    private Message message;
-    private int count;
+    private Context context;
 
     @Before
     public void before() {
-        account = mock(Account.class);
-        when(account.getDescription()).thenReturn("account");
-        folder = "folder";
-        errorMessage = "errorMessage";
-        message = mock(Message.class);
-        count = 1;
+        when(ACCOUNT.getDescription()).thenReturn("account");
         activityListener = new ActivityListener();
+        context = RuntimeEnvironment.application;
     }
 
     @Test
-    public void folderStatusChanged__shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, folder);
-        activityListener.folderStatusChanged(account, folder, count);
+    public void getOperation__whenFolderStatusChanged() {
+        activityListener.synchronizeMailboxStarted(ACCOUNT, FOLDER);
+        activityListener.folderStatusChanged(ACCOUNT, FOLDER, COUNT);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
         assertEquals("Poll account:folder", operation);
     }
 
     @Test
-    public void synchronizeMailboxStarted__shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, folder);
+    public void getOperation__whenSynchronizeMailboxStarted() {
+        activityListener.synchronizeMailboxStarted(ACCOUNT, FOLDER);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
         assertEquals("Poll account:folder", operation);
     }
 
     @Test
-    public void synchronizeMailboxProgress_shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, folder);
-        activityListener.synchronizeMailboxProgress(account, folder, count, count);
+    public void getOperation__whenSynchronizeMailboxProgress_shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(ACCOUNT, FOLDER);
+        activityListener.synchronizeMailboxProgress(ACCOUNT, FOLDER, COUNT, COUNT);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
-        assertEquals("Poll account:folder"+"\\u0020"+"1/1", operation);
+        assertEquals("Poll account:folder\u00201/1", operation);
     }
 
     @Test
-    public void synchronizeMailboxFailed_shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, folder);
-        activityListener.synchronizeMailboxFailed(account, folder, errorMessage);
+    public void getOperation__whenSynchronizeMailboxFailed_shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(ACCOUNT, FOLDER);
+        activityListener.synchronizeMailboxFailed(ACCOUNT, FOLDER, ERROR_MESSAGE);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
-        assertNotEquals("Poll account:folder", operation);
-        assertNotNull(operation);
+        assertEquals("Syncing disabled", operation);
     }
 
     @Test
-    public void synchronizeMailboxFinished__shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, folder);
-        activityListener.synchronizeMailboxFinished(account, folder, count, count);
+    public void getOperation__whenSynchronizeMailboxFinished() {
+        activityListener.synchronizeMailboxStarted(ACCOUNT, FOLDER);
+        activityListener.synchronizeMailboxFinished(ACCOUNT, FOLDER, COUNT, COUNT);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
-        assertNotNull(operation);
+        assertEquals("Syncing disabled", operation);
     }
 
     @Test
-    public void synchronizeMailboxHeadersStarted_shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxHeadersStarted(account, folder);
+    public void getOperation__whenSynchronizeMailboxHeadersStarted_shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxHeadersStarted(ACCOUNT, FOLDER);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
         assertEquals("Fetching headers account:folder", operation);
     }
 
     @Test
-    public void synchronizeMailboxHeadersProgress__shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxHeadersStarted(account, folder);
-        activityListener.synchronizeMailboxHeadersProgress(account, folder, count, count);
+    public void getOperation__whenSynchronizeMailboxHeadersProgress() {
+        activityListener.synchronizeMailboxHeadersStarted(ACCOUNT, FOLDER);
+        activityListener.synchronizeMailboxHeadersProgress(ACCOUNT, FOLDER, COUNT, COUNT);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
-        assertEquals("Fetching headers account:folder"+"\\u0020"+"1/1", operation);
+        assertEquals("Fetching headers account:folder\u00201/1", operation);
     }
 
     @Test
-    public void synchronizeMailboxHeadersFinished__shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxHeadersStarted(account, folder);
-        activityListener.synchronizeMailboxHeadersFinished(account, folder, count, count);
+    public void getOperation__whenSynchronizeMailboxHeadersFinished() {
+        activityListener.synchronizeMailboxHeadersStarted(ACCOUNT, FOLDER);
+        activityListener.synchronizeMailboxHeadersFinished(ACCOUNT, FOLDER, COUNT, COUNT);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
         assertEquals("", operation);
     }
 
     @Test
-    public void synchronizeMailboxAddOrUpdateMessage__shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, folder);
-        activityListener.synchronizeMailboxAddOrUpdateMessage(account, folder, message);
+    public void getOperation__whenSynchronizeMailboxAddOrUpdateMessage() {
+        activityListener.synchronizeMailboxStarted(ACCOUNT, FOLDER);
+        activityListener.synchronizeMailboxAddOrUpdateMessage(ACCOUNT, FOLDER, MESSAGE);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
         assertEquals("Poll account:folder", operation);
     }
 
     @Test
-    public void synchronizeMailboxNewMessage__shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, folder);
-        activityListener.synchronizeMailboxNewMessage(account, folder, message);
+    public void getOperation__whenSynchronizeMailboxNewMessage() {
+        activityListener.synchronizeMailboxStarted(ACCOUNT, FOLDER);
+        activityListener.synchronizeMailboxNewMessage(ACCOUNT, FOLDER, MESSAGE);
 
-        String operation = activityListener.getOperation(RuntimeEnvironment.application);
+        String operation = activityListener.getOperation(context);
 
         assertEquals("Poll account:folder", operation);
     }


### PR DESCRIPTION
First commit:

* Set account name when syncing headers
* Use headerFolderName to create `displayName` to show in the text when relevant
* Refactor the generation of the text into smaller chunks
* Add tests that check the correct English activity string is used

Second commit:

* Change %s to %d for some integers being passed in for `folder_progress` - fixes an error showing up in Android Studio.