### PR TITLE
Fix 'Fetching headers null:Folder'

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -161,6 +161,7 @@ public class ActivityListener extends MessagingListener {
     public void synchronizeMailboxFailed(Account account, String folder,
                                          String message) {
         mLoadingAccountDescription = null;
+        mLoadingHeaderFolderName = null;
         mLoadingFolderName = null;
         mAccount = null;
         informUserOfStatus();

--- a/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
@@ -80,6 +80,17 @@ public class ActivityListenerTest {
     }
 
     @Test
+    public void getOperation__whenSynchronizeMailboxFailedAfterHeadersStarted_shouldResultInValidStatus() {
+        activityListener.synchronizeMailboxStarted(account, FOLDER);
+        activityListener.synchronizeMailboxHeadersStarted(account, FOLDER);
+        activityListener.synchronizeMailboxFailed(account, FOLDER, ERROR_MESSAGE);
+
+        String operation = activityListener.getOperation(context);
+
+        assertEquals("Syncing disabled", operation);
+    }
+
+    @Test
     public void getOperation__whenSynchronizeMailboxFinished() {
         activityListener.synchronizeMailboxStarted(account, FOLDER);
         activityListener.synchronizeMailboxFinished(account, FOLDER, COUNT, COUNT);


### PR DESCRIPTION
If sync fails while trying to fetch headers (quite typical if it's an auth failure), you'll currently see 'Fetching headers null:Folder' until the next poll. This fixes that by correctly clearing the header folder name as well.