### PR TITLE
Hide the entire crypto component for alternate recipients when disabled

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
@@ -198,7 +198,7 @@ public class AlternateRecipientAdapter extends BaseAdapter {
         int cryptoStatusColor = ThemeUtils.getStyledColor(context, cryptoStatusColorAttr);
         drawable.setColorFilter(cryptoStatusColor, Mode.SRC_ATOP);
 
-        holder.itemCryptoStatus.setImageDrawable(drawable);
+        holder.itemCryptoStatusIcon.setImageDrawable(drawable);
         holder.itemCryptoStatus.setVisibility(View.VISIBLE);
     }
 
@@ -211,7 +211,8 @@ public class AlternateRecipientAdapter extends BaseAdapter {
         public final View headerRemove;
         public final TextView itemAddress;
         public final TextView itemAddressLabel;
-        public final ImageView itemCryptoStatus;
+        public final View itemCryptoStatus;
+        public final ImageView itemCryptoStatusIcon;
 
 
         public RecipientTokenHolder(View view) {
@@ -225,7 +226,8 @@ public class AlternateRecipientAdapter extends BaseAdapter {
 
             itemAddress = (TextView) view.findViewById(R.id.alternate_address);
             itemAddressLabel = (TextView) view.findViewById(R.id.alternate_address_label);
-            itemCryptoStatus = (ImageView) view.findViewById(R.id.alternate_crypto_status);
+            itemCryptoStatus = view.findViewById(R.id.alternate_crypto_status);
+            itemCryptoStatusIcon = (ImageView) view.findViewById(R.id.alternate_crypto_status_icon);
         }
 
         public void setShowAsHeader(boolean isHeader) {

--- a/k9mail/src/main/res/layout/recipient_alternate_item.xml
+++ b/k9mail/src/main/res/layout/recipient_alternate_item.xml
@@ -108,6 +108,7 @@
             />
 
         <FrameLayout
+            android:id="@+id/alternate_crypto_status"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:padding="13dp">
@@ -121,7 +122,7 @@
                 />
 
             <ImageView
-                android:id="@+id/alternate_crypto_status"
+                android:id="@+id/alternate_crypto_status_icon"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="left|center_vertical"


### PR DESCRIPTION
Should fix #1914. I don't have a physical device right now so I haven't actually tested it.