### PR TITLE
add missing pgpSignOnlyDialogCounter to GlobalSettings

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -279,6 +279,9 @@ public class GlobalSettings {
         s.put("pgpInlineDialogCounter", Settings.versions(
                 new V(43, new IntegerRangeSetting(0, Integer.MAX_VALUE, 0))
         ));
+        s.put("pgpSignOnlyDialogCounter", Settings.versions(
+                new V(45, new IntegerRangeSetting(0, Integer.MAX_VALUE, 0))
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 44;
+    public static final int VERSION = 45;
 
     public static Map<String, Object> validate(int version, Map<String,
             TreeMap<Integer, SettingsDescription>> settings,


### PR DESCRIPTION
Forgot to add that one, it seems. The version at that point was 43 (which also added pgpInlineDialogCounter), and this should have been in there from that point on so I didn't increment the version number but just retrofitted it in.