### PR TITLE
Fix for #1866 - Added settings to turn on/off each type of notification

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -969,6 +969,54 @@ public class K9 extends Application {
         mQuietTimeStarts = quietTimeStarts;
     }
 
+    public static boolean isCertificateErrorNotificationEnabled() {
+        return mCertificateErrorNotificationEnabled;
+    }
+
+    public static void setCertificateErrorNotificationEnabled(boolean mCertificateErrorNotificationEnabled) {
+        K9.mCertificateErrorNotificationEnabled = mCertificateErrorNotificationEnabled;
+    }
+
+    public static boolean isAuthenticationErrorNotificationEnabled() {
+        return mAuthenticationErrorNotificationEnabled;
+    }
+
+    public static void setAuthenticationErrorNotificationEnabled(boolean mAuthenticationErrorNotificationEnabled) {
+        K9.mAuthenticationErrorNotificationEnabled = mAuthenticationErrorNotificationEnabled;
+    }
+
+    public static boolean isSendingNotificationEnabled() {
+        return mSendingNotificationEnabled;
+    }
+
+    public static void setSendingNotificationEnabled(boolean mSendingNotificationEnabled) {
+        K9.mSendingNotificationEnabled = mSendingNotificationEnabled;
+    }
+
+    public static boolean isSendFailedNotificationEnabled() {
+        return mSendFailedNotificationEnabled;
+    }
+
+    public static void setSendFailedNotificationEnabled(boolean mSendFailedNotificationEnabled) {
+        K9.mSendFailedNotificationEnabled = mSendFailedNotificationEnabled;
+    }
+
+    public static boolean isFetchingMailNotificationEnabled() {
+        return mFetchingMailNotificationEnabled;
+    }
+
+    public static void setFetchingMailNotificationEnabled(boolean mFetchingMailNotificationEnabled) {
+        K9.mFetchingMailNotificationEnabled = mFetchingMailNotificationEnabled;
+    }
+
+    public static boolean isNewMailNotificationEnabled() {
+        return mNewMailNotificationEnabled;
+    }
+
+    public static void setNewMailNotificationEnabled(boolean mNewMailNotificationEnabled) {
+        K9.mNewMailNotificationEnabled = mNewMailNotificationEnabled;
+    }
+
     public static String getQuietTimeEnds() {
         return mQuietTimeEnds;
     }

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -241,6 +241,13 @@ public class K9 extends Application {
     private static boolean mHideUserAgent = false;
     private static boolean mHideTimeZone = false;
 
+    private static boolean mCertificateErrorNotificationEnabled = true;
+    private static boolean mAuthenticationErrorNotificationEnabled = true;
+    private static boolean mSendingNotificationEnabled = true;
+    private static boolean mSendFailedNotificationEnabled = true;
+    private static boolean mFetchingMailNotificationEnabled = true;
+    private static boolean mNewMailNotificationEnabled = true;
+
     private static SortType mSortType;
     private static Map<SortType, Boolean> mSortAscending = new HashMap<SortType, Boolean>();
 
@@ -475,6 +482,13 @@ public class K9 extends Application {
         editor.putBoolean("confirmDeleteStarred", mConfirmDeleteStarred);
         editor.putBoolean("confirmSpam", mConfirmSpam);
         editor.putBoolean("confirmDeleteFromNotification", mConfirmDeleteFromNotification);
+
+        editor.putBoolean("certificateErrorNotificationEnabled", mCertificateErrorNotificationEnabled);
+        editor.putBoolean("authenticationErrorNotificationEnabled", mAuthenticationErrorNotificationEnabled);
+        editor.putBoolean("sendingNotificationEnabled", mSendingNotificationEnabled);
+        editor.putBoolean("sendFailedNotificationEnabled", mSendFailedNotificationEnabled);
+        editor.putBoolean("fetchingMailNotificationEnabled", mFetchingMailNotificationEnabled);
+        editor.putBoolean("newMailNotificationEnabled", mNewMailNotificationEnabled);
 
         editor.putString("sortTypeEnum", mSortType.name());
         editor.putBoolean("sortAscending", mSortAscending.get(mSortType));
@@ -721,6 +735,13 @@ public class K9 extends Application {
         if (splitViewMode != null) {
             sSplitViewMode = SplitViewMode.valueOf(splitViewMode);
         }
+
+        mCertificateErrorNotificationEnabled = storage.getBoolean("certificateErrorNotificationEnabled", true);
+        mAuthenticationErrorNotificationEnabled = storage.getBoolean("authenticationErrorNotificationEnabled", true);
+        mSendingNotificationEnabled = storage.getBoolean("sendingNotificationEnabled", true);
+        mSendFailedNotificationEnabled = storage.getBoolean("sendFailedNotificationEnabled", true);
+        mFetchingMailNotificationEnabled = storage.getBoolean("fetchingMailNotificationEnabled", true);
+        mNewMailNotificationEnabled = storage.getBoolean("newMailNotificationEnabled", true);
 
         mAttachmentDefaultPath = storage.getString("attachmentdefaultpath",
                 Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).toString());

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -549,7 +549,7 @@ public class Prefs extends K9PreferenceActivity {
         K9.setFetchingMailNotificationEnabled(mEnableFetchingMailNotification.isChecked());
         K9.setNewMailNotificationEnabled(mEnableNewMailNotification.isChecked());
 
-		K9.setSplitViewMode(SplitViewMode.valueOf(mSplitViewMode.getValue()));
+	K9.setSplitViewMode(SplitViewMode.valueOf(mSplitViewMode.getValue()));
         K9.setAttachmentDefaultPath(mAttachmentPathPreference.getSummary().toString());
         boolean needsRefresh = K9.setBackgroundOps(mBackgroundOps.getValue());
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -88,6 +88,13 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_HIDE_USERAGENT = "privacy_hide_useragent";
     private static final String PREFERENCE_HIDE_TIMEZONE = "privacy_hide_timezone";
 
+    private static final String PREFERENCE_ENABLE_CERTIFICATE_ERROR_NOTIFICATION = "enable_certificate_error_notification";
+    private static final String PREFERENCE_ENABLE_AUTHENTICATION_ERROR_NOTIFICATION = "enable_authentication_error_notification";
+    private static final String PREFERENCE_ENABLE_SENDING_NOTIFICATION = "enable_sending_notification";
+    private static final String PREFERENCE_ENABLE_SEND_FAILED_NOTIFICATION = "enable_send_failed_notification";
+    private static final String PREFERENCE_ENABLE_FETCHING_MAIL_NOTIFICATION = "enable_fetching_mail_notification";
+    private static final String PREFERENCE_ENABLE_NEW_MAIL_NOTIFICATION = "enable_new_mail_notification";
+
     private static final String PREFERENCE_AUTOFIT_WIDTH = "messageview_autofit_width";
     private static final String PREFERENCE_BACKGROUND_OPS = "background_ops";
     private static final String PREFERENCE_DEBUG_LOGGING = "debug_logging";
@@ -150,6 +157,13 @@ public class Prefs extends K9PreferenceActivity {
     private ListPreference mNotificationQuickDelete;
     private ListPreference mLockScreenNotificationVisibility;
     private Preference mAttachmentPathPreference;
+
+    private CheckBoxPreference mEnableCertificateErrorNotification;
+    private CheckBoxPreference mEnableAuthenticationErrorNotification;
+    private CheckBoxPreference mEnableSendingNotification;
+    private CheckBoxPreference mEnableSendFailedNotification;
+    private CheckBoxPreference mEnableFetchingMailNotification;
+    private CheckBoxPreference mEnableNewMailNotification;
 
     private CheckBoxPreference mBackgroundAsUnreadIndicator;
     private CheckBoxPreference mThreadedView;
@@ -355,6 +369,25 @@ public class Prefs extends K9PreferenceActivity {
             mLockScreenNotificationVisibility = null;
         }
 
+        mEnableCertificateErrorNotification = (CheckBoxPreference) findPreference(
+                PREFERENCE_ENABLE_CERTIFICATE_ERROR_NOTIFICATION);
+        mEnableCertificateErrorNotification.setChecked(K9.isCertificateErrorNotificationEnabled());
+        mEnableAuthenticationErrorNotification = (CheckBoxPreference) findPreference(
+                PREFERENCE_ENABLE_AUTHENTICATION_ERROR_NOTIFICATION);
+        mEnableAuthenticationErrorNotification.setChecked(K9.isAuthenticationErrorNotificationEnabled());
+        mEnableSendingNotification = (CheckBoxPreference) findPreference(
+                PREFERENCE_ENABLE_SENDING_NOTIFICATION);
+        mEnableSendingNotification.setChecked(K9.isSendingNotificationEnabled());
+        mEnableSendFailedNotification = (CheckBoxPreference) findPreference(
+                PREFERENCE_ENABLE_SEND_FAILED_NOTIFICATION);
+        mEnableSendFailedNotification.setChecked(K9.isSendFailedNotificationEnabled());
+        mEnableFetchingMailNotification = (CheckBoxPreference) findPreference(
+                PREFERENCE_ENABLE_FETCHING_MAIL_NOTIFICATION);
+        mEnableFetchingMailNotification.setChecked(K9.isFetchingMailNotificationEnabled());
+        mEnableNewMailNotification = (CheckBoxPreference) findPreference(
+                PREFERENCE_ENABLE_NEW_MAIL_NOTIFICATION);
+        mEnableNewMailNotification.setChecked(K9.isNewMailNotificationEnabled());
+				
         mBackgroundOps = setupListPreference(PREFERENCE_BACKGROUND_OPS, K9.getBackgroundOps().name());
 
         mDebugLogging = (CheckBoxPreference)findPreference(PREFERENCE_DEBUG_LOGGING);
@@ -509,7 +542,14 @@ public class Prefs extends K9PreferenceActivity {
                 K9.LockScreenNotificationVisibility.valueOf(mLockScreenNotificationVisibility.getValue()));
         }
 
-        K9.setSplitViewMode(SplitViewMode.valueOf(mSplitViewMode.getValue()));
+        K9.setCertificateErrorNotificationEnabled(mEnableCertificateErrorNotification.isChecked());
+        K9.setAuthenticationErrorNotificationEnabled(mEnableAuthenticationErrorNotification.isChecked());
+        K9.setSendingNotificationEnabled(mEnableSendingNotification.isChecked());
+        K9.setSendFailedNotificationEnabled(mEnableSendFailedNotification.isChecked());
+        K9.setFetchingMailNotificationEnabled(mEnableFetchingMailNotification.isChecked());
+        K9.setNewMailNotificationEnabled(mEnableNewMailNotification.isChecked());
+
+		K9.setSplitViewMode(SplitViewMode.valueOf(mSplitViewMode.getValue()));
         K9.setAttachmentDefaultPath(mAttachmentPathPreference.getSummary().toString());
         boolean needsRefresh = K9.setBackgroundOps(mBackgroundOps.getValue());
 

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationController.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationController.java
@@ -62,6 +62,9 @@ public class NotificationController {
     }
 
     public void showCertificateErrorNotification(Account account, boolean incoming) {
+        if (!K9.isCertificateErrorNotificationEnabled()) {
+            return;
+        }
         certificateErrorNotifications.showCertificateErrorNotification(account, incoming);
     }
 
@@ -70,6 +73,9 @@ public class NotificationController {
     }
 
     public void showAuthenticationErrorNotification(Account account, boolean incoming) {
+        if (!K9.isAuthenticationErrorNotificationEnabled()) {
+            return;
+        }
         authenticationErrorNotifications.showAuthenticationErrorNotification(account, incoming);
     }
 
@@ -78,6 +84,9 @@ public class NotificationController {
     }
 
     public void showSendingNotification(Account account) {
+        if (!K9.isSendingNotificationEnabled()) {
+            return;
+        }
         syncNotifications.showSendingNotification(account);
     }
 
@@ -86,6 +95,9 @@ public class NotificationController {
     }
 
     public void showSendFailedNotification(Account account, Exception exception) {
+        if (!K9.isSendFailedNotificationEnabled()) {
+            return;
+        }
         sendFailedNotifications.showSendFailedNotification(account, exception);
     }
 
@@ -94,6 +106,9 @@ public class NotificationController {
     }
 
     public void showFetchingMailNotification(Account account, Folder folder) {
+        if (!K9.isFetchingMailNotificationEnabled()) {
+            return;
+        }
         syncNotifications.showFetchingMailNotification(account, folder);
     }
 
@@ -102,6 +117,9 @@ public class NotificationController {
     }
 
     public void addNewMailNotification(Account account, LocalMessage message, int previousUnreadMessageCount) {
+        if (!K9.isNewMailNotificationEnabled()) {
+            return;
+        }
         newMailNotifications.addNewMailNotification(account, message, previousUnreadMessageCount);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -271,8 +271,8 @@ public class GlobalSettings {
                 new V(39, new BooleanSetting(true))
             ));
 		
-		// each notification type in com.fsck.k9.notification.NotificationController
-		// can be enabled/disabled with these settings
+	// each notification type in com.fsck.k9.notification.NotificationController
+	// can be enabled/disabled with these settings
         s.put("enableCertificateErrorNotification", Settings.versions(
                 new V(44, new BooleanSetting(true))
             ));

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -270,6 +270,28 @@ public class GlobalSettings {
         s.put("notificationDuringQuietTimeEnabled", Settings.versions(
                 new V(39, new BooleanSetting(true))
             ));
+		
+		// each notification type in com.fsck.k9.notification.NotificationController
+		// can be enabled/disabled with these settings
+        s.put("enableCertificateErrorNotification", Settings.versions(
+                new V(44, new BooleanSetting(true))
+            ));
+        s.put("enableAuthenticationErrorNotification", Settings.versions(
+                new V(44, new BooleanSetting(true))
+            ));
+        s.put("enableSendingNotification", Settings.versions(
+                new V(44, new BooleanSetting(true))
+            ));
+        s.put("enableSendFailedNotification", Settings.versions(
+                new V(44, new BooleanSetting(true))
+            ));
+        s.put("enableFetchingMailNotification", Settings.versions(
+                new V(44, new BooleanSetting(true))
+            ));
+        s.put("enableNewMailNotification", Settings.versions(
+                new V(44, new BooleanSetting(true))
+            ));
+			
         s.put("confirmDiscardMessage", Settings.versions(
                 new V(40, new BooleanSetting(true))
             ));

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 43;
+    public static final int VERSION = 44;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -350,6 +350,24 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_lock_screen_notification_visibility_message_count">Unread message count</string>
     <string name="global_settings_lock_screen_notification_visibility_senders">Message count and senders</string>
     <string name="global_settings_lock_screen_notification_visibility_everything">Same as when screen unlocked</string>
+	
+    <string name="global_settings_enable_certificate_error_notification_label">Certificate Errors</string>
+    <string name="global_settings_enable_certificate_error_notification_summary">Enable notifications for certificate errors.</string>
+
+    <string name="global_settings_enable_authentication_error_notification_label">Authentication Errors</string>
+    <string name="global_settings_enable_authentication_error_notification_summary">Enable notifications for authentication errors.</string>
+	
+    <string name="global_settings_enable_sending_notification_label">Sending Mail</string>
+    <string name="global_settings_enable_sending_notification_summary">Enable notifications for sending mails.</string>
+	
+    <string name="global_settings_enable_send_failed_notification_label">Send Failed</string>
+    <string name="global_settings_enable_send_failed_notification_summary">Enable notifications for messages that failed to send.</string>
+	
+    <string name="global_settings_enable_fetching_mail_notification_label">Fetching Mail</string>
+    <string name="global_settings_enable_fetching_mail_notification_summary">Enable notifications for fetching mails.</string>
+	
+    <string name="global_settings_enable_new_mail_notification_label">New Mail</string>
+    <string name="global_settings_enable_new_mail_notification_summary">Enable notifications for new mails.</string>
 
     <string name="quiet_time">Quiet Time</string>
     <string name="quiet_time_description">Disable ringing, buzzing and flashing at night</string>
@@ -806,6 +824,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="accountlist_preferences">Account list</string>
     <string name="messagelist_preferences">Message lists</string>
     <string name="messageview_preferences">Messages</string>
+    <string name="notification_types_preferences">Notification Types</string>
     <string name="folderlist_preferences">Folder lists</string>
     <string name="settings_theme_label">Theme</string>
     <string name="settings_message_theme_label">Message view theme</string>

--- a/k9mail/src/main/res/xml/global_preferences.xml
+++ b/k9mail/src/main/res/xml/global_preferences.xml
@@ -385,7 +385,7 @@
 
         </PreferenceCategory>
 
-	</PreferenceScreen>
+    </PreferenceScreen>
 
     <PreferenceScreen
         android:title="@string/network_preferences"

--- a/k9mail/src/main/res/xml/global_preferences.xml
+++ b/k9mail/src/main/res/xml/global_preferences.xml
@@ -343,7 +343,49 @@
             android:entryValues="@array/global_settings_lock_screen_notification_visibility_values"
             android:dialogTitle="@string/global_settings_lock_screen_notification_visibility_title" />
 
-    </PreferenceScreen>
+        <PreferenceCategory
+            android:title="@string/notification_types_preferences"
+            android:key="notification_types_preferences">
+
+            <CheckBoxPreference
+                android:persistent="false"
+                android:key="enable_certificate_error_notification"
+                android:title="@string/global_settings_enable_certificate_error_notification_label"
+                android:summary="@string/global_settings_enable_certificate_error_notification_summary"/>
+
+            <CheckBoxPreference
+                android:persistent="false"
+                android:key="enable_authentication_error_notification"
+                android:title="@string/global_settings_enable_authentication_error_notification_label"
+                android:summary="@string/global_settings_enable_authentication_error_notification_summary"/>
+
+            <CheckBoxPreference
+                android:persistent="false"
+                android:key="enable_sending_notification"
+                android:title="@string/global_settings_enable_sending_notification_label"
+                android:summary="@string/global_settings_enable_sending_notification_summary"/>
+
+            <CheckBoxPreference
+                android:persistent="false"
+                android:key="enable_send_failed_notification"
+                android:title="@string/global_settings_enable_send_failed_notification_label"
+                android:summary="@string/global_settings_enable_send_failed_notification_summary"/>
+
+            <CheckBoxPreference
+                android:persistent="false"
+                android:key="enable_fetching_mail_notification"
+                android:title="@string/global_settings_enable_fetching_mail_notification_label"
+                android:summary="@string/global_settings_enable_fetching_mail_notification_summary"/>
+
+            <CheckBoxPreference
+                android:persistent="false"
+                android:key="enable_new_mail_notification"
+                android:title="@string/global_settings_enable_new_mail_notification_label"
+                android:summary="@string/global_settings_enable_new_mail_notification_summary"/>
+
+        </PreferenceCategory>
+
+	</PreferenceScreen>
 
     <PreferenceScreen
         android:title="@string/network_preferences"

--- a/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
@@ -30,10 +30,10 @@ public class SettingsExporterTest {
     }
 
     @Test
-    public void exportPreferences_setsVersionTo43() throws Exception {
+    public void exportPreferences_setsVersionTo44() throws Exception {
         Document document = exportPreferences(false, Collections.<String>emptySet());
 
-        assertEquals("43", document.getRootElement().getAttributeValue("version"));
+        assertEquals("44", document.getRootElement().getAttributeValue("version"));
     }
 
     @Test


### PR DESCRIPTION
This fixes #1866

Added 6 new settings - one for each of the 6 notification types. Using the new settings in the Notification Controller before spawning new notifications. As for the code style: I have taken all existing formatting/pattern from "notificationDuringQuietTimeEnabled" . 

I've tested it and I'm using this branch on my own phone "productively", becasue I need it, as state in #1866  

Adding a screenshot here of how it looks now.
![screenshot_20161223-163413](https://cloud.githubusercontent.com/assets/6048894/21450307/c2e11fa0-c930-11e6-89f1-974b56b7b9b8.png)