### PR TITLE
Activity Testing

### DIFF
--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -105,6 +105,12 @@ android {
     }
 }
 
+tasks.withType(Test) {
+    testLogging {
+        exceptionFormat "full"
+    }
+}
+
 if (project.hasProperty('keyAlias')) {
     android.signingConfigs.release.keyAlias = keyAlias
 }

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -99,7 +99,7 @@ public class K9 extends Application {
      * This will be {@code true} once the initialization is complete and {@link #notifyObservers()}
      * was called.
      * Afterwards calls to {@link #registerApplicationAware(com.fsck.k9.K9.ApplicationAware)} will
-     * immediately call {@link com.fsck.k9.K9.ApplicationAware#initializeComponent(K9)} for the
+     * immediately call {@link com.fsck.k9.K9.ApplicationAware#initializeComponent(Application)} for the
      * supplied argument.
      */
     private static boolean sInitialized = false;

--- a/k9mail/src/main/java/com/fsck/k9/Preferences.java
+++ b/k9mail/src/main/java/com/fsck/k9/Preferences.java
@@ -32,7 +32,7 @@ public class Preferences {
 
 
     private Storage mStorage;
-    private Map<String, Account> accounts = null;
+    private HashMap<String, Account> accounts = null;
     private List<Account> accountsInOrder = null;
     private Account newAccount;
     private Context mContext;
@@ -111,6 +111,9 @@ public class Preferences {
     }
 
     public synchronized Account newAccount() {
+        if (accounts == null) {
+            loadAccounts();
+        }
         newAccount = new Account(mContext);
         accounts.put(newAccount.getUuid(), newAccount);
         accountsInOrder.add(newAccount);
@@ -150,9 +153,9 @@ public class Preferences {
         Account defaultAccount = getAccount(defaultAccountUuid);
 
         if (defaultAccount == null) {
-            Collection<Account> accounts = getAvailableAccounts();
-            if (!accounts.isEmpty()) {
-                defaultAccount = accounts.iterator().next();
+            Collection<Account> availableAccounts = getAvailableAccounts();
+            if (!availableAccounts.isEmpty()) {
+                defaultAccount = availableAccounts.iterator().next();
                 setDefaultAccount(defaultAccount);
             }
         }

--- a/k9mail/src/main/res/layout/actionbar_custom.xml
+++ b/k9mail/src/main/res/layout/actionbar_custom.xml
@@ -40,7 +40,7 @@
 
         <ProgressBar
             android:id="@+id/actionbar_progress"
-            style="?android:attr/indeterminateProgressStyle"
+            android:indeterminate="true"
             android:layout_width="32dp"
             android:layout_height="32dp"
             android:layout_gravity="center"

--- a/k9mail/src/main/res/layout/actionbar_indeterminate_progress_actionview.xml
+++ b/k9mail/src/main/res/layout/actionbar_indeterminate_progress_actionview.xml
@@ -26,5 +26,5 @@
     <ProgressBar android:layout_width="32dp"
         android:layout_height="32dp"
         android:layout_gravity="center"
-        style="?android:attr/indeterminateProgressStyle" />
+        android:indeterminate="true" />
 </FrameLayout>

--- a/k9mail/src/test/java/com/fsck/k9/activity/AccountsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/AccountsTest.java
@@ -1,0 +1,134 @@
+package com.fsck.k9.activity;
+
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.widget.TextView;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.Identity;
+import com.fsck.k9.K9;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.Preferences;
+import com.fsck.k9.R;
+import com.fsck.k9.activity.setup.WelcomeMessage;
+import com.fsck.k9.helper.ParcelableUtil;
+import com.fsck.k9.search.LocalSearch;
+import org.apache.tools.ant.taskdefs.Local;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.robolectric.Shadows.shadowOf;
+
+
+@RunWith(K9RobolectricTestRunner.class)
+public class AccountsTest {
+    private Accounts activity;
+
+    @Before
+    public void before() throws Exception {
+        Field databasesUpToDate = K9.class.getDeclaredField("sDatabasesUpToDate");
+        databasesUpToDate.setAccessible(true);
+        databasesUpToDate.set(null, false);
+
+        List<Account> accounts = Preferences.getPreferences(RuntimeEnvironment.application).getAccounts();
+        for (Account account : accounts) {
+            Preferences.getPreferences(RuntimeEnvironment.application).deleteAccount(account);
+        }
+    }
+
+    @Test
+    public void onCreate_startsUpgradeDatabase_whenNotUpToDate() {
+        addAccountWithIdentity("user@example.org");
+        activity = Robolectric.buildActivity(Accounts.class).create().get();
+
+        assertNextStartedActivityIs(UpgradeDatabases.class);
+    }
+
+    @Test
+    public void onCreate_startsWelcomeMessage_withNoAccounts() {
+        K9.setDatabasesUpToDate(false);
+
+        activity = Robolectric.buildActivity(Accounts.class).create().get();
+
+        assertNextStartedActivityIs(WelcomeMessage.class);
+    }
+
+    @Test
+    public void onCreate_startsMessageListForIntegratedInbox__whenIntegratedInboxEnabled() {
+        K9.setStartIntegratedInbox(true);
+        K9.setDatabasesUpToDate(false);
+        addAccountWithIdentity("user@example.org");
+
+        activity = Robolectric.buildActivity(Accounts.class).create().get();
+
+        Intent nextStartedActivity = shadowOf(activity).getNextStartedActivity();
+        assertEquals(MessageList.class.getName(),
+                nextStartedActivity.getComponent().getClassName());
+        LocalSearch search = ParcelableUtil.unmarshall(nextStartedActivity.getByteArrayExtra("search_bytes"),
+                LocalSearch.CREATOR);
+        assertEquals(activity.getString(R.string.integrated_inbox_title),
+                search.getName());
+        //TODO: Decode search for unified inbox
+    }
+
+    @Test
+    public void onCreate_startsMessageListForSingleInbox__whenOnly1Account() {
+        K9.setStartIntegratedInbox(false);
+        K9.setDatabasesUpToDate(false);
+        String uuid = addAccountWithIdentity("user@example.org");
+
+        activity = Robolectric.buildActivity(Accounts.class).create().get();
+
+        Intent nextStartedActivity = shadowOf(activity).getNextStartedActivity();
+        assertEquals(MessageList.class.getName(),
+                nextStartedActivity.getComponent().getClassName());
+        LocalSearch search = ParcelableUtil.unmarshall(nextStartedActivity.getByteArrayExtra("search_bytes"),
+                LocalSearch.CREATOR);
+        assertEquals("INBOX",
+                search.getName());
+        assertEquals(1,
+                search.getAccountUuids().length);
+        assertEquals(uuid,
+                search.getAccountUuids()[0]);
+    }
+
+    @Test
+    public void onCreate_startsNothing__whenMultipleAccounts() {
+        K9.setStartIntegratedInbox(false);
+        K9.setDatabasesUpToDate(false);
+        addAccountWithIdentity("user@example.org");
+        addAccountWithIdentity("user@example2.org");
+
+        activity = Robolectric.buildActivity(Accounts.class).create().get();
+
+        Intent nextStartedActivity = shadowOf(activity).getNextStartedActivity();
+        assertNull(nextStartedActivity);
+    }
+
+    private void assertNextStartedActivityIs(Class<? extends Activity> nextActivity) {
+        assertEquals(nextActivity.getName(),
+                shadowOf(activity).getNextStartedActivity().getComponent().getClassName());
+    }
+
+    private String addAccountWithIdentity(String email) {
+        Preferences prefs = Preferences.getPreferences(RuntimeEnvironment.application);
+        Account account = prefs.newAccount();
+        ArrayList<Identity> identities = new ArrayList<>();
+        Identity identity = new Identity();
+        identity.setEmail(email);
+        identities.add(identity);
+        account.setIdentities(identities);
+        return account.getUuid();
+
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/activity/AccountsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/AccountsTest.java
@@ -128,6 +128,5 @@ public class AccountsTest {
         identities.add(identity);
         account.setIdentities(identities);
         return account.getUuid();
-
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/activity/AccountsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/AccountsTest.java
@@ -78,7 +78,6 @@ public class AccountsTest {
                 LocalSearch.CREATOR);
         assertEquals(activity.getString(R.string.integrated_inbox_title),
                 search.getName());
-        //TODO: Decode search for unified inbox
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/activity/MessageComposeTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/MessageComposeTest.java
@@ -3,6 +3,7 @@ package com.fsck.k9.activity;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
+import java.util.List;
 
 import android.app.Activity;
 import android.widget.TextView;
@@ -32,6 +33,11 @@ public class MessageComposeTest {
         Field databasesUpToDate = K9.class.getDeclaredField("sDatabasesUpToDate");
         databasesUpToDate.setAccessible(true);
         databasesUpToDate.set(null, false);
+
+        List<Account> accounts = Preferences.getPreferences(RuntimeEnvironment.application).getAccounts();
+        for (Account account : accounts) {
+            Preferences.getPreferences(RuntimeEnvironment.application).deleteAccount(account);
+        }
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/activity/MessageComposeTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/MessageComposeTest.java
@@ -1,0 +1,80 @@
+package com.fsck.k9.activity;
+
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+
+import android.app.Activity;
+import android.widget.TextView;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.Identity;
+import com.fsck.k9.K9;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.Preferences;
+import com.fsck.k9.R;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+
+import static org.junit.Assert.assertEquals;
+import static org.robolectric.Shadows.shadowOf;
+
+
+@RunWith(K9RobolectricTestRunner.class)
+public class MessageComposeTest {
+    private MessageCompose activity;
+
+    @Before
+    public void before() throws Exception {
+        Field databasesUpToDate = K9.class.getDeclaredField("sDatabasesUpToDate");
+        databasesUpToDate.setAccessible(true);
+        databasesUpToDate.set(null, false);
+    }
+
+    @Test
+    public void onCreate_startsUpgradeDatabase_whenNotUpToDate() {
+        activity = Robolectric.buildActivity(MessageCompose.class).create().get();
+
+        assertNextStartedActivityIs(UpgradeDatabases.class);
+    }
+
+    @Test
+    public void onCreate_startsAccounts_whenNoAccountsAvailable() {
+        K9.setDatabasesUpToDate(false);
+
+        activity = Robolectric.buildActivity(MessageCompose.class).create().get();
+
+        assertNextStartedActivityIs(Accounts.class);
+    }
+
+    @Test
+    public void onCreate_usesDefaultAccountFirstIdentity_whenNoAccountProvided() {
+        K9.setDatabasesUpToDate(false);
+        addDefaultAccountWithIdentity("user@example.org");
+
+        activity = Robolectric.buildActivity(MessageCompose.class).create().get();
+
+        assertEquals("user@example.org",
+                ((TextView) activity.findViewById(R.id.identity)).getText());
+    }
+
+    private void assertNextStartedActivityIs(Class<? extends Activity> nextActivity) {
+        assertEquals(nextActivity.getName(),
+                shadowOf(activity).getNextStartedActivity().getComponent().getClassName());
+    }
+
+    private void addDefaultAccountWithIdentity(String email) {
+        Preferences prefs = Preferences.getPreferences(RuntimeEnvironment.application);
+        Account account = prefs.newAccount();
+        ArrayList<Identity> identities = new ArrayList<>();
+        Identity identity = new Identity();
+        identity.setEmail(email);
+        identities.add(identity);
+        account.setIdentities(identities);
+        Preferences.getPreferences(RuntimeEnvironment.application).setDefaultAccount(account);
+
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/activity/MessageListTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/MessageListTest.java
@@ -1,0 +1,110 @@
+package com.fsck.k9.activity;
+
+
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.List;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.Identity;
+import com.fsck.k9.K9;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.Preferences;
+import com.fsck.k9.R;
+import com.fsck.k9.activity.Accounts;
+import com.fsck.k9.activity.MessageList;
+import com.fsck.k9.activity.UpgradeDatabases;
+import com.fsck.k9.activity.setup.WelcomeMessage;
+import com.fsck.k9.helper.ParcelableUtil;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.search.LocalSearch;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RuntimeEnvironment;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.robolectric.Shadows.shadowOf;
+
+
+@RunWith(K9RobolectricTestRunner.class)
+public class MessageListTest {
+    private MessageList activity;
+
+    @Before
+    public void before() throws Exception {
+        Field databasesUpToDate = K9.class.getDeclaredField("sDatabasesUpToDate");
+        databasesUpToDate.setAccessible(true);
+        databasesUpToDate.set(null, false);
+
+        List<Account> accounts = Preferences.getPreferences(RuntimeEnvironment.application).getAccounts();
+        for (Account account : accounts) {
+            Preferences.getPreferences(RuntimeEnvironment.application).deleteAccount(account);
+        }
+    }
+
+    @Test
+    public void onCreate_startsUpgradeDatabase_whenNotUpToDate() {
+        activity = Robolectric.buildActivity(MessageList.class).create().get();
+
+        assertNextStartedActivityIs(UpgradeDatabases.class);
+    }
+
+    @Test
+    public void onCreate_startsAccounts_whenNoAccountsExist() {
+        K9.setDatabasesUpToDate(false);
+
+        activity = Robolectric.buildActivity(MessageList.class).create().get();
+
+        assertNextStartedActivityIs(Accounts.class);
+    }
+
+    @Test
+    public void onCreate_startsAccounts_whenAnAccountExistsButNoSearchProvided() {
+        K9.setDatabasesUpToDate(false);
+        addAccountWithIdentity("user@example.org");
+
+        activity = Robolectric.buildActivity(MessageList.class).create().get();
+
+        assertNextStartedActivityIs(Accounts.class);
+    }
+
+    @Test
+    public void onCreate_startsNothing_whenSearchProvided() {
+        K9.setDatabasesUpToDate(false);
+        String uuid = addAccountWithIdentity("user@example.org");
+        Intent intent = new Intent();
+        LocalSearch localSearch = new LocalSearch();
+        localSearch.addAccountUuid(uuid);
+        localSearch.addAllowedFolder("INBOX");
+        intent.putExtra("search_bytes", ParcelableUtil.marshall(localSearch));
+
+        activity = Robolectric.buildActivity(MessageList.class, intent).create().get();
+
+        assertNull(shadowOf(activity).getNextStartedActivity());
+    }
+
+    private void assertNextStartedActivityIs(Class<? extends Activity> nextActivity) {
+        assertEquals(nextActivity.getName(),
+                shadowOf(activity).getNextStartedActivity().getComponent().getClassName());
+    }
+
+    private String addAccountWithIdentity(String email) {
+        Preferences prefs = Preferences.getPreferences(RuntimeEnvironment.application);
+        Account account = prefs.newAccount();
+        ArrayList<Identity> identities = new ArrayList<>();
+        Identity identity = new Identity();
+        identity.setEmail(email);
+        identities.add(identity);
+        account.setIdentities(identities);
+        account.setStoreUri("imap://PLAIN:user:password@server:port");
+        return account.getUuid();
+
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -138,7 +139,6 @@ public class MessagingControllerTest {
 
     @Before
     public void setUp() throws MessagingException {
-        ShadowLog.stream = System.out;
         MockitoAnnotations.initMocks(this);
         appContext = ShadowApplication.getInstance().getApplicationContext();
 
@@ -150,6 +150,7 @@ public class MessagingControllerTest {
 
     @After
     public void tearDown() throws Exception {
+        removeAccountsInPreferences();
         controller.stop();
     }
 
@@ -947,12 +948,18 @@ public class MessagingControllerTest {
             throws Exception {
         Field accounts = Preferences.class.getDeclaredField("accounts");
         accounts.setAccessible(true);
-        accounts.set(Preferences.getPreferences(appContext), newAccounts);
+        accounts.set(Preferences.getPreferences(appContext), new HashMap<>(newAccounts));
 
         Field accountsInOrder = Preferences.class.getDeclaredField("accountsInOrder");
         accountsInOrder.setAccessible(true);
         ArrayList<Account> newAccountsInOrder = new ArrayList<>();
         newAccountsInOrder.addAll(newAccounts.values());
         accountsInOrder.set(Preferences.getPreferences(appContext), newAccountsInOrder);
+    }
+
+    private void removeAccountsInPreferences() throws Exception {
+        Field accounts = Preferences.class.getDeclaredField("accounts");
+        accounts.setAccessible(true);
+        accounts.set(Preferences.getPreferences(appContext), null);
     }
 }


### PR DESCRIPTION
Right now we have little testing of "Android code" (Activities, Fragments, etc). It's hard to justify requesting it in code review for new functionality because it would be far beyond the scope of the issue being fixed.

But we need to add it to prevent regressions and verify fixes people write.

I'm going to start by writing skeleton tests for MessageCompose, Accounts and MessageList. Once that's in place, we can start request testing for new features and fixes and gradually cover off more functionality.


