### PR TITLE
Update existing Configuration instance instead of creating new one

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/K9ActivityCommon.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/K9ActivityCommon.java
@@ -47,9 +47,9 @@ public class K9ActivityCommon {
             locale = new Locale(language);
         }
 
-        Configuration config = new Configuration();
-        config.locale = locale;
         Resources resources = context.getResources();
+        Configuration config = resources.getConfiguration();
+        config.locale = locale;
         resources.updateConfiguration(config, resources.getDisplayMetrics());
     }
 


### PR DESCRIPTION
Creating a new Configuration instance lost the system's font size scaling factor. See #2280.
I'm surprised this didn't break more stuff.

Fixes #2280