### PR TITLE
Line wrap fix and unit test

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/filter/LineWrapOutputStream.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/filter/LineWrapOutputStream.java
@@ -22,8 +22,9 @@ public class LineWrapOutputStream extends FilterOutputStream {
     public void write(int oneByte) throws IOException {
         // Buffer full?
         if (lineLength == buffer.length) {
+            // Can skip the char if end of word
             // Usable word-boundary found earlier?
-            if (endOfLastWord > 0) {
+            if (endOfLastWord > 0 && oneByte != ' ') {
                 // Yes, so output everything up to that word-boundary
                 out.write(buffer, bufferStart, endOfLastWord - bufferStart);
                 out.write(CRLF);
@@ -45,6 +46,8 @@ public class LineWrapOutputStream extends FilterOutputStream {
                 lineLength = 0;
                 bufferStart = 0;
             }
+            if (oneByte == ' ')
+                return;
         }
 
         if ((oneByte == '\n') || (oneByte == '\r')) {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/filter/LineWrapOutputStreamTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/filter/LineWrapOutputStreamTest.java
@@ -1,0 +1,34 @@
+package com.fsck.k9.mail.filter;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+
+public class LineWrapOutputStreamTest {
+    private static final int maxLineLength = 28;
+    private static final String INPUT_STRING =
+            "This is going to be a long test string with some longer words."
+                    + " This allows testing for splitting words when needed."
+                    + " This will also mean a shortened maxLineLength.\r\n"
+                    + "ParticularlyLongWordToBeSplit.\r\n"
+                    + "This will also test for some end of lines.";
+
+    private static final String EXPECTED_OUTPUT =
+            "This is going to be a long\r\ntest string with some longer\r\nwords."
+                    + " This allows testing\r\nfor splitting words when\r\nneeded."
+                    + " This will also mean\r\na shortened maxLineLength.\r\n"
+                    + "ParticularlyLongWordToBeSpli\r\nt.\r\n"
+                    + "This will also test for some\r\nend of lines.";
+
+    @Test
+    public void testLineWrap() throws IOException{
+        OutputStream outputStream = new ByteArrayOutputStream();
+        LineWrapOutputStream lineWrapOutputStream = new LineWrapOutputStream(outputStream, maxLineLength+2);
+        lineWrapOutputStream.write(INPUT_STRING.getBytes("US-ASCII"));
+        lineWrapOutputStream.flush();
+        assertEquals(EXPECTED_OUTPUT,outputStream.toString());
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/filter/LineWrapOutputStreamTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/filter/LineWrapOutputStreamTest.java
@@ -8,7 +8,6 @@ import org.junit.Test;
 import static org.junit.Assert.assertEquals;
 
 public class LineWrapOutputStreamTest {
-    private static final int maxLineLength = 28;
     private static final String INPUT_STRING =
             "This is going to be a long test string with some longer words."
                     + " This allows testing for splitting words when needed."
@@ -16,19 +15,35 @@ public class LineWrapOutputStreamTest {
                     + "ParticularlyLongWordToBeSplit.\r\n"
                     + "This will also test for some end of lines.";
 
-    private static final String EXPECTED_OUTPUT =
+    private static final String EXPECTED_OUTPUT_28 =
             "This is going to be a long\r\ntest string with some longer\r\nwords."
                     + " This allows testing\r\nfor splitting words when\r\nneeded."
                     + " This will also mean\r\na shortened maxLineLength.\r\n"
                     + "ParticularlyLongWordToBeSpli\r\nt.\r\n"
                     + "This will also test for some\r\nend of lines.";
 
+    private static final String EXPECTED_OUTPUT_30 =
+            "This is going to be a long\r\ntest string with some longer\r\nwords."
+                    + " This allows testing for\r\nsplitting words when needed."
+                    + "\r\nThis will also mean a\r\nshortened maxLineLength.\r\n"
+                    + "ParticularlyLongWordToBeSplit.\r\n"
+                    + "This will also test for some\r\nend of lines.";
+
     @Test
-    public void testLineWrap() throws IOException{
+    public void testLineWrapLength28() throws IOException{
         OutputStream outputStream = new ByteArrayOutputStream();
-        LineWrapOutputStream lineWrapOutputStream = new LineWrapOutputStream(outputStream, maxLineLength+2);
+        LineWrapOutputStream lineWrapOutputStream = new LineWrapOutputStream(outputStream, 28+2);
         lineWrapOutputStream.write(INPUT_STRING.getBytes("US-ASCII"));
         lineWrapOutputStream.flush();
-        assertEquals(EXPECTED_OUTPUT,outputStream.toString());
+        assertEquals("Failed on length 28",EXPECTED_OUTPUT_28,outputStream.toString());
+    }
+
+    @Test
+    public void testLineWrapLength30() throws IOException{
+        OutputStream outputStream = new ByteArrayOutputStream();
+        LineWrapOutputStream lineWrapOutputStream = new LineWrapOutputStream(outputStream, 30+2);
+        lineWrapOutputStream.write(INPUT_STRING.getBytes("US-ASCII"));
+        lineWrapOutputStream.flush();
+        assertEquals("Failed on length 30",EXPECTED_OUTPUT_30,outputStream.toString());
     }
 }


### PR DESCRIPTION
Unit test for LineWrapOutputStream.
Also found possible fix where a space causes it to find an earlier word boundary when not needed.

This is issue #2209