### PR TITLE
Use attribute for delete icon so it works in dark theme

### DIFF
--- a/k9mail/src/main/res/layout/recipient_alternate_item.xml
+++ b/k9mail/src/main/res/layout/recipient_alternate_item.xml
@@ -66,7 +66,7 @@
             android:padding="8dp"
             android:id="@+id/alternate_remove"
             android:background="?android:selectableItemBackground"
-            android:src="@drawable/ic_action_cancel_light"
+            android:src="?attr/iconActionCancel"
             />
 
     </LinearLayout>


### PR DESCRIPTION
Must have missed this one being raised - these are generally really easy to solve. Fixes #2083 