### PR TITLE
use PendingIntent from encapsulated result if available for showing key info

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
@@ -102,6 +102,17 @@ public final class CryptoResultAnnotation {
     }
 
     @Nullable
+    public PendingIntent getOpenPgpSigningKeyIntentIfAny() {
+        if (hasSignatureResult()) {
+            return getOpenPgpPendingIntent();
+        }
+        if (encapsulatedResult != null && encapsulatedResult.hasSignatureResult()) {
+            return encapsulatedResult.getOpenPgpPendingIntent();
+        }
+        return null;
+    }
+
+    @Nullable
     public PendingIntent getOpenPgpPendingIntent() {
         return openPgpPendingIntent;
     }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -188,7 +188,7 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
 
     public void onClickShowCryptoKey() {
         try {
-            PendingIntent pendingIntent = cryptoResultAnnotation.getOpenPgpPendingIntent();
+            PendingIntent pendingIntent = cryptoResultAnnotation.getOpenPgpSigningKeyIntentIfAny();
             if (pendingIntent != null) {
                 messageCryptoMvpView.startPendingIntentForCryptoPresenter(
                         pendingIntent.getIntentSender(), null, null, 0, 0, 0);


### PR DESCRIPTION
I noticed that the "View Signer" button didn't work in these cases... fixed.