### PR TITLE
Call base implementation as per API requirements

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -960,6 +960,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
     @Override
     public boolean onPrepareOptionsMenu(Menu menu) {
+        super.onPrepareOptionsMenu(menu);
         configureMenu(menu);
         return true;
     }


### PR DESCRIPTION
The MessageList options menu isn't displaying properly occasionally (#1984). This isn't a guaranteed fix, because it's barely reproducible on my device anyway. However, per the spec for `onPrepareOptionsMenu`

> The default implementation updates the system menu items based on the activity's state. Deriving classes should always call through to the base class implementation.

https://developer.android.com/reference/android/app/Activity.html#onPrepareOptionsMenu(android.view.Menu)

We do for `MessageCompose`, we don't for `MessageList`

I've only seen this bug reported for MessageList so hopefully this fixes it. If not, well we should be calling it anyway.