### PR TITLE
Update robolectric, use Runner class instead of annotations

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ androidCompileSdkVersion=24
 androidBuildToolsVersion=24.0.3
 androidSupportLibraryVersion=23.1.1
 
-robolectricVersion=3.1.1
+robolectricVersion=3.2.2
 junitVersion=4.12
 mockitoVersion=1.10.19
 okioVersion=1.11.0

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/AddressTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/AddressTest.java
@@ -3,7 +3,6 @@ package com.fsck.k9.mail;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
@@ -12,8 +11,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class AddressTest {
     /**
      * test the possibility to parse "From:" fields with no email.

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/Address_quoteAtoms.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/Address_quoteAtoms.java
@@ -3,14 +3,11 @@ package com.fsck.k9.mail;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class Address_quoteAtoms {
     @Test
     public void testNoQuote() {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/K9LibRobolectricTestRunner.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/K9LibRobolectricTestRunner.java
@@ -1,0 +1,20 @@
+package com.fsck.k9.mail;
+
+import org.junit.runners.model.InitializationError;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+public class K9LibRobolectricTestRunner extends RobolectricTestRunner {
+
+    public K9LibRobolectricTestRunner(Class<?> testClass) throws InitializationError {
+        super(testClass);
+    }
+
+    @Override
+    protected Config buildGlobalConfig() {
+        return new Config.Builder()
+                .setSdk(21)
+                .setManifest(Config.NONE)
+                .build();
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/K9LibRobolectricTestRunner.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/K9LibRobolectricTestRunner.java
@@ -13,7 +13,7 @@ public class K9LibRobolectricTestRunner extends RobolectricTestRunner {
     @Override
     protected Config buildGlobalConfig() {
         return new Config.Builder()
-                .setSdk(21)
+                .setSdk(22)
                 .setManifest(Config.NONE)
                 .build();
     }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/MessageTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/MessageTest.java
@@ -26,7 +26,6 @@ import org.apache.james.mime4j.util.MimeUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
@@ -34,8 +33,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class MessageTest {
 
     private Context context;

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/CharsetSupportTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/CharsetSupportTest.java
@@ -1,16 +1,15 @@
 package com.fsck.k9.mail.internet;
 
 
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class CharsetSupportTest {
 
     @Test

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/DecoderUtilTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/DecoderUtilTest.java
@@ -1,16 +1,15 @@
 package com.fsck.k9.mail.internet;
 
 
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class DecoderUtilTest {
 
     @Test

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/ListHeadersTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/ListHeadersTest.java
@@ -2,19 +2,17 @@ package com.fsck.k9.mail.internet;
 
 
 import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class ListHeadersTest {
     private static final String[] TEST_EMAIL_ADDRESSES = new String[] {
             "prettyandsimple@example.com",

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MessageExtractorTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MessageExtractorTest.java
@@ -2,14 +2,13 @@ package com.fsck.k9.mail.internet;
 
 
 import com.fsck.k9.mail.Body;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.BinaryMemoryBody;
 import org.apache.james.mime4j.util.MimeUtil;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -18,8 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class MessageExtractorTest {
     private MimeBodyPart part;
 

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MessageIdGeneratorTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MessageIdGeneratorTest.java
@@ -2,18 +2,16 @@ package com.fsck.k9.mail.internet;
 
 
 import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.Message;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class MessageIdGeneratorTest {
     private MessageIdGenerator messageIdGenerator;
 

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MimeMessageParseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/MimeMessageParseTest.java
@@ -16,17 +16,15 @@ import org.junit.Test;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.Message.RecipientType;
 import com.fsck.k9.mail.Multipart;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class MimeMessageParseTest {
     @Before
     public void setup() {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/CopyUidResponseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/CopyUidResponseTest.java
@@ -1,13 +1,13 @@
 package com.fsck.k9.mail.store.imap;
 
 
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
+
 import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static com.fsck.k9.mail.store.imap.ImapResponseHelper.createImapResponse;
 import static org.junit.Assert.assertEquals;
@@ -15,8 +15,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class CopyUidResponseTest {
     @Test
     public void parse_withCopyUidResponse_shouldCreateUidMapping() throws Exception {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -11,6 +11,7 @@ import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.CertificateValidationException.Reason;
 import com.fsck.k9.mail.ConnectionSecurity;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.XOAuth2ChallengeParserTest;
@@ -23,8 +24,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
 import static org.hamcrest.core.StringContains.containsString;
@@ -38,8 +37,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class ImapConnectionTest {
     private static final boolean DEBUGGING = false;
 

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -17,6 +17,7 @@ import com.fsck.k9.mail.FetchProfile.Item;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.Folder.FolderType;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessageRetrievalListener;
 import com.fsck.k9.mail.MessagingException;
@@ -32,9 +33,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RO;
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
@@ -58,8 +57,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.internal.util.collections.Sets.newSet;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class ImapFolderTest {
     private ImapStore imapStore;
     private ImapConnection imapConnection;

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapPushStateTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapPushStateTest.java
@@ -1,17 +1,16 @@
 package com.fsck.k9.mail.store.imap;
 
 
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class ImapPushStateTest {
     @Test
     public void parse_withValidArgument() throws Exception {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapPusherTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapPusherTest.java
@@ -6,13 +6,12 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.PushReceiver;
 import com.fsck.k9.mail.store.StoreConfig;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.doThrow;
@@ -21,8 +20,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class ImapPusherTest {
     private ImapStore imapStore;
     private TestImapPusher imapPusher;

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.java
@@ -6,12 +6,11 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.filter.FixedLengthInputStream;
 import com.fsck.k9.mail.filter.PeekableInputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -20,8 +19,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class ImapResponseParserTest {
     private PeekableInputStream peekableInputStream;
 

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapUtilityTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapUtilityTest.java
@@ -17,18 +17,17 @@
 
 package com.fsck.k9.mail.store.imap;
 
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class ImapUtilityTest  {
     @Test
     public void testGetImapSequenceValues() {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavFolderTest.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.mail.store.webdav;
 
 import com.fsck.k9.mail.FetchProfile;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessageRetrievalListener;
 import com.fsck.k9.mail.MessagingException;
@@ -22,8 +23,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static java.util.Collections.singletonList;
 
@@ -58,8 +57,7 @@ import java.util.List;
 import java.util.Map;
 
 @SuppressWarnings("deprecation")
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class WebDavFolderTest {
     @Mock
     private MessageRetrievalListener<WebDavMessage> listener;

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavMessageTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavMessageTest.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.mail.store.webdav;
 
 import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.MessagingException;
 
 import org.junit.Before;
@@ -8,18 +9,14 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class WebDavMessageTest {
 
     private WebDavMessage message;

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
@@ -4,13 +4,13 @@ package com.fsck.k9.mail.store.webdav;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
-import java.util.HashMap;
 import java.util.List;
 
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mail.ServerSettings.Type;
@@ -44,10 +44,7 @@ import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.mockito.stubbing.OngoingStubbing;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
-
-import java.util.Collections;
 
 import static junit.framework.Assert.assertSame;
 import static org.junit.Assert.assertEquals;
@@ -58,8 +55,7 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("deprecation")
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class WebDavStoreTest {
     private static final HttpResponse OK_200_RESPONSE = createOkResponse();
     private static final HttpResponse UNAUTHORIZED_401_RESPONSE = createResponse(401);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/transport/SmtpTransportTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/transport/SmtpTransportTest.java
@@ -8,6 +8,7 @@ import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.ConnectionSecurity;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.ServerSettings;
@@ -18,7 +19,6 @@ import com.fsck.k9.mail.helpers.TestMessageBuilder;
 import com.fsck.k9.mail.helpers.TestTrustedSocketFactory;
 import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider;
-import com.fsck.k9.mail.oauth.XOAuth2ChallengeParser;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
 import com.fsck.k9.mail.store.StoreConfig;
 import com.fsck.k9.mail.transport.mockServer.MockSmtpServer;
@@ -26,13 +26,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InOrder;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
@@ -41,8 +39,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9LibRobolectricTestRunner.class)
 public class SmtpTransportTest {
     private static final String LOCALHOST_NAME = "localhost";
     private static final String USERNAME = "user";

--- a/k9mail/src/test/java/com/fsck/k9/K9RobolectricTestRunner.java
+++ b/k9mail/src/test/java/com/fsck/k9/K9RobolectricTestRunner.java
@@ -13,7 +13,7 @@ public class K9RobolectricTestRunner extends RobolectricTestRunner {
     @Override
     protected Config buildGlobalConfig() {
         return new Config.Builder()
-                .setSdk(21)
+                .setSdk(22)
                 .setManifest("src/main/AndroidManifest.xml")
                 .build();
     }

--- a/k9mail/src/test/java/com/fsck/k9/K9RobolectricTestRunner.java
+++ b/k9mail/src/test/java/com/fsck/k9/K9RobolectricTestRunner.java
@@ -1,0 +1,20 @@
+package com.fsck.k9;
+
+import org.junit.runners.model.InitializationError;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+public class K9RobolectricTestRunner extends RobolectricTestRunner {
+
+    public K9RobolectricTestRunner(Class<?> testClass) throws InitializationError {
+        super(testClass);
+    }
+
+    @Override
+    protected Config buildGlobalConfig() {
+        return new Config.Builder()
+                .setSdk(21)
+                .setManifest("src/main/AndroidManifest.xml")
+                .build();
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
@@ -4,21 +4,19 @@ package com.fsck.k9.activity;
 import android.content.Context;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mail.Message;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class ActivityListenerTest {
     private static final String FOLDER = "folder";
     private static final String ERROR_MESSAGE = "errorMessage";

--- a/k9mail/src/test/java/com/fsck/k9/activity/MessageReferenceTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/MessageReferenceTest.java
@@ -1,10 +1,10 @@
 package com.fsck.k9.activity;
 
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mail.Flag;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
@@ -14,8 +14,8 @@ import static junit.framework.Assert.assertTrue;
 import static org.junit.Assert.assertNotNull;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class MessageReferenceTest {
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
@@ -10,6 +10,7 @@ import android.content.Intent;
 import android.os.ParcelFileDescriptor;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.activity.compose.RecipientMvpView.CryptoSpecialModeDisplayType;
 import com.fsck.k9.activity.compose.RecipientMvpView.CryptoStatusDisplayType;
 import com.fsck.k9.activity.compose.RecipientPresenter.CryptoMode;
@@ -28,7 +29,6 @@ import org.openintents.openpgp.util.OpenPgpApi;
 import org.openintents.openpgp.util.OpenPgpServiceConnection;
 import org.openintents.openpgp.util.ShadowOpenPgpAsyncTask;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
@@ -43,8 +43,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21, shadows = {ShadowOpenPgpAsyncTask.class})
+@RunWith(K9RobolectricTestRunner.class)
+@Config(shadows = {ShadowOpenPgpAsyncTask.class})
 public class RecipientPresenterTest {
     private static final ReplyToAddresses TO_ADDRESSES = new ReplyToAddresses(Address.parse("to@example.org"));
     private static final List<Address> ALL_TO_ADDRESSES = Arrays.asList(Address.parse("allTo@example.org"));

--- a/k9mail/src/test/java/com/fsck/k9/cache/EmailProviderCacheTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/cache/EmailProviderCacheTest.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.cache;
 
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 
@@ -9,9 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import java.util.Collections;
 import java.util.UUID;
@@ -25,8 +24,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class EmailProviderCacheTest {
 
     private EmailProviderCache cache;

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -13,6 +13,7 @@ import android.content.Context;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.AccountStats;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.FetchProfile;
@@ -38,8 +39,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
 import static org.junit.Assert.assertEquals;
@@ -60,8 +59,7 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("unchecked")
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class MessagingControllerTest {
     private static final String FOLDER_NAME = "Folder";
     private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;

--- a/k9mail/src/test/java/com/fsck/k9/crypto/MessageDecryptVerifierTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/crypto/MessageDecryptVerifierTest.java
@@ -4,6 +4,7 @@ package com.fsck.k9.crypto;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
@@ -18,7 +19,6 @@ import com.fsck.k9.mail.internet.TextBody;
 import com.fsck.k9.ui.crypto.MessageCryptoAnnotations;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
@@ -29,8 +29,8 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class MessageDecryptVerifierTest {
     private static final String MIME_TYPE_MULTIPART_ENCRYPTED = "multipart/encrypted";
     private MessageCryptoAnnotations messageCryptoAnnotations = mock(MessageCryptoAnnotations.class);

--- a/k9mail/src/test/java/com/fsck/k9/crypto/OpenPgpApiHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/crypto/OpenPgpApiHelperTest.java
@@ -2,16 +2,16 @@ package com.fsck.k9.crypto;
 
 
 import com.fsck.k9.Identity;
+import com.fsck.k9.K9RobolectricTestRunner;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class OpenPgpApiHelperTest {
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/helper/MailToTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/MailToTest.java
@@ -7,13 +7,13 @@ import java.util.List;
 
 import android.net.Uri;
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.helper.MailTo.CaseInsensitiveParamWrapper;
 import com.fsck.k9.mail.Address;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
@@ -23,8 +23,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class MailToTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();

--- a/k9mail/src/test/java/com/fsck/k9/helper/MessageHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/MessageHelperTest.java
@@ -5,11 +5,11 @@ import android.content.Context;
 import android.graphics.Color;
 import android.text.SpannableString;
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mail.Address;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
@@ -17,8 +17,8 @@ import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class MessageHelperTest {
     private Contacts contacts;
     private Contacts mockContacts;

--- a/k9mail/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.helper.ReplyToParser.ReplyToAddresses;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
@@ -13,7 +14,6 @@ import com.fsck.k9.mail.internet.ListHeaders;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class ReplyToParserTest {
     private static final Address[] REPLY_TO_ADDRESSES = Address.parse("replyTo1@example.com, replyTo2@example.com");
     private static final Address[] LIST_POST_ADDRESSES = Address.parse("listPost@example.com");

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import android.net.Uri;
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.Multipart;
 import com.fsck.k9.mail.Part;
@@ -15,7 +16,6 @@ import com.fsck.k9.message.extractors.AttachmentInfoExtractor;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.*;
@@ -26,8 +26,8 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("unchecked")
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class AttachmentResolverTest {
     public static final Uri ATTACHMENT_TEST_URI_1 = Uri.parse("uri://test/1");
     public static final Uri ATTACHMENT_TEST_URI_2 = Uri.parse("uri://test/2");

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/DeferredFileBodyTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/DeferredFileBodyTest.java
@@ -7,13 +7,13 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mailstore.util.FileFactory;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.io.output.ByteArrayOutputStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -21,11 +21,10 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.fail;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class DeferredFileBodyTest {
     public static final String TEST_ENCODING = "test-encoding";
     public static final byte[] TEST_DATA_SHORT = "test data".getBytes();

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -11,6 +11,7 @@ import java.util.TimeZone;
 import android.app.Application;
 
 import com.fsck.k9.GlobalsHelper;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.activity.K9ActivityCommon;
 import com.fsck.k9.message.html.HtmlSanitizer;
 import com.fsck.k9.message.html.HtmlSanitizerHelper;
@@ -31,9 +32,7 @@ import com.fsck.k9.mailstore.MessageViewInfoExtractor.ViewableExtractedText;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertSame;
@@ -42,8 +41,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class MessageViewInfoExtractorTest {
     public static final String BODY_TEXT = "K-9 Mail rocks :>";
     public static final String BODY_TEXT_HTML = "K-9 Mail rocks :&gt;";

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MigrationTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MigrationTest.java
@@ -14,6 +14,7 @@ import android.database.sqlite.SQLiteDatabase;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.FetchProfile;
@@ -28,14 +29,11 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openintents.openpgp.util.OpenPgpUtils;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 import org.robolectric.shadows.ShadowSQLiteConnection;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class MigrationTest {
 
     Account account;

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
@@ -15,12 +15,12 @@ import com.fsck.k9.Account;
 import com.fsck.k9.BuildConfig;
 import com.fsck.k9.GlobalsHelper;
 import com.fsck.k9.K9;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.R;
 import com.fsck.k9.mail.MessagingException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
+@RunWith(K9RobolectricTestRunner.class)
 @Config(manifest = Config.NONE)
 public class StoreSchemaDefinitionTest {
     private StoreSchemaDefinition storeSchemaDefinition;

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationMimeStructureStateTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationMimeStructureStateTest.java
@@ -3,16 +3,14 @@ package com.fsck.k9.mailstore.migrations;
 
 import android.content.ContentValues;
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mailstore.migrations.MigrationTo51.MimeStructureState;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 
-@RunWith(RobolectricTestRunner.class) // required for ContentValues
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class) // required for ContentValues
 public class MigrationMimeStructureStateTest {
 
     @Test(expected = IllegalStateException.class)

--- a/k9mail/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
@@ -15,6 +15,7 @@ import android.app.Application;
 
 import com.fsck.k9.Account.QuoteStyle;
 import com.fsck.k9.Identity;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.activity.misc.Attachment;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.BodyPart;
@@ -32,9 +33,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -46,8 +45,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class MessageBuilderTest {
     public static final String TEST_MESSAGE_TEXT = "soviet message\r\ntext ☭";
     public static final String TEST_ATTACHMENT_TEXT = "text data in attachment";

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -17,6 +17,7 @@ import android.os.Bundle;
 
 import com.fsck.k9.Account.QuoteStyle;
 import com.fsck.k9.Identity;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.ComposeCryptoStatusBuilder;
 import com.fsck.k9.activity.compose.RecipientPresenter.CryptoMode;
@@ -46,9 +47,7 @@ import org.mockito.ArgumentCaptor;
 import org.openintents.openpgp.OpenPgpError;
 import org.openintents.openpgp.util.OpenPgpApi;
 import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -61,8 +60,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class PgpMessageBuilderTest {
     private static final long TEST_SIGN_KEY_ID = 123L;
     private static final long TEST_SELF_ENCRYPT_KEY_ID = 234L;

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MimeBodyPart;
 import com.fsck.k9.mail.internet.MimeHeader;
@@ -16,20 +17,18 @@ import com.fsck.k9.provider.AttachmentProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class AttachmentInfoExtractorTest {
     public static final Uri TEST_URI = Uri.parse("uri://test");
     public static final String TEST_MIME_TYPE = "text/plain";

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/EncryptionDetectorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/EncryptionDetectorTest.java
@@ -1,12 +1,11 @@
 package com.fsck.k9.message.extractors;
 
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mail.Message;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static com.fsck.k9.message.MessageCreationHelper.createMessage;
 import static com.fsck.k9.message.MessageCreationHelper.createMultipartMessage;
@@ -17,8 +16,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class EncryptionDetectorTest {
     private static final String CRLF = "\r\n";
 

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.java
@@ -1,20 +1,20 @@
 package com.fsck.k9.message.extractors;
 
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MimeBodyPart;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static com.fsck.k9.message.MessageCreationHelper.createTextPart;
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class PreviewTextExtractorTest {
     private PreviewTextExtractor previewTextExtractor;
 

--- a/k9mail/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
@@ -6,18 +6,17 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 
-import com.fsck.k9.message.html.HtmlConverter;
+import com.fsck.k9.K9RobolectricTestRunner;
 import org.apache.commons.io.IOUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static junit.framework.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class HtmlConverterTest {
     // Useful if you want to write stuff to a file for debugging in a browser.
     private static final boolean WRITE_TO_FILE = Boolean.parseBoolean(System.getProperty("k9.htmlConverterTest.writeToFile", "false"));

--- a/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerHelper.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerHelper.java
@@ -1,9 +1,6 @@
 package com.fsck.k9.message.html;
 
 
-import com.fsck.k9.message.html.HtmlSanitizer;
-
-
 public class HtmlSanitizerHelper {
     public static HtmlSanitizer getDummyHtmlSanitizer() {
         return new HtmlSanitizer() {

--- a/k9mail/src/test/java/com/fsck/k9/message/signature/HtmlSignatureRemoverTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/signature/HtmlSignatureRemoverTest.java
@@ -1,18 +1,19 @@
 package com.fsck.k9.message.signature;
 
 
+import com.fsck.k9.K9RobolectricTestRunner;
+
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static com.fsck.k9.message.html.HtmlHelper.extractText;
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class HtmlSignatureRemoverTest {
     @Test
     public void shouldStripSignatureFromK9StyleHtml() throws Exception {

--- a/k9mail/src/test/java/com/fsck/k9/message/signature/TextSignatureRemoverTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/signature/TextSignatureRemoverTest.java
@@ -1,7 +1,6 @@
 package com.fsck.k9.message.signature;
 
 
-import com.fsck.k9.message.signature.TextSignatureRemover;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;

--- a/k9mail/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationsTest.java
@@ -9,14 +9,13 @@ import android.support.v4.app.NotificationCompat.Builder;
 import android.support.v4.app.NotificationManagerCompat;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -25,8 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class AuthenticationErrorNotificationsTest {
     private static final boolean INCOMING = true;
     private static final boolean OUTGOING = false;

--- a/k9mail/src/test/java/com/fsck/k9/notification/BaseNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/BaseNotificationsTest.java
@@ -7,12 +7,12 @@ import android.support.v4.app.NotificationCompat.Builder;
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationQuickDelete;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertFalse;
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class BaseNotificationsTest {
     private static final int ACCOUNT_COLOR = 0xAABBCC;
     private static final String ACCOUNT_NAME = "AccountName";

--- a/k9mail/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationsTest.java
@@ -9,14 +9,13 @@ import android.support.v4.app.NotificationCompat.Builder;
 import android.support.v4.app.NotificationManagerCompat;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -25,8 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class CertificateErrorNotificationsTest {
     private static final boolean INCOMING = true;
     private static final boolean OUTGOING = false;

--- a/k9mail/src/test/java/com/fsck/k9/notification/DeviceNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/DeviceNotificationsTest.java
@@ -15,6 +15,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationHideSubject;
 import com.fsck.k9.K9.NotificationQuickDelete;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.NotificationSetting;
 import com.fsck.k9.R;
 import org.junit.Before;
@@ -22,9 +23,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static com.fsck.k9.MockHelper.mockBuilder;
 import static org.junit.Assert.assertEquals;
@@ -35,8 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class DeviceNotificationsTest {
     private static final int UNREAD_MESSAGE_COUNT = 42;
     private static final int NEW_MESSAGE_COUNT = 2;

--- a/k9mail/src/test/java/com/fsck/k9/notification/LockScreenNotificationTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/LockScreenNotificationTest.java
@@ -11,14 +11,13 @@ import android.support.v4.app.NotificationCompat.Builder;
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.LockScreenNotificationVisibility;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -28,8 +27,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class LockScreenNotificationTest {
     private static final String ACCOUNT_NAME = "Hugo";
     private static final int NEW_MESSAGE_COUNT = 3;

--- a/k9mail/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
@@ -7,13 +7,12 @@ import android.support.v4.app.NotificationManagerCompat;
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationHideSubject;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.mailstore.LocalMessage;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -26,8 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class NewMailNotificationsTest {
     private static final int ACCOUNT_NUMBER = 23;
 

--- a/k9mail/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.java
@@ -4,6 +4,7 @@ package com.fsck.k9.notification;
 import android.content.Context;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Flag;
@@ -13,9 +14,7 @@ import com.fsck.k9.message.extractors.PreviewResult.PreviewType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -23,8 +22,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class NotificationContentCreatorTest {
     private static final String ACCOUNT_UUID = "1-2-3";
     private static final String FOLDER_NAME = "INBOX";

--- a/k9mail/src/test/java/com/fsck/k9/notification/NotificationDataTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/NotificationDataTest.java
@@ -4,12 +4,12 @@ package com.fsck.k9.notification;
 import java.util.List;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.activity.MessageReference;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
@@ -20,8 +20,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class NotificationDataTest {
     private static final String ACCOUNT_UUID = "1-2-3";
     private static final int ACCOUNT_NUMBER = 23;

--- a/k9mail/src/test/java/com/fsck/k9/notification/NotificationIdsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/NotificationIdsTest.java
@@ -2,17 +2,18 @@ package com.fsck.k9.notification;
 
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class NotificationIdsTest {
     private static final boolean INCOMING = true;
     private static final boolean OUTGOING = false;

--- a/k9mail/src/test/java/com/fsck/k9/notification/SendFailedNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/SendFailedNotificationsTest.java
@@ -8,14 +8,13 @@ import android.support.v4.app.NotificationCompat.Builder;
 import android.support.v4.app.NotificationManagerCompat;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -25,8 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class SendFailedNotificationsTest {
     private static final int ACCOUNT_NUMBER = 1;
     private static final String ACCOUNT_NAME = "TestAccount";

--- a/k9mail/src/test/java/com/fsck/k9/notification/SyncNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/SyncNotificationsTest.java
@@ -8,15 +8,14 @@ import android.support.v4.app.NotificationCompat.Builder;
 import android.support.v4.app.NotificationManagerCompat;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
 import com.fsck.k9.mail.Folder;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
@@ -27,8 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class SyncNotificationsTest {
     private static final int ACCOUNT_NUMBER = 1;
     private static final String ACCOUNT_NAME = "TestAccount";

--- a/k9mail/src/test/java/com/fsck/k9/notification/WearNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/WearNotificationsTest.java
@@ -14,6 +14,7 @@ import android.support.v4.app.NotificationCompat.WearableExtender;
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationQuickDelete;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
 import com.fsck.k9.activity.MessageReference;
@@ -22,9 +23,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
@@ -35,8 +34,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class WearNotificationsTest {
     private static final int ACCOUNT_NUMBER = 42;
     private static final String ACCOUNT_NAME = "accountName";

--- a/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
@@ -1,12 +1,12 @@
 package com.fsck.k9.preferences;
 
+import com.fsck.k9.K9RobolectricTestRunner;
+
 import org.jdom2.Document;
 import org.jdom2.input.SAXBuilder;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -18,8 +18,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class SettingsExporterTest {
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
@@ -7,23 +7,21 @@ import java.util.List;
 import java.util.UUID;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.AuthType;
 import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
 
 @SuppressWarnings("unchecked")
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = "src/main/AndroidManifest.xml", sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
 public class SettingsImporterTest {
 
     @Before

--- a/k9mail/src/test/java/com/fsck/k9/setup/ServerNameSuggesterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/setup/ServerNameSuggesterTest.java
@@ -1,18 +1,18 @@
 package com.fsck.k9.setup;
 
 
+import com.fsck.k9.K9RobolectricTestRunner;
 import com.fsck.k9.mail.ServerSettings.Type;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
+@RunWith(K9RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
 public class ServerNameSuggesterTest {
     private ServerNameSuggester serverNameSuggester;
 


### PR DESCRIPTION
* updates robolectric to 3.2.2
* uses Runner class to configure Manifest path and SDK instead of repeating the same annotation again and again