### PR TITLE
Add support for the UIDVALIDITY field in IMAP accounts

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -39,7 +39,7 @@ import static com.fsck.k9.mail.K9MailLib.LOG_TAG;
 import static com.fsck.k9.mail.store.imap.ImapUtility.getLastResponse;
 
 
-class ImapFolder extends Folder<ImapMessage> {
+public class ImapFolder extends Folder<ImapMessage> {
     private static final ThreadLocal<SimpleDateFormat> RFC3501_DATE = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
@@ -161,6 +161,19 @@ class ImapFolder extends Folder<ImapMessage> {
             return responses;
         } catch (IOException ioe) {
             throw ioExceptionHandler(connection, ioe);
+        } catch (MessagingException me) {
+            Log.e(LOG_TAG, "Unable to open connection for " + getLogId(), me);
+            throw me;
+        }
+    }
+
+    public long getCurrentUidValidity() throws MessagingException {
+        if (isOpen()) {
+            close();
+        }
+        try {
+            List<ImapResponse> responses = internalOpen(OPEN_MODE_RO);
+            return SelectOrExamineResponse.extractUidValidity(responses);
         } catch (MessagingException me) {
             Log.e(LOG_TAG, "Unable to open connection for " + getLogId(), me);
             throw me;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponse.java
@@ -3,6 +3,8 @@ package com.fsck.k9.mail.store.imap;
 
 import com.fsck.k9.mail.Folder;
 
+import java.util.List;
+
 import static com.fsck.k9.mail.store.imap.ImapResponseParser.equalsIgnoreCase;
 
 
@@ -36,6 +38,24 @@ class SelectOrExamineResponse {
         }
 
         return noOpenModeInResponse();
+    }
+
+    public static long extractUidValidity(List<ImapResponse> responses) {
+        for(ImapResponse response : responses) {
+            int index = 0;
+            while (index < response.size()) {
+                if (response.isList(index)) {
+                    ImapList listResponse = response.getList(index);
+                    if (listResponse.isString(0) && listResponse.getString(0).equals("UIDVALIDITY")) {
+                        return Long.parseLong(listResponse.getString(1));
+                    }
+                }
+                index++;
+            }
+        }
+
+        //UIDVALIDITY was not found
+        return -1L;
     }
 
     private static SelectOrExamineResponse noOpenModeInResponse() {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseHelper.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseHelper.java
@@ -3,6 +3,8 @@ package com.fsck.k9.mail.store.imap;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 
 import com.fsck.k9.mail.filter.PeekableInputStream;
 
@@ -14,5 +16,13 @@ public class ImapResponseHelper {
         ImapResponseParser parser = new ImapResponseParser(inputStream);
 
         return parser.readResponse();
+    }
+
+    public static List<ImapResponse> createImapResponse(List<String> responses) throws IOException {
+        List<ImapResponse> imapResponses = new ArrayList<>();
+        for (String response : responses) {
+            imapResponses.add(createImapResponse(response));
+        }
+        return imapResponses;
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/SelectOrExamineResponseTest.java
@@ -3,6 +3,9 @@ package com.fsck.k9.mail.store.imap;
 
 import org.junit.Test;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RO;
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
 import static com.fsck.k9.mail.store.imap.ImapResponseHelper.createImapResponse;
@@ -13,6 +16,9 @@ import static org.junit.Assert.fail;
 
 
 public class SelectOrExamineResponseTest {
+
+    private static long UID_VALIDITY = 200L;
+
     @Test
     public void parse_withSelectResponse_shouldReturnOpenModeReadWrite() throws Exception {
         ImapResponse imapResponse = createImapResponse("x OK [READ-WRITE] Select completed.");
@@ -94,5 +100,17 @@ public class SelectOrExamineResponseTest {
         SelectOrExamineResponse result = SelectOrExamineResponse.parse(imapResponse);
 
         assertNull(result);
+    }
+
+    @Test
+    public void extractUidValidity_withSelectResponse_shouldReturnUidValidity() throws Exception {
+        List<String> stringResponse = new ArrayList<>();
+        stringResponse.add("* OK [UIDVALIDITY " + UID_VALIDITY + "] UIDs valid");
+        stringResponse.add("x OK [READ-WRITE] Select completed.");
+        List<ImapResponse> imapResponses = createImapResponse(stringResponse);
+
+        long uidValidity = SelectOrExamineResponse.extractUidValidity(imapResponses);
+
+        assertEquals(uidValidity, UID_VALIDITY);
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -90,6 +90,7 @@ import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mail.internet.TextBody;
 import com.fsck.k9.mail.power.TracingPowerManager;
 import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
+import com.fsck.k9.mail.store.imap.ImapFolder;
 import com.fsck.k9.mail.store.pop3.Pop3Store;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
@@ -842,6 +843,10 @@ public class MessagingController {
 
             }
 
+            if (account.getStoreUri().startsWith("imap")) {
+                handleImapUidValidity(account, tLocalFolder, (ImapFolder) remoteFolder, folder, listener);
+            }
+
             notificationController.clearAuthenticationErrorNotification(account, true);
 
             /*
@@ -1021,6 +1026,32 @@ public class MessagingController {
             closeFolder(tLocalFolder);
         }
 
+    }
+
+    private void handleImapUidValidity(Account account, LocalFolder localFolder,
+                                       ImapFolder remoteImapFolder, String folder,
+                                       MessagingListener listener) throws MessagingException {
+        long previousUidValidity = localFolder.getLastUidValidity(account.getUuid(), remoteImapFolder.getName());
+        long currentUidValidity = remoteImapFolder.getCurrentUidValidity();
+
+        if (previousUidValidity != -1L && currentUidValidity != -1L && currentUidValidity != previousUidValidity) {
+
+            //Delete all messages in the local folder
+            Set<String> localMessageUidSet = localFolder.getAllMessagesAndEffectiveDates().keySet();
+            List<String> localMessageUidList = new ArrayList<>();
+            localMessageUidList.addAll(localMessageUidSet);
+            List<LocalMessage> destroyMessages = localFolder.getMessagesByUids(localMessageUidList);
+            localFolder.destroyMessages(destroyMessages);
+            for (Message destroyMessage : destroyMessages) {
+                for (MessagingListener l : getListeners(listener)) {
+                    l.synchronizeMailboxRemovedMessage(account, folder, destroyMessage);
+                }
+            }
+        }
+
+        if (currentUidValidity != -1L) {
+            localFolder.saveUidValidity(currentUidValidity, account.getUuid(), remoteImapFolder.getName());
+        }
     }
 
     void handleAuthenticationFailure(Account account, boolean incoming) {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -30,6 +30,7 @@ import android.util.Log;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
+import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.activity.Search;
 import com.fsck.k9.helper.FileHelper;
@@ -74,6 +75,8 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     private static final long serialVersionUID = -1973296520918624767L;
     private static final int MAX_BODY_SIZE_FOR_DATABASE = 16 * 1024;
     static final long INVALID_MESSAGE_PART_ID = -1;
+    private static final char KEY_NAME_SEPARATOR = ':';
+    private static final String KEY_PREFIX_UIDVALIDITY = "uidvalidity";
 
     private final LocalStore localStore;
     private final AttachmentInfoExtractor attachmentInfoExtractor;
@@ -2059,6 +2062,21 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         }
 
         return new ThreadInfo(threadId, msgId, messageId, rootId, parentId);
+    }
+
+    public long getLastUidValidity(String accountUuid, String folderName) {
+        Storage storage = Preferences.getPreferences(K9.app).getStorage();
+        String[] keyParts = {KEY_PREFIX_UIDVALIDITY, accountUuid, folderName};
+        String key = Utility.combine(keyParts, KEY_NAME_SEPARATOR);
+        return storage.getLong(key, -1L);
+    }
+
+    public void saveUidValidity(long newUidValidity, String accountUuid, String folderName) {
+        StorageEditor editor = Preferences.getPreferences(K9.app).getStorage().edit();
+        String[] keyParts = {KEY_PREFIX_UIDVALIDITY, accountUuid, folderName};
+        String key = Utility.combine(keyParts, KEY_NAME_SEPARATOR);
+        editor.putLong(key, newUidValidity);
+        editor.commit();
     }
 
     public List<Message> extractNewMessages(final List<Message> messages)


### PR DESCRIPTION
Related issue : #1074 

I tested this by creating a new folder in my email account, deleting it and recreating it with the same name. All the emails in the folder were reloaded.