### PR TITLE
Properly handle multipart/digest content type

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
@@ -4,6 +4,7 @@ package com.fsck.k9.mail.internet;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.Multipart;
 
 import java.io.BufferedWriter;
 import java.io.IOException;
@@ -93,7 +94,14 @@ public class MimeBodyPart extends BodyPart {
     @Override
     public String getContentType() {
         String contentType = getFirstHeader(MimeHeader.HEADER_CONTENT_TYPE);
-        return (contentType == null) ? "text/plain" : MimeUtility.unfoldAndDecode(contentType);
+        if (contentType != null) {
+            return MimeUtility.unfoldAndDecode(contentType);
+        }
+        Multipart parent = getParent();
+        if (parent != null && "multipart/digest".equals(parent.getMimeType())) {
+            return "message/rfc822";
+        }
+        return "text/plain";
     }
 
     @Override

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.mailstore;
 
 
+import java.io.ByteArrayInputStream;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -25,6 +26,7 @@ import com.fsck.k9.mail.internet.MimeMessageHelper;
 import com.fsck.k9.mail.internet.MimeMultipart;
 import com.fsck.k9.mail.internet.TextBody;
 import com.fsck.k9.mail.internet.Viewable;
+import com.fsck.k9.mail.internet.Viewable.MessageHeader;
 import com.fsck.k9.mailstore.MessageViewInfoExtractor.ViewableExtractedText;
 import org.junit.Before;
 import org.junit.Test;
@@ -264,6 +266,71 @@ public class MessageViewInfoExtractorTest {
 
         assertEquals(expectedText, container.text);
         assertEquals(expectedHtml, getHtmlBodyText(container.html));
+    }
+
+    @Test
+    public void testMultipartDigestWithMessages() throws Exception {
+        String data = "Content-Type: multipart/digest; boundary=\"bndry\"\r\n" +
+                "\r\n" +
+                "--bndry\r\n" +
+                "\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "\r\n" +
+                "text body of first message\r\n" +
+                "\r\n" +
+                "--bndry\r\n" +
+                "\r\n" +
+                "Subject: subject of second message\r\n" +
+                "Content-Type: multipart/alternative; boundary=\"bndry2\"\r\n" +
+                "\r\n" +
+                "--bndry2\r\n" +
+                "Content-Type: text/plain\r\n" +
+                "\r\n" +
+                "text part of second message\r\n" +
+                "\r\n" +
+                "--bndry2\r\n" +
+                "Content-Type: text/html\"\r\n" +
+                "\r\n" +
+                "html part of second message\r\n" +
+                "\r\n" +
+                "--bndry2--\r\n" +
+                "\r\n" +
+                "--bndry--\r\n";
+        MimeMessage message = MimeMessage.parseMimeMessage(new ByteArrayInputStream(data.getBytes()), false);
+
+        // Extract text
+        List<Part> outputNonViewableParts = new ArrayList<>();
+        ArrayList<Viewable> outputViewableParts = new ArrayList<>();
+        MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
+
+        String expectedExtractedText = "Subject: (No subject)\r\n" +
+                "\r\n" +
+                "text body of first message\r\n" +
+                "\r\n" +
+                "\r\n" +
+                "------------------------------------------------------------------------\r\n" +
+                "\r\n" +
+                "Subject: subject of second message\r\n" +
+                "\r\n" +
+                "text part of second message\r\n";
+        String expectedHtmlText = "<table style=\"border: 0\">" +
+                "<tr><th style=\"text-align: left; vertical-align: top;\">Subject:</th><td>(No subject)</td></tr>" +
+                "</table>" +
+                "<pre class=\"k9mail\">text body of first message<br /></pre>" +
+                "<p style=\"margin-top: 2.5em; margin-bottom: 1em; border-bottom: 1px solid #000\"></p>" +
+                "<table style=\"border: 0\">" +
+                "<tr><th style=\"text-align: left; vertical-align: top;\">Subject:</th><td>subject of second message</td></tr>" +
+                "</table>" +
+                "<pre class=\"k9mail\">text part of second message<br /></pre>";
+
+
+        assertEquals(4, outputViewableParts.size());
+        assertEquals("subject of second message", ((MessageHeader) outputViewableParts.get(2)).getMessage().getSubject());
+
+        ViewableExtractedText firstMessageExtractedText =
+                messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
+        assertEquals(expectedExtractedText, firstMessageExtractedText.text);
+        assertEquals(expectedHtmlText, getHtmlBodyText(firstMessageExtractedText.html));
     }
 
     private static String getHtmlBodyText(String htmlText) {


### PR DESCRIPTION
As per [rfc1341](https://tools.ietf.org/html/rfc1341), the default content-type for sub parts of a multipart/digest part is `message/rfc822` rather than `text/plain` as usual. The mime4j parser handles this correctly and we get a structure of MimeMessage sub-parts, however those don't have an explicit content-type (they have no headers) so they return `text/plain`. This leads to a crash because the text extractor tries to extract the text from a body that considers itself a multipart.

The immediate fix is simple: If a part's parent is `multipart/digest`, return a different default mime type. Though I think we're still dos'able from malformed messages.

This fixes #1794, see the debian digest mail linked there for a real-world test case.