### PR TITLE
Add support for obsolete header field format

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeHeader.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeHeader.java
@@ -170,10 +170,6 @@ public class MimeHeader implements Cloneable {
             if (raw == null) {
                 throw new NullPointerException("Argument 'raw' cannot be null");
             }
-            if (name != null && !raw.startsWith(name + ":")) {
-                throw new IllegalArgumentException("The value of 'raw' needs to start with the supplied field name " +
-                        "followed by a colon");
-            }
 
             return new Field(name, null, raw);
         }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MimeMessageParseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MimeMessageParseTest.java
@@ -53,6 +53,16 @@ public class MimeMessageParseTest {
     }
 
     @Test
+    public void headerFieldNameWithSpace() throws Exception {
+        MimeMessage msg = parseWithoutRecurse(toStream("" +
+                "From : <adam@example.org>\r\n" +
+                "\r\n" +
+                "Body"));
+
+        assertEquals("<adam@example.org>", msg.getHeader("From")[0]);
+    }
+
+    @Test
     public void testSinglePart8BitRecurse() throws Exception {
         MimeMessage msg = parseWithRecurse(toStream(
                 "From: <adam@example.org>\r\n" +


### PR DESCRIPTION
Putting whitespace between header field name and colon is valid in the obsolete syntax.

The check in `Field.newRawField()` was an attempt to prevent users from creating invalid `Field` instances. But right now we only use this method with data coming from the MIME4J parser. So even an updated check has the potential to do more harm than good.

Fixes #1959 