### PR TITLE
Fix for #1761 : Show a warning if timestamp of email and timestamp of…

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -21,6 +21,8 @@ import com.fsck.k9.mailstore.CryptoResultAnnotation;
 import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.view.MessageCryptoDisplayStatus;
 
+import java.util.Date;
+
 
 public class MessageCryptoPresenter implements OnCryptoClickListener {
     public static final int REQUEST_CODE_UNKNOWN_KEY = 123;
@@ -36,6 +38,7 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
 
     // transient state
     private CryptoResultAnnotation cryptoResultAnnotation;
+    private Date messageSentDate;
 
 
     public MessageCryptoPresenter(Bundle savedInstanceState, MessageCryptoMvpView messageCryptoMvpView) {
@@ -52,9 +55,10 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
 
     public boolean maybeHandleShowMessage(MessageTopView messageView, Account account, MessageViewInfo messageViewInfo) {
         this.cryptoResultAnnotation = messageViewInfo.cryptoResultAnnotation;
+        this.messageSentDate = messageViewInfo.message.getSentDate();
 
         MessageCryptoDisplayStatus displayStatus =
-                MessageCryptoDisplayStatus.fromResultAnnotation(messageViewInfo.cryptoResultAnnotation);
+                MessageCryptoDisplayStatus.fromResultAnnotation(messageViewInfo.cryptoResultAnnotation, messageSentDate);
         if (displayStatus == MessageCryptoDisplayStatus.DISABLED) {
             return false;
         }
@@ -89,6 +93,12 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
             case ENCRYPTED_SIGN_ERROR: {
                 showMessageCryptoWarning(messageView, account, messageViewInfo,
                         R.string.messageview_crypto_warning_error);
+                break;
+            }
+            case UNENCRYPTED_SIGN_OLD:
+            case ENCRYPTED_SIGN_OLD: {
+                showMessageCryptoWarning(messageView, account, messageViewInfo,
+                        R.string.messageview_crypto_warning_old);
                 break;
             }
 
@@ -143,7 +153,7 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
             return;
         }
         MessageCryptoDisplayStatus displayStatus =
-                MessageCryptoDisplayStatus.fromResultAnnotation(cryptoResultAnnotation);
+                MessageCryptoDisplayStatus.fromResultAnnotation(cryptoResultAnnotation, messageSentDate);
         switch (displayStatus) {
             case LOADING:
                 // no need to do anything, there is a progress bar...

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1179,6 +1179,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="crypto_msg_sign_revoked">Signature made by revoked key.</string>
     <string name="crypto_msg_sign_insecure">Signature made by insecure key.</string>
     <string name="crypto_msg_sign_incomplete">Message must be fully downloaded to verify its signature.</string>
+    <string name="crypto_msg_sign_old">Signature timestamp differs too much from email timestamp.</string>
 
     <string name="crypto_msg_signed_encrypted">Message is signed and encrypted.</string>
     <string name="crypto_msg_unsigned_encrypted">There is no signature, this message may have been intercepted.</string>
@@ -1199,6 +1200,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="messageview_crypto_warning_revoked">This message was signed by a <b>revoked key!</b></string>
     <string name="messageview_crypto_warning_expired">This message was signed by an <b>expired key!</b></string>
     <string name="messageview_crypto_warning_insecure">This message was signed by an <b>insecure key!</b></string>
+    <string name="messageview_crypto_warning_old">Signature timestamp differs too much from email timestamp!</string>
     <string name="messageview_crypto_warning_error">There was an <b>error in this message\'s signature!</b></string>
     <string name="recipient_error_non_ascii">Special characters are currently not supported!</string>
     <string name="recipient_error_parse_failed">Error parsing address!</string>


### PR DESCRIPTION
… signature are too different.

Fixes #1761 

This prevents a possible replay attack, when using older signed generic messages (eg. "yes").

For user friendliness I decided not to show signature-timestamp additionally on the screen because in 99% that is equal to the email-timestamp.

I decided to show an red warning instead of the orange one, because this is actually something that should never happen.

I have set the constant MAX_ACCEPTABLE_TIME_DELTA_OF_SIGNATURE to 48 hours. But there is still an ongoing discussion, of what value is really good here. I could also make this a user-setting, but I have been told, that the long term intention is to reduce the amount of settings.

So for now this solution is working, but it still has to be checked if 48 hours a good or not?!

![screenshot_20170118-210322](https://cloud.githubusercontent.com/assets/6048894/22066265/292f8530-ddc7-11e6-9ea0-5b24e94a2e27.png)
![screenshot_20170118-210333](https://cloud.githubusercontent.com/assets/6048894/22066266/2933ffc0-ddc7-11e6-89ad-26d1a8bf3a0f.png)
