### PR TITLE
Throw instead of returning null when Body.getInputStream() is not supported

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -430,7 +430,7 @@ public class MimeMessage extends Message {
 
     @Override
     public InputStream getInputStream() throws MessagingException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMultipart.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMultipart.java
@@ -106,6 +106,6 @@ public class MimeMultipart extends Multipart {
 
     @Override
     public InputStream getInputStream() throws MessagingException {
-        return null;
+        throw new UnsupportedOperationException();
     }
 }


### PR DESCRIPTION
Inspired by trying to find out what happened in issue #1794