### PR TITLE
Don't hardcode check for version in SettingsExporterTest

### DIFF
--- a/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
@@ -30,10 +30,10 @@ public class SettingsExporterTest {
     }
 
     @Test
-    public void exportPreferences_setsVersionTo43() throws Exception {
+    public void exportPreferences_setsVersionToLatest() throws Exception {
         Document document = exportPreferences(false, Collections.<String>emptySet());
 
-        assertEquals("43", document.getRootElement().getAttributeValue("version"));
+        assertEquals(Integer.toString(Settings.VERSION), document.getRootElement().getAttributeValue("version"));
     }
 
     @Test


### PR DESCRIPTION
Otherwise every time we add a setting this test needs to be touched.