### PR TITLE
Add feature: only download image via Wi-Fi

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -197,6 +197,7 @@ public class Account implements BaseAccount, StoreConfig {
     private SortType sortType;
     private Map<SortType, Boolean> sortAscending = new HashMap<>();
     private ShowPictures showPictures;
+    private boolean onlyShowPicturesViaWiFi;
     private boolean isSignatureBeforeQuotedText;
     private Expunge expungePolicy = Expunge.EXPUNGE_IMMEDIATELY;
     private int maxPushFolders;
@@ -295,6 +296,7 @@ public class Account implements BaseAccount, StoreConfig {
         sortType = DEFAULT_SORT_TYPE;
         sortAscending.put(DEFAULT_SORT_TYPE, DEFAULT_SORT_ASCENDING);
         showPictures = ShowPictures.NEVER;
+        onlyShowPicturesViaWiFi = false;
         isSignatureBeforeQuotedText = false;
         expungePolicy = Expunge.EXPUNGE_IMMEDIATELY;
         autoExpandFolderName = INBOX;
@@ -446,7 +448,9 @@ public class Account implements BaseAccount, StoreConfig {
         notificationSetting.setVibrateTimes(storage.getInt(accountUuid + ".vibrateTimes", 5));
         notificationSetting.setRingEnabled(storage.getBoolean(accountUuid + ".ring", true));
         notificationSetting.setRingtone(storage.getString(accountUuid + ".ringtone",
-                                         "content://settings/system/notification_sound"));
+                "content://settings/system/notification_sound"));
+        onlyShowPicturesViaWiFi = storage.getBoolean(accountUuid + ".onlyShowPicturesViaWiFi", false);
+
         notificationSetting.setLed(storage.getBoolean(accountUuid + ".led", true));
         notificationSetting.setLedColor(storage.getInt(accountUuid + ".ledColor", chipColor));
 
@@ -699,6 +703,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putString(accountUuid + ".sortTypeEnum", sortType.name());
         editor.putBoolean(accountUuid + ".sortAscending", sortAscending.get(sortType));
         editor.putString(accountUuid + ".showPicturesEnum", showPictures.name());
+        editor.putBoolean(accountUuid + ".onlyShowPicturesViaWiFi", onlyShowPicturesViaWiFi);
         editor.putString(accountUuid + ".folderDisplayMode", folderDisplayMode.name());
         editor.putString(accountUuid + ".folderSyncMode", folderSyncMode.name());
         editor.putString(accountUuid + ".folderPushMode", folderPushMode.name());
@@ -1212,6 +1217,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public synchronized void setShowPictures(ShowPictures showPictures) {
         this.showPictures = showPictures;
+    }
+
+    public synchronized boolean isOnlyShowPicturesViaWiFi() {
+        return onlyShowPicturesViaWiFi;
+    }
+
+    public synchronized void setOnlyShowPicturesViaWiFi(boolean onlyShowPicturesViaWiFi) {
+        this.onlyShowPicturesViaWiFi = onlyShowPicturesViaWiFi;
     }
 
     public synchronized FolderMode getFolderTargetMode() {

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -554,6 +554,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.remove(accountUuid + ".sortTypeEnum");
         editor.remove(accountUuid + ".sortAscending");
         editor.remove(accountUuid + ".showPicturesEnum");
+        editor.remove(accountUuid + ".onlyShowPicturesViaWiFi");
         editor.remove(accountUuid + ".replyAfterQuote");
         editor.remove(accountUuid + ".stripSignature");
         editor.remove(accountUuid + ".cryptoApp"); // this is no longer set, but cleans up legacy values

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -74,6 +74,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_DISPLAY_COUNT = "account_display_count";
     private static final String PREFERENCE_DEFAULT = "account_default";
     private static final String PREFERENCE_SHOW_PICTURES = "show_pictures_enum";
+    private static final String PREFERENCE_ONLY_SHOW_PICTURES_VIA_WIFI = "only_show_pictures_via_wifi";
     private static final String PREFERENCE_NOTIFY = "account_notify";
     private static final String PREFERENCE_NOTIFY_NEW_MAIL_MODE = "folder_notify_new_mail_mode";
     private static final String PREFERENCE_NOTIFY_SELF = "account_notify_self";
@@ -147,6 +148,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private CheckBoxPreference accountNotifySelf;
     private CheckBoxPreference accountNotifyContactsMailOnly;
     private ListPreference accountShowPictures;
+    private CheckBoxPreference accountOnlyShowPicturesViaWiFi;
     private CheckBoxPreference accountNotifySync;
     private CheckBoxPreference accountVibrateEnabled;
     private CheckBoxPreference accountLedEnabled;
@@ -472,10 +474,17 @@ public class AccountSettings extends K9PreferenceActivity {
                 int index = accountShowPictures.findIndexOfValue(summary);
                 accountShowPictures.setSummary(accountShowPictures.getEntries()[index]);
                 accountShowPictures.setValue(summary);
+
+                accountOnlyShowPicturesViaWiFi.setEnabled(ShowPictures.valueOf(summary) != ShowPictures.NEVER);
+
                 return false;
             }
         });
 
+        accountOnlyShowPicturesViaWiFi = (CheckBoxPreference) findPreference(PREFERENCE_ONLY_SHOW_PICTURES_VIA_WIFI);
+        accountOnlyShowPicturesViaWiFi.setChecked(account.isOnlyShowPicturesViaWiFi());
+        accountOnlyShowPicturesViaWiFi
+                .setEnabled(ShowPictures.valueOf(accountShowPictures.getValue()) != ShowPictures.NEVER);
 
         localStorageProvider = (ListPreference) findPreference(PREFERENCE_LOCAL_STORAGE_PROVIDER);
         {
@@ -834,6 +843,8 @@ public class AccountSettings extends K9PreferenceActivity {
         }
 
         account.setShowPictures(ShowPictures.valueOf(accountShowPictures.getValue()));
+
+        account.setOnlyShowPicturesViaWiFi(accountOnlyShowPicturesViaWiFi.isChecked());
 
         //IMAP specific stuff
         if (isPushCapable) {

--- a/k9mail/src/main/java/com/fsck/k9/helper/NetworkHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/NetworkHelper.java
@@ -1,0 +1,31 @@
+package com.fsck.k9.helper;
+
+
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+
+import com.fsck.k9.Globals;
+import com.fsck.k9.mail.NetworkType;
+
+
+/**
+ * Created by daquexian on 17-4-7.
+ */
+
+public class NetworkHelper {
+    public static boolean isActiveNetworkMeteredCompat() {
+        ConnectivityManager connectivityManager =
+                (ConnectivityManager) Globals.getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+
+        if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN) {
+            return connectivityManager.isActiveNetworkMetered();
+        } else {
+            NetworkType networkType =
+                    NetworkType.fromConnectivityManagerType(connectivityManager.getActiveNetworkInfo().getType());
+
+            return networkType != NetworkType.WIFI;
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -7,6 +7,9 @@ import android.animation.ObjectAnimator;
 import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.net.ConnectivityManager;
+import android.os.Build;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.support.annotation.StringRes;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -20,9 +23,11 @@ import android.widget.TextView;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.ShowPictures;
+import com.fsck.k9.BuildConfig;
 import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.helper.NetworkHelper;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.NetworkType;
@@ -307,16 +312,7 @@ public class MessageTopView extends LinearLayout {
     }
 
     private boolean shouldShowPicturesInCurrentNetwork(boolean onlyShowViaWiFi) {
-        if (!onlyShowViaWiFi) {
-            return true;
-        }
-
-        final ConnectivityManager connectivityManager =
-                (ConnectivityManager) getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
-        NetworkType networkType =
-                NetworkType.fromConnectivityManagerType(connectivityManager.getActiveNetworkInfo().getType());
-
-        return networkType == NetworkType.WIFI;
+        return !onlyShowViaWiFi || !NetworkHelper.isActiveNetworkMeteredCompat();
     }
 
     private String getSenderEmailAddress(Message message) {

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -554,6 +554,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_show_pictures_only_from_contacts">From contacts</string>
     <string name="account_settings_show_pictures_always">From anyone</string>
 
+    <string name="account_settings_only_show_pictures_via_wifi">Only download images via Wi-Fi</string>
+
     <string name="account_settings_composition">Sending mail</string>
 
     <string name="account_settings_default_quoted_text_shown_label">Quote message when replying</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -68,6 +68,11 @@
 
         <CheckBoxPreference
             android:persistent="false"
+            android:key="only_show_pictures_via_wifi"
+            android:title="@string/account_settings_only_show_pictures_via_wifi" />
+
+        <CheckBoxPreference
+            android:persistent="false"
             android:key="mark_message_as_read_on_view"
             android:title="@string/account_settings_mark_message_as_read_on_view_label"
             android:summary="@string/account_settings_mark_message_as_read_on_view_summary" />


### PR DESCRIPTION
Fixes #1502 

Add a feature that only download images via Wi-Fi

Since this option should be parallel with "Always show images" (the option "only download image via Wi-Fi" should have its own value regardless of the value of "Always show images"), so a separate checkbox is added.