### PR TITLE
Timber format error

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/service/MailService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/MailService.java
@@ -276,7 +276,7 @@ public class MailService extends CoreService {
                     !considerLastCheckEnd ? System.currentTimeMillis() : lastCheckEnd);
             long nextTime = base + delay;
 
-            Timber.i("previousInterval = %d, shortestInterval = %d, lastCheckEnd = %tc, considerLastCheckEnd = %tc",
+            Timber.i("previousInterval = %d, shortestInterval = %d, lastCheckEnd = %tc, considerLastCheckEnd = %b",
                     previousInterval,
                     shortestInterval,
                     lastCheckEnd,


### PR DESCRIPTION
considerLastCheckEnd is a boolean.
Timber was trating a boolean as a time which will cause a crash on boot when called.