### PR TITLE
Allow disable of default encryption

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -220,6 +220,7 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean mStripSignature;
     private boolean mSyncRemoteDeletions;
     private long mCryptoKey;
+    private boolean mCryptoDefaultDisabled;
     private boolean mMarkMessageAsReadOnView;
     private boolean mAlwaysShowCcBcc;
     private boolean mAllowRemoteSearch;
@@ -315,6 +316,7 @@ public class Account implements BaseAccount, StoreConfig {
         mStripSignature = DEFAULT_STRIP_SIGNATURE;
         mSyncRemoteDeletions = true;
         mCryptoKey = NO_OPENPGP_KEY;
+        mCryptoDefaultDisabled = false;
         mAllowRemoteSearch = false;
         mRemoteSearchFullText = false;
         mRemoteSearchNumResults = DEFAULT_REMOTE_SEARCH_NUM_RESULTS;
@@ -463,6 +465,7 @@ public class Account implements BaseAccount, StoreConfig {
         identities = loadIdentities(storage);
 
         mCryptoKey = storage.getLong(mUuid + ".cryptoKey", NO_OPENPGP_KEY);
+        mCryptoDefaultDisabled = storage.getBoolean(mUuid + ".cryptoDefaultDisabled", false);
         mAllowRemoteSearch = storage.getBoolean(mUuid + ".allowRemoteSearch", false);
         mRemoteSearchFullText = storage.getBoolean(mUuid + ".remoteSearchFullText", false);
         mRemoteSearchNumResults = storage.getInt(mUuid + ".remoteSearchNumResults", DEFAULT_REMOTE_SEARCH_NUM_RESULTS);
@@ -729,6 +732,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(mUuid + ".replyAfterQuote", mReplyAfterQuote);
         editor.putBoolean(mUuid + ".stripSignature", mStripSignature);
         editor.putLong(mUuid + ".cryptoKey", mCryptoKey);
+        editor.putBoolean(mUuid + ".cryptoDefaultDisabled", mCryptoDefaultDisabled);
         editor.putBoolean(mUuid + ".allowRemoteSearch", mAllowRemoteSearch);
         editor.putBoolean(mUuid + ".remoteSearchFullText", mRemoteSearchFullText);
         editor.putInt(mUuid + ".remoteSearchNumResults", mRemoteSearchNumResults);
@@ -1598,6 +1602,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public void setCryptoKey(long keyId) {
         mCryptoKey = keyId;
+    }
+
+    public boolean getCryptoDefaultDisabled() {
+        return mCryptoDefaultDisabled;
+    }
+
+    public void setCryptoDefaultDisabled(boolean cryptoDefaultDisabled) {
+        mCryptoDefaultDisabled = cryptoDefaultDisabled;
     }
 
     public boolean allowRemoteSearch() {

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -220,7 +220,7 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean mStripSignature;
     private boolean mSyncRemoteDeletions;
     private long mCryptoKey;
-    private boolean mCryptoDefaultDisabled;
+    private CryptoDefaultMode mCryptoDefaultMode;
     private boolean mMarkMessageAsReadOnView;
     private boolean mAlwaysShowCcBcc;
     private boolean mAllowRemoteSearch;
@@ -240,6 +240,7 @@ public class Account implements BaseAccount, StoreConfig {
      * <p>
      * Right now newly imported accounts are disabled if the settings file didn't contain a
      * password for the incoming and/or outgoing server.
+     *
      * </p>
      */
     private boolean mEnabled;
@@ -270,6 +271,10 @@ public class Account implements BaseAccount, StoreConfig {
 
     public enum QuoteStyle {
         PREFIX, HEADER
+    }
+
+    public enum CryptoDefaultMode {
+        DEFAULT, DISABLE
     }
 
     public enum MessageFormat {
@@ -316,7 +321,7 @@ public class Account implements BaseAccount, StoreConfig {
         mStripSignature = DEFAULT_STRIP_SIGNATURE;
         mSyncRemoteDeletions = true;
         mCryptoKey = NO_OPENPGP_KEY;
-        mCryptoDefaultDisabled = false;
+        mCryptoDefaultMode = CryptoDefaultMode.DEFAULT;
         mAllowRemoteSearch = false;
         mRemoteSearchFullText = false;
         mRemoteSearchNumResults = DEFAULT_REMOTE_SEARCH_NUM_RESULTS;
@@ -465,7 +470,7 @@ public class Account implements BaseAccount, StoreConfig {
         identities = loadIdentities(storage);
 
         mCryptoKey = storage.getLong(mUuid + ".cryptoKey", NO_OPENPGP_KEY);
-        mCryptoDefaultDisabled = storage.getBoolean(mUuid + ".cryptoDefaultDisabled", false);
+        mCryptoDefaultMode = getEnumStringPref(storage, mUuid + ".cryptoDefaultMode", CryptoDefaultMode.DEFAULT);
         mAllowRemoteSearch = storage.getBoolean(mUuid + ".allowRemoteSearch", false);
         mRemoteSearchFullText = storage.getBoolean(mUuid + ".remoteSearchFullText", false);
         mRemoteSearchNumResults = storage.getInt(mUuid + ".remoteSearchNumResults", DEFAULT_REMOTE_SEARCH_NUM_RESULTS);
@@ -732,7 +737,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(mUuid + ".replyAfterQuote", mReplyAfterQuote);
         editor.putBoolean(mUuid + ".stripSignature", mStripSignature);
         editor.putLong(mUuid + ".cryptoKey", mCryptoKey);
-        editor.putBoolean(mUuid + ".cryptoDefaultDisabled", mCryptoDefaultDisabled);
+        editor.putString(mUuid + ".cryptoDefaultMode", mCryptoDefaultMode.name());
         editor.putBoolean(mUuid + ".allowRemoteSearch", mAllowRemoteSearch);
         editor.putBoolean(mUuid + ".remoteSearchFullText", mRemoteSearchFullText);
         editor.putInt(mUuid + ".remoteSearchNumResults", mRemoteSearchNumResults);
@@ -1604,12 +1609,12 @@ public class Account implements BaseAccount, StoreConfig {
         mCryptoKey = keyId;
     }
 
-    public boolean getCryptoDefaultDisabled() {
-        return mCryptoDefaultDisabled;
+    public CryptoDefaultMode getCryptoDefaultMode() {
+        return mCryptoDefaultMode;
     }
 
-    public void setCryptoDefaultDisabled(boolean cryptoDefaultDisabled) {
-        mCryptoDefaultDisabled = cryptoDefaultDisabled;
+    public void setCryptoDefaultMode(CryptoDefaultMode cryptoDefaultDisabled) {
+        mCryptoDefaultMode = cryptoDefaultDisabled;
     }
 
     public boolean allowRemoteSearch() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -77,7 +77,7 @@ public class RecipientPresenter implements PermissionPingCallback {
 
     // persistent state, saved during onSaveInstanceState
     private RecipientType lastFocusedType = RecipientType.TO;
-    private CryptoMode currentCryptoMode = CryptoMode.OPPORTUNISTIC;
+    private CryptoMode currentCryptoMode;
     private boolean cryptoEnablePgpInline = false;
 
 
@@ -95,8 +95,13 @@ public class RecipientPresenter implements PermissionPingCallback {
         onSwitchAccount(account);
 
         // TODO initialize cryptoMode to other values under some circumstances, e.g. if we reply to an encrypted e-mail
-        if (account.getCryptoDefaultDisabled()) {
-            currentCryptoMode = CryptoMode.DISABLE;
+        switch (account.getCryptoDefaultMode()) {
+            case DISABLE:
+                currentCryptoMode = CryptoMode.DISABLE;
+                break;
+            default:
+                currentCryptoMode = CryptoMode.OPPORTUNISTIC;
+                break;
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -77,7 +77,6 @@ public class RecipientPresenter implements PermissionPingCallback {
 
     // persistent state, saved during onSaveInstanceState
     private RecipientType lastFocusedType = RecipientType.TO;
-    // TODO initialize cryptoMode to other values under some circumstances, e.g. if we reply to an encrypted e-mail
     private CryptoMode currentCryptoMode = CryptoMode.OPPORTUNISTIC;
     private boolean cryptoEnablePgpInline = false;
 
@@ -94,6 +93,11 @@ public class RecipientPresenter implements PermissionPingCallback {
         recipientMvpView.setPresenter(this);
         recipientMvpView.setLoaderManager(loaderManager);
         onSwitchAccount(account);
+
+        // TODO initialize cryptoMode to other values under some circumstances, e.g. if we reply to an encrypted e-mail
+        if (account.getCryptoDefaultDisabled()) {
+            currentCryptoMode = CryptoMode.DISABLE;
+        }
     }
 
     public List<Address> getToAddresses() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -26,6 +26,7 @@ import android.util.Log;
 import android.widget.Toast;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.Account.CryptoDefaultMode;
 import com.fsck.k9.Account.DeletePolicy;
 import com.fsck.k9.Account.Expunge;
 import com.fsck.k9.Account.FolderMode;
@@ -715,7 +716,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
             cryptoMenu.setOnPreferenceClickListener(null);
 
-            mCryptoDefaultDisabled.setChecked(mAccount.getCryptoDefaultDisabled());
+            mCryptoDefaultDisabled.setChecked(mAccount.getCryptoDefaultMode() == CryptoDefaultMode.DISABLE);
         } else {
             cryptoMenu.setSummary(R.string.account_settings_no_openpgp_provider_configured);
             cryptoMenu.setOnPreferenceClickListener(new OnPreferenceClickListener() {
@@ -793,10 +794,11 @@ public class AccountSettings extends K9PreferenceActivity {
         mAccount.setLocalStorageProviderId(mLocalStorageProvider.getValue());
         if (mHasCrypto) {
             mAccount.setCryptoKey(mCryptoKey.getValue());
-            mAccount.setCryptoDefaultDisabled(mCryptoDefaultDisabled.isChecked());
+            mAccount.setCryptoDefaultMode(mCryptoDefaultDisabled.isChecked() ?
+                    CryptoDefaultMode.DISABLE : CryptoDefaultMode.DEFAULT);
         } else {
             mAccount.setCryptoKey(Account.NO_OPENPGP_KEY);
-            mAccount.setCryptoDefaultDisabled(false);
+            mAccount.setCryptoDefaultMode(CryptoDefaultMode.DEFAULT);
         }
 
         // In webdav account we use the exact folder name also for inbox,

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -113,6 +113,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_SYNC_REMOTE_DELETIONS = "account_sync_remote_deletetions";
     private static final String PREFERENCE_CRYPTO = "crypto";
     private static final String PREFERENCE_CRYPTO_KEY = "crypto_key";
+    private static final String PREFERENCE_CRYPTO_DEFAULT_DISABLED = "crypto_default_disabled";
     private static final String PREFERENCE_CLOUD_SEARCH_ENABLED = "remote_search_enabled";
     private static final String PREFERENCE_REMOTE_SEARCH_NUM_RESULTS = "account_remote_search_num_results";
     private static final String PREFERENCE_REMOTE_SEARCH_FULL_TEXT = "account_remote_search_full_text";
@@ -180,6 +181,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private boolean mHasCrypto = false;
     private OpenPgpKeyPreference mCryptoKey;
     private CheckBoxPreference mCryptoSupportSignOnly;
+    private CheckBoxPreference mCryptoDefaultDisabled;
 
     private PreferenceScreen mSearchScreen;
     private CheckBoxPreference mCloudSearchEnabled;
@@ -697,6 +699,7 @@ public class AccountSettings extends K9PreferenceActivity {
         PreferenceScreen cryptoMenu = (PreferenceScreen) findPreference(PREFERENCE_CRYPTO);
         if (mHasCrypto) {
             mCryptoKey = (OpenPgpKeyPreference) findPreference(PREFERENCE_CRYPTO_KEY);
+            mCryptoDefaultDisabled = (CheckBoxPreference) findPreference(PREFERENCE_CRYPTO_DEFAULT_DISABLED);
 
             mCryptoKey.setValue(mAccount.getCryptoKey());
             mCryptoKey.setOpenPgpProvider(K9.getOpenPgpProvider());
@@ -711,6 +714,8 @@ public class AccountSettings extends K9PreferenceActivity {
             });
 
             cryptoMenu.setOnPreferenceClickListener(null);
+
+            mCryptoDefaultDisabled.setChecked(mAccount.getCryptoDefaultDisabled());
         } else {
             cryptoMenu.setSummary(R.string.account_settings_no_openpgp_provider_configured);
             cryptoMenu.setOnPreferenceClickListener(new OnPreferenceClickListener() {
@@ -788,8 +793,10 @@ public class AccountSettings extends K9PreferenceActivity {
         mAccount.setLocalStorageProviderId(mLocalStorageProvider.getValue());
         if (mHasCrypto) {
             mAccount.setCryptoKey(mCryptoKey.getValue());
+            mAccount.setCryptoDefaultDisabled(mCryptoDefaultDisabled.isChecked());
         } else {
             mAccount.setCryptoKey(Account.NO_OPENPGP_KEY);
+            mAccount.setCryptoDefaultDisabled(false);
         }
 
         // In webdav account we use the exact folder name also for inbox,

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1207,6 +1207,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="recipient_error_non_ascii">Special characters are currently not supported!</string>
     <string name="recipient_error_parse_failed">Error parsing address!</string>
     <string name="account_settings_crypto_support_sign_only">Support signing of unencrypted messages</string>
+    <string name="account_settings_crypto_default_disabled">Disable automatic encryption</string>
     <string name="error_sign_only_no_encryption">Encryption unavailable in sign-only mode!</string>
     <string name="unsigned_text_divider_label">Unsigned Text</string>
     <string name="apg_deprecated_title">APG Deprecation Warning</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -479,6 +479,12 @@
             android:key="crypto_key"
             android:title="@string/account_settings_crypto_key" />
 
+        <CheckBoxPreference
+            android:persistent="false"
+            android:key="crypto_default_disabled"
+            android:title="@string/account_settings_crypto_default_disabled"
+            />
+
     </PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
Picking up #2087. This is rebased on current master, and saves the default mode in an enum to allow for different settings in the future without requiring migration.

*However* I might want to do this with a different mechanism, please don't merge this for now.