### PR TITLE
Option to disable the mark all as read dialog

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -167,6 +167,7 @@ public class K9 extends Application {
     private static boolean mConfirmDeleteStarred = false;
     private static boolean mConfirmSpam = false;
     private static boolean mConfirmDeleteFromNotification = true;
+    private static boolean mConfirmMarkAllRead = true;
 
     private static NotificationHideSubject sNotificationHideSubject = NotificationHideSubject.NEVER;
 
@@ -475,6 +476,7 @@ public class K9 extends Application {
         editor.putBoolean("confirmDeleteStarred", mConfirmDeleteStarred);
         editor.putBoolean("confirmSpam", mConfirmSpam);
         editor.putBoolean("confirmDeleteFromNotification", mConfirmDeleteFromNotification);
+        editor.putBoolean("confirmMarkAllRead", mConfirmMarkAllRead);
 
         editor.putString("sortTypeEnum", mSortType.name());
         editor.putBoolean("sortAscending", mSortAscending.get(mSortType));
@@ -686,6 +688,7 @@ public class K9 extends Application {
         mConfirmDeleteStarred = storage.getBoolean("confirmDeleteStarred", false);
         mConfirmSpam = storage.getBoolean("confirmSpam", false);
         mConfirmDeleteFromNotification = storage.getBoolean("confirmDeleteFromNotification", true);
+        mConfirmMarkAllRead = storage.getBoolean("confirmMarkAllRead", true);
 
         try {
             String value = storage.getString("sortTypeEnum", Account.DEFAULT_SORT_TYPE.name());
@@ -1170,6 +1173,14 @@ public class K9 extends Application {
 
     public static void setConfirmDeleteFromNotification(final boolean confirm) {
         mConfirmDeleteFromNotification = confirm;
+    }
+
+    public static boolean confirmMarkAllRead() {
+        return mConfirmMarkAllRead;
+    }
+
+    public static void setConfirmMarkAllRead(final boolean confirm) {
+        mConfirmMarkAllRead = confirm;
     }
 
     public static NotificationHideSubject getNotificationHideSubject() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -214,8 +214,8 @@ public class Prefs extends K9PreferenceActivity {
         mConfirmActions = (CheckBoxListPreference) findPreference(PREFERENCE_CONFIRM_ACTIONS);
 
         boolean canDeleteFromNotification = NotificationController.platformSupportsExtendedNotifications();
-        CharSequence[] confirmActionEntries = new CharSequence[canDeleteFromNotification ? 5 : 4];
-        boolean[] confirmActionValues = new boolean[canDeleteFromNotification ? 5 : 4];
+        CharSequence[] confirmActionEntries = new CharSequence[canDeleteFromNotification ? 6 : 5];
+        boolean[] confirmActionValues = new boolean[confirmActionEntries.length];
         int index = 0;
 
         confirmActionEntries[index] = getString(R.string.global_settings_confirm_action_delete);
@@ -230,6 +230,8 @@ public class Prefs extends K9PreferenceActivity {
         confirmActionValues[index++] = K9.confirmSpam();
         confirmActionEntries[index] = getString(R.string.global_settings_confirm_menu_discard);
         confirmActionValues[index++] = K9.confirmDiscardMessage();
+        confirmActionEntries[index] = getString(R.string.global_settings_confirm_menu_mark_all_read);
+        confirmActionValues[index++] = K9.confirmMarkAllRead();
 
         mConfirmActions.setItems(confirmActionEntries);
         mConfirmActions.setCheckedItems(confirmActionValues);
@@ -466,6 +468,7 @@ public class Prefs extends K9PreferenceActivity {
         }
         K9.setConfirmSpam(mConfirmActions.getCheckedItems()[index++]);
         K9.setConfirmDiscardMessage(mConfirmActions.getCheckedItems()[index++]);
+        K9.setConfirmMarkAllRead(mConfirmActions.getCheckedItems()[index++]);
 
         K9.setMeasureAccounts(mMeasureAccounts.isChecked());
         K9.setCountSearchMessages(mCountSearch.isChecked());

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -3455,7 +3455,11 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     public void confirmMarkAllAsRead() {
-        showDialog(R.id.dialog_confirm_mark_all_as_read);
+        if (K9.confirmMarkAllRead()) {
+            showDialog(R.id.dialog_confirm_mark_all_as_read);
+        } else {
+            markAllAsRead();
+        }
     }
 
     public void markAllAsRead() {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -62,6 +62,9 @@ public class GlobalSettings {
         s.put("confirmSpam", Settings.versions(
                 new V(1, new BooleanSetting(false))
             ));
+        s.put("confirmMarkAllRead", Settings.versions(
+                new V(44, new BooleanSetting(false))
+        ));
         s.put("countSearchMessages", Settings.versions(
                 new V(1, new BooleanSetting(false))
             ));

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -63,7 +63,7 @@ public class GlobalSettings {
                 new V(1, new BooleanSetting(false))
             ));
         s.put("confirmMarkAllRead", Settings.versions(
-                new V(44, new BooleanSetting(false))
+                new V(44, new BooleanSetting(true))
         ));
         s.put("countSearchMessages", Settings.versions(
                 new V(1, new BooleanSetting(false))

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 43;
+    public static final int VERSION = 44;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -329,6 +329,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_confirm_action_delete_starred">Delete Starred (in message view)</string>
     <string name="global_settings_confirm_action_spam">Spam</string>
     <string name="global_settings_confirm_menu_discard">Discard message</string>
+    <string name="global_settings_confirm_menu_mark_all_read">Mark all messages as read</string>
     <string name="global_settings_confirm_action_delete_notif">Delete (from notification)</string>
 
     <string name="global_settings_privacy_hide_useragent">Remove K-9 User-Agent from mail headers</string>

--- a/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
@@ -30,10 +30,10 @@ public class SettingsExporterTest {
     }
 
     @Test
-    public void exportPreferences_setsVersionTo43() throws Exception {
+    public void exportPreferences_setsVersionTo44() throws Exception {
         Document document = exportPreferences(false, Collections.<String>emptySet());
 
-        assertEquals("43", document.getRootElement().getAttributeValue("version"));
+        assertEquals("44", document.getRootElement().getAttributeValue("version"));
     }
 
     @Test


### PR DESCRIPTION
This is a fix for #1923 and my first contribution to this project.
I tested it and it looks like it's working. Do I need to add something else? What happens with the translations for the newly added string resource?