### PR TITLE
Make test expectation more generic

### DIFF
--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -2,7 +2,6 @@ package com.fsck.k9.mail.store.imap;
 
 
 import java.io.IOException;
-import java.net.ConnectException;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.security.KeyManagementException;
@@ -356,8 +355,7 @@ public class ImapConnectionTest {
         } catch (MessagingException e) {
             //FIXME: Throw ConnectException
             assertEquals("Cannot connect to host", e.getMessage());
-            assertNotNull(e.getCause());
-            assertEquals(ConnectException.class, e.getCause().getClass());
+            assertTrue(e.getCause() instanceof IOException);
         }
     }
 


### PR DESCRIPTION
On my system (OSX+Java8) this test fails with a `SocketTimeoutException`