### PR TITLE
Allow pgp/inline with sign-only again

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -93,12 +93,16 @@ public class ComposeCryptoStatus {
             return CryptoSpecialModeDisplayType.NONE;
         }
 
-        if (isPgpInlineModeEnabled()) {
-            return CryptoSpecialModeDisplayType.PGP_INLINE;
+        if (isSignOnly() && isPgpInlineModeEnabled()) {
+            return CryptoSpecialModeDisplayType.SIGN_ONLY_PGP_INLINE;
         }
 
         if (isSignOnly()) {
             return CryptoSpecialModeDisplayType.SIGN_ONLY;
+        }
+
+        if (isPgpInlineModeEnabled()) {
+            return CryptoSpecialModeDisplayType.PGP_INLINE;
         }
 
         return CryptoSpecialModeDisplayType.NONE;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -37,6 +37,7 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
 
     private static final int VIEW_INDEX_CRYPTO_SPECIAL_PGP_INLINE = 0;
     private static final int VIEW_INDEX_CRYPTO_SPECIAL_SIGN_ONLY = 1;
+    private static final int VIEW_INDEX_CRYPTO_SPECIAL_SIGN_ONLY_PGP_INLINE = 2;
 
     private static final int VIEW_INDEX_BCC_EXPANDER_VISIBLE = 0;
     private static final int VIEW_INDEX_BCC_EXPANDER_HIDDEN = 1;
@@ -335,14 +336,6 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
         Toast.makeText(activity, R.string.compose_error_private_missing_keys, Toast.LENGTH_LONG).show();
     }
 
-    public void showErrorSignOnlyInline() {
-        Toast.makeText(activity, R.string.error_crypto_sign_only_inline, Toast.LENGTH_LONG).show();
-    }
-
-    public void showErrorInlineSignOnly() {
-        Toast.makeText(activity, R.string.error_crypto_inline_sign_only, Toast.LENGTH_LONG).show();
-    }
-
     public void showErrorInlineAttach() {
         Toast.makeText(activity, R.string.error_crypto_inline_attach, Toast.LENGTH_LONG).show();
     }
@@ -449,7 +442,8 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
     public enum CryptoSpecialModeDisplayType {
         NONE(VIEW_INDEX_HIDDEN),
         PGP_INLINE(VIEW_INDEX_CRYPTO_SPECIAL_PGP_INLINE),
-        SIGN_ONLY(VIEW_INDEX_CRYPTO_SPECIAL_SIGN_ONLY);
+        SIGN_ONLY(VIEW_INDEX_CRYPTO_SPECIAL_SIGN_ONLY),
+        SIGN_ONLY_PGP_INLINE(VIEW_INDEX_CRYPTO_SPECIAL_SIGN_ONLY_PGP_INLINE);
 
 
         final int childToDisplay;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -743,6 +743,7 @@ public class RecipientPresenter implements PermissionPingCallback {
     }
 
     public void onCryptoPgpSignOnlyDisabled() {
+        onCryptoPgpInlineChanged(false);
         onCryptoModeChanged(CryptoMode.OPPORTUNISTIC);
     }
 
@@ -766,10 +767,10 @@ public class RecipientPresenter implements PermissionPingCallback {
 
     void onClickCryptoSpecialModeIndicator() {
         ComposeCryptoStatus currentCryptoStatus = getCurrentCryptoStatus();
-        if (currentCryptoStatus.isPgpInlineModeEnabled()) {
-            recipientMvpView.showOpenPgpInlineDialog(false);
-        } else if (currentCryptoStatus.isSignOnly()) {
+        if (currentCryptoStatus.isSignOnly()) {
             recipientMvpView.showOpenPgpSignOnlyDialog(false);
+        } else if (currentCryptoStatus.isPgpInlineModeEnabled()) {
+            recipientMvpView.showOpenPgpInlineDialog(false);
         } else {
             throw new IllegalStateException("This icon should not be clickable while no special mode is active!");
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -721,16 +721,6 @@ public class RecipientPresenter implements PermissionPingCallback {
     }
 
     public void onMenuSetPgpInline(boolean enablePgpInline) {
-        if (getCurrentCryptoStatus().isSignOnly()) {
-            if (cryptoEnablePgpInline) {
-                Log.e(K9.LOG_TAG, "Inconsistent state: PGP/INLINE was enabled in sign-only mode!");
-                onCryptoPgpInlineChanged(false);
-            }
-
-            recipientMvpView.showErrorSignOnlyInline();
-            return;
-        }
-
         onCryptoPgpInlineChanged(enablePgpInline);
         if (enablePgpInline) {
             boolean shouldShowPgpInlineDialog = checkAndIncrementPgpInlineDialogCounter();
@@ -742,12 +732,6 @@ public class RecipientPresenter implements PermissionPingCallback {
 
     public void onMenuSetSignOnly(boolean enableSignOnly) {
         if (enableSignOnly) {
-            if (getCurrentCryptoStatus().isPgpInlineModeEnabled()) {
-                recipientMvpView.showErrorInlineSignOnly();
-                return;
-            }
-
-            onCryptoPgpInlineChanged(false);
             onCryptoModeChanged(CryptoMode.SIGN_ONLY);
             boolean shouldShowPgpSignOnlyDialog = checkAndIncrementPgpSignOnlyDialogCounter();
             if (shouldShowPgpSignOnlyDialog) {

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -41,7 +41,6 @@ import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
 public class PgpMessageBuilder extends MessageBuilder {
     private static final int REQUEST_USER_INTERACTION = 1;
 
-
     private OpenPgpApi openPgpApi;
 
     private MimeMessage currentProcessedMimeMessage;
@@ -115,16 +114,12 @@ public class PgpMessageBuilder extends MessageBuilder {
                 throw new MessagingException("Attachments are not supported in PGP/INLINE format!");
             }
 
-            if (isPgpInlineMode && shouldSign && !shouldEncrypt) {
-                throw new UnsupportedOperationException("Clearsigning is not supported!");
-            }
-
             if (pgpApiIntent == null) {
                 pgpApiIntent = buildOpenPgpApiIntent(shouldSign, shouldEncrypt, isPgpInlineMode);
             }
 
             PendingIntent returnedPendingIntent = launchOpenPgpApiIntent(
-                    pgpApiIntent, shouldEncrypt, isPgpInlineMode);
+                    pgpApiIntent, shouldEncrypt || isPgpInlineMode, shouldEncrypt || !isPgpInlineMode, isPgpInlineMode);
             if (returnedPendingIntent != null) {
                 queueMessageBuildPendingIntent(returnedPendingIntent, REQUEST_USER_INTERACTION);
                 return;
@@ -174,7 +169,7 @@ public class PgpMessageBuilder extends MessageBuilder {
     }
 
     private PendingIntent launchOpenPgpApiIntent(@NonNull Intent openPgpIntent,
-            boolean captureOutputPart, boolean writeBodyContentOnly) throws MessagingException {
+            boolean captureOutputPart, boolean capturedOutputPartIs7Bit, boolean writeBodyContentOnly) throws MessagingException {
         final MimeBodyPart bodyPart = currentProcessedMimeMessage.toBodyPart();
         String[] contentType = currentProcessedMimeMessage.getHeader(MimeHeader.HEADER_CONTENT_TYPE);
         if (contentType.length > 0) {
@@ -187,7 +182,8 @@ public class PgpMessageBuilder extends MessageBuilder {
         OutputStream outputStream = null;
         if (captureOutputPart) {
             try {
-                pgpResultTempBody = new BinaryTempFileBody(MimeUtil.ENC_7BIT);
+                pgpResultTempBody = new BinaryTempFileBody(
+                        capturedOutputPartIs7Bit ? MimeUtil.ENC_7BIT : MimeUtil.ENC_8BIT);
                 outputStream = pgpResultTempBody.getOutputStream();
                 // OpenKeychain/BouncyCastle at this point use the system newline for formatting, which is LF on android.
                 // we need this to be CRLF, so we convert the data after receiving.

--- a/k9mail/src/main/res/layout/message_compose_recipients.xml
+++ b/k9mail/src/main/res/layout/message_compose_recipients.xml
@@ -51,31 +51,52 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_vertical"
-            android:padding="8dp"
             android:id="@+id/crypto_special_mode"
             android:visibility="gone"
             tools:visibility="visible"
             android:inAnimation="@anim/fade_in"
             android:outAnimation="@anim/fade_out"
-            custom:previewInitialChild="0">
+            custom:previewInitialChild="2">
 
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_vertical"
+                android:layout_margin="8dp"
                 android:src="@drawable/compatibility"
                 android:tint="@color/light_black"
-                android:visibility="gone"
-                tools:visibility="visible"
                 />
 
             <ImageView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center"
+                android:layout_margin="8dp"
                 android:src="@drawable/status_signature_verified_cutout"
                 android:tint="?attr/openpgp_blue"
                 />
+
+            <FrameLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content">
+
+                <ImageView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center"
+                    android:layout_margin="8dp"
+                    android:src="@drawable/status_signature_verified_cutout"
+                    android:tint="?attr/openpgp_blue"
+                    />
+
+                <ImageView
+                    android:layout_width="16dp"
+                    android:layout_height="16dp"
+                    android:layout_gravity="right|bottom"
+                    android:src="@drawable/compatibility"
+                    android:tint="@color/light_black"
+                    />
+            </FrameLayout>
 
         </com.fsck.k9.view.ToolableViewAnimator>
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1136,8 +1136,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="error_crypto_provider_connect">Cannot connect to crypto provider, check your settings or click crypto icon to retry!</string>
     <string name="error_crypto_provider_ui_required">Crypto provider access denied, click crypto icon to retry!</string>
     <string name="error_crypto_inline_attach">PGP/INLINE mode does not support attachments!</string>
-    <string name="error_crypto_inline_sign_only">PGP/INLINE mode does not support sign-only mode!</string>
-    <string name="error_crypto_sign_only_inline">Sign-Only mode does not support PGP/INLINE!</string>
     <string name="enable_inline_pgp">Enable PGP/INLINE</string>
     <string name="disable_inline_pgp">Disable PGP/INLINE</string>
     <string name="enable_sign_only">Enable PGP Sign-Only</string>


### PR DESCRIPTION
While making sign-only a mode of its own I disabled clearsign, to avoid having two "modes" at the same time. Clearsign is a legitimate use case though, so this patch readds it.

I'm not *super happy* with the icon as it is now, but then again both sign-only and pgp/inline are out of most users' way so far that I don't really care... :)

Fixes #1974.

\\ edit

Screenshot for reference:
![](https://lh3.googleusercontent.com/Kx9h5bZgqBjmc94bZeSS0U69btYUC4woP-8MqpDZjgh4iK-TjF6EpGz2zlP7KQ51gIvRtHfb9lQT6bOcMGN-eEwfJmqB)