### PR TITLE
Avoid crashing with NPE when creating exception message

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
@@ -54,10 +54,10 @@ public class MessageExtractor {
                         part.isMimeType("application/pgp")) {
                     return getTextFromTextPart(part, body, mimeType, textSizeLimit);
                 } else {
-                    throw new MessagingException("Provided non-text part: " + part);
+                    throw new MessagingException("Provided non-text part: " + mimeType);
                 }
             } else {
-                throw new MessagingException("Provided invalid part: " + part);
+                throw new MessagingException("Provided invalid part");
             }
         } catch (IOException e) {
             Log.e(LOG_TAG, "Unable to getTextFromPart", e);


### PR DESCRIPTION
On Android `Object.toString()` invokes `hashCode()` which potentially throws a `NullPointerException` for `Message` instances.