### PR TITLE
WebDAV: Use the proper sendRequest mechanism to append messages

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -27,6 +27,7 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -678,28 +679,8 @@ class WebDavFolder extends Folder<WebDavMessage> {
 
                 Log.i(LOG_TAG, "Uploading message as " + messageURL);
 
-                httpmethod = new HttpGeneric(messageURL);
-                httpmethod.setMethod("PUT");
-                httpmethod.setEntity(bodyEntity);
+                store.sendRequest(messageURL, "PUT", bodyEntity, null, true);
 
-                String mAuthString = store.getAuthString();
-
-                if (mAuthString != null) {
-                    httpmethod.setHeader("Authorization", mAuthString);
-                }
-
-                response = httpclient.executeOverride(httpmethod, store.getContext());
-                statusCode = response.getStatusLine().getStatusCode();
-
-                if (statusCode < 200 ||
-                        statusCode > 300) {
-
-                    //TODO: Could we handle a login timeout here?
-
-                    throw new IOException("Error with status code " + statusCode
-                            + " while sending/appending message.  Response = "
-                            + response.getStatusLine().toString() + " for message " + messageURL);
-                }
                 WebDavMessage retMessage = new WebDavMessage(message.getUid(), this);
 
                 retMessage.setUrl(messageURL);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -830,7 +830,7 @@ public class WebDavStore extends RemoteStore {
         return mHttpClient;
     }
 
-    private InputStream sendRequest(String url, String method, StringEntity messageBody,
+    protected InputStream sendRequest(String url, String method, StringEntity messageBody,
                                     Map<String, String> headers, boolean tryAuth)
             throws MessagingException {
         if (url == null || method == null) {


### PR DESCRIPTION
This should fix #1500 

I say should because I don't have a WebDAV set-up any more but the code does roughly the same as it did, only using the proper sendRequest code to handle auth errors - so I think it's fairly safe.