### PR TITLE
Add database migration to clean up orphaned data

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -153,7 +153,7 @@ public class LocalStore extends Store implements Serializable {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 57;
+    public static final int DB_VERSION = 58;
 
 
     public static String getColumnNameForFlag(Flag flag) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -204,7 +204,8 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
         db.execSQL("CREATE TRIGGER delete_message " +
                 "BEFORE DELETE ON messages " +
                 "BEGIN " +
-                "DELETE FROM message_parts WHERE root = OLD.message_part_id;" +
+                "DELETE FROM message_parts WHERE root = OLD.message_part_id; " +
+                "DELETE FROM messages_fulltext WHERE docid = OLD.id; " +
                 "END");
 
         db.execSQL("DROP TABLE IF EXISTS messages_fulltext");

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo58.java
@@ -1,0 +1,31 @@
+package com.fsck.k9.mailstore.migrations;
+
+
+import android.database.sqlite.SQLiteDatabase;
+
+
+class MigrationTo58 {
+    static void cleanUpOrphanedData(SQLiteDatabase db) {
+        cleanUpFtsTable(db);
+        cleanUpMessagePartsTable(db);
+    }
+    
+    private static void cleanUpFtsTable(SQLiteDatabase db) {
+        MigrationTo56.cleanUpFtsTable(db);
+    }
+
+    private static void cleanUpMessagePartsTable(SQLiteDatabase db) {
+        db.execSQL("DELETE FROM message_parts WHERE root NOT IN " +
+                "(SELECT message_part_id FROM messages WHERE deleted = 0)");
+    }
+
+    static void createDeleteMessageTrigger(SQLiteDatabase db) {
+        db.execSQL("DROP TRIGGER IF EXISTS delete_message");
+        db.execSQL("CREATE TRIGGER delete_message " +
+                "BEFORE DELETE ON messages " +
+                "BEGIN " +
+                "DELETE FROM message_parts WHERE root = OLD.message_part_id; " +
+                "DELETE FROM messages_fulltext WHERE docid = OLD.id; " +
+                "END");
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
@@ -68,6 +68,9 @@ public class Migrations {
                 MigrationTo56.cleanUpFtsTable(db);
             case 56:
                 MigrationTo57.fixDataLocationForMultipartParts(db);
+            case 57:
+                MigrationTo58.cleanUpOrphanedData(db);
+                MigrationTo58.createDeleteMessageTrigger(db);
         }
     }
 }


### PR DESCRIPTION
Also extend database trigger to remove entries from `messages_fulltext`

Fixes #2103