### PR TITLE
Insert <hr> element when converting from text to HTML

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
@@ -14,7 +14,7 @@ public class HorizontalRuleHelper {
 	snips aligned in different directions and replaces them with <hr />
 
 	Usage - 
-	String replaced = HorizontalRuleHelper.replaceHorizontalRule(stringToReplcaeFrom);
+	String replaced = HorizontalRuleHelper.replaceHorizontalRule(stringToReplaceFrom);
 	*/
 
 	private String pattern = "[-=_]{4,}|(-|=){2,}-|(-| )+ *>8 *(-| )+|(-| )+ *8< *(-| )+";

--- a/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
@@ -1,0 +1,29 @@
+package com.fsck.k9.helper;
+
+/**
+ * HorizontalRuleHelper
+ * author - Sayan Goswami (goswami.sayan47@gmail.com)
+ * date - 02/28/2017
+ * issue - https://github.com/k9mail/k-9/issues/2259
+ */
+
+public class HorizontalRuleHelper {
+
+	/*
+	pattern checks for dashes, equals, underscores, combination of dashes and equals,
+	snips aligned in different directions and replaces them with <hr />
+
+	Usage - 
+	String replaced = HorizontalRuleHelper.replaceHorizontalRule(stringToReplcaeFrom);
+	*/
+
+	private String pattern = "[-=_]{4,}|(-|=){2,}-|(-| )+ *>8 *(-| )+|(-| )+ *8< *(-| )+";
+
+	public void HorizontalRuleHelper(){
+		// Empty constructor
+	}
+
+	public String replaceHorizontalRule(String text){
+		return text.replaceAll(pattern, "<hr />");
+	}
+}

--- a/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
@@ -11,11 +11,11 @@ public class HorizontalRuleHelper {
 	String replaced = HorizontalRuleHelper.replaceHorizontalRule(stringToReplaceFrom);
 	*/
 
-	private String pattern = "[-=_]{4,}|(-=){2,}-|(-| )+ *>8 *(-| )+|(-| )+ *8< *(-| )+";
+	private String pattern;
 
-	public void HorizontalRuleHelper(){
-		// Empty constructor
-	}
+	public HorizontalRuleHelper(){
+        pattern = "[-=_]{4,}|(-=){2,}-|(-| )+ *>8 *(-| )+|(-| )+ *8< *(-| )+";
+    }
 
 	public String replaceHorizontalRule(String text){
 		return text.replaceAll(pattern, "<hr />");

--- a/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
@@ -1,11 +1,5 @@
 package com.fsck.k9.helper;
 
-/**
- * HorizontalRuleHelper
- * author - Sayan Goswami (goswami.sayan47@gmail.com)
- * date - 02/28/2017
- * issue - https://github.com/k9mail/k-9/issues/2259
- */
 
 public class HorizontalRuleHelper {
 

--- a/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
@@ -18,6 +18,15 @@ public class HorizontalRuleHelper {
     }
 
 	public String replaceHorizontalRule(String text){
-		return text.replaceAll(pattern, "<hr />");
+
+		if (text != null && !text.isEmpty()) {
+			return text.replaceAll(pattern, "<hr />");
+		}
+
+		else {
+			return "";
+		}
+
+
 	}
 }

--- a/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/HorizontalRuleHelper.java
@@ -11,7 +11,7 @@ public class HorizontalRuleHelper {
 	String replaced = HorizontalRuleHelper.replaceHorizontalRule(stringToReplaceFrom);
 	*/
 
-	private String pattern = "[-=_]{4,}|(-|=){2,}-|(-| )+ *>8 *(-| )+|(-| )+ *8< *(-| )+";
+	private String pattern = "[-=_]{4,}|(-=){2,}-|(-| )+ *>8 *(-| )+|(-| )+ *8< *(-| )+";
 
 	public void HorizontalRuleHelper(){
 		// Empty constructor

--- a/k9mail/src/test/java/com/fsck/k9/helper/HorizontalRuleHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/HorizontalRuleHelperTest.java
@@ -9,58 +9,93 @@ public class HorizontalRuleHelperTest {
 
 	@Test
 	public void replaceHorizontalRule_withDashes_shouldReturnReplacementWithHR() {
-		String result = HorizontalRuleHelper.replaceHorizontalRule("--------------");
+		String result = new HorizontalRuleHelper().replaceHorizontalRule("--------------");
 
 		assertEquals("<hr />", result);
 	}
+
+    @Test
+    public void replaceHorizontalRule_withLessNumberOfDashes_shouldReturnWithoutReplacement() {
+        String result = new HorizontalRuleHelper().replaceHorizontalRule("---");
+
+        assertEquals("---", result);
+    }
 
 	@Test
 	public void replaceHorizontalRule_withEquals_shouldReturnReplacementWithHR() {
-		String result = HorizontalRuleHelper.replaceHorizontalRule("==============");
+		String result = new HorizontalRuleHelper().replaceHorizontalRule("==============");
 
 		assertEquals("<hr />", result);
 	}
+
+    @Test
+    public void replaceHorizontalRule_withLessNumberOfEquals_shouldReturnWithoutReplacement() {
+        String result = new HorizontalRuleHelper().replaceHorizontalRule("===");
+
+        assertEquals("===", result);
+    }
 
 	@Test
 	public void replaceHorizontalRule_withFancyDashEquals_shouldReturnReplacementWithHR() {
-		String result = HorizontalRuleHelper.replaceHorizontalRule("-=-=-=-=-=-=-=-");
+		String result = new HorizontalRuleHelper().replaceHorizontalRule("-=-=-=-=-=-=-=-");
 
 		assertEquals("<hr />", result);
 	}
 
+    @Test
+    public void replaceHorizontalRule_withLessNumberOfFancyDashEquals_shouldReturnWithoutReplacement() {
+        String result = new HorizontalRuleHelper().replaceHorizontalRule("-=-");
+
+        assertEquals("-=-", result);
+    }
+
 	@Test
 	public void replaceHorizontalRule_withUnderscores_shouldReturnReplacementWithHR() {
-		String result = HorizontalRuleHelper.replaceHorizontalRule("_______________");
+		String result = new HorizontalRuleHelper().replaceHorizontalRule("_______________");
 
 		assertEquals("<hr />", result);
 	}
 
 	@Test
 	public void replaceHorizontalRule_withScissorsLeft_shouldReturnReplacementWithHR() {
-		String result = HorizontalRuleHelper.replaceHorizontalRule("- - - >8 - - -");
+		String result = new HorizontalRuleHelper().replaceHorizontalRule("- - - >8 - - -");
 
 		assertEquals("<hr />", result);
 	}
 
 	@Test
 	public void replaceHorizontalRule_withScissorsLeft2_shouldReturnReplacementWithHR() {
-		String result = HorizontalRuleHelper.replaceHorizontalRule("--- >8 ---");
+		String result = new HorizontalRuleHelper().replaceHorizontalRule("--- >8 ---");
 
 		assertEquals("<hr />", result);
 	}
 
+    @Test
+    public void replaceHorizontalRule_withScissorsLeft3_shouldReturnReplacementWithHR() {
+        String result = new HorizontalRuleHelper().replaceHorizontalRule(" >8 ");
+
+        assertEquals("<hr />", result);
+    }
+
 	@Test
 	public void replaceHorizontalRule_withScissorsRight_shouldReturnReplacementWithHR() {
-		String result = HorizontalRuleHelper.replaceHorizontalRule("- - - 8< - - -");
+		String result = new HorizontalRuleHelper().replaceHorizontalRule("- - - 8< - - -");
 
 		assertEquals("<hr />", result);
 	}
 
 	@Test
 	public void replaceHorizontalRule_withScissorsRight2_shouldReturnReplacementWithHR() {
-		String result = HorizontalRuleHelper.replaceHorizontalRule("--- 8< ---");
+		String result = new HorizontalRuleHelper().replaceHorizontalRule("--- 8< ---");
 
 		assertEquals("<hr />", result);
 	}
+
+    @Test
+    public void replaceHorizontalRule_withScissorsRight3_shouldReturnReplacementWithHR() {
+        String result = new HorizontalRuleHelper().replaceHorizontalRule(" 8< ");
+
+        assertEquals("<hr />", result);
+    }
 
 }

--- a/k9mail/src/test/java/com/fsck/k9/helper/HorizontalRuleHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/HorizontalRuleHelperTest.java
@@ -29,10 +29,17 @@ public class HorizontalRuleHelperTest {
 	}
 
     @Test
-    public void replaceHorizontalRule_withLessNumberOfEquals_shouldReturnWithoutReplacement() {
-        String result = new HorizontalRuleHelper().replaceHorizontalRule("===");
+	public void replaceHorizontalRule_withLessNumberOfEquals_shouldReturnWithoutReplacement() {
+		String result = new HorizontalRuleHelper().replaceHorizontalRule("===");
 
-        assertEquals("===", result);
+		assertEquals("===", result);
+	}
+
+    @Test
+    public void replaceHorizontalRule_withDoubleEquals_shouldReturnWithoutReplacement() {
+        String result = new HorizontalRuleHelper().replaceHorizontalRule("==");
+
+        assertEquals("==", result);
     }
 
 	@Test
@@ -47,6 +54,13 @@ public class HorizontalRuleHelperTest {
         String result = new HorizontalRuleHelper().replaceHorizontalRule("-=-");
 
         assertEquals("-=-", result);
+    }
+
+    @Test
+    public void replaceHorizontalRule_withLMinusEquals_shouldReturnWithoutReplacement() {
+        String result = new HorizontalRuleHelper().replaceHorizontalRule("-=");
+
+        assertEquals("-=", result);
     }
 
 	@Test
@@ -96,6 +110,20 @@ public class HorizontalRuleHelperTest {
         String result = new HorizontalRuleHelper().replaceHorizontalRule(" 8< ");
 
         assertEquals("<hr />", result);
+    }
+
+    @Test
+    public void replaceHorizontalRule_withEmptyString_shouldReturnEmptyString() {
+        String result = new HorizontalRuleHelper().replaceHorizontalRule("");
+
+        assertEquals("", result);
+    }
+
+    @Test
+    public void replaceHorizontalRule_withNull_shouldReturnEmptyString() {
+        String result = new HorizontalRuleHelper().replaceHorizontalRule(null);
+
+        assertEquals("", result);
     }
 
 }

--- a/k9mail/src/test/java/com/fsck/k9/helper/HorizontalRuleHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/HorizontalRuleHelperTest.java
@@ -1,0 +1,73 @@
+package com.fsck.k9.helper;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * HorizontalRuleHelperTest
+ * author - Sayan Goswami (goswami.sayan47@gmail.com)
+ * date - 02/28/2017
+ * issue - https://github.com/k9mail/k-9/issues/2259
+ */
+
+public class HorizontalRuleHelperTest {
+
+	@Test
+	public void replaceHorizontalRule_withDashes_shouldReturnReplacementWithHR() {
+		String result = HorizontalRuleHelper.replaceHorizontalRule("--------------");
+
+		assertEquals("<hr />", result);
+	}
+
+	@Test
+	public void replaceHorizontalRule_withEquals_shouldReturnReplacementWithHR() {
+		String result = HorizontalRuleHelper.replaceHorizontalRule("==============");
+
+		assertEquals("<hr />", result);
+	}
+
+	@Test
+	public void replaceHorizontalRule_withFancyDashEquals_shouldReturnReplacementWithHR() {
+		String result = HorizontalRuleHelper.replaceHorizontalRule("-=-=-=-=-=-=-=-");
+
+		assertEquals("<hr />", result);
+	}
+
+	@Test
+	public void replaceHorizontalRule_withUnderscores_shouldReturnReplacementWithHR() {
+		String result = HorizontalRuleHelper.replaceHorizontalRule("_______________");
+
+		assertEquals("<hr />", result);
+	}
+
+	@Test
+	public void replaceHorizontalRule_withScissorsLeft_shouldReturnReplacementWithHR() {
+		String result = HorizontalRuleHelper.replaceHorizontalRule("- - - >8 - - -");
+
+		assertEquals("<hr />", result);
+	}
+
+	@Test
+	public void replaceHorizontalRule_withScissorsLeft2_shouldReturnReplacementWithHR() {
+		String result = HorizontalRuleHelper.replaceHorizontalRule("--- >8 ---");
+
+		assertEquals("<hr />", result);
+	}
+
+	@Test
+	public void replaceHorizontalRule_withScissorsRight_shouldReturnReplacementWithHR() {
+		String result = HorizontalRuleHelper.replaceHorizontalRule("- - - 8< - - -");
+
+		assertEquals("<hr />", result);
+	}
+
+	@Test
+	public void replaceHorizontalRule_withScissorsRight2_shouldReturnReplacementWithHR() {
+		String result = HorizontalRuleHelper.replaceHorizontalRule("--- 8< ---");
+
+		assertEquals("<hr />", result);
+	}
+
+}

--- a/k9mail/src/test/java/com/fsck/k9/helper/HorizontalRuleHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/HorizontalRuleHelperTest.java
@@ -5,13 +5,6 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 
-/**
- * HorizontalRuleHelperTest
- * author - Sayan Goswami (goswami.sayan47@gmail.com)
- * date - 02/28/2017
- * issue - https://github.com/k9mail/k-9/issues/2259
- */
-
 public class HorizontalRuleHelperTest {
 
 	@Test


### PR DESCRIPTION
Implemented `HorizontalRuleHelper` which take a message body as string input and replaces all possible horizontal rule like ASCII sequences by `<hr />` and `HorizontalRuleHelperTest` which has various unit test showing wanted behaviour.

**What this does?**

`---------------------------` gets replaced to `<hr />`
`===========================` gets replaced to `<hr />`
`-=-=-=-=-=-=-=-=-=-=-=-=-=-` gets replaced to `<hr />`
`-- >8  --` gets replaced to `<hr />`
`- >8 -` gets replaced to `<hr />`
`- - - >8 - - -` gets replaced to `<hr />`
` >8 ` gets replaced to `<hr />` 
`-- 8< --` gets replaced to `<hr />`
`- 8< -` gets replaced to `<hr />`
`- - - 8< - - -` gets replaced to `<hr />`
` 8< ` gets replaced to `<hr />`
`___________________________` gets replaced to `<hr />`
`-=` remains unaffected
`==` remains unaffected
`-- ` remains unaffected
`=-` remains unaffected
`-` remains unaffected
`=` remains unaffected
`_` remains unaffected