### PR TITLE
Added up button to MessageCompose Activity

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.regex.Pattern;
 
 import android.annotation.SuppressLint;
+import android.app.ActionBar;
 import android.app.AlertDialog;
 import android.app.AlertDialog.Builder;
 import android.app.Dialog;
@@ -190,6 +191,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
     private Action action;
 
+    private ActionBar mActionBar;
+
     private boolean requestReadReceipt = false;
 
     private TextView chooseIdentityButton;
@@ -233,6 +236,10 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
         // on api level 15, setContentView() shows the progress bar for some reason...
         setProgressBarIndeterminateVisibility(false);
+
+        mActionBar = getActionBar();
+        mActionBar.setDisplayShowCustomEnabled(true);
+        mActionBar.setDisplayHomeAsUpEnabled(true);
 
         final Intent intent = getIntent();
 
@@ -924,6 +931,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     @Override
     public boolean onOptionsItemSelected(MenuItem item) {
         switch (item.getItemId()) {
+            case android.R.id.home:
+                onAccounts();
+                break;
             case R.id.send:
                 checkToSendMessage();
                 break;
@@ -1410,6 +1420,13 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
         currentMessageFormat = format;
     }
+
+    private void onAccounts() {
+        Accounts.listAccounts(this);
+        finish();
+    }
+
+
 
     public void updateMessageFormat() {
         MessageFormat origMessageFormat = account.getMessageFormat();


### PR DESCRIPTION
_Added a back button to Action bar which acts as an Up button and open Accounts list Activity._
#2238 
I was conflicted between unified inbox activity and accounts, but current order as now is also confusing, Inbox sends to Folders, Folder sends to Accounts List.

As it was stated all Up buttons should go to the same activity, going to Accounts activity made more sense to me as it acts like the root activity.  