### PR TITLE
Continue to support old 'search' extra in MessageList Intent

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -72,8 +72,11 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         MessageViewFragmentListener, OnBackStackChangedListener, OnSwipeGestureListener,
         OnSwitchCompleteListener {
 
-    // for this activity
-    private static final String EXTRA_SEARCH = "search";
+    @Deprecated
+    //TODO: Remove after 2017-09-11
+    private static final String EXTRA_SEARCH_OLD = "search";
+
+    private static final String EXTRA_SEARCH = "search_bytes";
     private static final String EXTRA_NO_THREADING = "no_threading";
 
     private static final String ACTION_SHORTCUT = "shortcut";
@@ -431,6 +434,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                     mSearch.addAccountUuid(LocalSearch.ALL_ACCOUNTS);
                 }
             }
+        } else if (intent.hasExtra(EXTRA_SEARCH_OLD)) {
+            mSearch = intent.getParcelableExtra(EXTRA_SEARCH_OLD);
+            mNoThreading = intent.getBooleanExtra(EXTRA_NO_THREADING, false);
         } else {
             // regular LocalSearch object was passed
             mSearch = intent.hasExtra(EXTRA_SEARCH) ?


### PR DESCRIPTION
PR #2169 changed the format of the search extra in the Intent used to start the message list. But when a user had an unread widget on the home screen the system would hold on to a PendingIntent with a search extra in the old format. That's why opening the app using the unread widget would crash.

I re-added support for the old extra. A reboot recreates the PendingIntent for existing unread widgets (then using the new format). That's why there's an expiration date that is not too far in the future.

Fixes #2282