### PR TITLE
Clean up MessagingListener

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -30,7 +30,7 @@ import com.fsck.k9.Account.SortType;
 import com.fsck.k9.activity.MessageCompose;
 import com.fsck.k9.activity.UpgradeDatabases;
 import com.fsck.k9.controller.MessagingController;
-import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.Message;
@@ -553,7 +553,7 @@ public class K9 extends Application {
         setServicesEnabled(this);
         registerReceivers();
 
-        MessagingController.getInstance(this).addListener(new MessagingListener() {
+        MessagingController.getInstance(this).addListener(new SimpleMessagingListener() {
             private void broadcastIntent(String action, Account account, String folder, Message message) {
                 Uri uri = Uri.parse("email://messages/" + account.getAccountNumber() + "/" + Uri.encode(folder) + "/" + Uri.encode(message.getUid()));
                 Intent intent = new Intent(action, uri);

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -10,10 +10,10 @@ import com.fsck.k9.Account;
 import com.fsck.k9.AccountStats;
 import com.fsck.k9.K9;
 import com.fsck.k9.R;
-import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.service.MailService;
 
-public class ActivityListener extends MessagingListener {
+public class ActivityListener extends SimpleMessagingListener {
     private Account mAccount = null;
     private String mLoadingFolderName = null;
     private String mLoadingHeaderFolderName = null;

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -27,6 +27,7 @@ import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mailstore.LocalFolder;
 
@@ -241,7 +242,7 @@ public class ChooseFolder extends K9ListActivity {
         MessagingController.getInstance(getApplication()).listFolders(mAccount, false, mListener);
     }
 
-    private MessagingListener mListener = new MessagingListener() {
+    private MessagingListener mListener = new SimpleMessagingListener() {
         @Override
         public void listFoldersStarted(Account account) {
             if (!account.equals(mAccount)) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -52,6 +52,7 @@ import com.fsck.k9.activity.setup.FolderSettings;
 import com.fsck.k9.activity.setup.Prefs;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.helper.SizeFormatter;
 import com.fsck.k9.mail.power.TracingPowerManager;
 import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
@@ -210,7 +211,7 @@ public class FolderList extends K9ListActivity {
         final TracingWakeLock wakeLock = pm.newWakeLock(PowerManager.PARTIAL_WAKE_LOCK, "FolderList checkMail");
         wakeLock.setReferenceCounted(false);
         wakeLock.acquire(K9.WAKE_LOCK_TIMEOUT);
-        MessagingListener listener = new MessagingListener() {
+        MessagingListener listener = new SimpleMessagingListener() {
             @Override
             public void synchronizeMailboxFinished(Account account, String folder, int totalMessagesInMailbox, int numNewMessages) {
                 if (!account.equals(mAccount)) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -67,6 +67,7 @@ import com.fsck.k9.activity.compose.SaveMessageTask;
 import com.fsck.k9.activity.misc.Attachment;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.fragment.ProgressDialogFragment;
 import com.fsck.k9.fragment.ProgressDialogFragment.CancelListener;
 import com.fsck.k9.helper.Contacts;
@@ -1588,7 +1589,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     };
 
     // TODO We miss callbacks for this listener if they happens while we are paused!
-    public MessagingListener messagingListener = new MessagingListener() {
+    public MessagingListener messagingListener = new SimpleMessagingListener() {
 
         @Override
         public void messageUidChanged(Account account, String folder, String oldUid, String newUid) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -20,6 +20,7 @@ import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.helper.RetainFragment;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mailstore.LocalMessage;
@@ -430,7 +431,7 @@ public class MessageLoaderHelper {
         }
     }
 
-    MessagingListener downloadMessageListener = new MessagingListener() {
+    MessagingListener downloadMessageListener = new SimpleMessagingListener() {
         @Override
         public void loadMessageRemoteFinished(Account account, String folder, String uid) {
             if (!messageReference.equals(account.getUuid(), folder, uid)) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
@@ -9,7 +9,7 @@ import java.util.Map.Entry;
 import com.fsck.k9.Account;
 
 
-class MemorizingMessagingListener extends MessagingListener {
+class MemorizingMessagingListener extends SimpleMessagingListener {
     Map<String, Memory> memories = new HashMap<>(31);
 
     synchronized void removeAccount(Account account) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
@@ -43,7 +43,7 @@ public class MessagingControllerPushReceiver implements PushReceiver {
         if (K9.DEBUG)
             Log.v(K9.LOG_TAG, "syncFolder(" + folder.getName() + ")");
         final CountDownLatch latch = new CountDownLatch(1);
-        controller.synchronizeMailbox(account, folder.getName(), new MessagingListener() {
+        controller.synchronizeMailbox(account, folder.getName(), new SimpleMessagingListener() {
             @Override
             public void synchronizeMailboxFinished(Account account, String folder,
             int totalMessagesInMailbox, int numNewMessages) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
@@ -1,6 +1,7 @@
 
 package com.fsck.k9.controller;
 
+
 import java.util.List;
 
 import android.content.Context;
@@ -13,162 +14,71 @@ import com.fsck.k9.mail.Part;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 
-/**
- * Defines the interface that {@link MessagingController} will use to callback to requesters.
- *
- * <p>
- * This class is defined as non-abstract so that someone who wants to receive only a few messages
- * can do so without implementing the entire interface. It is highly recommended that users of this
- * interface use the {@code @Override} annotation in their implementations to avoid being caught by
- * changes in this class.
- * </p>
- */
-public class MessagingListener {
-    public void searchStats(AccountStats stats) {}
 
+public interface MessagingListener {
+    void searchStats(AccountStats stats);
 
-    public void accountStatusChanged(BaseAccount account, AccountStats stats) {}
+    void accountStatusChanged(BaseAccount account, AccountStats stats);
+    void accountSizeChanged(Account account, long oldSize, long newSize);
 
-    public void accountSizeChanged(Account account, long oldSize, long newSize) {}
+    void listFoldersStarted(Account account);
+    void listFolders(Account account, List<LocalFolder> folders);
+    void listFoldersFinished(Account account);
+    void listFoldersFailed(Account account, String message);
 
+    void listLocalMessagesStarted(Account account, String folder);
+    void listLocalMessagesAddMessages(Account account, String folder, List<LocalMessage> messages);
+    void listLocalMessagesUpdateMessage(Account account, String folder, Message message);
+    void listLocalMessagesRemoveMessage(Account account, String folder, Message message);
+    void listLocalMessagesFinished(Account account, String folder);
+    void listLocalMessagesFailed(Account account, String folder, String message);
 
-    public void listFoldersStarted(Account account) {}
+    void synchronizeMailboxStarted(Account account, String folder);
+    void synchronizeMailboxHeadersStarted(Account account, String folder);
+    void synchronizeMailboxHeadersProgress(Account account, String folder, int completed, int total);
+    void synchronizeMailboxHeadersFinished(Account account, String folder, int totalMessagesInMailbox,
+            int numNewMessages);
+    void synchronizeMailboxProgress(Account account, String folder, int completed, int total);
+    void synchronizeMailboxNewMessage(Account account, String folder, Message message);
+    void synchronizeMailboxAddOrUpdateMessage(Account account, String folder, Message message);
+    void synchronizeMailboxRemovedMessage(Account account, String folder, Message message);
+    void synchronizeMailboxFinished(Account account, String folder, int totalMessagesInMailbox, int numNewMessages);
+    void synchronizeMailboxFailed(Account account, String folder, String message);
 
-    public void listFolders(Account account, List<LocalFolder> folders) {}
+    void loadMessageRemoteFinished(Account account, String folder, String uid);
+    void loadMessageRemoteFailed(Account account, String folder, String uid, Throwable t);
 
-    public void listFoldersFinished(Account account) {}
+    void checkMailStarted(Context context, Account account);
+    void checkMailFinished(Context context, Account account);
+    void checkMailFailed(Context context, Account account, String reason);
 
-    public void listFoldersFailed(Account account, String message) {}
+    void sendPendingMessagesStarted(Account account);
+    void sendPendingMessagesCompleted(Account account);
+    void sendPendingMessagesFailed(Account account);
 
+    void emptyTrashCompleted(Account account);
 
-    public void listLocalMessagesStarted(Account account, String folder) {}
+    void folderStatusChanged(Account account, String folderName, int unreadMessageCount);
+    void systemStatusChanged();
 
-    public void listLocalMessagesAddMessages(Account account, String folder,
-            List<LocalMessage> messages) {}
+    void messageDeleted(Account account, String folder, Message message);
+    void messageUidChanged(Account account, String folder, String oldUid, String newUid);
 
-    public void listLocalMessagesUpdateMessage(Account account, String folder, Message message) {}
+    void setPushActive(Account account, String folderName, boolean enabled);
 
-    public void listLocalMessagesRemoveMessage(Account account, String folder, Message message) {}
+    void loadAttachmentFinished(Account account, Message message, Part part);
+    void loadAttachmentFailed(Account account, Message message, Part part, String reason);
 
-    public void listLocalMessagesFinished(Account account, String folder) {}
+    void pendingCommandStarted(Account account, String commandTitle);
+    void pendingCommandsProcessing(Account account);
+    void pendingCommandCompleted(Account account, String commandTitle);
+    void pendingCommandsFinished(Account account);
 
-    public void listLocalMessagesFailed(Account account, String folder, String message) {}
-
-
-    public void synchronizeMailboxStarted(Account account, String folder) {}
-
-    public void synchronizeMailboxHeadersStarted(Account account, String folder) {}
-
-    public void synchronizeMailboxHeadersProgress(Account account, String folder,
-            int completed, int total) {}
-
-    public void synchronizeMailboxHeadersFinished(Account account, String folder,
-            int totalMessagesInMailbox, int numNewMessages) {}
-
-    public void synchronizeMailboxProgress(Account account, String folder, int completed,
-            int total) {}
-
-    public void synchronizeMailboxNewMessage(Account account, String folder, Message message) {}
-
-    public void synchronizeMailboxAddOrUpdateMessage(Account account, String folder,
-            Message message) {}
-
-    public void synchronizeMailboxRemovedMessage(Account account, String folder,
-            Message message) {}
-
-    public void synchronizeMailboxFinished(Account account, String folder,
-            int totalMessagesInMailbox, int numNewMessages) {}
-
-    public void synchronizeMailboxFailed(Account account, String folder, String message) {}
-
-    public void loadMessageRemoteFinished(Account account, String folder, String uid) {}
-
-    public void loadMessageRemoteFailed(Account account, String folder, String uid,
-            Throwable t) {}
-
-    public void checkMailStarted(Context context, Account account) {}
-
-    public void checkMailFinished(Context context, Account account) {}
-
-    public void checkMailFailed(Context context, Account account, String reason) {}
-
-
-    public void sendPendingMessagesStarted(Account account) {}
-
-    public void sendPendingMessagesCompleted(Account account) {}
-
-    public void sendPendingMessagesFailed(Account account) {}
-
-
-    public void emptyTrashCompleted(Account account) {}
-
-
-    public void folderStatusChanged(Account account, String folderName, int unreadMessageCount) {}
-
-
-    public void systemStatusChanged() {}
-
-
-    public void messageDeleted(Account account, String folder, Message message) {}
-
-    public void messageUidChanged(Account account, String folder, String oldUid, String newUid) {}
-
-
-    public void setPushActive(Account account, String folderName, boolean enabled) {}
-
-
-    public void loadAttachmentFinished(Account account, Message message, Part part) {}
-
-    public void loadAttachmentFailed(Account account, Message message, Part part, String reason) {}
-
-
-
-    public void pendingCommandStarted(Account account, String commandTitle) {}
-
-    public void pendingCommandsProcessing(Account account) {}
-
-    public void pendingCommandCompleted(Account account, String commandTitle) {}
-
-    public void pendingCommandsFinished(Account account) {}
-
-
-    /**
-     * Called when a remote search is started
-     *
-     * @param folder
-     */
-    public void remoteSearchStarted(String folder) {}
-
-
-    /**
-     * Called when server has responded to our query.  Messages have not yet been downloaded.
-     *
-     * @param numResults
-     */
-    public void remoteSearchServerQueryComplete(String folderName, int numResults, int maxResults) { }
-
-
-    /**
-     * Called when a new result message is available for a remote search
-     * Can assume headers have been downloaded, but potentially not body.
-     * @param folder
-     * @param message
-     */
-    public void remoteSearchAddMessage(String folder, Message message, int numDone, int numTotal) { }
-
-    /**
-     * Called when Remote Search is fully complete
-     *  @param folder
-     * @param numResults
-     */
-    public void remoteSearchFinished(String folder, int numResults, int maxResults, List<Message> extraResults) {}
-
-    /**
-     * Called when there was a problem with a remote search operation.
-     *  @param folder
-     * @param err
-     */
-    public void remoteSearchFailed(String folder, String err) { }
+    void remoteSearchStarted(String folder);
+    void remoteSearchServerQueryComplete(String folderName, int numResults, int maxResults);
+    void remoteSearchAddMessage(String folder, Message message, int numDone, int numTotal);
+    void remoteSearchFinished(String folder, int numResults, int maxResults, List<Message> extraResults);
+    void remoteSearchFailed(String folder, String err);
 
     /**
      * General notification messages subclasses can override to be notified that the controller
@@ -179,7 +89,7 @@ public class MessagingListener {
      *         {@code true} if the controller will continue on to another command immediately.
      *         {@code false} otherwise.
      */
-    public void controllerCommandCompleted(boolean moreCommandsToRun) {}
+    void controllerCommandCompleted(boolean moreCommandsToRun);
 
-    public void enableProgressIndicator(boolean enable) { }
+    void enableProgressIndicator(boolean enable);
 }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
@@ -26,12 +26,7 @@ public interface MessagingListener {
     void listFoldersFinished(Account account);
     void listFoldersFailed(Account account, String message);
 
-    void listLocalMessagesStarted(Account account, String folder);
     void listLocalMessagesAddMessages(Account account, String folder, List<LocalMessage> messages);
-    void listLocalMessagesUpdateMessage(Account account, String folder, Message message);
-    void listLocalMessagesRemoveMessage(Account account, String folder, Message message);
-    void listLocalMessagesFinished(Account account, String folder);
-    void listLocalMessagesFailed(Account account, String folder, String message);
 
     void synchronizeMailboxStarted(Account account, String folder);
     void synchronizeMailboxHeadersStarted(Account account, String folder);
@@ -40,7 +35,6 @@ public interface MessagingListener {
             int numNewMessages);
     void synchronizeMailboxProgress(Account account, String folder, int completed, int total);
     void synchronizeMailboxNewMessage(Account account, String folder, Message message);
-    void synchronizeMailboxAddOrUpdateMessage(Account account, String folder, Message message);
     void synchronizeMailboxRemovedMessage(Account account, String folder, Message message);
     void synchronizeMailboxFinished(Account account, String folder, int totalMessagesInMailbox, int numNewMessages);
     void synchronizeMailboxFailed(Account account, String folder, String message);
@@ -50,7 +44,6 @@ public interface MessagingListener {
 
     void checkMailStarted(Context context, Account account);
     void checkMailFinished(Context context, Account account);
-    void checkMailFailed(Context context, Account account, String reason);
 
     void sendPendingMessagesStarted(Account account);
     void sendPendingMessagesCompleted(Account account);
@@ -76,20 +69,8 @@ public interface MessagingListener {
 
     void remoteSearchStarted(String folder);
     void remoteSearchServerQueryComplete(String folderName, int numResults, int maxResults);
-    void remoteSearchAddMessage(String folder, Message message, int numDone, int numTotal);
     void remoteSearchFinished(String folder, int numResults, int maxResults, List<Message> extraResults);
     void remoteSearchFailed(String folder, String err);
-
-    /**
-     * General notification messages subclasses can override to be notified that the controller
-     * has completed a command. This is useful for turning off progress indicators that may have
-     * been left over from previous commands.
-     *
-     * @param moreCommandsToRun
-     *         {@code true} if the controller will continue on to another command immediately.
-     *         {@code false} otherwise.
-     */
-    void controllerCommandCompleted(boolean moreCommandsToRun);
 
     void enableProgressIndicator(boolean enable);
 }

--- a/k9mail/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
@@ -1,0 +1,220 @@
+
+package com.fsck.k9.controller;
+
+
+import java.util.List;
+
+import android.content.Context;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.AccountStats;
+import com.fsck.k9.BaseAccount;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.Part;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+
+
+public abstract class SimpleMessagingListener implements MessagingListener {
+    @Override
+    public void searchStats(AccountStats stats) {
+    }
+
+    @Override
+    public void accountStatusChanged(BaseAccount account, AccountStats stats) {
+    }
+
+    @Override
+    public void accountSizeChanged(Account account, long oldSize, long newSize) {
+    }
+
+    @Override
+    public void listFoldersStarted(Account account) {
+    }
+
+    @Override
+    public void listFolders(Account account, List<LocalFolder> folders) {
+    }
+
+    @Override
+    public void listFoldersFinished(Account account) {
+    }
+
+    @Override
+    public void listFoldersFailed(Account account, String message) {
+    }
+
+    @Override
+    public void listLocalMessagesStarted(Account account, String folder) {
+    }
+
+    @Override
+    public void listLocalMessagesAddMessages(Account account, String folder, List<LocalMessage> messages) {
+    }
+
+    @Override
+    public void listLocalMessagesUpdateMessage(Account account, String folder, Message message) {
+    }
+
+    @Override
+    public void listLocalMessagesRemoveMessage(Account account, String folder, Message message) {
+    }
+
+    @Override
+    public void listLocalMessagesFinished(Account account, String folder) {
+    }
+
+    @Override
+    public void listLocalMessagesFailed(Account account, String folder, String message) {
+    }
+
+    @Override
+    public void synchronizeMailboxStarted(Account account, String folder) {
+    }
+
+    @Override
+    public void synchronizeMailboxHeadersStarted(Account account, String folder) {
+    }
+
+    @Override
+    public void synchronizeMailboxHeadersProgress(Account account, String folder, int completed, int total) {
+    }
+
+    @Override
+    public void synchronizeMailboxHeadersFinished(Account account, String folder, int totalMessagesInMailbox,
+            int numNewMessages) {
+    }
+
+    @Override
+    public void synchronizeMailboxProgress(Account account, String folder, int completed, int total) {
+    }
+
+    @Override
+    public void synchronizeMailboxNewMessage(Account account, String folder, Message message) {
+    }
+
+    @Override
+    public void synchronizeMailboxAddOrUpdateMessage(Account account, String folder, Message message) {
+    }
+
+    @Override
+    public void synchronizeMailboxRemovedMessage(Account account, String folder, Message message) {
+    }
+
+    @Override
+    public void synchronizeMailboxFinished(Account account, String folder, int totalMessagesInMailbox,
+            int numNewMessages) {
+    }
+
+    @Override
+    public void synchronizeMailboxFailed(Account account, String folder, String message) {
+    }
+
+    @Override
+    public void loadMessageRemoteFinished(Account account, String folder, String uid) {
+    }
+
+    @Override
+    public void loadMessageRemoteFailed(Account account, String folder, String uid, Throwable t) {
+    }
+
+    @Override
+    public void checkMailStarted(Context context, Account account) {
+    }
+
+    @Override
+    public void checkMailFinished(Context context, Account account) {
+    }
+
+    @Override
+    public void checkMailFailed(Context context, Account account, String reason) {
+    }
+
+    @Override
+    public void sendPendingMessagesStarted(Account account) {
+    }
+
+    @Override
+    public void sendPendingMessagesCompleted(Account account) {
+    }
+
+    @Override
+    public void sendPendingMessagesFailed(Account account) {
+    }
+
+    @Override
+    public void emptyTrashCompleted(Account account) {
+    }
+
+    @Override
+    public void folderStatusChanged(Account account, String folderName, int unreadMessageCount) {
+    }
+
+    @Override
+    public void systemStatusChanged() {
+    }
+
+    @Override
+    public void messageDeleted(Account account, String folder, Message message) {
+    }
+
+    @Override
+    public void messageUidChanged(Account account, String folder, String oldUid, String newUid) {
+    }
+
+    @Override
+    public void setPushActive(Account account, String folderName, boolean enabled) {
+    }
+
+    @Override
+    public void loadAttachmentFinished(Account account, Message message, Part part) {
+    }
+
+    @Override
+    public void loadAttachmentFailed(Account account, Message message, Part part, String reason) {
+    }
+
+    @Override
+    public void pendingCommandStarted(Account account, String commandTitle) {
+    }
+
+    @Override
+    public void pendingCommandsProcessing(Account account) {
+    }
+
+    @Override
+    public void pendingCommandCompleted(Account account, String commandTitle) {
+    }
+
+    @Override
+    public void pendingCommandsFinished(Account account) {
+    }
+
+    @Override
+    public void remoteSearchStarted(String folder) {
+    }
+
+    @Override
+    public void remoteSearchServerQueryComplete(String folderName, int numResults, int maxResults) {
+    }
+
+    @Override
+    public void remoteSearchAddMessage(String folder, Message message, int numDone, int numTotal) {
+    }
+
+    @Override
+    public void remoteSearchFinished(String folder, int numResults, int maxResults, List<Message> extraResults) {
+    }
+
+    @Override
+    public void remoteSearchFailed(String folder, String err) {
+    }
+
+    @Override
+    public void controllerCommandCompleted(boolean moreCommandsToRun) {
+    }
+
+    @Override
+    public void enableProgressIndicator(boolean enable) {
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
@@ -45,27 +45,7 @@ public abstract class SimpleMessagingListener implements MessagingListener {
     }
 
     @Override
-    public void listLocalMessagesStarted(Account account, String folder) {
-    }
-
-    @Override
     public void listLocalMessagesAddMessages(Account account, String folder, List<LocalMessage> messages) {
-    }
-
-    @Override
-    public void listLocalMessagesUpdateMessage(Account account, String folder, Message message) {
-    }
-
-    @Override
-    public void listLocalMessagesRemoveMessage(Account account, String folder, Message message) {
-    }
-
-    @Override
-    public void listLocalMessagesFinished(Account account, String folder) {
-    }
-
-    @Override
-    public void listLocalMessagesFailed(Account account, String folder, String message) {
     }
 
     @Override
@@ -91,10 +71,6 @@ public abstract class SimpleMessagingListener implements MessagingListener {
 
     @Override
     public void synchronizeMailboxNewMessage(Account account, String folder, Message message) {
-    }
-
-    @Override
-    public void synchronizeMailboxAddOrUpdateMessage(Account account, String folder, Message message) {
     }
 
     @Override
@@ -124,10 +100,6 @@ public abstract class SimpleMessagingListener implements MessagingListener {
 
     @Override
     public void checkMailFinished(Context context, Account account) {
-    }
-
-    @Override
-    public void checkMailFailed(Context context, Account account, String reason) {
     }
 
     @Override
@@ -199,19 +171,11 @@ public abstract class SimpleMessagingListener implements MessagingListener {
     }
 
     @Override
-    public void remoteSearchAddMessage(String folder, Message message, int numDone, int numTotal) {
-    }
-
-    @Override
     public void remoteSearchFinished(String folder, int numResults, int maxResults, List<Message> extraResults) {
     }
 
     @Override
     public void remoteSearchFailed(String folder, String err) {
-    }
-
-    @Override
-    public void controllerCommandCompleted(boolean moreCommandsToRun) {
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -45,7 +45,7 @@ import com.fsck.k9.activity.FolderInfoHolder;
 import com.fsck.k9.activity.MessageInfoHolder;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.controller.MessagingController;
-import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.helper.MessageHelper;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
@@ -79,7 +79,7 @@ public class MessageProvider extends ContentProvider {
             UnreadColumns.UNREAD
     };
 
-    
+
     private UriMatcher uriMatcher = new UriMatcher(UriMatcher.NO_MATCH);
     private List<QueryHandler> queryHandlers = new ArrayList<QueryHandler>();
     private MessageHelper messageHelper;
@@ -91,7 +91,7 @@ public class MessageProvider extends ContentProvider {
 
     ScheduledExecutorService scheduledPool = Executors.newScheduledThreadPool(1);
 
-    
+
     @Override
     public boolean onCreate() {
         messageHelper = MessageHelper.getInstance(getContext());
@@ -105,7 +105,7 @@ public class MessageProvider extends ContentProvider {
             public void initializeComponent(final Application application) {
                 Log.v(K9.LOG_TAG, "Registering content resolver notifier");
 
-                MessagingController.getInstance(application).addListener(new MessagingListener() {
+                MessagingController.getInstance(application).addListener(new SimpleMessagingListener() {
                     @Override
                     public void folderStatusChanged(Account account, String folderName, int unreadMessageCount) {
                         application.getContentResolver().notifyChange(CONTENT_URI, null);
@@ -242,7 +242,7 @@ public class MessageProvider extends ContentProvider {
         uriMatcher.addURI(AUTHORITY, handler.getPath(), code);
     }
 
-    
+
     public static class ReverseDateComparator implements Comparator<MessageInfoHolder> {
         @Override
         public int compare(MessageInfoHolder object2, MessageInfoHolder object1) {
@@ -1089,7 +1089,7 @@ public class MessageProvider extends ContentProvider {
     /**
      * Synchronized listener used to retrieve {@link MessageInfoHolder}s using a given {@link BlockingQueue}.
      */
-    protected class MessageInfoHolderRetrieverListener extends MessagingListener {
+    protected class MessageInfoHolderRetrieverListener extends SimpleMessagingListener {
         private final BlockingQueue<List<MessageInfoHolder>> queue;
         private List<MessageInfoHolder> holders = new ArrayList<MessageInfoHolder>();
 

--- a/k9mail/src/main/java/com/fsck/k9/service/PollService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/PollService.java
@@ -7,7 +7,7 @@ import android.os.PowerManager;
 import android.util.Log;
 import com.fsck.k9.*;
 import com.fsck.k9.controller.MessagingController;
-import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.mail.power.TracingPowerManager;
 import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
 
@@ -77,7 +77,7 @@ public class PollService extends CoreService {
         return null;
     }
 
-    class Listener extends MessagingListener {
+    class Listener extends SimpleMessagingListener {
         Map<String, Integer> accountsChecked = new HashMap<String, Integer>();
         private TracingWakeLock wakeLock = null;
         private int startId = -1;

--- a/k9mail/src/main/java/com/fsck/k9/service/PollService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/PollService.java
@@ -109,11 +109,6 @@ public class PollService extends CoreService {
         }
 
         @Override
-        public void checkMailFailed(Context context, Account account, String reason) {
-            release();
-        }
-
-        @Override
         public void synchronizeMailboxFinished(
             Account account,
             String folder,

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
@@ -27,7 +27,7 @@ import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
 import com.fsck.k9.cache.TemporaryAttachmentStore;
 import com.fsck.k9.controller.MessagingController;
-import com.fsck.k9.controller.MessagingListener;
+import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.helper.FileHelper;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Part;
@@ -97,7 +97,7 @@ public class AttachmentController {
         LocalMessage message = localPart.getMessage();
 
         messageViewFragment.showAttachmentLoadingDialog();
-        controller.loadAttachment(account, message, attachment.part, new MessagingListener() {
+        controller.loadAttachment(account, message, attachment.part, new SimpleMessagingListener() {
             @Override
             public void loadAttachmentFinished(Account account, Message message, Part part) {
                 messageViewFragment.hideAttachmentLoadingDialogOnMainThread();

--- a/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
@@ -141,16 +141,6 @@ public class ActivityListenerTest {
     }
 
     @Test
-    public void getOperation__whenSynchronizeMailboxAddOrUpdateMessage() {
-        activityListener.synchronizeMailboxStarted(account, FOLDER);
-        activityListener.synchronizeMailboxAddOrUpdateMessage(account, FOLDER, message);
-
-        String operation = activityListener.getOperation(context);
-
-        assertEquals("Poll account:folder", operation);
-    }
-
-    @Test
     public void getOperation__whenSynchronizeMailboxNewMessage() {
         activityListener.synchronizeMailboxStarted(account, FOLDER);
         activityListener.synchronizeMailboxNewMessage(account, FOLDER, message);

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -86,7 +86,7 @@ public class MessagingControllerTest {
     @Mock
     private AccountStats accountStats;
     @Mock
-    private MessagingListener listener;
+    private SimpleMessagingListener listener;
     @Mock
     private LocalSearch search;
     @Mock

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -361,17 +361,6 @@ public class MessagingControllerTest {
     }
 
     @Test
-    public void searchLocalMessagesSynchronous_shouldNotifyStartedListingLocalMessages()
-            throws Exception {
-        setAccountsInPreferences(Collections.singletonMap("1", account));
-        when(search.getAccountUuids()).thenReturn(new String[]{"allAccounts"});
-
-        controller.searchLocalMessagesSynchronous(search, listener);
-
-        verify(listener).listLocalMessagesStarted(account, null);
-    }
-
-    @Test
     public void searchLocalMessagesSynchronous_shouldCallSearchForMessagesOnLocalStore()
             throws Exception {
         setAccountsInPreferences(Collections.singletonMap("1", account));
@@ -380,18 +369,6 @@ public class MessagingControllerTest {
         controller.searchLocalMessagesSynchronous(search, listener);
 
         verify(localStore).searchForMessages(any(MessageRetrievalListener.class), eq(search));
-    }
-
-    @Test
-    public void searchLocalMessagesSynchronous_shouldNotifyFailureIfStoreThrowsException() throws Exception {
-        setAccountsInPreferences(Collections.singletonMap("1", account));
-        when(search.getAccountUuids()).thenReturn(new String[]{"allAccounts"});
-        when(localStore.searchForMessages(any(MessageRetrievalListener.class), eq(search)))
-                .thenThrow(new MessagingException("Test"));
-
-        controller.searchLocalMessagesSynchronous(search, listener);
-
-        verify(listener).listLocalMessagesFailed(account, null, "Test");
     }
 
     @Test
@@ -520,16 +497,6 @@ public class MessagingControllerTest {
 
         verify(remoteFolder, never()).fetch(eq(Collections.singletonList(remoteNewMessage1)),
                 fetchProfileCaptor.capture(), Matchers.<MessageRetrievalListener>eq(null));
-    }
-
-    @Test
-    public void searchRemoteMessagesSynchronous_shouldNotifyListenerOfNewMessages() throws Exception {
-        setupRemoteSearch();
-
-        controller.searchRemoteMessagesSynchronous("1", FOLDER_NAME, "query", reqFlags, forbiddenFlags, listener);
-
-        verify(listener).remoteSearchAddMessage(FOLDER_NAME, localNewMessage1, 1, 2);
-        verify(listener).remoteSearchAddMessage(FOLDER_NAME, localNewMessage2, 2, 2);
     }
 
     @Test


### PR DESCRIPTION
I started doing this to get rid of the dozens of Checkstyle warnings in `MessagingListener`. But I also found and removed a couple of methods that were never used.