### PR TITLE
Fixes to various lint-detected issues

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/BinaryTempFileBody.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/BinaryTempFileBody.java
@@ -138,7 +138,8 @@ public class BinaryTempFileBody implements RawDataBody, SizeAware {
             } finally {
                 Log.d(K9MailLib.LOG_TAG, "deleting temp file");
                 boolean fileDeleteResult = mFile.delete();
-                if (!fileDeleteResult) Log.i(K9MailLib.LOG_TAG, "fail to delete temp file");
+                if (!fileDeleteResult)
+                    Log.i(K9MailLib.LOG_TAG, "fail to delete temp file");
             }
         }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/BinaryTempFileBody.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/BinaryTempFileBody.java
@@ -136,10 +136,11 @@ public class BinaryTempFileBody implements RawDataBody, SizeAware {
             try {
                 super.close();
             } finally {
-                Log.d(K9MailLib.LOG_TAG, "deleting temp file");
-                boolean fileDeleteResult = mFile.delete();
-                if (!fileDeleteResult)
-                    Log.i(K9MailLib.LOG_TAG, "fail to delete temp file");
+                Log.d(K9MailLib.LOG_TAG, "deleting " + mFile.getName() + " file");
+                boolean fileSuccessfullyDeleted = mFile.delete();
+                if (!fileSuccessfullyDeleted){
+                    Log.i(K9MailLib.LOG_TAG, "fail to delete " + mFile.getName() + " file");
+                }
             }
         }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/BinaryTempFileBody.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/BinaryTempFileBody.java
@@ -59,7 +59,7 @@ public class BinaryTempFileBody implements RawDataBody, SizeAware {
             File newFile = File.createTempFile("body", null, mTempDirectory);
             final OutputStream out = new FileOutputStream(newFile);
             try {
-                OutputStream wrappedOut = null;
+                OutputStream wrappedOut;
                 if (MimeUtil.ENC_QUOTED_PRINTABLE.equals(encoding)) {
                     wrappedOut = new QuotedPrintableOutputStream(out, false);
                 } else if (MimeUtil.ENC_BASE64.equals(encoding)) {
@@ -137,7 +137,8 @@ public class BinaryTempFileBody implements RawDataBody, SizeAware {
                 super.close();
             } finally {
                 Log.d(K9MailLib.LOG_TAG, "deleting temp file");
-                mFile.delete();
+                boolean fileDeleteResult = mFile.delete();
+                if (!fileDeleteResult) Log.i(K9MailLib.LOG_TAG, "fail to delete temp file");
             }
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -4,6 +4,8 @@ package com.fsck.k9;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +25,6 @@ import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.StrictMode;
-import android.text.format.Time;
 
 import com.fsck.k9.Account.SortType;
 import com.fsck.k9.activity.MessageCompose;
@@ -979,14 +980,14 @@ public class K9 extends Application {
             return false;
         }
 
-        Time time = new Time();
-        time.setToNow();
+        GregorianCalendar gregorianCalendar = new GregorianCalendar();
+
         Integer startHour = Integer.parseInt(mQuietTimeStarts.split(":")[0]);
         Integer startMinute = Integer.parseInt(mQuietTimeStarts.split(":")[1]);
         Integer endHour = Integer.parseInt(mQuietTimeEnds.split(":")[0]);
         Integer endMinute = Integer.parseInt(mQuietTimeEnds.split(":")[1]);
 
-        Integer now = (time.hour * 60) + time.minute;
+        Integer now = (gregorianCalendar.get(Calendar.HOUR) * 60) + gregorianCalendar.get(Calendar.MINUTE);
         Integer quietStarts = startHour * 60 + startMinute;
         Integer quietEnds =  endHour * 60 + endMinute;
 
@@ -1422,7 +1423,7 @@ public class K9 extends Application {
         if (save) {
             Editor editor = sDatabaseVersionCache.edit();
             editor.putInt(KEY_LAST_ACCOUNT_DATABASE_VERSION, LocalStore.DB_VERSION);
-            editor.commit();
+            editor.apply();
         }
     }
 


### PR DESCRIPTION
Hi @philipwhiuk, I have made the changes accordingly.

1. As mentioned, this will be fixed by the change to Material Design and I did not make any changes to it.

2. For the fixed on 'android.text.format.Time' is deprecated, I used java.util for GregorianCalendar and Calendar instead of android.icu.util. Using android.icu.util will result in "Call requires API level 24 (current min is 15)", hence I believed it would be better for us to use java.util instead of making changes to the API level; which will cause the app to stop working properly on older devices.

3. As for Result of File.delete() is ignored, I have added some logging in the case of failure.

I have also inspected BinaryTempFileBody.java and K9.java with Lint and make some fixed on code style.

4. OutputStream warappedOut = null; has been indicated as redundancy by Lint.

5. Lint - Correctness suggested using ['apply()'](https://developer.android.com/reference/android/content/SharedPreferences.Editor.html#apply()) instead of 'commit()'. As commit writes its data to persistent storage immediately, whereas 'apply' will handle it in background. 

At the current stage, Lint has cleared BinaryTempFileBody.java of any warnings. While there is still some issues flag by Lint in K9.java which I will look into it later on.

Do take a look and give me some feedback as I am new to this and looking for learning opportunities by participating in GSOC this year under K9. Let me know if there are any issues and I will be glad to make any changes.
