### PR TITLE
Use Storage Access Framework for settings export

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -15,6 +15,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import android.content.Context;
+import android.net.Uri;
 import android.os.Environment;
 import timber.log.Timber;
 import android.util.Xml;
@@ -32,7 +33,7 @@ import org.xmlpull.v1.XmlSerializer;
 
 
 public class SettingsExporter {
-    private static final String EXPORT_FILENAME = "settings.k9s";
+    public static final String EXPORT_FILENAME = "settings.k9s";
 
     /**
      * File format version number.
@@ -108,7 +109,28 @@ public class SettingsExporter {
         }
     }
 
-    static void exportPreferences(Context context, OutputStream os, boolean includeGlobals, Set<String> accountUuids)
+    public static void exportToUri(Context context, boolean includeGlobals, Set<String> accountUuids, Uri uri)
+            throws SettingsImportExportException {
+
+        OutputStream os = null;
+        String filename = null;
+        try {
+            os = context.getContentResolver().openOutputStream(uri);
+            exportPreferences(context, os, includeGlobals, accountUuids);
+        } catch (Exception e) {
+            throw new SettingsImportExportException(e);
+        } finally {
+            if (os != null) {
+                try {
+                    os.close();
+                } catch (IOException ioe) {
+                    Log.w(K9.LOG_TAG, "Couldn't close exported settings file: " + filename);
+                }
+            }
+        }
+    }
+
+   static void exportPreferences(Context context, OutputStream os, boolean includeGlobals, Set<String> accountUuids)
             throws SettingsImportExportException {
 
         try {

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -975,6 +975,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="settings_importing">Importing settings…</string>
     <string name="settings_import_scanning_file">Scanning file…</string>
     <string name="settings_export_success">Saved exported settings to <xliff:g id="filename">%s</xliff:g></string>
+    <string name="settings_export_success_generic">Settings successfully exported</string>
     <string name="settings_import_global_settings_success">Imported global settings from <xliff:g id="filename">%s</xliff:g></string>
     <string name="settings_import_success">Imported <xliff:g id="accounts">%s</xliff:g> from <xliff:g id="filename">%s</xliff:g></string>
     <plurals name="settings_import_accounts">


### PR DESCRIPTION
On API 19+ devices the Storage Access Framework will be used to allow the user to specify where the settings file will be saved.

This continues the work started by @GoneUp in PR #2256.