### PR TITLE
ignore leading whitespace for pgp/inline messages

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Stack;
 
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 
 import com.fsck.k9.mail.Body;
@@ -188,13 +189,17 @@ public class MessageDecryptVerifier {
         return isPgpEncrypted || isPgpSigned;
     }
 
-    private static boolean isPartPgpInlineEncryptedOrSigned(Part part) {
+    @VisibleForTesting
+    static boolean isPartPgpInlineEncryptedOrSigned(Part part) {
         if (!part.isMimeType(TEXT_PLAIN) && !part.isMimeType(APPLICATION_PGP)) {
             return false;
         }
         String text = MessageExtractor.getTextFromPart(part, TEXT_LENGTH_FOR_INLINE_CHECK);
-        return !TextUtils.isEmpty(text) &&
-                (text.startsWith(PGP_INLINE_START_MARKER) || text.startsWith(PGP_INLINE_SIGNED_START_MARKER));
+        if (TextUtils.isEmpty(text)) {
+            return false;
+        }
+        text = text.trim();
+        return text.startsWith(PGP_INLINE_START_MARKER) || text.startsWith(PGP_INLINE_SIGNED_START_MARKER);
     }
 
     public static boolean isPartPgpInlineEncrypted(@Nullable Part part) {
@@ -205,7 +210,11 @@ public class MessageDecryptVerifier {
             return false;
         }
         String text = MessageExtractor.getTextFromPart(part, TEXT_LENGTH_FOR_INLINE_CHECK);
-        return !TextUtils.isEmpty(text) && text.startsWith(PGP_INLINE_START_MARKER);
+        if (TextUtils.isEmpty(text)) {
+            return false;
+        }
+        text = text.trim();
+        return text.startsWith(PGP_INLINE_START_MARKER);
     }
 
 }


### PR DESCRIPTION
...in MessageDecryptVerifier (fixes #1823)

What it says on the tin, also adding unit tests. I simply added a call to `.trim()` in the right place. Decryption already works, it was just a problem in the detector.