### PR TITLE
Don't crash on unknown content transfer encoding

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
@@ -9,6 +9,7 @@ import java.util.Locale;
 import java.util.regex.Pattern;
 
 import android.support.annotation.NonNull;
+import android.util.Log;
 
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;
@@ -20,6 +21,8 @@ import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.codec.Base64InputStream;
 import org.apache.james.mime4j.codec.QuotedPrintableInputStream;
 import org.apache.james.mime4j.util.MimeUtil;
+
+import static com.fsck.k9.mail.K9MailLib.LOG_TAG;
 
 
 public class MimeUtility {
@@ -1047,7 +1050,8 @@ public class MimeUtility {
                     }
                 };
             } else {
-                throw new UnsupportedContentTransferEncodingException(encoding);
+                Log.w(LOG_TAG, "Unsupported encoding: " + encoding);
+                inputStream = rawInputStream;
             }
         } else {
             inputStream = body.getInputStream();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/UnsupportedContentTransferEncodingException.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/UnsupportedContentTransferEncodingException.java
@@ -1,9 +1,0 @@
-package com.fsck.k9.mail.internet;
-
-import com.fsck.k9.mail.MessagingException;
-
-public class UnsupportedContentTransferEncodingException extends MessagingException {
-    public UnsupportedContentTransferEncodingException(String encoding) {
-        super("Unsupported encoding: "+encoding);
-    }
-}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MessageExtractorTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MessageExtractorTest.java
@@ -75,12 +75,13 @@ public class MessageExtractorTest {
     @Test
     public void getTextFromPart_withUnknownEncoding_shouldReturnNull() throws Exception {
         part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, "text/plain");
-        BinaryMemoryBody body = new BinaryMemoryBody("Sample text body".getBytes(), "unknown encoding");
+        String bodyText = "Sample text body";
+        BinaryMemoryBody body = new BinaryMemoryBody(bodyText.getBytes(), "unknown encoding");
         part.setBody(body);
 
         String result = MessageExtractor.getTextFromPart(part);
         
-        assertNull(result);
+        assertEquals(bodyText, result);
     }
 
     @Test

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MessageExtractorTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MessageExtractorTest.java
@@ -73,7 +73,7 @@ public class MessageExtractorTest {
     }
 
     @Test
-    public void getTextFromPart_withUnknownEncoding_shouldReturnNull() throws Exception {
+    public void getTextFromPart_withUnknownEncoding_shouldReturnUnmodifiedBodyContents() throws Exception {
         part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, "text/plain");
         String bodyText = "Sample text body";
         BinaryMemoryBody body = new BinaryMemoryBody(bodyText.getBytes(), "unknown encoding");

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MimeMessageParseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MimeMessageParseTest.java
@@ -138,7 +138,7 @@ public class MimeMessageParseTest {
                         "");
     }
 
-    @Test(expected = UnsupportedContentTransferEncodingException.class)
+    @Test
     public void testSinglePartUnknownEncoding_throwsUnsupportedEncodingException() throws Exception {
         MimeMessage msg = parseWithoutRecurse(toStream(
                 "From: <adam@example.org>\r\n" +
@@ -150,7 +150,9 @@ public class MimeMessageParseTest {
                         "\r\n" +
                         "dGhpcyBpcyBzb21lIG1vcmUgdGVzdCB0ZXh0Lg==\r\n"));
 
-        MimeUtility.decodeBody(msg.getBody());
+        InputStream inputStream = MimeUtility.decodeBody(msg.getBody());
+
+        assertEquals("dGhpcyBpcyBzb21lIG1vcmUgdGVzdCB0ZXh0Lg==\r\n", streamToString(inputStream));
     }
 
     @Test

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MimeMessageParseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MimeMessageParseTest.java
@@ -139,7 +139,7 @@ public class MimeMessageParseTest {
     }
 
     @Test
-    public void testSinglePartUnknownEncoding_throwsUnsupportedEncodingException() throws Exception {
+    public void decodeBody_withUnknownEncoding_shouldReturnUnmodifiedBodyContents() throws Exception {
         MimeMessage msg = parseWithoutRecurse(toStream(
                 "From: <adam@example.org>\r\n" +
                         "To: <eva@example.org>\r\n" +


### PR DESCRIPTION
See #2044 

This avoids the crash. But to properly fix the issue we have to take the `Content-Transfer-Encoding` into account when collecting viewable parts.