### PR TITLE
Rename encryption options

### DIFF
--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1158,8 +1158,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="crypto_mode_disabled">Never Encrypt.</string>
     <string name="crypto_mode_opportunistic">Encrypt if possible.</string>
     <string name="crypto_mode_private">Always Encrypt.</string>
-    <string name="crypto_mode_supsig_disabled">Don't Sign or Encrypt.</string>
-    <string name="crypto_mode_supsig_sign_only">Sign, Don't Encrypt.</string>
+    <string name="crypto_mode_supsig_disabled">Don\'t Sign or Encrypt.</string>
+    <string name="crypto_mode_supsig_sign_only">Sign, Don\'t Encrypt.</string>
     <string name="crypto_mode_supsig_opportunistic">Sign, Encrypt if possible.</string>
     <string name="crypto_mode_supsig_private">Sign and Encrypt.</string>
     <string name="error_crypto_provider_connect">Cannot connect to crypto provider, check your settings or click crypto icon to retry!</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1158,10 +1158,10 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="crypto_mode_disabled">Never Encrypt.</string>
     <string name="crypto_mode_opportunistic">Encrypt if possible.</string>
     <string name="crypto_mode_private">Always Encrypt.</string>
-    <string name="crypto_mode_supsig_disabled">Never Sign or Encrypt.</string>
-    <string name="crypto_mode_supsig_sign_only">Always Sign, Never Encrypt.</string>
-    <string name="crypto_mode_supsig_opportunistic">Always Sign, Encrypt if possible.</string>
-    <string name="crypto_mode_supsig_private">Always Sign, Always Encrypt.</string>
+    <string name="crypto_mode_supsig_disabled">Don't Sign or Encrypt.</string>
+    <string name="crypto_mode_supsig_sign_only">Sign, Don't Encrypt.</string>
+    <string name="crypto_mode_supsig_opportunistic">Sign, Encrypt if possible.</string>
+    <string name="crypto_mode_supsig_private">Sign and Encrypt.</string>
     <string name="error_crypto_provider_connect">Cannot connect to crypto provider, check your settings or click crypto icon to retry!</string>
     <string name="error_crypto_provider_ui_required">Crypto provider access denied, click crypto icon to retry!</string>
     <string name="error_crypto_inline_attach">PGP/INLINE mode does not support attachments!</string>


### PR DESCRIPTION
I keep thinking about this when I'm not actually in a position to change it. I finally remembered it while at a PC.

The 'Always Sign' makes it sound to a user like you're changing a setting. So 'Always Sign, Always Encrypt' sounds like this and future messages will be signed and encrypted. Whereas in practice - it's not a setting it's just for that e-mail (unless my app has been broken).

Instead, use 'Sign' and 'Don't Sign' / 'Encrypt' & 'Don't Encrypt'.

If we want a configurable default, that should be in settings, not on the compose screen.

I'm not expressing an opinion with regard to what settings we support here, just the language we use on the options.