### PR TITLE
Stop trying to process flags on messages in the outbox

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2138,7 +2138,7 @@ public class MessagingController {
     private void processPendingSetFlag(PendingCommand command, Account account) throws MessagingException {
         String folder = command.arguments[0];
 
-        if (account.getErrorFolderName().equals(folder)) {
+        if (account.getErrorFolderName().equals(folder) || account.getOutboxFolderName().equals(folder)) {
             return;
         }
 
@@ -2180,7 +2180,7 @@ public class MessagingController {
         String folder = command.arguments[0];
         String uid = command.arguments[1];
 
-        if (account.getErrorFolderName().equals(folder)) {
+        if (account.getErrorFolderName().equals(folder) || account.getOutboxFolderName().equals(folder)) {
             return;
         }
         if (K9.DEBUG)


### PR DESCRIPTION
The Outbox is like the Errors folder - we never create the folder remotely and so we never append messages to it. Thus there's no need to try and sync flags either.