### PR TITLE
Fix 2 for drafts getting deleted during IMAP sync

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Flag.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Flag.java
@@ -62,4 +62,12 @@ public enum Flag {
      * This flag is used for drafts where the message should be sent as PGP/INLINE.
      */
     X_DRAFT_OPENPGP_INLINE,
+
+    X_DRAFT_CRYPTO_DISABLED,
+
+    X_DRAFT_CRYPTO_OPPORTUNISTIC,
+
+    X_DRAFT_CRYPTO_PRIVATE,
+
+    X_DRAFT_CRYPTO_SIGN_ONLY,
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -141,6 +141,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private static final int MSG_PROGRESS_OFF = 2;
     public static final int MSG_SAVED_DRAFT = 4;
     private static final int MSG_DISCARDED_DRAFT = 5;
+    public static final int SECURE_MSG_DRAFT_SAVED = 6;
 
     private static final int REQUEST_MASK_RECIPIENT_PRESENTER = (1 << 8);
     private static final int REQUEST_MASK_LOADER_HELPER = (1 << 9);
@@ -1479,9 +1480,28 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             }
 
             // TODO more appropriate logic here? not sure
-            boolean saveRemotely = !recipientPresenter.getCurrentCryptoStatus().shouldUsePgpMessageBuilder();
+            //boolean saveRemotely = !recipientPresenter.getCurrentCryptoStatus().shouldUsePgpMessageBuilder();
+            recipientPresenter.updateCryptoStatus();
+            ComposeCryptoStatus currentCryptoStatus = recipientPresenter.getCurrentCryptoStatus();
+            CryptoMode currentCryptoMode = currentCryptoStatus.getCryptoMode();
+            Flag cryptoModeFlag = null;
+            switch (currentCryptoMode) {
+                case DISABLE:
+                    cryptoModeFlag = Flag.X_DRAFT_CRYPTO_DISABLED;
+                    break;
+                case OPPORTUNISTIC:
+                    cryptoModeFlag = Flag.X_DRAFT_CRYPTO_OPPORTUNISTIC;
+                    break;
+                case PRIVATE:
+                    cryptoModeFlag = Flag.X_DRAFT_CRYPTO_PRIVATE;
+                    break;
+                case SIGN_ONLY:
+                    cryptoModeFlag = Flag.X_DRAFT_CRYPTO_SIGN_ONLY;
+                    break;
+            }
+
             new SaveMessageTask(getApplicationContext(), account, contacts, internalMessageHandler,
-                    message, draftId, saveRemotely).execute();
+                    message, draftId, cryptoModeFlag).execute();
             if (finishAfterDraftSaved) {
                 finish();
             } else {
@@ -1770,6 +1790,13 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                     Toast.makeText(
                             MessageCompose.this,
                             getString(R.string.message_discarded_toast),
+                            Toast.LENGTH_LONG).show();
+                    break;
+                case SECURE_MSG_DRAFT_SAVED:
+                    draftId = (Long) msg.obj;
+                    Toast.makeText(
+                            MessageCompose.this,
+                            getString(R.string.secure_message_draft_saved_toast),
                             Toast.LENGTH_LONG).show();
                     break;
                 default:

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -44,6 +44,8 @@ public class ComposeCryptoStatus {
         return signingKeyId;
     }
 
+    public CryptoMode getCryptoMode() { return cryptoMode; }
+
     CryptoStatusDisplayType getCryptoStatusDisplayType() {
         switch (cryptoProviderState) {
             case UNCONFIGURED:

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -204,6 +204,7 @@ public class RecipientPresenter implements PermissionPingCallback {
     public void initFromDraftMessage(Message message) {
         initRecipientsFromDraftMessage(message);
         initPgpInlineFromDraftMessage(message);
+        initCryptoModeFromDraftMessage(message);
     }
 
     private void initRecipientsFromDraftMessage(Message message) {
@@ -218,6 +219,13 @@ public class RecipientPresenter implements PermissionPingCallback {
 
     private void initPgpInlineFromDraftMessage(Message message) {
         cryptoEnablePgpInline = message.isSet(Flag.X_DRAFT_OPENPGP_INLINE);
+    }
+
+    private void initCryptoModeFromDraftMessage(Message message) {
+        if(message.isSet(Flag.X_DRAFT_CRYPTO_DISABLED)) currentCryptoMode = CryptoMode.DISABLE;
+        if(message.isSet(Flag.X_DRAFT_CRYPTO_OPPORTUNISTIC)) currentCryptoMode = CryptoMode.OPPORTUNISTIC;
+        if(message.isSet(Flag.X_DRAFT_CRYPTO_PRIVATE)) currentCryptoMode = CryptoMode.PRIVATE;
+        if(message.isSet(Flag.X_DRAFT_CRYPTO_SIGN_ONLY)) currentCryptoMode = CryptoMode.SIGN_ONLY;
     }
 
     private void addToAddresses(Address... toAddresses) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
@@ -8,6 +8,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.activity.MessageCompose;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 
 public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
@@ -17,26 +18,31 @@ public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
     Handler handler;
     Message message;
     long draftId;
-    boolean saveRemotely;
+    Flag cryptoModeFlag;
 
     public SaveMessageTask(Context context, Account account, Contacts contacts,
-                           Handler handler, Message message, long draftId, boolean saveRemotely) {
+                           Handler handler, Message message, long draftId, Flag cryptoModeFlag) {
         this.context = context;
         this.account = account;
         this.contacts = contacts;
         this.handler = handler;
         this.message = message;
         this.draftId = draftId;
-        this.saveRemotely = saveRemotely;
+        this.cryptoModeFlag = cryptoModeFlag;
     }
 
     @Override
     protected Void doInBackground(Void... params) {
         final MessagingController messagingController = MessagingController.getInstance(context);
-        Message draftMessage = messagingController.saveDraft(account, message, draftId, saveRemotely);
+        Message draftMessage = messagingController.saveDraft(account, message, draftId, cryptoModeFlag);
         draftId = messagingController.getId(draftMessage);
 
-        android.os.Message msg = android.os.Message.obtain(handler, MessageCompose.MSG_SAVED_DRAFT, draftId);
+        android.os.Message msg = null;
+        if(draftMessage.isSet(Flag.X_DRAFT_CRYPTO_OPPORTUNISTIC) || draftMessage.isSet(Flag.X_DRAFT_CRYPTO_PRIVATE)) {
+            msg = android.os.Message.obtain(handler, MessageCompose.SECURE_MSG_DRAFT_SAVED, draftId);
+        } else {
+            msg = android.os.Message.obtain(handler, MessageCompose.MSG_SAVED_DRAFT, draftId);
+        }
         handler.sendMessage(msg);
         return null;
     }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -894,7 +894,10 @@ public class MessagingController {
                 List<String> destroyMessageUids = new ArrayList<>();
                 for (String localMessageUid : localUidMap.keySet()) {
                     if (remoteUidMap.get(localMessageUid) == null) {
-                        destroyMessageUids.add(localMessageUid);
+                        if(localFolder.getMessage(localMessageUid).isSet(Flag.X_DRAFT_CRYPTO_DISABLED) ||
+                                localFolder.getMessage(localMessageUid).isSet(Flag.X_DRAFT_CRYPTO_SIGN_ONLY)) {
+                            destroyMessageUids.add(localMessageUid);
+                        }
                     }
                 }
 
@@ -3949,7 +3952,7 @@ public class MessagingController {
      *
      * @return Message representing the entry in the local store.
      */
-    public Message saveDraft(final Account account, final Message message, long existingDraftId, boolean saveRemotely) {
+    public Message saveDraft(final Account account, final Message message, long existingDraftId, Flag cryptoModeFlag) {
         Message localMessage = null;
         try {
             LocalStore localStore = account.getLocalStore();
@@ -3966,8 +3969,10 @@ public class MessagingController {
             // Fetch the message back from the store.  This is the Message that's returned to the caller.
             localMessage = localFolder.getMessage(message.getUid());
             localMessage.setFlag(Flag.X_DOWNLOADED_FULL, true);
+            localMessage.setFlag(cryptoModeFlag, true);
 
-            if (saveRemotely) {
+            if (cryptoModeFlag == Flag.X_DRAFT_CRYPTO_DISABLED ||
+                    cryptoModeFlag == Flag.X_DRAFT_CRYPTO_SIGN_ONLY) {
                 PendingCommand command = PendingAppend.create(localFolder.getName(), localMessage.getUid());
                 queuePendingCommand(account, command);
                 processPendingCommands(account);

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -301,6 +301,7 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="message_discarded_toast">Message discarded</string>
     <string name="message_saved_toast">Message saved as draft</string>
+    <string name="secure_message_draft_saved_toast">Secure message draft saved locally. It will not be synced with server.</string>
 
     <string name="global_settings_flag_label">Show stars</string>
     <string name="global_settings_flag_summary">Stars indicate flagged messages</string>

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -727,8 +727,10 @@ public class MessagingControllerTest {
             throws Exception {
         messageCountInRemoteFolder(0);
         LocalMessage localCopyOfRemoteDeletedMessage = mock(LocalMessage.class);
+        when(localCopyOfRemoteDeletedMessage.isSet(Flag.X_DRAFT_CRYPTO_DISABLED)).thenReturn(true);
         when(account.syncRemoteDeletions()).thenReturn(true);
         when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(Collections.singletonMap(MESSAGE_UID1, 0L));
+        when(localFolder.getMessage(any(String.class))).thenReturn(localCopyOfRemoteDeletedMessage);
         when(localFolder.getMessagesByUids(any(List.class)))
                 .thenReturn(Collections.singletonList(localCopyOfRemoteDeletedMessage));
 


### PR DESCRIPTION
This is the second possible fix for issue #2164 and builds on the work submitted as part of PR #2407 (which I had submitted a couple of days back). This fix expands on the approach used in PR #2407 to also fix the issue of drafts not retaining cryptomode setting across draft editing sessions, described in the following scenario: 
1. User starts composing a message. 
2. User sets the cryptomode setting to one of the non-default ones (i.e., "do not encrypt" or "encrypt").
3. User saves the draft with the intention of continuing again later.
4. User re-opens the draft in order to continue editing further.
5. The cryptomode setting automatically gets reset to the default setting of "encrypt if possible".

I have gone through some of the material about why cryptography features are implemented in a certain way in k-9 (https://goo.gl/2SS2f2) but have not been able to find any reason for automatically resetting the cryptomode setting back to "encrypt if possible". It seems to me that, as long as users are given the option to change the cryptomode setting, the setting made by them for a draft should be retained across draft editing sessions (until they decide to change it again for some reason). 
This fix saves cryptomode setting along with the draft and then restores it when the draft is re-opened for further editing (and of course also prevents the deletion of secure message drafts during IMAP sync). Please let me know if any changes are needed. 