### PR TITLE
Copy email id to clipboard on long press

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -183,6 +183,7 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
                 TokenImageSpan[] links = text.getSpans(offset, offset, RecipientTokenSpan.class);
                 if (links.length > 0) {
                     showAlternates(links[0].getToken());
+                    handler.removeCallbacks(recipientLongPressed);
                     return true;
                 }
             }

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -203,6 +203,8 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="account_size_changed">Account \"<xliff:g id="account">%s</xliff:g>\" shrunk from <xliff:g id="oldSize">%s</xliff:g> to <xliff:g id="newSize">%s</xliff:g></string>
 
+    <string name="email_copied_to_clipboard">Copied to clipboard</string>
+
     <string name="compacting_account">Compacting account \"<xliff:g id="account">%s</xliff:g>\"</string>
     <string name="clearing_account">Clearing account \"<xliff:g id="account">%s</xliff:g>\"</string>
     <string name="recreating_account">Recreating account \"<xliff:g id="account">%s</xliff:g>\"</string>


### PR DESCRIPTION
Added ability to copy an email address from the recipient field to the clipboard if the recipient is long pressed. A toast is also shown to the user for visual confirmation.
For issue #2364 