### PR TITLE
Fix remote search use of quantity resource

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -1577,7 +1577,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 mHandler.updateFooter(mContext.getString(R.string.remote_search_downloading_limited,
                         maxResults, numResults));
             } else {
-                mHandler.updateFooter(mContext.getString(R.string.remote_search_downloading, numResults));
+                mHandler.updateFooter(getResources().getQuantityString(
+                        R.plurals.remote_search_downloading, numResults, numResults));
             }
             mFragmentListener.setMessageListProgress(Window.PROGRESS_START);
         }


### PR DESCRIPTION
We were using the quantity resource incorrectly. This causes the search to fail (you get 'Remote search failed' even though the search itself works)

Possible cause of #1140 and #1985