### PR TITLE
hide recipient dots if no crypto provider is configured

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
@@ -6,8 +6,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import android.content.Context;
-import android.graphics.PorterDuff.Mode;
 import android.graphics.drawable.Drawable;
+import android.support.v4.content.ContextCompat;
+import android.support.v4.graphics.drawable.DrawableCompat;
 import android.text.Spannable;
 import android.text.style.ForegroundColorSpan;
 import android.view.LayoutInflater;
@@ -114,11 +115,9 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
         }
 
         if (cryptoStatusRes != null) {
-            // noinspection deprecation, we could do this easier with setImageTintList, but that's API level 21
-            Drawable drawable = context.getResources().getDrawable(cryptoStatusRes);
-            // noinspection ConstantConditions, we know the resource exists!
-            drawable.mutate();
-            drawable.setColorFilter(cryptoStatusColor, Mode.SRC_ATOP);
+            Drawable drawable = ContextCompat.getDrawable(context, cryptoStatusRes);
+            DrawableCompat.wrap(drawable);
+            DrawableCompat.setTint(drawable.mutate(), cryptoStatusColor);
             holder.cryptoStatusIcon.setImageDrawable(drawable);
             holder.cryptoStatus.setVisibility(View.VISIBLE);
         } else {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
@@ -119,7 +119,7 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
             // noinspection ConstantConditions, we know the resource exists!
             drawable.mutate();
             drawable.setColorFilter(cryptoStatusColor, Mode.SRC_ATOP);
-            holder.cryptoStatus.setImageDrawable(drawable);
+            holder.cryptoStatusIcon.setImageDrawable(drawable);
             holder.cryptoStatus.setVisibility(View.VISIBLE);
         } else {
             holder.cryptoStatus.setVisibility(View.GONE);
@@ -167,14 +167,16 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
         public final TextView name;
         public final TextView email;
         public final ImageView photo;
-        public final ImageView cryptoStatus;
+        public final View cryptoStatus;
+        public final ImageView cryptoStatusIcon;
 
 
         public RecipientTokenHolder(View view) {
             name = (TextView) view.findViewById(R.id.text1);
             email = (TextView) view.findViewById(R.id.text2);
             photo = (ImageView) view.findViewById(R.id.contact_photo);
-            cryptoStatus = (ImageView) view.findViewById(R.id.contact_crypto_status);
+            cryptoStatus = view.findViewById(R.id.contact_crypto_status);
+            cryptoStatusIcon = (ImageView) view.findViewById(R.id.contact_crypto_status_icon);
         }
     }
 

--- a/k9mail/src/main/res/layout/recipient_dropdown_item.xml
+++ b/k9mail/src/main/res/layout/recipient_dropdown_item.xml
@@ -48,7 +48,8 @@
     <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="13dp">
+        android:padding="13dp"
+        android:id="@+id/contact_crypto_status">
 
         <ImageView
             android:layout_width="wrap_content"
@@ -59,7 +60,7 @@
             />
 
         <ImageView
-            android:id="@+id/contact_crypto_status"
+            android:id="@+id/contact_crypto_status_icon"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="left|center_vertical"


### PR DESCRIPTION
What it says on the tin.

Also got rid of two noinspection comments in the immediate vicinity of the touched code, using `Compat` classes instead. (tested on api levels 15 and 23)