### PR TITLE
Fix BCC recipients visible in sent message

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -2,6 +2,8 @@ package com.fsck.k9.mailstore;
 
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.OutputStream;
 import java.util.Date;
 
 import android.content.ContentValues;
@@ -40,6 +42,7 @@ public class LocalMessage extends MimeMessage {
     private long messagePartId;
     private String mimeType;
     private PreviewType previewType;
+    private boolean headerNeedsUpdating = false;
 
 
     private LocalMessage(LocalStore localStore) {
@@ -128,10 +131,12 @@ public class LocalMessage extends MimeMessage {
         } else {
             Log.d(K9.LOG_TAG, "No headers available for this message!");
         }
+        
+        headerNeedsUpdating = false;
     }
 
     @VisibleForTesting
-    public void setMessagePartId(long messagePartId) {
+    void setMessagePartId(long messagePartId) {
         this.messagePartId = messagePartId;
     }
 
@@ -165,12 +170,14 @@ public class LocalMessage extends MimeMessage {
     @Override
     public void setSubject(String subject) {
         mSubject = subject;
+        headerNeedsUpdating = true;
     }
 
 
     @Override
     public void setMessageId(String messageId) {
         mMessageId = messageId;
+        headerNeedsUpdating = true;
     }
 
     @Override
@@ -191,6 +198,7 @@ public class LocalMessage extends MimeMessage {
     @Override
     public void setFrom(Address from) {
         this.mFrom = new Address[] { from };
+        headerNeedsUpdating = true;
     }
 
 
@@ -201,6 +209,8 @@ public class LocalMessage extends MimeMessage {
         } else {
             mReplyTo = replyTo;
         }
+
+        headerNeedsUpdating = true;
     }
 
 
@@ -231,6 +241,8 @@ public class LocalMessage extends MimeMessage {
         } else {
             throw new IllegalArgumentException("Unrecognized recipient type.");
         }
+
+        headerNeedsUpdating = true;
     }
 
     public void setFlagInternal(Flag flag, boolean set) throws MessagingException {
@@ -517,6 +529,7 @@ public class LocalMessage extends MimeMessage {
         message.messagePartId = messagePartId;
         message.mimeType = mimeType;
         message.previewType = previewType;
+        message.headerNeedsUpdating = headerNeedsUpdating;
 
         return message;
     }
@@ -547,6 +560,33 @@ public class LocalMessage extends MimeMessage {
 
     public String getUri() {
         return "email://messages/" +  getAccount().getAccountNumber() + "/" + getFolder().getName() + "/" + getUid();
+    }
+
+    @Override
+    public void writeTo(OutputStream out) throws IOException, MessagingException {
+        if (headerNeedsUpdating) {
+            updateHeader();
+        }
+        
+        super.writeTo(out);
+    }
+
+    private void updateHeader() {
+        super.setSubject(mSubject);
+        super.setReplyTo(mReplyTo);
+        super.setRecipients(RecipientType.TO, mTo);
+        super.setRecipients(RecipientType.CC, mCc);
+        super.setRecipients(RecipientType.BCC, mBcc);
+
+        if (mFrom != null && mFrom.length > 0) {
+            super.setFrom(mFrom[0]);
+        }
+
+        if (mMessageId != null) {
+            super.setMessageId(mMessageId);
+        }
+        
+        headerNeedsUpdating = false;
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -507,10 +507,16 @@ public class LocalMessage extends MimeMessage {
         LocalMessage message = new LocalMessage(localStore);
         super.copy(message);
 
+        message.mReference = mReference;
         message.mId = mId;
         message.mAttachmentCount = mAttachmentCount;
         message.mSubject = mSubject;
         message.mPreview = mPreview;
+        message.mThreadId = mThreadId;
+        message.mRootId = mRootId;
+        message.messagePartId = messagePartId;
+        message.mimeType = mimeType;
+        message.previewType = previewType;
 
         return message;
     }
@@ -532,14 +538,6 @@ public class LocalMessage extends MimeMessage {
             mReference = new MessageReference(getFolder().getAccountUuid(), getFolder().getName(), mUid, null);
         }
         return mReference;
-    }
-
-    @Override
-    protected void copy(MimeMessage destination) {
-        super.copy(destination);
-        if (destination instanceof LocalMessage) {
-            ((LocalMessage)destination).mReference = mReference;
-        }
     }
 
     @Override


### PR DESCRIPTION
Looks like this was broken in all alpha releases since January 2015 -> https://github.com/k9mail/k-9/commit/523ebd0f2afeba538924a5836bc242429c8202ed

This whole mutable `LocalMessage` thing is a mess. I feel dirty :(

Fixes #1938