### PR TITLE
Inject config from properties file

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,19 +9,15 @@ buildscript {
 }
 
 project.ext {
-    preDexLibs = !project.hasProperty('disablePreDex')
     testCoverage = project.hasProperty('testCoverage')
     optimizeForDevelopment = project.hasProperty('optimizeForDevelopment') && optimizeForDevelopment == 'true'
-
-    compileSdkVersion = 24
-    buildToolsVersion = '24.0.3'
 }
 
 subprojects {
     project.plugins.whenPluginAdded { plugin ->
         if ("com.android.build.gradle.AppPlugin".equals(plugin.class.name) ||
                 "com.android.build.gradle.LibraryPlugin".equals(plugin.class.name)) {
-            project.android.dexOptions.preDexLibraries = rootProject.ext.preDexLibs
+            project.android.dexOptions.preDexLibraries = !rootProject.hasProperty('disablePreDex')
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,7 @@
+androidCompileSdkVersion=24
+androidBuildToolsVersion=24.0.3
+androidSupportLibraryVersion=23.1.1
+
+robolectricVersion=3.1.1
+junitVersion=4.12
+mockitoVersion=1.10.19

--- a/k9mail-library/build.gradle
+++ b/k9mail-library/build.gradle
@@ -19,20 +19,20 @@ dependencies {
     compile 'commons-io:commons-io:2.4'
     compile 'com.jcraft:jzlib:1.0.7'
     compile 'com.beetstra.jutf7:jutf7:1.0.0'
-    compile 'com.android.support:support-annotations:23.3.0'
+    compile "com.android.support:support-annotations:${androidSupportLibraryVersion}"
 
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.madgag.spongycastle:pg:1.51.0.0'
 
     testCompile 'com.squareup.okio:okio:1.6.0'
-    testCompile 'org.robolectric:robolectric:3.0'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile "org.robolectric:robolectric:${robolectricVersion}"
+    testCompile "junit:junit:${junitVersion}"
+    testCompile "org.mockito:mockito-core:${mockitoVersion}"
 }
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
+    compileSdkVersion androidCompileSdkVersion.toInteger()
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         minSdkVersion 15

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -13,14 +13,10 @@ repositories {
     jcenter()
 }
 
-ext {
-    supportLibraryVersion = '23.1.1'
-}
-
 //noinspection GroovyAssignabilityCheck
 configurations.all {
     resolutionStrategy {
-        force "com.android.support:support-annotations:${project.supportLibraryVersion}"
+        force "com.android.support:support-annotations:${androidSupportLibraryVersion}"
     }
 }
 
@@ -30,7 +26,7 @@ dependencies {
     compile project(':plugins:HoloColorPicker')
     compile project(':plugins:openpgp-api-lib:openpgp-api')
     compile 'commons-io:commons-io:2.4'
-    compile "com.android.support:support-v4:${project.supportLibraryVersion}"
+    compile "com.android.support:support-v4:${androidSupportLibraryVersion}"
     compile 'net.sourceforge.htmlcleaner:htmlcleaner:2.16'
     compile 'de.cketti.library.changelog:ckchangelog:1.2.1'
     compile 'com.github.bumptech.glide:glide:3.6.1'
@@ -40,14 +36,14 @@ dependencies {
 
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.1'
 
-    testCompile 'org.robolectric:robolectric:3.1.1'
-    testCompile 'junit:junit:4.12'
-    testCompile 'org.mockito:mockito-core:1.10.19'
+    testCompile "org.robolectric:robolectric:${robolectricVersion}"
+    testCompile "junit:junit:${junitVersion}"
+    testCompile "org.mockito:mockito-core:${mockitoVersion}"
 }
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
+    compileSdkVersion androidCompileSdkVersion.toInteger()
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         applicationId "com.fsck.k9"

--- a/plugins/Android-PullToRefresh/library/build.gradle
+++ b/plugins/Android-PullToRefresh/library/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
+    compileSdkVersion androidCompileSdkVersion.toInteger()
+    buildToolsVersion androidBuildToolsVersion
 
     sourceSets {
         main {

--- a/plugins/HoloColorPicker/build.gradle
+++ b/plugins/HoloColorPicker/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
+    compileSdkVersion androidCompileSdkVersion.toInteger()
+    buildToolsVersion androidBuildToolsVersion
 
     sourceSets {
         main {

--- a/plugins/openpgp-api-lib/openpgp-api/build.gradle
+++ b/plugins/openpgp-api-lib/openpgp-api/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.library'
 // apply plugin: 'bintray-release' // must be applied after your artifact generating plugin (eg. java / com.android.library)
 
 android {
-    compileSdkVersion rootProject.compileSdkVersion
-    buildToolsVersion rootProject.buildToolsVersion
+    compileSdkVersion androidCompileSdkVersion.toInteger()
+    buildToolsVersion androidBuildToolsVersion
 
     defaultConfig {
         versionCode 8


### PR DESCRIPTION
This decouples the projects slightly and makes it possible to override settings on a per-project basis.

Also removes some config duplication between k9mail / k9mail-library.