### PR TITLE
avoid indirect call to invalidateOptionsMenu() before recipientPresenter is initialized

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -360,6 +360,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         ComposePgpInlineDecider composePgpInlineDecider = new ComposePgpInlineDecider();
         recipientPresenter = new RecipientPresenter(getApplicationContext(), getLoaderManager(), recipientMvpView,
                 mAccount, composePgpInlineDecider, new ReplyToParser());
+        recipientPresenter.updateCryptoStatus();
+
 
         mSubjectView = (EditText) findViewById(R.id.subject);
         mSubjectView.getInputExtras(true).putBoolean("allowEmoji", true);

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -89,7 +89,6 @@ public class RecipientPresenter implements PermissionPingCallback {
         recipientMvpView.setPresenter(this);
         recipientMvpView.setLoaderManager(loaderManager);
         onSwitchAccount(account);
-        updateCryptoStatus();
     }
 
     public List<Address> getToAddresses() {

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
@@ -57,6 +57,7 @@ public class RecipientPresenterTest {
 
         recipientPresenter = new RecipientPresenter(
                 context, loaderManager, recipientMvpView, account, composePgpInlineDecider, replyToParser);
+        recipientPresenter.updateCryptoStatus();
     }
 
     @Test


### PR DESCRIPTION
Older API levels call `onPrepareOptionsMenu` directly if `invalidateOptionsMenu` is called inside `onCreate`. The constructor of `RecipientPresenter` indirectly does this,  which causes a NPE because recipientPresenter is referenced in `prepareOptionsMenu` but not actually assigned at that point.

```
FATAL EXCEPTION: main
java.lang.RuntimeException: Unable to start activity ComponentInfo{com.fsck.k9.debug/com.fsck.k9.activity.MessageCompose}: java.lang.NullPointerException
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2059)
at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:2084)
at android.app.ActivityThread.access$600(ActivityThread.java:130)
at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1195)
at android.os.Handler.dispatchMessage(Handler.java:99)
at android.os.Looper.loop(Looper.java:137)
at android.app.ActivityThread.main(ActivityThread.java:4745)
at java.lang.reflect.Method.invokeNative(Native Method)
at java.lang.reflect.Method.invoke(Method.java:511)
at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:786)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:553)
at dalvik.system.NativeStart.main(Native Method)
Caused by: java.lang.NullPointerException
at com.fsck.k9.activity.MessageCompose.onPrepareOptionsMenu(MessageCompose.java:1023)
at android.app.Activity.onPreparePanel(Activity.java:2494)
at com.android.internal.policy.impl.PhoneWindow.preparePanel(PhoneWindow.java:421)
at com.android.internal.policy.impl.PhoneWindow.invalidatePanelMenu(PhoneWindow.java:747)
at android.app.Activity.invalidateOptionsMenu(Activity.java:2595)
at com.fsck.k9.activity.compose.RecipientMvpView.showPgpInlineModeIndicator(RecipientMvpView.java:287)
at com.fsck.k9.activity.compose.RecipientPresenter.updateCryptoStatus(RecipientPresenter.java:350)
at com.fsck.k9.activity.compose.RecipientPresenter.<init>(RecipientPresenter.java:92)
at com.fsck.k9.activity.MessageCompose.onCreate(MessageCompose.java:361)
at android.app.Activity.performCreate(Activity.java:5008)
at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1079)
at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2023)
```