### PR TITLE
Add encrypted.asc filename to PGP/MIME emails

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -308,7 +308,9 @@ public class PgpMessageBuilder extends MessageBuilder {
         MimeMultipart multipartEncrypted = createMimeMultipart();
         multipartEncrypted.setSubType("encrypted");
         multipartEncrypted.addBodyPart(new MimeBodyPart(new TextBody("Version: 1"), "application/pgp-encrypted"));
-        multipartEncrypted.addBodyPart(new MimeBodyPart(encryptedBodyPart, "application/octet-stream"));
+        MimeBodyPart encryptedPart = new MimeBodyPart(encryptedBodyPart, "application/octet-stream; name=\"encrypted.asc\"");
+        encryptedPart.addHeader(MimeHeader.HEADER_CONTENT_DISPOSITION, "inline; filename=\"encrypted.asc\"");
+        multipartEncrypted.addBodyPart(encryptedPart);
         MimeMessageHelper.setBody(currentProcessedMimeMessage, multipartEncrypted);
 
         String contentType = String.format(

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -302,7 +302,7 @@ public class PgpMessageBuilderTest {
 
         BodyPart encryptedBodyPart = multipart.getBodyPart(1);
         Assert.assertEquals("second part must be octet-stream of encrypted data",
-                "application/octet-stream", encryptedBodyPart.getContentType());
+                "application/octet-stream; name=\"encrypted.asc\"", encryptedBodyPart.getContentType());
         Assert.assertTrue("message body must be BinaryTempFileBody",
                 encryptedBodyPart.getBody() instanceof BinaryTempFileBody);
         Assert.assertEquals(MimeUtil.ENC_7BIT, ((BinaryTempFileBody) encryptedBodyPart.getBody()).getEncoding());


### PR DESCRIPTION
Following what Thunderbird and GPGTools does, I am naming the encrypted part "encrypted.asc".
Fixes https://github.com/k9mail/k-9/issues/2031