### PR TITLE
Update targetSdkVersion to 25

### DIFF
--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -53,7 +53,7 @@ android {
         versionName '5.115'
 
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 25
 
         generatedDensities = ['mdpi', 'hdpi', 'xhdpi']
 


### PR DESCRIPTION
Updating to at least 24 will fix #781 
Updating to at least 23 is a necessary pre-requisite of handling #857 

I'd like to see this in a 5.3x beta sooner rather than later because a lot has changed since 22 and so there's room for a lot of unexpected behaviour.

