### PR TITLE
fix issue 2057

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
@@ -2,6 +2,7 @@ package com.fsck.k9.activity.compose;
 
 
 import java.util.List;
+import java.util.WeakHashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -32,6 +33,7 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
     private final Context context;
     private List<Recipient> recipients;
     private String highlight;
+    private WeakHashMap<Integer, View> positionToViewMap = new WeakHashMap<>();
 
 
     public RecipientAdapter(Context context) {
@@ -65,13 +67,13 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
 
     @Override
     public View getView(int position, View view, ViewGroup parent) {
-        if (view == null) {
+        if ((view = positionToViewMap.get(position)) == null) {
             view = newView(parent);
+            positionToViewMap.put(position, view);
         }
 
         Recipient recipient = getItem(position);
         bindView(view, recipient);
-
         return view;
     }
 


### PR DESCRIPTION
issue #2057 

I reproduced it and found the reason of this issue. `getView` method in `RecipientAdapter` was called several times. `getView(0, null, parent)` is called firstly. if the view created for position 0 in the first call is view `A`, then `getView(1, A, parent)` and `getView(0, A, parent)` are called. Maybe it's a intended behavior of Android system. In most instances, the information of position 0 will be filled in View `A` again in the third call. But in our app, the contact photo is loaded by Glide asynchronously. So when the photo of position 1 is completely loaded, it will override the photo of position 0, especially when the contact of position 0 doesn't have a photo (the fallback image will be loaded rapidly).

And the reason why the wrong photo is corrected when the input continues is `getView` for view `A` is only called one time then.

The reason why the photo is correct if we see a wrong photo, clear the input, and then type the name again is that Glide has already cached the image and retrieve it more rapidly.

My solution is use a map to map the position to view explicitly :) Could this solution be accepted?