### PR TITLE
Improve behavior for broken signatures

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
@@ -72,8 +72,14 @@ public final class CryptoResultAnnotation {
         return new CryptoResultAnnotation(CryptoError.OPENPGP_UI_CANCELED, null, null, null, null, null);
     }
 
-    public static CryptoResultAnnotation createOpenPgpErrorAnnotation(OpenPgpError error) {
-        return new CryptoResultAnnotation(CryptoError.OPENPGP_API_RETURNED_ERROR, null, null, null, null, error);
+    public static CryptoResultAnnotation createOpenPgpSignatureErrorAnnotation(
+            OpenPgpError error, MimeBodyPart replacementData) {
+        return new CryptoResultAnnotation(
+                CryptoError.OPENPGP_SIGNED_API_ERROR, replacementData, null, null, null, error);
+    }
+
+    public static CryptoResultAnnotation createOpenPgpEncryptionErrorAnnotation(OpenPgpError error) {
+        return new CryptoResultAnnotation(CryptoError.OPENPGP_ENCRYPTED_API_ERROR, null, null, null, null, error);
     }
 
     public boolean isOpenPgpResult() {
@@ -136,7 +142,8 @@ public final class CryptoResultAnnotation {
     public enum CryptoError {
         OPENPGP_OK,
         OPENPGP_UI_CANCELED,
-        OPENPGP_API_RETURNED_ERROR,
+        OPENPGP_SIGNED_API_ERROR,
+        OPENPGP_ENCRYPTED_API_ERROR,
         OPENPGP_SIGNED_BUT_INCOMPLETE,
         OPENPGP_ENCRYPTED_BUT_INCOMPLETE,
         SIGNED_BUT_UNSUPPORTED,

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
@@ -560,8 +560,14 @@ public class MessageCryptoHelper {
     }
 
     private void onCryptoOperationFailed(OpenPgpError error) {
-        CryptoResultAnnotation errorPart = CryptoResultAnnotation.createOpenPgpErrorAnnotation(error);
-        addCryptoResultAnnotationToMessage(errorPart);
+        CryptoResultAnnotation annotation;
+        if (currentCryptoPart.type == CryptoPartType.PGP_SIGNED) {
+            MimeBodyPart replacementPart = getMultipartSignedContentPartIfAvailable(currentCryptoPart.part);
+            annotation = CryptoResultAnnotation.createOpenPgpSignatureErrorAnnotation(error, replacementPart);
+        } else {
+            annotation = CryptoResultAnnotation.createOpenPgpEncryptionErrorAnnotation(error);
+        }
+        addCryptoResultAnnotationToMessage(annotation);
         onCryptoFinished();
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
@@ -347,7 +347,7 @@ public class MessageCryptoHelper {
     }
 
     private void callAsyncDetachedVerify(Intent intent) throws IOException, MessagingException {
-        OpenPgpDataSource dataSource = getDataSourceForSignedData();
+        OpenPgpDataSource dataSource = getDataSourceForSignedData(currentCryptoPart.part);
 
         byte[] signatureData = MessageDecryptVerifier.getSignatureData(currentCryptoPart.part);
         intent.putExtra(OpenPgpApi.EXTRA_DETACHED_SIGNATURE, signatureData);
@@ -368,12 +368,12 @@ public class MessageCryptoHelper {
         });
     }
 
-    private OpenPgpDataSource getDataSourceForSignedData() throws IOException {
+    private OpenPgpDataSource getDataSourceForSignedData(final Part signedPart) throws IOException {
         return new OpenPgpDataSource() {
             @Override
             public void writeTo(OutputStream os) throws IOException {
                 try {
-                    Multipart multipartSignedMultipart = (Multipart) currentCryptoPart.part.getBody();
+                    Multipart multipartSignedMultipart = (Multipart) signedPart.getBody();
                     BodyPart signatureBodyPart = multipartSignedMultipart.getBodyPart(0);
                     Log.d(K9.LOG_TAG, "signed data type: " + signatureBodyPart.getMimeType());
                     signatureBodyPart.writeTo(os);

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
@@ -209,7 +209,10 @@ public enum MessageCryptoDisplayStatus {
             case OPENPGP_UI_CANCELED:
                 return CANCELLED;
 
-            case OPENPGP_API_RETURNED_ERROR:
+            case OPENPGP_SIGNED_API_ERROR:
+                return UNENCRYPTED_SIGN_ERROR;
+
+            case OPENPGP_ENCRYPTED_API_ERROR:
                 return ENCRYPTED_ERROR;
         }
         throw new IllegalStateException("Unhandled case!");


### PR DESCRIPTION
This PR improves behavior when signature data is broken, which happens e.g. if there is an error in the ascii-armor CRC. Happened in a mail I received (indirectly, thanks @Emantor) from Airmail. Previously, we didn't show the data in that case because it was treated the same as a decryption error. It's now correctly treated as a signature error.

test case: http://sprunge.us/ffjC
