### PR TITLE
Issue#2210 : Unit Tests for SmtpDataStuffing

### DIFF
--- a/k9mail-library/src/androidTest/java/com/fsck/k9/mail/filter/SmtpDataStuffingTest.java
+++ b/k9mail-library/src/androidTest/java/com/fsck/k9/mail/filter/SmtpDataStuffingTest.java
@@ -1,0 +1,51 @@
+package com.fsck.k9.mail.filter;
+
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.io.ByteArrayOutputStream;
+
+
+import static junit.framework.Assert.assertEquals;
+
+@RunWith(AndroidJUnit4.class)
+public class SmtpDataStuffingTest {
+    @Test
+    public void TestSmtpDotStuffing() throws IOException {
+        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
+
+        EOLConvertingOutputStream eolConvertingOutputStream = new EOLConvertingOutputStream(
+                new LineWrapOutputStream(new SmtpDataStuffing(byteArrayOutputStream), 1000));
+
+        String messageAfterStuffing = "Hello dot\r\n..";
+
+        // sampleDotText = "Hello dot\n."
+        byte[] sampleDotText = {
+                72,
+                101,
+                108,
+                108,
+                111,
+                32,
+                100,
+                111,
+                116,
+                10,
+                46
+        };
+
+        try {
+            eolConvertingOutputStream.write(sampleDotText, 0, 11);
+        }
+        finally {
+            eolConvertingOutputStream.close();
+            byteArrayOutputStream.close();
+        }
+
+        String stuffedMessage = new String(byteArrayOutputStream.toByteArray());
+        assertEquals(stuffedMessage, messageAfterStuffing);
+    }
+}


### PR DESCRIPTION
#2210 
I've noticed that k-9 mail replaces '.' (char 46) with '=2E' (char byte sequence 61, 50, 69). This eliminates the need for dot stuffing SMTP content (this is good in a way as it allows to stop relying on servers to perform dot removal correctly).
Let me know if more test cases need to be added.