### PR TITLE
Set appropriate categories for notifications

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotifications.java
@@ -42,7 +42,8 @@ class AuthenticationErrorNotifications {
                 .setContentText(text)
                 .setContentIntent(editServerSettingsPendingIntent)
                 .setStyle(new BigTextStyle().bigText(text))
-                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setCategory(NotificationCompat.CATEGORY_ERROR);
 
         controller.configureNotification(builder, null, null,
                 NOTIFICATION_LED_FAILURE_COLOR,

--- a/k9mail/src/main/java/com/fsck/k9/notification/BaseNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/BaseNotifications.java
@@ -55,7 +55,8 @@ abstract class BaseNotifications {
                 .setSmallIcon(getNewMailNotificationIcon())
                 .setColor(account.getChipColor())
                 .setWhen(System.currentTimeMillis())
-                .setAutoCancel(true);
+                .setAutoCancel(true)
+                .setCategory(NotificationCompat.CATEGORY_EMAIL);
     }
 
     protected boolean isDeleteActionEnabled() {

--- a/k9mail/src/main/java/com/fsck/k9/notification/CertificateErrorNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/CertificateErrorNotifications.java
@@ -40,7 +40,8 @@ class CertificateErrorNotifications {
                 .setContentTitle(title)
                 .setContentText(text)
                 .setContentIntent(editServerSettingsPendingIntent)
-                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setCategory(NotificationCompat.CATEGORY_ERROR);
 
         controller.configureNotification(builder, null, null,
                 NOTIFICATION_LED_FAILURE_COLOR,

--- a/k9mail/src/main/java/com/fsck/k9/notification/LockScreenNotification.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/LockScreenNotification.java
@@ -99,7 +99,8 @@ class LockScreenNotification {
                 .setSmallIcon(R.drawable.notification_icon_new_mail)
                 .setColor(account.getChipColor())
                 .setNumber(unreadCount)
-                .setContentTitle(title);
+                .setContentTitle(title)
+                .setCategory(NotificationCompat.CATEGORY_EMAIL);
     }
 
 

--- a/k9mail/src/main/java/com/fsck/k9/notification/SendFailedNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/SendFailedNotifications.java
@@ -41,7 +41,8 @@ class SendFailedNotifications {
                 .setContentTitle(title)
                 .setContentText(text)
                 .setContentIntent(folderListPendingIntent)
-                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setCategory(NotificationCompat.CATEGORY_ERROR);
 
         controller.configureNotification(builder, null, null, NOTIFICATION_LED_FAILURE_COLOR,
                 NOTIFICATION_LED_BLINK_FAST, true);

--- a/k9mail/src/main/java/com/fsck/k9/notification/SyncNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/SyncNotifications.java
@@ -83,7 +83,8 @@ class SyncNotifications {
                 .setContentTitle(title)
                 .setContentText(text)
                 .setContentIntent(showMessageListPendingIntent)
-                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC);
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setCategory(NotificationCompat.CATEGORY_SERVICE);
 
         if (NOTIFICATION_LED_WHILE_SYNCING) {
             controller.configureNotification(builder, null, null,


### PR DESCRIPTION
Per the Android Material design guidelines we ought to be setting categories to tell Android better about what we're notifying: https://material.io/guidelines/patterns/notifications.html#notifications-settings-priority

I've updated all the different types with the most appropriate category.