### PR TITLE
Rework InfoExtractors to avoid leaking Context

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1202,7 +1202,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         // Quote the message and setup the UI.
-        quotedMessagePresenter.initFromReplyToMessage(messageViewInfo, action);
+        quotedMessagePresenter.initFromReplyToMessage(messageViewInfo, action, this);
 
         if (action == Action.REPLY || action == Action.REPLY_ALL) {
             Identity useIdentity = IdentityHelper.getRecipientIdentityFromMessage(account, message);
@@ -1238,7 +1238,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         // Quote the message and setup the UI.
-        quotedMessagePresenter.processMessageToForward(messageViewInfo);
+        quotedMessagePresenter.processMessageToForward(messageViewInfo, this);
         attachmentPresenter.processMessageToForward(messageViewInfo);
     }
 
@@ -1322,7 +1322,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         updateSignature();
         updateFrom();
 
-        quotedMessagePresenter.processDraftMessage(messageViewInfo, k9identity);
+        quotedMessagePresenter.processDraftMessage(messageViewInfo, k9identity, this);
     }
 
     static class SendMessageTask extends AsyncTask<Void, Void, Void> {
@@ -1513,7 +1513,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         // part).
         if (relatedMessageProcessed) {
             try {
-                quotedMessagePresenter.populateUIWithQuotedMessage(messageViewInfo, true, action);
+                quotedMessagePresenter.populateUIWithQuotedMessage(messageViewInfo, true, action, this);
             } catch (MessagingException e) {
                 // Hm, if we couldn't populate the UI after source reprocessing, let's just delete it?
                 quotedMessagePresenter.showOrHideQuotedText(QuotedTextMode.HIDE);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Stack;
 
+import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -41,15 +42,15 @@ public class AttachmentResolver {
     }
 
     @WorkerThread
-    public static AttachmentResolver createFromPart(Part part) {
-        AttachmentInfoExtractor attachmentInfoExtractor = AttachmentInfoExtractor.getInstance();
-        Map<String, Uri> contentIdToAttachmentUriMap = buildCidToAttachmentUriMap(attachmentInfoExtractor, part);
+    public static AttachmentResolver createFromPart(Part part, Context context) {
+        AttachmentInfoExtractor attachmentInfoExtractor = new AttachmentInfoExtractor();
+        Map<String, Uri> contentIdToAttachmentUriMap = buildCidToAttachmentUriMap(attachmentInfoExtractor, part, context);
         return new AttachmentResolver(contentIdToAttachmentUriMap);
     }
 
     @VisibleForTesting
     static Map<String,Uri> buildCidToAttachmentUriMap(AttachmentInfoExtractor attachmentInfoExtractor,
-            Part rootPart) {
+            Part rootPart, Context context) {
         HashMap<String,Uri> result = new HashMap<>();
 
         Stack<Part> partsToCheck = new Stack<>();
@@ -68,7 +69,7 @@ public class AttachmentResolver {
                 try {
                     String contentId = part.getContentId();
                     if (contentId != null) {
-                        AttachmentViewInfo attachmentInfo = attachmentInfoExtractor.extractAttachmentInfo(part);
+                        AttachmentViewInfo attachmentInfo = attachmentInfoExtractor.extractAttachmentInfo(part, context);
                         result.put(contentId, attachmentInfo.internalUri);
                     }
                 } catch (MessagingException e) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -73,7 +73,8 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
     private static final long serialVersionUID = -1973296520918624767L;
     private static final int MAX_BODY_SIZE_FOR_DATABASE = 16 * 1024;
-    private static final AttachmentInfoExtractor attachmentInfoExtractor = AttachmentInfoExtractor.getInstance();
+    private static final AttachmentInfoExtractor attachmentInfoExtractor =
+            new AttachmentInfoExtractor();
     static final long INVALID_MESSAGE_PART_ID = -1;
 
     private final LocalStore localStore;

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -29,26 +29,14 @@ import com.fsck.k9.provider.DecryptedFileProvider;
 
 
 public class AttachmentInfoExtractor {
-    private final Context context;
-
-
-    public static AttachmentInfoExtractor getInstance() {
-        Context context = Globals.getContext();
-        return new AttachmentInfoExtractor(context);
-    }
-
-    @VisibleForTesting
-    AttachmentInfoExtractor(Context context) {
-        this.context = context;
-    }
 
     @WorkerThread
-    public List<AttachmentViewInfo> extractAttachmentInfoForView(List<Part> attachmentParts)
+    public List<AttachmentViewInfo> extractAttachmentInfoForView(List<Part> attachmentParts, Context context)
             throws MessagingException {
 
         List<AttachmentViewInfo> attachments = new ArrayList<>();
         for (Part part : attachmentParts) {
-            AttachmentViewInfo attachmentViewInfo = extractAttachmentInfo(part);
+            AttachmentViewInfo attachmentViewInfo = extractAttachmentInfo(part, context);
             attachments.add(attachmentViewInfo);
         }
 
@@ -56,7 +44,7 @@ public class AttachmentInfoExtractor {
     }
 
     @WorkerThread
-    public AttachmentViewInfo extractAttachmentInfo(Part part) throws MessagingException {
+    public AttachmentViewInfo extractAttachmentInfo(Part part, Context context) throws MessagingException {
         Uri uri;
         long size;
         boolean isContentAvailable;
@@ -80,7 +68,7 @@ public class AttachmentInfoExtractor {
             if (body instanceof DeferredFileBody) {
                 DeferredFileBody decryptedTempFileBody = (DeferredFileBody) body;
                 size = decryptedTempFileBody.getSize();
-                uri = getDecryptedFileProviderUri(decryptedTempFileBody, part.getMimeType());
+                uri = getDecryptedFileProviderUri(decryptedTempFileBody, part.getMimeType(), context);
                 isContentAvailable = true;
             } else {
                 throw new IllegalArgumentException("Unsupported part type provided");
@@ -92,7 +80,8 @@ public class AttachmentInfoExtractor {
 
     @Nullable
     @VisibleForTesting
-    protected Uri getDecryptedFileProviderUri(DeferredFileBody decryptedTempFileBody, String mimeType) {
+    protected Uri getDecryptedFileProviderUri(DeferredFileBody decryptedTempFileBody, String mimeType,
+                                              Context context) {
         Uri uri;
         try {
             File file = decryptedTempFileBody.getFile();

--- a/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -3,6 +3,7 @@ package com.fsck.k9.ui.compose;
 
 import java.util.Map;
 
+import android.content.Context;
 import android.content.res.Resources;
 import android.os.Bundle;
 import android.util.Log;
@@ -79,7 +80,8 @@ public class QuotedMessagePresenter {
      * @param showQuotedText
      *         {@code true} if the quoted text should be shown, {@code false} otherwise.
      */
-    public void populateUIWithQuotedMessage(MessageViewInfo messageViewInfo, boolean showQuotedText, Action action)
+    public void populateUIWithQuotedMessage(MessageViewInfo messageViewInfo,
+                                            boolean showQuotedText, Action action, Context context)
             throws MessagingException {
         MessageFormat origMessageFormat = account.getMessageFormat();
 
@@ -113,7 +115,7 @@ public class QuotedMessagePresenter {
 
             // Load the message with the reply header. TODO replace with MessageViewInfo data
             view.setQuotedHtml(quotedHtmlContent.getQuotedContent(),
-                    AttachmentResolver.createFromPart(messageViewInfo.rootPart));
+                    AttachmentResolver.createFromPart(messageViewInfo.rootPart, context));
 
             // TODO: Also strip the signature from the text/plain part
             view.setQuotedText(QuotedMessageHelper.quoteOriginalTextMessage(resources, messageViewInfo.message,
@@ -166,17 +168,17 @@ public class QuotedMessagePresenter {
                 (QuotedTextMode) savedInstanceState.getSerializable(STATE_KEY_QUOTED_TEXT_MODE));
     }
 
-    public void processMessageToForward(MessageViewInfo messageViewInfo) throws MessagingException {
+    public void processMessageToForward(MessageViewInfo messageViewInfo, Context context) throws MessagingException {
         quoteStyle = QuoteStyle.HEADER;
-        populateUIWithQuotedMessage(messageViewInfo, true, Action.FORWARD);
+        populateUIWithQuotedMessage(messageViewInfo, true, Action.FORWARD, context);
     }
 
-    public void initFromReplyToMessage(MessageViewInfo messageViewInfo, Action action)
+    public void initFromReplyToMessage(MessageViewInfo messageViewInfo, Action action, Context context)
             throws MessagingException {
-        populateUIWithQuotedMessage(messageViewInfo, account.isDefaultQuotedTextShown(), action);
+        populateUIWithQuotedMessage(messageViewInfo, account.isDefaultQuotedTextShown(), action, context);
     }
 
-    public void processDraftMessage(MessageViewInfo messageViewInfo, Map<IdentityField, String> k9identity) {
+    public void processDraftMessage(MessageViewInfo messageViewInfo, Map<IdentityField, String> k9identity, Context context) {
         quoteStyle = k9identity.get(IdentityField.QUOTE_STYLE) != null
                 ? QuoteStyle.valueOf(k9identity.get(IdentityField.QUOTE_STYLE))
                 : account.getQuoteStyle();
@@ -277,7 +279,7 @@ public class QuotedMessagePresenter {
                     }
                     // TODO replace with MessageViewInfo data
                     view.setQuotedHtml(quotedHtmlContent.getQuotedContent(),
-                            AttachmentResolver.createFromPart(messageViewInfo.rootPart));
+                            AttachmentResolver.createFromPart(messageViewInfo.rootPart, context));
                 }
             }
             if (bodyPlainOffset != null && bodyPlainLength != null) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageExtractorLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageExtractorLoader.java
@@ -52,7 +52,7 @@ public class LocalMessageExtractorLoader extends AsyncTaskLoader<MessageViewInfo
     @WorkerThread
     public MessageViewInfo loadInBackground() {
         try {
-            return messageViewInfoExtractor.extractMessageForView(message, annotations);
+            return messageViewInfoExtractor.extractMessageForView(message, annotations, getContext());
         } catch (Exception e) {
             Log.e(K9.LOG_TAG, "Error while decoding message", e);
             return null;

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
@@ -3,6 +3,7 @@ package com.fsck.k9.mailstore;
 
 import java.util.Map;
 
+import android.content.Context;
 import android.net.Uri;
 
 import com.fsck.k9.mail.BodyPart;
@@ -16,6 +17,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.*;
@@ -34,10 +36,12 @@ public class AttachmentResolverTest {
 
 
     private AttachmentInfoExtractor attachmentInfoExtractor;
+    private Context context;
 
 
     @Before
     public void setUp() throws Exception {
+        context = RuntimeEnvironment.application;
         attachmentInfoExtractor = mock(AttachmentInfoExtractor.class);
     }
 
@@ -45,7 +49,7 @@ public class AttachmentResolverTest {
     public void buildCidMap__onPartWithNoBody__shouldReturnEmptyMap() throws Exception {
         Part part = new MimeBodyPart();
 
-        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, part);
+        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, part, context);
 
         assertTrue(result.isEmpty());
     }
@@ -55,7 +59,7 @@ public class AttachmentResolverTest {
         Multipart multipartBody = MimeMultipart.newInstance();
         Part multipartPart = new MimeBodyPart(multipartBody);
 
-        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart);
+        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart, context);
 
         assertTrue(result.isEmpty());
     }
@@ -67,7 +71,7 @@ public class AttachmentResolverTest {
         Part multipartPart = new MimeBodyPart(multipartBody);
         multipartBody.addBodyPart(bodyPart);
 
-        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart);
+        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart, context);
 
         verify(bodyPart).getContentId();
         assertTrue(result.isEmpty());
@@ -86,13 +90,13 @@ public class AttachmentResolverTest {
         subPart1.setHeader(MimeHeader.HEADER_CONTENT_ID, "cid-1");
         subPart2.setHeader(MimeHeader.HEADER_CONTENT_ID, "cid-2");
 
-        when(attachmentInfoExtractor.extractAttachmentInfo(subPart1)).thenReturn(new AttachmentViewInfo(
+        when(attachmentInfoExtractor.extractAttachmentInfo(subPart1, context)).thenReturn(new AttachmentViewInfo(
                         null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_1, false, subPart1, true));
-        when(attachmentInfoExtractor.extractAttachmentInfo(subPart2)).thenReturn(new AttachmentViewInfo(
+        when(attachmentInfoExtractor.extractAttachmentInfo(subPart2, context)).thenReturn(new AttachmentViewInfo(
                         null, null, AttachmentViewInfo.UNKNOWN_SIZE, ATTACHMENT_TEST_URI_2, false, subPart2, true));
 
 
-        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart);
+        Map<String,Uri> result = AttachmentResolver.buildCidToAttachmentUriMap(attachmentInfoExtractor, multipartPart, context);
 
 
         assertEquals(2, result.size());

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -62,8 +62,7 @@ public class MessageViewInfoExtractorTest {
 
         HtmlSanitizer dummyHtmlSanitizer = HtmlSanitizerHelper.getDummyHtmlSanitizer();
 
-        messageViewInfoExtractor = new MessageViewInfoExtractor(context,
-                null, dummyHtmlSanitizer);
+        messageViewInfoExtractor = new MessageViewInfoExtractor(null, dummyHtmlSanitizer);
     }
 
     @Test
@@ -79,7 +78,7 @@ public class MessageViewInfoExtractorTest {
         // Prepare fixture
         HtmlSanitizer htmlSanitizer = mock(HtmlSanitizer.class);
         MessageViewInfoExtractor messageViewInfoExtractor =
-                new MessageViewInfoExtractor(context, null, htmlSanitizer);
+                new MessageViewInfoExtractor(null, htmlSanitizer);
         String value = "--sanitized html--";
         when(htmlSanitizer.sanitize(any(String.class))).thenReturn(value);
 
@@ -88,7 +87,7 @@ public class MessageViewInfoExtractorTest {
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
         ViewableExtractedText viewableExtractedText =
-                messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
+                messageViewInfoExtractor.extractTextFromViewables(outputViewableParts, context);
 
         assertSame(value, viewableExtractedText.html);
     }
@@ -107,7 +106,7 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
+        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts, context);
 
         String expectedText = BODY_TEXT;
         String expectedHtml =
@@ -133,7 +132,7 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
+        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts, context);
 
         String expectedText = "K-9 Mail rocks :> flowed line\r\n" +
                 "not flowed line";
@@ -162,11 +161,10 @@ public class MessageViewInfoExtractorTest {
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, null);
         assertEquals(outputViewableParts.size(), 1);
-        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
+        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts, context);
 
         String expectedText = BODY_TEXT;
-        String expectedHtml =
-                bodyText;
+        String expectedHtml = bodyText;
 
         assertEquals(expectedText, container.text);
         assertEquals(expectedHtml, getHtmlBodyText(container.html));
@@ -196,7 +194,7 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
+        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts, context);
 
         String expectedText =
                 bodyText1 + "\r\n\r\n" +
@@ -255,7 +253,7 @@ public class MessageViewInfoExtractorTest {
         List<Part> outputNonViewableParts = new ArrayList<Part>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
-        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
+        ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts, context);
 
         String expectedText =
                 BODY_TEXT +
@@ -357,7 +355,7 @@ public class MessageViewInfoExtractorTest {
         assertEquals("subject of second message", ((MessageHeader) outputViewableParts.get(2)).getMessage().getSubject());
 
         ViewableExtractedText firstMessageExtractedText =
-                messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
+                messageViewInfoExtractor.extractTextFromViewables(outputViewableParts, context);
         assertEquals(expectedExtractedText, firstMessageExtractedText.text);
         assertEquals(expectedHtmlText, getHtmlBodyText(firstMessageExtractedText.html));
     }

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
@@ -46,14 +46,14 @@ public class AttachmentInfoExtractorTest {
     @Before
     public void setUp() throws Exception {
         context = RuntimeEnvironment.application;
-        attachmentInfoExtractor = new AttachmentInfoExtractor(context);
+        attachmentInfoExtractor = new AttachmentInfoExtractor();
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void extractInfo__withGenericPart_shouldThrow() throws Exception {
         Part part = mock(Part.class);
 
-        attachmentInfoExtractor.extractAttachmentInfo(part);
+        attachmentInfoExtractor.extractAttachmentInfo(part, context);
     }
 
     @Test
@@ -61,7 +61,7 @@ public class AttachmentInfoExtractorTest {
         LocalBodyPart part = new LocalBodyPart(TEST_ACCOUNT_UUID, null, TEST_ID, TEST_SIZE);
         part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, TEST_MIME_TYPE);
 
-        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(part);
+        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(part, context);
 
         assertEquals(AttachmentProvider.getAttachmentUri(TEST_ACCOUNT_UUID, TEST_ID), attachmentViewInfo.internalUri);
         assertEquals(TEST_SIZE, attachmentViewInfo.size);
@@ -184,10 +184,10 @@ public class AttachmentInfoExtractorTest {
 
     @Test
     public void extractInfo__withDeferredFileBody() throws Exception {
-        attachmentInfoExtractor = new AttachmentInfoExtractor(context) {
+        attachmentInfoExtractor = new AttachmentInfoExtractor() {
             @Nullable
             @Override
-            protected Uri getDecryptedFileProviderUri(DeferredFileBody decryptedTempFileBody, String mimeType) {
+            protected Uri getDecryptedFileProviderUri(DeferredFileBody decryptedTempFileBody, String mimeType, Context context) {
                 return TEST_URI;
             }
         };
@@ -200,7 +200,7 @@ public class AttachmentInfoExtractorTest {
         part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, TEST_MIME_TYPE);
 
 
-        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(part);
+        AttachmentViewInfo attachmentViewInfo = attachmentInfoExtractor.extractAttachmentInfo(part, context);
 
 
         assertEquals(TEST_URI, attachmentViewInfo.internalUri);


### PR DESCRIPTION
This one's a bit more involved due to the nesting of classes which have no access to a context.