### PR TITLE
Settings classes cleanup

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -1,6 +1,7 @@
 
 package com.fsck.k9;
 
+
 import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,13 +34,12 @@ import com.fsck.k9.controller.MessagingListener;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.Message;
-import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.BinaryTempFileBody;
+import com.fsck.k9.mail.ssl.LocalKeyStore;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
 import com.fsck.k9.provider.UnreadWidgetProvider;
-import com.fsck.k9.mail.ssl.LocalKeyStore;
 import com.fsck.k9.service.BootReceiver;
 import com.fsck.k9.service.MailService;
 import com.fsck.k9.service.ShutdownReceiver;

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -32,12 +32,11 @@ import com.fsck.k9.preferences.Settings.StringSetting;
 import com.fsck.k9.preferences.Settings.V;
 
 public class AccountSettings {
-    public static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
-    public static final Map<Integer, SettingsUpgrader> UPGRADERS;
+    static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
+    private static final Map<Integer, SettingsUpgrader> UPGRADERS;
 
     static {
-        Map<String, TreeMap<Integer, SettingsDescription>> s =
-            new LinkedHashMap<String, TreeMap<Integer, SettingsDescription>>();
+        Map<String, TreeMap<Integer, SettingsDescription>> s = new LinkedHashMap<>();
 
         /**
          * When adding new settings here, be sure to increment {@link Settings.VERSION}
@@ -85,16 +84,16 @@ public class AccountSettings {
                         R.array.account_setup_expunge_policy_values))
             ));
         s.put("folderDisplayMode", Settings.versions(
-                new V(1, new EnumSetting<FolderMode>(FolderMode.class, FolderMode.NOT_SECOND_CLASS))
+                new V(1, new EnumSetting<>(FolderMode.class, FolderMode.NOT_SECOND_CLASS))
             ));
         s.put("folderPushMode", Settings.versions(
-                new V(1, new EnumSetting<FolderMode>(FolderMode.class, FolderMode.FIRST_CLASS))
+                new V(1, new EnumSetting<>(FolderMode.class, FolderMode.FIRST_CLASS))
             ));
         s.put("folderSyncMode", Settings.versions(
-                new V(1, new EnumSetting<FolderMode>(FolderMode.class, FolderMode.FIRST_CLASS))
+                new V(1, new EnumSetting<>(FolderMode.class, FolderMode.FIRST_CLASS))
             ));
         s.put("folderTargetMode", Settings.versions(
-                new V(1, new EnumSetting<FolderMode>(FolderMode.class, FolderMode.NOT_SECOND_CLASS))
+                new V(1, new EnumSetting<>(FolderMode.class, FolderMode.NOT_SECOND_CLASS))
             ));
         s.put("goToUnreadMessageSearch", Settings.versions(
                 new V(1, new BooleanSetting(false))
@@ -129,7 +128,7 @@ public class AccountSettings {
                         R.array.account_settings_message_age_values))
             ));
         s.put("messageFormat", Settings.versions(
-                new V(1, new EnumSetting<MessageFormat>(
+                new V(1, new EnumSetting<>(
                         MessageFormat.class, Account.DEFAULT_MESSAGE_FORMAT))
             ));
         s.put("messageFormatAuto", Settings.versions(
@@ -145,7 +144,7 @@ public class AccountSettings {
                 new V(1, new BooleanSetting(false))
             ));
         s.put("folderNotifyNewMailMode", Settings.versions(
-                new V(34, new EnumSetting<FolderMode>(FolderMode.class, FolderMode.ALL))
+                new V(34, new EnumSetting<>(FolderMode.class, FolderMode.ALL))
             ));
         s.put("notifySelfNewMail", Settings.versions(
                 new V(1, new BooleanSetting(true))
@@ -157,8 +156,7 @@ public class AccountSettings {
                 new V(1, new StringSetting(Account.DEFAULT_QUOTE_PREFIX))
             ));
         s.put("quoteStyle", Settings.versions(
-                new V(1, new EnumSetting<QuoteStyle>(
-                        QuoteStyle.class, Account.DEFAULT_QUOTE_STYLE))
+                new V(1, new EnumSetting<>(QuoteStyle.class, Account.DEFAULT_QUOTE_STYLE))
             ));
         s.put("replyAfterQuote", Settings.versions(
                 new V(1, new BooleanSetting(Account.DEFAULT_REPLY_AFTER_QUOTE))
@@ -170,21 +168,19 @@ public class AccountSettings {
                 new V(1, new RingtoneSetting("content://settings/system/notification_sound"))
             ));
         s.put("searchableFolders", Settings.versions(
-                new V(1, new EnumSetting<Searchable>(
-                        Searchable.class, Searchable.ALL))
+                new V(1, new EnumSetting<>(Searchable.class, Searchable.ALL))
             ));
         s.put("sentFolderName", Settings.versions(
                 new V(1, new StringSetting("Sent"))
             ));
         s.put("sortTypeEnum", Settings.versions(
-                new V(9, new EnumSetting<SortType>(SortType.class, Account.DEFAULT_SORT_TYPE))
+                new V(9, new EnumSetting<>(SortType.class, Account.DEFAULT_SORT_TYPE))
             ));
         s.put("sortAscending", Settings.versions(
                 new V(9, new BooleanSetting(Account.DEFAULT_SORT_ASCENDING))
             ));
         s.put("showPicturesEnum", Settings.versions(
-                new V(1, new EnumSetting<ShowPictures>(
-                        ShowPictures.class, ShowPictures.NEVER))
+                new V(1, new EnumSetting<>(ShowPictures.class, ShowPictures.NEVER))
             ));
         s.put("signatureBeforeQuotedText", Settings.versions(
                 new V(1, new BooleanSetting(false))
@@ -240,11 +236,12 @@ public class AccountSettings {
 
         SETTINGS = Collections.unmodifiableMap(s);
 
-        Map<Integer, SettingsUpgrader> u = new HashMap<Integer, SettingsUpgrader>();
+        // noinspection MismatchedQueryAndUpdateOfCollection, this map intentionally left blank
+        Map<Integer, SettingsUpgrader> u = new HashMap<>();
         UPGRADERS = Collections.unmodifiableMap(u);
     }
 
-    public static Map<String, Object> validate(int version, Map<String, String> importedSettings,
+    static Map<String, Object> validate(int version, Map<String, String> importedSettings,
             boolean useDefaultValues) {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
@@ -257,8 +254,8 @@ public class AccountSettings {
         return Settings.convert(settings, SETTINGS);
     }
 
-    public static Map<String, String> getAccountSettings(Storage storage, String uuid) {
-        Map<String, String> result = new HashMap<String, String>();
+    static Map<String, String> getAccountSettings(Storage storage, String uuid) {
+        Map<String, String> result = new HashMap<>();
         String prefix = uuid + ".";
         for (String key : SETTINGS.keySet()) {
             String value = storage.getString(prefix + key, null);
@@ -277,10 +274,10 @@ public class AccountSettings {
      * integer strings.
      * </p>
      */
-    public static class IntegerResourceSetting extends PseudoEnumSetting<Integer> {
+    private static class IntegerResourceSetting extends PseudoEnumSetting<Integer> {
         private final Map<Integer, String> mMapping;
 
-        public IntegerResourceSetting(int defaultValue, int resId) {
+        IntegerResourceSetting(int defaultValue, int resId) {
             super(defaultValue);
 
             Map<Integer, String> mapping = new HashMap<>();
@@ -314,13 +311,13 @@ public class AccountSettings {
      * Basically a {@link PseudoEnumSetting} that is initialized from a resource array.
      * </p>
      */
-    public static class StringResourceSetting extends PseudoEnumSetting<String> {
+    private static class StringResourceSetting extends PseudoEnumSetting<String> {
         private final Map<String, String> mMapping;
 
-        public StringResourceSetting(String defaultValue, int resId) {
+        StringResourceSetting(String defaultValue, int resId) {
             super(defaultValue);
 
-            Map<String, String> mapping = new HashMap<String, String>();
+            Map<String, String> mapping = new HashMap<>();
             String[] values = K9.app.getResources().getStringArray(resId);
             for (String value : values) {
                 mapping.put(value, value);
@@ -345,8 +342,8 @@ public class AccountSettings {
     /**
      * The notification ringtone setting.
      */
-    public static class RingtoneSetting extends SettingsDescription<String> {
-        public RingtoneSetting(String defaultValue) {
+    private static class RingtoneSetting extends SettingsDescription<String> {
+        RingtoneSetting(String defaultValue) {
             super(defaultValue);
         }
 
@@ -360,8 +357,8 @@ public class AccountSettings {
     /**
      * The storage provider setting.
      */
-    public static class StorageProviderSetting extends SettingsDescription<String> {
-        public StorageProviderSetting() {
+    private static class StorageProviderSetting extends SettingsDescription<String> {
+        StorageProviderSetting() {
             super(null);
         }
 
@@ -381,10 +378,10 @@ public class AccountSettings {
         }
     }
 
-    public static class DeletePolicySetting extends PseudoEnumSetting<Integer> {
+    private static class DeletePolicySetting extends PseudoEnumSetting<Integer> {
         private Map<Integer, String> mMapping;
 
-        public DeletePolicySetting(DeletePolicy defaultValue) {
+        DeletePolicySetting(DeletePolicy defaultValue) {
             super(defaultValue.setting);
             Map<Integer, String> mapping = new HashMap<>();
             mapping.put(DeletePolicy.NEVER.setting, "NEVER");

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -31,6 +31,7 @@ import com.fsck.k9.preferences.Settings.SettingsUpgrader;
 import com.fsck.k9.preferences.Settings.StringSetting;
 import com.fsck.k9.preferences.Settings.V;
 
+
 public class AccountSettings {
     static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
     private static final Map<Integer, SettingsUpgrader> UPGRADERS;
@@ -38,195 +39,195 @@ public class AccountSettings {
     static {
         Map<String, TreeMap<Integer, SettingsDescription>> s = new LinkedHashMap<>();
 
-        /**
+        /*
          * When adding new settings here, be sure to increment {@link Settings.VERSION}
          * and use that for whatever you add here.
          */
 
         s.put("alwaysBcc", Settings.versions(
                 new V(11, new StringSetting(""))
-            ));
+        ));
         s.put("alwaysShowCcBcc", Settings.versions(
                 new V(13, new BooleanSetting(false))
-            ));
+        ));
         s.put("archiveFolderName", Settings.versions(
                 new V(1, new StringSetting("Archive"))
-            ));
+        ));
         s.put("autoExpandFolderName", Settings.versions(
                 new V(1, new StringSetting("INBOX"))
-            ));
+        ));
         s.put("automaticCheckIntervalMinutes", Settings.versions(
                 new V(1, new IntegerResourceSetting(-1, R.array.account_settings_check_frequency_values))
-            ));
+        ));
         s.put("chipColor", Settings.versions(
                 new V(1, new ColorSetting(0xFF0000FF))
-            ));
+        ));
         s.put("cryptoApp", Settings.versions(
                 new V(1, new StringSetting("apg")),
                 new V(36, new StringSetting(Account.NO_OPENPGP_PROVIDER))
-            ));
+        ));
         s.put("defaultQuotedTextShown", Settings.versions(
                 new V(1, new BooleanSetting(Account.DEFAULT_QUOTED_TEXT_SHOWN))
-            ));
+        ));
         s.put("deletePolicy", Settings.versions(
                 new V(1, new DeletePolicySetting(DeletePolicy.NEVER))
-            ));
+        ));
         s.put("displayCount", Settings.versions(
                 new V(1, new IntegerResourceSetting(K9.DEFAULT_VISIBLE_LIMIT,
                         R.array.account_settings_display_count_values))
-            ));
+        ));
         s.put("draftsFolderName", Settings.versions(
                 new V(1, new StringSetting("Drafts"))
-            ));
+        ));
         s.put("expungePolicy", Settings.versions(
                 new V(1, new StringResourceSetting(Expunge.EXPUNGE_IMMEDIATELY.name(),
                         R.array.account_setup_expunge_policy_values))
-            ));
+        ));
         s.put("folderDisplayMode", Settings.versions(
                 new V(1, new EnumSetting<>(FolderMode.class, FolderMode.NOT_SECOND_CLASS))
-            ));
+        ));
         s.put("folderPushMode", Settings.versions(
                 new V(1, new EnumSetting<>(FolderMode.class, FolderMode.FIRST_CLASS))
-            ));
+        ));
         s.put("folderSyncMode", Settings.versions(
                 new V(1, new EnumSetting<>(FolderMode.class, FolderMode.FIRST_CLASS))
-            ));
+        ));
         s.put("folderTargetMode", Settings.versions(
                 new V(1, new EnumSetting<>(FolderMode.class, FolderMode.NOT_SECOND_CLASS))
-            ));
+        ));
         s.put("goToUnreadMessageSearch", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("idleRefreshMinutes", Settings.versions(
                 new V(1, new IntegerResourceSetting(24, R.array.idle_refresh_period_values))
-            ));
+        ));
         s.put("inboxFolderName", Settings.versions(
                 new V(1, new StringSetting("INBOX"))
-            ));
+        ));
         s.put("led", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("ledColor", Settings.versions(
                 new V(1, new ColorSetting(0xFF0000FF))
-            ));
+        ));
         s.put("localStorageProvider", Settings.versions(
                 new V(1, new StorageProviderSetting())
-            ));
+        ));
         s.put("markMessageAsReadOnView", Settings.versions(
                 new V(7, new BooleanSetting(true))
-            ));
+        ));
         s.put("maxPushFolders", Settings.versions(
                 new V(1, new IntegerRangeSetting(0, 100, 10))
-            ));
+        ));
         s.put("maximumAutoDownloadMessageSize", Settings.versions(
                 new V(1, new IntegerResourceSetting(32768, R.array.account_settings_autodownload_message_size_values))
-            ));
+        ));
         s.put("maximumPolledMessageAge", Settings.versions(
                 new V(1, new IntegerResourceSetting(-1, R.array.account_settings_message_age_values))
-            ));
+        ));
         s.put("messageFormat", Settings.versions(
                 new V(1, new EnumSetting<>(MessageFormat.class, Account.DEFAULT_MESSAGE_FORMAT))
-            ));
+        ));
         s.put("messageFormatAuto", Settings.versions(
                 new V(2, new BooleanSetting(Account.DEFAULT_MESSAGE_FORMAT_AUTO))
-            ));
+        ));
         s.put("messageReadReceipt", Settings.versions(
                 new V(1, new BooleanSetting(Account.DEFAULT_MESSAGE_READ_RECEIPT))
-            ));
+        ));
         s.put("notifyMailCheck", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("notifyNewMail", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("folderNotifyNewMailMode", Settings.versions(
                 new V(34, new EnumSetting<>(FolderMode.class, FolderMode.ALL))
-            ));
+        ));
         s.put("notifySelfNewMail", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("pushPollOnConnect", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("quotePrefix", Settings.versions(
                 new V(1, new StringSetting(Account.DEFAULT_QUOTE_PREFIX))
-            ));
+        ));
         s.put("quoteStyle", Settings.versions(
                 new V(1, new EnumSetting<>(QuoteStyle.class, Account.DEFAULT_QUOTE_STYLE))
-            ));
+        ));
         s.put("replyAfterQuote", Settings.versions(
                 new V(1, new BooleanSetting(Account.DEFAULT_REPLY_AFTER_QUOTE))
-            ));
+        ));
         s.put("ring", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("ringtone", Settings.versions(
                 new V(1, new RingtoneSetting("content://settings/system/notification_sound"))
-            ));
+        ));
         s.put("searchableFolders", Settings.versions(
                 new V(1, new EnumSetting<>(Searchable.class, Searchable.ALL))
-            ));
+        ));
         s.put("sentFolderName", Settings.versions(
                 new V(1, new StringSetting("Sent"))
-            ));
+        ));
         s.put("sortTypeEnum", Settings.versions(
                 new V(9, new EnumSetting<>(SortType.class, Account.DEFAULT_SORT_TYPE))
-            ));
+        ));
         s.put("sortAscending", Settings.versions(
                 new V(9, new BooleanSetting(Account.DEFAULT_SORT_ASCENDING))
-            ));
+        ));
         s.put("showPicturesEnum", Settings.versions(
                 new V(1, new EnumSetting<>(ShowPictures.class, ShowPictures.NEVER))
-            ));
+        ));
         s.put("signatureBeforeQuotedText", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("spamFolderName", Settings.versions(
                 new V(1, new StringSetting("Spam"))
-            ));
+        ));
         s.put("stripSignature", Settings.versions(
                 new V(2, new BooleanSetting(Account.DEFAULT_STRIP_SIGNATURE))
-            ));
+        ));
         s.put("subscribedFoldersOnly", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("syncRemoteDeletions", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("trashFolderName", Settings.versions(
                 new V(1, new StringSetting("Trash"))
-            ));
+        ));
         s.put("useCompression.MOBILE", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("useCompression.OTHER", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("useCompression.WIFI", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("vibrate", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("vibratePattern", Settings.versions(
                 new V(1, new IntegerResourceSetting(0, R.array.account_settings_vibrate_pattern_values))
-            ));
+        ));
         s.put("vibrateTimes", Settings.versions(
                 new V(1, new IntegerResourceSetting(5, R.array.account_settings_vibrate_times_label))
-            ));
+        ));
         s.put("allowRemoteSearch", Settings.versions(
                 new V(18, new BooleanSetting(true))
-            ));
+        ));
         s.put("remoteSearchNumResults", Settings.versions(
                 new V(18, new IntegerResourceSetting(Account.DEFAULT_REMOTE_SEARCH_NUM_RESULTS,
-                R.array.account_settings_remote_search_num_results_values))
-            ));
+                        R.array.account_settings_remote_search_num_results_values))
+        ));
         s.put("remoteSearchFullText", Settings.versions(
                 new V(18, new BooleanSetting(false))
-            ));
+        ));
         s.put("notifyContactsMailOnly", Settings.versions(
                 new V(42, new BooleanSetting(false))
-            ));
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -268,7 +268,7 @@ public class AccountSettings {
      * </p>
      */
     private static class IntegerResourceSetting extends PseudoEnumSetting<Integer> {
-        private final Map<Integer, String> mMapping;
+        private final Map<Integer, String> mapping;
 
         IntegerResourceSetting(int defaultValue, int resId) {
             super(defaultValue);
@@ -279,12 +279,12 @@ public class AccountSettings {
                 int intValue = Integer.parseInt(value);
                 mapping.put(intValue, value);
             }
-            mMapping = Collections.unmodifiableMap(mapping);
+            this.mapping = Collections.unmodifiableMap(mapping);
         }
 
         @Override
         protected Map<Integer, String> getMapping() {
-            return mMapping;
+            return mapping;
         }
 
         @Override
@@ -305,7 +305,7 @@ public class AccountSettings {
      * </p>
      */
     private static class StringResourceSetting extends PseudoEnumSetting<String> {
-        private final Map<String, String> mMapping;
+        private final Map<String, String> mapping;
 
         StringResourceSetting(String defaultValue, int resId) {
             super(defaultValue);
@@ -315,17 +315,17 @@ public class AccountSettings {
             for (String value : values) {
                 mapping.put(value, value);
             }
-            mMapping = Collections.unmodifiableMap(mapping);
+            this.mapping = Collections.unmodifiableMap(mapping);
         }
 
         @Override
         protected Map<String, String> getMapping() {
-            return mMapping;
+            return mapping;
         }
 
         @Override
         public String fromString(String value) throws InvalidSettingValueException {
-            if (!mMapping.containsKey(value)) {
+            if (!mapping.containsKey(value)) {
                 throw new InvalidSettingValueException();
             }
             return value;
@@ -372,7 +372,7 @@ public class AccountSettings {
     }
 
     private static class DeletePolicySetting extends PseudoEnumSetting<Integer> {
-        private Map<Integer, String> mMapping;
+        private Map<Integer, String> mapping;
 
         DeletePolicySetting(DeletePolicy defaultValue) {
             super(defaultValue.setting);
@@ -380,19 +380,19 @@ public class AccountSettings {
             mapping.put(DeletePolicy.NEVER.setting, "NEVER");
             mapping.put(DeletePolicy.ON_DELETE.setting, "DELETE");
             mapping.put(DeletePolicy.MARK_AS_READ.setting, "MARK_AS_READ");
-            mMapping = Collections.unmodifiableMap(mapping);
+            this.mapping = Collections.unmodifiableMap(mapping);
         }
 
         @Override
         protected Map<Integer, String> getMapping() {
-            return mMapping;
+            return mapping;
         }
 
         @Override
         public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 Integer deletePolicy = Integer.parseInt(value);
-                if (mMapping.containsKey(deletePolicy)) {
+                if (mapping.containsKey(deletePolicy)) {
                     return deletePolicy;
                 }
             } catch (NumberFormatException e) { /* do nothing */ }

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.preferences;
 
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -19,7 +20,16 @@ import com.fsck.k9.Account.SortType;
 import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.mailstore.StorageManager;
-import com.fsck.k9.preferences.Settings.*;
+import com.fsck.k9.preferences.Settings.BooleanSetting;
+import com.fsck.k9.preferences.Settings.ColorSetting;
+import com.fsck.k9.preferences.Settings.EnumSetting;
+import com.fsck.k9.preferences.Settings.IntegerRangeSetting;
+import com.fsck.k9.preferences.Settings.InvalidSettingValueException;
+import com.fsck.k9.preferences.Settings.PseudoEnumSetting;
+import com.fsck.k9.preferences.Settings.SettingsDescription;
+import com.fsck.k9.preferences.Settings.SettingsUpgrader;
+import com.fsck.k9.preferences.Settings.StringSetting;
+import com.fsck.k9.preferences.Settings.V;
 
 public class AccountSettings {
     public static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
@@ -273,7 +283,7 @@ public class AccountSettings {
         public IntegerResourceSetting(int defaultValue, int resId) {
             super(defaultValue);
 
-            Map<Integer, String> mapping = new HashMap<Integer, String>();
+            Map<Integer, String> mapping = new HashMap<>();
             String[] values = K9.app.getResources().getStringArray(resId);
             for (String value : values) {
                 int intValue = Integer.parseInt(value);
@@ -288,7 +298,7 @@ public class AccountSettings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 return Integer.parseInt(value);
             } catch (NumberFormatException e) {
@@ -324,7 +334,7 @@ public class AccountSettings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public String fromString(String value) throws InvalidSettingValueException {
             if (!mMapping.containsKey(value)) {
                 throw new InvalidSettingValueException();
             }
@@ -335,13 +345,13 @@ public class AccountSettings {
     /**
      * The notification ringtone setting.
      */
-    public static class RingtoneSetting extends SettingsDescription {
+    public static class RingtoneSetting extends SettingsDescription<String> {
         public RingtoneSetting(String defaultValue) {
             super(defaultValue);
         }
 
         @Override
-        public Object fromString(String value) {
+        public String fromString(String value) {
             //TODO: add validation
             return value;
         }
@@ -350,18 +360,18 @@ public class AccountSettings {
     /**
      * The storage provider setting.
      */
-    public static class StorageProviderSetting extends SettingsDescription {
+    public static class StorageProviderSetting extends SettingsDescription<String> {
         public StorageProviderSetting() {
             super(null);
         }
 
         @Override
-        public Object getDefaultValue() {
+        public String getDefaultValue() {
             return StorageManager.getInstance(K9.app).getDefaultProviderId();
         }
 
         @Override
-        public Object fromString(String value) {
+        public String fromString(String value) {
             StorageManager storageManager = StorageManager.getInstance(K9.app);
             Map<String, String> providers = storageManager.getAvailableProviders();
             if (providers.containsKey(value)) {
@@ -375,8 +385,8 @@ public class AccountSettings {
         private Map<Integer, String> mMapping;
 
         public DeletePolicySetting(DeletePolicy defaultValue) {
-            super(defaultValue);
-            Map<Integer, String> mapping = new HashMap<Integer, String>();
+            super(defaultValue.setting);
+            Map<Integer, String> mapping = new HashMap<>();
             mapping.put(DeletePolicy.NEVER.setting, "NEVER");
             mapping.put(DeletePolicy.ON_DELETE.setting, "DELETE");
             mapping.put(DeletePolicy.MARK_AS_READ.setting, "MARK_AS_READ");
@@ -389,7 +399,7 @@ public class AccountSettings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 Integer deletePolicy = Integer.parseInt(value);
                 if (mMapping.containsKey(deletePolicy)) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -56,8 +56,7 @@ public class AccountSettings {
                 new V(1, new StringSetting("INBOX"))
             ));
         s.put("automaticCheckIntervalMinutes", Settings.versions(
-                new V(1, new IntegerResourceSetting(-1,
-                        R.array.account_settings_check_frequency_values))
+                new V(1, new IntegerResourceSetting(-1, R.array.account_settings_check_frequency_values))
             ));
         s.put("chipColor", Settings.versions(
                 new V(1, new ColorSetting(0xFF0000FF))
@@ -120,16 +119,13 @@ public class AccountSettings {
                 new V(1, new IntegerRangeSetting(0, 100, 10))
             ));
         s.put("maximumAutoDownloadMessageSize", Settings.versions(
-                new V(1, new IntegerResourceSetting(32768,
-                        R.array.account_settings_autodownload_message_size_values))
+                new V(1, new IntegerResourceSetting(32768, R.array.account_settings_autodownload_message_size_values))
             ));
         s.put("maximumPolledMessageAge", Settings.versions(
-                new V(1, new IntegerResourceSetting(-1,
-                        R.array.account_settings_message_age_values))
+                new V(1, new IntegerResourceSetting(-1, R.array.account_settings_message_age_values))
             ));
         s.put("messageFormat", Settings.versions(
-                new V(1, new EnumSetting<>(
-                        MessageFormat.class, Account.DEFAULT_MESSAGE_FORMAT))
+                new V(1, new EnumSetting<>(MessageFormat.class, Account.DEFAULT_MESSAGE_FORMAT))
             ));
         s.put("messageFormatAuto", Settings.versions(
                 new V(2, new BooleanSetting(Account.DEFAULT_MESSAGE_FORMAT_AUTO))
@@ -213,12 +209,10 @@ public class AccountSettings {
                 new V(1, new BooleanSetting(false))
             ));
         s.put("vibratePattern", Settings.versions(
-                new V(1, new IntegerResourceSetting(0,
-                R.array.account_settings_vibrate_pattern_values))
+                new V(1, new IntegerResourceSetting(0, R.array.account_settings_vibrate_pattern_values))
             ));
         s.put("vibrateTimes", Settings.versions(
-                new V(1, new IntegerResourceSetting(5,
-                R.array.account_settings_vibrate_times_label))
+                new V(1, new IntegerResourceSetting(5, R.array.account_settings_vibrate_times_label))
             ));
         s.put("allowRemoteSearch", Settings.versions(
                 new V(18, new BooleanSetting(true))
@@ -241,8 +235,7 @@ public class AccountSettings {
         UPGRADERS = Collections.unmodifiableMap(u);
     }
 
-    static Map<String, Object> validate(int version, Map<String, String> importedSettings,
-            boolean useDefaultValues) {
+    static Map<String, Object> validate(int version, Map<String, String> importedSettings, boolean useDefaultValues) {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -260,14 +260,6 @@ public class AccountSettings {
         return result;
     }
 
-    /**
-     * An integer resource setting.
-     *
-     * <p>
-     * Basically a {@link PseudoEnumSetting} that is initialized from a resource array containing
-     * integer strings.
-     * </p>
-     */
     private static class IntegerResourceSetting extends PseudoEnumSetting<Integer> {
         private final Map<Integer, String> mapping;
 
@@ -298,13 +290,6 @@ public class AccountSettings {
         }
     }
 
-    /**
-     * A string resource setting.
-     *
-     * <p>
-     * Basically a {@link PseudoEnumSetting} that is initialized from a resource array.
-     * </p>
-     */
     private static class StringResourceSetting extends PseudoEnumSetting<String> {
         private final Map<String, String> mapping;
 
@@ -333,9 +318,6 @@ public class AccountSettings {
         }
     }
 
-    /**
-     * The notification ringtone setting.
-     */
     private static class RingtoneSetting extends SettingsDescription<String> {
         RingtoneSetting(String defaultValue) {
             super(defaultValue);
@@ -348,9 +330,6 @@ public class AccountSettings {
         }
     }
 
-    /**
-     * The storage provider setting.
-     */
     private static class StorageProviderSetting extends SettingsDescription<String> {
         StorageProviderSetting() {
             super(null);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/CheckBoxListPreference.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/CheckBoxListPreference.java
@@ -17,19 +17,10 @@ public class CheckBoxListPreference extends DialogPreference {
      */
     private boolean[] mPendingItems;
 
-    /**
-     * @param context
-     * @param attrs
-     * @param defStyle
-     */
     public CheckBoxListPreference(Context context, AttributeSet attrs, int defStyle) {
         super(context, attrs, defStyle);
     }
 
-    /**
-     * @param context
-     * @param attrs
-     */
     public CheckBoxListPreference(Context context, AttributeSet attrs) {
         super(context, attrs);
     }

--- a/k9mail/src/main/java/com/fsck/k9/preferences/FolderSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/FolderSettings.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.preferences;
 
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -8,7 +9,12 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import com.fsck.k9.mail.Folder.FolderClass;
-import com.fsck.k9.preferences.Settings.*;
+import com.fsck.k9.preferences.Settings.BooleanSetting;
+import com.fsck.k9.preferences.Settings.EnumSetting;
+import com.fsck.k9.preferences.Settings.SettingsDescription;
+import com.fsck.k9.preferences.Settings.SettingsUpgrader;
+import com.fsck.k9.preferences.Settings.V;
+
 
 class FolderSettings {
     static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
@@ -17,29 +23,29 @@ class FolderSettings {
     static {
         Map<String, TreeMap<Integer, SettingsDescription>> s = new LinkedHashMap<>();
 
-        /**
+        /*
          * When adding new settings here, be sure to increment {@link Settings.VERSION}
          * and use that for whatever you add here.
          */
 
         s.put("displayMode", Settings.versions(
                 new V(1, new EnumSetting<>(FolderClass.class, FolderClass.NO_CLASS))
-            ));
+        ));
         s.put("notifyMode", Settings.versions(
                 new V(34, new EnumSetting<>(FolderClass.class, FolderClass.INHERITED))
-            ));
+        ));
         s.put("syncMode", Settings.versions(
                 new V(1, new EnumSetting<>(FolderClass.class, FolderClass.INHERITED))
-            ));
+        ));
         s.put("pushMode", Settings.versions(
                 new V(1, new EnumSetting<>(FolderClass.class, FolderClass.INHERITED))
-            ));
+        ));
         s.put("inTopGroup", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("integrate", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/FolderSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/FolderSettings.java
@@ -48,8 +48,7 @@ class FolderSettings {
         UPGRADERS = Collections.unmodifiableMap(u);
     }
 
-    static Map<String, Object> validate(int version, Map<String, String> importedSettings,
-            boolean useDefaultValues) {
+    static Map<String, Object> validate(int version, Map<String, String> importedSettings, boolean useDefaultValues) {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
 
@@ -61,8 +60,7 @@ class FolderSettings {
         return Settings.convert(settings, SETTINGS);
     }
 
-    static Map<String, String> getFolderSettings(Storage storage, String uuid,
-            String folderName) {
+    static Map<String, String> getFolderSettings(Storage storage, String uuid, String folderName) {
         Map<String, String> result = new HashMap<>();
         String prefix = uuid + "." + folderName + ".";
         for (String key : SETTINGS.keySet()) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/FolderSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/FolderSettings.java
@@ -10,13 +10,12 @@ import java.util.TreeMap;
 import com.fsck.k9.mail.Folder.FolderClass;
 import com.fsck.k9.preferences.Settings.*;
 
-public class FolderSettings {
-    public static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
-    public static final Map<Integer, SettingsUpgrader> UPGRADERS;
+class FolderSettings {
+    static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
+    private static final Map<Integer, SettingsUpgrader> UPGRADERS;
 
     static {
-        Map<String, TreeMap<Integer, SettingsDescription>> s =
-            new LinkedHashMap<String, TreeMap<Integer, SettingsDescription>>();
+        Map<String, TreeMap<Integer, SettingsDescription>> s = new LinkedHashMap<>();
 
         /**
          * When adding new settings here, be sure to increment {@link Settings.VERSION}
@@ -24,16 +23,16 @@ public class FolderSettings {
          */
 
         s.put("displayMode", Settings.versions(
-                new V(1, new EnumSetting<FolderClass>(FolderClass.class, FolderClass.NO_CLASS))
+                new V(1, new EnumSetting<>(FolderClass.class, FolderClass.NO_CLASS))
             ));
         s.put("notifyMode", Settings.versions(
-                new V(34, new EnumSetting<FolderClass>(FolderClass.class, FolderClass.INHERITED))
+                new V(34, new EnumSetting<>(FolderClass.class, FolderClass.INHERITED))
             ));
         s.put("syncMode", Settings.versions(
-                new V(1, new EnumSetting<FolderClass>(FolderClass.class, FolderClass.INHERITED))
+                new V(1, new EnumSetting<>(FolderClass.class, FolderClass.INHERITED))
             ));
         s.put("pushMode", Settings.versions(
-                new V(1, new EnumSetting<FolderClass>(FolderClass.class, FolderClass.INHERITED))
+                new V(1, new EnumSetting<>(FolderClass.class, FolderClass.INHERITED))
             ));
         s.put("inTopGroup", Settings.versions(
                 new V(1, new BooleanSetting(false))
@@ -44,11 +43,12 @@ public class FolderSettings {
 
         SETTINGS = Collections.unmodifiableMap(s);
 
-        Map<Integer, SettingsUpgrader> u = new HashMap<Integer, SettingsUpgrader>();
+        // noinspection MismatchedQueryAndUpdateOfCollection, this map intentionally left blank
+        Map<Integer, SettingsUpgrader> u = new HashMap<>();
         UPGRADERS = Collections.unmodifiableMap(u);
     }
 
-    public static Map<String, Object> validate(int version, Map<String, String> importedSettings,
+    static Map<String, Object> validate(int version, Map<String, String> importedSettings,
             boolean useDefaultValues) {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
@@ -61,9 +61,9 @@ public class FolderSettings {
         return Settings.convert(settings, SETTINGS);
     }
 
-    public static Map<String, String> getFolderSettings(Storage storage, String uuid,
+    static Map<String, String> getFolderSettings(Storage storage, String uuid,
             String folderName) {
-        Map<String, String> result = new HashMap<String, String>();
+        Map<String, String> result = new HashMap<>();
         String prefix = uuid + "." + folderName + ".";
         for (String key : SETTINGS.keySet()) {
             String value = storage.getString(prefix + key, null);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -2,7 +2,6 @@ package com.fsck.k9.preferences;
 
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,12 +36,11 @@ import com.fsck.k9.preferences.Settings.WebFontSizeSetting;
 import static com.fsck.k9.K9.LockScreenNotificationVisibility;
 
 public class GlobalSettings {
-    public static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
-    public static final Map<Integer, SettingsUpgrader> UPGRADERS;
+    static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
+    private static final Map<Integer, SettingsUpgrader> UPGRADERS;
 
     static {
-        Map<String, TreeMap<Integer, SettingsDescription>> s =
-            new LinkedHashMap<String, TreeMap<Integer, SettingsDescription>>();
+        Map<String, TreeMap<Integer, SettingsDescription>> s = new LinkedHashMap<>();
 
         /**
          * When adding new settings here, be sure to increment {@link Settings.VERSION}
@@ -58,7 +56,7 @@ public class GlobalSettings {
                         Environment.DIRECTORY_DOWNLOADS)))
             ));
         s.put("backgroundOperations", Settings.versions(
-                new V(1, new EnumSetting<K9.BACKGROUND_OPS>(
+                new V(1, new EnumSetting<>(
                         K9.BACKGROUND_OPS.class, K9.BACKGROUND_OPS.WHEN_CHECKED_AUTO_SYNC))
             ));
         s.put("changeRegisteredNameColor", Settings.versions(
@@ -191,7 +189,7 @@ public class GlobalSettings {
                 new V(1, new BooleanSetting(true))
             ));
         s.put("sortTypeEnum", Settings.versions(
-                new V(10, new EnumSetting<SortType>(SortType.class, Account.DEFAULT_SORT_TYPE))
+                new V(10, new EnumSetting<>(SortType.class, Account.DEFAULT_SORT_TYPE))
             ));
         s.put("sortAscending", Settings.versions(
                 new V(10, new BooleanSetting(Account.DEFAULT_SORT_ASCENDING))
@@ -216,7 +214,7 @@ public class GlobalSettings {
                 new V(22, new BooleanSetting(false))
             ));
         s.put("notificationHideSubject", Settings.versions(
-                new V(12, new EnumSetting<NotificationHideSubject>(
+                new V(12, new EnumSetting<>(
                         NotificationHideSubject.class, NotificationHideSubject.NEVER))
             ));
         s.put("useBackgroundAsUnreadIndicator", Settings.versions(
@@ -226,7 +224,7 @@ public class GlobalSettings {
                 new V(20, new BooleanSetting(true))
             ));
         s.put("splitViewMode", Settings.versions(
-                new V(23, new EnumSetting<SplitViewMode>(SplitViewMode.class, SplitViewMode.NEVER))
+                new V(23, new EnumSetting<>(SplitViewMode.class, SplitViewMode.NEVER))
             ));
         s.put("messageComposeTheme", Settings.versions(
                 new V(24, new SubThemeSetting(K9.Theme.USE_GLOBAL))
@@ -268,7 +266,7 @@ public class GlobalSettings {
                 new V(32, new BooleanSetting(false))
             ));
         s.put("lockScreenNotificationVisibility", Settings.versions(
-                new V(37, new EnumSetting<LockScreenNotificationVisibility>(LockScreenNotificationVisibility.class,
+                new V(37, new EnumSetting<>(LockScreenNotificationVisibility.class,
                         LockScreenNotificationVisibility.MESSAGE_COUNT))
             ));
         s.put("confirmDeleteFromNotification", Settings.versions(
@@ -278,7 +276,7 @@ public class GlobalSettings {
                 new V(38, new BooleanSetting(false))
             ));
         s.put("notificationQuickDelete", Settings.versions(
-                new V(38, new EnumSetting<NotificationQuickDelete>(NotificationQuickDelete.class,
+                new V(38, new EnumSetting<>(NotificationQuickDelete.class,
                         NotificationQuickDelete.NEVER))
             ));
         s.put("notificationDuringQuietTimeEnabled", Settings.versions(
@@ -293,7 +291,7 @@ public class GlobalSettings {
 
         SETTINGS = Collections.unmodifiableMap(s);
 
-        Map<Integer, SettingsUpgrader> u = new HashMap<Integer, SettingsUpgrader>();
+        Map<Integer, SettingsUpgrader> u = new HashMap<>();
         u.put(12, new SettingsUpgraderV12());
         u.put(24, new SettingsUpgraderV24());
         u.put(31, new SettingsUpgraderV31());
@@ -301,7 +299,7 @@ public class GlobalSettings {
         UPGRADERS = Collections.unmodifiableMap(u);
     }
 
-    public static Map<String, Object> validate(int version, Map<String, String> importedSettings) {
+    static Map<String, Object> validate(int version, Map<String, String> importedSettings) {
         return Settings.validate(version, SETTINGS, importedSettings, false);
     }
 
@@ -313,8 +311,8 @@ public class GlobalSettings {
         return Settings.convert(settings, SETTINGS);
     }
 
-    public static Map<String, String> getGlobalSettings(Storage storage) {
-        Map<String, String> result = new HashMap<String, String>();
+    static Map<String, String> getGlobalSettings(Storage storage) {
+        Map<String, String> result = new HashMap<>();
         for (String key : SETTINGS.keySet()) {
             String value = storage.getString(key, null);
             if (value != null) {
@@ -329,19 +327,19 @@ public class GlobalSettings {
      *
      * Map the 'keyguardPrivacy' value to the new NotificationHideSubject enum.
      */
-    public static class SettingsUpgraderV12 implements SettingsUpgrader {
+    private static class SettingsUpgraderV12 implements SettingsUpgrader {
 
         @Override
         public Set<String> upgrade(Map<String, Object> settings) {
             Boolean keyguardPrivacy = (Boolean) settings.get("keyguardPrivacy");
-            if (keyguardPrivacy != null && keyguardPrivacy.booleanValue()) {
+            if (keyguardPrivacy != null && keyguardPrivacy) {
                 // current setting: only show subject when unlocked
                 settings.put("notificationHideSubject", NotificationHideSubject.WHEN_LOCKED);
             } else {
                 // always show subject [old default]
                 settings.put("notificationHideSubject", NotificationHideSubject.NEVER);
             }
-            return new HashSet<String>(Arrays.asList("keyguardPrivacy"));
+            return new HashSet<>(Collections.singletonList("keyguardPrivacy"));
         }
     }
 
@@ -353,7 +351,7 @@ public class GlobalSettings {
      * the same value as <em>theme</em>.
      * </p>
      */
-    public static class SettingsUpgraderV24 implements SettingsUpgrader {
+    private static class SettingsUpgraderV24 implements SettingsUpgrader {
 
         @Override
         public Set<String> upgrade(Map<String, Object> settings) {
@@ -379,13 +377,13 @@ public class GlobalSettings {
 
         @Override
         public Set<String> upgrade(Map<String, Object> settings) {
-            int oldSize = ((Integer) settings.get("fontSizeMessageViewContent")).intValue();
+            int oldSize = (Integer) settings.get("fontSizeMessageViewContent");
 
             int newSize = convertFromOldSize(oldSize);
 
             settings.put("fontSizeMessageViewContentPercent", newSize);
 
-            return new HashSet<String>(Arrays.asList("fontSizeMessageViewContent"));
+            return new HashSet<>(Collections.singletonList("fontSizeMessageViewContent"));
         }
 
         public static int convertFromOldSize(int oldSize) {
@@ -418,13 +416,13 @@ public class GlobalSettings {
      * {@code res/values/arrays.xml}.
      * </p>
      */
-    public static class LanguageSetting extends PseudoEnumSetting<String> {
+    private static class LanguageSetting extends PseudoEnumSetting<String> {
         private final Map<String, String> mMapping;
 
-        public LanguageSetting() {
+        LanguageSetting() {
             super("");
 
-            Map<String, String> mapping = new HashMap<String, String>();
+            Map<String, String> mapping = new HashMap<>();
             String[] values = K9.app.getResources().getStringArray(R.array.settings_language_values);
             for (String value : values) {
                 if (value.length() == 0) {
@@ -454,11 +452,11 @@ public class GlobalSettings {
     /**
      * The theme setting.
      */
-    public static class ThemeSetting extends SettingsDescription<K9.Theme> {
+    static class ThemeSetting extends SettingsDescription<K9.Theme> {
         private static final String THEME_LIGHT = "light";
         private static final String THEME_DARK = "dark";
 
-        public ThemeSetting(K9.Theme defaultValue) {
+        ThemeSetting(K9.Theme defaultValue) {
             super(defaultValue);
         }
 
@@ -512,10 +510,10 @@ public class GlobalSettings {
     /**
      * The message view theme setting.
      */
-    public static class SubThemeSetting extends ThemeSetting {
+    private static class SubThemeSetting extends ThemeSetting {
         private static final String THEME_USE_GLOBAL = "use_global";
 
-        public SubThemeSetting(Theme defaultValue) {
+        SubThemeSetting(Theme defaultValue) {
             super(defaultValue);
         }
 
@@ -555,8 +553,8 @@ public class GlobalSettings {
     /**
      * A time setting.
      */
-    public static class TimeSetting extends SettingsDescription<String> {
-        public TimeSetting(String defaultValue) {
+    private static class TimeSetting extends SettingsDescription<String> {
+        TimeSetting(String defaultValue) {
             super(defaultValue);
         }
 
@@ -572,8 +570,8 @@ public class GlobalSettings {
     /**
      * A directory on the file system.
      */
-    public static class DirectorySetting extends SettingsDescription<String> {
-        public DirectorySetting(File defaultPath) {
+    private static class DirectorySetting extends SettingsDescription<String> {
+        DirectorySetting(File defaultPath) {
             super(defaultPath.toString());
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -56,8 +56,7 @@ public class GlobalSettings {
                         Environment.DIRECTORY_DOWNLOADS)))
             ));
         s.put("backgroundOperations", Settings.versions(
-                new V(1, new EnumSetting<>(
-                        K9.BACKGROUND_OPS.class, K9.BACKGROUND_OPS.WHEN_CHECKED_AUTO_SYNC))
+                new V(1, new EnumSetting<>(K9.BACKGROUND_OPS.class, K9.BACKGROUND_OPS.WHEN_CHECKED_AUTO_SYNC))
             ));
         s.put("changeRegisteredNameColor", Settings.versions(
                 new V(1, new BooleanSetting(false))
@@ -214,8 +213,7 @@ public class GlobalSettings {
                 new V(22, new BooleanSetting(false))
             ));
         s.put("notificationHideSubject", Settings.versions(
-                new V(12, new EnumSetting<>(
-                        NotificationHideSubject.class, NotificationHideSubject.NEVER))
+                new V(12, new EnumSetting<>(NotificationHideSubject.class, NotificationHideSubject.NEVER))
             ));
         s.put("useBackgroundAsUnreadIndicator", Settings.versions(
                 new V(19, new BooleanSetting(true))
@@ -276,8 +274,7 @@ public class GlobalSettings {
                 new V(38, new BooleanSetting(false))
             ));
         s.put("notificationQuickDelete", Settings.versions(
-                new V(38, new EnumSetting<>(NotificationQuickDelete.class,
-                        NotificationQuickDelete.NEVER))
+                new V(38, new EnumSetting<>(NotificationQuickDelete.class, NotificationQuickDelete.NEVER))
             ));
         s.put("notificationDuringQuietTimeEnabled", Settings.versions(
                 new V(39, new BooleanSetting(true))
@@ -287,7 +284,7 @@ public class GlobalSettings {
             ));
         s.put("pgpInlineDialogCounter", Settings.versions(
                 new V(43, new IntegerRangeSetting(0, Integer.MAX_VALUE, 0))
-        ));
+            ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -406,14 +406,6 @@ public class GlobalSettings {
         }
     }
 
-    /**
-     * The language setting.
-     *
-     * <p>
-     * Valid values are read from {@code settings_language_values} in
-     * {@code res/values/arrays.xml}.
-     * </p>
-     */
     private static class LanguageSetting extends PseudoEnumSetting<String> {
         private final Map<String, String> mapping;
 
@@ -447,9 +439,6 @@ public class GlobalSettings {
         }
     }
 
-    /**
-     * The theme setting.
-     */
     static class ThemeSetting extends SettingsDescription<K9.Theme> {
         private static final String THEME_LIGHT = "light";
         private static final String THEME_DARK = "dark";
@@ -505,9 +494,6 @@ public class GlobalSettings {
         }
     }
 
-    /**
-     * The message view theme setting.
-     */
     private static class SubThemeSetting extends ThemeSetting {
         private static final String THEME_USE_GLOBAL = "use_global";
 
@@ -548,9 +534,6 @@ public class GlobalSettings {
         }
     }
 
-    /**
-     * A time setting.
-     */
     private static class TimeSetting extends SettingsDescription<String> {
         TimeSetting(String defaultValue) {
             super(defaultValue);
@@ -565,9 +548,6 @@ public class GlobalSettings {
         }
     }
 
-    /**
-     * A directory on the file system.
-     */
     private static class DirectorySetting extends SettingsDescription<String> {
         DirectorySetting(File defaultPath) {
             super(defaultPath.toString());

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.preferences;
 
+
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -13,6 +14,7 @@ import java.util.TreeMap;
 import android.os.Environment;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.Account.SortType;
 import com.fsck.k9.FontSizes;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationHideSubject;
@@ -20,8 +22,17 @@ import com.fsck.k9.K9.NotificationQuickDelete;
 import com.fsck.k9.K9.SplitViewMode;
 import com.fsck.k9.K9.Theme;
 import com.fsck.k9.R;
-import com.fsck.k9.Account.SortType;
-import com.fsck.k9.preferences.Settings.*;
+import com.fsck.k9.preferences.Settings.BooleanSetting;
+import com.fsck.k9.preferences.Settings.ColorSetting;
+import com.fsck.k9.preferences.Settings.EnumSetting;
+import com.fsck.k9.preferences.Settings.FontSizeSetting;
+import com.fsck.k9.preferences.Settings.IntegerRangeSetting;
+import com.fsck.k9.preferences.Settings.InvalidSettingValueException;
+import com.fsck.k9.preferences.Settings.PseudoEnumSetting;
+import com.fsck.k9.preferences.Settings.SettingsDescription;
+import com.fsck.k9.preferences.Settings.SettingsUpgrader;
+import com.fsck.k9.preferences.Settings.V;
+import com.fsck.k9.preferences.Settings.WebFontSizeSetting;
 
 import static com.fsck.k9.K9.LockScreenNotificationVisibility;
 
@@ -431,7 +442,7 @@ public class GlobalSettings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public String fromString(String value) throws InvalidSettingValueException {
             if (mMapping.containsKey(value)) {
                 return value;
             }
@@ -443,7 +454,7 @@ public class GlobalSettings {
     /**
      * The theme setting.
      */
-    public static class ThemeSetting extends SettingsDescription {
+    public static class ThemeSetting extends SettingsDescription<K9.Theme> {
         private static final String THEME_LIGHT = "light";
         private static final String THEME_DARK = "dark";
 
@@ -452,7 +463,7 @@ public class GlobalSettings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public K9.Theme fromString(String value) throws InvalidSettingValueException {
             try {
                 Integer theme = Integer.parseInt(value);
                 if (theme == K9.Theme.LIGHT.ordinal() ||
@@ -470,7 +481,7 @@ public class GlobalSettings {
         }
 
         @Override
-        public Object fromPrettyString(String value) throws InvalidSettingValueException {
+        public K9.Theme fromPrettyString(String value) throws InvalidSettingValueException {
             if (THEME_LIGHT.equals(value)) {
                 return K9.Theme.LIGHT;
             } else if (THEME_DARK.equals(value)) {
@@ -481,8 +492,8 @@ public class GlobalSettings {
         }
 
         @Override
-        public String toPrettyString(Object value) {
-            switch ((K9.Theme) value) {
+        public String toPrettyString(K9.Theme value) {
+            switch (value) {
                 case DARK: {
                     return THEME_DARK;
                 }
@@ -493,8 +504,8 @@ public class GlobalSettings {
         }
 
         @Override
-        public String toString(Object value) {
-            return Integer.toString(((K9.Theme) value).ordinal());
+        public String toString(K9.Theme value) {
+            return Integer.toString(value.ordinal());
         }
     }
 
@@ -509,7 +520,7 @@ public class GlobalSettings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public K9.Theme fromString(String value) throws InvalidSettingValueException {
             try {
                 Integer theme = Integer.parseInt(value);
                 if (theme == K9.Theme.USE_GLOBAL.ordinal()) {
@@ -523,7 +534,7 @@ public class GlobalSettings {
         }
 
         @Override
-        public Object fromPrettyString(String value) throws InvalidSettingValueException {
+        public K9.Theme fromPrettyString(String value) throws InvalidSettingValueException {
             if (THEME_USE_GLOBAL.equals(value)) {
                 return K9.Theme.USE_GLOBAL;
             }
@@ -532,8 +543,8 @@ public class GlobalSettings {
         }
 
         @Override
-        public String toPrettyString(Object value) {
-            if (((K9.Theme) value) == K9.Theme.USE_GLOBAL) {
+        public String toPrettyString(K9.Theme value) {
+            if (value == K9.Theme.USE_GLOBAL) {
                 return THEME_USE_GLOBAL;
             }
 
@@ -544,13 +555,13 @@ public class GlobalSettings {
     /**
      * A time setting.
      */
-    public static class TimeSetting extends SettingsDescription {
+    public static class TimeSetting extends SettingsDescription<String> {
         public TimeSetting(String defaultValue) {
             super(defaultValue);
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public String fromString(String value) throws InvalidSettingValueException {
             if (!value.matches(TimePickerPreference.VALIDATION_EXPRESSION)) {
                 throw new InvalidSettingValueException();
             }
@@ -561,13 +572,13 @@ public class GlobalSettings {
     /**
      * A directory on the file system.
      */
-    public static class DirectorySetting extends SettingsDescription {
+    public static class DirectorySetting extends SettingsDescription<String> {
         public DirectorySetting(File defaultPath) {
             super(defaultPath.toString());
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public String fromString(String value) throws InvalidSettingValueException {
             try {
                 if (new File(value).isDirectory()) {
                     return value;

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -35,6 +35,7 @@ import com.fsck.k9.preferences.Settings.WebFontSizeSetting;
 
 import static com.fsck.k9.K9.LockScreenNotificationVisibility;
 
+
 public class GlobalSettings {
     static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
     private static final Map<Integer, SettingsUpgrader> UPGRADERS;
@@ -42,249 +43,249 @@ public class GlobalSettings {
     static {
         Map<String, TreeMap<Integer, SettingsDescription>> s = new LinkedHashMap<>();
 
-        /**
+        /*
          * When adding new settings here, be sure to increment {@link Settings.VERSION}
          * and use that for whatever you add here.
          */
 
         s.put("animations", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("attachmentdefaultpath", Settings.versions(
                 new V(1, new DirectorySetting(Environment.getExternalStorageDirectory())),
                 new V(41, new DirectorySetting(Environment.getExternalStoragePublicDirectory(
                         Environment.DIRECTORY_DOWNLOADS)))
-            ));
+        ));
         s.put("backgroundOperations", Settings.versions(
                 new V(1, new EnumSetting<>(K9.BACKGROUND_OPS.class, K9.BACKGROUND_OPS.WHEN_CHECKED_AUTO_SYNC))
-            ));
+        ));
         s.put("changeRegisteredNameColor", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("confirmDelete", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("confirmDeleteStarred", Settings.versions(
                 new V(2, new BooleanSetting(false))
-            ));
+        ));
         s.put("confirmSpam", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("confirmMarkAllRead", Settings.versions(
                 new V(44, new BooleanSetting(true))
         ));
         s.put("countSearchMessages", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("enableDebugLogging", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("enableSensitiveLogging", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("fontSizeAccountDescription", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeAccountName", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeFolderName", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeFolderStatus", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageComposeInput", Settings.versions(
                 new V(5, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageListDate", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageListPreview", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageListSender", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageListSubject", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageViewAdditionalHeaders", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageViewCC", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageViewContent", Settings.versions(
                 new V(1, new WebFontSizeSetting(3)),
                 new V(31, null)
-            ));
+        ));
         s.put("fontSizeMessageViewDate", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageViewSender", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageViewSubject", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageViewTime", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("fontSizeMessageViewTo", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
-            ));
+        ));
         s.put("gesturesEnabled", Settings.versions(
                 new V(1, new BooleanSetting(true)),
                 new V(4, new BooleanSetting(false))
-            ));
+        ));
         s.put("hideSpecialAccounts", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("keyguardPrivacy", Settings.versions(
                 new V(1, new BooleanSetting(false)),
                 new V(12, null)
-            ));
+        ));
         s.put("language", Settings.versions(
                 new V(1, new LanguageSetting())
-            ));
+        ));
         s.put("measureAccounts", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("messageListCheckboxes", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("messageListPreviewLines", Settings.versions(
                 new V(1, new IntegerRangeSetting(1, 100, 2))
-            ));
+        ));
         s.put("messageListStars", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("messageViewFixedWidthFont", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("messageViewReturnToList", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("messageViewShowNext", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("quietTimeEnabled", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("quietTimeEnds", Settings.versions(
                 new V(1, new TimeSetting("7:00"))
-            ));
+        ));
         s.put("quietTimeStarts", Settings.versions(
                 new V(1, new TimeSetting("21:00"))
-            ));
+        ));
         s.put("registeredNameColor", Settings.versions(
                 new V(1, new ColorSetting(0xFF00008F))
-            ));
+        ));
         s.put("showContactName", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("showCorrespondentNames", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("sortTypeEnum", Settings.versions(
                 new V(10, new EnumSetting<>(SortType.class, Account.DEFAULT_SORT_TYPE))
-            ));
+        ));
         s.put("sortAscending", Settings.versions(
                 new V(10, new BooleanSetting(Account.DEFAULT_SORT_ASCENDING))
-            ));
+        ));
         s.put("startIntegratedInbox", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("theme", Settings.versions(
                 new V(1, new ThemeSetting(K9.Theme.LIGHT))
-            ));
+        ));
         s.put("messageViewTheme", Settings.versions(
                 new V(16, new ThemeSetting(K9.Theme.LIGHT)),
                 new V(24, new SubThemeSetting(K9.Theme.USE_GLOBAL))
-            ));
+        ));
         s.put("useVolumeKeysForListNavigation", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("useVolumeKeysForNavigation", Settings.versions(
                 new V(1, new BooleanSetting(false))
-            ));
+        ));
         s.put("wrapFolderNames", Settings.versions(
                 new V(22, new BooleanSetting(false))
-            ));
+        ));
         s.put("notificationHideSubject", Settings.versions(
                 new V(12, new EnumSetting<>(NotificationHideSubject.class, NotificationHideSubject.NEVER))
-            ));
+        ));
         s.put("useBackgroundAsUnreadIndicator", Settings.versions(
                 new V(19, new BooleanSetting(true))
-            ));
+        ));
         s.put("threadedView", Settings.versions(
                 new V(20, new BooleanSetting(true))
-            ));
+        ));
         s.put("splitViewMode", Settings.versions(
                 new V(23, new EnumSetting<>(SplitViewMode.class, SplitViewMode.NEVER))
-            ));
+        ));
         s.put("messageComposeTheme", Settings.versions(
                 new V(24, new SubThemeSetting(K9.Theme.USE_GLOBAL))
-            ));
+        ));
         s.put("fixedMessageViewTheme", Settings.versions(
                 new V(24, new BooleanSetting(true))
-            ));
+        ));
         s.put("showContactPicture", Settings.versions(
                 new V(25, new BooleanSetting(true))
-            ));
+        ));
         s.put("autofitWidth", Settings.versions(
                 new V(28, new BooleanSetting(true))
-            ));
+        ));
         s.put("colorizeMissingContactPictures", Settings.versions(
                 new V(29, new BooleanSetting(true))
-            ));
+        ));
         s.put("messageViewDeleteActionVisible", Settings.versions(
                 new V(30, new BooleanSetting(true))
-            ));
+        ));
         s.put("messageViewArchiveActionVisible", Settings.versions(
                 new V(30, new BooleanSetting(false))
-            ));
+        ));
         s.put("messageViewMoveActionVisible", Settings.versions(
                 new V(30, new BooleanSetting(false))
-            ));
+        ));
         s.put("messageViewCopyActionVisible", Settings.versions(
                 new V(30, new BooleanSetting(false))
-            ));
+        ));
         s.put("messageViewSpamActionVisible", Settings.versions(
                 new V(30, new BooleanSetting(false))
-            ));
+        ));
         s.put("fontSizeMessageViewContentPercent", Settings.versions(
                 new V(31, new IntegerRangeSetting(40, 250, 100))
-            ));
+        ));
         s.put("hideUserAgent", Settings.versions(
                 new V(32, new BooleanSetting(false))
-            ));
+        ));
         s.put("hideTimeZone", Settings.versions(
                 new V(32, new BooleanSetting(false))
-            ));
+        ));
         s.put("lockScreenNotificationVisibility", Settings.versions(
                 new V(37, new EnumSetting<>(LockScreenNotificationVisibility.class,
                         LockScreenNotificationVisibility.MESSAGE_COUNT))
-            ));
+        ));
         s.put("confirmDeleteFromNotification", Settings.versions(
                 new V(38, new BooleanSetting(true))
-            ));
+        ));
         s.put("messageListSenderAboveSubject", Settings.versions(
                 new V(38, new BooleanSetting(false))
-            ));
+        ));
         s.put("notificationQuickDelete", Settings.versions(
                 new V(38, new EnumSetting<>(NotificationQuickDelete.class, NotificationQuickDelete.NEVER))
-            ));
+        ));
         s.put("notificationDuringQuietTimeEnabled", Settings.versions(
                 new V(39, new BooleanSetting(true))
-            ));
+        ));
         s.put("confirmDiscardMessage", Settings.versions(
                 new V(40, new BooleanSetting(true))
-            ));
+        ));
         s.put("pgpInlineDialogCounter", Settings.versions(
                 new V(43, new IntegerRangeSetting(0, Integer.MAX_VALUE, 0))
-            ));
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -414,7 +414,7 @@ public class GlobalSettings {
      * </p>
      */
     private static class LanguageSetting extends PseudoEnumSetting<String> {
-        private final Map<String, String> mMapping;
+        private final Map<String, String> mapping;
 
         LanguageSetting() {
             super("");
@@ -428,17 +428,17 @@ public class GlobalSettings {
                     mapping.put(value, value);
                 }
             }
-            mMapping = Collections.unmodifiableMap(mapping);
+            this.mapping = Collections.unmodifiableMap(mapping);
         }
 
         @Override
         protected Map<String, String> getMapping() {
-            return mMapping;
+            return mapping;
         }
 
         @Override
         public String fromString(String value) throws InvalidSettingValueException {
-            if (mMapping.containsKey(value)) {
+            if (mapping.containsKey(value)) {
                 return value;
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
@@ -76,18 +76,18 @@ public class IdentitySettings {
     /**
      * The message signature setting.
      */
-    public static class SignatureSetting extends SettingsDescription {
+    public static class SignatureSetting extends SettingsDescription<String> {
         public SignatureSetting() {
             super(null);
         }
 
         @Override
-        public Object getDefaultValue() {
+        public String getDefaultValue() {
             return K9.app.getResources().getString(R.string.default_signature);
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public String fromString(String value) throws InvalidSettingValueException {
             return value;
         }
     }
@@ -95,7 +95,7 @@ public class IdentitySettings {
     /**
      * An optional email address setting.
      */
-    public static class OptionalEmailAddressSetting extends SettingsDescription {
+    public static class OptionalEmailAddressSetting extends SettingsDescription<String> {
         private EmailAddressValidator mValidator;
 
         public OptionalEmailAddressSetting() {
@@ -104,7 +104,7 @@ public class IdentitySettings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public String fromString(String value) throws InvalidSettingValueException {
             if (value != null && !mValidator.isValidAddressOnly(value)) {
                 throw new InvalidSettingValueException();
             }
@@ -112,18 +112,18 @@ public class IdentitySettings {
         }
 
         @Override
-        public String toString(Object value) {
-            return (value != null) ? value.toString() : null;
+        public String toString(String value) {
+            return (value != null) ? value : null;
         }
 
         @Override
-        public String toPrettyString(Object value) {
-            return (value == null) ? "" : value.toString();
+        public String toPrettyString(String value) {
+            return (value == null) ? "" : value;
         }
 
         @Override
-        public Object fromPrettyString(String value) throws InvalidSettingValueException {
-            return ("".equals(value)) ? null : fromString(value);
+        public String fromPrettyString(String value) throws InvalidSettingValueException {
+            return "".equals(value) ? null : fromString(value);
         }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
@@ -17,8 +17,7 @@ class IdentitySettings {
     private static final Map<Integer, SettingsUpgrader> UPGRADERS;
 
     static {
-        Map<String, TreeMap<Integer, SettingsDescription>> s =
-                new LinkedHashMap<>();
+        Map<String, TreeMap<Integer, SettingsDescription>> s = new LinkedHashMap<>();
 
         /**
          * When adding new settings here, be sure to increment {@link Settings.VERSION}
@@ -42,8 +41,7 @@ class IdentitySettings {
         UPGRADERS = Collections.unmodifiableMap(u);
     }
 
-    static Map<String, Object> validate(int version, Map<String, String> importedSettings,
-            boolean useDefaultValues) {
+    static Map<String, Object> validate(int version, Map<String, String> importedSettings, boolean useDefaultValues) {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
 
@@ -55,8 +53,7 @@ class IdentitySettings {
         return Settings.convert(settings, SETTINGS);
     }
 
-    static Map<String, String> getIdentitySettings(Storage storage, String uuid,
-            int identityIndex) {
+    static Map<String, String> getIdentitySettings(Storage storage, String uuid, int identityIndex) {
         Map<String, String> result = new HashMap<>();
         String prefix = uuid + ".";
         String suffix = "." + Integer.toString(identityIndex);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
@@ -12,13 +12,13 @@ import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.preferences.Settings.*;
 
-public class IdentitySettings {
-    public static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
-    public static final Map<Integer, SettingsUpgrader> UPGRADERS;
+class IdentitySettings {
+    static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
+    private static final Map<Integer, SettingsUpgrader> UPGRADERS;
 
     static {
         Map<String, TreeMap<Integer, SettingsDescription>> s =
-            new LinkedHashMap<String, TreeMap<Integer, SettingsDescription>>();
+                new LinkedHashMap<>();
 
         /**
          * When adding new settings here, be sure to increment {@link Settings.VERSION}
@@ -37,11 +37,12 @@ public class IdentitySettings {
 
         SETTINGS = Collections.unmodifiableMap(s);
 
-        Map<Integer, SettingsUpgrader> u = new HashMap<Integer, SettingsUpgrader>();
+        // noinspection MismatchedQueryAndUpdateOfCollection, this map intentionally left blank
+        Map<Integer, SettingsUpgrader> u = new HashMap<>();
         UPGRADERS = Collections.unmodifiableMap(u);
     }
 
-    public static Map<String, Object> validate(int version, Map<String, String> importedSettings,
+    static Map<String, Object> validate(int version, Map<String, String> importedSettings,
             boolean useDefaultValues) {
         return Settings.validate(version, SETTINGS, importedSettings, useDefaultValues);
     }
@@ -54,9 +55,9 @@ public class IdentitySettings {
         return Settings.convert(settings, SETTINGS);
     }
 
-    public static Map<String, String> getIdentitySettings(Storage storage, String uuid,
+    static Map<String, String> getIdentitySettings(Storage storage, String uuid,
             int identityIndex) {
-        Map<String, String> result = new HashMap<String, String>();
+        Map<String, String> result = new HashMap<>();
         String prefix = uuid + ".";
         String suffix = "." + Integer.toString(identityIndex);
         for (String key : SETTINGS.keySet()) {
@@ -69,15 +70,15 @@ public class IdentitySettings {
     }
 
 
-    public static boolean isEmailAddressValid(String email) {
+    static boolean isEmailAddressValid(String email) {
         return new EmailAddressValidator().isValidAddressOnly(email);
     }
 
     /**
      * The message signature setting.
      */
-    public static class SignatureSetting extends SettingsDescription<String> {
-        public SignatureSetting() {
+    private static class SignatureSetting extends SettingsDescription<String> {
+        SignatureSetting() {
             super(null);
         }
 
@@ -95,10 +96,10 @@ public class IdentitySettings {
     /**
      * An optional email address setting.
      */
-    public static class OptionalEmailAddressSetting extends SettingsDescription<String> {
+    private static class OptionalEmailAddressSetting extends SettingsDescription<String> {
         private EmailAddressValidator mValidator;
 
-        public OptionalEmailAddressSetting() {
+        OptionalEmailAddressSetting() {
             super(null);
             mValidator = new EmailAddressValidator();
         }

--- a/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
@@ -77,9 +77,6 @@ class IdentitySettings {
         return new EmailAddressValidator().isValidAddressOnly(email);
     }
 
-    /**
-     * The message signature setting.
-     */
     private static class SignatureSetting extends SettingsDescription<String> {
         SignatureSetting() {
             super(null);
@@ -96,9 +93,6 @@ class IdentitySettings {
         }
     }
 
-    /**
-     * An optional email address setting.
-     */
     private static class OptionalEmailAddressSetting extends SettingsDescription<String> {
         private EmailAddressValidator validator;
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.preferences;
 
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
@@ -10,7 +11,12 @@ import java.util.TreeMap;
 import com.fsck.k9.EmailAddressValidator;
 import com.fsck.k9.K9;
 import com.fsck.k9.R;
-import com.fsck.k9.preferences.Settings.*;
+import com.fsck.k9.preferences.Settings.BooleanSetting;
+import com.fsck.k9.preferences.Settings.InvalidSettingValueException;
+import com.fsck.k9.preferences.Settings.SettingsDescription;
+import com.fsck.k9.preferences.Settings.SettingsUpgrader;
+import com.fsck.k9.preferences.Settings.V;
+
 
 class IdentitySettings {
     static final Map<String, TreeMap<Integer, SettingsDescription>> SETTINGS;
@@ -19,20 +25,20 @@ class IdentitySettings {
     static {
         Map<String, TreeMap<Integer, SettingsDescription>> s = new LinkedHashMap<>();
 
-        /**
+        /*
          * When adding new settings here, be sure to increment {@link Settings.VERSION}
          * and use that for whatever you add here.
          */
 
         s.put("signature", Settings.versions(
                 new V(1, new SignatureSetting())
-            ));
+        ));
         s.put("signatureUse", Settings.versions(
                 new V(1, new BooleanSetting(true))
-            ));
+        ));
         s.put("replyTo", Settings.versions(
                 new V(1, new OptionalEmailAddressSetting())
-            ));
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/IdentitySettings.java
@@ -94,16 +94,16 @@ class IdentitySettings {
      * An optional email address setting.
      */
     private static class OptionalEmailAddressSetting extends SettingsDescription<String> {
-        private EmailAddressValidator mValidator;
+        private EmailAddressValidator validator;
 
         OptionalEmailAddressSetting() {
             super(null);
-            mValidator = new EmailAddressValidator();
+            validator = new EmailAddressValidator();
         }
 
         @Override
         public String fromString(String value) throws InvalidSettingValueException {
-            if (value != null && !mValidator.isValidAddressOnly(value)) {
+            if (value != null && !validator.isValidAddressOnly(value)) {
                 throw new InvalidSettingValueException();
             }
             return value;

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -142,11 +142,14 @@ public class Settings {
                 }
 
                 SettingsDescription setting = versionedSettings.get(toVersion);
+                if (setting == null) {
+                    throw new AssertionError("First version of a setting must be non-null!");
+                }
                 upgradeSettingInsertDefault(validatedSettingsMutable, settingName, setting);
             }
 
             Integer highestVersion = versionedSettings.lastKey();
-            boolean isRemovedSetting = highestVersion == toVersion && versionedSettings.get(highestVersion) == null;
+            boolean isRemovedSetting = (highestVersion == toVersion && versionedSettings.get(highestVersion) == null);
             if (isRemovedSetting) {
                 if (deletedSettingsMutable == null) {
                     deletedSettingsMutable = new HashSet<>();

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -283,10 +283,10 @@ public class Settings {
         /**
          * The setting's default value (internal representation).
          */
-        T mDefaultValue;
+        T defaultValue;
 
         SettingsDescription(T defaultValue) {
-            mDefaultValue = defaultValue;
+            this.defaultValue = defaultValue;
         }
 
         /**
@@ -295,7 +295,7 @@ public class Settings {
          * @return The internal representation of the default value.
          */
         public T getDefaultValue() {
-            return mDefaultValue;
+            return defaultValue;
         }
 
         /**
@@ -463,17 +463,17 @@ public class Settings {
      * </p>
      */
     static class EnumSetting<T extends Enum<T>> extends SettingsDescription<T> {
-        private Class<T> mEnumClass;
+        private Class<T> enumClass;
 
         EnumSetting(Class<T> enumClass, T defaultValue) {
             super(defaultValue);
-            mEnumClass = enumClass;
+            this.enumClass = enumClass;
         }
 
         @Override
         public T fromString(String value) throws InvalidSettingValueException {
             try {
-                return Enum.valueOf(mEnumClass, value);
+                return Enum.valueOf(enumClass, value);
             } catch (Exception e) {
                 throw new InvalidSettingValueException();
             }
@@ -514,7 +514,7 @@ public class Settings {
      * A font size setting.
      */
     static class FontSizeSetting extends PseudoEnumSetting<Integer> {
-        private final Map<Integer, String> mMapping;
+        private final Map<Integer, String> mapping;
 
         FontSizeSetting(int defaultValue) {
             super(defaultValue);
@@ -527,19 +527,19 @@ public class Settings {
             mapping.put(FontSizes.MEDIUM, "medium");
             mapping.put(FontSizes.FONT_20SP, "large");
             mapping.put(FontSizes.LARGE, "larger");
-            mMapping = Collections.unmodifiableMap(mapping);
+            this.mapping = Collections.unmodifiableMap(mapping);
         }
 
         @Override
         protected Map<Integer, String> getMapping() {
-            return mMapping;
+            return mapping;
         }
 
         @Override
         public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 Integer fontSize = Integer.parseInt(value);
-                if (mMapping.containsKey(fontSize)) {
+                if (mapping.containsKey(fontSize)) {
                     return fontSize;
                 }
             } catch (NumberFormatException e) { /* do nothing */ }
@@ -552,7 +552,7 @@ public class Settings {
      * A {@link android.webkit.WebView} font size setting.
      */
     static class WebFontSizeSetting extends PseudoEnumSetting<Integer> {
-        private final Map<Integer, String> mMapping;
+        private final Map<Integer, String> mapping;
 
         WebFontSizeSetting(int defaultValue) {
             super(defaultValue);
@@ -563,19 +563,19 @@ public class Settings {
             mapping.put(3, "normal");
             mapping.put(4, "larger");
             mapping.put(5, "largest");
-            mMapping = Collections.unmodifiableMap(mapping);
+            this.mapping = Collections.unmodifiableMap(mapping);
         }
 
         @Override
         protected Map<Integer, String> getMapping() {
-            return mMapping;
+            return mapping;
         }
 
         @Override
         public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 Integer fontSize = Integer.parseInt(value);
-                if (mMapping.containsKey(fontSize)) {
+                if (mapping.containsKey(fontSize)) {
                     return fontSize;
                 }
             } catch (NumberFormatException e) { /* do nothing */ }
@@ -588,20 +588,20 @@ public class Settings {
      * An integer settings whose values a limited to a certain range.
      */
     static class IntegerRangeSetting extends SettingsDescription<Integer> {
-        private int mStart;
-        private int mEnd;
+        private int start;
+        private int end;
 
         IntegerRangeSetting(int start, int end, int defaultValue) {
             super(defaultValue);
-            mStart = start;
-            mEnd = end;
+            this.start = start;
+            this.end = end;
         }
 
         @Override
         public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 int intValue = Integer.parseInt(value);
-                if (mStart <= intValue && intValue <= mEnd) {
+                if (start <= intValue && intValue <= end) {
                     return intValue;
                 }
             } catch (NumberFormatException e) { /* do nothing */ }

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -272,13 +272,13 @@ public class Settings {
      * negligible.
      * </p>
      */
-    static abstract class SettingsDescription {
+    static abstract class SettingsDescription<A> {
         /**
          * The setting's default value (internal representation).
          */
-        Object mDefaultValue;
+        A mDefaultValue;
 
-        SettingsDescription(Object defaultValue) {
+        SettingsDescription(A defaultValue) {
             mDefaultValue = defaultValue;
         }
 
@@ -287,7 +287,7 @@ public class Settings {
          *
          * @return The internal representation of the default value.
          */
-        public Object getDefaultValue() {
+        public A getDefaultValue() {
             return mDefaultValue;
         }
 
@@ -299,7 +299,7 @@ public class Settings {
          *
          * @return The string representation of {@code value}.
          */
-        public String toString(Object value) {
+        public String toString(A value) {
             return value.toString();
         }
 
@@ -314,7 +314,7 @@ public class Settings {
          * @throws InvalidSettingValueException
          *         If {@code value} contains an invalid value.
          */
-        public abstract Object fromString(String value) throws InvalidSettingValueException;
+        public abstract A fromString(String value) throws InvalidSettingValueException;
 
         /**
          * Convert a setting value to the "pretty" string representation.
@@ -324,7 +324,7 @@ public class Settings {
          *
          * @return A pretty-printed version of the setting's value.
          */
-        public String toPrettyString(Object value) {
+        public String toPrettyString(A value) {
             return toString(value);
         }
 
@@ -340,7 +340,7 @@ public class Settings {
          * @throws InvalidSettingValueException
          *         If {@code value} contains an invalid value.
          */
-        public Object fromPrettyString(String value) throws InvalidSettingValueException {
+        public A fromPrettyString(String value) throws InvalidSettingValueException {
             return fromString(value);
         }
     }
@@ -383,13 +383,13 @@ public class Settings {
     /**
      * A string setting.
      */
-    static class StringSetting extends SettingsDescription {
+    static class StringSetting extends SettingsDescription<String> {
         StringSetting(String defaultValue) {
             super(defaultValue);
         }
 
         @Override
-        public Object fromString(String value) {
+        public String fromString(String value) {
             return value;
         }
     }
@@ -397,13 +397,13 @@ public class Settings {
     /**
      * A boolean setting.
      */
-    static class BooleanSetting extends SettingsDescription {
+    static class BooleanSetting extends SettingsDescription<Boolean> {
         BooleanSetting(boolean defaultValue) {
             super(defaultValue);
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public Boolean fromString(String value) throws InvalidSettingValueException {
             if (Boolean.TRUE.toString().equals(value)) {
                 return true;
             } else if (Boolean.FALSE.toString().equals(value)) {
@@ -416,13 +416,13 @@ public class Settings {
     /**
      * A color setting.
      */
-    static class ColorSetting extends SettingsDescription {
+    static class ColorSetting extends SettingsDescription<Integer> {
         ColorSetting(int defaultValue) {
             super(defaultValue);
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 return Integer.parseInt(value);
             } catch (NumberFormatException e) {
@@ -431,13 +431,13 @@ public class Settings {
         }
 
         @Override
-        public String toPrettyString(Object value) {
-            int color = ((Integer) value) & 0x00FFFFFF;
+        public String toPrettyString(Integer value) {
+            int color = value & 0x00FFFFFF;
             return String.format("#%06x", color);
         }
 
         @Override
-        public Object fromPrettyString(String value) throws InvalidSettingValueException {
+        public Integer fromPrettyString(String value) throws InvalidSettingValueException {
             try {
                 if (value.length() == 7) {
                     return Integer.parseInt(value.substring(1), 16) | 0xFF000000;
@@ -455,16 +455,16 @@ public class Settings {
      * {@link Enum#toString()} is used to obtain the "pretty" string representation.
      * </p>
      */
-    static class EnumSetting<T extends Enum<T>> extends SettingsDescription {
+    static class EnumSetting<T extends Enum<T>> extends SettingsDescription<T> {
         private Class<T> mEnumClass;
 
-        EnumSetting(Class<T> enumClass, Object defaultValue) {
+        EnumSetting(Class<T> enumClass, T defaultValue) {
             super(defaultValue);
             mEnumClass = enumClass;
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public T fromString(String value) throws InvalidSettingValueException {
             try {
                 return Enum.valueOf(mEnumClass, value);
             } catch (Exception e) {
@@ -479,20 +479,20 @@ public class Settings {
      * @param <A>
      *         The type of the internal representation (e.g. {@code Integer}).
      */
-    abstract static class PseudoEnumSetting<A> extends SettingsDescription {
-        PseudoEnumSetting(Object defaultValue) {
+    abstract static class PseudoEnumSetting<A> extends SettingsDescription<A> {
+        PseudoEnumSetting(A defaultValue) {
             super(defaultValue);
         }
 
         protected abstract Map<A, String> getMapping();
 
         @Override
-        public String toPrettyString(Object value) {
+        public String toPrettyString(A value) {
             return getMapping().get(value);
         }
 
         @Override
-        public Object fromPrettyString(String value) throws InvalidSettingValueException {
+        public A fromPrettyString(String value) throws InvalidSettingValueException {
             for (Entry<A, String> entry : getMapping().entrySet()) {
                 if (entry.getValue().equals(value)) {
                     return entry.getKey();
@@ -529,7 +529,7 @@ public class Settings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 Integer fontSize = Integer.parseInt(value);
                 if (mMapping.containsKey(fontSize)) {
@@ -565,7 +565,7 @@ public class Settings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 Integer fontSize = Integer.parseInt(value);
                 if (mMapping.containsKey(fontSize)) {
@@ -580,7 +580,7 @@ public class Settings {
     /**
      * An integer settings whose values a limited to a certain range.
      */
-    static class IntegerRangeSetting extends SettingsDescription {
+    static class IntegerRangeSetting extends SettingsDescription<Integer> {
         private int mStart;
         private int mEnd;
 
@@ -591,7 +591,7 @@ public class Settings {
         }
 
         @Override
-        public Object fromString(String value) throws InvalidSettingValueException {
+        public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 int intValue = Integer.parseInt(value);
                 if (mStart <= intValue && intValue <= mEnd) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -1,13 +1,14 @@
 package com.fsck.k9.preferences;
 
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
-import java.util.Map.Entry;
 
 import android.util.Log;
 
@@ -225,8 +226,7 @@ public class Settings {
      * @return A {@code TreeMap} using the version number as key, the {@code SettingsDescription}
      *         as value.
      */
-    static TreeMap<Integer, SettingsDescription> versions(
-            V... versionDescriptions) {
+    static TreeMap<Integer, SettingsDescription> versions(V... versionDescriptions) {
         TreeMap<Integer, SettingsDescription> map = new TreeMap<>();
         for (V v : versionDescriptions) {
             map.put(v.version, v.description);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -279,7 +279,7 @@ public class Settings {
      * negligible.
      * </p>
      */
-    static abstract class SettingsDescription<T> {
+    abstract static class SettingsDescription<T> {
         /**
          * The setting's default value (internal representation).
          */

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -242,12 +242,6 @@ public class Settings {
     }
 
 
-    /**
-     * Indicates an invalid setting value.
-     *
-     * @see SettingsDescription#fromString(String)
-     * @see SettingsDescription#fromPrettyString(String)
-     */
     static class InvalidSettingValueException extends Exception {
         private static final long serialVersionUID = 1L;
     }
@@ -352,11 +346,6 @@ public class Settings {
         }
     }
 
-    /**
-     * Container to hold a {@link SettingsDescription} instance and a version number.
-     *
-     * @see Settings#versions(V...)
-     */
     public static class V {
         public final Integer version;
         public final SettingsDescription description;
@@ -387,9 +376,6 @@ public class Settings {
     }
 
 
-    /**
-     * A string setting.
-     */
     static class StringSetting extends SettingsDescription<String> {
         StringSetting(String defaultValue) {
             super(defaultValue);
@@ -401,9 +387,6 @@ public class Settings {
         }
     }
 
-    /**
-     * A boolean setting.
-     */
     static class BooleanSetting extends SettingsDescription<Boolean> {
         BooleanSetting(boolean defaultValue) {
             super(defaultValue);
@@ -420,9 +403,6 @@ public class Settings {
         }
     }
 
-    /**
-     * A color setting.
-     */
     static class ColorSetting extends SettingsDescription<Integer> {
         ColorSetting(int defaultValue) {
             super(defaultValue);
@@ -455,13 +435,6 @@ public class Settings {
         }
     }
 
-    /**
-     * An {@code Enum} setting.
-     *
-     * <p>
-     * {@link Enum#toString()} is used to obtain the "pretty" string representation.
-     * </p>
-     */
     static class EnumSetting<T extends Enum<T>> extends SettingsDescription<T> {
         private Class<T> enumClass;
 
@@ -510,9 +483,6 @@ public class Settings {
         }
     }
 
-    /**
-     * A font size setting.
-     */
     static class FontSizeSetting extends PseudoEnumSetting<Integer> {
         private final Map<Integer, String> mapping;
 
@@ -548,9 +518,6 @@ public class Settings {
         }
     }
 
-    /**
-     * A {@link android.webkit.WebView} font size setting.
-     */
     static class WebFontSizeSetting extends PseudoEnumSetting<Integer> {
         private final Map<Integer, String> mapping;
 
@@ -584,9 +551,6 @@ public class Settings {
         }
     }
 
-    /**
-     * An integer settings whose values a limited to a certain range.
-     */
     static class IntegerRangeSetting extends SettingsDescription<Integer> {
         private int start;
         private int end;

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -157,9 +157,9 @@ public class Settings {
         return deletedSettingsMutable;
     }
 
-    private static <A> void upgradeSettingInsertDefault(Map<String, Object> validatedSettingsMutable,
-            String settingName, SettingsDescription<A> setting) {
-        A defaultValue = setting.getDefaultValue();
+    private static <T> void upgradeSettingInsertDefault(Map<String, Object> validatedSettingsMutable,
+            String settingName, SettingsDescription<T> setting) {
+        T defaultValue = setting.getDefaultValue();
         validatedSettingsMutable.put(settingName, defaultValue);
 
         if (K9.DEBUG) {
@@ -279,13 +279,13 @@ public class Settings {
      * negligible.
      * </p>
      */
-    static abstract class SettingsDescription<A> {
+    static abstract class SettingsDescription<T> {
         /**
          * The setting's default value (internal representation).
          */
-        A mDefaultValue;
+        T mDefaultValue;
 
-        SettingsDescription(A defaultValue) {
+        SettingsDescription(T defaultValue) {
             mDefaultValue = defaultValue;
         }
 
@@ -294,7 +294,7 @@ public class Settings {
          *
          * @return The internal representation of the default value.
          */
-        public A getDefaultValue() {
+        public T getDefaultValue() {
             return mDefaultValue;
         }
 
@@ -306,7 +306,7 @@ public class Settings {
          *
          * @return The string representation of {@code value}.
          */
-        public String toString(A value) {
+        public String toString(T value) {
             return value.toString();
         }
 
@@ -321,7 +321,7 @@ public class Settings {
          * @throws InvalidSettingValueException
          *         If {@code value} contains an invalid value.
          */
-        public abstract A fromString(String value) throws InvalidSettingValueException;
+        public abstract T fromString(String value) throws InvalidSettingValueException;
 
         /**
          * Convert a setting value to the "pretty" string representation.
@@ -331,7 +331,7 @@ public class Settings {
          *
          * @return A pretty-printed version of the setting's value.
          */
-        public String toPrettyString(A value) {
+        public String toPrettyString(T value) {
             return toString(value);
         }
 
@@ -347,7 +347,7 @@ public class Settings {
          * @throws InvalidSettingValueException
          *         If {@code value} contains an invalid value.
          */
-        public A fromPrettyString(String value) throws InvalidSettingValueException {
+        public T fromPrettyString(String value) throws InvalidSettingValueException {
             return fromString(value);
         }
     }
@@ -483,24 +483,24 @@ public class Settings {
     /**
      * A setting that has multiple valid values but doesn't use an {@link Enum} internally.
      *
-     * @param <A>
+     * @param <T>
      *         The type of the internal representation (e.g. {@code Integer}).
      */
-    abstract static class PseudoEnumSetting<A> extends SettingsDescription<A> {
-        PseudoEnumSetting(A defaultValue) {
+    abstract static class PseudoEnumSetting<T> extends SettingsDescription<T> {
+        PseudoEnumSetting(T defaultValue) {
             super(defaultValue);
         }
 
-        protected abstract Map<A, String> getMapping();
+        protected abstract Map<T, String> getMapping();
 
         @Override
-        public String toPrettyString(A value) {
+        public String toPrettyString(T value) {
             return getMapping().get(value);
         }
 
         @Override
-        public A fromPrettyString(String value) throws InvalidSettingValueException {
-            for (Entry<A, String> entry : getMapping().entrySet()) {
+        public T fromPrettyString(String value) throws InvalidSettingValueException {
+            for (Entry<T, String> entry : getMapping().entrySet()) {
                 if (entry.getValue().equals(value)) {
                     return entry.getKey();
                 }

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -38,13 +38,11 @@ public class Settings {
      */
     public static final int VERSION = 44;
 
-    static Map<String, Object> validate(int version, Map<String,
-            TreeMap<Integer, SettingsDescription>> settings,
+    static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {
 
         Map<String, Object> validatedSettings = new HashMap<>();
-        for (Map.Entry<String, TreeMap<Integer, SettingsDescription>> versionedSetting :
-                settings.entrySet()) {
+        for (Map.Entry<String, TreeMap<Integer, SettingsDescription>> versionedSetting : settings.entrySet()) {
 
             // Get the setting description with the highest version lower than or equal to the
             // supplied content version.
@@ -112,8 +110,7 @@ public class Settings {
      *         if none were removed.
      */
     public static Set<String> upgrade(int version, Map<Integer, SettingsUpgrader> customUpgraders,
-            Map<String, TreeMap<Integer, SettingsDescription>> settings,
-            Map<String, Object> validatedSettingsMutable) {
+            Map<String, TreeMap<Integer, SettingsDescription>> settings, Map<String, Object> validatedSettingsMutable) {
         Set<String> deletedSettings = null;
 
         for (int toVersion = version + 1; toVersion <= VERSION; toVersion++) {
@@ -201,8 +198,7 @@ public class Settings {
             String settingName = setting.getKey();
             Object internalValue = setting.getValue();
 
-            TreeMap<Integer, SettingsDescription> versionedSetting =
-                    settingDescriptions.get(settingName);
+            TreeMap<Integer, SettingsDescription> versionedSetting = settingDescriptions.get(settingName);
             Integer highestVersion = versionedSetting.lastKey();
             SettingsDescription settingDesc = versionedSetting.get(highestVersion);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -76,8 +76,7 @@ public class SettingsExporter {
     static final String DESCRIPTION_ELEMENT = "description";
 
 
-    public static String exportToFile(Context context, boolean includeGlobals,
-            Set<String> accountUuids)
+    public static String exportToFile(Context context, boolean includeGlobals, Set<String> accountUuids)
             throws SettingsImportExportException {
 
         OutputStream os = null;
@@ -110,8 +109,8 @@ public class SettingsExporter {
         }
     }
 
-    static void exportPreferences(Context context, OutputStream os, boolean includeGlobals,
-            Set<String> accountUuids) throws SettingsImportExportException  {
+    static void exportPreferences(Context context, OutputStream os, boolean includeGlobals, Set<String> accountUuids)
+            throws SettingsImportExportException  {
 
         try {
             XmlSerializer serializer = Xml.newSerializer();
@@ -124,8 +123,7 @@ public class SettingsExporter {
 
             serializer.startTag(null, ROOT_ELEMENT);
             serializer.attribute(null, VERSION_ATTRIBUTE, Integer.toString(Settings.VERSION));
-            serializer.attribute(null, FILE_FORMAT_ATTRIBUTE,
-                    Integer.toString(FILE_FORMAT_VERSION));
+            serializer.attribute(null, FILE_FORMAT_ATTRIBUTE, Integer.toString(FILE_FORMAT_VERSION));
 
             Log.i(K9.LOG_TAG, "Exporting preferences");
 
@@ -167,10 +165,9 @@ public class SettingsExporter {
         }
     }
 
-    private static void writeSettings(XmlSerializer serializer,
-            Map<String, Object> prefs) throws IOException {
+    private static void writeSettings(XmlSerializer serializer, Map<String, Object> prefs) throws IOException {
 
-        for (Entry<String, TreeMap<Integer, SettingsDescription>> versionedSetting :
+        for (Entry<String, TreeMap<Integer, SettingsDescription>> versionedSetting : 
                 GlobalSettings.SETTINGS.entrySet()) {
 
             String key = versionedSetting.getKey();
@@ -192,8 +189,7 @@ public class SettingsExporter {
                 }
             } else {
                 if (K9.DEBUG) {
-                    Log.d(K9.LOG_TAG, "Couldn't find key \"" + key + "\" in preference storage." +
-                            "Using default value.");
+                    Log.d(K9.LOG_TAG, "Couldn't find key \"" + key + "\" in preference storage. Using default value.");
                 }
 
                 writeKeyAndDefaultValueFromSetting(serializer, key, setting);
@@ -201,8 +197,8 @@ public class SettingsExporter {
         }
     }
 
-    private static void writeAccount(XmlSerializer serializer, Account account,
-            Map<String, Object> prefs) throws IOException {
+    private static void writeAccount(XmlSerializer serializer, Account account, Map<String, Object> prefs)
+            throws IOException {
 
         Set<Integer> identities = new HashSet<>();
         Set<String> folders = new HashSet<>();
@@ -217,7 +213,6 @@ public class SettingsExporter {
             serializer.text(name);
             serializer.endTag(null, NAME_ELEMENT);
         }
-
 
         // Write incoming server settings
         ServerSettings incoming = RemoteStore.decodeStoreUri(account.getStoreUri());
@@ -326,8 +321,7 @@ public class SettingsExporter {
                 }
             }
 
-            TreeMap<Integer, SettingsDescription> versionedSetting =
-                AccountSettings.SETTINGS.get(keyPart);
+            TreeMap<Integer, SettingsDescription> versionedSetting = AccountSettings.SETTINGS.get(keyPart);
 
             if (versionedSetting != null) {
                 Integer highestVersion = versionedSetting.lastKey();
@@ -371,8 +365,8 @@ public class SettingsExporter {
         serializer.endTag(null, ACCOUNT_ELEMENT);
     }
 
-    private static void writeIdentity(XmlSerializer serializer, String accountUuid,
-            String identity, Map<String, Object> prefs) throws IOException {
+    private static void writeIdentity(XmlSerializer serializer, String accountUuid, String identity, 
+            Map<String, Object> prefs) throws IOException {
 
         serializer.startTag(null, IDENTITY_ELEMENT);
 
@@ -419,8 +413,7 @@ public class SettingsExporter {
                 continue;
             }
 
-            TreeMap<Integer, SettingsDescription> versionedSetting =
-                IdentitySettings.SETTINGS.get(identityKey);
+            TreeMap<Integer, SettingsDescription> versionedSetting = IdentitySettings.SETTINGS.get(identityKey);
 
             if (versionedSetting != null) {
                 Integer highestVersion = versionedSetting.lastKey();
@@ -431,9 +424,8 @@ public class SettingsExporter {
                     try {
                         writeKeyAndPrettyValueFromSetting(serializer, identityKey, setting, valueString);
                     } catch (InvalidSettingValueException e) {
-                        Log.w(K9.LOG_TAG, "Identity setting \"" + identityKey +
-                                "\" has invalid value \"" + valueString +
-                                "\" in preference storage. This shouldn't happen!");
+                        Log.w(K9.LOG_TAG, "Identity setting \"" + identityKey + "\" has invalid value \"" +
+                                valueString + "\" in preference storage. This shouldn't happen!");
                     }
                 }
             }
@@ -443,8 +435,8 @@ public class SettingsExporter {
         serializer.endTag(null, IDENTITY_ELEMENT);
     }
 
-    private static void writeFolder(XmlSerializer serializer, String accountUuid,
-            String folder, Map<String, Object> prefs) throws IOException {
+    private static void writeFolder(XmlSerializer serializer, String accountUuid, String folder,
+            Map<String, Object> prefs) throws IOException {
 
         serializer.startTag(null, FOLDER_ELEMENT);
         serializer.attribute(null, NAME_ATTRIBUTE, folder);
@@ -470,8 +462,7 @@ public class SettingsExporter {
                 continue;
             }
 
-            TreeMap<Integer, SettingsDescription> versionedSetting =
-                FolderSettings.SETTINGS.get(folderKey);
+            TreeMap<Integer, SettingsDescription> versionedSetting = FolderSettings.SETTINGS.get(folderKey);
 
             if (versionedSetting != null) {
                 Integer highestVersion = versionedSetting.lastKey();
@@ -482,8 +473,7 @@ public class SettingsExporter {
                     try {
                         writeKeyAndPrettyValueFromSetting(serializer, folderKey, setting, valueString);
                     } catch (InvalidSettingValueException e) {
-                        Log.w(K9.LOG_TAG, "Folder setting \"" + folderKey +
-                                "\" has invalid value \"" + valueString +
+                        Log.w(K9.LOG_TAG, "Folder setting \"" + folderKey + "\" has invalid value \"" + valueString +
                                 "\" in preference storage. This shouldn't happen!");
                     }
                 }
@@ -502,8 +492,8 @@ public class SettingsExporter {
         }
     }
 
-    private static <A> void writeKeyAndPrettyValueFromSetting(XmlSerializer serializer,
-            String key, SettingsDescription<A> setting, String valueString)
+    private static <A> void writeKeyAndPrettyValueFromSetting(XmlSerializer serializer, String key,
+            SettingsDescription<A> setting, String valueString)
             throws IllegalArgumentException, IllegalStateException, IOException, InvalidSettingValueException {
         A value = setting.fromString(valueString);
         String outputValue = setting.toPrettyString(value);
@@ -511,9 +501,8 @@ public class SettingsExporter {
         writeKeyAndPrettyValueFromSetting(serializer, key, outputValue);
     }
 
-    private static <A> void writeKeyAndDefaultValueFromSetting(XmlSerializer serializer,
-            String key, SettingsDescription<A> setting)
-            throws IllegalArgumentException, IllegalStateException, IOException {
+    private static <A> void writeKeyAndDefaultValueFromSetting(XmlSerializer serializer, String key,
+            SettingsDescription<A> setting) throws IllegalArgumentException, IllegalStateException, IOException {
         A value = setting.getDefaultValue();
         String outputValue = setting.toPrettyString(value);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -492,18 +492,18 @@ public class SettingsExporter {
         }
     }
 
-    private static <A> void writeKeyAndPrettyValueFromSetting(XmlSerializer serializer, String key,
-            SettingsDescription<A> setting, String valueString)
+    private static <T> void writeKeyAndPrettyValueFromSetting(XmlSerializer serializer, String key,
+            SettingsDescription<T> setting, String valueString)
             throws IllegalArgumentException, IllegalStateException, IOException, InvalidSettingValueException {
-        A value = setting.fromString(valueString);
+        T value = setting.fromString(valueString);
         String outputValue = setting.toPrettyString(value);
 
         writeKeyAndPrettyValueFromSetting(serializer, key, outputValue);
     }
 
-    private static <A> void writeKeyAndDefaultValueFromSetting(XmlSerializer serializer, String key,
-            SettingsDescription<A> setting) throws IllegalArgumentException, IllegalStateException, IOException {
-        A value = setting.getDefaultValue();
+    private static <T> void writeKeyAndDefaultValueFromSetting(XmlSerializer serializer, String key,
+            SettingsDescription<T> setting) throws IllegalArgumentException, IllegalStateException, IOException {
+        T value = setting.getDefaultValue();
         String outputValue = setting.toPrettyString(value);
 
         writeKeyAndPrettyValueFromSetting(serializer, key, outputValue);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -43,37 +43,37 @@ public class SettingsExporter {
      * for that to {@link SettingsImporter} :)
      * </p>
      */
-    public static final int FILE_FORMAT_VERSION = 1;
+    static final int FILE_FORMAT_VERSION = 1;
 
-    public static final String ROOT_ELEMENT = "k9settings";
-    public static final String VERSION_ATTRIBUTE = "version";
-    public static final String FILE_FORMAT_ATTRIBUTE = "format";
-    public static final String GLOBAL_ELEMENT = "global";
-    public static final String SETTINGS_ELEMENT = "settings";
-    public static final String ACCOUNTS_ELEMENT = "accounts";
-    public static final String ACCOUNT_ELEMENT = "account";
-    public static final String UUID_ATTRIBUTE = "uuid";
-    public static final String INCOMING_SERVER_ELEMENT = "incoming-server";
-    public static final String OUTGOING_SERVER_ELEMENT = "outgoing-server";
-    public static final String TYPE_ATTRIBUTE = "type";
-    public static final String HOST_ELEMENT = "host";
-    public static final String PORT_ELEMENT = "port";
-    public static final String CONNECTION_SECURITY_ELEMENT = "connection-security";
-    public static final String AUTHENTICATION_TYPE_ELEMENT = "authentication-type";
-    public static final String USERNAME_ELEMENT = "username";
-    public static final String CLIENT_CERTIFICATE_ALIAS_ELEMENT = "client-cert-alias";
-    public static final String PASSWORD_ELEMENT = "password";
-    public static final String EXTRA_ELEMENT = "extra";
-    public static final String IDENTITIES_ELEMENT = "identities";
-    public static final String IDENTITY_ELEMENT = "identity";
-    public static final String FOLDERS_ELEMENT = "folders";
-    public static final String FOLDER_ELEMENT = "folder";
-    public static final String NAME_ATTRIBUTE = "name";
-    public static final String VALUE_ELEMENT = "value";
-    public static final String KEY_ATTRIBUTE = "key";
-    public static final String NAME_ELEMENT = "name";
-    public static final String EMAIL_ELEMENT = "email";
-    public static final String DESCRIPTION_ELEMENT = "description";
+    static final String ROOT_ELEMENT = "k9settings";
+    static final String VERSION_ATTRIBUTE = "version";
+    static final String FILE_FORMAT_ATTRIBUTE = "format";
+    static final String GLOBAL_ELEMENT = "global";
+    static final String SETTINGS_ELEMENT = "settings";
+    static final String ACCOUNTS_ELEMENT = "accounts";
+    static final String ACCOUNT_ELEMENT = "account";
+    static final String UUID_ATTRIBUTE = "uuid";
+    static final String INCOMING_SERVER_ELEMENT = "incoming-server";
+    static final String OUTGOING_SERVER_ELEMENT = "outgoing-server";
+    static final String TYPE_ATTRIBUTE = "type";
+    static final String HOST_ELEMENT = "host";
+    static final String PORT_ELEMENT = "port";
+    static final String CONNECTION_SECURITY_ELEMENT = "connection-security";
+    static final String AUTHENTICATION_TYPE_ELEMENT = "authentication-type";
+    static final String USERNAME_ELEMENT = "username";
+    static final String CLIENT_CERTIFICATE_ALIAS_ELEMENT = "client-cert-alias";
+    static final String PASSWORD_ELEMENT = "password";
+    static final String EXTRA_ELEMENT = "extra";
+    static final String IDENTITIES_ELEMENT = "identities";
+    static final String IDENTITY_ELEMENT = "identity";
+    static final String FOLDERS_ELEMENT = "folders";
+    static final String FOLDER_ELEMENT = "folder";
+    static final String NAME_ATTRIBUTE = "name";
+    static final String VALUE_ELEMENT = "value";
+    static final String KEY_ATTRIBUTE = "key";
+    static final String NAME_ELEMENT = "name";
+    static final String EMAIL_ELEMENT = "email";
+    static final String DESCRIPTION_ELEMENT = "description";
 
 
     public static String exportToFile(Context context, boolean includeGlobals,
@@ -110,7 +110,7 @@ public class SettingsExporter {
         }
     }
 
-    public static void exportPreferences(Context context, OutputStream os, boolean includeGlobals,
+    static void exportPreferences(Context context, OutputStream os, boolean includeGlobals,
             Set<String> accountUuids) throws SettingsImportExportException  {
 
         try {
@@ -135,7 +135,7 @@ public class SettingsExporter {
             Set<String> exportAccounts;
             if (accountUuids == null) {
                 List<Account> accounts = preferences.getAccounts();
-                exportAccounts = new HashSet<String>();
+                exportAccounts = new HashSet<>();
                 for (Account account : accounts) {
                     exportAccounts.add(account.getUuid());
                 }
@@ -185,9 +185,7 @@ public class SettingsExporter {
 
             if (valueString != null) {
                 try {
-                    Object value = setting.fromString(valueString);
-                    String outputValue = setting.toPrettyString(value);
-                    writeKeyValue(serializer, key, outputValue);
+                    writeKeyAndPrettyValueFromSetting(serializer, key, setting, valueString);
                 } catch (InvalidSettingValueException e) {
                     Log.w(K9.LOG_TAG, "Global setting \"" + key  + "\" has invalid value \"" +
                             valueString + "\" in preference storage. This shouldn't happen!");
@@ -198,9 +196,7 @@ public class SettingsExporter {
                             "Using default value.");
                 }
 
-                Object value = setting.getDefaultValue();
-                String outputValue = setting.toPrettyString(value);
-                writeKeyValue(serializer, key, outputValue);
+                writeKeyAndDefaultValueFromSetting(serializer, key, setting);
             }
         }
     }
@@ -208,8 +204,8 @@ public class SettingsExporter {
     private static void writeAccount(XmlSerializer serializer, Account account,
             Map<String, Object> prefs) throws IOException {
 
-        Set<Integer> identities = new HashSet<Integer>();
-        Set<String> folders = new HashSet<String>();
+        Set<Integer> identities = new HashSet<>();
+        Set<String> folders = new HashSet<>();
         String accountUuid = account.getUuid();
 
         serializer.startTag(null, ACCOUNT_ELEMENT);
@@ -247,7 +243,7 @@ public class SettingsExporter {
         if (extras != null && extras.size() > 0) {
             serializer.startTag(null, EXTRA_ELEMENT);
             for (Entry<String, String> extra : extras.entrySet()) {
-                writeKeyValue(serializer, extra.getKey(), extra.getValue());
+                writeKeyAndPrettyValueFromSetting(serializer, extra.getKey(), extra.getValue());
             }
             serializer.endTag(null, EXTRA_ELEMENT);
         }
@@ -279,7 +275,7 @@ public class SettingsExporter {
         if (extras != null && extras.size() > 0) {
             serializer.startTag(null, EXTRA_ELEMENT);
             for (Entry<String, String> extra : extras.entrySet()) {
-                writeKeyValue(serializer, extra.getKey(), extra.getValue());
+                writeKeyAndPrettyValueFromSetting(serializer, extra.getKey(), extra.getValue());
             }
             serializer.endTag(null, EXTRA_ELEMENT);
         }
@@ -340,9 +336,7 @@ public class SettingsExporter {
                 if (setting != null) {
                     // Only export account settings that can be found in AccountSettings.SETTINGS
                     try {
-                        Object value = setting.fromString(valueString);
-                        String pretty = setting.toPrettyString(value);
-                        writeKeyValue(serializer, keyPart, pretty);
+                        writeKeyAndPrettyValueFromSetting(serializer, keyPart, setting, valueString);
                     } catch (InvalidSettingValueException e) {
                         Log.w(K9.LOG_TAG, "Account setting \"" + keyPart + "\" (" +
                                 account.getDescription() + ") has invalid value \"" + valueString +
@@ -357,7 +351,7 @@ public class SettingsExporter {
             serializer.startTag(null, IDENTITIES_ELEMENT);
 
             // Sort identity indices (that's why we store them as Integers)
-            List<Integer> sortedIdentities = new ArrayList<Integer>(identities);
+            List<Integer> sortedIdentities = new ArrayList<>(identities);
             Collections.sort(sortedIdentities);
 
             for (Integer identityIndex : sortedIdentities) {
@@ -435,9 +429,7 @@ public class SettingsExporter {
                 if (setting != null) {
                     // Only write settings that have an entry in IdentitySettings.SETTINGS
                     try {
-                        Object value = setting.fromString(valueString);
-                        String outputValue = setting.toPrettyString(value);
-                        writeKeyValue(serializer, identityKey, outputValue);
+                        writeKeyAndPrettyValueFromSetting(serializer, identityKey, setting, valueString);
                     } catch (InvalidSettingValueException e) {
                         Log.w(K9.LOG_TAG, "Identity setting \"" + identityKey +
                                 "\" has invalid value \"" + valueString +
@@ -488,9 +480,7 @@ public class SettingsExporter {
                 if (setting != null) {
                     // Only write settings that have an entry in FolderSettings.SETTINGS
                     try {
-                        Object value = setting.fromString(valueString);
-                        String outputValue = setting.toPrettyString(value);
-                        writeKeyValue(serializer, folderKey, outputValue);
+                        writeKeyAndPrettyValueFromSetting(serializer, folderKey, setting, valueString);
                     } catch (InvalidSettingValueException e) {
                         Log.w(K9.LOG_TAG, "Folder setting \"" + folderKey +
                                 "\" has invalid value \"" + valueString +
@@ -512,12 +502,30 @@ public class SettingsExporter {
         }
     }
 
-    private static void writeKeyValue(XmlSerializer serializer, String key, String value)
+    private static <A> void writeKeyAndPrettyValueFromSetting(XmlSerializer serializer,
+            String key, SettingsDescription<A> setting, String valueString)
+            throws IllegalArgumentException, IllegalStateException, IOException, InvalidSettingValueException {
+        A value = setting.fromString(valueString);
+        String outputValue = setting.toPrettyString(value);
+
+        writeKeyAndPrettyValueFromSetting(serializer, key, outputValue);
+    }
+
+    private static <A> void writeKeyAndDefaultValueFromSetting(XmlSerializer serializer,
+            String key, SettingsDescription<A> setting)
+            throws IllegalArgumentException, IllegalStateException, IOException {
+        A value = setting.getDefaultValue();
+        String outputValue = setting.toPrettyString(value);
+
+        writeKeyAndPrettyValueFromSetting(serializer, key, outputValue);
+    }
+
+    private static void writeKeyAndPrettyValueFromSetting(XmlSerializer serializer, String key, String literalValue)
             throws IllegalArgumentException, IllegalStateException, IOException {
         serializer.startTag(null, VALUE_ELEMENT);
         serializer.attribute(null, KEY_ATTRIBUTE, key);
-        if (value != null) {
-            serializer.text(value);
+        if (literalValue != null) {
+            serializer.text(literalValue);
         }
         serializer.endTag(null, VALUE_ELEMENT);
     }

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.preferences;
 
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -9,12 +10,9 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
-import java.util.Map.Entry;
-
-import com.fsck.k9.helper.FileHelper;
-import org.xmlpull.v1.XmlSerializer;
 
 import android.content.Context;
 import android.os.Environment;
@@ -24,11 +22,13 @@ import android.util.Xml;
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
+import com.fsck.k9.helper.FileHelper;
 import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mail.Transport;
 import com.fsck.k9.mail.store.RemoteStore;
 import com.fsck.k9.preferences.Settings.InvalidSettingValueException;
 import com.fsck.k9.preferences.Settings.SettingsDescription;
+import org.xmlpull.v1.XmlSerializer;
 
 
 public class SettingsExporter {
@@ -81,8 +81,7 @@ public class SettingsExporter {
 
         OutputStream os = null;
         String filename = null;
-        try
-        {
+        try {
             File dir = new File(Environment.getExternalStorageDirectory() + File.separator + context.getPackageName());
             if (!dir.mkdirs()) {
                 Log.d(K9.LOG_TAG, "Unable to create directory: " + dir.getAbsolutePath());
@@ -110,7 +109,7 @@ public class SettingsExporter {
     }
 
     static void exportPreferences(Context context, OutputStream os, boolean includeGlobals, Set<String> accountUuids)
-            throws SettingsImportExportException  {
+            throws SettingsImportExportException {
 
         try {
             XmlSerializer serializer = Xml.newSerializer();
@@ -167,7 +166,7 @@ public class SettingsExporter {
 
     private static void writeSettings(XmlSerializer serializer, Map<String, Object> prefs) throws IOException {
 
-        for (Entry<String, TreeMap<Integer, SettingsDescription>> versionedSetting : 
+        for (Entry<String, TreeMap<Integer, SettingsDescription>> versionedSetting :
                 GlobalSettings.SETTINGS.entrySet()) {
 
             String key = versionedSetting.getKey();
@@ -184,7 +183,7 @@ public class SettingsExporter {
                 try {
                     writeKeyAndPrettyValueFromSetting(serializer, key, setting, valueString);
                 } catch (InvalidSettingValueException e) {
-                    Log.w(K9.LOG_TAG, "Global setting \"" + key  + "\" has invalid value \"" +
+                    Log.w(K9.LOG_TAG, "Global setting \"" + key + "\" has invalid value \"" +
                             valueString + "\" in preference storage. This shouldn't happen!");
                 }
             } else {
@@ -365,7 +364,7 @@ public class SettingsExporter {
         serializer.endTag(null, ACCOUNT_ELEMENT);
     }
 
-    private static void writeIdentity(XmlSerializer serializer, String accountUuid, String identity, 
+    private static void writeIdentity(XmlSerializer serializer, String accountUuid, String identity,
             Map<String, Object> prefs) throws IOException {
 
         serializer.startTag(null, IDENTITY_ELEMENT);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -1045,20 +1045,20 @@ public class SettingsImporter {
     }
 
     private static class ImportedServerSettings extends ServerSettings {
-        private final ImportedServer mImportedServer;
+        private final ImportedServer importedServer;
 
         public ImportedServerSettings(ImportedServer server) {
             super(ServerSettings.Type.valueOf(server.type), server.host, convertPort(server.port),
                     convertConnectionSecurity(server.connectionSecurity),
                     server.authenticationType, server.username, server.password,
                     server.clientCertificateAlias);
-            mImportedServer = server;
+            importedServer = server;
         }
 
         @Override
         public Map<String, String> getExtra() {
-            return (mImportedServer.extras != null) ?
-                    Collections.unmodifiableMap(mImportedServer.extras.settings) : null;
+            return (importedServer.extras != null) ?
+                    Collections.unmodifiableMap(importedServer.extras.settings) : null;
         }
 
         private static int convertPort(String port) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -57,20 +57,8 @@ public class SettingsImporter {
         }
     }
 
-    /**
-     * Class to describe an account (name, UUID).
-     *
-     * @see ImportContents
-     */
     public static class AccountDescription {
-        /**
-         * The name of the account.
-         */
         public final String name;
-
-        /**
-         * The UUID of the account.
-         */
         public final String uuid;
 
         private AccountDescription(String name, String uuid) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -129,7 +129,7 @@ public class SettingsImporter {
             // If the stream contains global settings the "globalSettings" member will not be null
             boolean globalSettings = (imported.globalSettings != null);
 
-            final List<AccountDescription> accounts = new ArrayList<AccountDescription>();
+            final List<AccountDescription> accounts = new ArrayList<>();
             // If the stream contains at least one account configuration the "accounts" member
             // will not be null.
             if (imported.accounts != null) {
@@ -181,8 +181,8 @@ public class SettingsImporter {
         try
         {
             boolean globalSettingsImported = false;
-            List<AccountDescriptionPair> importedAccounts = new ArrayList<AccountDescriptionPair>();
-            List<AccountDescription> errorneousAccounts = new ArrayList<AccountDescription>();
+            List<AccountDescriptionPair> importedAccounts = new ArrayList<>();
+            List<AccountDescription> errorneousAccounts = new ArrayList<>();
 
             Imported imported = parseSettings(inputStream, globalSettings, accountUuids, false);
 
@@ -325,7 +325,7 @@ public class SettingsImporter {
         // Use current global settings as base and overwrite with validated settings read from the
         // import file.
         Map<String, String> mergedSettings =
-            new HashMap<String, String>(GlobalSettings.getGlobalSettings(storage));
+                new HashMap<>(GlobalSettings.getGlobalSettings(storage));
         mergedSettings.putAll(stringSettings);
 
         for (Map.Entry<String, String> setting : mergedSettings.entrySet()) {
@@ -433,7 +433,7 @@ public class SettingsImporter {
         // Merge account settings if necessary
         Map<String, String> writeSettings;
         if (mergeImportedAccount) {
-            writeSettings = new HashMap<String, String>(
+            writeSettings = new HashMap<>(
                     AccountSettings.getAccountSettings(prefs.getStorage(), uuid));
             writeSettings.putAll(stringSettings);
         } else {
@@ -522,7 +522,7 @@ public class SettingsImporter {
             existingIdentities = existingAccount.getIdentities();
             nextIdentityIndex = existingIdentities.size();
         } else {
-            existingIdentities = new ArrayList<Identity>();
+            existingIdentities = new ArrayList<>();
         }
 
         // Write identities
@@ -590,7 +590,7 @@ public class SettingsImporter {
                 // Merge identity settings if necessary
                 Map<String, String> writeSettings;
                 if (mergeSettings) {
-                    writeSettings = new HashMap<String, String>(IdentitySettings.getIdentitySettings(
+                    writeSettings = new HashMap<>(IdentitySettings.getIdentitySettings(
                             prefs.getStorage(), uuid, writeIdentityIndex));
                     writeSettings.putAll(stringSettings);
                 } else {
@@ -869,7 +869,7 @@ public class SettingsImporter {
                 String element = xpp.getName();
                 if (SettingsExporter.ACCOUNT_ELEMENT.equals(element)) {
                     if (accounts == null) {
-                        accounts = new HashMap<String, ImportedAccount>();
+                        accounts = new HashMap<>();
                     }
 
                     ImportedAccount account = parseAccount(xpp, accountUuids, overview);
@@ -1012,7 +1012,7 @@ public class SettingsImporter {
                 String element = xpp.getName();
                 if (SettingsExporter.IDENTITY_ELEMENT.equals(element)) {
                     if (identities == null) {
-                        identities = new ArrayList<ImportedIdentity>();
+                        identities = new ArrayList<>();
                     }
 
                     ImportedIdentity identity = parseIdentity(xpp);
@@ -1067,7 +1067,7 @@ public class SettingsImporter {
                 String element = xpp.getName();
                 if (SettingsExporter.FOLDER_ELEMENT.equals(element)) {
                     if (folders == null) {
-                        folders = new ArrayList<ImportedFolder>();
+                        folders = new ArrayList<>();
                     }
 
                     ImportedFolder folder = parseFolder(xpp);
@@ -1154,7 +1154,7 @@ public class SettingsImporter {
     }
 
     private static class ImportedSettings {
-        public Map<String, String> settings = new HashMap<String, String>();
+        public Map<String, String> settings = new HashMap<>();
     }
 
     @VisibleForTesting

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -93,13 +93,13 @@ public class SettingsImporter {
     public static class ImportResults {
         public final boolean globalSettings;
         public final List<AccountDescriptionPair> importedAccounts;
-        public final List<AccountDescription> errorneousAccounts;
+        public final List<AccountDescription> erroneousAccounts;
 
         private ImportResults(boolean globalSettings, List<AccountDescriptionPair> importedAccounts,
-                List<AccountDescription> errorneousAccounts) {
+                List<AccountDescription> erroneousAccounts) {
            this.globalSettings = globalSettings;
            this.importedAccounts = importedAccounts;
-           this.errorneousAccounts = errorneousAccounts;
+           this.erroneousAccounts = erroneousAccounts;
         }
     }
 
@@ -179,7 +179,7 @@ public class SettingsImporter {
         {
             boolean globalSettingsImported = false;
             List<AccountDescriptionPair> importedAccounts = new ArrayList<>();
-            List<AccountDescription> errorneousAccounts = new ArrayList<>();
+            List<AccountDescription> erroneousAccounts = new ArrayList<>();
 
             Imported imported = parseSettings(inputStream, globalSettings, accountUuids, false);
 
@@ -252,17 +252,17 @@ public class SettingsImporter {
                                         Log.w(K9.LOG_TAG, "Error while committing settings for account \"" +
                                                 importResult.original.name + "\" to the settings database.");
                                     }
-                                    errorneousAccounts.add(importResult.original);
+                                    erroneousAccounts.add(importResult.original);
                                 }
                             } catch (InvalidSettingValueException e) {
                                 if (K9.DEBUG) {
                                     Log.e(K9.LOG_TAG, "Encountered invalid setting while " +
                                             "importing account \"" + account.name + "\"", e);
                                 }
-                                errorneousAccounts.add(new AccountDescription(account.name, account.uuid));
+                                erroneousAccounts.add(new AccountDescription(account.name, account.uuid));
                             } catch (Exception e) {
                                 Log.e(K9.LOG_TAG, "Exception while importing account \"" + account.name + "\"", e);
-                                errorneousAccounts.add(new AccountDescription(account.name, account.uuid));
+                                erroneousAccounts.add(new AccountDescription(account.name, account.uuid));
                             }
                         } else {
                             Log.w(K9.LOG_TAG, "Was asked to import account with UUID " + accountUuid + 
@@ -289,7 +289,7 @@ public class SettingsImporter {
             K9.loadPrefs(preferences);
             K9.setServicesEnabled(context);
 
-            return new ImportResults(globalSettingsImported, importedAccounts, errorneousAccounts);
+            return new ImportResults(globalSettingsImported, importedAccounts, erroneousAccounts);
 
         } catch (SettingsImportExportException e) {
             throw e;

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.preferences;
 
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -9,10 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-
-import org.xmlpull.v1.XmlPullParser;
-import org.xmlpull.v1.XmlPullParserException;
-import org.xmlpull.v1.XmlPullParserFactory;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -31,6 +28,10 @@ import com.fsck.k9.mail.Transport;
 import com.fsck.k9.mail.filter.Base64;
 import com.fsck.k9.mail.store.RemoteStore;
 import com.fsck.k9.preferences.Settings.InvalidSettingValueException;
+import org.xmlpull.v1.XmlPullParser;
+import org.xmlpull.v1.XmlPullParserException;
+import org.xmlpull.v1.XmlPullParserFactory;
+
 
 public class SettingsImporter {
 
@@ -97,9 +98,9 @@ public class SettingsImporter {
 
         private ImportResults(boolean globalSettings, List<AccountDescriptionPair> importedAccounts,
                 List<AccountDescription> erroneousAccounts) {
-           this.globalSettings = globalSettings;
-           this.importedAccounts = importedAccounts;
-           this.erroneousAccounts = erroneousAccounts;
+            this.globalSettings = globalSettings;
+            this.importedAccounts = importedAccounts;
+            this.erroneousAccounts = erroneousAccounts;
         }
     }
 
@@ -115,7 +116,7 @@ public class SettingsImporter {
      *         settings file.
      *
      * @throws SettingsImportExportException
-     *          In case of an error.
+     *         In case of an error.
      */
     public static ImportContents getImportStreamContents(InputStream inputStream)
             throws SettingsImportExportException {
@@ -170,13 +171,12 @@ public class SettingsImporter {
      *         successfully imported accounts.
      *
      * @throws SettingsImportExportException
-     *          In case of an error.
+     *         In case of an error.
      */
     public static ImportResults importSettings(Context context, InputStream inputStream, boolean globalSettings,
             List<String> accountUuids, boolean overwrite) throws SettingsImportExportException {
 
-        try
-        {
+        try {
             boolean globalSettingsImported = false;
             List<AccountDescriptionPair> importedAccounts = new ArrayList<>();
             List<AccountDescription> erroneousAccounts = new ArrayList<>();
@@ -265,7 +265,7 @@ public class SettingsImporter {
                                 erroneousAccounts.add(new AccountDescription(account.name, account.uuid));
                             }
                         } else {
-                            Log.w(K9.LOG_TAG, "Was asked to import account with UUID " + accountUuid + 
+                            Log.w(K9.LOG_TAG, "Was asked to import account with UUID " + accountUuid +
                                     ". But this account wasn't found.");
                         }
                     }
@@ -462,7 +462,7 @@ public class SettingsImporter {
 
         // Validate folder settings
         Map<String, Object> validatedSettings =
-            FolderSettings.validate(contentVersion, folder.settings.settings, !overwrite);
+                FolderSettings.validate(contentVersion, folder.settings.settings, !overwrite);
 
         // Upgrade folder settings to current content version
         if (contentVersion != Settings.VERSION) {
@@ -658,7 +658,7 @@ public class SettingsImporter {
             Imported imported = null;
             int eventType = xpp.getEventType();
             while (eventType != XmlPullParser.END_DOCUMENT) {
-                if(eventType == XmlPullParser.START_TAG) {
+                if (eventType == XmlPullParser.START_TAG) {
                     if (SettingsExporter.ROOT_ELEMENT.equals(xpp.getName())) {
                         imported = parseRoot(xpp, globalSettings, accountUuids, overview);
                     } else {
@@ -706,7 +706,7 @@ public class SettingsImporter {
 
         int eventType = xpp.next();
         while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.ROOT_ELEMENT.equals(xpp.getName()))) {
-            if(eventType == XmlPullParser.START_TAG) {
+            if (eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.GLOBAL_ELEMENT.equals(element)) {
                     if (overview || globalSettings) {
@@ -779,7 +779,7 @@ public class SettingsImporter {
         return version;
     }
 
-    private static ImportedSettings parseSettings(XmlPullParser xpp, String endTag) 
+    private static ImportedSettings parseSettings(XmlPullParser xpp, String endTag)
             throws XmlPullParserException, IOException {
 
         ImportedSettings result = null;
@@ -787,7 +787,7 @@ public class SettingsImporter {
         int eventType = xpp.next();
         while (!(eventType == XmlPullParser.END_TAG && endTag.equals(xpp.getName()))) {
 
-            if(eventType == XmlPullParser.START_TAG) {
+            if (eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.VALUE_ELEMENT.equals(element)) {
                     String key = xpp.getAttributeValue(null, SettingsExporter.KEY_ATTRIBUTE);
@@ -819,7 +819,7 @@ public class SettingsImporter {
 
         int eventType = xpp.next();
         while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.ACCOUNTS_ELEMENT.equals(xpp.getName()))) {
-            if(eventType == XmlPullParser.START_TAG) {
+            if (eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.ACCOUNT_ELEMENT.equals(element)) {
                     if (accounts == null) {
@@ -864,7 +864,7 @@ public class SettingsImporter {
         if (overview || accountUuids.contains(uuid)) {
             int eventType = xpp.next();
             while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.ACCOUNT_ELEMENT.equals(xpp.getName()))) {
-                if(eventType == XmlPullParser.START_TAG) {
+                if (eventType == XmlPullParser.START_TAG) {
                     String element = xpp.getName();
                     if (SettingsExporter.NAME_ELEMENT.equals(element)) {
                         account.name = getText(xpp);
@@ -921,7 +921,7 @@ public class SettingsImporter {
 
         int eventType = xpp.next();
         while (!(eventType == XmlPullParser.END_TAG && endTag.equals(xpp.getName()))) {
-            if(eventType == XmlPullParser.START_TAG) {
+            if (eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.HOST_ELEMENT.equals(element)) {
                     server.host = getText(xpp);
@@ -950,13 +950,13 @@ public class SettingsImporter {
         return server;
     }
 
-    private static List<ImportedIdentity> parseIdentities(XmlPullParser xpp) 
+    private static List<ImportedIdentity> parseIdentities(XmlPullParser xpp)
             throws XmlPullParserException, IOException {
         List<ImportedIdentity> identities = null;
 
         int eventType = xpp.next();
         while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.IDENTITIES_ELEMENT.equals(xpp.getName()))) {
-            if(eventType == XmlPullParser.START_TAG) {
+            if (eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.IDENTITY_ELEMENT.equals(element)) {
                     if (identities == null) {
@@ -981,7 +981,7 @@ public class SettingsImporter {
         int eventType = xpp.next();
         while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.IDENTITY_ELEMENT.equals(xpp.getName()))) {
 
-            if(eventType == XmlPullParser.START_TAG) {
+            if (eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.NAME_ELEMENT.equals(element)) {
                     identity.name = getText(xpp);
@@ -1006,7 +1006,7 @@ public class SettingsImporter {
 
         int eventType = xpp.next();
         while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.FOLDERS_ELEMENT.equals(xpp.getName()))) {
-            if(eventType == XmlPullParser.START_TAG) {
+            if (eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.FOLDER_ELEMENT.equals(element)) {
                     if (folders == null) {
@@ -1038,7 +1038,7 @@ public class SettingsImporter {
 
     private static String getAccountDisplayName(ImportedAccount account) {
         String name = account.name;
-        if (TextUtils.isEmpty(name) && account.identities != null && account.identities.size() > 0){
+        if (TextUtils.isEmpty(name) && account.identities != null && account.identities.size() > 0) {
             name = account.identities.get(0).email;
         }
         return name;

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -83,8 +83,7 @@ public class SettingsImporter {
         public final AccountDescription imported;
         public final boolean overwritten;
 
-        private AccountDescriptionPair(AccountDescription original, AccountDescription imported,
-                boolean overwritten) {
+        private AccountDescriptionPair(AccountDescription original, AccountDescription imported, boolean overwritten) {
             this.original = original;
             this.imported = imported;
             this.overwritten = overwritten;
@@ -96,8 +95,7 @@ public class SettingsImporter {
         public final List<AccountDescriptionPair> importedAccounts;
         public final List<AccountDescription> errorneousAccounts;
 
-        private ImportResults(boolean globalSettings,
-                List<AccountDescriptionPair> importedAccounts,
+        private ImportResults(boolean globalSettings, List<AccountDescriptionPair> importedAccounts,
                 List<AccountDescription> errorneousAccounts) {
            this.globalSettings = globalSettings;
            this.importedAccounts = importedAccounts;
@@ -174,9 +172,8 @@ public class SettingsImporter {
      * @throws SettingsImportExportException
      *          In case of an error.
      */
-    public static ImportResults importSettings(Context context, InputStream inputStream,
-            boolean globalSettings, List<String> accountUuids, boolean overwrite)
-    throws SettingsImportExportException {
+    public static ImportResults importSettings(Context context, InputStream inputStream, boolean globalSettings,
+            List<String> accountUuids, boolean overwrite) throws SettingsImportExportException {
 
         try
         {
@@ -193,21 +190,18 @@ public class SettingsImporter {
                 try {
                     StorageEditor editor = storage.edit();
                     if (imported.globalSettings != null) {
-                        importGlobalSettings(storage, editor, imported.contentVersion,
-                                imported.globalSettings);
+                        importGlobalSettings(storage, editor, imported.contentVersion, imported.globalSettings);
                     } else {
                         Log.w(K9.LOG_TAG, "Was asked to import global settings but none found.");
                     }
                     if (editor.commit()) {
                         if (K9.DEBUG) {
-                            Log.v(K9.LOG_TAG, "Committed global settings to the preference " +
-                                    "storage.");
+                            Log.v(K9.LOG_TAG, "Committed global settings to the preference storage.");
                         }
                         globalSettingsImported = true;
                     } else {
                         if (K9.DEBUG) {
-                            Log.v(K9.LOG_TAG, "Failed to commit global settings to the " +
-                                    "preference storage");
+                            Log.v(K9.LOG_TAG, "Failed to commit global settings to the preference storage");
                         }
                     }
                 } catch (Exception e) {
@@ -223,14 +217,13 @@ public class SettingsImporter {
                             try {
                                 StorageEditor editor = storage.edit();
 
-                                AccountDescriptionPair importResult = importAccount(context,
-                                        editor, imported.contentVersion, account, overwrite);
+                                AccountDescriptionPair importResult = importAccount(context, editor,
+                                        imported.contentVersion, account, overwrite);
 
                                 if (editor.commit()) {
                                     if (K9.DEBUG) {
                                         Log.v(K9.LOG_TAG, "Committed settings for account \"" +
-                                                importResult.imported.name +
-                                                "\" to the settings database.");
+                                                importResult.imported.name + "\" to the settings database.");
                                     }
 
                                     // Add UUID of the account we just imported to the list of
@@ -256,9 +249,8 @@ public class SettingsImporter {
                                     importedAccounts.add(importResult);
                                 } else {
                                     if (K9.DEBUG) {
-                                        Log.w(K9.LOG_TAG, "Error while committing settings for " +
-                                                "account \"" + importResult.original.name +
-                                                "\" to the settings database.");
+                                        Log.w(K9.LOG_TAG, "Error while committing settings for account \"" +
+                                                importResult.original.name + "\" to the settings database.");
                                     }
                                     errorneousAccounts.add(importResult.original);
                                 }
@@ -269,13 +261,12 @@ public class SettingsImporter {
                                 }
                                 errorneousAccounts.add(new AccountDescription(account.name, account.uuid));
                             } catch (Exception e) {
-                                Log.e(K9.LOG_TAG, "Exception while importing account \"" +
-                                        account.name + "\"", e);
+                                Log.e(K9.LOG_TAG, "Exception while importing account \"" + account.name + "\"", e);
                                 errorneousAccounts.add(new AccountDescription(account.name, account.uuid));
                             }
                         } else {
-                            Log.w(K9.LOG_TAG, "Was asked to import account with UUID " +
-                                    accountUuid + ". But this account wasn't found.");
+                            Log.w(K9.LOG_TAG, "Was asked to import account with UUID " + accountUuid + 
+                                    ". But this account wasn't found.");
                         }
                     }
 
@@ -307,12 +298,11 @@ public class SettingsImporter {
         }
     }
 
-    private static void importGlobalSettings(Storage storage,
-            StorageEditor editor, int contentVersion, ImportedSettings settings) {
+    private static void importGlobalSettings(Storage storage, StorageEditor editor, int contentVersion,
+            ImportedSettings settings) {
 
         // Validate global settings
-        Map<String, Object> validatedSettings = GlobalSettings.validate(contentVersion,
-                settings.settings);
+        Map<String, Object> validatedSettings = GlobalSettings.validate(contentVersion, settings.settings);
 
         // Upgrade global settings to current content version
         if (contentVersion != Settings.VERSION) {
@@ -322,10 +312,8 @@ public class SettingsImporter {
         // Convert global settings to the string representation used in preference storage
         Map<String, String> stringSettings = GlobalSettings.convert(validatedSettings);
 
-        // Use current global settings as base and overwrite with validated settings read from the
-        // import file.
-        Map<String, String> mergedSettings =
-                new HashMap<>(GlobalSettings.getGlobalSettings(storage));
+        // Use current global settings as base and overwrite with validated settings read from the import file.
+        Map<String, String> mergedSettings = new HashMap<>(GlobalSettings.getGlobalSettings(storage));
         mergedSettings.putAll(stringSettings);
 
         for (Map.Entry<String, String> setting : mergedSettings.entrySet()) {
@@ -335,9 +323,8 @@ public class SettingsImporter {
         }
     }
 
-    private static AccountDescriptionPair importAccount(Context context,
-            StorageEditor editor, int contentVersion, ImportedAccount account,
-            boolean overwrite) throws InvalidSettingValueException {
+    private static AccountDescriptionPair importAccount(Context context, StorageEditor editor, int contentVersion,
+            ImportedAccount account, boolean overwrite) throws InvalidSettingValueException {
 
         AccountDescription original = new AccountDescription(account.name, account.uuid);
 
@@ -357,8 +344,8 @@ public class SettingsImporter {
         // Make sure the account name is unique
         String accountName = account.name;
         if (isAccountNameUsed(accountName, accounts)) {
-            // Account name is already in use. So generate a new one by appending " (x)", where x
-            // is the first number >= 1 that results in an unused account name.
+            // Account name is already in use. So generate a new one by appending " (x)", where x is the first
+            // number >= 1 that results in an unused account name.
             for (int i = 1; i <= accounts.size(); i++) {
                 accountName = account.name + " (" + i + ")";
                 if (!isAccountNameUsed(accountName, accounts)) {
@@ -398,11 +385,9 @@ public class SettingsImporter {
             putString(editor, accountKeyPrefix + Account.TRANSPORT_URI_KEY, Base64.encode(transportUri));
 
             /*
-             * Mark account as disabled if the settings file contained a
-             * username but no password. However, no password is required for
-             * the outgoing server for WebDAV accounts, because incoming and
-             * outgoing servers are identical for this account type. Nor is a
-             * password required if the AuthType is EXTERNAL.
+             * Mark account as disabled if the settings file contained a username but no password. However, no password
+             * is required for the outgoing server for WebDAV accounts, because incoming and outgoing servers are 
+             * identical for this account type. Nor is a password required if the AuthType is EXTERNAL.
              */
             boolean outgoingPasswordNeeded = AuthType.EXTERNAL != outgoing.authenticationType &&
                     !(ServerSettings.Type.WebDAV == outgoing.type) &&
@@ -419,8 +404,7 @@ public class SettingsImporter {
 
         // Validate account settings
         Map<String, Object> validatedSettings =
-            AccountSettings.validate(contentVersion, account.settings.settings,
-                    !mergeImportedAccount);
+                AccountSettings.validate(contentVersion, account.settings.settings, !mergeImportedAccount);
 
         // Upgrade account settings to current content version
         if (contentVersion != Settings.VERSION) {
@@ -433,8 +417,7 @@ public class SettingsImporter {
         // Merge account settings if necessary
         Map<String, String> writeSettings;
         if (mergeImportedAccount) {
-            writeSettings = new HashMap<>(
-                    AccountSettings.getAccountSettings(prefs.getStorage(), uuid));
+            writeSettings = new HashMap<>(AccountSettings.getAccountSettings(prefs.getStorage(), uuid));
             writeSettings.putAll(stringSettings);
         } else {
             writeSettings = stringSettings;
@@ -455,8 +438,7 @@ public class SettingsImporter {
 
         // Write identities
         if (account.identities != null) {
-            importIdentities(editor, contentVersion, uuid, account, overwrite, existingAccount,
-                    prefs);
+            importIdentities(editor, contentVersion, uuid, account, overwrite, existingAccount, prefs);
         } else if (!mergeImportedAccount) {
             // Require accounts to at least have one identity
             throw new InvalidSettingValueException();
@@ -475,8 +457,8 @@ public class SettingsImporter {
         return new AccountDescriptionPair(original, imported, mergeImportedAccount);
     }
 
-    private static void importFolder(StorageEditor editor, int contentVersion,
-            String uuid, ImportedFolder folder, boolean overwrite, Preferences prefs) {
+    private static void importFolder(StorageEditor editor, int contentVersion, String uuid, ImportedFolder folder,
+            boolean overwrite, Preferences prefs) {
 
         // Validate folder settings
         Map<String, Object> validatedSettings =
@@ -493,8 +475,7 @@ public class SettingsImporter {
         // Merge folder settings if necessary
         Map<String, String> writeSettings;
         if (overwrite) {
-            writeSettings = FolderSettings.getFolderSettings(prefs.getStorage(),
-                    uuid, folder.name);
+            writeSettings = FolderSettings.getFolderSettings(prefs.getStorage(), uuid, folder.name);
             writeSettings.putAll(stringSettings);
         } else {
             writeSettings = stringSettings;
@@ -509,9 +490,8 @@ public class SettingsImporter {
         }
     }
 
-    private static void importIdentities(StorageEditor editor, int contentVersion,
-            String uuid, ImportedAccount account, boolean overwrite, Account existingAccount,
-            Preferences prefs) throws InvalidSettingValueException {
+    private static void importIdentities(StorageEditor editor, int contentVersion, String uuid, ImportedAccount account,
+            boolean overwrite, Account existingAccount, Preferences prefs) throws InvalidSettingValueException {
 
         String accountKeyPrefix = uuid + ".";
 
@@ -540,8 +520,7 @@ public class SettingsImporter {
                 nextIdentityIndex++;
             }
 
-            String identityDescription = (identity.description == null) ?
-                    "Imported" : identity.description;
+            String identityDescription = (identity.description == null) ? "Imported" : identity.description;
             if (isIdentityDescriptionUsed(identityDescription, existingIdentities)) {
                 // Identity description is already in use. So generate a new one by appending
                 // " (x)", where x is the first number >= 1 that results in an unused identity
@@ -558,8 +537,7 @@ public class SettingsImporter {
 
             // Write name used in identity
             String identityName = (identity.name == null) ? "" : identity.name;
-            putString(editor, accountKeyPrefix + Account.IDENTITY_NAME_KEY + identitySuffix,
-                    identityName);
+            putString(editor, accountKeyPrefix + Account.IDENTITY_NAME_KEY + identitySuffix, identityName);
 
             // Validate email address
             if (!IdentitySettings.isEmailAddressValid(identity.email)) {
@@ -567,8 +545,7 @@ public class SettingsImporter {
             }
 
             // Write email address
-            putString(editor, accountKeyPrefix + Account.IDENTITY_EMAIL_KEY + identitySuffix,
-                    identity.email);
+            putString(editor, accountKeyPrefix + Account.IDENTITY_EMAIL_KEY + identitySuffix, identity.email);
 
             // Write identity description
             putString(editor, accountKeyPrefix + Account.IDENTITY_DESCRIPTION_KEY + identitySuffix,
@@ -629,8 +606,7 @@ public class SettingsImporter {
         return false;
     }
 
-    private static int findIdentity(ImportedIdentity identity,
-            List<Identity> identities) {
+    private static int findIdentity(ImportedIdentity identity, List<Identity> identities) {
         for (int i = 0; i < identities.size(); i++) {
             Identity existingIdentity = identities.get(i);
             if (existingIdentity.getName().equals(identity.name) &&
@@ -655,8 +631,7 @@ public class SettingsImporter {
     private static void putString(StorageEditor editor, String key, String value) {
         if (K9.DEBUG) {
             String outputValue = value;
-            if (!K9.DEBUG_SENSITIVE &&
-                    (key.endsWith(".transportUri") || key.endsWith(".storeUri"))) {
+            if (!K9.DEBUG_SENSITIVE && (key.endsWith(".transportUri") || key.endsWith(".storeUri"))) {
                 outputValue = "*sensitive*";
             }
             Log.v(K9.LOG_TAG, "Setting " + key + "=" + outputValue);
@@ -665,9 +640,8 @@ public class SettingsImporter {
     }
 
     @VisibleForTesting
-    static Imported parseSettings(InputStream inputStream, boolean globalSettings,
-                                  List<String> accountUuids, boolean overview)
-    throws SettingsImportExportException {
+    static Imported parseSettings(InputStream inputStream, boolean globalSettings, List<String> accountUuids,
+            boolean overview) throws SettingsImportExportException {
 
         if (!overview && accountUuids == null) {
             throw new IllegalArgumentException("Argument 'accountUuids' must not be null.");
@@ -694,8 +668,7 @@ public class SettingsImporter {
                 eventType = xpp.next();
             }
 
-            if (imported == null || (overview && imported.globalSettings == null &&
-                    imported.accounts == null)) {
+            if (imported == null || (overview && imported.globalSettings == null && imported.accounts == null)) {
                 throw new SettingsImportExportException("Invalid import data");
             }
 
@@ -705,18 +678,14 @@ public class SettingsImporter {
         }
     }
 
-    private static void skipToEndTag(XmlPullParser xpp, String endTag)
-    throws XmlPullParserException, IOException {
-
+    private static void skipToEndTag(XmlPullParser xpp, String endTag) throws XmlPullParserException, IOException {
         int eventType = xpp.next();
         while (!(eventType == XmlPullParser.END_TAG && endTag.equals(xpp.getName()))) {
             eventType = xpp.next();
         }
     }
 
-    private static String getText(XmlPullParser xpp)
-    throws XmlPullParserException, IOException {
-
+    private static String getText(XmlPullParser xpp) throws XmlPullParserException, IOException {
         int eventType = xpp.next();
         if (eventType != XmlPullParser.TEXT) {
             return "";
@@ -724,24 +693,19 @@ public class SettingsImporter {
         return xpp.getText();
     }
 
-    private static Imported parseRoot(XmlPullParser xpp, boolean globalSettings,
-            List<String> accountUuids, boolean overview)
-    throws XmlPullParserException, IOException, SettingsImportExportException {
+    private static Imported parseRoot(XmlPullParser xpp, boolean globalSettings, List<String> accountUuids,
+            boolean overview) throws XmlPullParserException, IOException, SettingsImportExportException {
 
         Imported result = new Imported();
 
-        String fileFormatVersionString = xpp.getAttributeValue(null,
-                SettingsExporter.FILE_FORMAT_ATTRIBUTE);
+        String fileFormatVersionString = xpp.getAttributeValue(null, SettingsExporter.FILE_FORMAT_ATTRIBUTE);
         validateFileFormatVersion(fileFormatVersionString);
 
-        String contentVersionString = xpp.getAttributeValue(null,
-                SettingsExporter.VERSION_ATTRIBUTE);
+        String contentVersionString = xpp.getAttributeValue(null, SettingsExporter.VERSION_ATTRIBUTE);
         result.contentVersion = validateContentVersion(contentVersionString);
 
         int eventType = xpp.next();
-        while (!(eventType == XmlPullParser.END_TAG &&
-                 SettingsExporter.ROOT_ELEMENT.equals(xpp.getName()))) {
-
+        while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.ROOT_ELEMENT.equals(xpp.getName()))) {
             if(eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.GLOBAL_ELEMENT.equals(element)) {
@@ -777,9 +741,7 @@ public class SettingsImporter {
         return result;
     }
 
-    private static int validateFileFormatVersion(String versionString)
-            throws SettingsImportExportException {
-
+    private static int validateFileFormatVersion(String versionString) throws SettingsImportExportException {
         if (versionString == null) {
             throw new SettingsImportExportException("Missing file format version");
         }
@@ -788,21 +750,17 @@ public class SettingsImporter {
         try {
             version = Integer.parseInt(versionString);
         } catch (NumberFormatException e) {
-            throw new SettingsImportExportException("Invalid file format version: " +
-                    versionString);
+            throw new SettingsImportExportException("Invalid file format version: " + versionString);
         }
 
         if (version != SettingsExporter.FILE_FORMAT_VERSION) {
-            throw new SettingsImportExportException("Unsupported file format version: " +
-                    versionString);
+            throw new SettingsImportExportException("Unsupported file format version: " + versionString);
         }
 
         return version;
     }
 
-    private static int validateContentVersion(String versionString)
-            throws SettingsImportExportException {
-
+    private static int validateContentVersion(String versionString) throws SettingsImportExportException {
         if (versionString == null) {
             throw new SettingsImportExportException("Missing content version");
         }
@@ -811,8 +769,7 @@ public class SettingsImporter {
         try {
             version = Integer.parseInt(versionString);
         } catch (NumberFormatException e) {
-            throw new SettingsImportExportException("Invalid content version: " +
-                    versionString);
+            throw new SettingsImportExportException("Invalid content version: " + versionString);
         }
 
         if (version < 1) {
@@ -822,8 +779,8 @@ public class SettingsImporter {
         return version;
     }
 
-    private static ImportedSettings parseSettings(XmlPullParser xpp, String endTag)
-    throws XmlPullParserException, IOException {
+    private static ImportedSettings parseSettings(XmlPullParser xpp, String endTag) 
+            throws XmlPullParserException, IOException {
 
         ImportedSettings result = null;
 
@@ -855,16 +812,13 @@ public class SettingsImporter {
         return result;
     }
 
-    private static Map<String, ImportedAccount> parseAccounts(XmlPullParser xpp,
-            List<String> accountUuids, boolean overview)
-    throws XmlPullParserException, IOException {
+    private static Map<String, ImportedAccount> parseAccounts(XmlPullParser xpp, List<String> accountUuids,
+            boolean overview) throws XmlPullParserException, IOException {
 
         Map<String, ImportedAccount> accounts = null;
 
         int eventType = xpp.next();
-        while (!(eventType == XmlPullParser.END_TAG &&
-                 SettingsExporter.ACCOUNTS_ELEMENT.equals(xpp.getName()))) {
-
+        while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.ACCOUNTS_ELEMENT.equals(xpp.getName()))) {
             if(eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.ACCOUNT_ELEMENT.equals(element)) {
@@ -879,8 +833,7 @@ public class SettingsImporter {
                     } else if (!accounts.containsKey(account.uuid)) {
                         accounts.put(account.uuid, account);
                     } else {
-                        Log.w(K9.LOG_TAG, "Duplicate account entries with UUID " + account.uuid +
-                                ". Ignoring!");
+                        Log.w(K9.LOG_TAG, "Duplicate account entries with UUID " + account.uuid + ". Ignoring!");
                     }
                 } else {
                     Log.w(K9.LOG_TAG, "Unexpected start tag: " + xpp.getName());
@@ -892,9 +845,8 @@ public class SettingsImporter {
         return accounts;
     }
 
-    private static ImportedAccount parseAccount(XmlPullParser xpp, List<String> accountUuids,
-            boolean overview)
-    throws XmlPullParserException, IOException {
+    private static ImportedAccount parseAccount(XmlPullParser xpp, List<String> accountUuids, boolean overview)
+            throws XmlPullParserException, IOException {
 
         String uuid = xpp.getAttributeValue(null, SettingsExporter.UUID_ATTRIBUTE);
 
@@ -911,9 +863,7 @@ public class SettingsImporter {
 
         if (overview || accountUuids.contains(uuid)) {
             int eventType = xpp.next();
-            while (!(eventType == XmlPullParser.END_TAG &&
-                     SettingsExporter.ACCOUNT_ELEMENT.equals(xpp.getName()))) {
-
+            while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.ACCOUNT_ELEMENT.equals(xpp.getName()))) {
                 if(eventType == XmlPullParser.START_TAG) {
                     String element = xpp.getName();
                     if (SettingsExporter.NAME_ELEMENT.equals(element)) {
@@ -964,7 +914,7 @@ public class SettingsImporter {
     }
 
     private static ImportedServer parseServerSettings(XmlPullParser xpp, String endTag)
-    throws XmlPullParserException, IOException {
+            throws XmlPullParserException, IOException {
         ImportedServer server = new ImportedServer();
 
         server.type = xpp.getAttributeValue(null, SettingsExporter.TYPE_ATTRIBUTE);
@@ -1000,14 +950,12 @@ public class SettingsImporter {
         return server;
     }
 
-    private static List<ImportedIdentity> parseIdentities(XmlPullParser xpp)
-    throws XmlPullParserException, IOException {
+    private static List<ImportedIdentity> parseIdentities(XmlPullParser xpp) 
+            throws XmlPullParserException, IOException {
         List<ImportedIdentity> identities = null;
 
         int eventType = xpp.next();
-        while (!(eventType == XmlPullParser.END_TAG &&
-                 SettingsExporter.IDENTITIES_ELEMENT.equals(xpp.getName()))) {
-
+        while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.IDENTITIES_ELEMENT.equals(xpp.getName()))) {
             if(eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.IDENTITY_ELEMENT.equals(element)) {
@@ -1027,13 +975,11 @@ public class SettingsImporter {
         return identities;
     }
 
-    private static ImportedIdentity parseIdentity(XmlPullParser xpp)
-    throws XmlPullParserException, IOException {
+    private static ImportedIdentity parseIdentity(XmlPullParser xpp) throws XmlPullParserException, IOException {
         ImportedIdentity identity = new ImportedIdentity();
 
         int eventType = xpp.next();
-        while (!(eventType == XmlPullParser.END_TAG &&
-                 SettingsExporter.IDENTITY_ELEMENT.equals(xpp.getName()))) {
+        while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.IDENTITY_ELEMENT.equals(xpp.getName()))) {
 
             if(eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
@@ -1055,14 +1001,11 @@ public class SettingsImporter {
         return identity;
     }
 
-    private static List<ImportedFolder> parseFolders(XmlPullParser xpp)
-    throws XmlPullParserException, IOException {
+    private static List<ImportedFolder> parseFolders(XmlPullParser xpp) throws XmlPullParserException, IOException {
         List<ImportedFolder> folders = null;
 
         int eventType = xpp.next();
-        while (!(eventType == XmlPullParser.END_TAG &&
-                 SettingsExporter.FOLDERS_ELEMENT.equals(xpp.getName()))) {
-
+        while (!(eventType == XmlPullParser.END_TAG && SettingsExporter.FOLDERS_ELEMENT.equals(xpp.getName()))) {
             if(eventType == XmlPullParser.START_TAG) {
                 String element = xpp.getName();
                 if (SettingsExporter.FOLDER_ELEMENT.equals(element)) {
@@ -1082,8 +1025,7 @@ public class SettingsImporter {
         return folders;
     }
 
-    private static ImportedFolder parseFolder(XmlPullParser xpp)
-    throws XmlPullParserException, IOException {
+    private static ImportedFolder parseFolder(XmlPullParser xpp) throws XmlPullParserException, IOException {
         ImportedFolder folder = new ImportedFolder();
 
         String name = xpp.getAttributeValue(null, SettingsExporter.NAME_ATTRIBUTE);

--- a/k9mail/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
@@ -171,7 +171,7 @@ public class SettingsImporterTest {
         SettingsImporter.ImportResults results = SettingsImporter.importSettings(
                 RuntimeEnvironment.application, inputStream, true, accountUuids, false);
 
-        assertEquals(0, results.errorneousAccounts.size());
+        assertEquals(0, results.erroneousAccounts.size());
         assertEquals(1, results.importedAccounts.size());
         assertEquals("Account", results.importedAccounts.get(0).imported.name);
         assertEquals(validUUID, results.importedAccounts.get(0).imported.uuid);


### PR DESCRIPTION
The .preferences.* classes have not been touched in a long time and had a lot of warnings, particularly use of the diamond operator, unnecessarily broad visibility, typecasts that can be handled with generics, and unnecessary unboxing.

I also broke down the `upgrade` method into smaller methods because it took me way too long to figure out what was going on.

There should be no semantic changes in this entire PR, besides a checked assertion in `Settings.upgrade`.