### PR TITLE
UTC time in quotes (Issue #2403)

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/message/quote/QuoteHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/quote/QuoteHelper.java
@@ -28,10 +28,15 @@ class QuoteHelper {
             final int dateStyle = DateFormat.LONG;
             final int timeStyle = DateFormat.LONG;
             Date date = message.getSentDate();
-            Locale locale = resources.getConfiguration().locale;
-            DateFormat dateFormat = DateFormat.getDateTimeInstance(dateStyle, timeStyle, locale);
+            DateFormat dateFormat;
+            Locale locale;
             if (K9.hideTimeZone()) {
+                locale=Locale.ROOT;
+                dateFormat = DateFormat.getDateTimeInstance(dateStyle, timeStyle, locale);
                 dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            } else {
+                locale = resources.getConfiguration().locale;
+                dateFormat = DateFormat.getDateTimeInstance(dateStyle, timeStyle, locale);
             }
             return dateFormat.format(date);
         } catch (Exception e) {

--- a/k9mail/src/main/java/com/fsck/k9/message/quote/QuoteHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/quote/QuoteHelper.java
@@ -4,9 +4,11 @@ package com.fsck.k9.message.quote;
 import java.text.DateFormat;
 import java.util.Date;
 import java.util.Locale;
+import java.util.TimeZone;
 
 import android.content.res.Resources;
 
+import com.fsck.k9.K9;
 import com.fsck.k9.mail.Message;
 
 
@@ -27,8 +29,11 @@ class QuoteHelper {
             final int timeStyle = DateFormat.LONG;
             Date date = message.getSentDate();
             Locale locale = resources.getConfiguration().locale;
-            return DateFormat.getDateTimeInstance(dateStyle, timeStyle, locale)
-                    .format(date);
+            DateFormat dateFormat = DateFormat.getDateTimeInstance(dateStyle, timeStyle, locale);
+            if (K9.hideTimeZone()) {
+                dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
+            }
+            return dateFormat.format(date);
         } catch (Exception e) {
             return "";
         }

--- a/k9mail/src/main/java/com/fsck/k9/message/quote/QuoteHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/quote/QuoteHelper.java
@@ -28,14 +28,13 @@ class QuoteHelper {
             final int dateStyle = DateFormat.LONG;
             final int timeStyle = DateFormat.LONG;
             Date date = message.getSentDate();
+
             DateFormat dateFormat;
-            Locale locale;
             if (K9.hideTimeZone()) {
-                locale=Locale.ROOT;
-                dateFormat = DateFormat.getDateTimeInstance(dateStyle, timeStyle, locale);
+                dateFormat = DateFormat.getDateTimeInstance(dateStyle, timeStyle, Locale.ROOT);
                 dateFormat.setTimeZone(TimeZone.getTimeZone("UTC"));
             } else {
-                locale = resources.getConfiguration().locale;
+                Locale locale = resources.getConfiguration().locale;
                 dateFormat = DateFormat.getDateTimeInstance(dateStyle, timeStyle, locale);
             }
             return dateFormat.format(date);

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -342,7 +342,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_privacy_hide_useragent">Hide mail client</string>
     <string name="global_settings_privacy_hide_useragent_detail">Remove K-9 User-Agent from mail headers</string>
     <string name="global_settings_privacy_hide_timezone">Hide timezone</string>
-    <string name="global_settings_privacy_hide_timezone_detail">Use UTC instead of local timezone in mail headers</string>
+    <string name="global_settings_privacy_hide_timezone_detail">Use UTC instead of local timezone in mail headers and reply quotes</string>
     <string name="global_settings_notification_hide_subject_title">Hide subject in notifications</string>
     <string name="global_settings_notification_hide_subject_never">Never</string>
     <string name="global_settings_notification_hide_subject_when_locked">When device is locked</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -342,7 +342,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_privacy_hide_useragent">Hide mail client</string>
     <string name="global_settings_privacy_hide_useragent_detail">Remove K-9 User-Agent from mail headers</string>
     <string name="global_settings_privacy_hide_timezone">Hide timezone</string>
-    <string name="global_settings_privacy_hide_timezone_detail">Use UTC instead of local timezone in mail headers and reply quotes</string>
+    <string name="global_settings_privacy_hide_timezone_detail">Use UTC instead of local timezone in mail headers and reply header</string>
     <string name="global_settings_notification_hide_subject_title">Hide subject in notifications</string>
     <string name="global_settings_notification_hide_subject_never">Never</string>
     <string name="global_settings_notification_hide_subject_when_locked">When device is locked</string>


### PR DESCRIPTION
Before, the time in the quoted message of a reply was always in the
local timezone, even when the "Hide timezone" setting was selected. Now,
when the option is enabled, that is changed to UTC just like the time in
headers. I also changed the description for the option in the English
strings.xml to better describe the new behavior.


