### PR TITLE
Fix consecutive retrying of crypto operations

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -258,7 +258,7 @@ public class MessageLoaderHelper {
     // process with crypto helper
 
     private void startOrResumeCryptoOperation() {
-        RetainFragment<MessageCryptoHelper> retainCryptoHelperFragment = getMessageCryptoHelperRetainFragment();
+        RetainFragment<MessageCryptoHelper> retainCryptoHelperFragment = getMessageCryptoHelperRetainFragment(true);
         if (retainCryptoHelperFragment.hasData()) {
             messageCryptoHelper = retainCryptoHelperFragment.getData();
         } else {
@@ -270,7 +270,7 @@ public class MessageLoaderHelper {
     }
 
     private void cancelAndClearCryptoOperation() {
-        RetainFragment<MessageCryptoHelper> retainCryptoHelperFragment = getMessageCryptoHelperRetainFragment();
+        RetainFragment<MessageCryptoHelper> retainCryptoHelperFragment = getMessageCryptoHelperRetainFragment(false);
         if (retainCryptoHelperFragment != null) {
             if (retainCryptoHelperFragment.hasData()) {
                 messageCryptoHelper = retainCryptoHelperFragment.getData();
@@ -281,8 +281,12 @@ public class MessageLoaderHelper {
         }
     }
 
-    private RetainFragment<MessageCryptoHelper> getMessageCryptoHelperRetainFragment() {
-        return RetainFragment.findOrCreate(fragmentManager, "crypto_helper_" + messageReference.hashCode());
+    private RetainFragment<MessageCryptoHelper> getMessageCryptoHelperRetainFragment(boolean createIfNotExists) {
+        if (createIfNotExists) {
+            return RetainFragment.findOrCreate(fragmentManager, "crypto_helper_" + messageReference.hashCode());
+        } else {
+            return RetainFragment.findOrNull(fragmentManager, "crypto_helper_" + messageReference.hashCode());
+        }
     }
 
     private MessageCryptoCallback messageCryptoCallback = new MessageCryptoCallback() {

--- a/k9mail/src/main/java/com/fsck/k9/helper/RetainFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/RetainFragment.java
@@ -10,6 +10,7 @@ import android.os.Bundle;
 
 public class RetainFragment<T> extends Fragment {
     private T data;
+    private boolean cleared;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -39,7 +40,7 @@ public class RetainFragment<T> extends Fragment {
         // noinspection unchecked, we know this is the the right type
         RetainFragment<T> retainFragment = (RetainFragment<T>) fm.findFragmentByTag(tag);
 
-        if (retainFragment == null) {
+        if (retainFragment == null || retainFragment.cleared) {
             retainFragment = new RetainFragment<>();
             fm.beginTransaction()
                     .add(retainFragment, tag)
@@ -51,6 +52,7 @@ public class RetainFragment<T> extends Fragment {
 
     public void clearAndRemove(FragmentManager fm) {
         data = null;
+        cleared = true;
 
         if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1 && fm.isDestroyed()) {
             return;

--- a/k9mail/src/main/java/com/fsck/k9/helper/RetainFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/RetainFragment.java
@@ -30,6 +30,11 @@ public class RetainFragment<T> extends Fragment {
         this.data = data;
     }
 
+    public static <T> RetainFragment<T> findOrNull(FragmentManager fm, String tag) {
+        // noinspection unchecked, we know this is the the right type
+        return (RetainFragment<T>) fm.findFragmentByTag(tag);
+    }
+
     public static <T> RetainFragment<T> findOrCreate(FragmentManager fm, String tag) {
         // noinspection unchecked, we know this is the the right type
         RetainFragment<T> retainFragment = (RetainFragment<T>) fm.findFragmentByTag(tag);


### PR DESCRIPTION
This PR fixes two small bugs with RetainFragment. Most importantly, a fragment could be returned if cleared and retrieved before FragmentManager had a chance to execute pending actions, leading to inconsistent state.