### PR TITLE
Add notification actions to "stacked notifications"

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionCreator.java
@@ -95,14 +95,14 @@ class NotificationActionCreator {
         Intent intent = MessageActions.getActionReplyIntent(context, messageReference);
 
         return PendingIntent.getActivity(context, notificationId, intent,
-                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT);
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT);
     }
 
     public PendingIntent createMarkMessageAsReadPendingIntent(MessageReference messageReference, int notificationId) {
         Intent intent = NotificationActionService.createMarkMessageAsReadIntent(context, messageReference);
 
         return PendingIntent.getService(context, notificationId, intent,
-                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT);
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT);
     }
 
     public PendingIntent createMarkAllAsReadPendingIntent(Account account,
@@ -137,13 +137,13 @@ class NotificationActionCreator {
         Intent intent = NotificationActionService.createDeleteMessageIntent(context, messageReference);
 
         return PendingIntent.getService(context, notificationId, intent,
-                PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT);
+                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_ONE_SHOT);
     }
 
     private PendingIntent createDeleteConfirmationPendingIntent(MessageReference messageReference, int notificationId) {
         Intent intent = NotificationDeleteConfirmation.getIntent(context, messageReference);
 
-        return PendingIntent.getActivity(context, notificationId, intent, PendingIntent.FLAG_CANCEL_CURRENT);
+        return PendingIntent.getActivity(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
     }
 
     public PendingIntent createDeleteAllPendingIntent(Account account, ArrayList<MessageReference> messageReferences,

--- a/k9mail/src/main/java/com/fsck/k9/notification/WearNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/WearNotifications.java
@@ -94,6 +94,57 @@ class WearNotifications extends BaseNotifications {
     }
 
     private void addActions(Builder builder, Account account, NotificationHolder holder) {
+        addDeviceActions(builder, holder);
+        addWearActions(builder, account, holder);
+    }
+
+    private void addDeviceActions(Builder builder, NotificationHolder holder) {
+        addDeviceReplyAction(builder, holder);
+        addDeviceMarkAsReadAction(builder, holder);
+        addDeviceDeleteAction(builder, holder);
+    }
+
+    private void addDeviceReplyAction(Builder builder, NotificationHolder holder) {
+        int icon = R.drawable.notification_action_mark_as_read;
+        String title = context.getString(R.string.notification_action_reply);
+
+        NotificationContent content = holder.content;
+        MessageReference messageReference = content.messageReference;
+        PendingIntent replyToMessagePendingIntent =
+                actionCreator.createReplyPendingIntent(messageReference, holder.notificationId);
+
+        builder.addAction(icon, title, replyToMessagePendingIntent);
+    }
+
+    private void addDeviceMarkAsReadAction(Builder builder, NotificationHolder holder) {
+        int icon = R.drawable.notification_action_mark_as_read;
+        String title = context.getString(R.string.notification_action_mark_as_read);
+
+        NotificationContent content = holder.content;
+        int notificationId = holder.notificationId;
+        MessageReference messageReference = content.messageReference;
+        PendingIntent action = actionCreator.createMarkMessageAsReadPendingIntent(messageReference, notificationId);
+
+        builder.addAction(icon, title, action);
+    }
+
+    private void addDeviceDeleteAction(Builder builder, NotificationHolder holder) {
+        if (!isDeleteActionEnabled()) {
+            return;
+        }
+
+        int icon = R.drawable.notification_action_delete;
+        String title = context.getString(R.string.notification_action_delete);
+
+        NotificationContent content = holder.content;
+        int notificationId = holder.notificationId;
+        MessageReference messageReference = content.messageReference;
+        PendingIntent action = actionCreator.createDeleteMessagePendingIntent(messageReference, notificationId);
+
+        builder.addAction(icon, title, action);
+    }
+
+    private void addWearActions(Builder builder, Account account, NotificationHolder holder) {
         NotificationCompat.WearableExtender wearableExtender = new NotificationCompat.WearableExtender();
 
         addReplyAction(wearableExtender, holder);


### PR DESCRIPTION
On Android 7.0 notifications that previously only showed on Android Wear devices are also displayed on the phone/tablet. To be able to use notification actions there and have a separate set of actions for Wear devices we need to do some extra work.

This change leaves the code in a somewhat ugly state because `WearNotifications` really deals with notifications for individual messages that can be displayed on both Android 7.0+ and Android Wear devices. I created issue #1754 to clean this up later.

Fixes #1741
