### PR TITLE
Handle download of attachment correctly when saving requested

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
@@ -17,6 +17,7 @@ import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Environment;
+import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -84,7 +85,7 @@ public class AttachmentController {
             @Override
             public void run() {
                 messageViewFragment.refreshAttachmentThumbnail(attachment);
-                saveAttachmentTo(directory);
+                saveLocalAttachmentTo(directory);
             }
         });
     }
@@ -127,6 +128,7 @@ public class AttachmentController {
             saveLocalAttachmentTo(directory);
         }
     }
+
 
     private void saveLocalAttachmentTo(File directory) {
         new SaveAttachmentAsyncTask().executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, directory);


### PR DESCRIPTION
Call correct method following download of attachment.

Fixed #1629

I tried to write tests for this, but the AsyncTask that gets called made it overly complex to isolate just the change I made.