### PR TITLE
Turn support for signed-only mails into an opt-in feature

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -176,7 +176,6 @@ public class Account implements BaseAccount, StoreConfig {
     private int mAutomaticCheckIntervalMinutes;
     private int mDisplayCount;
     private int mChipColor;
-    private long mLastAutomaticCheckTime;
     private long mLatestOldMessageSeenTime;
     private boolean mNotifyNewMail;
     private FolderMode mFolderNotifyNewMailMode;
@@ -395,7 +394,6 @@ public class Account implements BaseAccount, StoreConfig {
         if (mDisplayCount < 0) {
             mDisplayCount = K9.DEFAULT_VISIBLE_LIMIT;
         }
-        mLastAutomaticCheckTime = storage.getLong(mUuid + ".lastAutomaticCheckTime", 0);
         mLatestOldMessageSeenTime = storage.getLong(mUuid + ".latestOldMessageSeenTime", 0);
         mNotifyNewMail = storage.getBoolean(mUuid + ".notifyNewMail", false);
 
@@ -690,7 +688,6 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putInt(mUuid + ".idleRefreshMinutes", mIdleRefreshMinutes);
         editor.putBoolean(mUuid + ".pushPollOnConnect", mPushPollOnConnect);
         editor.putInt(mUuid + ".displayCount", mDisplayCount);
-        editor.putLong(mUuid + ".lastAutomaticCheckTime", mLastAutomaticCheckTime);
         editor.putLong(mUuid + ".latestOldMessageSeenTime", mLatestOldMessageSeenTime);
         editor.putBoolean(mUuid + ".notifyNewMail", mNotifyNewMail);
         editor.putString(mUuid + ".folderNotifyNewMailMode", mFolderNotifyNewMailMode.name());
@@ -1008,14 +1005,6 @@ public class Account implements BaseAccount, StoreConfig {
             this.mDisplayCount = K9.DEFAULT_VISIBLE_LIMIT;
         }
         resetVisibleLimits();
-    }
-
-    public synchronized long getLastAutomaticCheckTime() {
-        return mLastAutomaticCheckTime;
-    }
-
-    public synchronized void setLastAutomaticCheckTime(long lastAutomaticCheckTime) {
-        this.mLastAutomaticCheckTime = lastAutomaticCheckTime;
     }
 
     public synchronized long getLatestOldMessageSeenTime() {

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -224,6 +224,7 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean mSyncRemoteDeletions;
     private String mCryptoApp;
     private long mCryptoKey;
+    private boolean mCryptoSupportSignOnly;
     private boolean mMarkMessageAsReadOnView;
     private boolean mAlwaysShowCcBcc;
     private boolean mAllowRemoteSearch;
@@ -320,6 +321,7 @@ public class Account implements BaseAccount, StoreConfig {
         mSyncRemoteDeletions = true;
         mCryptoApp = NO_OPENPGP_PROVIDER;
         mCryptoKey = NO_OPENPGP_KEY;
+        mCryptoSupportSignOnly = false;
         mAllowRemoteSearch = false;
         mRemoteSearchFullText = false;
         mRemoteSearchNumResults = DEFAULT_REMOTE_SEARCH_NUM_RESULTS;
@@ -471,6 +473,7 @@ public class Account implements BaseAccount, StoreConfig {
         String cryptoApp = storage.getString(mUuid + ".cryptoApp", NO_OPENPGP_PROVIDER);
         setCryptoApp(cryptoApp);
         mCryptoKey = storage.getLong(mUuid + ".cryptoKey", NO_OPENPGP_KEY);
+        mCryptoSupportSignOnly = storage.getBoolean(mUuid + ".cryptoSupportSignOnly", false);
         mAllowRemoteSearch = storage.getBoolean(mUuid + ".allowRemoteSearch", false);
         mRemoteSearchFullText = storage.getBoolean(mUuid + ".remoteSearchFullText", false);
         mRemoteSearchNumResults = storage.getInt(mUuid + ".remoteSearchNumResults", DEFAULT_REMOTE_SEARCH_NUM_RESULTS);
@@ -736,6 +739,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(mUuid + ".stripSignature", mStripSignature);
         editor.putString(mUuid + ".cryptoApp", mCryptoApp);
         editor.putLong(mUuid + ".cryptoKey", mCryptoKey);
+        editor.putBoolean(mUuid + ".cryptoSupportSignOnly", mCryptoSupportSignOnly);
         editor.putBoolean(mUuid + ".allowRemoteSearch", mAllowRemoteSearch);
         editor.putBoolean(mUuid + ".remoteSearchFullText", mRemoteSearchFullText);
         editor.putInt(mUuid + ".remoteSearchNumResults", mRemoteSearchNumResults);
@@ -1626,6 +1630,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public void setCryptoKey(long keyId) {
         mCryptoKey = keyId;
+    }
+
+    public boolean getCryptoSupportSignOnly() {
+        return mCryptoSupportSignOnly;
+    }
+
+    public void setCryptoSupportSignOnly(boolean cryptoSupportSignOnly) {
+        mCryptoSupportSignOnly = cryptoSupportSignOnly;
     }
 
     public boolean allowRemoteSearch() {

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -54,7 +54,6 @@ import static com.fsck.k9.Preferences.getEnumStringPref;
  * Account stores all of the settings for a single account defined by the user. It is able to save
  * and delete itself given a Preferences to work with. Each account is defined by a UUID.
  */
-@SuppressWarnings("unused") // unused methods are public API
 public class Account implements BaseAccount, StoreConfig {
     /**
      * Default value for the inbox folder (never changes for POP3 and IMAP)
@@ -565,6 +564,9 @@ public class Account implements BaseAccount, StoreConfig {
         editor.remove(mUuid + ".cryptoApp");
         editor.remove(mUuid + ".cryptoAutoSignature");
         editor.remove(mUuid + ".cryptoAutoEncrypt");
+        editor.remove(mUuid + ".cryptoApp");
+        editor.remove(mUuid + ".cryptoKey");
+        editor.remove(mUuid + ".cryptoSupportSignOnly");
         editor.remove(mUuid + ".enabled");
         editor.remove(mUuid + ".markMessageAsReadOnView");
         editor.remove(mUuid + ".alwaysShowCcBcc");
@@ -767,8 +769,7 @@ public class Account implements BaseAccount, StoreConfig {
 
     }
 
-    @SuppressWarnings("WeakerAccess") // public interface
-    public void resetVisibleLimits() {
+    private void resetVisibleLimits() {
         try {
             getLocalStore().resetVisibleLimits(getDisplayCount());
         } catch (MessagingException e) {
@@ -873,10 +874,6 @@ public class Account implements BaseAccount, StoreConfig {
     @Override
     public String getUuid() {
         return mUuid;
-    }
-
-    public Uri getContentUri() {
-        return Uri.parse("content://accounts/" + getUuid());
     }
 
     public synchronized String getStoreUri() {
@@ -1183,8 +1180,13 @@ public class Account implements BaseAccount, StoreConfig {
         FolderMode oldSyncMode = mFolderSyncMode;
         mFolderSyncMode = syncMode;
 
-        // return true iff sync mode was changed to or from FolderMode.NONE (and hence needs a refresh)
-        return (syncMode == FolderMode.NONE) != (oldSyncMode == FolderMode.NONE);
+        if (syncMode == FolderMode.NONE && oldSyncMode != FolderMode.NONE) {
+            return true;
+        }
+        if (syncMode != FolderMode.NONE && oldSyncMode == FolderMode.NONE) {
+            return true;
+        }
+        return false;
     }
 
     public synchronized FolderMode getFolderPushMode() {
@@ -1483,8 +1485,7 @@ public class Account implements BaseAccount, StoreConfig {
      *            Never <code>null</code>.
      * @throws MessagingException
      */
-    @SuppressWarnings("WeakerAccess") // public api
-    public void switchLocalStorage(final String newStorageProviderId) throws MessagingException {
+    private void switchLocalStorage(final String newStorageProviderId) throws MessagingException {
         if (!mLocalStorageProviderId.equals(newStorageProviderId)) {
             getLocalStore().switchLocalStorage(newStorageProviderId);
         }

--- a/k9mail/src/main/java/com/fsck/k9/Preferences.java
+++ b/k9mail/src/main/java/com/fsck/k9/Preferences.java
@@ -132,7 +132,6 @@ public class Preferences {
         }
         LocalStore.removeAccount(account);
 
-        account.deleteCertificates();
         account.delete(this);
 
         if (newAccount == account) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -1795,8 +1795,8 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
                 holder.chip.setBackgroundColor(realAccount.getChipColor());
 
-                holder.flaggedMessageCountIcon.setBackgroundDrawable( realAccount.generateColorChip(false, false, false, false,true).drawable() );
-                holder.newMessageCountIcon.setBackgroundDrawable( realAccount.generateColorChip(false, false, false, false, false).drawable() );
+                holder.flaggedMessageCountIcon.setBackgroundDrawable( realAccount.generateColorChip(false, true).drawable() );
+                holder.newMessageCountIcon.setBackgroundDrawable( realAccount.generateColorChip(false, false).drawable() );
 
             } else {
                 holder.chip.setBackgroundColor(0xff999999);

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -1050,7 +1050,7 @@ public class FolderList extends K9ListActivity {
                         createUnreadSearch(mAccount, folder));
                 holder.newMessageCountWrapper.setVisibility(View.VISIBLE);
                 holder.newMessageCountIcon.setBackgroundDrawable(
-                        mAccount.generateColorChip(false, false, false, false, false).drawable());
+                        mAccount.generateColorChip(false, false).drawable());
             } else {
                 holder.newMessageCountWrapper.setVisibility(View.GONE);
             }
@@ -1072,7 +1072,7 @@ public class FolderList extends K9ListActivity {
                         createFlaggedSearch(mAccount, folder));
                 holder.flaggedMessageCountWrapper.setVisibility(View.VISIBLE);
                 holder.flaggedMessageCountIcon.setBackgroundDrawable(
-                        mAccount.generateColorChip(false, false, false, false,true).drawable());
+                        mAccount.generateColorChip(false, true).drawable());
             } else {
                 holder.flaggedMessageCountWrapper.setVisibility(View.GONE);
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -19,6 +19,7 @@ public class ComposeCryptoStatus {
 
     private CryptoProviderState cryptoProviderState;
     private CryptoMode cryptoMode;
+    private boolean cryptoSupportSignOnly;
     private boolean allKeysAvailable;
     private boolean allKeysVerified;
     private boolean hasRecipients;
@@ -99,6 +100,10 @@ public class ComposeCryptoStatus {
         return cryptoMode == CryptoMode.OPPORTUNISTIC;
     }
 
+    public boolean isOpportunisticSignOnly() {
+        return cryptoSupportSignOnly;
+    }
+
     public boolean isSigningEnabled() {
         return cryptoMode != CryptoMode.DISABLE && signingKeyId != null;
     }
@@ -123,6 +128,7 @@ public class ComposeCryptoStatus {
         private Long selfEncryptKeyId;
         private List<Recipient> recipients;
         private Boolean enablePgpInline;
+        private Boolean cryptoSupportSignOnly;
 
         public ComposeCryptoStatusBuilder setCryptoProviderState(CryptoProviderState cryptoProviderState) {
             this.cryptoProviderState = cryptoProviderState;
@@ -131,6 +137,11 @@ public class ComposeCryptoStatus {
 
         public ComposeCryptoStatusBuilder setCryptoMode(CryptoMode cryptoMode) {
             this.cryptoMode = cryptoMode;
+            return this;
+        }
+
+        public ComposeCryptoStatusBuilder setCryptoSupportSignOnly(boolean cryptoSupportSignOnly) {
+            this.cryptoSupportSignOnly = cryptoSupportSignOnly;
             return this;
         }
 
@@ -167,6 +178,9 @@ public class ComposeCryptoStatus {
             if (enablePgpInline == null) {
                 throw new AssertionError("enablePgpInline must be set!");
             }
+            if (cryptoSupportSignOnly == null) {
+                throw new AssertionError("supportSignOnly must be set!");
+            }
 
             ArrayList<String> recipientAddresses = new ArrayList<>();
             boolean allKeysAvailable = true;
@@ -187,6 +201,7 @@ public class ComposeCryptoStatus {
             ComposeCryptoStatus result = new ComposeCryptoStatus();
             result.cryptoProviderState = cryptoProviderState;
             result.cryptoMode = cryptoMode;
+            result.cryptoSupportSignOnly = cryptoSupportSignOnly;
             result.recipientAddresses = recipientAddresses.toArray(new String[0]);
             result.allKeysAvailable = allKeysAvailable;
             result.allKeysVerified = allKeysVerified;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/CryptoSettingsDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/CryptoSettingsDialog.java
@@ -15,24 +15,28 @@ import android.view.View;
 import com.fsck.k9.R;
 import com.fsck.k9.activity.compose.RecipientPresenter.CryptoMode;
 import com.fsck.k9.view.CryptoModeSelector;
+import com.fsck.k9.view.CryptoModeSelector.CryptoModeSelectorState;
 import com.fsck.k9.view.CryptoModeSelector.CryptoStatusSelectedListener;
 import com.fsck.k9.view.LinearViewAnimator;
 
 
 public class CryptoSettingsDialog extends DialogFragment implements CryptoStatusSelectedListener {
+    private static final String ARG_CURRENT_MODE = "current_mode";
+    private static final String ARG_SUPPORT_SIGN_ONLY = "support_sing_only";
 
-    private static final String ARG_CURRENT_MODE = "current_override";
 
     private CryptoModeSelector cryptoModeSelector;
     private LinearViewAnimator cryptoStatusText;
 
     private CryptoMode currentMode;
 
-    public static CryptoSettingsDialog newInstance(CryptoMode initialOverride) {
+
+    public static CryptoSettingsDialog newInstance(CryptoMode initialMode, boolean supportSignOnly) {
         CryptoSettingsDialog dialog = new CryptoSettingsDialog();
 
         Bundle args = new Bundle();
-        args.putString(ARG_CURRENT_MODE, initialOverride.toString());
+        args.putString(ARG_CURRENT_MODE, initialMode.toString());
+        args.putBoolean(ARG_SUPPORT_SIGN_ONLY, supportSignOnly);
         dialog.setArguments(args);
 
         return dialog;
@@ -40,15 +44,18 @@ public class CryptoSettingsDialog extends DialogFragment implements CryptoStatus
 
     @Override
     public Dialog onCreateDialog(Bundle savedInstanceState) {
+        Bundle arguments = savedInstanceState != null ? savedInstanceState : getArguments();
+        boolean supportSignOnly = arguments.getBoolean(ARG_SUPPORT_SIGN_ONLY);
+        currentMode = CryptoMode.valueOf(arguments.getString(ARG_CURRENT_MODE));
+
         @SuppressLint("InflateParams")
-        View view = LayoutInflater.from(getActivity()).inflate(R.layout.crypto_settings_dialog, null);
+        View view = LayoutInflater.from(getActivity()).inflate(supportSignOnly ?
+                R.layout.crypto_settings_dialog_sign_only : R.layout.crypto_settings_dialog, null);
         cryptoModeSelector = (CryptoModeSelector) view.findViewById(R.id.crypto_status_selector);
         cryptoStatusText = (LinearViewAnimator) view.findViewById(R.id.crypto_status_text);
 
         cryptoModeSelector.setCryptoStatusListener(this);
 
-        Bundle arguments = savedInstanceState != null ? savedInstanceState : getArguments();
-        currentMode = CryptoMode.valueOf(arguments.getString(ARG_CURRENT_MODE));
         updateView(false);
 
         AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
@@ -87,19 +94,19 @@ public class CryptoSettingsDialog extends DialogFragment implements CryptoStatus
     void updateView(boolean animate) {
         switch (currentMode) {
             case DISABLE:
-                cryptoModeSelector.setCryptoStatus(0);
+                cryptoModeSelector.setCryptoStatus(CryptoModeSelectorState.DISABLED);
                 cryptoStatusText.setDisplayedChild(0, animate);
                 break;
             case SIGN_ONLY:
-                cryptoModeSelector.setCryptoStatus(1);
+                cryptoModeSelector.setCryptoStatus(CryptoModeSelectorState.SIGN_ONLY);
                 cryptoStatusText.setDisplayedChild(1, animate);
                 break;
             case OPPORTUNISTIC:
-                cryptoModeSelector.setCryptoStatus(2);
+                cryptoModeSelector.setCryptoStatus(CryptoModeSelectorState.OPPORTUNISTIC);
                 cryptoStatusText.setDisplayedChild(2, animate);
                 break;
             case PRIVATE:
-                cryptoModeSelector.setCryptoStatus(3);
+                cryptoModeSelector.setCryptoStatus(CryptoModeSelectorState.PRIVATE);
                 cryptoStatusText.setDisplayedChild(3, animate);
                 break;
         }
@@ -113,15 +120,20 @@ public class CryptoSettingsDialog extends DialogFragment implements CryptoStatus
     }
 
     @Override
-    public void onCryptoStatusSelected(int status) {
-        if (status == 0) {
-            currentMode = CryptoMode.DISABLE;
-        } else if (status == 1) {
-            currentMode = CryptoMode.SIGN_ONLY;
-        } else if (status == 2) {
-            currentMode = CryptoMode.OPPORTUNISTIC;
-        } else {
-            currentMode = CryptoMode.PRIVATE;
+    public void onCryptoStatusSelected(CryptoModeSelectorState status) {
+        switch (status) {
+            case DISABLED:
+                currentMode = CryptoMode.DISABLE;
+                break;
+            case SIGN_ONLY:
+                currentMode = CryptoMode.SIGN_ONLY;
+                break;
+            case OPPORTUNISTIC:
+                currentMode = CryptoMode.OPPORTUNISTIC;
+                break;
+            case PRIVATE:
+                currentMode = CryptoMode.PRIVATE;
+                break;
         }
         updateView(true);
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -378,8 +378,8 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
         }
     }
 
-    public void showCryptoDialog(CryptoMode currentCryptoMode) {
-        CryptoSettingsDialog dialog = CryptoSettingsDialog.newInstance(currentCryptoMode);
+    public void showCryptoDialog(CryptoMode currentCryptoMode, boolean supportSignOnly) {
+        CryptoSettingsDialog dialog = CryptoSettingsDialog.newInstance(currentCryptoMode, supportSignOnly);
         dialog.show(activity.getFragmentManager(), "crypto_settings");
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -354,6 +354,7 @@ public class RecipientPresenter implements PermissionPingCallback {
             ComposeCryptoStatusBuilder builder = new ComposeCryptoStatusBuilder()
                     .setCryptoProviderState(cryptoProviderState)
                     .setCryptoMode(currentCryptoMode)
+                    .setCryptoSupportSignOnly(account.getCryptoSupportSignOnly())
                     .setEnablePgpInline(cryptoEnablePgpInline)
                     .setRecipients(getAllRecipients());
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -545,7 +545,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                 Log.e(K9.LOG_TAG, "click on crypto status while unconfigured - this should not really happen?!");
                 return;
             case OK:
-                recipientMvpView.showCryptoDialog(currentCryptoMode);
+                recipientMvpView.showCryptoDialog(currentCryptoMode, account.getCryptoSupportSignOnly());
                 return;
 
             case LOST_CONNECTION:

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -726,13 +726,6 @@ public class AccountSettings extends K9PreferenceActivity {
             });
 
             mCryptoSupportSignOnly.setChecked(mAccount.getCryptoSupportSignOnly());
-            mCryptoSupportSignOnly.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-                public boolean onPreferenceChange(Preference preference, Object newValue) {
-                    boolean value = (Boolean) newValue;
-                    mCryptoSupportSignOnly.setChecked(value);
-                    return false;
-                }
-            });
         } else {
             final Preference mCryptoMenu = findPreference(PREFERENCE_CRYPTO);
             mCryptoMenu.setEnabled(false);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -114,6 +114,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_CRYPTO = "crypto";
     private static final String PREFERENCE_CRYPTO_APP = "crypto_app";
     private static final String PREFERENCE_CRYPTO_KEY = "crypto_key";
+    private static final String PREFERENCE_CRYPTO_SUPPORT_SIGN_ONLY = "crypto_support_sign_only";
     private static final String PREFERENCE_CLOUD_SEARCH_ENABLED = "remote_search_enabled";
     private static final String PREFERENCE_REMOTE_SEARCH_NUM_RESULTS = "account_remote_search_num_results";
     private static final String PREFERENCE_REMOTE_SEARCH_FULL_TEXT = "account_remote_search_full_text";
@@ -181,6 +182,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private boolean mHasCrypto = false;
     private OpenPgpAppPreference mCryptoApp;
     private OpenPgpKeyPreference mCryptoKey;
+    private CheckBoxPreference mCryptoSupportSignOnly;
 
     private PreferenceScreen mSearchScreen;
     private CheckBoxPreference mCloudSearchEnabled;
@@ -698,6 +700,7 @@ public class AccountSettings extends K9PreferenceActivity {
         if (mHasCrypto) {
             mCryptoApp = (OpenPgpAppPreference) findPreference(PREFERENCE_CRYPTO_APP);
             mCryptoKey = (OpenPgpKeyPreference) findPreference(PREFERENCE_CRYPTO_KEY);
+            mCryptoSupportSignOnly = (CheckBoxPreference) findPreference(PREFERENCE_CRYPTO_SUPPORT_SIGN_ONLY);
 
             mCryptoApp.setValue(String.valueOf(mAccount.getCryptoApp()));
             mCryptoApp.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
@@ -718,6 +721,15 @@ public class AccountSettings extends K9PreferenceActivity {
                 public boolean onPreferenceChange(Preference preference, Object newValue) {
                     long value = (Long) newValue;
                     mCryptoKey.setValue(value);
+                    return false;
+                }
+            });
+
+            mCryptoSupportSignOnly.setChecked(mAccount.getCryptoSupportSignOnly());
+            mCryptoSupportSignOnly.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+                public boolean onPreferenceChange(Preference preference, Object newValue) {
+                    boolean value = (Boolean) newValue;
+                    mCryptoSupportSignOnly.setChecked(value);
                     return false;
                 }
             });
@@ -789,9 +801,11 @@ public class AccountSettings extends K9PreferenceActivity {
         if (mHasCrypto) {
             mAccount.setCryptoApp(mCryptoApp.getValue());
             mAccount.setCryptoKey(mCryptoKey.getValue());
+            mAccount.setCryptoSupportSignOnly(mCryptoSupportSignOnly.isChecked());
         } else {
             mAccount.setCryptoApp(Account.NO_OPENPGP_PROVIDER);
             mAccount.setCryptoKey(Account.NO_OPENPGP_KEY);
+            mAccount.setCryptoSupportSignOnly(false);
         }
 
         // In webdav account we use the exact folder name also for inbox,

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -128,7 +128,8 @@ public class PgpMessageBuilder extends MessageBuilder {
                 return;
             }
 
-            if (opportunisticSkipEncryption && !opportunisticSecondPass) {
+            boolean shouldSignOnly = cryptoStatus.isOpportunisticSignOnly();
+            if (opportunisticSkipEncryption && shouldSignOnly && !opportunisticSecondPass) {
                 opportunisticSecondPass = true;
                 startOrContinueBuildMessage(null);
                 return;

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -59,6 +59,11 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
             return false;
         }
 
+        boolean suppressSignOnlyMessages = !account.getCryptoSupportSignOnly();
+        if (suppressSignOnlyMessages && displayStatus.isUnencryptedSigned()) {
+            return false;
+        }
+
         messageView.getMessageHeaderView().setCryptoStatus(displayStatus);
 
         switch (displayStatus) {

--- a/k9mail/src/main/java/com/fsck/k9/view/CryptoModeSelector.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/CryptoModeSelector.java
@@ -1,185 +1,29 @@
 package com.fsck.k9.view;
 
 
-import android.animation.ArgbEvaluator;
-import android.animation.ObjectAnimator;
 import android.content.Context;
-import android.graphics.PorterDuff;
 import android.util.AttributeSet;
 import android.widget.FrameLayout;
-import android.widget.ImageView;
-import android.widget.SeekBar;
-import android.widget.SeekBar.OnSeekBarChangeListener;
-
-import com.fsck.k9.R;
 
 
-public class CryptoModeSelector extends FrameLayout implements OnSeekBarChangeListener {
-    public static final int CROSSFADE_THRESH_1_LOW = -50;
-    public static final int CROSSFADE_THRESH_1_HIGH = 50;
-    public static final int CROSSFADE_THRESH_2_LOW = 50;
-    public static final int CROSSFADE_THRESH_2_HIGH = 150;
-    public static final int CROSSFADE_THRESH_3_LOW = 150;
-    public static final int CROSSFADE_THRESH_3_HIGH = 250;
-    public static final int CROSSFADE_THRESH_4_LOW = 250;
-    public static final float CROSSFADE_DIVISOR_1 = 50.0f;
-    public static final float CROSSFADE_DIVISOR_2 = 50.0f;
-    public static final float CROSSFADE_DIVISOR_3 = 50.0f;
-    public static final float CROSSFADE_DIVISOR_4 = 50.0f;
-
-
-    private SeekBar seekbar;
-    private ImageView modeIcon1;
-    private ImageView modeIcon2;
-    private ImageView modeIcon3;
-    private ImageView modeIcon4;
-
-    private ObjectAnimator currentSeekbarAnim;
-
-    private int currentCryptoStatus;
-
-    private CryptoStatusSelectedListener cryptoStatusListener;
-    private static final ArgbEvaluator ARGB_EVALUATOR = new ArgbEvaluator();
-
-
+public abstract class CryptoModeSelector extends FrameLayout {
     public CryptoModeSelector(Context context, AttributeSet attrs) {
         super(context, attrs);
-        init();
     }
 
     public CryptoModeSelector(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
-        init();
     }
 
-    public void init() {
-        inflate(getContext(), R.layout.crypto_mode_selector, this);
-        seekbar = (SeekBar) findViewById(R.id.seek_bar);
-        modeIcon1 = (ImageView) findViewById(R.id.icon_1);
-        modeIcon2 = (ImageView) findViewById(R.id.icon_2);
-        modeIcon3 = (ImageView) findViewById(R.id.icon_3);
-        modeIcon4 = (ImageView) findViewById(R.id.icon_4);
+    public abstract void setCryptoStatusListener(CryptoStatusSelectedListener cryptoStatusListener);
 
-        seekbar.setOnSeekBarChangeListener(this);
-        onProgressChanged(seekbar, seekbar.getProgress(), false);
-    }
-
-    @Override
-    public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
-        int grey = ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_grey);
-
-        float crossfadeValue1, crossfadeValue2, crossfadeValue3, crossfadeValue4;
-
-        if (progress < CROSSFADE_THRESH_1_HIGH) {
-            crossfadeValue1 = (progress -CROSSFADE_THRESH_1_LOW) / CROSSFADE_DIVISOR_1;
-            if (crossfadeValue1 > 1.0f) {
-                crossfadeValue1 = 2.0f -crossfadeValue1;
-            }
-        } else {
-            crossfadeValue1 = 0.0f;
-        }
-
-
-        if (progress > CROSSFADE_THRESH_2_LOW && progress < CROSSFADE_THRESH_2_HIGH) {
-            crossfadeValue2 = (progress -CROSSFADE_THRESH_2_LOW) / CROSSFADE_DIVISOR_2;
-            if (crossfadeValue2 > 1.0f) {
-                crossfadeValue2 = 2.0f -crossfadeValue2;
-            }
-        } else {
-            crossfadeValue2 = 0.0f;
-        }
-
-        if (progress > CROSSFADE_THRESH_3_LOW && progress < CROSSFADE_THRESH_3_HIGH) {
-            crossfadeValue3 = (progress -CROSSFADE_THRESH_3_LOW) / CROSSFADE_DIVISOR_3;
-            if (crossfadeValue3 > 1.0f) {
-                crossfadeValue3 = 2.0f -crossfadeValue3;
-            }
-        } else {
-            crossfadeValue3 = 0.0f;
-        }
-
-        if (progress > CROSSFADE_THRESH_4_LOW) {
-            crossfadeValue4 = (progress -CROSSFADE_THRESH_4_LOW) / CROSSFADE_DIVISOR_4;
-        } else {
-            crossfadeValue4 = 0.0f;
-        }
-
-        int crossfadedColor;
-
-        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_dark_grey), crossfadeValue1);
-        modeIcon1.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
-
-        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_blue), crossfadeValue2);
-        modeIcon2.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
-
-        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_orange), crossfadeValue3);
-        modeIcon3.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
-
-        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_green), crossfadeValue4);
-        modeIcon4.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
-    }
-
-    @Override
-    public void onStartTrackingTouch(SeekBar seekBar) {
-    }
-
-    @Override
-    public void onStopTrackingTouch(SeekBar seekBar) {
-        int newCryptoStatus;
-
-        int progress = seekbar.getProgress();
-        if (progress < 50) {
-            animateSnapTo(0);
-            newCryptoStatus = 0;
-        } else if (progress < 150) {
-            animateSnapTo(100);
-            newCryptoStatus = 1;
-        } else if (progress < 250) {
-            animateSnapTo(200);
-            newCryptoStatus = 2;
-        } else {
-            animateSnapTo(300);
-            newCryptoStatus = 3;
-        }
-
-        if (currentCryptoStatus != newCryptoStatus) {
-            currentCryptoStatus = newCryptoStatus;
-            cryptoStatusListener.onCryptoStatusSelected(newCryptoStatus);
-        }
-    }
-
-    private void animateSnapTo(int value) {
-        if (currentSeekbarAnim != null) {
-            currentSeekbarAnim.cancel();
-        }
-        currentSeekbarAnim = ObjectAnimator.ofInt(seekbar, "progress", seekbar.getProgress(), value);
-        currentSeekbarAnim.setDuration(150);
-        currentSeekbarAnim.start();
-    }
-
-    public static int crossfadeColor(int color1, int color2, float factor) {
-        return (Integer) ARGB_EVALUATOR.evaluate(factor, color1, color2);
-    }
-
-    public void setCryptoStatusListener(CryptoStatusSelectedListener cryptoStatusListener) {
-        this.cryptoStatusListener = cryptoStatusListener;
-    }
-
-    public void setCryptoStatus(int status) {
-        currentCryptoStatus = status;
-        if (status == 0) {
-            seekbar.setProgress(0);
-        } else if (status == 1) {
-            seekbar.setProgress(100);
-        } else if (status == 2) {
-            seekbar.setProgress(200);
-        } else {
-            seekbar.setProgress(300);
-        }
-    }
+    public abstract void setCryptoStatus(CryptoModeSelectorState status);
 
     public interface CryptoStatusSelectedListener {
-        void onCryptoStatusSelected(int type);
+        void onCryptoStatusSelected(CryptoModeSelectorState type);
     }
 
+    public enum CryptoModeSelectorState {
+        DISABLED, SIGN_ONLY, OPPORTUNISTIC, PRIVATE
+    }
 }

--- a/k9mail/src/main/java/com/fsck/k9/view/CryptoModeSelector.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/CryptoModeSelector.java
@@ -1,29 +1,15 @@
 package com.fsck.k9.view;
 
 
-import android.content.Context;
-import android.util.AttributeSet;
-import android.widget.FrameLayout;
+public interface CryptoModeSelector {
+    void setCryptoStatusListener(CryptoStatusSelectedListener cryptoStatusListener);
+    void setCryptoStatus(CryptoModeSelectorState status);
 
-
-public abstract class CryptoModeSelector extends FrameLayout {
-    public CryptoModeSelector(Context context, AttributeSet attrs) {
-        super(context, attrs);
-    }
-
-    public CryptoModeSelector(Context context, AttributeSet attrs, int defStyleAttr) {
-        super(context, attrs, defStyleAttr);
-    }
-
-    public abstract void setCryptoStatusListener(CryptoStatusSelectedListener cryptoStatusListener);
-
-    public abstract void setCryptoStatus(CryptoModeSelectorState status);
-
-    public interface CryptoStatusSelectedListener {
+    interface CryptoStatusSelectedListener {
         void onCryptoStatusSelected(CryptoModeSelectorState type);
     }
 
-    public enum CryptoModeSelectorState {
+    enum CryptoModeSelectorState {
         DISABLED, SIGN_ONLY, OPPORTUNISTIC, PRIVATE
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/view/CryptoModeWithSignOnlySelector.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/CryptoModeWithSignOnlySelector.java
@@ -1,0 +1,184 @@
+package com.fsck.k9.view;
+
+
+import android.animation.ArgbEvaluator;
+import android.animation.ObjectAnimator;
+import android.content.Context;
+import android.graphics.PorterDuff;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+import android.widget.SeekBar;
+import android.widget.SeekBar.OnSeekBarChangeListener;
+
+import com.fsck.k9.R;
+
+
+public class CryptoModeWithSignOnlySelector extends CryptoModeSelector implements OnSeekBarChangeListener {
+    public static final int CROSSFADE_THRESH_1_LOW = -50;
+    public static final int CROSSFADE_THRESH_1_HIGH = 50;
+    public static final int CROSSFADE_THRESH_2_LOW = 50;
+    public static final int CROSSFADE_THRESH_2_HIGH = 150;
+    public static final int CROSSFADE_THRESH_3_LOW = 150;
+    public static final int CROSSFADE_THRESH_3_HIGH = 250;
+    public static final int CROSSFADE_THRESH_4_LOW = 250;
+    public static final float CROSSFADE_DIVISOR_1 = 50.0f;
+    public static final float CROSSFADE_DIVISOR_2 = 50.0f;
+    public static final float CROSSFADE_DIVISOR_3 = 50.0f;
+    public static final float CROSSFADE_DIVISOR_4 = 50.0f;
+
+
+    private SeekBar seekbar;
+    private ImageView modeIconDisabled;
+    private ImageView modeIconSignOnly;
+    private ImageView modeIconOpportunistic;
+    private ImageView modeIconPrivate;
+
+    private ObjectAnimator currentSeekbarAnim;
+
+    private CryptoModeSelectorState currentCryptoStatus;
+
+    private CryptoStatusSelectedListener cryptoStatusListener;
+    private static final ArgbEvaluator ARGB_EVALUATOR = new ArgbEvaluator();
+
+
+    public CryptoModeWithSignOnlySelector(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public CryptoModeWithSignOnlySelector(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    public void init() {
+        inflate(getContext(), R.layout.crypto_mode_with_sign_only_selector, this);
+        seekbar = (SeekBar) findViewById(R.id.seek_bar);
+        modeIconDisabled = (ImageView) findViewById(R.id.icon_disabled);
+        modeIconSignOnly = (ImageView) findViewById(R.id.icon_sign_only);
+        modeIconOpportunistic = (ImageView) findViewById(R.id.icon_opportunistic);
+        modeIconPrivate = (ImageView) findViewById(R.id.icon_private);
+
+        seekbar.setOnSeekBarChangeListener(this);
+        onProgressChanged(seekbar, seekbar.getProgress(), false);
+    }
+
+    @Override
+    public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+        int grey = ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_grey);
+
+        float crossfadeValue1, crossfadeValue2, crossfadeValue3, crossfadeValue4;
+
+        if (progress < CROSSFADE_THRESH_1_HIGH) {
+            crossfadeValue1 = (progress -CROSSFADE_THRESH_1_LOW) / CROSSFADE_DIVISOR_1;
+            if (crossfadeValue1 > 1.0f) {
+                crossfadeValue1 = 2.0f -crossfadeValue1;
+            }
+        } else {
+            crossfadeValue1 = 0.0f;
+        }
+
+
+        if (progress > CROSSFADE_THRESH_2_LOW && progress < CROSSFADE_THRESH_2_HIGH) {
+            crossfadeValue2 = (progress -CROSSFADE_THRESH_2_LOW) / CROSSFADE_DIVISOR_2;
+            if (crossfadeValue2 > 1.0f) {
+                crossfadeValue2 = 2.0f -crossfadeValue2;
+            }
+        } else {
+            crossfadeValue2 = 0.0f;
+        }
+
+        if (progress > CROSSFADE_THRESH_3_LOW && progress < CROSSFADE_THRESH_3_HIGH) {
+            crossfadeValue3 = (progress -CROSSFADE_THRESH_3_LOW) / CROSSFADE_DIVISOR_3;
+            if (crossfadeValue3 > 1.0f) {
+                crossfadeValue3 = 2.0f -crossfadeValue3;
+            }
+        } else {
+            crossfadeValue3 = 0.0f;
+        }
+
+        if (progress > CROSSFADE_THRESH_4_LOW) {
+            crossfadeValue4 = (progress -CROSSFADE_THRESH_4_LOW) / CROSSFADE_DIVISOR_4;
+        } else {
+            crossfadeValue4 = 0.0f;
+        }
+
+        int crossfadedColor;
+
+        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_dark_grey), crossfadeValue1);
+        modeIconDisabled.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
+
+        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_blue), crossfadeValue2);
+        modeIconSignOnly.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
+
+        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_orange), crossfadeValue3);
+        modeIconOpportunistic.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
+
+        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_green), crossfadeValue4);
+        modeIconPrivate.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
+    }
+
+    @Override
+    public void onStartTrackingTouch(SeekBar seekBar) {
+    }
+
+    @Override
+    public void onStopTrackingTouch(SeekBar seekBar) {
+        CryptoModeSelectorState newCryptoStatus;
+
+        int progress = seekbar.getProgress();
+        if (progress < 50) {
+            animateSnapTo(0);
+            newCryptoStatus = CryptoModeSelectorState.DISABLED;
+        } else if (progress < 150) {
+            animateSnapTo(100);
+            newCryptoStatus = CryptoModeSelectorState.SIGN_ONLY;
+        } else if (progress < 250) {
+            animateSnapTo(200);
+            newCryptoStatus = CryptoModeSelectorState.OPPORTUNISTIC;
+        } else {
+            animateSnapTo(300);
+            newCryptoStatus = CryptoModeSelectorState.PRIVATE;
+        }
+
+        if (currentCryptoStatus != newCryptoStatus) {
+            currentCryptoStatus = newCryptoStatus;
+            cryptoStatusListener.onCryptoStatusSelected(newCryptoStatus);
+        }
+    }
+
+    private void animateSnapTo(int value) {
+        if (currentSeekbarAnim != null) {
+            currentSeekbarAnim.cancel();
+        }
+        currentSeekbarAnim = ObjectAnimator.ofInt(seekbar, "progress", seekbar.getProgress(), value);
+        currentSeekbarAnim.setDuration(150);
+        currentSeekbarAnim.start();
+    }
+
+    public static int crossfadeColor(int color1, int color2, float factor) {
+        return (Integer) ARGB_EVALUATOR.evaluate(factor, color1, color2);
+    }
+
+    public void setCryptoStatusListener(CryptoStatusSelectedListener cryptoStatusListener) {
+        this.cryptoStatusListener = cryptoStatusListener;
+    }
+
+    public void setCryptoStatus(CryptoModeSelectorState status) {
+        currentCryptoStatus = status;
+        switch (status) {
+            case DISABLED:
+                seekbar.setProgress(0);
+                break;
+            case SIGN_ONLY:
+                seekbar.setProgress(100);
+                break;
+            case OPPORTUNISTIC:
+                seekbar.setProgress(200);
+                break;
+            case PRIVATE:
+                seekbar.setProgress(300);
+                break;
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/view/CryptoModeWithSignOnlySelector.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/CryptoModeWithSignOnlySelector.java
@@ -6,6 +6,7 @@ import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.util.AttributeSet;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
@@ -13,7 +14,7 @@ import android.widget.SeekBar.OnSeekBarChangeListener;
 import com.fsck.k9.R;
 
 
-public class CryptoModeWithSignOnlySelector extends CryptoModeSelector implements OnSeekBarChangeListener {
+public class CryptoModeWithSignOnlySelector extends FrameLayout implements CryptoModeSelector, OnSeekBarChangeListener {
     public static final int CROSSFADE_THRESH_1_LOW = -50;
     public static final int CROSSFADE_THRESH_1_HIGH = 50;
     public static final int CROSSFADE_THRESH_2_LOW = 50;

--- a/k9mail/src/main/java/com/fsck/k9/view/CryptoModeWithoutSignOnlySelector.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/CryptoModeWithoutSignOnlySelector.java
@@ -6,6 +6,7 @@ import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.graphics.PorterDuff;
 import android.util.AttributeSet;
+import android.widget.FrameLayout;
 import android.widget.ImageView;
 import android.widget.SeekBar;
 import android.widget.SeekBar.OnSeekBarChangeListener;
@@ -13,7 +14,8 @@ import android.widget.SeekBar.OnSeekBarChangeListener;
 import com.fsck.k9.R;
 
 
-public class CryptoModeWithoutSignOnlySelector extends CryptoModeSelector implements OnSeekBarChangeListener {
+public class CryptoModeWithoutSignOnlySelector extends FrameLayout
+        implements CryptoModeSelector, OnSeekBarChangeListener {
     public static final int CROSSFADE_THRESH_1_LOW = -50;
     public static final int CROSSFADE_THRESH_1_HIGH = 50;
     public static final int CROSSFADE_THRESH_2_LOW = 50;

--- a/k9mail/src/main/java/com/fsck/k9/view/CryptoModeWithoutSignOnlySelector.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/CryptoModeWithoutSignOnlySelector.java
@@ -1,0 +1,166 @@
+package com.fsck.k9.view;
+
+
+import android.animation.ArgbEvaluator;
+import android.animation.ObjectAnimator;
+import android.content.Context;
+import android.graphics.PorterDuff;
+import android.util.AttributeSet;
+import android.widget.ImageView;
+import android.widget.SeekBar;
+import android.widget.SeekBar.OnSeekBarChangeListener;
+
+import com.fsck.k9.R;
+
+
+public class CryptoModeWithoutSignOnlySelector extends CryptoModeSelector implements OnSeekBarChangeListener {
+    public static final int CROSSFADE_THRESH_1_LOW = -50;
+    public static final int CROSSFADE_THRESH_1_HIGH = 50;
+    public static final int CROSSFADE_THRESH_2_LOW = 50;
+    public static final int CROSSFADE_THRESH_2_HIGH = 150;
+    public static final int CROSSFADE_THRESH_3_LOW = 150;
+    public static final float CROSSFADE_DIVISOR_1 = 50.0f;
+    public static final float CROSSFADE_DIVISOR_2 = 50.0f;
+    public static final float CROSSFADE_DIVISOR_3 = 50.0f;
+
+
+    private SeekBar seekbar;
+    private ImageView modeIconDisabled;
+    private ImageView modeIconOpportunistic;
+    private ImageView modeIconPrivate;
+
+    private ObjectAnimator currentSeekbarAnim;
+
+    private CryptoModeSelectorState currentCryptoStatus;
+
+    private CryptoStatusSelectedListener cryptoStatusListener;
+    private static final ArgbEvaluator ARGB_EVALUATOR = new ArgbEvaluator();
+
+
+    public CryptoModeWithoutSignOnlySelector(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    public CryptoModeWithoutSignOnlySelector(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        init();
+    }
+
+    public void init() {
+        inflate(getContext(), R.layout.crypto_mode_selector, this);
+        seekbar = (SeekBar) findViewById(R.id.seek_bar);
+        modeIconDisabled = (ImageView) findViewById(R.id.icon_disabled);
+        modeIconOpportunistic = (ImageView) findViewById(R.id.icon_opportunistic);
+        modeIconPrivate = (ImageView) findViewById(R.id.icon_private);
+
+        seekbar.setOnSeekBarChangeListener(this);
+        onProgressChanged(seekbar, seekbar.getProgress(), false);
+    }
+
+    @Override
+    public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+        int grey = ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_grey);
+
+        float crossfadeValue1, crossfadeValue2, crossfadeValue3;
+
+        if (progress < CROSSFADE_THRESH_1_HIGH) {
+            crossfadeValue1 = (progress -CROSSFADE_THRESH_1_LOW) / CROSSFADE_DIVISOR_1;
+            if (crossfadeValue1 > 1.0f) {
+                crossfadeValue1 = 2.0f -crossfadeValue1;
+            }
+        } else {
+            crossfadeValue1 = 0.0f;
+        }
+
+
+        if (progress > CROSSFADE_THRESH_2_LOW && progress < CROSSFADE_THRESH_2_HIGH) {
+            crossfadeValue2 = (progress -CROSSFADE_THRESH_2_LOW) / CROSSFADE_DIVISOR_2;
+            if (crossfadeValue2 > 1.0f) {
+                crossfadeValue2 = 2.0f -crossfadeValue2;
+            }
+        } else {
+            crossfadeValue2 = 0.0f;
+        }
+
+        if (progress > CROSSFADE_THRESH_3_LOW) {
+            crossfadeValue3 = (progress -CROSSFADE_THRESH_3_LOW) / CROSSFADE_DIVISOR_3;
+        } else {
+            crossfadeValue3 = 0.0f;
+        }
+
+        int crossfadedColor;
+
+        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_dark_grey), crossfadeValue1);
+        modeIconDisabled.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
+
+        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_orange), crossfadeValue2);
+        modeIconOpportunistic.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
+
+        crossfadedColor = crossfadeColor(grey, ThemeUtils.getStyledColor(getContext(), R.attr.openpgp_green), crossfadeValue3);
+        modeIconPrivate.setColorFilter(crossfadedColor, PorterDuff.Mode.SRC_ATOP);
+    }
+
+    @Override
+    public void onStartTrackingTouch(SeekBar seekBar) {
+    }
+
+    @Override
+    public void onStopTrackingTouch(SeekBar seekBar) {
+        CryptoModeSelectorState newCryptoStatus;
+
+        int progress = seekbar.getProgress();
+        if (progress < 50) {
+            animateSnapTo(0);
+            newCryptoStatus = CryptoModeSelectorState.DISABLED;
+        } else if (progress < 150) {
+            animateSnapTo(100);
+            newCryptoStatus = CryptoModeSelectorState.OPPORTUNISTIC;
+        } else {
+            animateSnapTo(200);
+            newCryptoStatus = CryptoModeSelectorState.PRIVATE;
+        }
+
+        if (currentCryptoStatus != newCryptoStatus) {
+            currentCryptoStatus = newCryptoStatus;
+            cryptoStatusListener.onCryptoStatusSelected(newCryptoStatus);
+        }
+    }
+
+    private void animateSnapTo(int value) {
+        if (currentSeekbarAnim != null) {
+            currentSeekbarAnim.cancel();
+        }
+        currentSeekbarAnim = ObjectAnimator.ofInt(seekbar, "progress", seekbar.getProgress(), value);
+        currentSeekbarAnim.setDuration(150);
+        currentSeekbarAnim.start();
+    }
+
+    public static int crossfadeColor(int color1, int color2, float factor) {
+        return (Integer) ARGB_EVALUATOR.evaluate(factor, color1, color2);
+    }
+
+    @Override
+    public void setCryptoStatusListener(CryptoStatusSelectedListener cryptoStatusListener) {
+        this.cryptoStatusListener = cryptoStatusListener;
+    }
+
+    @Override
+    public void setCryptoStatus(CryptoModeSelectorState status) {
+        currentCryptoStatus = status;
+        switch (status) {
+            case DISABLED:
+                seekbar.setProgress(0);
+                break;
+            case SIGN_ONLY:
+                throw new IllegalStateException("This widget doesn't support sign-only state!");
+            case OPPORTUNISTIC:
+                seekbar.setProgress(100);
+                break;
+            case PRIVATE:
+                seekbar.setProgress(200);
+                break;
+        }
+    }
+
+}

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
@@ -351,4 +351,19 @@ public enum MessageCryptoDisplayStatus {
         return false;
     }
 
+    public boolean isUnencryptedSigned() {
+        switch (this) {
+            case UNENCRYPTED_SIGN_ERROR:
+            case UNENCRYPTED_SIGN_UNKNOWN:
+            case UNENCRYPTED_SIGN_VERIFIED:
+            case UNENCRYPTED_SIGN_UNVERIFIED:
+            case UNENCRYPTED_SIGN_MISMATCH:
+            case UNENCRYPTED_SIGN_EXPIRED:
+            case UNENCRYPTED_SIGN_REVOKED:
+            case UNENCRYPTED_SIGN_INSECURE:
+                return true;
+        }
+        return false;
+    }
+
 }

--- a/k9mail/src/main/res/layout/crypto_mode_with_sign_only_selector.xml
+++ b/k9mail/src/main/res/layout/crypto_mode_with_sign_only_selector.xml
@@ -26,6 +26,15 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_weight="1"
+                android:src="@drawable/status_signature_verified_cutout"
+                android:id="@+id/icon_sign_only"
+                tools:tint="?attr/openpgp_blue"
+                />
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
                 android:src="@drawable/status_lock_opportunistic"
                 android:id="@+id/icon_opportunistic"
                 tools:tint="?attr/openpgp_orange"
@@ -47,12 +56,12 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:layout_marginTop="15dp"
-            android:layout_marginLeft="21dp"
-            android:layout_marginRight="21dp"
+            android:layout_marginLeft="12dp"
+            android:layout_marginRight="12dp"
             android:progressDrawable="@drawable/seekbar_background"
             android:id="@+id/seek_bar"
             android:progress="100"
-            android:max="200" />
+            android:max="300" />
 
     </LinearLayout>
 

--- a/k9mail/src/main/res/layout/crypto_settings_dialog_sign_only.xml
+++ b/k9mail/src/main/res/layout/crypto_settings_dialog_sign_only.xml
@@ -21,13 +21,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:textAppearance="?android:textAppearanceMedium"
-            android:text="@string/crypto_mode_disabled"
-            />
-
-        <Space
-            android:layout_height="wrap_content"
-            android:layout_width="wrap_content"
-            android:layout_gravity="center_horizontal"
+            android:text="@string/crypto_mode_supsig_disabled"
             />
 
         <TextView
@@ -35,7 +29,7 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:textAppearance="?android:textAppearanceMedium"
-            android:text="@string/crypto_mode_opportunistic"
+            android:text="@string/crypto_mode_supsig_sign_only"
             />
 
         <TextView
@@ -43,12 +37,20 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:textAppearance="?android:textAppearanceMedium"
-            android:text="@string/crypto_mode_private"
+            android:text="@string/crypto_mode_supsig_opportunistic"
+            />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:textAppearance="?android:textAppearanceMedium"
+            android:text="@string/crypto_mode_supsig_private"
             />
 
     </com.fsck.k9.view.LinearViewAnimator>
 
-    <com.fsck.k9.view.CryptoModeWithoutSignOnlySelector
+    <com.fsck.k9.view.CryptoModeWithSignOnlySelector
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:id="@+id/crypto_status_selector"

--- a/k9mail/src/main/res/layout/message_compose_recipients.xml
+++ b/k9mail/src/main/res/layout/message_compose_recipients.xml
@@ -76,7 +76,7 @@
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
                 android:src="@drawable/status_lock_disabled"
-                android:tint="?attr/openpgp_grey"
+                android:tint="?attr/openpgp_dark_grey"
                 />
 
             <ImageView

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1221,6 +1221,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="messageview_crypto_warning_error">There was an <b>error in this message\'s signature!</b></string>
     <string name="recipient_error_non_ascii">Special characters are currently not supported!</string>
     <string name="recipient_error_parse_failed">Error parsing address!</string>
-    <string name="account_settings_crypto_support_sign_only">Support unencrypted authentication</string>
+    <string name="account_settings_crypto_support_sign_only">Support signing of unencrypted messages</string>
 
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1218,5 +1218,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="messageview_crypto_warning_error">There was an <b>error in this message\'s signature!</b></string>
     <string name="recipient_error_non_ascii">Special characters are currently not supported!</string>
     <string name="recipient_error_parse_failed">Error parsing address!</string>
+    <string name="account_settings_crypto_support_sign_only">Support unencrypted authentication</string>
 
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1155,10 +1155,13 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="compose_error_pgp_error">Error with OpenPGP provider. Check your settings!</string>
     <string name="compose_error_no_signing_key">No key configured for signing! Please check your settings.</string>
     <string name="compose_error_private_missing_keys">Private mode is enabled, but some recipients do not have keys!</string>
-    <string name="crypto_mode_disabled">Never Sign or Encrypt.</string>
-    <string name="crypto_mode_sign_only">Always Sign, Never Encrypt.</string>
-    <string name="crypto_mode_opportunistic">Always Sign, Encrypt if possible.</string>
-    <string name="crypto_mode_private">Always Sign, Always Encrypt.</string>
+    <string name="crypto_mode_disabled">Never Encrypt.</string>
+    <string name="crypto_mode_opportunistic">Encrypt if possible.</string>
+    <string name="crypto_mode_private">Always Encrypt.</string>
+    <string name="crypto_mode_supsig_disabled">Never Sign or Encrypt.</string>
+    <string name="crypto_mode_supsig_sign_only">Always Sign, Never Encrypt.</string>
+    <string name="crypto_mode_supsig_opportunistic">Always Sign, Encrypt if possible.</string>
+    <string name="crypto_mode_supsig_private">Always Sign, Always Encrypt.</string>
     <string name="error_crypto_provider_connect">Cannot connect to crypto provider, check your settings or click crypto icon to retry!</string>
     <string name="error_crypto_provider_ui_required">Crypto provider access denied, click crypto icon to retry!</string>
     <string name="error_crypto_inline_attach">PGP/INLINE mode does not support attachments!</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -484,6 +484,13 @@
             android:key="crypto_key"
             android:title="@string/account_settings_crypto_key" />
 
+        <CheckBoxPreference
+            android:persistent="false"
+            android:key="crypto_support_sign_only"
+            android:title="@string/account_settings_crypto_support_sign_only"
+            />
+
+
     </PreferenceScreen>
 
 </PreferenceScreen>

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -412,7 +412,8 @@ public class PgpMessageBuilderTest {
                 .setSigningKeyId(TEST_SIGN_KEY_ID)
                 .setSelfEncryptId(TEST_SELF_ENCRYPT_KEY_ID)
                 .setRecipients(new ArrayList<Recipient>())
-                .setCryptoProviderState(CryptoProviderState.OK);
+                .setCryptoProviderState(CryptoProviderState.OK)
+                .setCryptoSupportSignOnly(true);
     }
 
     private static PgpMessageBuilder createDefaultPgpMessageBuilder(OpenPgpApi openPgpApi) {


### PR DESCRIPTION
I've been thinking about this one for a bit, and I've come to the conclusion that signed-only emails do more harm than good.

1) It's very difficult to explain to non-technical users what a cryptographic signature is, and unlike encryption there is not really a benefit to signed-only mails unless the users knows what they're all about
2) On the sending side, it's not obvious why even non-encrypted messages require a password entry. I received different feedback about this, but most of it boiled down to the simple fact that people don't want to input their password if they send an unencrypted email
3) On the receiving side, the status icon has too many states (Struck-Through-Lock/Checkmark/Lock in broken/unconfirmed/confirmed each, plus unknown-key, plus error states) which makes it quite unintuitive
4) Even among people who know what a crytographic signature is, an unsigned email from a person who usually signs their emails will rarely raise any eyebrows, and even less often trigger an investigation of what's going on. Even a broken signature will usually be attributed to transport breakage.

All things considered, I've come to the conclusion that signatures on emails are nearly useless even for technical users, and they do increase UI complexity which distracts. Consequently, I moved signing of unencrypted messages, and display of signatures (outside of encrypted emails) into an opt-in setting.