### PR TITLE
Virgin Media recommends a single set of mail settings for all its domains

### DIFF
--- a/k9mail/src/main/res/xml/providers.xml
+++ b/k9mail/src/main/res/xml/providers.xml
@@ -281,16 +281,16 @@
         <outgoing uri="smtp+ssl+://smtp.virginmedia.com" username="$email" />
     </provider>
     <provider id="virgin.net" label="Virgin Media" domain="virgin.net">
-        <incoming uri="imap+ssl+://imap4.virgin.net" username="$email" />
-        <outgoing uri="smtp+ssl+://smtp.virgin.net" username="$email" />
+        <incoming uri="imap+ssl+://imap.virginmedia.com" username="$email" />
+        <outgoing uri="smtp+ssl+://smtp.virginmedia.com" username="$email" />
     </provider>
     <provider id="blueyonder.co.uk" label="Virgin Media" domain="blueyonder.co.uk">
-        <incoming uri="imap+ssl+://imap4.blueyonder.co.uk" username="$email" />
-        <outgoing uri="smtp+ssl+://smtp.blueyonder.co.uk" username="$email" />
+        <incoming uri="imap+ssl+://imap.virginmedia.com" username="$email" />
+        <outgoing uri="smtp+ssl+://smtp.virginmedia.com" username="$email" />
     </provider>
     <provider id="ntlworld.com" label="Virgin Media" domain="ntlworld.com">
-        <incoming uri="imap+ssl+://imap.ntlworld.com" username="$email" />
-        <outgoing uri="smtp+ssl+://smtp.ntlworld.com" username="$email" />
+        <incoming uri="imap+ssl+://imap.virginmedia.com" username="$email" />
+        <outgoing uri="smtp+ssl+://smtp.virginmedia.com" username="$email" />
     </provider>
     
     <!-- Germany -->


### PR DESCRIPTION
Virgin Media now uses a single set of settings for its domains. This is documented on their website:

https://help.virginmedia.com/system/templates/selfservice/vm/help/customer/locale/en-GB/portal/200300000001000/article/HELP-2203/Email-Settings-for-all-Virgin-Media-domains

And announced here:
http://community.virginmedia.com/t5/Email/Email-settings-change/m-p/3369438


