### PR TITLE
Make Hex.encodeHex returns a String (was char[])

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Authentication.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Authentication.java
@@ -75,7 +75,7 @@ public class Authentication {
             md.update(opad);
             byte[] result = md.digest(firstPass);
 
-            String plainCRAM = username + " " + new String(Hex.encodeHex(result));
+            String plainCRAM = username + " " + Hex.encodeHex(result);
             byte[] b64CRAM = Base64.encodeBase64(plainCRAM.getBytes());
 
             return b64CRAM;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/filter/Hex.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/filter/Hex.java
@@ -36,9 +36,9 @@ public class Hex {
      *
      * @param data
      *                  a byte[] to convert to Hex characters
-     * @return A char[] containing lower-case hexadecimal characters
+     * @return A String containing lower-case hexadecimal characters
      */
-    public static char[] encodeHex(byte[] data) {
+    public static String encodeHex(byte[] data) {
 
         int l = data.length;
 
@@ -50,7 +50,7 @@ public class Hex {
             out[j++] = DIGITS[ 0x0F & data[i] ];
         }
 
-        return out;
+        return new String(out);
     }
 
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -459,7 +459,7 @@ public class Pop3Store extends RemoteStore {
                         "MD5 failure during POP3 auth APOP", e);
             }
             byte[] digest = md.digest((timestamp + mPassword).getBytes());
-            String hexDigest = new String(Hex.encodeHex(digest));
+            String hexDigest = Hex.encodeHex(digest);
             try {
                 executeSimpleCommand("APOP " + mUsername + " " + hexDigest, true);
             } catch (Pop3ErrorResponse e) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -238,8 +238,8 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
                     if (sha1 != null) {
                         sha1.reset();
                         try {
-                            char[] sha1sum = Hex.encodeHex(sha1.digest(chain[i].getEncoded()));
-                            chainInfo.append("Fingerprint (SHA-1): ").append(new String(sha1sum)).append("\n");
+                            String sha1sum = Hex.encodeHex(sha1.digest(chain[i].getEncoded()));
+                            chainInfo.append("Fingerprint (SHA-1): ").append(sha1sum).append("\n");
                         } catch (CertificateEncodingException e) {
                             Log.e(K9.LOG_TAG, "Error while encoding certificate", e);
                         }


### PR DESCRIPTION
This PR replace the signature of `Hex.encodeHex` to return a `String` instead of a `char[]`.

Related issue: #2208 