### PR TITLE
use AttachmentTempFileProvider to expose file-backed content uris

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,3 +5,4 @@ androidSupportLibraryVersion=23.1.1
 robolectricVersion=3.1.1
 junitVersion=4.12
 mockitoVersion=1.10.19
+okioVersion=1.11.0

--- a/k9mail-library/build.gradle
+++ b/k9mail-library/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     androidTestCompile 'com.android.support.test:runner:0.4.1'
     androidTestCompile 'com.madgag.spongycastle:pg:1.51.0.0'
 
-    testCompile 'com.squareup.okio:okio:1.6.0'
+    testCompile "com.squareup.okio:okio:${okioVersion}"
     testCompile "org.robolectric:robolectric:${robolectricVersion}"
     testCompile "junit:junit:${junitVersion}"
     testCompile "org.mockito:mockito-core:${mockitoVersion}"

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     compile project(':plugins:Android-PullToRefresh:library')
     compile project(':plugins:HoloColorPicker')
     compile project(':plugins:openpgp-api-lib:openpgp-api')
+    compile "com.squareup.okio:okio:${okioVersion}"
     compile 'commons-io:commons-io:2.4'
     compile "com.android.support:support-v4:${androidSupportLibraryVersion}"
     compile 'net.sourceforge.htmlcleaner:htmlcleaner:2.16'

--- a/k9mail/src/main/AndroidManifest.xml
+++ b/k9mail/src/main/AndroidManifest.xml
@@ -422,7 +422,17 @@
             <meta-data
                 android:name="android.support.FILE_PROVIDER_PATHS"
                 android:resource="@xml/decrypted_file_provider_paths" />
+        </provider>
 
+        <provider
+            android:name=".provider.AttachmentTempFileProvider"
+            android:authorities="${applicationId}.tempfileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/temp_file_provider_paths" />
         </provider>
 
     </application>

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -127,13 +127,13 @@ public class AttachmentPresenter {
     }
 
     public void addAttachment(AttachmentViewInfo attachmentViewInfo) {
-        if (attachments.containsKey(attachmentViewInfo.uri)) {
+        if (attachments.containsKey(attachmentViewInfo.internalUri)) {
             throw new IllegalStateException("Received the same attachmentViewInfo twice!");
         }
 
         int loaderId = getNextFreeLoaderId();
         Attachment attachment = Attachment.createAttachment(
-                attachmentViewInfo.uri, loaderId, attachmentViewInfo.mimeType);
+                attachmentViewInfo.internalUri, loaderId, attachmentViewInfo.mimeType);
         attachment = attachment.deriveWithMetadataLoaded(
                 attachmentViewInfo.mimeType, attachmentViewInfo.displayName, attachmentViewInfo.size);
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
@@ -69,7 +69,7 @@ public class AttachmentResolver {
                     String contentId = part.getContentId();
                     if (contentId != null) {
                         AttachmentViewInfo attachmentInfo = attachmentInfoExtractor.extractAttachmentInfo(part);
-                        result.put(contentId, attachmentInfo.uri);
+                        result.put(contentId, attachmentInfo.internalUri);
                     }
                 } catch (MessagingException e) {
                     Log.e(K9.LOG_TAG, "Error extracting attachment info", e);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
@@ -17,20 +17,18 @@ public class AttachmentViewInfo {
      * A content provider URI that can be used to retrieve the decoded attachment.
      * <p/>
      * Note: All content providers must support an alternative MIME type appended as last URI segment.
-     *
-     * @see com.fsck.k9.ui.messageview.AttachmentController#getAttachmentUriForMimeType(AttachmentViewInfo, String)
      */
-    public final Uri uri;
+    public final Uri internalUri;
     public final boolean inlineAttachment;
     public final Part part;
     public final boolean isContentAvailable;
 
-    public AttachmentViewInfo(String mimeType, String displayName, long size, Uri uri, boolean inlineAttachment,
+    public AttachmentViewInfo(String mimeType, String displayName, long size, Uri internalUri, boolean inlineAttachment,
             Part part, boolean isContentAvailable) {
         this.mimeType = mimeType;
         this.displayName = displayName;
         this.size = size;
-        this.uri = uri;
+        this.internalUri = internalUri;
         this.inlineAttachment = inlineAttachment;
         this.part = part;
         this.isContentAvailable = isContentAvailable;

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -49,9 +49,7 @@ public class AttachmentInfoExtractor {
         List<AttachmentViewInfo> attachments = new ArrayList<>();
         for (Part part : attachmentParts) {
             AttachmentViewInfo attachmentViewInfo = extractAttachmentInfo(part);
-            if (!attachmentViewInfo.inlineAttachment) {
-                attachments.add(attachmentViewInfo);
-            }
+            attachments.add(attachmentViewInfo);
         }
 
         return attachments;

--- a/k9mail/src/main/java/com/fsck/k9/provider/AttachmentTempFileProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/AttachmentTempFileProvider.java
@@ -5,8 +5,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.util.Date;
 import java.util.Locale;
 
@@ -24,7 +22,7 @@ import android.util.Log;
 
 import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
-import com.fsck.k9.mail.filter.Hex;
+import okio.ByteString;
 import org.apache.commons.io.IOUtils;
 
 
@@ -62,12 +60,7 @@ public class AttachmentTempFileProvider extends FileProvider {
     }
 
     private static String getTempFilenameForUri(Uri uri) {
-        try {
-            byte[] digest = MessageDigest.getInstance("SHA-1").digest(uri.toString().getBytes());
-            return new String(Hex.encodeHex(digest));
-        } catch (NoSuchAlgorithmException e) {
-            throw new AssertionError(e);
-        }
+        return ByteString.encodeUtf8(uri.toString()).sha1().hex();
     }
 
     private static void writeUriContentToTempFileIfNotExists(Context context, Uri uri, File tempFile)

--- a/k9mail/src/main/java/com/fsck/k9/provider/AttachmentTempFileProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/AttachmentTempFileProvider.java
@@ -1,0 +1,219 @@
+package com.fsck.k9.provider;
+
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Date;
+import java.util.Locale;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.net.Uri;
+import android.os.AsyncTask;
+import android.support.annotation.MainThread;
+import android.support.annotation.NonNull;
+import android.support.annotation.WorkerThread;
+import android.support.v4.content.FileProvider;
+import android.util.Log;
+
+import com.fsck.k9.BuildConfig;
+import com.fsck.k9.K9;
+import com.fsck.k9.mail.filter.Hex;
+import org.apache.commons.io.IOUtils;
+
+
+public class AttachmentTempFileProvider extends FileProvider {
+    private static final String AUTHORITY = BuildConfig.APPLICATION_ID + ".tempfileprovider";
+    private static final String CACHE_DIRECTORY = "temp";
+    private static final long FILE_DELETE_THRESHOLD_MILLISECONDS = 3 * 60 * 1000;
+    private static final Object tempFileWriteMonitor = new Object();
+    private static final Object cleanupReceiverMonitor = new Object();
+
+
+    private static AttachmentTempFileProviderCleanupReceiver cleanupReceiver = null;
+
+
+    @WorkerThread
+    public static Uri createTempUriForContentUri(Context context, Uri uri) throws IOException {
+        Context applicationContext = context.getApplicationContext();
+
+        File tempFile = getTempFileForUri(uri, applicationContext);
+        writeUriContentToTempFileIfNotExists(context, uri, tempFile);
+        Uri tempFileUri = FileProvider.getUriForFile(context, AUTHORITY, tempFile);
+
+        registerFileCleanupReceiver(applicationContext);
+
+        return tempFileUri;
+    }
+
+    @NonNull
+    private static File getTempFileForUri(Uri uri, Context context) {
+        Context applicationContext = context.getApplicationContext();
+
+        String tempFilename = getTempFilenameForUri(uri);
+        File tempDirectory = getTempFileDirectory(applicationContext);
+        return new File(tempDirectory, tempFilename);
+    }
+
+    private static String getTempFilenameForUri(Uri uri) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-1").digest(uri.toString().getBytes());
+            return new String(Hex.encodeHex(digest));
+        } catch (NoSuchAlgorithmException e) {
+            throw new AssertionError(e);
+        }
+    }
+
+    private static void writeUriContentToTempFileIfNotExists(Context context, Uri uri, File tempFile)
+            throws IOException {
+        synchronized (tempFileWriteMonitor) {
+            if (tempFile.exists()) {
+                return;
+            }
+
+            FileOutputStream outputStream = new FileOutputStream(tempFile);
+            InputStream inputStream = context.getContentResolver().openInputStream(uri);
+            if (inputStream == null) {
+                throw new IOException("Failed to resolve content at uri: " + uri);
+            }
+            IOUtils.copy(inputStream, outputStream);
+
+            outputStream.close();
+            IOUtils.closeQuietly(inputStream);
+        }
+    }
+
+    public static Uri getMimeTypeUri(Uri contentUri, String mimeType) {
+        if (!AUTHORITY.equals(contentUri.getAuthority())) {
+            throw new IllegalArgumentException("Can only call this method for URIs within this authority!");
+        }
+        if (contentUri.getQueryParameter("mime_type") != null) {
+            throw new IllegalArgumentException("Can only call this method for not yet typed URIs!");
+        }
+        return contentUri.buildUpon().appendQueryParameter("mime_type", mimeType).build();
+    }
+
+    public static boolean deleteOldTemporaryFiles(Context context) {
+        File tempDirectory = getTempFileDirectory(context);
+        boolean allFilesDeleted = true;
+        long deletionThreshold = new Date().getTime() - FILE_DELETE_THRESHOLD_MILLISECONDS;
+        for (File tempFile : tempDirectory.listFiles()) {
+            long lastModified = tempFile.lastModified();
+            if (lastModified < deletionThreshold) {
+                boolean fileDeleted = tempFile.delete();
+                if (!fileDeleted) {
+                    Log.e(K9.LOG_TAG, "Failed to delete temporary file");
+                    // TODO really do this? might cause our service to stay up indefinitely if a file can't be deleted
+                    allFilesDeleted = false;
+                }
+            } else {
+                if (K9.DEBUG) {
+                    String timeLeftStr = String.format(
+                            Locale.ENGLISH, "%.2f", (lastModified - deletionThreshold) / 1000 / 60.0);
+                    Log.e(K9.LOG_TAG, "Not deleting temp file (for another " + timeLeftStr + " minutes)");
+                }
+                allFilesDeleted = false;
+            }
+        }
+
+        return allFilesDeleted;
+    }
+
+    private static File getTempFileDirectory(Context context) {
+        File directory = new File(context.getCacheDir(), CACHE_DIRECTORY);
+        if (!directory.exists()) {
+            if (!directory.mkdir()) {
+                Log.e(K9.LOG_TAG, "Error creating directory: " + directory.getAbsolutePath());
+            }
+        }
+
+        return directory;
+    }
+
+
+    @Override
+    public String getType(Uri uri) {
+        return uri.getQueryParameter("mime_type");
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void onTrimMemory(int level) {
+        if (level < TRIM_MEMORY_COMPLETE) {
+            return;
+        }
+        final Context context = getContext();
+        if (context == null) {
+            return;
+        }
+
+        new AsyncTask<Void,Void,Void>() {
+            @Override
+            protected Void doInBackground(Void... voids) {
+                deleteOldTemporaryFiles(context);
+                return null;
+            }
+        }.execute();
+
+        unregisterFileCleanupReceiver(context);
+    }
+
+    private static void unregisterFileCleanupReceiver(Context context) {
+        synchronized (cleanupReceiverMonitor) {
+            if (cleanupReceiver == null) {
+                return;
+            }
+
+            if (K9.DEBUG) {
+                Log.d(K9.LOG_TAG, "Unregistering temp file cleanup receiver");
+            }
+            context.unregisterReceiver(cleanupReceiver);
+            cleanupReceiver = null;
+        }
+    }
+
+    private static void registerFileCleanupReceiver(Context context) {
+        synchronized (cleanupReceiverMonitor) {
+            if (cleanupReceiver != null) {
+                return;
+            }
+            if (K9.DEBUG) {
+                Log.d(K9.LOG_TAG, "Registering temp file cleanup receiver");
+            }
+            cleanupReceiver = new AttachmentTempFileProviderCleanupReceiver();
+
+            IntentFilter intentFilter = new IntentFilter();
+            intentFilter.addAction(Intent.ACTION_SCREEN_OFF);
+            context.registerReceiver(cleanupReceiver, intentFilter);
+        }
+    }
+
+    private static class AttachmentTempFileProviderCleanupReceiver extends BroadcastReceiver {
+        @Override
+        @MainThread
+        public void onReceive(Context context, Intent intent) {
+            if (!Intent.ACTION_SCREEN_OFF.equals(intent.getAction())) {
+                throw new IllegalArgumentException("onReceive called with action that isn't screen off!");
+            }
+
+            if (K9.DEBUG) {
+                Log.d(K9.LOG_TAG, "Cleaning up temp files");
+            }
+
+            boolean allFilesDeleted = deleteOldTemporaryFiles(context);
+            if (allFilesDeleted) {
+                unregisterFileCleanupReceiver(context);
+            }
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
@@ -17,6 +17,7 @@ import android.content.pm.ResolveInfo;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Environment;
+import android.support.annotation.WorkerThread;
 import android.util.Log;
 import android.widget.Toast;
 
@@ -34,6 +35,7 @@ import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mailstore.AttachmentViewInfo;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalPart;
+import com.fsck.k9.provider.AttachmentTempFileProvider;
 import org.apache.commons.io.IOUtils;
 
 
@@ -144,7 +146,7 @@ public class AttachmentController {
     }
 
     private void writeAttachmentToStorage(File file) throws IOException {
-        InputStream in = context.getContentResolver().openInputStream(attachment.uri);
+        InputStream in = context.getContentResolver().openInputStream(attachment.internalUri);
         try {
             OutputStream out = new FileOutputStream(file);
             try {
@@ -167,23 +169,33 @@ public class AttachmentController {
         downloadManager.addCompletedDownload(fileName, fileName, true, mimeType, path, fileLength, true);
     }
 
-    private Intent getBestViewIntentAndSaveFileIfNecessary() {
+    @WorkerThread
+    private Intent getBestViewIntentAndSaveFile() {
+        Uri intentDataUri;
+        try {
+            intentDataUri = AttachmentTempFileProvider.createTempUriForContentUri(context, attachment.internalUri);
+        } catch (IOException e) {
+            Log.e(K9.LOG_TAG, "Error creating temp file for attachment!", e);
+            return null;
+        }
+
         String displayName = attachment.displayName;
         String inferredMimeType = MimeUtility.getMimeTypeByExtension(displayName);
 
         IntentAndResolvedActivitiesCount resolvedIntentInfo;
         String mimeType = attachment.mimeType;
         if (MimeUtility.isDefaultMimeType(mimeType)) {
-            resolvedIntentInfo = getBestViewIntentForMimeType(inferredMimeType);
+            resolvedIntentInfo = getBestViewIntentForMimeType(intentDataUri, inferredMimeType);
         } else {
-            resolvedIntentInfo = getBestViewIntentForMimeType(mimeType);
+            resolvedIntentInfo = getBestViewIntentForMimeType(intentDataUri, mimeType);
             if (!resolvedIntentInfo.hasResolvedActivities() && !inferredMimeType.equals(mimeType)) {
-                resolvedIntentInfo = getBestViewIntentForMimeType(inferredMimeType);
+                resolvedIntentInfo = getBestViewIntentForMimeType(intentDataUri, inferredMimeType);
             }
         }
 
         if (!resolvedIntentInfo.hasResolvedActivities()) {
-            resolvedIntentInfo = getBestViewIntentForMimeType(MimeUtility.DEFAULT_ATTACHMENT_MIME_TYPE);
+            resolvedIntentInfo = getBestViewIntentForMimeType(
+                    intentDataUri, MimeUtility.DEFAULT_ATTACHMENT_MIME_TYPE);
         }
 
         Intent viewIntent;
@@ -196,7 +208,7 @@ public class AttachmentController {
                 if (K9.DEBUG) {
                     Log.e(K9.LOG_TAG, "Error while saving attachment to use file:// URI with ACTION_VIEW Intent", e);
                 }
-                viewIntent = createViewIntentForAttachmentProviderUri(MimeUtility.DEFAULT_ATTACHMENT_MIME_TYPE);
+                viewIntent = createViewIntentForAttachmentProviderUri(intentDataUri, MimeUtility.DEFAULT_ATTACHMENT_MIME_TYPE);
             }
         } else {
             viewIntent = resolvedIntentInfo.getIntent();
@@ -205,8 +217,8 @@ public class AttachmentController {
         return viewIntent;
     }
 
-    private IntentAndResolvedActivitiesCount getBestViewIntentForMimeType(String mimeType) {
-        Intent contentUriIntent = createViewIntentForAttachmentProviderUri(mimeType);
+    private IntentAndResolvedActivitiesCount getBestViewIntentForMimeType(Uri contentUri, String mimeType) {
+        Intent contentUriIntent = createViewIntentForAttachmentProviderUri(contentUri, mimeType);
         int contentUriActivitiesCount = getResolvedIntentActivitiesCount(contentUriIntent);
 
         if (contentUriActivitiesCount > 0) {
@@ -225,8 +237,8 @@ public class AttachmentController {
         return new IntentAndResolvedActivitiesCount(contentUriIntent, contentUriActivitiesCount);
     }
 
-    private Intent createViewIntentForAttachmentProviderUri(String mimeType) {
-        Uri uri = getAttachmentUriForMimeType(attachment, mimeType);
+    private Intent createViewIntentForAttachmentProviderUri(Uri contentUri, String mimeType) {
+        Uri uri = AttachmentTempFileProvider.getMimeTypeUri(contentUri, mimeType);
 
         Intent intent = new Intent(Intent.ACTION_VIEW);
         intent.setDataAndType(uri, mimeType);
@@ -234,16 +246,6 @@ public class AttachmentController {
         addUiIntentFlags(intent);
 
         return intent;
-    }
-
-    private Uri getAttachmentUriForMimeType(AttachmentViewInfo attachment, String mimeType) {
-        if (attachment.mimeType.equals(mimeType)) {
-            return attachment.uri;
-        }
-
-        return attachment.uri.buildUpon()
-                .appendPath(mimeType)
-                .build();
     }
 
     private Intent createViewIntentForFileUri(String mimeType, Uri uri) {
@@ -311,7 +313,7 @@ public class AttachmentController {
 
         @Override
         protected Intent doInBackground(Void... params) {
-            return getBestViewIntentAndSaveFileIfNecessary();
+            return getBestViewIntentAndSaveFile();
         }
 
         @Override

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentView.java
@@ -132,7 +132,7 @@ public class AttachmentView extends FrameLayout implements OnClickListener, OnLo
     public void refreshThumbnail() {
         ImageView thumbnailView = (ImageView) findViewById(R.id.attachment_icon);
         Glide.with(getContext())
-                .load(attachment.uri)
+                .load(attachment.internalUri)
                 .placeholder(R.drawable.attached_image_placeholder)
                 .centerCrop()
                 .into(thumbnailView);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -167,14 +167,16 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
                 if (uri == null) {
                     return;
                 }
+                
                 final AttachmentViewInfo attachmentViewInfo = getAttachmentViewInfoIfCidUri(uri);
+                final boolean inlineImage = attachmentViewInfo != null;
 
                 OnMenuItemClickListener listener = new OnMenuItemClickListener() {
                     @Override
                     public boolean onMenuItemClick(MenuItem item) {
                         switch (item.getItemId()) {
                             case MENU_ITEM_IMAGE_VIEW: {
-                                if (attachmentViewInfo != null) {
+                                if (inlineImage) {
                                     attachmentCallback.onViewAttachment(attachmentViewInfo);
                                     break;
                                 }
@@ -183,7 +185,7 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
                                 break;
                             }
                             case MENU_ITEM_IMAGE_SAVE: {
-                                if (attachmentViewInfo != null) {
+                                if (inlineImage) {
                                     attachmentCallback.onSaveAttachment(attachmentViewInfo);
                                     break;
                                 }
@@ -202,20 +204,20 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
                     }
                 };
 
-                menu.setHeaderTitle(attachmentViewInfo == null ?
-                        uri.toString() : context.getString(R.string.webview_contextmenu_image_title));
+                menu.setHeaderTitle(inlineImage ?
+                        context.getString(R.string.webview_contextmenu_image_title) : uri.toString());
 
                 menu.add(Menu.NONE, MENU_ITEM_IMAGE_VIEW, 0,
                         context.getString(R.string.webview_contextmenu_image_view_action))
                         .setOnMenuItemClickListener(listener);
 
                 menu.add(Menu.NONE, MENU_ITEM_IMAGE_SAVE, 1,
-                        attachmentViewInfo == null ?
-                            context.getString(R.string.webview_contextmenu_image_download_action) :
-                            context.getString(R.string.webview_contextmenu_image_save_action))
+                        inlineImage ?
+                                context.getString(R.string.webview_contextmenu_image_save_action) :
+                                context.getString(R.string.webview_contextmenu_image_download_action))
                         .setOnMenuItemClickListener(listener);
 
-                if (attachmentViewInfo == null) {
+                if (!inlineImage) {
                     menu.add(Menu.NONE, MENU_ITEM_IMAGE_COPY, 2,
                             context.getString(R.string.webview_contextmenu_image_copy_action))
                             .setOnMenuItemClickListener(listener);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -178,19 +178,19 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
                             case MENU_ITEM_IMAGE_VIEW: {
                                 if (inlineImage) {
                                     attachmentCallback.onViewAttachment(attachmentViewInfo);
-                                    break;
+                                } else {
+                                    Intent intent = new Intent(Intent.ACTION_VIEW, uri);
+                                    startActivityIfAvailable(getContext(), intent);
                                 }
-                                Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-                                startActivityIfAvailable(getContext(), intent);
                                 break;
                             }
                             case MENU_ITEM_IMAGE_SAVE: {
                                 if (inlineImage) {
                                     attachmentCallback.onSaveAttachment(attachmentViewInfo);
-                                    break;
+                                } else {
+                                    //TODO: Use download manager
+                                    new DownloadImageTask(getContext()).execute(uri.toString());
                                 }
-                                //TODO: Use download manager
-                                new DownloadImageTask(getContext()).execute(uri.toString());
                                 break;
                             }
                             case MENU_ITEM_IMAGE_COPY: {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -324,7 +324,7 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
             return null;
         }
 
-        return attachment.uri.toString();
+        return attachment.internalUri.toString();
     }
 
     private AttachmentViewInfo getAttachmentByContentId(String cid) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -69,7 +69,8 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
     private AttachmentViewCallback attachmentCallback;
     private SavedState mSavedState;
     private ClipboardManager mClipboardManager;
-    private Map<AttachmentViewInfo, AttachmentView> attachments = new HashMap<>();
+    private Map<AttachmentViewInfo, AttachmentView> attachmentViewMap = new HashMap<>();
+    private Map<Uri, AttachmentViewInfo> attachments = new HashMap<>();
     private boolean hasHiddenExternalImages;
 
     private String currentHtmlText;
@@ -162,35 +163,38 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
             }
             case HitTestResult.IMAGE_TYPE:
             case HitTestResult.SRC_IMAGE_ANCHOR_TYPE: {
-                final String url = getUriForExternalAccess(result.getExtra());
-                if (url == null) {
+                final Uri uri = Uri.parse(result.getExtra());
+                if (uri == null) {
                     return;
                 }
+                final AttachmentViewInfo attachmentViewInfo = getAttachmentViewInfoIfCidUri(uri);
 
-                final boolean externalImage = url.startsWith("http");
                 OnMenuItemClickListener listener = new OnMenuItemClickListener() {
                     @Override
                     public boolean onMenuItemClick(MenuItem item) {
                         switch (item.getItemId()) {
                             case MENU_ITEM_IMAGE_VIEW: {
-                                Intent intent = new Intent(Intent.ACTION_VIEW, Uri.parse(url));
-                                if (!externalImage) {
-                                    // Grant read permission if this points to our
-                                    // AttachmentProvider
-                                    intent.addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION);
+                                if (attachmentViewInfo != null) {
+                                    attachmentCallback.onViewAttachment(attachmentViewInfo);
+                                    break;
                                 }
+                                Intent intent = new Intent(Intent.ACTION_VIEW, uri);
                                 startActivityIfAvailable(getContext(), intent);
                                 break;
                             }
                             case MENU_ITEM_IMAGE_SAVE: {
+                                if (attachmentViewInfo != null) {
+                                    attachmentCallback.onSaveAttachment(attachmentViewInfo);
+                                    break;
+                                }
                                 //TODO: Use download manager
-                                new DownloadImageTask(getContext()).execute(url);
+                                new DownloadImageTask(getContext()).execute(uri.toString());
                                 break;
                             }
                             case MENU_ITEM_IMAGE_COPY: {
                                 String label = getContext().getString(
                                         R.string.webview_contextmenu_image_clipboard_label);
-                                mClipboardManager.setText(label, url);
+                                mClipboardManager.setText(label, uri.toString());
                                 break;
                             }
                         }
@@ -198,20 +202,20 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
                     }
                 };
 
-                menu.setHeaderTitle((externalImage) ?
-                        url : context.getString(R.string.webview_contextmenu_image_title));
+                menu.setHeaderTitle(attachmentViewInfo == null ?
+                        uri.toString() : context.getString(R.string.webview_contextmenu_image_title));
 
                 menu.add(Menu.NONE, MENU_ITEM_IMAGE_VIEW, 0,
                         context.getString(R.string.webview_contextmenu_image_view_action))
                         .setOnMenuItemClickListener(listener);
 
                 menu.add(Menu.NONE, MENU_ITEM_IMAGE_SAVE, 1,
-                        (externalImage) ?
+                        attachmentViewInfo == null ?
                             context.getString(R.string.webview_contextmenu_image_download_action) :
                             context.getString(R.string.webview_contextmenu_image_save_action))
                         .setOnMenuItemClickListener(listener);
 
-                if (externalImage) {
+                if (attachmentViewInfo == null) {
                     menu.add(Menu.NONE, MENU_ITEM_IMAGE_COPY, 2,
                             context.getString(R.string.webview_contextmenu_image_copy_action))
                             .setOnMenuItemClickListener(listener);
@@ -312,29 +316,15 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
         }
     }
 
-    private String getUriForExternalAccess(String url) {
-        if (!url.startsWith("cid:")) {
-            return url;
-        }
-
-        String cid = Uri.parse(url).getSchemeSpecificPart();
-
-        AttachmentViewInfo attachment = getAttachmentByContentId(cid);
-        if (attachment == null) {
+    private AttachmentViewInfo getAttachmentViewInfoIfCidUri(Uri uri) {
+        if (!"cid".equals(uri.getScheme())) {
             return null;
         }
 
-        return attachment.internalUri.toString();
-    }
+        String cid = uri.getSchemeSpecificPart();
+        Uri internalUri = currentAttachmentResolver.getAttachmentUriForContentId(cid);
 
-    private AttachmentViewInfo getAttachmentByContentId(String cid) {
-        for (AttachmentViewInfo attachment : attachments.keySet()) {
-            if (cid.equals(attachment.part.getContentId())) {
-                return attachment;
-            }
-        }
-
-        return null;
+        return attachments.get(internalUri);
     }
 
     private void startActivityIfAvailable(Context context, Intent intent) {
@@ -365,13 +355,13 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
     }
 
     public void enableAttachmentButtons() {
-        for (AttachmentView attachmentView : attachments.values()) {
+        for (AttachmentView attachmentView : attachmentViewMap.values()) {
             attachmentView.enableButtons();
         }
     }
 
     public void disableAttachmentButtons() {
-        for (AttachmentView attachmentView : attachments.values()) {
+        for (AttachmentView attachmentView : attachmentViewMap.values()) {
             attachmentView.disableButtons();
         }
     }
@@ -445,22 +435,30 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
     }
 
     public void renderAttachments(MessageViewInfo messageViewInfo) {
-        boolean hasHiddenAttachments = false;
-
         if (messageViewInfo.attachments != null) {
             for (AttachmentViewInfo attachment : messageViewInfo.attachments) {
+                attachments.put(attachment.internalUri, attachment);
+                if (attachment.inlineAttachment) {
+                    continue;
+                }
+
                 AttachmentView view =
                         (AttachmentView) mInflater.inflate(R.layout.message_view_attachment, mAttachments, false);
                 view.setCallback(attachmentCallback);
                 view.setAttachment(attachment);
 
-                attachments.put(attachment, view);
+                attachmentViewMap.put(attachment, view);
                 mAttachments.addView(view);
             }
         }
 
         if (messageViewInfo.extraAttachments != null) {
             for (AttachmentViewInfo attachment : messageViewInfo.extraAttachments) {
+                attachments.put(attachment.internalUri, attachment);
+                if (attachment.inlineAttachment) {
+                    continue;
+                }
+
                 LockedAttachmentView view = (LockedAttachmentView) mInflater
                         .inflate(R.layout.message_view_attachment_locked, mAttachments, false);
                 view.setCallback(attachmentCallback);
@@ -547,7 +545,7 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
     }
 
     private AttachmentView getAttachmentView(AttachmentViewInfo attachment) {
-        return attachments.get(attachment);
+        return attachmentViewMap.get(attachment);
     }
 
     static class SavedState extends BaseSavedState {

--- a/k9mail/src/main/res/xml/temp_file_provider_paths.xml
+++ b/k9mail/src/main/res/xml/temp_file_provider_paths.xml
@@ -1,0 +1,3 @@
+<paths>
+    <cache-path name="temp" path="temp" />
+</paths>

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
@@ -63,7 +63,7 @@ public class AttachmentInfoExtractorTest {
 
         AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(part);
 
-        assertEquals(AttachmentProvider.getAttachmentUri(TEST_ACCOUNT_UUID, TEST_ID), attachmentViewInfo.uri);
+        assertEquals(AttachmentProvider.getAttachmentUri(TEST_ACCOUNT_UUID, TEST_ID), attachmentViewInfo.internalUri);
         assertEquals(TEST_SIZE, attachmentViewInfo.size);
         assertEquals(TEST_MIME_TYPE, attachmentViewInfo.mimeType);
     }
@@ -74,7 +74,7 @@ public class AttachmentInfoExtractorTest {
 
         AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfoForDatabase(part);
 
-        assertEquals(Uri.EMPTY, attachmentViewInfo.uri);
+        assertEquals(Uri.EMPTY, attachmentViewInfo.internalUri);
         assertEquals(AttachmentViewInfo.UNKNOWN_SIZE, attachmentViewInfo.size);
         assertEquals("noname.txt", attachmentViewInfo.displayName);
         assertEquals("text/plain", attachmentViewInfo.mimeType);
@@ -100,7 +100,7 @@ public class AttachmentInfoExtractorTest {
 
         AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfoForDatabase(part);
 
-        assertEquals(Uri.EMPTY, attachmentViewInfo.uri);
+        assertEquals(Uri.EMPTY, attachmentViewInfo.internalUri);
         assertEquals(TEST_MIME_TYPE, attachmentViewInfo.mimeType);
         assertEquals("filename.ext", attachmentViewInfo.displayName);
         assertFalse(attachmentViewInfo.inlineAttachment);
@@ -125,7 +125,7 @@ public class AttachmentInfoExtractorTest {
 
         AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfoForDatabase(part);
 
-        assertEquals(Uri.EMPTY, attachmentViewInfo.uri);
+        assertEquals(Uri.EMPTY, attachmentViewInfo.internalUri);
         assertEquals("filename.ext", attachmentViewInfo.displayName);
         assertFalse(attachmentViewInfo.inlineAttachment);
     }
@@ -203,7 +203,7 @@ public class AttachmentInfoExtractorTest {
         AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(part);
 
 
-        assertEquals(TEST_URI, attachmentViewInfo.uri);
+        assertEquals(TEST_URI, attachmentViewInfo.internalUri);
         assertEquals(TEST_SIZE, attachmentViewInfo.size);
         assertEquals(TEST_MIME_TYPE, attachmentViewInfo.mimeType);
         assertFalse(attachmentViewInfo.inlineAttachment);


### PR DESCRIPTION
This PR changes the "uri" field in AttachmentViewInfo into an internalUri, which is then turned into an externally accessible, file-backed URI in AttachmentController using AttachmentTempFileProvider

Should fix #1644 