### PR TITLE
MessageCompose cleanup

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -114,15 +114,15 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
     public static final String EXTRA_ACCOUNT = "account";
     public static final String EXTRA_MESSAGE_REFERENCE = "message_reference";
-    public static final String EXTRA_MESSAGE_DECRYPTION_RESULT  = "message_decryption_result";
+    public static final String EXTRA_MESSAGE_DECRYPTION_RESULT = "message_decryption_result";
 
     private static final String STATE_KEY_SOURCE_MESSAGE_PROCED =
-        "com.fsck.k9.activity.MessageCompose.stateKeySourceMessageProced";
+            "com.fsck.k9.activity.MessageCompose.stateKeySourceMessageProced";
     private static final String STATE_KEY_DRAFT_ID = "com.fsck.k9.activity.MessageCompose.draftId";
     private static final String STATE_IDENTITY_CHANGED =
-        "com.fsck.k9.activity.MessageCompose.identityChanged";
+            "com.fsck.k9.activity.MessageCompose.identityChanged";
     private static final String STATE_IDENTITY =
-        "com.fsck.k9.activity.MessageCompose.identity";
+            "com.fsck.k9.activity.MessageCompose.identity";
     private static final String STATE_IN_REPLY_TO = "com.fsck.k9.activity.MessageCompose.inReplyTo";
     private static final String STATE_REFERENCES = "com.fsck.k9.activity.MessageCompose.references";
     private static final String STATE_KEY_READ_RECEIPT = "com.fsck.k9.activity.MessageCompose.messageReadReceipt";
@@ -136,10 +136,10 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     public static final int MSG_SAVED_DRAFT = 4;
     private static final int MSG_DISCARDED_DRAFT = 5;
 
-    private static final int REQUEST_MASK_RECIPIENT_PRESENTER = (1<<8);
-    private static final int REQUEST_MASK_LOADER_HELPER = (1<<9);
-    private static final int REQUEST_MASK_ATTACHMENT_PRESENTER = (1<<10);
-    private static final int REQUEST_MASK_MESSAGE_BUILDER = (1<<11);
+    private static final int REQUEST_MASK_RECIPIENT_PRESENTER = (1 << 8);
+    private static final int REQUEST_MASK_LOADER_HELPER = (1 << 9);
+    private static final int REQUEST_MASK_ATTACHMENT_PRESENTER = (1 << 10);
+    private static final int REQUEST_MASK_MESSAGE_BUILDER = (1 << 11);
 
     /**
      * Regular expression to remove the first localized "Re:" prefix in subjects.
@@ -236,8 +236,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         relatedMessageReference = intent.getParcelableExtra(EXTRA_MESSAGE_REFERENCE);
 
         final String accountUuid = (relatedMessageReference != null) ?
-                                   relatedMessageReference.getAccountUuid() :
-                                   intent.getStringExtra(EXTRA_ACCOUNT);
+                relatedMessageReference.getAccountUuid() :
+                intent.getStringExtra(EXTRA_ACCOUNT);
 
         account = Preferences.getPreferences(this).getAccount(accountUuid);
 
@@ -271,17 +271,17 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         subjectView = (EditText) findViewById(R.id.subject);
         subjectView.getInputExtras(true).putBoolean("allowEmoji", true);
 
-        EolConvertingEditText upperSignature = (EolConvertingEditText)findViewById(R.id.upper_signature);
-        EolConvertingEditText lowerSignature = (EolConvertingEditText)findViewById(R.id.lower_signature);
+        EolConvertingEditText upperSignature = (EolConvertingEditText) findViewById(R.id.upper_signature);
+        EolConvertingEditText lowerSignature = (EolConvertingEditText) findViewById(R.id.lower_signature);
 
         QuotedMessageMvpView quotedMessageMvpView = new QuotedMessageMvpView(this);
         quotedMessagePresenter = new QuotedMessagePresenter(this, quotedMessageMvpView, account);
         attachmentPresenter = new AttachmentPresenter(getApplicationContext(), attachmentMvpView, getLoaderManager());
 
-        messageContentView = (EolConvertingEditText)findViewById(R.id.message_content);
+        messageContentView = (EolConvertingEditText) findViewById(R.id.message_content);
         messageContentView.getInputExtras(true).putBoolean("allowEmoji", true);
 
-        attachmentsView = (LinearLayout)findViewById(R.id.attachments);
+        attachmentsView = (LinearLayout) findViewById(R.id.attachments);
 
         TextWatcher draftNeedsChangingTextWatcher = new SimpleTextWatcher() {
             @Override
@@ -429,8 +429,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     public void onDestroy() {
         super.onDestroy();
 
-        if (recipientPresenter != null)
+        if (recipientPresenter != null) {
             recipientPresenter.onActivityDestroy();
+        }
     }
 
     /**
@@ -595,7 +596,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         attachmentPresenter.onRestoreInstanceState(savedInstanceState);
 
         draftId = savedInstanceState.getLong(STATE_KEY_DRAFT_ID);
-        identity = (Identity)savedInstanceState.getSerializable(STATE_IDENTITY);
+        identity = (Identity) savedInstanceState.getSerializable(STATE_IDENTITY);
         identityChanged = savedInstanceState.getBoolean(STATE_IDENTITY_CHANGED);
         repliedToMessageId = savedInstanceState.getString(STATE_IN_REPLY_TO);
         referencedMessageIds = savedInstanceState.getString(STATE_REFERENCES);
@@ -618,7 +619,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         recipientPresenter.updateCryptoStatus();
         ComposeCryptoStatus cryptoStatus = recipientPresenter.getCurrentCryptoStatus();
         // TODO encrypt drafts for storage
-        if(!isDraft && cryptoStatus.shouldUsePgpMessageBuilder()) {
+        if (!isDraft && cryptoStatus.shouldUsePgpMessageBuilder()) {
             SendErrorState maybeSendErrorState = cryptoStatus.getSendErrorStateOrNull();
             if (maybeSendErrorState != null) {
                 recipientPresenter.showPgpSendError(maybeSendErrorState);
@@ -813,8 +814,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
                 if (previousDraftId != INVALID_DRAFT_ID) {
                     if (K9.DEBUG) {
-                        Log.v(K9.LOG_TAG, "Account switch, deleting draft from previous account: "
-                              + previousDraftId);
+                        Log.v(K9.LOG_TAG, "Account switch, deleting draft from previous account: " + previousDraftId);
                     }
                     MessagingController.getInstance(getApplication()).deleteDraft(previousAccount,
                             previousDraftId);
@@ -861,7 +861,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
     @Override
     public void onFocusChange(View v, boolean hasFocus) {
-        switch(v.getId()) {
+        switch (v.getId()) {
             case R.id.message_content:
             case R.id.subject:
                 if (hasFocus) {
@@ -947,11 +947,11 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     @Override
     public boolean onCreateOptionsMenu(Menu menu) {
         super.onCreateOptionsMenu(menu);
-        
+
         if (isFinishing()) {
             return false;
         }
-        
+
         getMenuInflater().inflate(R.menu.message_compose_option, menu);
 
         // Disable the 'Save' menu option if Drafts folder is set to -NONE-
@@ -998,49 +998,49 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         switch (id) {
             case DIALOG_SAVE_OR_DISCARD_DRAFT_MESSAGE:
                 return new AlertDialog.Builder(this)
-                       .setTitle(R.string.save_or_discard_draft_message_dlg_title)
-                       .setMessage(R.string.save_or_discard_draft_message_instructions_fmt)
-                .setPositiveButton(R.string.save_draft_action, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int whichButton) {
-                        dismissDialog(DIALOG_SAVE_OR_DISCARD_DRAFT_MESSAGE);
-                        checkToSaveDraftAndSave();
-                    }
-                })
-                .setNegativeButton(R.string.discard_action, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int whichButton) {
-                        dismissDialog(DIALOG_SAVE_OR_DISCARD_DRAFT_MESSAGE);
-                        onDiscard();
-                    }
-                })
-                .create();
+                        .setTitle(R.string.save_or_discard_draft_message_dlg_title)
+                        .setMessage(R.string.save_or_discard_draft_message_instructions_fmt)
+                        .setPositiveButton(R.string.save_draft_action, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int whichButton) {
+                                dismissDialog(DIALOG_SAVE_OR_DISCARD_DRAFT_MESSAGE);
+                                checkToSaveDraftAndSave();
+                            }
+                        })
+                        .setNegativeButton(R.string.discard_action, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int whichButton) {
+                                dismissDialog(DIALOG_SAVE_OR_DISCARD_DRAFT_MESSAGE);
+                                onDiscard();
+                            }
+                        })
+                        .create();
             case DIALOG_CONFIRM_DISCARD_ON_BACK:
                 return new AlertDialog.Builder(this)
-                       .setTitle(R.string.confirm_discard_draft_message_title)
-                       .setMessage(R.string.confirm_discard_draft_message)
-                .setPositiveButton(R.string.cancel_action, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int whichButton) {
-                        dismissDialog(DIALOG_CONFIRM_DISCARD_ON_BACK);
-                    }
-                })
-                .setNegativeButton(R.string.discard_action, new DialogInterface.OnClickListener() {
-                    @Override
-                    public void onClick(DialogInterface dialog, int whichButton) {
-                        dismissDialog(DIALOG_CONFIRM_DISCARD_ON_BACK);
-                        Toast.makeText(MessageCompose.this,
-                                       getString(R.string.message_discarded_toast),
-                                       Toast.LENGTH_LONG).show();
-                        onDiscard();
-                    }
-                })
-                .create();
+                        .setTitle(R.string.confirm_discard_draft_message_title)
+                        .setMessage(R.string.confirm_discard_draft_message)
+                        .setPositiveButton(R.string.cancel_action, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int whichButton) {
+                                dismissDialog(DIALOG_CONFIRM_DISCARD_ON_BACK);
+                            }
+                        })
+                        .setNegativeButton(R.string.discard_action, new DialogInterface.OnClickListener() {
+                            @Override
+                            public void onClick(DialogInterface dialog, int whichButton) {
+                                dismissDialog(DIALOG_CONFIRM_DISCARD_ON_BACK);
+                                Toast.makeText(MessageCompose.this,
+                                        getString(R.string.message_discarded_toast),
+                                        Toast.LENGTH_LONG).show();
+                                onDiscard();
+                            }
+                        })
+                        .create();
             case DIALOG_CHOOSE_IDENTITY:
                 Context context = new ContextThemeWrapper(this,
                         (K9.getK9Theme() == K9.Theme.LIGHT) ?
-                        R.style.Theme_K9_Dialog_Light :
-                        R.style.Theme_K9_Dialog_Dark);
+                                R.style.Theme_K9_Dialog_Light :
+                                R.style.Theme_K9_Dialog_Dark);
                 Builder builder = new AlertDialog.Builder(context);
                 builder.setTitle(R.string.send_as);
                 final IdentityAdapter adapter = new IdentityAdapter(context);
@@ -1115,7 +1115,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 }
             }
         } catch (MessagingException me) {
-            /**
+            /*
              * Let the user continue composing their message even if we have a problem processing
              * the source message. Log it as an error, though.
              */
@@ -1299,7 +1299,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         final MessageReference messageReference;
 
         SendMessageTask(Context context, Account account, Contacts contacts, Message message,
-                        Long draftId, MessageReference messageReference) {
+                Long draftId, MessageReference messageReference) {
             this.context = context;
             this.account = account;
             this.contacts = contacts;
@@ -1576,7 +1576,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     };
 
     AttachmentMvpView attachmentMvpView = new AttachmentMvpView() {
-        private HashMap<Uri,View> attachmentViews = new HashMap<>();
+        private HashMap<Uri, View> attachmentViews = new HashMap<>();
 
         @Override
         public void showWaitingForAttachmentDialog(WaitingAction waitingAction) {
@@ -1734,5 +1734,4 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             return titleResource;
         }
     }
-
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -32,8 +32,8 @@ public class AttachmentPresenter {
 
     private static final String LOADER_ARG_ATTACHMENT = "attachment";
     private static final int LOADER_ID_MASK = 1 << 6;
-    public static final int MAX_TOTAL_LOADERS = LOADER_ID_MASK -1;
-    public static final int REQUEST_CODE_ATTACHMENT_URI = 1;
+    private static final int MAX_TOTAL_LOADERS = LOADER_ID_MASK -1;
+    private static final int REQUEST_CODE_ATTACHMENT_URI = 1;
 
 
     // injected state
@@ -126,7 +126,7 @@ public class AttachmentPresenter {
         addAttachment(uri, null);
     }
 
-    public void addAttachment(AttachmentViewInfo attachmentViewInfo) {
+    private void addAttachment(AttachmentViewInfo attachmentViewInfo) {
         if (attachments.containsKey(attachmentViewInfo.internalUri)) {
             throw new IllegalStateException("Received the same attachmentViewInfo twice!");
         }
@@ -286,7 +286,7 @@ public class AttachmentPresenter {
         });
     }
 
-    void performStalledAction() {
+    private void performStalledAction() {
         attachmentMvpView.dismissWaitingForAttachmentDialog();
 
         WaitingAction waitingFor = actionToPerformAfterWaiting;
@@ -305,7 +305,7 @@ public class AttachmentPresenter {
     }
 
     @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
-    void addAttachmentsFromResultIntent(Intent data) {
+    private void addAttachmentsFromResultIntent(Intent data) {
         // TODO draftNeedsSaving = true
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             ClipData clipData = data.getClipData();

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -32,7 +32,7 @@ public class AttachmentPresenter {
 
     private static final String LOADER_ARG_ATTACHMENT = "attachment";
     private static final int LOADER_ID_MASK = 1 << 6;
-    private static final int MAX_TOTAL_LOADERS = LOADER_ID_MASK -1;
+    private static final int MAX_TOTAL_LOADERS = LOADER_ID_MASK - 1;
     private static final int REQUEST_CODE_ATTACHMENT_URI = 1;
 
 
@@ -113,7 +113,8 @@ public class AttachmentPresenter {
     }
 
     public void onClickAddAttachment(RecipientPresenter recipientPresenter) {
-        AttachErrorState maybeAttachErrorState = recipientPresenter.getCurrentCryptoStatus().getAttachErrorStateOrNull();
+        AttachErrorState maybeAttachErrorState =
+                recipientPresenter.getCurrentCryptoStatus().getAttachErrorStateOrNull();
         if (maybeAttachErrorState != null) {
             recipientPresenter.showPgpAttachError(maybeAttachErrorState);
             return;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -100,51 +100,51 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
         toView.setTokenListener(new TokenListener<Recipient>() {
             @Override
             public void onTokenAdded(Recipient recipient) {
-                presenter.onToTokenAdded(recipient);
+                presenter.onToTokenAdded();
             }
 
             @Override
             public void onTokenRemoved(Recipient recipient) {
-                presenter.onToTokenRemoved(recipient);
+                presenter.onToTokenRemoved();
             }
 
             @Override
             public void onTokenChanged(Recipient recipient) {
-                presenter.onToTokenChanged(recipient);
+                presenter.onToTokenChanged();
             }
         });
 
         ccView.setTokenListener(new TokenListener<Recipient>() {
             @Override
             public void onTokenAdded(Recipient recipient) {
-                presenter.onCcTokenAdded(recipient);
+                presenter.onCcTokenAdded();
             }
 
             @Override
             public void onTokenRemoved(Recipient recipient) {
-                presenter.onCcTokenRemoved(recipient);
+                presenter.onCcTokenRemoved();
             }
 
             @Override
             public void onTokenChanged(Recipient recipient) {
-                presenter.onCcTokenChanged(recipient);
+                presenter.onCcTokenChanged();
             }
         });
 
         bccView.setTokenListener(new TokenListener<Recipient>() {
             @Override
             public void onTokenAdded(Recipient recipient) {
-                presenter.onBccTokenAdded(recipient);
+                presenter.onBccTokenAdded();
             }
 
             @Override
             public void onTokenRemoved(Recipient recipient) {
-                presenter.onBccTokenRemoved(recipient);
+                presenter.onBccTokenRemoved();
             }
 
             @Override
             public void onTokenChanged(Recipient recipient) {
-                presenter.onBccTokenChanged(recipient);
+                presenter.onBccTokenChanged();
             }
         });
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -506,7 +506,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                 return CONTACT_PICKER_BCC;
             }
         }
-        
+
         throw new AssertionError("Unhandled case: " + type);
     }
 
@@ -522,7 +522,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                 return RecipientType.BCC;
             }
         }
-        
+
         throw new AssertionError("Unhandled case: " + type);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -104,7 +104,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         return recipientMvpView.getBccAddresses();
     }
 
-    public List<Recipient> getAllRecipients() {
+    private List<Recipient> getAllRecipients() {
         ArrayList<Recipient> result = new ArrayList<>();
 
         result.addAll(recipientMvpView.getToRecipients());
@@ -216,11 +216,11 @@ public class RecipientPresenter implements PermissionPingCallback {
         cryptoEnablePgpInline = message.isSet(Flag.X_DRAFT_OPENPGP_INLINE);
     }
 
-    void addToAddresses(Address... toAddresses) {
+    private void addToAddresses(Address... toAddresses) {
         addRecipientsFromAddresses(RecipientType.TO, toAddresses);
     }
 
-    void addCcAddresses(Address... ccAddresses) {
+    private void addCcAddresses(Address... ccAddresses) {
         if (ccAddresses.length > 0) {
             addRecipientsFromAddresses(RecipientType.CC, ccAddresses);
             recipientMvpView.setCcVisibility(true);
@@ -299,19 +299,19 @@ public class RecipientPresenter implements PermissionPingCallback {
         return result.toArray(new Address[result.size()]);
     }
 
-    public void onClickToLabel() {
+    void onClickToLabel() {
         recipientMvpView.requestFocusOnToField();
     }
 
-    public void onClickCcLabel() {
+    void onClickCcLabel() {
         recipientMvpView.requestFocusOnCcField();
     }
 
-    public void onClickBccLabel() {
+    void onClickBccLabel() {
         recipientMvpView.requestFocusOnBccField();
     }
 
-    public void onClickRecipientExpander() {
+    void onClickRecipientExpander() {
         recipientMvpView.setCcVisibility(true);
         recipientMvpView.setBccVisibility(true);
         updateRecipientExpanderVisibility();
@@ -383,47 +383,47 @@ public class RecipientPresenter implements PermissionPingCallback {
     }
 
     @SuppressWarnings("UnusedParameters")
-    public void onToTokenAdded(Recipient recipient) {
+    void onToTokenAdded(Recipient recipient) {
         updateCryptoStatus();
     }
 
     @SuppressWarnings("UnusedParameters")
-    public void onToTokenRemoved(Recipient recipient) {
+    void onToTokenRemoved(Recipient recipient) {
         updateCryptoStatus();
     }
 
     @SuppressWarnings("UnusedParameters")
-    public void onToTokenChanged(Recipient recipient) {
+    void onToTokenChanged(Recipient recipient) {
         updateCryptoStatus();
     }
 
     @SuppressWarnings("UnusedParameters")
-    public void onCcTokenAdded(Recipient recipient) {
+    void onCcTokenAdded(Recipient recipient) {
         updateCryptoStatus();
     }
 
     @SuppressWarnings("UnusedParameters")
-    public void onCcTokenRemoved(Recipient recipient) {
+    void onCcTokenRemoved(Recipient recipient) {
         updateCryptoStatus();
     }
 
     @SuppressWarnings("UnusedParameters")
-    public void onCcTokenChanged(Recipient recipient) {
+    void onCcTokenChanged(Recipient recipient) {
         updateCryptoStatus();
     }
 
     @SuppressWarnings("UnusedParameters")
-    public void onBccTokenAdded(Recipient recipient) {
+    void onBccTokenAdded(Recipient recipient) {
         updateCryptoStatus();
     }
 
     @SuppressWarnings("UnusedParameters")
-    public void onBccTokenRemoved(Recipient recipient) {
+    void onBccTokenRemoved(Recipient recipient) {
         updateCryptoStatus();
     }
 
     @SuppressWarnings("UnusedParameters")
-    public void onBccTokenChanged(Recipient recipient) {
+    void onBccTokenChanged(Recipient recipient) {
         updateCryptoStatus();
     }
 
@@ -469,15 +469,15 @@ public class RecipientPresenter implements PermissionPingCallback {
         }.startLoading();
     }
 
-    public void onToFocused() {
+    void onToFocused() {
         lastFocusedType = RecipientType.TO;
     }
 
-    public void onCcFocused() {
+    void onCcFocused() {
         lastFocusedType = RecipientType.CC;
     }
 
-    public void onBccFocused() {
+    void onBccFocused() {
         lastFocusedType = RecipientType.BCC;
     }
 
@@ -539,7 +539,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         }
     }
 
-    public void onClickCryptoStatus() {
+    void onClickCryptoStatus() {
         switch (cryptoProviderState) {
             case UNCONFIGURED:
                 Log.e(K9.LOG_TAG, "click on crypto status while unconfigured - this should not really happen?!");
@@ -566,7 +566,7 @@ public class RecipientPresenter implements PermissionPingCallback {
      *
      * @return True, if the device supports picking contacts. False, otherwise.
      */
-    public boolean hasContactPicker() {
+    private boolean hasContactPicker() {
         if (hasContactPicker == null) {
             Contacts contacts = Contacts.getInstance(context);
 
@@ -594,7 +594,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         }
     }
 
-    public void showPgpAttachError(AttachErrorState attachErrorState) {
+    void showPgpAttachError(AttachErrorState attachErrorState) {
         switch (attachErrorState) {
             case IS_INLINE:
                 recipientMvpView.showErrorInlineAttach();
@@ -702,7 +702,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         openPgpServiceConnection = null;
     }
 
-    public OpenPgpApi getOpenPgpApi() {
+    private OpenPgpApi getOpenPgpApi() {
         if (openPgpServiceConnection == null || !openPgpServiceConnection.isBound()) {
             Log.e(K9.LOG_TAG, "obtained openpgpapi object, but service is not bound! inconsistent state?");
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -382,48 +382,39 @@ public class RecipientPresenter implements PermissionPingCallback {
         }
     }
 
-    @SuppressWarnings("UnusedParameters")
-    void onToTokenAdded(Recipient recipient) {
+    void onToTokenAdded() {
         updateCryptoStatus();
     }
 
-    @SuppressWarnings("UnusedParameters")
-    void onToTokenRemoved(Recipient recipient) {
+    void onToTokenRemoved() {
         updateCryptoStatus();
     }
 
-    @SuppressWarnings("UnusedParameters")
-    void onToTokenChanged(Recipient recipient) {
+    void onToTokenChanged() {
         updateCryptoStatus();
     }
 
-    @SuppressWarnings("UnusedParameters")
-    void onCcTokenAdded(Recipient recipient) {
+    void onCcTokenAdded() {
         updateCryptoStatus();
     }
 
-    @SuppressWarnings("UnusedParameters")
-    void onCcTokenRemoved(Recipient recipient) {
+    void onCcTokenRemoved() {
         updateCryptoStatus();
     }
 
-    @SuppressWarnings("UnusedParameters")
-    void onCcTokenChanged(Recipient recipient) {
+    void onCcTokenChanged() {
         updateCryptoStatus();
     }
 
-    @SuppressWarnings("UnusedParameters")
-    void onBccTokenAdded(Recipient recipient) {
+    void onBccTokenAdded() {
         updateCryptoStatus();
     }
 
-    @SuppressWarnings("UnusedParameters")
-    void onBccTokenRemoved(Recipient recipient) {
+    void onBccTokenRemoved() {
         updateCryptoStatus();
     }
 
-    @SuppressWarnings("UnusedParameters")
-    void onBccTokenChanged(Recipient recipient) {
+    void onBccTokenChanged() {
         updateCryptoStatus();
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -496,8 +496,7 @@ public class RecipientPresenter implements PermissionPingCallback {
 
     private static int recipientTypeToRequestCode(RecipientType type) {
         switch (type) {
-            case TO:
-            default: {
+            case TO: {
                 return CONTACT_PICKER_TO;
             }
             case CC: {
@@ -507,12 +506,13 @@ public class RecipientPresenter implements PermissionPingCallback {
                 return CONTACT_PICKER_BCC;
             }
         }
+        
+        throw new AssertionError("Unhandled case: " + type);
     }
 
     private static RecipientType recipientTypeFromRequestCode(int type) {
         switch (type) {
-            case CONTACT_PICKER_TO:
-            default: {
+            case CONTACT_PICKER_TO: {
                 return RecipientType.TO;
             }
             case CONTACT_PICKER_CC: {
@@ -522,6 +522,8 @@ public class RecipientPresenter implements PermissionPingCallback {
                 return RecipientType.BCC;
             }
         }
+        
+        throw new AssertionError("Unhandled case: " + type);
     }
 
     public void onNonRecipientFieldFocused() {

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -353,19 +353,19 @@ public class QuotedMessagePresenter {
         }
     }
 
-    public void onClickShowQuotedText() {
+    void onClickShowQuotedText() {
         showOrHideQuotedText(QuotedTextMode.SHOW);
         messageCompose.updateMessageFormat();
         messageCompose.saveDraftEventually();
     }
 
-    public void onClickDeleteQuotedText() {
+    void onClickDeleteQuotedText() {
         showOrHideQuotedText(QuotedTextMode.HIDE);
         messageCompose.updateMessageFormat();
         messageCompose.saveDraftEventually();
     }
 
-    public void onClickEditQuotedText() {
+    void onClickEditQuotedText() {
         forcePlainText = true;
         messageCompose.loadQuotedTextForEdit();
     }

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -381,5 +381,4 @@ public class QuotedMessagePresenter {
     public boolean isQuotedTextText() {
         return quotedTextFormat == SimpleMessageFormat.TEXT;
     }
-
 }


### PR DESCRIPTION
Cleaning up these classes while we don't have a lot of MessageCompose changes in the queue. This mostly just fixes android studio warnings, cleans up the order of fields and gets rid of the m prefix.