### PR TITLE
Ignore the captures folder - generated by AndroidStudio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 .settings
 .classpath
 bin
+captures
 coverage
 coverage.ec
 coverage.em


### PR DESCRIPTION
See http://stackoverflow.com/questions/16736856/what-should-be-in-my-gitignore-for-an-android-studio-project

It's generated when you do an application capture in AndroidStudio.