### PR TITLE
handle attachments with CHILD_PART_CONTAINS_DATA data location

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
@@ -145,7 +145,7 @@ public abstract class Message implements Part, Body {
 
     public abstract boolean hasAttachments();
 
-    public abstract int getSize();
+    public abstract long getSize();
 
     public void delete(String trashFolderName) throws MessagingException {}
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -182,7 +182,7 @@ public class MimeMessage extends Message {
     }
 
     @Override
-    public int getSize() {
+    public long getSize() {
         return mSize;
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -655,7 +655,11 @@ class WebDavFolder extends Folder<WebDavMessage> {
             try {
                 ByteArrayOutputStream out;
 
-                out = new ByteArrayOutputStream(message.getSize());
+                long size = message.getSize();
+                if (size > Integer.MAX_VALUE) {
+                    throw new MessagingException("message size > Integer.MAX_VALUE!");
+                }
+                out = new ByteArrayOutputStream((int) size);
 
                 open(Folder.OPEN_MODE_RW);
                 EOLConvertingOutputStream msgOut = new EOLConvertingOutputStream(

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -740,7 +740,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                 ((Multipart) parentPart.getBody()).addBodyPart(bodyPart);
                 part = bodyPart;
             } else if (MimeUtility.isMessage(parentMimeType)) {
-                Message innerMessage = new MimeMessage();
+                Message innerMessage = new LocalMimeMessage(getAccountUuid(), message, id);
                 parentPart.setBody(innerMessage);
                 part = innerMessage;
             } else {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import android.content.ContentValues;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.support.annotation.VisibleForTesting;
 import android.util.Log;
 
 import com.fsck.k9.Account;
@@ -118,7 +119,7 @@ public class LocalMessage extends MimeMessage {
         setFlagInternal(Flag.ANSWERED, answered);
         setFlagInternal(Flag.FORWARDED, forwarded);
 
-        messagePartId = cursor.getLong(22);
+        setMessagePartId(cursor.getLong(22));
         mimeType = cursor.getString(23);
 
         byte[] header = cursor.getBlob(25);
@@ -127,6 +128,11 @@ public class LocalMessage extends MimeMessage {
         } else {
             Log.d(K9.LOG_TAG, "No headers available for this message!");
         }
+    }
+
+    @VisibleForTesting
+    public void setMessagePartId(long messagePartId) {
+        this.messagePartId = messagePartId;
     }
 
     public long getMessagePartId() {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMimeMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMimeMessage.java
@@ -1,0 +1,35 @@
+package com.fsck.k9.mailstore;
+
+
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.internet.MimeMessage;
+
+
+public class LocalMimeMessage extends MimeMessage implements LocalPart {
+    private final String accountUuid;
+    private final LocalMessage message;
+    private final long messagePartId;
+
+    public LocalMimeMessage(String accountUuid, LocalMessage message, long messagePartId)
+            throws MessagingException {
+        super();
+        this.accountUuid = accountUuid;
+        this.message = message;
+        this.messagePartId = messagePartId;
+    }
+
+    @Override
+    public String getAccountUuid() {
+        return accountUuid;
+    }
+
+    @Override
+    public long getId() {
+        return messagePartId;
+    }
+
+    @Override
+    public LocalMessage getMessage() {
+        return message;
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -716,14 +716,14 @@ public class MessagingControllerTest {
     private Message buildSmallNewMessage() {
         Message message = mock(Message.class);
         when(message.olderThan(any(Date.class))).thenReturn(false);
-        when(message.getSize()).thenReturn(MAXIMUM_SMALL_MESSAGE_SIZE);
+        when(message.getSize()).thenReturn((long) MAXIMUM_SMALL_MESSAGE_SIZE);
         return message;
     }
 
     private Message buildLargeNewMessage() {
         Message message = mock(Message.class);
         when(message.olderThan(any(Date.class))).thenReturn(false);
-        when(message.getSize()).thenReturn(MAXIMUM_SMALL_MESSAGE_SIZE + 1);
+        when(message.getSize()).thenReturn((long) (MAXIMUM_SMALL_MESSAGE_SIZE + 1));
         return message;
     }
 

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/LocalStoreTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/LocalStoreTest.java
@@ -1,0 +1,83 @@
+package com.fsck.k9.mailstore;
+
+
+import com.fsck.k9.mail.Part;
+import com.fsck.k9.mail.internet.MimeBodyPart;
+import com.fsck.k9.mail.internet.MimeMessage;
+import com.fsck.k9.mail.internet.MimeMultipart;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class LocalStoreTest {
+
+    @Test
+    public void findPartById__withRootLocalBodyPart() throws Exception {
+        LocalBodyPart searchRoot = new LocalBodyPart(null, null, 123L, -1L);
+
+        Part part = LocalStore.findPartById(searchRoot, 123L);
+
+        assertSame(searchRoot, part);
+    }
+
+    @Test
+    public void findPartById__withRootLocalMessage() throws Exception {
+        LocalMessage searchRoot = new LocalMessage(null, "uid", null);
+        searchRoot.setMessagePartId(123L);
+
+        Part part = LocalStore.findPartById(searchRoot, 123L);
+
+        assertSame(searchRoot, part);
+    }
+
+    @Test
+    public void findPartById__withNestedLocalBodyPart() throws Exception {
+        LocalBodyPart searchRoot = new LocalBodyPart(null, null, 1L, -1L);
+
+        LocalBodyPart needlePart = new LocalBodyPart(null, null, 123L, -1L);
+        MimeMultipart mimeMultipart = new MimeMultipart("boundary");
+        mimeMultipart.addBodyPart(needlePart);
+        searchRoot.setBody(mimeMultipart);
+
+
+        Part part = LocalStore.findPartById(searchRoot, 123L);
+
+
+        assertSame(needlePart, part);
+    }
+
+    @Test
+    public void findPartById__withNestedLocalMessagePart() throws Exception {
+        LocalBodyPart searchRoot = new LocalBodyPart(null, null, 1L, -1L);
+
+        LocalMimeMessage needlePart = new LocalMimeMessage(null, null, 123L);
+        MimeMultipart mimeMultipart = new MimeMultipart("boundary");
+        mimeMultipart.addBodyPart(new MimeBodyPart(needlePart));
+        searchRoot.setBody(mimeMultipart);
+
+
+        Part part = LocalStore.findPartById(searchRoot, 123L);
+
+
+        assertSame(needlePart, part);
+    }
+
+    @Test
+    public void findPartById__withTwoTimesNestedLocalMessagePart() throws Exception {
+        LocalBodyPart searchRoot = new LocalBodyPart(null, null, 1L, -1L);
+
+        LocalMimeMessage needlePart = new LocalMimeMessage(null, null, 123L);
+        MimeMultipart mimeMultipartInner = new MimeMultipart("boundary");
+        mimeMultipartInner.addBodyPart(new MimeBodyPart(needlePart));
+        MimeMultipart mimeMultipart = new MimeMultipart("boundary");
+        mimeMultipart.addBodyPart(new MimeBodyPart(mimeMultipartInner));
+        searchRoot.setBody(mimeMultipart);
+
+
+        Part part = LocalStore.findPartById(searchRoot, 123L);
+
+
+        assertSame(needlePart, part);
+    }
+}

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
@@ -507,7 +507,7 @@ public class OpenPgpApi {
             return isCancelled;
         }
 
-        private ParcelFileDescriptor startPumpThread() throws IOException {
+        public ParcelFileDescriptor startPumpThread() throws IOException {
             if (writeSidePfd != null) {
                 throw new IllegalStateException("startPumpThread() must only be called once!");
             }


### PR DESCRIPTION
There is not really a very nice way to do this because writing out the data depends on the message strucutre, which we only really have after loading the message. I opted for loading the whole message and writing it with the regular `writeTo()` routines, but also had to change the `getInputStream` logic to `writeToOutputStream`.

fixes #1826 