### PR TITLE
Checking case insensitivity only for INBOX 

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -1370,7 +1370,10 @@ class ImapFolder extends Folder<ImapMessage> {
     public boolean equals(Object other) {
         if (other instanceof ImapFolder) {
             ImapFolder otherFolder = (ImapFolder) other;
-            return otherFolder.getName().equalsIgnoreCase(getName());
+            if(otherFolder.getName().equalsIgnoreCase("INBOX")){
+                return getName().equalsIgnoreCase("INBOX");
+            }
+            return otherFolder.getName().equals(getName());
         }
 
         return super.equals(other);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -1369,11 +1369,8 @@ class ImapFolder extends Folder<ImapMessage> {
     @Override
     public boolean equals(Object other) {
         if (other instanceof ImapFolder) {
-            ImapFolder otherFolder = (ImapFolder) other;
-            if(otherFolder.getName().equalsIgnoreCase("INBOX")){
-                return getName().equalsIgnoreCase("INBOX");
-            }
-            return otherFolder.getName().equals(getName());
+
+            return other.hashCode() == hashCode() ;
         }
 
         return super.equals(other);
@@ -1381,6 +1378,10 @@ class ImapFolder extends Folder<ImapMessage> {
 
     @Override
     public int hashCode() {
+        if(getName().equalsIgnoreCase("INBOX")){
+
+            return "INBOX".hashCode();
+        }
         return getName().hashCode();
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -1369,8 +1369,11 @@ class ImapFolder extends Folder<ImapMessage> {
     @Override
     public boolean equals(Object other) {
         if (other instanceof ImapFolder) {
-
-            return other.hashCode() == hashCode() ;
+            ImapFolder otherFolder = (ImapFolder) other;
+            if (otherFolder.getName().equalsIgnoreCase("INBOX")) {
+                return otherFolder.getName().equalsIgnoreCase(getName());
+            }
+            return otherFolder.getName().equals(getName());
         }
 
         return super.equals(other);
@@ -1378,7 +1381,7 @@ class ImapFolder extends Folder<ImapMessage> {
 
     @Override
     public int hashCode() {
-        if(getName().equalsIgnoreCase("INBOX")){
+        if (getName().equalsIgnoreCase("INBOX")) {
 
             return "INBOX".hashCode();
         }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -39,9 +39,11 @@ import static com.fsck.k9.mail.Folder.OPEN_MODE_RO;
 import static com.fsck.k9.mail.Folder.OPEN_MODE_RW;
 import static com.fsck.k9.mail.store.imap.ImapResponseHelper.createImapResponse;
 import static java.util.Arrays.asList;
+import static java.util.Arrays.copyOfRange;
 import static java.util.Collections.singletonList;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
@@ -1237,5 +1239,31 @@ public class ImapFolderTest {
 
     private void assertCheckOpenErrorMessage(String folderName, MessagingException e) {
         assertEquals("Folder " + folderName + " is not open.", e.getMessage());
+    }
+
+    @Test
+    public void equals_returnsFalse_whenCaseDifferent() {
+        ImapFolder imapFolder = createFolder("Folder");
+        ImapFolder imapFolder2 = createFolder("folder");
+        assertNotEquals(imapFolder.hashCode(), imapFolder2.hashCode());
+        assertFalse(imapFolder.equals(imapFolder2));
+    }
+
+    @Test
+    public void equlas_returnsTrue_inboxCaseDifferent(){
+        ImapFolder imapFolder = createFolder("Inbox");
+        ImapFolder imapFolder2 = createFolder("inbox");
+        ImapFolder imapFolder3 = createFolder("INBOX");
+
+        assertTrue(imapFolder.equals(imapFolder2));
+        assertTrue(imapFolder2.equals(imapFolder3));
+    }
+
+    @Test
+    public void equals_returnsTrue_inboxCaseSame(){
+        ImapFolder imapFolder = createFolder("INBOX");
+        ImapFolder imapFolder2 = createFolder("INBOX");
+
+        assertTrue(imapFolder.equals(imapFolder2));
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -1250,7 +1250,7 @@ public class ImapFolderTest {
     }
 
     @Test
-    public void equlas_returnsTrue_inboxCaseDifferent(){
+    public void equals_returnsTrue_inboxCaseDifferent(){
         ImapFolder imapFolder = createFolder("Inbox");
         ImapFolder imapFolder2 = createFolder("inbox");
         ImapFolder imapFolder3 = createFolder("INBOX");
@@ -1265,5 +1265,13 @@ public class ImapFolderTest {
         ImapFolder imapFolder2 = createFolder("INBOX");
 
         assertTrue(imapFolder.equals(imapFolder2));
+    }
+
+    @Test
+    public void hashCode_returnTrue_inboxCaseDifferent(){
+        ImapFolder imapFolder = createFolder("Inbox");
+        ImapFolder imapFolder2 = createFolder("inbox");
+
+        assertEquals(imapFolder.hashCode(),imapFolder2.hashCode());
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -1242,15 +1242,15 @@ public class ImapFolderTest {
     }
 
     @Test
-    public void equals_returnsFalse_whenCaseDifferent() {
+    public void equals_withDifferentCase_shouldReturnFalse() {
         ImapFolder imapFolder = createFolder("Folder");
         ImapFolder imapFolder2 = createFolder("folder");
-        assertNotEquals(imapFolder.hashCode(), imapFolder2.hashCode());
+
         assertFalse(imapFolder.equals(imapFolder2));
     }
 
     @Test
-    public void equals_returnsTrue_inboxCaseDifferent(){
+    public void equals_withInboxCaseDifferent_shouldReturnTrue() {
         ImapFolder imapFolder = createFolder("Inbox");
         ImapFolder imapFolder2 = createFolder("inbox");
         ImapFolder imapFolder3 = createFolder("INBOX");
@@ -1260,7 +1260,7 @@ public class ImapFolderTest {
     }
 
     @Test
-    public void equals_returnsTrue_inboxCaseSame(){
+    public void equals_withInboxCaseSame_shouldReturnTrue() {
         ImapFolder imapFolder = createFolder("INBOX");
         ImapFolder imapFolder2 = createFolder("INBOX");
 
@@ -1268,10 +1268,10 @@ public class ImapFolderTest {
     }
 
     @Test
-    public void hashCode_returnTrue_inboxCaseDifferent(){
+    public void hashCode_withInboxCaseDifferent_shouldReturnTrue() {
         ImapFolder imapFolder = createFolder("Inbox");
         ImapFolder imapFolder2 = createFolder("inbox");
 
-        assertEquals(imapFolder.hashCode(),imapFolder2.hashCode());
+        assertEquals(imapFolder.hashCode(), imapFolder2.hashCode());
     }
 }


### PR DESCRIPTION
rfc 3501 specify that you must provide case Insensitivity to INBOX folder and other folder may or may not be case sensitive depending upon the server implementation .
Added tests as provided by @philipwhiuk .

resolve Issue  #632