### PR TITLE
Update labels used for application permissions

### DIFF
--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -79,9 +79,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="app_libraries">We\'re using the following third-party libraries: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="app_emoji_icons">Emoji icons: <xliff:g id="app_emoji_icons_link">%s</xliff:g></string>
 
-    <string name="read_attachment_label">read Email attachments</string>
+    <string name="read_attachment_label">Read Email attachments</string>
     <string name="read_attachment_desc">Allows this application to read your Email attachments.</string>
-    <string name="read_messages_label">read Emails</string>
+    <string name="read_messages_label">Read Emails</string>
     <string name="read_messages_desc">Allows this application to read your Emails.</string>
     <string name="delete_messages_label">Delete Emails</string>
     <string name="delete_messages_desc">Allows this application to delete your Emails.</string>


### PR DESCRIPTION
I don't know whether the default strings  are best updated here or in Transifex. 

These values are shown to the end user in my version of Android - see screenshot in #2110 