### PR TITLE
Don't build messages without a format

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
@@ -183,6 +183,8 @@ public abstract class MessageBuilder {
                 // No attachments to include, just stick the text body in the message and call it good.
                 MimeMessageHelper.setBody(message, body);
             }
+        } else {
+            throw new MessagingException("Unexpected message fomat: " + messageFormat);
         }
 
         // If this is a draft, add metadata for thawing.

--- a/k9mail/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
@@ -258,6 +258,14 @@ public class MessageBuilderTest {
         verifyNoMoreInteractions(anotherCallback);
     }
 
+    @Test(expected = MessagingException.class)
+    public void buildWithNullMessageFormat_shouldThrow() throws MessagingException {
+        MessageBuilder messageBuilder = createSimpleMessageBuilder();
+        messageBuilder.setMessageFormat(null);
+
+        messageBuilder.build();
+    }
+
     private MimeMessage getMessageFromCallback() {
         ArgumentCaptor<MimeMessage> mimeMessageCaptor = ArgumentCaptor.forClass(MimeMessage.class);
         verify(callback).onMessageBuildSuccess(mimeMessageCaptor.capture(), eq(false));


### PR DESCRIPTION
This doesn't fix #2188 but it will prevent bad messages from being sent and should give a stack trace for why we are not setting the MIME Version (which we do by calling `MimeMessageHelper.setBody(message, body);`

(I'm currently looking at why exactly it happens).