### PR TITLE
Fixed empty account name at import dialog 2

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -134,7 +134,6 @@ public class SettingsImporter {
             // will not be null.
             if (imported.accounts != null) {
                 for (ImportedAccount account : imported.accounts.values()) {
-                    //Show a alternative text in the case the description is empty
                     String name = account.name;
                     if (TextUtils.isEmpty(name) && account.identities != null && account.identities.size() > 0){
                         name = account.identities.get(0).email;
@@ -942,7 +941,6 @@ public class SettingsImporter {
                             account.settings = parseSettings(xpp, SettingsExporter.SETTINGS_ELEMENT);
                         }
                     } else if (SettingsExporter.IDENTITIES_ELEMENT.equals(element)) {
-                        //Read the full content to have an alternative identifier to display if the name is empty
                         account.identities = parseIdentities(xpp);
                     } else if (SettingsExporter.FOLDERS_ELEMENT.equals(element)) {
                         if (overview) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -134,12 +134,8 @@ public class SettingsImporter {
             // will not be null.
             if (imported.accounts != null) {
                 for (ImportedAccount account : imported.accounts.values()) {
-                    String name = account.name;
-                    if (TextUtils.isEmpty(name) && account.identities != null && account.identities.size() > 0){
-                        name = account.identities.get(0).email;
-                    }
-
-                    accounts.add(new AccountDescription(name, account.uuid));
+                    String accountName = getAccountDisplayName(account);
+                    accounts.add(new AccountDescription(accountName, account.uuid));
                 }
             }
 
@@ -1096,6 +1092,14 @@ public class SettingsImporter {
         folder.settings = parseSettings(xpp, SettingsExporter.FOLDER_ELEMENT);
 
         return folder;
+    }
+
+    private static String getAccountDisplayName(ImportedAccount account) {
+        String name = account.name;
+        if (TextUtils.isEmpty(name) && account.identities != null && account.identities.size() > 0){
+            name = account.identities.get(0).email;
+        }
+        return name;
     }
 
     private static class ImportedServerSettings extends ServerSettings {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -17,6 +17,7 @@ import org.xmlpull.v1.XmlPullParserFactory;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.support.annotation.VisibleForTesting;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.fsck.k9.Account;
@@ -133,7 +134,13 @@ public class SettingsImporter {
             // will not be null.
             if (imported.accounts != null) {
                 for (ImportedAccount account : imported.accounts.values()) {
-                    accounts.add(new AccountDescription(account.name, account.uuid));
+                    //Show a alternative text in the case the description is empty
+                    String name = account.name;
+                    if (TextUtils.isEmpty(name) && account.identities != null && account.identities.size() > 0){
+                        name = account.identities.get(0).email;
+                    }
+
+                    accounts.add(new AccountDescription(name, account.uuid));
                 }
             }
 
@@ -935,11 +942,8 @@ public class SettingsImporter {
                             account.settings = parseSettings(xpp, SettingsExporter.SETTINGS_ELEMENT);
                         }
                     } else if (SettingsExporter.IDENTITIES_ELEMENT.equals(element)) {
-                        if (overview) {
-                            skipToEndTag(xpp, SettingsExporter.IDENTITIES_ELEMENT);
-                        } else {
-                            account.identities = parseIdentities(xpp);
-                        }
+                        //Read the full content to have an alternative identifier to display if the name is empty
+                        account.identities = parseIdentities(xpp);
                     } else if (SettingsExporter.FOLDERS_ELEMENT.equals(element)) {
                         if (overview) {
                             skipToEndTag(xpp, SettingsExporter.FOLDERS_ELEMENT);

--- a/k9mail/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
@@ -1,9 +1,14 @@
 package com.fsck.k9.preferences;
 
+
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 import com.fsck.k9.Account;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.AuthType;
-
 import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.Before;
 import org.junit.Test;
@@ -12,13 +17,9 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+
 
 @SuppressWarnings("unchecked")
 @RunWith(RobolectricTestRunner.class)
@@ -32,7 +33,7 @@ public class SettingsImporterTest {
 
     private void deletePreExistingAccounts() {
         Preferences preferences = Preferences.getPreferences(RuntimeEnvironment.application);
-        for (Account account: preferences.getAccounts()) {
+        for (Account account : preferences.getAccounts()) {
             preferences.deleteAccount(account);
         }
     }
@@ -97,7 +98,7 @@ public class SettingsImporterTest {
     public void parseSettings_account() throws SettingsImportExportException {
         String validUUID = UUID.randomUUID().toString();
         InputStream inputStream = new StringInputStream("<k9settings format=\"1\" version=\"1\">" +
-                "<accounts><account uuid=\""+validUUID+"\"><name>Account</name></account></accounts></k9settings>");
+                "<accounts><account uuid=\"" + validUUID + "\"><name>Account</name></account></accounts></k9settings>");
         List<String> accountUuids = new ArrayList<>();
         accountUuids.add("1");
 
@@ -112,7 +113,7 @@ public class SettingsImporterTest {
     public void parseSettings_account_identities() throws SettingsImportExportException {
         String validUUID = UUID.randomUUID().toString();
         InputStream inputStream = new StringInputStream("<k9settings format=\"1\" version=\"1\">" +
-                "<accounts><account uuid=\""+validUUID+"\"><name>Account</name>" +
+                "<accounts><account uuid=\"" + validUUID + "\"><name>Account</name>" +
                 "<identities><identity><email>user@gmail.com</email></identity></identities>" +
                 "</account></accounts></k9settings>");
         List<String> accountUuids = new ArrayList<>();
@@ -131,7 +132,7 @@ public class SettingsImporterTest {
     public void parseSettings_account_cram_md5() throws SettingsImportExportException {
         String validUUID = UUID.randomUUID().toString();
         InputStream inputStream = new StringInputStream("<k9settings format=\"1\" version=\"1\">" +
-                "<accounts><account uuid=\""+validUUID+"\"><name>Account</name>" +
+                "<accounts><account uuid=\"" + validUUID + "\"><name>Account</name>" +
                 "<incoming-server><authentication-type>CRAM_MD5</authentication-type></incoming-server>" +
                 "</account></accounts></k9settings>");
         List<String> accountUuids = new ArrayList<>();
@@ -148,7 +149,7 @@ public class SettingsImporterTest {
     public void importSettings_disablesAccountsNeedingPasswords() throws SettingsImportExportException {
         String validUUID = UUID.randomUUID().toString();
         InputStream inputStream = new StringInputStream("<k9settings format=\"1\" version=\"1\">" +
-                "<accounts><account uuid=\""+validUUID+"\"><name>Account</name>" +
+                "<accounts><account uuid=\"" + validUUID + "\"><name>Account</name>" +
                 "<incoming-server type=\"IMAP\">" +
                     "<connection-security>SSL_TLS_REQUIRED</connection-security>" +
                     "<username>user@gmail.com</username>" +
@@ -183,9 +184,16 @@ public class SettingsImporterTest {
     public void getImportStreamContents_account() throws SettingsImportExportException {
         String validUUID = UUID.randomUUID().toString();
         InputStream inputStream = new StringInputStream("<k9settings format=\"1\" version=\"1\">" +
-                "<accounts><account uuid=\""+validUUID+"\"><name>Account</name>" +
-                "<identities><identity><email>user@gmail.com</email></identity></identities>" +
-                "</account></accounts></k9settings>");
+                "<accounts>" +
+                    "<account uuid=\"" + validUUID + "\">" +
+                        "<name>Account</name>" +
+                        "<identities>" +
+                            "<identity>" +
+                                "<email>user@gmail.com</email>" +
+                            "</identity>" +
+                        "</identities>" +
+                    "</account>" +
+                "</accounts></k9settings>");
 
         SettingsImporter.ImportContents results = SettingsImporter.getImportStreamContents(inputStream);
 
@@ -199,9 +207,16 @@ public class SettingsImporterTest {
     public void getImportStreamContents_alternativeName() throws SettingsImportExportException {
         String validUUID = UUID.randomUUID().toString();
         InputStream inputStream = new StringInputStream("<k9settings format=\"1\" version=\"1\">" +
-                "<accounts><account uuid=\""+validUUID+"\"><name></name>" +
-                "<identities><identity><email>user@gmail.com</email></identity></identities>" +
-                "</account></accounts></k9settings>");
+                "<accounts>" +
+                    "<account uuid=\"" + validUUID + "\">" +
+                        "<name></name>" +
+                        "<identities>" +
+                            "<identity>" +
+                                "<email>user@gmail.com</email>" +
+                            "</identity>" +
+                        "</identities>" +
+                    "</account>" +
+                "</accounts></k9settings>");
 
         SettingsImporter.ImportContents results = SettingsImporter.getImportStreamContents(inputStream);
 


### PR DESCRIPTION
This PR is fixing a problem with the import settings dialog. In the dialog the name field will be empty if no description is set on the account.
http://i.imgur.com/5dWkfiS.png
The proposed fix is like the main account listing, instead of the name the first identities email is used. For this I had to change the xml parser a bit.

I also made a test for the new behaviour. 