### PR TITLE
Settings export over storage access framework

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -1967,7 +1967,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                             mAccountUuids);
                 } else {
                     SettingsExporter.exportToUri(mContext, mIncludeGlobals, mAccountUuids, mUri);
-                    mFileName = mUri.toString();
                 }
 
             } catch (SettingsImportExportException e) {
@@ -1987,8 +1986,13 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
             removeProgressDialog();
 
             if (success) {
-                activity.showSimpleDialog(R.string.settings_export_success_header,
-                                          R.string.settings_export_success, mFileName);
+                if (mFileName != null) {
+                    activity.showSimpleDialog(R.string.settings_export_success_header,
+                            R.string.settings_export_success_path, mFileName);
+                } else {
+                    activity.showSimpleDialog(R.string.settings_export_success_header,
+                            R.string.settings_export_success);
+                }
             } else {
                 //TODO: better error messages
                 activity.showSimpleDialog(R.string.settings_export_failed_header,

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -146,6 +146,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
 
     private static final int ACTIVITY_REQUEST_PICK_SETTINGS_FILE = 1;
+    private static final int ACTIVITY_REQUEST_SAVE_SETTINGS_FILE = 2;
 
     class AccountsHandler extends Handler {
         private void setViewTitle() {
@@ -1290,7 +1291,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                               getString(R.string.app_revision_url) +
                               "</a>"))
         .append("</p><hr/><p>")
-        .append(String.format(getString(R.string.app_copyright_fmt), year, year))
+        .append(String.format(getString(R.string.app_copyright_fmt), Integer.toString(year), Integer.toString(year)))
         .append("</p><hr/><p>")
         .append(getString(R.string.app_license))
         .append("</p><hr/><p>");
@@ -1418,9 +1419,12 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
             return;
         }
         switch (requestCode) {
-        case ACTIVITY_REQUEST_PICK_SETTINGS_FILE:
-            onImport(data.getData());
-            break;
+            case ACTIVITY_REQUEST_PICK_SETTINGS_FILE:
+                onImport(data.getData());
+                break;
+            case ACTIVITY_REQUEST_SAVE_SETTINGS_FILE:
+                onExport(data);
+                break;
         }
     }
 
@@ -1883,16 +1887,47 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
     }
 
-    public void onExport(final boolean includeGlobals, final Account account) {
+    public static final String EXTRA_INC_GLOBALS = "include_globals";
+    public static final String EXTRA_ACCOUNTS = "accountUuids";
 
+    public void onExport(final boolean includeGlobals, final Account account) {
         // TODO, prompt to allow a user to choose which accounts to export
-        Set<String> accountUuids = null;
+        ArrayList<String> accountUuids = null;
         if (account != null) {
-            accountUuids = new HashSet<String>();
+            accountUuids = new ArrayList<>();
             accountUuids.add(account.getUuid());
         }
 
-        ExportAsyncTask asyncTask = new ExportAsyncTask(this, includeGlobals, accountUuids);
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.KITKAT) {
+            Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("text/plain");
+            intent.putExtra(Intent.EXTRA_TITLE, SettingsExporter.EXPORT_FILENAME);
+            intent.putStringArrayListExtra(EXTRA_ACCOUNTS, accountUuids);
+            intent.putExtra(EXTRA_INC_GLOBALS, includeGlobals);
+
+            PackageManager packageManager = getPackageManager();
+            List<ResolveInfo> infos = packageManager.queryIntentActivities(intent, 0);
+
+            if (infos.size() > 0) {
+                startActivityForResult(Intent.createChooser(intent, null), ACTIVITY_REQUEST_SAVE_SETTINGS_FILE);
+            } else {
+                showDialog(DIALOG_NO_FILE_MANAGER);
+            }
+        } else {
+            //Pre-Kitkat
+            ExportAsyncTask asyncTask = new ExportAsyncTask(this, includeGlobals, accountUuids, null);
+            setNonConfigurationInstance(asyncTask);
+            asyncTask.execute();
+        }
+    }
+
+    public void onExport(Intent intent) {
+        boolean includeGlobals = intent.getBooleanExtra(EXTRA_INC_GLOBALS, false);
+        ArrayList<String> accountUuids = intent.getStringArrayListExtra(EXTRA_ACCOUNTS);
+
+        ExportAsyncTask asyncTask = new ExportAsyncTask(this, includeGlobals, accountUuids, intent.getData());
         setNonConfigurationInstance(asyncTask);
         asyncTask.execute();
     }
@@ -1904,13 +1939,17 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         private boolean mIncludeGlobals;
         private Set<String> mAccountUuids;
         private String mFileName;
+        private Uri mUri;
 
 
         private ExportAsyncTask(Accounts activity, boolean includeGlobals,
-                                Set<String> accountUuids) {
+                                List<String> accountUuids, Uri uri) {
             super(activity);
             mIncludeGlobals = includeGlobals;
-            mAccountUuids = accountUuids;
+            mUri = uri;
+            if (accountUuids != null) {
+                mAccountUuids = new HashSet<>(accountUuids);
+            }
         }
 
         @Override
@@ -1923,8 +1962,14 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         @Override
         protected Boolean doInBackground(Void... params) {
             try {
-                mFileName = SettingsExporter.exportToFile(mContext, mIncludeGlobals,
+                if (mUri == null) {
+                    mFileName = SettingsExporter.exportToFile(mContext, mIncludeGlobals,
                             mAccountUuids);
+                } else {
+                    SettingsExporter.exportToUri(mContext, mIncludeGlobals, mAccountUuids, mUri);
+                    mFileName = mUri.toString();
+                }
+
             } catch (SettingsImportExportException e) {
                 Log.w(K9.LOG_TAG, "Exception during export", e);
                 return false;

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import android.content.Context;
+import android.net.Uri;
 import android.os.Environment;
 import android.util.Log;
 import android.util.Xml;
@@ -32,7 +33,7 @@ import org.xmlpull.v1.XmlSerializer;
 
 
 public class SettingsExporter {
-    private static final String EXPORT_FILENAME = "settings.k9s";
+    public static final String EXPORT_FILENAME = "settings.k9s";
 
     /**
      * File format version number.
@@ -108,7 +109,28 @@ public class SettingsExporter {
         }
     }
 
-    static void exportPreferences(Context context, OutputStream os, boolean includeGlobals, Set<String> accountUuids)
+    public static void exportToUri(Context context, boolean includeGlobals, Set<String> accountUuids, Uri uri)
+            throws SettingsImportExportException {
+
+        OutputStream os = null;
+        String filename = null;
+        try {
+            os = context.getContentResolver().openOutputStream(uri);
+            exportPreferences(context, os, includeGlobals, accountUuids);
+        } catch (Exception e) {
+            throw new SettingsImportExportException(e);
+        } finally {
+            if (os != null) {
+                try {
+                    os.close();
+                } catch (IOException ioe) {
+                    Log.w(K9.LOG_TAG, "Couldn't close exported settings file: " + filename);
+                }
+            }
+        }
+    }
+
+   static void exportPreferences(Context context, OutputStream os, boolean includeGlobals, Set<String> accountUuids)
             throws SettingsImportExportException {
 
         try {

--- a/k9mail/src/main/res/values-bg/strings.xml
+++ b/k9mail/src/main/res/values-bg/strings.xml
@@ -788,7 +788,7 @@ K-9 Mail е мощен, безплатен имейл клиент за Андр
   <string name="settings_exporting">Настройки на изнсянето...</string>
   <string name="settings_importing">Настройки на внасянето...</string>
   <string name="settings_import_scanning_file">Сканиране на файл...</string>
-  <string name="settings_export_success">Изнесенети настройки са запазени като <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Изнесенети настройки са запазени като <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Внесени настройки от <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Внесени <xliff:g id="accounts">%s</xliff:g> от <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-ca/strings.xml
+++ b/k9mail/src/main/res/values-ca/strings.xml
@@ -691,7 +691,7 @@
   <string name="settings_exporting">Exporta els paràmetres</string>
   <string name="settings_importing">S\'està important els paràmetres.</string>
   <string name="settings_import_scanning_file">S\'està examinant el fitxer.</string>
-  <string name="settings_export_success">S\'han exportat els paràmetres globals a <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">S\'han exportat els paràmetres globals a <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">S\'han importat els paràmetres globals de <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">S\'ha importat <xliff:g id="accounts">%s</xliff:g> des de <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-cs/strings.xml
+++ b/k9mail/src/main/res/values-cs/strings.xml
@@ -793,7 +793,7 @@ Chybová hlášení prosím posílejte, přispívejte novými funkcemi a ptejte 
   <string name="settings_exporting">Exportování nastavení…</string>
   <string name="settings_importing">Importování nastavení…</string>
   <string name="settings_import_scanning_file">Skenuji soubor…</string>
-  <string name="settings_export_success">Export nastavení uložen do <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Export nastavení uložen do <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Importováno globální nastaveni z <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importováno <xliff:g id="accounts">%s</xliff:g> z <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-da/strings.xml
+++ b/k9mail/src/main/res/values-da/strings.xml
@@ -762,7 +762,7 @@ Send venligst fejlrapporter, forslag til nye funktioner samt spørgsmål på:
   <string name="settings_exporting">Ekporterer indstillinger…</string>
   <string name="settings_importing">Importerer indstillinger…</string>
   <string name="settings_import_scanning_file">Skanner fil…</string>
-  <string name="settings_export_success">Indstillinger gemt som <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Indstillinger gemt som <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Importerede globale indstillinger fra <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importerede <xliff:g id="accounts">%s</xliff:g> fra <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-de/strings.xml
+++ b/k9mail/src/main/res/values-de/strings.xml
@@ -789,7 +789,7 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="settings_exporting">Einstellungen werden exportiert…</string>
   <string name="settings_importing">Einstellungen werden importiert…</string>
   <string name="settings_import_scanning_file">Datei wird gelesen…</string>
-  <string name="settings_export_success">Exportierte Einstellungen wurden erfolgreich nach <xliff:g id="filename">%s</xliff:g> gespeichert</string>
+  <string name="settings_export_success_path">Exportierte Einstellungen wurden erfolgreich nach <xliff:g id="filename">%s</xliff:g> gespeichert</string>
   <string name="settings_import_global_settings_success">Globale Einstellungen erfolgreich aus <xliff:g id="filename">%s</xliff:g> importiert</string>
   <string name="settings_import_success">\'<xliff:g id="accounts">%s</xliff:g>\' erfolgreich aus <xliff:g id="filename">%s</xliff:g> importiert</string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-el/strings.xml
+++ b/k9mail/src/main/res/values-el/strings.xml
@@ -790,7 +790,7 @@
   <string name="settings_exporting">Εξαγωγή ρυθμίσεων σε εξέλιξη…</string>
   <string name="settings_importing">Εισαγωγή ρυθμίσεων σε εξέλιξη…</string>
   <string name="settings_import_scanning_file">Ανίχνευση αρχείου…</string>
-  <string name="settings_export_success">Οι εξαγόμενες ρυθμίσεις αποθηκεύτηκαν στο <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Οι εξαγόμενες ρυθμίσεις αποθηκεύτηκαν στο <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Ρυθμίσεις εισήχθηκαν από το <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Εισήχθηκαν <xliff:g id="accounts">%s</xliff:g> λογαριασμοί από το <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-es/strings.xml
+++ b/k9mail/src/main/res/values-es/strings.xml
@@ -788,7 +788,7 @@ Por favor informe de fallos, aporte nueva funcionalidad o envíe sus preguntas a
   <string name="settings_exporting">Exportando ajustes…</string>
   <string name="settings_importing">Importando ajustes…</string>
   <string name="settings_import_scanning_file">Buscando archivo…</string>
-  <string name="settings_export_success">Ajustes guardados en <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Ajustes guardados en <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Ajustes globales importados desde <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importado <xliff:g id="accounts">%s</xliff:g> desde <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-et/strings.xml
+++ b/k9mail/src/main/res/values-et/strings.xml
@@ -709,7 +709,7 @@
   <string name="settings_exporting">Ekspordib sätteid…</string>
   <string name="settings_importing">Impordib sätteid…</string>
   <string name="settings_import_scanning_file">Skanneerib faili…</string>
-  <string name="settings_export_success">Salvestas eksporditud sätted <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Salvestas eksporditud sätted <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Impordi üldised sätted <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_export_failure">Sätete eksportimine ebaõnnestus</string>
   <string name="settings_import_failure">Sätete importimine  <xliff:g id="filename">%s</xliff:g> ebaõnnestus</string>

--- a/k9mail/src/main/res/values-eu/strings.xml
+++ b/k9mail/src/main/res/values-eu/strings.xml
@@ -702,7 +702,7 @@
   <string name="settings_exporting">Ezarpenak esportatzen…</string>
   <string name="settings_importing">Ezarpenak inportatzen…</string>
   <string name="settings_import_scanning_file">Fitxategia aztertzen…</string>
-  <string name="settings_export_success">Esportatutako ezarpenak hemen gorde dira: <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Esportatutako ezarpenak hemen gorde dira: <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Ezarpen orokorran hemendik inportatu dira: <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success"><xliff:g id="accounts">%s</xliff:g> inportatuta hemendik: <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-fi/strings.xml
+++ b/k9mail/src/main/res/values-fi/strings.xml
@@ -787,7 +787,7 @@ Ilmoita virheistä, ota osaa sovelluskehitykseen ja esitä kysymyksiä osoittees
   <string name="settings_exporting">Viedään asetuksia…</string>
   <string name="settings_importing">Tuodaan asetuksia…</string>
   <string name="settings_import_scanning_file">Tarkistetaan tiedostoa…</string>
-  <string name="settings_export_success">Viedyt asetukset tallennettu tiedostoon <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Viedyt asetukset tallennettu tiedostoon <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Yleiset asetukset tuotu tiedostosta <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Tuotu <xliff:g id="accounts">%s</xliff:g> tiedostosta <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-fr/strings.xml
+++ b/k9mail/src/main/res/values-fr/strings.xml
@@ -790,7 +790,7 @@ jusqu\'à <xliff:g id="messages_to_load">%d</xliff:g> de plus</string>
   <string name="settings_exporting">Exportation des paramètres…</string>
   <string name="settings_importing">Importation des paramètres…</string>
   <string name="settings_import_scanning_file">Analyse du fichier…</string>
-  <string name="settings_export_success">Paramètres exportés vers <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Paramètres exportés vers <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Paramètres globaux importés depuis <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importé <xliff:g id="accounts">%s</xliff:g> depuis <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-gl-rES/strings.xml
+++ b/k9mail/src/main/res/values-gl-rES/strings.xml
@@ -729,7 +729,7 @@
   <string name="settings_exporting">A exportar os axustes…</string>
   <string name="settings_importing">A importar os axustes…</string>
   <string name="settings_import_scanning_file">A escanear ficheiro…</string>
-  <string name="settings_export_success">Axustes exportados gardados en <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Axustes exportados gardados en <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Axustes globais importados desde <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importado <xliff:g id="accounts">%s</xliff:g> desde <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-hr/strings.xml
+++ b/k9mail/src/main/res/values-hr/strings.xml
@@ -742,7 +742,7 @@
   <string name="settings_exporting">Izvozim postavke…</string>
   <string name="settings_importing">Uvozim postavke…</string>
   <string name="settings_import_scanning_file">Skeniram datoteku…</string>
-  <string name="settings_export_success">Spremi izvezene postavke u <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Spremi izvezene postavke u <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Uvezene opće postavke iz  <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Uvezeni <xliff:g id="accounts">%s</xliff:g> iz <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-hu/strings.xml
+++ b/k9mail/src/main/res/values-hu/strings.xml
@@ -771,7 +771,7 @@ Kérünk küldj hibajelentést, hozzájárulva az új verziókhoz, és tegyél f
   <string name="settings_exporting">Beállítások exportálása…</string>
   <string name="settings_importing">Beállítások importálása…</string>
   <string name="settings_import_scanning_file">Fájl beolvasása…</string>
-  <string name="settings_export_success">Exportált beállítások mentve ide: <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Exportált beállítások mentve ide: <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Az általános beállítások importálva innen: <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">A(z) <xliff:g id="accounts">%s</xliff:g> importálva innen: <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-it/strings.xml
+++ b/k9mail/src/main/res/values-it/strings.xml
@@ -790,7 +790,7 @@ Invia segnalazioni di bug, contribuisci con nuove funzionalità e poni domande s
   <string name="settings_exporting">Esportazione impostazioni…</string>
   <string name="settings_importing">Importazione impostazioni…</string>
   <string name="settings_import_scanning_file">Scansione del file…</string>
-  <string name="settings_export_success">Impostazioni esportate salvate in <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Impostazioni esportate salvate in <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Impostazioni globali importate da <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importato <xliff:g id="accounts">%s</xliff:g> da <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-iw/strings.xml
+++ b/k9mail/src/main/res/values-iw/strings.xml
@@ -629,7 +629,7 @@
   <string name="settings_exporting">מייצא הגדרות…</string>
   <string name="settings_importing">מייבא הגדרות…</string>
   <string name="settings_import_scanning_file">סורק קבצים…</string>
-  <string name="settings_export_success">יצוא הגדרות נשמרו ל <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">יצוא הגדרות נשמרו ל <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">יבא הגדרות כלליות מ <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">יבא <xliff:g id="accounts">%s</xliff:g> מ <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-ja/strings.xml
+++ b/k9mail/src/main/res/values-ja/strings.xml
@@ -786,7 +786,7 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
   <string name="settings_exporting">設定をエクスポートしています…</string>
   <string name="settings_importing">設定をインポートしています…</string>
   <string name="settings_import_scanning_file">ファイルを調べています…</string>
-  <string name="settings_export_success">設定を <xliff:g id="filename">%s</xliff:g> に保存しました。</string>
+  <string name="settings_export_success_path">設定を <xliff:g id="filename">%s</xliff:g> に保存しました。</string>
   <string name="settings_import_global_settings_success">グローバル設定を <xliff:g id="filename">%s</xliff:g> からインポートしました。</string>
   <string name="settings_import_success"><xliff:g id="accounts">%s</xliff:g> の設定を <xliff:g id="filename">%s</xliff:g> からインポートしました。</string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-ko/strings.xml
+++ b/k9mail/src/main/res/values-ko/strings.xml
@@ -744,7 +744,7 @@
   <string name="settings_exporting">설정 내보내는 중…</string>
   <string name="settings_importing">설정 가져오는 중…</string>
   <string name="settings_import_scanning_file">파일 스캔 중…</string>
-  <string name="settings_export_success">설정을 파일 <xliff:g id="filename">%s</xliff:g>로 내보냄</string>
+  <string name="settings_export_success_path">설정을 파일 <xliff:g id="filename">%s</xliff:g>로 내보냄</string>
   <string name="settings_import_global_settings_success">설정을 <xliff:g id="filename">%s</xliff:g>로부터 가져옴</string>
   <string name="settings_import_success"><xliff:g id="filename">%s</xliff:g>에서 <xliff:g id="accounts">%s</xliff:g>를 가져옴</string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-lt/strings.xml
+++ b/k9mail/src/main/res/values-lt/strings.xml
@@ -681,7 +681,7 @@
   <string name="settings_exporting">Eksportuojami nustatymai…</string>
   <string name="settings_importing">Importuojami nustatymai…</string>
   <string name="settings_import_scanning_file">Skenuojamas failas…</string>
-  <string name="settings_export_success">Eksportuoti nustatymai išsaugoti <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Eksportuoti nustatymai išsaugoti <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Importuoti globalius nustatymus iš <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importuota <xliff:g id="accounts">%s</xliff:g> iš <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_export_failure">Eksportuoti nustatymų nepavyko</string>

--- a/k9mail/src/main/res/values-lv/strings.xml
+++ b/k9mail/src/main/res/values-lv/strings.xml
@@ -793,7 +793,7 @@ pat <xliff:g id="messages_to_load">%d</xliff:g> vairāk</string>
   <string name="settings_exporting">Eksportē iestatījumus…</string>
   <string name="settings_importing">Importē iestatījumus…</string>
   <string name="settings_import_scanning_file">Skenē datni…</string>
-  <string name="settings_export_success">Eksportētie iestatījumi saglabāti <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Eksportētie iestatījumi saglabāti <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Importēti vispārīgie iestatījumi no <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importēts <xliff:g id="accounts">%s</xliff:g> no <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-nb/strings.xml
+++ b/k9mail/src/main/res/values-nb/strings.xml
@@ -790,7 +790,7 @@ til <xliff:g id="messages_to_load">%d</xliff:g> flere</string>
   <string name="settings_exporting">Eksporterer innstillnger …</string>
   <string name="settings_importing">Importerer innstillinger …</string>
   <string name="settings_import_scanning_file">Skanner fil …</string>
-  <string name="settings_export_success">Lagret eksporterte innstillinger til <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Lagret eksporterte innstillinger til <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Importerte globale innstillinger fra <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importerte <xliff:g id="accounts">%s</xliff:g> fra <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-nl/strings.xml
+++ b/k9mail/src/main/res/values-nl/strings.xml
@@ -784,7 +784,7 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   <string name="settings_exporting">Instellingen exporteren…</string>
   <string name="settings_importing">Instellingen importeren…</string>
   <string name="settings_import_scanning_file">Bestanden scannen…</string>
-  <string name="settings_export_success">Geexporteerde instellingen opgeslagen in <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Geexporteerde instellingen opgeslagen in <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Globale instellingen geimporteerd van <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success"><xliff:g id="accounts">%s</xliff:g> geimporteerd vanuit <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-pl/strings.xml
+++ b/k9mail/src/main/res/values-pl/strings.xml
@@ -755,7 +755,7 @@ Wysłane za pomocą K-9 Mail.</string>
   <string name="settings_exporting">Eksportowanie ustawień…</string>
   <string name="settings_importing">Importowanie ustawień…</string>
   <string name="settings_import_scanning_file">Skanowanie pliku…</string>
-  <string name="settings_export_success">Zapisano ustawienia do <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Zapisano ustawienia do <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Importowano ustawienia z <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importowano <xliff:g id="accounts">%s</xliff:g> z <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-pt-rBR/strings.xml
+++ b/k9mail/src/main/res/values-pt-rBR/strings.xml
@@ -782,7 +782,7 @@ Por favor encaminhe relatórios de bugs, contribua com novos recursos e tire dú
   <string name="settings_exporting">Exportando…</string>
   <string name="settings_importing">Importando…</string>
   <string name="settings_import_scanning_file">Buscando arquivo…</string>
-  <string name="settings_export_success">Configurações salvas para <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Configurações salvas para <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Configurações importadas de <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importação concluída para <xliff:g id="accounts">%s</xliff:g> de <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-pt-rPT/strings.xml
+++ b/k9mail/src/main/res/values-pt-rPT/strings.xml
@@ -789,7 +789,7 @@ Por favor envie relatórios de falhas, contribua com novas funcionalidades e col
   <string name="settings_exporting">A exportar definições...</string>
   <string name="settings_importing">A importar definições...</string>
   <string name="settings_import_scanning_file">A examinar ficheiro...</string>
-  <string name="settings_export_success">As definições exportadas foram guardadas em <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">As definições exportadas foram guardadas em <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">As definições globais foram importadas a partir de <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importado <xliff:g id="accounts">%s</xliff:g> a partir de <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-ru/strings.xml
+++ b/k9mail/src/main/res/values-ru/strings.xml
@@ -796,7 +796,7 @@ K-9 Mail — почтовый клиент для Android.
   <string name="settings_exporting">Экспорт настроек…</string>
   <string name="settings_importing">Импорт настроек…</string>
   <string name="settings_import_scanning_file">Проверка файла…</string>
-  <string name="settings_export_success">Настройки сохранены в <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Настройки сохранены в <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Настройки K-9 импортированы из <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Импортировано: <xliff:g id="accounts">%s</xliff:g> из <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-sk/strings.xml
+++ b/k9mail/src/main/res/values-sk/strings.xml
@@ -793,7 +793,7 @@ Prosím, nahlasujte prípadné chyby, prispievajte novými funkciami a pýtajte 
   <string name="settings_exporting">Exportovanie nastavení…</string>
   <string name="settings_importing">Importovanie nastavení…</string>
   <string name="settings_import_scanning_file">Skenovanie súboru…</string>
-  <string name="settings_export_success">Exportované nastavenia boli uložené do <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Exportované nastavenia boli uložené do <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Importované všeobecné nastavenia z <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importované <xliff:g id="accounts">%s</xliff:g> z <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-sl/strings.xml
+++ b/k9mail/src/main/res/values-sl/strings.xml
@@ -798,7 +798,7 @@ Prosimo pošljite poročila o napakah, predloge za nove funkcije in vprašanja n
   <string name="settings_exporting">Izvažanje nastavitev …</string>
   <string name="settings_importing">Uvažanje nastavitev …</string>
   <string name="settings_import_scanning_file">Preverjanje datoteke ...</string>
-  <string name="settings_export_success">Izvožene nastavitve shranjene v <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Izvožene nastavitve shranjene v <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Uvožene splošne nastavitve iz <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Uvoženo <xliff:g id="accounts">%s</xliff:g> iz <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-sr/strings.xml
+++ b/k9mail/src/main/res/values-sr/strings.xml
@@ -793,7 +793,7 @@
   <string name="settings_exporting">Извозим поставке…</string>
   <string name="settings_importing">Увозим поставке…</string>
   <string name="settings_import_scanning_file">Очитавам фајл…</string>
-  <string name="settings_export_success">Извезене поставке сачуване у <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Извезене поставке сачуване у <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Увезене опште поставке из <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Увезено <xliff:g id="accounts">%s</xliff:g> из <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-sv/strings.xml
+++ b/k9mail/src/main/res/values-sv/strings.xml
@@ -789,7 +789,7 @@ Skicka gärna in rapporter om buggar, eller bidra med nya funktioner eller stäl
   <string name="settings_exporting">Exporterar inställningar…</string>
   <string name="settings_importing">Importerar inställningar…</string>
   <string name="settings_import_scanning_file">Skannar fil…</string>
-  <string name="settings_export_success">Sparade exporterade inställningar till <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Sparade exporterade inställningar till <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Importerade globala inställningar från <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Importerade <xliff:g id="accounts">%s</xliff:g> från <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-tr/strings.xml
+++ b/k9mail/src/main/res/values-tr/strings.xml
@@ -756,7 +756,7 @@
   <string name="settings_exporting">Dışarı aktarma ayarları…</string>
   <string name="settings_importing">İçeri aktarma ayarları…</string>
   <string name="settings_import_scanning_file">Dosya taranıyor…</string>
-  <string name="settings_export_success">Dışarı aktarılan ayarlar <xliff:g id="filename">%s</xliff:g> olarak kaydedildi.</string>
+  <string name="settings_export_success_path">Dışarı aktarılan ayarlar <xliff:g id="filename">%s</xliff:g> olarak kaydedildi.</string>
   <string name="settings_import_global_settings_success">Genel ayarlar <xliff:g id="filename">%s</xliff:g> dosyasından alındı</string>
   <string name="settings_import_success"><xliff:g id="accounts">%s</xliff:g>, <xliff:g id="filename">%s</xliff:g> dosyasından alındı</string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-uk/strings.xml
+++ b/k9mail/src/main/res/values-uk/strings.xml
@@ -793,7 +793,7 @@ K-9 Mail — це вільний клієнт електронної пошти 
   <string name="settings_exporting">Експортуються налаштування…</string>
   <string name="settings_importing">Імпортуються налаштування…</string>
   <string name="settings_import_scanning_file">Сканується файл…</string>
-  <string name="settings_export_success">Налаштування були експортовані у <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">Налаштування були експортовані у <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">Глобальні налаштування були імпортовані з <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_success">Імпортовано <xliff:g id="accounts">%s</xliff:g> з <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-zh-rCN/strings.xml
+++ b/k9mail/src/main/res/values-zh-rCN/strings.xml
@@ -739,7 +739,7 @@
   <string name="settings_exporting">正在导出设置…</string>
   <string name="settings_importing">正在导入设置…</string>
   <string name="settings_import_scanning_file">正在扫描文件…</string>
-  <string name="settings_export_success">设置已导出到<xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">设置已导出到<xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">全局设置已自<xliff:g id="filename">%s</xliff:g>导入</string>
   <string name="settings_import_success">账户<xliff:g id="accounts">%s</xliff:g>已自<xliff:g id="filename">%s</xliff:g>导入</string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values-zh-rTW/strings.xml
+++ b/k9mail/src/main/res/values-zh-rTW/strings.xml
@@ -680,7 +680,7 @@
   <string name="settings_exporting">正在匯出設定…</string>
   <string name="settings_importing">正在匯入設定…</string>
   <string name="settings_import_scanning_file">檢查檔案…</string>
-  <string name="settings_export_success">匯出的設定檔案已經儲存到 <xliff:g id="filename">%s</xliff:g></string>
+  <string name="settings_export_success_path">匯出的設定檔案已經儲存到 <xliff:g id="filename">%s</xliff:g></string>
   <string name="settings_import_global_settings_success">從 <xliff:g id="filename">%s</xliff:g> 匯入全域設定檔案</string>
   <string name="settings_import_success">成功匯入 <xliff:g id="accounts">%s</xliff:g> 從 <xliff:g id="filename">%s</xliff:g></string>
   <plurals name="settings_import_accounts">

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -972,7 +972,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="settings_exporting">Exporting settings…</string>
     <string name="settings_importing">Importing settings…</string>
     <string name="settings_import_scanning_file">Scanning file…</string>
-    <string name="settings_export_success">Saved exported settings to <xliff:g id="filename">%s</xliff:g></string>
+    <string name="settings_export_success_path">Saved exported settings to <xliff:g id="filename">%s</xliff:g></string>
+    <string name="settings_export_success">Saved exported settings to the selected destination</string>
     <string name="settings_import_global_settings_success">Imported global settings from <xliff:g id="filename">%s</xliff:g></string>
     <string name="settings_import_success">Imported <xliff:g id="accounts">%s</xliff:g> from <xliff:g id="filename">%s</xliff:g></string>
     <plurals name="settings_import_accounts">


### PR DESCRIPTION
Intention:
In the pr for the runtime permission (#2110) it became clear that it is a good idea to move the export to saf to reduce the need for the external storage permission.

Notes;
That works only in android version newer than Kitkat, so I left the old legacy path for those devices. I tested the functionality with the jelly bean emulator.

I'm not sure about the "no_file_manager" check in the `onImport` function. Since Android is shipping with the content provider to save at the internal storage/external storage there should always be a provider. Or?

