### PR TITLE
handle encrypted parts in multipart/alternative

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
@@ -35,9 +35,9 @@ public class MessageDecryptVerifier {
     // APPLICATION/PGP is a special case which occurs from mutt. see http://www.mutt.org/doc/PGP-Notes.txt
     private static final String APPLICATION_PGP = "application/pgp";
 
-    public static final String PGP_INLINE_START_MARKER = "-----BEGIN PGP MESSAGE-----";
-    public static final String PGP_INLINE_SIGNED_START_MARKER = "-----BEGIN PGP SIGNED MESSAGE-----";
-    public static final int TEXT_LENGTH_FOR_INLINE_CHECK = 36;
+    private static final String PGP_INLINE_START_MARKER = "-----BEGIN PGP MESSAGE-----";
+    private static final String PGP_INLINE_SIGNED_START_MARKER = "-----BEGIN PGP SIGNED MESSAGE-----";
+    private static final int TEXT_LENGTH_FOR_INLINE_CHECK = 36;
 
 
     public static Part findPrimaryEncryptedOrSignedPart(Part part, List<Part> outputExtraParts) {
@@ -45,16 +45,55 @@ public class MessageDecryptVerifier {
             return part;
         }
 
+        Part foundPart;
+
+        foundPart = findPrimaryPartInAlternative(part);
+        if (foundPart != null) {
+            return foundPart;
+        }
+
+        foundPart = findPrimaryPartInMixed(part, outputExtraParts);
+        if (foundPart != null) {
+            return foundPart;
+        }
+
+        return null;
+    }
+
+    @Nullable
+    private static Part findPrimaryPartInMixed(Part part, List<Part> outputExtraParts) {
         Body body = part.getBody();
-        if (part.isMimeType("multipart/mixed") && body instanceof Multipart) {
+
+        boolean isMultipartMixed = part.isMimeType("multipart/mixed") && body instanceof Multipart;
+        if (!isMultipartMixed) {
+            return null;
+        }
+
+        Multipart multipart = (Multipart) body;
+        BodyPart firstBodyPart = multipart.getBodyPart(0);
+
+        Part foundPart;
+        if (isPartEncryptedOrSigned(firstBodyPart)) {
+            foundPart = firstBodyPart;
+        } else {
+            foundPart = findPrimaryPartInAlternative(firstBodyPart);
+        }
+
+        if (foundPart != null && outputExtraParts != null) {
+            for (int i = 1; i < multipart.getCount(); i++) {
+                outputExtraParts.add(multipart.getBodyPart(i));
+            }
+        }
+
+        return foundPart;
+    }
+
+    private static Part findPrimaryPartInAlternative(Part part) {
+        Body body = part.getBody();
+        if (part.isMimeType("multipart/alternative") && body instanceof Multipart) {
             Multipart multipart = (Multipart) body;
             BodyPart firstBodyPart = multipart.getBodyPart(0);
-            if (isPartEncryptedOrSigned(firstBodyPart)) {
-                if (outputExtraParts != null) {
-                    for (int i = 1; i < multipart.getCount(); i++) {
-                        outputExtraParts.add(multipart.getBodyPart(i));
-                    }
-                }
+            if (isPartPgpInlineEncryptedOrSigned(firstBodyPart)) {
                 return firstBodyPart;
             }
         }

--- a/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
@@ -70,6 +70,10 @@ public class MessageDecryptVerifier {
         }
 
         Multipart multipart = (Multipart) body;
+        if (multipart.getCount() == 0) {
+            return null;
+        }
+        
         BodyPart firstBodyPart = multipart.getBodyPart(0);
 
         Part foundPart;
@@ -92,6 +96,10 @@ public class MessageDecryptVerifier {
         Body body = part.getBody();
         if (part.isMimeType("multipart/alternative") && body instanceof Multipart) {
             Multipart multipart = (Multipart) body;
+            if (multipart.getCount() == 0) {
+                return null;
+            }
+            
             BodyPart firstBodyPart = multipart.getBodyPart(0);
             if (isPartPgpInlineEncryptedOrSigned(firstBodyPart)) {
                 return firstBodyPart;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -9,8 +9,10 @@ import java.util.List;
 import android.content.Context;
 import android.support.annotation.VisibleForTesting;
 import android.support.annotation.WorkerThread;
+import android.util.Log;
 
 import com.fsck.k9.Globals;
+import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.helper.HtmlConverter;
 import com.fsck.k9.helper.HtmlSanitizer;
@@ -78,6 +80,9 @@ public class MessageViewInfoExtractor {
             cryptoResultAnnotation = cryptoMessageParts.contentCryptoAnnotation;
             extraParts = cryptoMessageParts.extraParts;
         } else {
+            if (!annotations.isEmpty()) {
+                Log.e(K9.LOG_TAG, "Got message annotations but no crypto root part!");
+            }
             rootPart = message;
             cryptoResultAnnotation = null;
             extraParts = null;

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoAnnotations.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoAnnotations.java
@@ -28,6 +28,10 @@ public class MessageCryptoAnnotations {
         return annotations.containsKey(part);
     }
 
+    public boolean isEmpty() {
+        return annotations.isEmpty();
+    }
+
     public Part findKeyForAnnotationWithReplacementPart(Part part) {
         for (HashMap.Entry<Part, CryptoResultAnnotation> entry : annotations.entrySet()) {
             if (part == entry.getValue().getReplacementData()) {


### PR DESCRIPTION
When people paste a pgp/inline encrypted text into MUAs that send html mails by default, that text often ends up as the first part in a `multipart/alternative`. So far we only considered the first part, or the first part of a multipart/mixed as candidates for the displayed root part. This PR now also considers the first part of `multipart/alternative`, if it has pgp/inline content.

fixes #1901 and #1960