### PR TITLE
Add happy message about empty folders and inboxes

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -217,6 +217,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
     private ListView mListView;
     private SwipeRefreshLayout mSwipeRefreshLayout;
+    private View mEmptyView;
+    private View mEmptyViewInbox;
     private Parcelable mSavedListState;
 
     private int mPreviewLines = 0;
@@ -945,6 +947,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     private void initializePullToRefresh(View layout) {
         mSwipeRefreshLayout = (SwipeRefreshLayout) layout.findViewById(R.id.swiperefresh);
         mListView = (ListView) layout.findViewById(R.id.message_list);
+        mEmptyViewInbox = layout.findViewById(R.id.empty_view_inbox);
+        mEmptyView = layout.findViewById(R.id.empty_view);
 
         if (isRemoteSearchAllowed()) {
             mSwipeRefreshLayout.setOnRefreshListener(
@@ -976,6 +980,12 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         mListView.setFastScrollEnabled(true);
         mListView.setScrollingCacheEnabled(false);
         mListView.setOnItemClickListener(this);
+
+        if (mFolderName != null && mAccount != null && mFolderName.equals(mAccount.getInboxFolderName())) {
+            mListView.setEmptyView(mEmptyViewInbox);
+        } else {
+            mListView.setEmptyView(mEmptyView);
+        }
 
         registerForContextMenu(mListView);
     }

--- a/k9mail/src/main/res/drawable/ic_inbox_dark.xml
+++ b/k9mail/src/main/res/drawable/ic_inbox_dark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="64dp"
+        android:height="64dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M19,3L4.99,3c-1.11,0 -1.98,0.89 -1.98,2L3,19c0,1.1 0.88,2 1.99,2L19,21c1.1,0 2,-0.9 2,-2L21,5c0,-1.11 -0.9,-2 -2,-2zM19,15h-4c0,1.66 -1.35,3 -3,3s-3,-1.34 -3,-3L4.99,15L4.99,5L19,5v10z"/>
+</vector>

--- a/k9mail/src/main/res/drawable/ic_inbox_light.xml
+++ b/k9mail/src/main/res/drawable/ic_inbox_light.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="64dp"
+        android:height="64dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#646464"
+        android:pathData="M19,3L4.99,3c-1.11,0 -1.98,0.89 -1.98,2L3,19c0,1.1 0.88,2 1.99,2L19,21c1.1,0 2,-0.9 2,-2L21,5c0,-1.11 -0.9,-2 -2,-2zM19,15h-4c0,1.66 -1.35,3 -3,3s-3,-1.34 -3,-3L4.99,15L4.99,5L19,5v10z"/>
+</vector>

--- a/k9mail/src/main/res/drawable/ic_sunny_dark.xml
+++ b/k9mail/src/main/res/drawable/ic_sunny_dark.xml
@@ -1,0 +1,8 @@
+<!-- drawable/white_balance_sunny.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="64dp"
+    android:width="64dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FFFFFF" android:pathData="M3.55,18.54L4.96,19.95L6.76,18.16L5.34,16.74M11,22.45C11.32,22.45 13,22.45 13,22.45V19.5H11M12,5.5A6,6 0 0,0 6,11.5A6,6 0 0,0 12,17.5A6,6 0 0,0 18,11.5C18,8.18 15.31,5.5 12,5.5M20,12.5H23V10.5H20M17.24,18.16L19.04,19.95L20.45,18.54L18.66,16.74M20.45,4.46L19.04,3.05L17.24,4.84L18.66,6.26M13,0.55H11V3.5H13M4,10.5H1V12.5H4M6.76,4.84L4.96,3.05L3.55,4.46L5.34,6.26L6.76,4.84Z" />
+</vector>

--- a/k9mail/src/main/res/drawable/ic_sunny_light.xml
+++ b/k9mail/src/main/res/drawable/ic_sunny_light.xml
@@ -1,0 +1,8 @@
+<!-- drawable/white_balance_sunny.xml -->
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:height="64dp"
+    android:width="64dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#646464" android:pathData="M3.55,18.54L4.96,19.95L6.76,18.16L5.34,16.74M11,22.45C11.32,22.45 13,22.45 13,22.45V19.5H11M12,5.5A6,6 0 0,0 6,11.5A6,6 0 0,0 12,17.5A6,6 0 0,0 18,11.5C18,8.18 15.31,5.5 12,5.5M20,12.5H23V10.5H20M17.24,18.16L19.04,19.95L20.45,18.54L18.66,16.74M20.45,4.46L19.04,3.05L17.24,4.84L18.66,6.26M13,0.55H11V3.5H13M4,10.5H1V12.5H4M6.76,4.84L4.96,3.05L3.55,4.46L5.34,6.26L6.76,4.84Z" />
+</vector>

--- a/k9mail/src/main/res/layout/message_list_fragment.xml
+++ b/k9mail/src/main/res/layout/message_list_fragment.xml
@@ -6,10 +6,69 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <ListView
-        android:id="@+id/message_list"
+    <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:layout_weight="5" />
+        android:layout_weight="5"
+        android:gravity="center">
+
+        <RelativeLayout
+            android:id="@+id/empty_view"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:visibility="gone">
+
+            <ImageView
+                android:id="@+id/empty_view_icon"
+                android:layout_width="64dp"
+                android:layout_height="64dp"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="10dp"
+                android:src="?attr/iconFolderEmpty" />
+
+            <TextView
+                android:id="@+id/empty_view_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/empty_view_icon"
+                android:gravity="center_horizontal"
+                android:text="@string/message_list_empty"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="?android:attr/textColorPrimary" />
+        </RelativeLayout>
+
+        <RelativeLayout
+            android:id="@+id/empty_view_inbox"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:gravity="center"
+            android:visibility="gone">
+
+            <ImageView
+                android:id="@+id/empty_view_inbox_icon"
+                android:layout_width="64dp"
+                android:layout_height="64dp"
+                android:layout_centerHorizontal="true"
+                android:layout_marginBottom="10dp"
+                android:src="?attr/iconInboxEmpty" />
+
+            <TextView
+                android:id="@+id/empty_view_inbox_text"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_below="@id/empty_view_inbox_icon"
+                android:gravity="center_horizontal"
+                android:text="@string/message_list_inbox_empty"
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                android:textColor="?android:attr/textColorPrimary" />
+        </RelativeLayout>
+
+        <ListView
+            android:id="@+id/message_list"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+    </RelativeLayout>
 
 </android.support.v4.widget.SwipeRefreshLayout>

--- a/k9mail/src/main/res/values/attrs.xml
+++ b/k9mail/src/main/res/values/attrs.xml
@@ -37,6 +37,8 @@
         <attr name="iconActionRequestReadReceipt" format="reference" />
         <attr name="iconActionExpand" format="reference" />
         <attr name="iconActionCollapse" format="reference" />
+        <attr name="iconFolderEmpty" format="reference" />
+        <attr name="iconInboxEmpty" format="reference" />
         <attr name="textColorPrimaryRecipientDropdown" format="reference" />
         <attr name="textColorSecondaryRecipientDropdown" format="reference" />
         <attr name="backgroundColorChooseAccountHeader" format="color" />

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1075,6 +1075,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="upgrade_database_format">Upgrading database of account \"<xliff:g id="account">%s</xliff:g>\"</string>
 
     <string name="message_list_loading">Loading…</string>
+    <string name="message_list_empty">There are no messages in this folder.</string>
+    <string name="message_list_inbox_empty">Your inbox is empty. Have a nice day!</string>
 
     <string name="global_settings_splitview_mode_label">Show split-screen</string>
     <string name="global_settings_splitview_always">Always</string>

--- a/k9mail/src/main/res/values/themes.xml
+++ b/k9mail/src/main/res/values/themes.xml
@@ -45,6 +45,8 @@
         <item name="iconActionRequestReadReceipt">@drawable/ic_action_request_read_receipt_light</item>
         <item name="iconActionExpand">@drawable/ic_action_expand_light</item>
         <item name="iconActionCollapse">@drawable/ic_action_collapse_light</item>
+        <item name="iconFolderEmpty">@drawable/ic_inbox_light</item>
+        <item name="iconInboxEmpty">@drawable/ic_sunny_light</item>
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_light</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_light</item>
         <item name="messageListSelectedBackgroundColor">#8038B8E2</item>
@@ -110,6 +112,8 @@
         <item name="iconActionRequestReadReceipt">@drawable/ic_action_request_read_receipt_dark</item>
         <item name="iconActionExpand">@drawable/ic_action_expand_dark</item>
         <item name="iconActionCollapse">@drawable/ic_action_collapse_dark</item>
+        <item name="iconFolderEmpty">@drawable/ic_inbox_dark</item>
+        <item name="iconInboxEmpty">@drawable/ic_sunny_dark</item>
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_dark</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_dark</item>
         <item name="messageListSelectedBackgroundColor">#8038B8E2</item>


### PR DESCRIPTION
K-9 currently looks rather dull if you have no emails in a folder:

<img src="https://cloud.githubusercontent.com/assets/64280/21976646/1efcda9a-dbd3-11e6-90e1-17808f7a3d89.png" width="200">

I suggest to change this, in order to do two things:

* Indicate to the user that the folder is actually empty and the big white area is not just a rendering bug
* Spread some happiness :)

<img src="https://cloud.githubusercontent.com/assets/64280/21976433/148916a6-dbd2-11e6-9829-4c7092357b5e.png" width="200"> <img src="https://cloud.githubusercontent.com/assets/64280/21976432/148912fa-dbd2-11e6-98b5-1e007d756b9c.png" width="200">
<img src="https://cloud.githubusercontent.com/assets/64280/21976434/148acb22-dbd2-11e6-8ff0-34dd90f4bdb7.png" width="200"> <img src="https://cloud.githubusercontent.com/assets/64280/21976435/148bb014-dbd2-11e6-8585-8f840d1aa99d.png" width="200">

I'm still struggling how to recognize the unified inbox as an inbox folder. Any suggestions?