### PR TITLE
use CHILD_PART_CONTAINS_DATA as data location for multipart

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -1438,7 +1438,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     }
 
     private void multipartToContentValues(ContentValues cv, Multipart multipart) {
-        cv.put("data_location", DataLocation.IN_DATABASE);
+        cv.put("data_location", DataLocation.CHILD_PART_CONTAINS_DATA);
         cv.put("preamble", multipart.getPreamble());
         cv.put("epilogue", multipart.getEpilogue());
         cv.put("boundary", multipart.getBoundary());

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -153,7 +153,7 @@ public class LocalStore extends Store implements Serializable {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 56;
+    public static final int DB_VERSION = 57;
 
 
     public static String getColumnNameForFlag(Flag flag) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo57.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo57.java
@@ -1,0 +1,15 @@
+package com.fsck.k9.mailstore.migrations;
+
+
+import android.database.sqlite.SQLiteDatabase;
+
+
+class MigrationTo57 {
+    private static final int IN_DATABASE = 1;
+    private static final int CHILD_PART_CONTAINS_DATA = 3;
+
+    static void fixDataLocationForMultipartParts(SQLiteDatabase db) {
+        db.execSQL("UPDATE message_parts SET data_location = " + CHILD_PART_CONTAINS_DATA + " " +
+                "WHERE data_location = " + IN_DATABASE + " AND mime_type LIKE 'multipart/%'");
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
@@ -66,6 +66,8 @@ public class Migrations {
                 MigrationTo55.createFtsSearchTable(db, migrationsHelper);
             case 55:
                 MigrationTo56.cleanUpFtsTable(db);
+            case 56:
+                MigrationTo57.fixDataLocationForMultipartParts(db);
         }
     }
 }


### PR DESCRIPTION
Working with `CHILD_PART_CONTAINS_DATA` is handled in `LocalStore.writeCursorPartsToOutputStream` since 0ecbf441c19434a1280dc05aa335f7ee4b6a4d47. Tested that regular messages, and both inline and attached message/rfc822 still work as expected.

fixes #1899 