### PR TITLE
Rework ClipboardManager to avoid leaking Context

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/helper/ClipboardManager.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/ClipboardManager.java
@@ -8,32 +8,6 @@ import android.content.Context;
  * Access the system clipboard using the new {@link ClipboardManager} introduced with API 11
  */
 public class ClipboardManager {
-
-    private static ClipboardManager sInstance = null;
-
-    public static ClipboardManager getInstance(Context context) {
-        Context appContext = context.getApplicationContext();
-
-        if (sInstance == null) {
-            sInstance = new ClipboardManager(appContext);
-        }
-
-        return sInstance;
-    }
-
-
-    protected Context mContext;
-
-    /**
-     * Constructor
-     *
-     * @param context
-     *         A {@link Context} instance.
-     */
-    protected ClipboardManager(Context context) {
-        mContext = context;
-    }
-
     /**
      * Copy a text string to the system clipboard
      *
@@ -42,9 +16,9 @@ public class ClipboardManager {
      * @param text
      *         The actual text to be copied to the clipboard.
      */
-    public void setText(String label, String text) {
+    public static void setText(Context context, String label, String text) {
         android.content.ClipboardManager clipboardManager =
-                (android.content.ClipboardManager) mContext.getSystemService(Context.CLIPBOARD_SERVICE);
+                (android.content.ClipboardManager) context.getSystemService(Context.CLIPBOARD_SERVICE);
         ClipData clip = ClipData.newPlainText(label, text);
         clipboardManager.setPrimaryClip(clip);
     }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -69,7 +69,6 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
     private LayoutInflater mInflater;
     private AttachmentViewCallback attachmentCallback;
     private SavedState mSavedState;
-    private ClipboardManager mClipboardManager;
     private Map<AttachmentViewInfo, AttachmentView> attachmentViewMap = new HashMap<>();
     private Map<Uri, AttachmentViewInfo> attachments = new HashMap<>();
     private boolean hasHiddenExternalImages;
@@ -100,7 +99,6 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
 
         Context context = getContext();
         mInflater = LayoutInflater.from(context);
-        mClipboardManager = ClipboardManager.getInstance(context);
     }
 
     @Override
@@ -139,7 +137,7 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
                             case MENU_ITEM_LINK_COPY: {
                                 String label = getContext().getString(
                                         R.string.webview_contextmenu_link_clipboard_label);
-                                mClipboardManager.setText(label, url);
+                                ClipboardManager.setText(MessageContainerView.this.getContext(), label, url);
                                 break;
                             }
                         }
@@ -198,7 +196,8 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
                             case MENU_ITEM_IMAGE_COPY: {
                                 String label = getContext().getString(
                                         R.string.webview_contextmenu_image_clipboard_label);
-                                mClipboardManager.setText(label, uri.toString());
+                                ClipboardManager.setText(
+                                        MessageContainerView.this.getContext(), label, uri.toString());
                                 break;
                             }
                         }
@@ -247,7 +246,9 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
                             case MENU_ITEM_PHONE_COPY: {
                                 String label = getContext().getString(
                                         R.string.webview_contextmenu_phone_clipboard_label);
-                                mClipboardManager.setText(label, phoneNumber);
+                                ClipboardManager.setText(
+                                        MessageContainerView.this.getContext(),
+                                        label, phoneNumber);
                                 break;
                             }
                         }
@@ -292,7 +293,8 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
                             case MENU_ITEM_EMAIL_COPY: {
                                 String label = getContext().getString(
                                         R.string.webview_contextmenu_email_clipboard_label);
-                                mClipboardManager.setText(label, email);
+                                ClipboardManager.setText(MessageContainerView.this.getContext(),
+                                        label, email);
                                 break;
                             }
                         }

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -197,8 +197,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
     private void onAddAddressesToClipboard(Address[] addresses) {
         String addressList = Address.toString(addresses);
 
-        ClipboardManager clipboardManager = ClipboardManager.getInstance(mContext);
-        clipboardManager.setText("addresses", addressList);
+        ClipboardManager.setText(mContext, "addresses", addressList);
 
         Toast.makeText(mContext, createMessage(addresses.length), Toast.LENGTH_LONG).show();
     }


### PR DESCRIPTION
Solving a lint warning:

> Do not place Android context classes in static fields (static reference to `ClipboardManager` which has field `mContext` pointing to Context); this is a memory leak (and also breaks Instant Run)