### PR TITLE
Close AccountSetup activity immediately after cancellation, fixes #2425

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -302,6 +302,8 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
     private void onCancel() {
         mCanceled = true;
         setMessage(R.string.account_setup_check_settings_canceling_msg);
+        setResult(RESULT_CANCELED);
+        finish();
     }
 
     public void onClick(View v) {


### PR DESCRIPTION
A very short request, so I kept it in master. Closes the set up activity with the cancellation code immediately on press. Tested on Android 6.0