### PR TITLE
Use SystremClock.elapsedRealtime() to measure durations

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/power/TracingPowerManager.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/power/TracingPowerManager.java
@@ -4,12 +4,13 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import com.fsck.k9.mail.K9MailLib;
-
 import android.content.Context;
 import android.os.PowerManager;
 import android.os.PowerManager.WakeLock;
+import android.os.SystemClock;
 import android.util.Log;
+
+import com.fsck.k9.mail.K9MailLib;
 
 import static com.fsck.k9.mail.K9MailLib.LOG_TAG;
 
@@ -67,7 +68,7 @@ public class TracingPowerManager {
             }
             raiseNotification();
             if (startTime == null) {
-                startTime = System.currentTimeMillis();
+                startTime = SystemClock.elapsedRealtime();
             }
             this.timeout = timeout;
         }
@@ -80,7 +81,7 @@ public class TracingPowerManager {
                 Log.w(LOG_TAG, "TracingWakeLock for tag " + tag + " / id " + id + ": acquired with no timeout.  K-9 Mail should not do this");
             }
             if (startTime == null) {
-                startTime = System.currentTimeMillis();
+                startTime = SystemClock.elapsedRealtime();
             }
             timeout = null;
         }
@@ -91,7 +92,7 @@ public class TracingPowerManager {
         }
         public void release() {
             if (startTime != null) {
-                Long endTime = System.currentTimeMillis();
+                Long endTime = SystemClock.elapsedRealtime();
                 if (K9MailLib.isDebug()) {
                     Log.v(LOG_TAG, "TracingWakeLock for tag " + tag + " / id " + id + ": releasing after " + (endTime - startTime) + " ms, timeout = " + timeout + " ms");
                 }
@@ -126,7 +127,7 @@ public class TracingPowerManager {
                         @Override
                         public void run() {
                             if (startTime != null) {
-                                Long endTime = System.currentTimeMillis();
+                                Long endTime = SystemClock.elapsedRealtime();
                                 Log.i(LOG_TAG, "TracingWakeLock for tag " + tag + " / id " + id + ": has been active for "
                                       + (endTime - startTime) + " ms, timeout = " + timeout + " ms");
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo42.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo42.java
@@ -3,14 +3,14 @@ package com.fsck.k9.mailstore.migrations;
 
 import java.util.List;
 
-import timber.log.Timber;
+import android.os.SystemClock;
 
-import com.fsck.k9.K9;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
+import timber.log.Timber;
 
 
 class MigrationTo42 {
@@ -19,7 +19,7 @@ class MigrationTo42 {
             LocalStore localStore = migrationsHelper.getLocalStore();
             Storage storage = migrationsHelper.getStorage();
 
-            long startTime = System.currentTimeMillis();
+            long startTime = SystemClock.elapsedRealtime();
             StorageEditor editor = storage.edit();
 
             List<? extends Folder > folders = localStore.getPersonalNamespaces(true);
@@ -31,7 +31,7 @@ class MigrationTo42 {
             }
 
             editor.commit();
-            long endTime = System.currentTimeMillis();
+            long endTime = SystemClock.elapsedRealtime();
             Timber.i("Putting folder preferences for %d folders back into Preferences took %d ms",
                     folders.size(), endTime - startTime);
         } catch (Exception e) {

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Storage.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Storage.java
@@ -1,16 +1,5 @@
 package com.fsck.k9.preferences;
 
-import android.content.ContentValues;
-import android.content.Context;
-import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteStatement;
-import timber.log.Timber;
-
-import com.fsck.k9.K9;
-import com.fsck.k9.helper.UrlEncodingHelper;
-import com.fsck.k9.helper.Utility;
-import com.fsck.k9.mail.filter.Base64;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -18,6 +7,18 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
+import android.os.SystemClock;
+
+import com.fsck.k9.helper.UrlEncodingHelper;
+import com.fsck.k9.helper.Utility;
+import com.fsck.k9.mail.filter.Base64;
+import timber.log.Timber;
 
 public class Storage {
     private static ConcurrentMap<Context, Storage> storages =
@@ -158,7 +159,7 @@ public class Storage {
     }
 
     private void loadValues() {
-        long startTime = System.currentTimeMillis();
+        long startTime = SystemClock.elapsedRealtime();
         Timber.i("Loading preferences from DB into Storage");
         Cursor cursor = null;
         SQLiteDatabase mDb = null;
@@ -177,7 +178,7 @@ public class Storage {
             if (mDb != null) {
                 mDb.close();
             }
-            long endTime = System.currentTimeMillis();
+            long endTime = SystemClock.elapsedRealtime();
             Timber.i("Preferences load took %d ms", endTime - startTime);
         }
     }

--- a/k9mail/src/main/java/com/fsck/k9/preferences/StorageEditor.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/StorageEditor.java
@@ -1,13 +1,15 @@
 package com.fsck.k9.preferences;
 
-import timber.log.Timber;
-import com.fsck.k9.K9;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+
+import android.os.SystemClock;
+
+import timber.log.Timber;
 
 
 public class StorageEditor {
@@ -48,7 +50,7 @@ public class StorageEditor {
     }
 
     private void commitChanges() {
-        long startTime = System.currentTimeMillis();
+        long startTime = SystemClock.elapsedRealtime();
         Timber.i("Committing preference changes");
         Runnable committer = new Runnable() {
             public void run() {
@@ -68,7 +70,7 @@ public class StorageEditor {
             }
         };
         storage.doInTransaction(committer);
-        long endTime = System.currentTimeMillis();
+        long endTime = SystemClock.elapsedRealtime();
         Timber.i("Preferences commit took %d ms", endTime - startTime);
 
     }

--- a/k9mail/src/main/java/com/fsck/k9/service/MailService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/MailService.java
@@ -1,26 +1,25 @@
 
 package com.fsck.k9.service;
 
+
 import java.util.Collection;
-import java.util.Date;
 
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.os.IBinder;
-import timber.log.Timber;
+import android.os.SystemClock;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.Account.FolderMode;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
-import com.fsck.k9.Account.FolderMode;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Pusher;
 import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
-
-import static java.lang.System.currentTimeMillis;
+import timber.log.Timber;
 
 
 public class MailService extends CoreService {
@@ -88,7 +87,7 @@ public class MailService extends CoreService {
 
     @Override
     public int startService(Intent intent, int startId) {
-        long startTime = System.currentTimeMillis();
+        long startTime = SystemClock.elapsedRealtime();
         boolean oldIsSyncDisabled = isSyncDisabled();
         boolean doBackground = true;
 
@@ -149,7 +148,7 @@ public class MailService extends CoreService {
             MessagingController.getInstance(getApplication()).systemStatusChanged();
         }
 
-        Timber.i("MailService.onStart took %d ms", currentTimeMillis() - startTime);
+        Timber.i("MailService.onStart took %d ms", SystemClock.elapsedRealtime() - startTime);
 
         return START_NOT_STICKY;
     }

--- a/k9mail/src/main/java/com/fsck/k9/service/SleepService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/SleepService.java
@@ -1,15 +1,17 @@
 package com.fsck.k9.service;
 
-import android.content.Context;
-import android.content.Intent;
-import timber.log.Timber;
-import com.fsck.k9.K9;
-import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.SystemClock;
+
+import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
+import timber.log.Timber;
 
 import static java.lang.Thread.currentThread;
 
@@ -37,7 +39,7 @@ public class SleepService extends CoreService {
         Intent i = new Intent(context, SleepService.class);
         i.putExtra(LATCH_ID, id);
         i.setAction(ALARM_FIRED + "." + id);
-        long startTime = System.currentTimeMillis();
+        long startTime = SystemClock.elapsedRealtime();
         long nextTime = startTime + sleepTime;
         BootReceiver.scheduleIntent(context, nextTime, i);
         if (wakeLock != null) {
@@ -73,7 +75,7 @@ public class SleepService extends CoreService {
             reacquireWakeLock(releaseDatum);
         }
 
-        long endTime = System.currentTimeMillis();
+        long endTime = SystemClock.elapsedRealtime();
         long actualSleep = endTime - startTime;
 
         if (actualSleep < sleepTime) {


### PR DESCRIPTION
Issue #2318 Used `SystremClock.elapsedRealtime()` to measure time durations between two events instead of `System.currentTimeMillis`