### PR TITLE
Enhance test for database upgrade process

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -12,6 +12,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mailstore.migrations.Migrations;
 import com.fsck.k9.mailstore.migrations.MigrationsHelper;
 import com.fsck.k9.preferences.Storage;
@@ -89,7 +90,7 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
                 "poll_class TEXT, " +
                 "push_class TEXT, " +
                 "display_class TEXT, " +
-                "notify_class TEXT, " +
+                "notify_class TEXT default '"+ Folder.FolderClass.INHERITED.name() + "', " +
                 "more_messages TEXT default \"unknown\"" +
                 ")");
 

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
@@ -297,15 +297,13 @@ public class StoreSchemaDefinitionTest {
 
     private List<String> objectsInDatabase(SQLiteDatabase db, String type) {
         List<String> databaseObjects = new ArrayList<>();
-        Cursor cursor = db.rawQuery("SELECT sql FROM sqlite_master WHERE type = ? AND sql IS NOT NULL", new String[] { type });
+        Cursor cursor = db.rawQuery("SELECT sql FROM sqlite_master WHERE type = ? AND sql IS NOT NULL",
+                new String[] { type });
         try {
-            if (cursor.moveToFirst()) {
-                while (!cursor.isAfterLast()) {
-                    String sql = cursor.getString(cursor.getColumnIndex("sql"));
-                    String resortedSql = "table".equals(type) ? sortTableColumns(sql) : sql;
-                    databaseObjects.add(resortedSql);
-                    cursor.moveToNext();
-                }
+            while (cursor.moveToNext()) {
+                String sql = cursor.getString(cursor.getColumnIndex("sql"));
+                String resortedSql = "table".equals(type) ? sortTableColumns(sql) : sql;
+                databaseObjects.add(resortedSql);
             }
         } finally {
             cursor.close();
@@ -316,10 +314,13 @@ public class StoreSchemaDefinitionTest {
 
     private String sortTableColumns(String sql) {
         int positionOfColumnDefinitions = sql.indexOf('(');
-        String colsStr = sql.substring(positionOfColumnDefinitions+1, sql.length()-1);
-        String[] cols = colsStr.split(" *, *(?![^\\(]*\\))");
-        Arrays.sort(cols);
-        return sql.substring(0, positionOfColumnDefinitions+1) + TextUtils.join(", ", cols) + ")";
+        String columnDefinitionsSql = sql.substring(positionOfColumnDefinitions + 1, sql.length() - 1);
+        String[] columnDefinitions = columnDefinitionsSql.split(" *, *(?![^(]*\\))");
+        Arrays.sort(columnDefinitions);
+
+        String sqlPrefix = sql.substring(0, positionOfColumnDefinitions + 1);
+        String sortedColumnDefinitionsSql = TextUtils.join(", ", columnDefinitions);
+        return sqlPrefix + sortedColumnDefinitionsSql + ")";
     }
 
     private void insertMessageWithSubject(SQLiteDatabase database, String subject) {

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
@@ -296,13 +296,14 @@ public class StoreSchemaDefinitionTest {
     }
 
     private List<String> objectsInDatabase(SQLiteDatabase db, String type) {
-        List<String> tables = new ArrayList<>();
+        List<String> databaseObjects = new ArrayList<>();
         Cursor cursor = db.rawQuery("SELECT sql FROM sqlite_master WHERE type = ? AND sql IS NOT NULL", new String[] { type });
         try {
             if (cursor.moveToFirst()) {
                 while (!cursor.isAfterLast()) {
                     String sql = cursor.getString(cursor.getColumnIndex("sql"));
-                    tables.add("table".equals(type) ? sortTableColumns(sql) : sql);
+                    String resortedSql = "table".equals(type) ? sortTableColumns(sql) : sql;
+                    databaseObjects.add(resortedSql);
                     cursor.moveToNext();
                 }
             }
@@ -310,15 +311,15 @@ public class StoreSchemaDefinitionTest {
             cursor.close();
         }
 
-        return tables;
+        return databaseObjects;
     }
 
     private String sortTableColumns(String sql) {
-        int posColDef = sql.indexOf('(');
-        String colsStr = sql.substring(posColDef+1, sql.length()-1);
+        int positionOfColumnDefinitions = sql.indexOf('(');
+        String colsStr = sql.substring(positionOfColumnDefinitions+1, sql.length()-1);
         String[] cols = colsStr.split(" *, *(?![^\\(]*\\))");
         Arrays.sort(cols);
-        return sql.substring(0, posColDef+1) + TextUtils.join(", ", cols) + ")";
+        return sql.substring(0, positionOfColumnDefinitions+1) + TextUtils.join(", ", cols) + ")";
     }
 
     private void insertMessageWithSubject(SQLiteDatabase database, String subject) {


### PR DESCRIPTION
As proposed in https://github.com/k9mail/k-9/pull/2158#issuecomment-277963119, I've extended the test for the database upgrade process, which was introduced in #2158. There, the test was restricted on the existence of tables, indexes and triggers. Now, the test also checks the structure of these entities using the `sql` column in `sqlite_master`.

Fortunately, I've only found one issue with this new test, and that is minor. It concerns the column `notify_class` of table `folders`. Using the upgrade process, this column is created with `default 'INHERITED'`. However, when the database is created from scratch, the default is missing.

Therefore, I've added the default value to `dbCreateDatabaseFromScratch` to fix the test.

However, this approach show also the lack of current tests: They test only if upgrading from a *virtual* v29 database comes to the same result like creating a new one from scratch (see #2158). But, additionally, a respective test would be nice for **every** release (not only v29)! Because you have to note, that my solution for the `notify_class` column only applies to future new installations. People with a former new installation of a release with database v50 and above will still not have the correct default value. Nevertheless, I've chosen that approach, because the default should not be that important and we would have to re-create the whole table in order to change it. But the message is, that there may be much more problems of this type. They can only be detected with a test of the upgrade-paths of every release! However, that's not that easy, but I have some ideas how to realize this. I will write them down in a new issue in the next days. But for now, this pull request is good enhancement :smile: 