### PR TITLE
Delete data from Full-Text-Search table

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -322,6 +322,8 @@ public class LocalMessage extends MimeMessage {
                         throw new WrappedException(e);
                     }
 
+                    deleteFulltextIndexEntry(db, mId);
+
                     return null;
                 }
             });

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -153,7 +153,7 @@ public class LocalStore extends Store implements Serializable {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 55;
+    public static final int DB_VERSION = 56;
 
 
     public static String getColumnNameForFlag(Flag flag) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -331,6 +331,10 @@ public class LocalStore extends Store implements Serializable {
                 // Don't delete deleted messages. They are essentially placeholders for UIDs of messages that have
                 // been deleted locally.
                 db.delete("messages", "deleted = 0", null);
+
+                // We don't need the search data now either
+                db.delete("messages_fulltext", null, null);
+
                 return null;
             }
         });

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo56.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo56.java
@@ -1,0 +1,11 @@
+package com.fsck.k9.mailstore.migrations;
+
+
+import android.database.sqlite.SQLiteDatabase;
+
+
+class MigrationTo56 {
+    static void cleanUpFtsTable(SQLiteDatabase db) {
+        db.execSQL("DELETE FROM messages_fulltext WHERE docid NOT IN (SELECT id FROM messages WHERE deleted = 0)");
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
@@ -64,6 +64,8 @@ public class Migrations {
                 MigrationTo54.addPreviewTypeColumn(db);
             case 54:
                 MigrationTo55.createFtsSearchTable(db, migrationsHelper);
+            case 55:
+                MigrationTo56.cleanUpFtsTable(db);
         }
     }
 }


### PR DESCRIPTION
Should fix #1917 

I'm guessing there's other places where we might not be deleting from full-text search (i.e. on deleting messages from the store) but this fixes the problem in the bug report.