### PR TITLE
Clear folder using the MessagingController instead of on the UI thread

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -476,30 +476,8 @@ public class FolderList extends K9ListActivity {
     }
 
     private void onClearFolder(Account account, String folderName) {
-        // There has to be a cheaper way to get at the localFolder object than this
-        LocalFolder localFolder = null;
-        try {
-            if (account == null || folderName == null || !account.isAvailable(FolderList.this)) {
-                Log.i(K9.LOG_TAG, "not clear folder of unavailable account");
-                return;
-            }
-            localFolder = account.getLocalStore().getFolder(folderName);
-            localFolder.open(Folder.OPEN_MODE_RW);
-            localFolder.clearAllMessages();
-        } catch (Exception e) {
-            Log.e(K9.LOG_TAG, "Exception while clearing folder", e);
-        } finally {
-            if (localFolder != null) {
-                localFolder.close();
-            }
-        }
-
-        onRefresh(!REFRESH_REMOTE);
+        MessagingController.getInstance(getApplication()).clearFolder(account, folderName, mAdapter.mListener);
     }
-
-
-
-
 
     private void sendMail(Account account) {
         MessagingController.getInstance(getApplication()).sendPendingMessages(account, mAdapter.mListener);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -3518,28 +3518,29 @@ public class MessagingController {
         putBackground("clearFolder", listener, new Runnable() {
             @Override
             public void run() {
-                LocalFolder localFolder = null;
-                try {
-                    Store localStore = account.getLocalStore();
-                    localFolder = (LocalFolder) localStore.getFolder(account.getTrashFolderName());
-                    localFolder.open(Folder.OPEN_MODE_RW);
-
-                    localFolder = account.getLocalStore().getFolder(folderName);
-                    localFolder.open(Folder.OPEN_MODE_RW);
-                    localFolder.clearAllMessages();
-                } catch (UnavailableStorageException e) {
-                    Log.i(K9.LOG_TAG, "Failed to clear folder because storage is not available - trying again later.");
-                    throw new UnavailableAccountException(e);
-                } catch (Exception e) {
-                    Log.e(K9.LOG_TAG, "clearFolder failed", e);
-                    addErrorMessage(account, null, e);
-                } finally {
-                    closeFolder(localFolder);
-                }
-
-                listFoldersSynchronous(account, false, listener);
+                clearFolderSynchronous(account, folderName, listener);
             }
         });
+    }
+
+    @VisibleForTesting
+    protected void clearFolderSynchronous(Account account, String folderName, MessagingListener listener) {
+        LocalFolder localFolder = null;
+        try {
+            localFolder = account.getLocalStore().getFolder(folderName);
+            localFolder.open(Folder.OPEN_MODE_RW);
+            localFolder.clearAllMessages();
+        } catch (UnavailableStorageException e) {
+            Log.i(K9.LOG_TAG, "Failed to clear folder because storage is not available - trying again later.");
+            throw new UnavailableAccountException(e);
+        } catch (Exception e) {
+            Log.e(K9.LOG_TAG, "clearFolder failed", e);
+            addErrorMessage(account, null, e);
+        } finally {
+            closeFolder(localFolder);
+        }
+
+        listFoldersSynchronous(account, false, listener);
     }
 
 


### PR DESCRIPTION
Seems to be mostly legacy that we weren't already doing it. Code was super-easy to port over.

Fixes #2143