### PR TITLE
Always show subject in message header when split mode is active

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1435,6 +1435,8 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     public void displayMessageSubject(String subject) {
         if (mDisplayMode == DisplayMode.MESSAGE_VIEW) {
             mActionBarSubject.setText(subject);
+        } else {
+            mActionBarSubject.showSubjectInMessageHeader();
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageTitleView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageTitleView.java
@@ -51,7 +51,7 @@ public class MessageTitleView extends TextView {
                 if (getLayout().getLineCount() > MAX_LINES) {
                     int lineEndIndex = getLayout().getLineEnd(MAX_LINES - 1);
                     setText(getText().subSequence(0, lineEndIndex - 2) + ELLIPSIS);
-                    mHeader.showSubjectLine();
+                    showSubjectInMessageHeader();
                 }
                 mNeedEllipsizeCheck = false;
             }
@@ -61,5 +61,9 @@ public class MessageTitleView extends TextView {
 
     public void setMessageHeader(final MessageHeader header) {
         mHeader = header;
+    }
+    
+    public void showSubjectInMessageHeader() {
+        mHeader.showSubjectLine();
     }
 }


### PR DESCRIPTION
I opted for minimal amount of changes rather than clean code. Hopefully this doesn't live long and we'll get to the UI overhaul soon.

Fixes #1915 