### PR TITLE
make sure bcc is filled out correctly when resending

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -476,11 +476,17 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 messageLoaderHelper.asyncStartOrResumeLoadingMessage(mMessageReference, cachedDecryptionResult);
             }
 
-            if (mAction != Action.EDIT_DRAFT) {
-                String alwaysBccString = mAccount.getAlwaysBcc();
-                if (!TextUtils.isEmpty(alwaysBccString)) {
-                    recipientPresenter.addBccAddresses(Address.parse(alwaysBccString));
+            String alwaysBccString = mAccount.getAlwaysBcc();
+            if (mAction == Action.EDIT_DRAFT) {
+                Preferences prefs = Preferences.getPreferences(getApplicationContext());
+                Account account = prefs.getAccount(mMessageReference.getAccountUuid());
+                String folderName = mMessageReference.getFolderName();
+                if (folderName.equals(account.getDraftsFolderName())) {
+                    alwaysBccString = null;
                 }
+            }
+            if (!TextUtils.isEmpty(alwaysBccString)) {
+                recipientPresenter.addBccAddresses(Address.parse(alwaysBccString));
             }
         }
 


### PR DESCRIPTION
when using an existing message as a template for a new mail, the bcc was not filled out correctly.
only when editing an actual draft then the bcc shall not be modified.

so we need to check if the message that we edit is a draft.
if not we need to add the bcc.