### PR TITLE
Fix for drafts getting deleted during IMAP sync

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Flag.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Flag.java
@@ -62,4 +62,10 @@ public enum Flag {
      * This flag is used for drafts where the message should be sent as PGP/INLINE.
      */
     X_DRAFT_OPENPGP_INLINE,
+
+    /**
+     * This flag is used for secure message drafts which are to be stored locally only and not remotely (until draft encryption is implemented).
+     */
+    X_SECURE_MESSAGE_DRAFT,
+
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -141,6 +141,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private static final int MSG_PROGRESS_OFF = 2;
     public static final int MSG_SAVED_DRAFT = 4;
     private static final int MSG_DISCARDED_DRAFT = 5;
+    public static final int SECURE_MSG_DRAFT_SAVED = 6;
 
     private static final int REQUEST_MASK_RECIPIENT_PRESENTER = (1 << 8);
     private static final int REQUEST_MASK_LOADER_HELPER = (1 << 9);
@@ -1770,6 +1771,13 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                     Toast.makeText(
                             MessageCompose.this,
                             getString(R.string.message_discarded_toast),
+                            Toast.LENGTH_LONG).show();
+                    break;
+                case SECURE_MSG_DRAFT_SAVED:
+                    draftId = (Long) msg.obj;
+                    Toast.makeText(
+                            MessageCompose.this,
+                            getString(R.string.secure_message_draft_saved_toast),
                             Toast.LENGTH_LONG).show();
                     break;
                 default:

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
@@ -8,6 +8,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.activity.MessageCompose;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 
 public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
@@ -36,7 +37,12 @@ public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
         Message draftMessage = messagingController.saveDraft(account, message, draftId, saveRemotely);
         draftId = messagingController.getId(draftMessage);
 
-        android.os.Message msg = android.os.Message.obtain(handler, MessageCompose.MSG_SAVED_DRAFT, draftId);
+        android.os.Message msg = null;
+        if(draftMessage.isSet(Flag.X_SECURE_MESSAGE_DRAFT)) {
+            msg = android.os.Message.obtain(handler, MessageCompose.SECURE_MSG_DRAFT_SAVED, draftId);
+        } else {
+            msg = android.os.Message.obtain(handler, MessageCompose.MSG_SAVED_DRAFT, draftId);
+        }
         handler.sendMessage(msg);
         return null;
     }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -894,7 +894,9 @@ public class MessagingController {
                 List<String> destroyMessageUids = new ArrayList<>();
                 for (String localMessageUid : localUidMap.keySet()) {
                     if (remoteUidMap.get(localMessageUid) == null) {
-                        destroyMessageUids.add(localMessageUid);
+                        if(!localFolder.getMessage(localMessageUid).isSet(Flag.X_SECURE_MESSAGE_DRAFT)) {
+                            destroyMessageUids.add(localMessageUid);
+                        }
                     }
                 }
 
@@ -3971,6 +3973,8 @@ public class MessagingController {
                 PendingCommand command = PendingAppend.create(localFolder.getName(), localMessage.getUid());
                 queuePendingCommand(account, command);
                 processPendingCommands(account);
+            } else {
+                localMessage.setFlag(Flag.X_SECURE_MESSAGE_DRAFT, true);
             }
 
         } catch (MessagingException e) {

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -301,6 +301,7 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="message_discarded_toast">Message discarded</string>
     <string name="message_saved_toast">Message saved as draft</string>
+    <string name="secure_message_draft_saved_toast">Secure message draft saved locally. It will not be synced with server.</string>
 
     <string name="global_settings_flag_label">Show stars</string>
     <string name="global_settings_flag_summary">Stars indicate flagged messages</string>

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -114,6 +114,8 @@ public class MessagingControllerTest {
     @Captor
     private ArgumentCaptor<FetchProfile> fetchProfileCaptor;
     @Captor
+    private ArgumentCaptor<List<String>> stringListArgumentCaptor;
+    @Captor
     private ArgumentCaptor<MessageRetrievalListener<LocalMessage>> messageRetrievalListenerCaptor;
 
     private Context appContext;
@@ -725,8 +727,10 @@ public class MessagingControllerTest {
             throws Exception {
         messageCountInRemoteFolder(0);
         LocalMessage localCopyOfRemoteDeletedMessage = mock(LocalMessage.class);
+        when(localCopyOfRemoteDeletedMessage.isSet(Flag.X_SECURE_MESSAGE_DRAFT)).thenReturn(false);
         when(account.syncRemoteDeletions()).thenReturn(true);
         when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(Collections.singletonMap(MESSAGE_UID1, 0L));
+        when(localFolder.getMessage(any(String.class))).thenReturn(localCopyOfRemoteDeletedMessage);
         when(localFolder.getMessagesByUids(any(List.class)))
                 .thenReturn(Collections.singletonList(localCopyOfRemoteDeletedMessage));
 
@@ -734,6 +738,22 @@ public class MessagingControllerTest {
 
         verify(localFolder).destroyMessages(messageListCaptor.capture());
         assertEquals(localCopyOfRemoteDeletedMessage, messageListCaptor.getValue().get(0));
+    }
+
+    @Test
+    public void synchronizeMailboxSynchronous_withAccountSetToSyncRemoteDeletions_shouldNotDeleteSecureMessageDrafts()
+            throws Exception {
+        messageCountInRemoteFolder(0);
+        LocalMessage localCopyOfRemoteDeletedMessage = mock(LocalMessage.class);
+        when(localCopyOfRemoteDeletedMessage.isSet(Flag.X_SECURE_MESSAGE_DRAFT)).thenReturn(true);
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(Collections.singletonMap(MESSAGE_UID1, 0L));
+        when(localFolder.getMessage(any(String.class))).thenReturn(localCopyOfRemoteDeletedMessage);
+
+        controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
+
+        verify(localFolder).getMessagesByUids(stringListArgumentCaptor.capture());
+        assertEquals(stringListArgumentCaptor.getValue().isEmpty(),true);
     }
 
     @Test
@@ -760,9 +780,11 @@ public class MessagingControllerTest {
         Date dateOfEarliestPoll = new Date();
         when(account.syncRemoteDeletions()).thenReturn(true);
         when(account.getEarliestPollDate()).thenReturn(dateOfEarliestPoll);
+        when(localMessage.isSet(Flag.X_SECURE_MESSAGE_DRAFT)).thenReturn(false);
         when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(true);
         when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(Collections.singletonMap(MESSAGE_UID1, 0L));
         when(localFolder.getMessagesByUids(any(List.class))).thenReturn(Collections.singletonList(localMessage));
+        when(localFolder.getMessage(any(String.class))).thenReturn(localMessage);
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, remoteFolder);
 


### PR DESCRIPTION
This is a possible fix for issue #2164. Specifically, the following scenario mentioned in that issue:
1. Create a draft email with text in the body.
2. Select "encrypt" or "encrypt if possible".
3. Save draft by selecting either "save draft" or by pressing back and "save draft".
4. Draft is gone after server sync.

As per the comment by @Valodim on Jan 7 in issue #1983, the intent, at least until draft encryption is implemented, is to save drafts of secure messages ("encrypt" / "encrypt if possible") locally only and not upload them to the server during IMAP sync. But, as mentioned above, such drafts are getting saved locally initially but then getting deleted during the sync. (As per my testing, the issue of drafts getting deleted during sync seems to have been there for a while. In releases 5.108 to 5.200 (which I tested), drafts of secure messages were getting copied to the server in plain text (issue #711) and normal drafts were getting deleted upon sync (opposite of the #2164 scenario mentioned above)).

Hope my fix addresses the issue adequately. Please let me know if any further changes are required. 
(Note: I am planning to apply to k-9 as part of GSOC)