### PR TITLE
set content-transfer-encoding for RawDataBody in `setBody`

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessageHelper.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessageHelper.java
@@ -42,6 +42,9 @@ public class MimeMessageHelper {
             part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType);
 
             setEncoding(part, MimeUtil.ENC_QUOTED_PRINTABLE);
+        } else if (body instanceof RawDataBody) {
+            String encoding = ((RawDataBody) body).getEncoding();
+            part.setHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING, encoding);
         }
     }
 


### PR DESCRIPTION
This fixes an issue brought up on the openkeychian tracker: https://github.com/open-keychain/open-keychain/issues/1986

The change is simple and I think it always does the right thing, but it touches `setBody` so it *does* have the potential to subtly change a lot of things.