### PR TITLE
update OpenPgpSignatureResult to version 4

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
@@ -260,14 +260,14 @@ public enum MessageCryptoDisplayStatus {
 
             case OpenPgpSignatureResult.RESULT_VALID_KEY_CONFIRMED:
             case OpenPgpSignatureResult.RESULT_VALID_KEY_UNCONFIRMED:
-                switch (signatureResult.getSenderResult()) {
-                    case OpenPgpSignatureResult.SENDER_RESULT_UID_CONFIRMED:
+                switch (signatureResult.getSenderStatusResult()) {
+                    case UNKNOWN:
                         return ENCRYPTED_SIGN_VERIFIED;
-                    case OpenPgpSignatureResult.SENDER_RESULT_UID_UNCONFIRMED:
+                    case USER_ID_UNCONFIRMED:
                         return ENCRYPTED_SIGN_UNVERIFIED;
-                    case OpenPgpSignatureResult.SENDER_RESULT_UID_MISSING:
+                    case USER_ID_MISSING:
                         return ENCRYPTED_SIGN_MISMATCH;
-                    case OpenPgpSignatureResult.SENDER_RESULT_NO_SENDER:
+                    case USER_ID_CONFIRMED:
                         return ENCRYPTED_SIGN_UNVERIFIED;
                 }
                 throw new IllegalStateException("unhandled encrypted result case!");
@@ -300,14 +300,14 @@ public enum MessageCryptoDisplayStatus {
 
             case OpenPgpSignatureResult.RESULT_VALID_KEY_CONFIRMED:
             case OpenPgpSignatureResult.RESULT_VALID_KEY_UNCONFIRMED:
-                switch (signatureResult.getSenderResult()) {
-                    case OpenPgpSignatureResult.SENDER_RESULT_UID_CONFIRMED:
+                switch (signatureResult.getSenderStatusResult()) {
+                    case USER_ID_CONFIRMED:
                         return UNENCRYPTED_SIGN_VERIFIED;
-                    case OpenPgpSignatureResult.SENDER_RESULT_UID_UNCONFIRMED:
+                    case USER_ID_UNCONFIRMED:
                         return UNENCRYPTED_SIGN_UNVERIFIED;
-                    case OpenPgpSignatureResult.SENDER_RESULT_UID_MISSING:
+                    case USER_ID_MISSING:
                         return UNENCRYPTED_SIGN_MISMATCH;
-                    case OpenPgpSignatureResult.SENDER_RESULT_NO_SENDER:
+                    case UNKNOWN:
                         return UNENCRYPTED_SIGN_UNVERIFIED;
                 }
                 throw new IllegalStateException("unhandled encrypted result case!");


### PR DESCRIPTION
See https://github.com/open-keychain/open-keychain/pull/1950

This updates OpenPgpSignatureResult to version 4, which uses an enum for SenderStatusResult instead of int constants. This is much nicer and also consistent with other changes in the pipeline for the tofu trust model info.

This version of the parcelable is backwards compatible (i.e. if OpenKeychain delivers version 3 it's fine) but not forward compatible (if OpenKeychain delivers version 4 while this patch isn't through, K-9 will break), so it's important that K-9 updates *before* OpenKeychain on this one. Version 3 was never deployed outside of K-9 beta, so to reduce compat baggage I'd like to do this while we can. We won't deploy this in OpenKeychain for some time, to further reduce the scenario that someone updates their K-9 from the beta channel but not the OpenKeychain from the stable release channel.