### PR TITLE
Add gravatar support

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -197,6 +197,7 @@ public class Account implements BaseAccount, StoreConfig {
     private SortType sortType;
     private Map<SortType, Boolean> sortAscending = new HashMap<>();
     private ShowPictures showPictures;
+    private UseGravatar useGravatar;
     private boolean isSignatureBeforeQuotedText;
     private Expunge expungePolicy = Expunge.EXPUNGE_IMMEDIATELY;
     private int maxPushFolders;
@@ -263,6 +264,10 @@ public class Account implements BaseAccount, StoreConfig {
         NEVER, ALWAYS, ONLY_FROM_CONTACTS
     }
 
+    public enum UseGravatar {
+        NEVER, ALWAYS, ON_WIFI
+    }
+
     public enum Searchable {
         ALL, DISPLAYABLE, NONE
     }
@@ -295,6 +300,7 @@ public class Account implements BaseAccount, StoreConfig {
         sortType = DEFAULT_SORT_TYPE;
         sortAscending.put(DEFAULT_SORT_TYPE, DEFAULT_SORT_ASCENDING);
         showPictures = ShowPictures.NEVER;
+        useGravatar = UseGravatar.NEVER;
         isSignatureBeforeQuotedText = false;
         expungePolicy = Expunge.EXPUNGE_IMMEDIATELY;
         autoExpandFolderName = INBOX;
@@ -447,6 +453,8 @@ public class Account implements BaseAccount, StoreConfig {
         notificationSetting.setRingEnabled(storage.getBoolean(accountUuid + ".ring", true));
         notificationSetting.setRingtone(storage.getString(accountUuid + ".ringtone",
                                          "content://settings/system/notification_sound"));
+        useGravatar = getEnumStringPref(storage, accountUuid + ".useGravatar", UseGravatar.NEVER);
+
         notificationSetting.setLed(storage.getBoolean(accountUuid + ".led", true));
         notificationSetting.setLedColor(storage.getInt(accountUuid + ".ledColor", chipColor));
 
@@ -550,6 +558,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.remove(accountUuid + ".sortTypeEnum");
         editor.remove(accountUuid + ".sortAscending");
         editor.remove(accountUuid + ".showPicturesEnum");
+        editor.remove(accountUuid + ".useGravatar");
         editor.remove(accountUuid + ".replyAfterQuote");
         editor.remove(accountUuid + ".stripSignature");
         editor.remove(accountUuid + ".cryptoApp"); // this is no longer set, but cleans up legacy values
@@ -699,6 +708,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putString(accountUuid + ".sortTypeEnum", sortType.name());
         editor.putBoolean(accountUuid + ".sortAscending", sortAscending.get(sortType));
         editor.putString(accountUuid + ".showPicturesEnum", showPictures.name());
+        editor.putString(accountUuid + ".useGravatar", useGravatar.name());
         editor.putString(accountUuid + ".folderDisplayMode", folderDisplayMode.name());
         editor.putString(accountUuid + ".folderSyncMode", folderSyncMode.name());
         editor.putString(accountUuid + ".folderPushMode", folderPushMode.name());
@@ -1212,6 +1222,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public synchronized void setShowPictures(ShowPictures showPictures) {
         this.showPictures = showPictures;
+    }
+
+    public synchronized UseGravatar getUseGravatar() {
+        return useGravatar;
+    }
+
+    public synchronized void setUseGravatar(UseGravatar useGravatar) {
+        this.useGravatar = useGravatar;
     }
 
     public synchronized FolderMode getFolderTargetMode() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/AlternateRecipientAdapter.java
@@ -19,6 +19,7 @@ import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.fsck.k9.Account;
 import com.fsck.k9.R;
 import com.fsck.k9.activity.compose.RecipientAdapter;
 import com.fsck.k9.ui.ContactBadge;
@@ -128,7 +129,7 @@ public class AlternateRecipientAdapter extends BaseAdapter {
             holder.headerAddressLabel.setVisibility(View.GONE);
         }
 
-        RecipientAdapter.setContactPhotoOrPlaceholder(context, holder.headerPhoto, recipient);
+        RecipientAdapter.setContactPhotoOrPlaceholder(context, getAccount(), holder.headerPhoto, recipient);
         holder.headerPhoto.assignContactUri(recipient.getContactLookupUri());
 
         holder.headerRemove.setOnClickListener(new OnClickListener() {
@@ -164,6 +165,10 @@ public class AlternateRecipientAdapter extends BaseAdapter {
         });
 
         configureCryptoStatusView(holder, recipient);
+    }
+
+    private Account getAccount() {
+        return ((MessageCompose) context).getAccount();
     }
 
     private void configureCryptoStatusView(RecipientTokenHolder holder, Recipient recipient) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1349,6 +1349,10 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         quotedMessagePresenter.processDraftMessage(messageViewInfo, k9identity);
     }
 
+    public Account getAccount() {
+        return account;
+    }
+
     static class SendMessageTask extends AsyncTask<Void, Void, Void> {
         final Context context;
         final Account account;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientAdapter.java
@@ -20,6 +20,7 @@ import android.widget.Filterable;
 import android.widget.ImageView;
 import android.widget.TextView;
 
+import com.fsck.k9.Account;
 import com.fsck.k9.R;
 import com.fsck.k9.helper.ContactPicture;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
@@ -31,6 +32,8 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
     private final Context context;
     private List<Recipient> recipients;
     private String highlight;
+
+    private Account account;
 
 
     public RecipientAdapter(Context context) {
@@ -91,7 +94,7 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
         String address = recipient.address.getAddress();
         holder.email.setText(highlightText(address));
 
-        setContactPhotoOrPlaceholder(context, holder.photo, recipient);
+        setContactPhotoOrPlaceholder(context, account, holder.photo, recipient);
 
         Integer cryptoStatusRes = null, cryptoStatusColor = null;
         RecipientCryptoStatus cryptoStatus = recipient.getCryptoStatus();
@@ -124,8 +127,16 @@ public class RecipientAdapter extends BaseAdapter implements Filterable {
         }
     }
 
-    public static void setContactPhotoOrPlaceholder(Context context, ImageView imageView, Recipient recipient) {
-        ContactPicture.getContactPictureLoader(context).loadContactPicture(recipient, imageView);
+    public static void setContactPhotoOrPlaceholder(Context context, Account account, ImageView imageView, Recipient recipient) {
+        ContactPicture.getContactPictureLoader(context).loadContactPicture(account, recipient, imageView);
+    }
+
+    public Account getAccount() {
+        return account;
+    }
+
+    public void setAccount(Account account) {
+        this.account = account;
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -32,6 +32,7 @@ import com.fsck.k9.Account.MessageFormat;
 import com.fsck.k9.Account.QuoteStyle;
 import com.fsck.k9.Account.Searchable;
 import com.fsck.k9.Account.ShowPictures;
+import com.fsck.k9.Account.UseGravatar;
 import com.fsck.k9.K9;
 import com.fsck.k9.NotificationSetting;
 import com.fsck.k9.Preferences;
@@ -74,6 +75,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_DISPLAY_COUNT = "account_display_count";
     private static final String PREFERENCE_DEFAULT = "account_default";
     private static final String PREFERENCE_SHOW_PICTURES = "show_pictures_enum";
+    private static final String PREFERENCE_USE_GRAVATAR = "use_gravatar_enum";
     private static final String PREFERENCE_NOTIFY = "account_notify";
     private static final String PREFERENCE_NOTIFY_NEW_MAIL_MODE = "folder_notify_new_mail_mode";
     private static final String PREFERENCE_NOTIFY_SELF = "account_notify_self";
@@ -147,6 +149,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private CheckBoxPreference accountNotifySelf;
     private CheckBoxPreference accountNotifyContactsMailOnly;
     private ListPreference accountShowPictures;
+    private ListPreference accountUseGravatar;
     private CheckBoxPreference accountNotifySync;
     private CheckBoxPreference accountVibrateEnabled;
     private CheckBoxPreference accountLedEnabled;
@@ -472,6 +475,19 @@ public class AccountSettings extends K9PreferenceActivity {
                 int index = accountShowPictures.findIndexOfValue(summary);
                 accountShowPictures.setSummary(accountShowPictures.getEntries()[index]);
                 accountShowPictures.setValue(summary);
+                return false;
+            }
+        });
+
+        accountUseGravatar = (ListPreference) findPreference(PREFERENCE_USE_GRAVATAR);
+        accountUseGravatar.setValue("" + account.getUseGravatar());
+        accountUseGravatar.setSummary(accountUseGravatar.getEntry());
+        accountUseGravatar.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            public boolean onPreferenceChange(Preference preference, Object newValue) {
+                final String summary = newValue.toString();
+                int index = accountUseGravatar.findIndexOfValue(summary);
+                accountUseGravatar.setSummary(accountUseGravatar.getEntries()[index]);
+                accountUseGravatar.setValue(summary);
                 return false;
             }
         });
@@ -834,6 +850,8 @@ public class AccountSettings extends K9PreferenceActivity {
         }
 
         account.setShowPictures(ShowPictures.valueOf(accountShowPictures.getValue()));
+
+        account.setUseGravatar(UseGravatar.valueOf(accountUseGravatar.getValue()));
 
         //IMAP specific stuff
         if (isPushCapable) {

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
@@ -186,7 +186,7 @@ public class MessageListAdapter extends CursorAdapter {
         }
         holder.position = cursor.getPosition();
         if (holder.contactBadge != null) {
-            updateContactBadge(holder, counterpartyAddress);
+            updateContactBadge(account, holder, counterpartyAddress);
         }
         setBackgroundColor(view, selected, read);
         if (fragment.activeMessage != null) {
@@ -271,7 +271,7 @@ public class MessageListAdapter extends CursorAdapter {
         return null;
     }
 
-    private void updateContactBadge(MessageViewHolder holder, Address counterpartyAddress) {
+    private void updateContactBadge(Account account, MessageViewHolder holder, Address counterpartyAddress) {
         if (counterpartyAddress != null) {
             Utility.setContactForBadge(holder.contactBadge, counterpartyAddress);
                     /*
@@ -280,7 +280,7 @@ public class MessageListAdapter extends CursorAdapter {
                      * doesn't reset the padding, so we do it ourselves.
                      */
             holder.contactBadge.setPadding(0, 0, 0, 0);
-            fragment.contactsPictureLoader.loadContactPicture(counterpartyAddress, holder.contactBadge);
+            fragment.contactsPictureLoader.loadContactPicture(account, counterpartyAddress, holder.contactBadge);
         } else {
             holder.contactBadge.assignContactUri(null);
             holder.contactBadge.setImageResource(R.drawable.ic_contact_picture);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -17,6 +17,7 @@ import com.fsck.k9.Account.QuoteStyle;
 import com.fsck.k9.Account.Searchable;
 import com.fsck.k9.Account.ShowPictures;
 import com.fsck.k9.Account.SortType;
+import com.fsck.k9.Account.UseGravatar;
 import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.mailstore.StorageManager;
@@ -174,6 +175,9 @@ public class AccountSettings {
         ));
         s.put("showPicturesEnum", Settings.versions(
                 new V(1, new EnumSetting<>(ShowPictures.class, ShowPictures.NEVER))
+        ));
+        s.put("useGravatarEnum", Settings.versions(
+                new V(1, new EnumSetting<>(UseGravatar.class, UseGravatar.NEVER))
         ));
         s.put("signatureBeforeQuotedText", Settings.versions(
                 new V(1, new BooleanSetting(false))

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -326,7 +326,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         if (K9.showContactPicture()) {
             if (counterpartyAddress != null) {
                 Utility.setContactForBadge(mContactBadge, counterpartyAddress);
-                mContactsPictureLoader.loadContactPicture(counterpartyAddress, mContactBadge);
+                mContactsPictureLoader.loadContactPicture(mAccount, counterpartyAddress, mContactBadge);
             } else {
                 mContactBadge.setImageResource(R.drawable.ic_contact_picture);
             }

--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -22,6 +22,9 @@ import android.support.annotation.Nullable;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.util.AttributeSet;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.activity.MessageCompose;
 import timber.log.Timber;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -66,7 +69,6 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
     private AlternateRecipientAdapter alternatesAdapter;
     private Recipient alternatesPopupRecipient;
     private TokenListener<Recipient> listener;
-
 
     public RecipientSelectView(Context context) {
         super(context);
@@ -126,7 +128,7 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
 
         holder.vName.setText(recipient.getDisplayNameOrAddress());
 
-        RecipientAdapter.setContactPhotoOrPlaceholder(getContext(), holder.vContactPhoto, recipient);
+        RecipientAdapter.setContactPhotoOrPlaceholder(getContext(), getAccount(), holder.vContactPhoto, recipient);
 
         boolean hasCryptoProvider = cryptoProvider != null;
         if (!hasCryptoProvider) {
@@ -264,6 +266,10 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         for (Recipient recipient : recipients) {
             addObject(recipient);
         }
+    }
+
+    public Account getAccount() {
+        return ((MessageCompose) getContext()).getAccount();
     }
 
     public Address[] getAddresses() {

--- a/k9mail/src/main/res/values/arrays.xml
+++ b/k9mail/src/main/res/values/arrays.xml
@@ -167,6 +167,18 @@
         <item>ALWAYS</item>
     </string-array>
 
+    <string-array name="account_settings_use_gravatar_entries">
+        <item>@string/account_setting_use_gravatar_never</item>
+        <item>@string/account_setting_use_gravatar_on_wifi</item>
+        <item>@string/account_setting_use_gravatar_always</item>
+    </string-array>
+
+    <string-array name="account_settings_use_gravatar_values" translatable="false">
+        <item>NEVER</item>
+        <item>ON_WIFI</item>
+        <item>ALWAYS</item>
+    </string-array>
+
     <string-array name="account_settings_searchable_entries">
         <item>@string/account_settings_searchable_all</item>
         <item>@string/account_settings_searchable_displayable</item>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -554,6 +554,12 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_show_pictures_only_from_contacts">From contacts</string>
     <string name="account_settings_show_pictures_always">From anyone</string>
 
+    <string name="account_setting_use_gravatar_label">Use Gravatar as fallback</string>
+    <string name="account_setting_use_gravatar_summary">Try to use Gravatar when a contact has no avatar</string>
+    <string name="account_setting_use_gravatar_never">No</string>
+    <string name="account_setting_use_gravatar_always">Always</string>
+    <string name="account_setting_use_gravatar_on_wifi">Only on Wi-Fi</string>
+
     <string name="account_settings_composition">Sending mail</string>
 
     <string name="account_settings_default_quoted_text_shown_label">Quote message when replying</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -72,6 +72,15 @@
             android:title="@string/account_settings_mark_message_as_read_on_view_label"
             android:summary="@string/account_settings_mark_message_as_read_on_view_summary" />
 
+        <ListPreference
+            android:persistent="false"
+            android:key="use_gravatar_enum"
+            android:title="@string/account_setting_use_gravatar_label"
+            android:summary="@string/account_setting_use_gravatar_summary"
+            android:entries="@array/account_settings_use_gravatar_entries"
+            android:entryValues="@array/account_settings_use_gravatar_values"
+            android:dialogTitle="@string/account_setting_use_gravatar_label" />
+
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
Try to load gravatar as contact's picture as fallback. And a option in settings is added.

However it is hard to get `Account` object in `ContactPictureLoader`, so signatures of many methods are modified for passing the `Account` object to `ContactPictureLoader`. It will be better if there is a way to get `Account` object directly anywhere.