### PR TITLE
Fix K9RobolectricTestRunner

### DIFF
--- a/k9mail/src/test/java/com/fsck/k9/K9RobolectricTestRunner.java
+++ b/k9mail/src/test/java/com/fsck/k9/K9RobolectricTestRunner.java
@@ -14,7 +14,7 @@ public class K9RobolectricTestRunner extends RobolectricTestRunner {
     protected Config buildGlobalConfig() {
         return new Config.Builder()
                 .setSdk(22)
-                .setManifest("src/main/AndroidManifest.xml")
+                .setManifest("k9mail/src/main/AndroidManifest.xml")
                 .build();
     }
 }


### PR DESCRIPTION
As seen in testing, the path for the manifest is wrong.

