### PR TITLE
use uncorrelated subquery for fts search term

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
@@ -80,7 +80,7 @@ public class SqlQueryBuilder {
                     if (condition.attribute != Attribute.CONTAINS) {
                         Timber.e("message contents can only be matched!");
                     }
-                    query.append("(EXISTS (SELECT docid FROM messages_fulltext WHERE docid = id AND fulltext MATCH ?))");
+                    query.append("m.id IN (SELECT docid FROM messages_fulltext WHERE fulltext MATCH ?)");
                     selectionArgs.add(fulltextQueryString);
                     break;
                 }


### PR DESCRIPTION
query plan before:

```
0|0|0|SEARCH TABLE messages AS m USING INDEX msg_composite (deleted=? AND empty=?)
0|0|0|EXECUTE CORRELATED SCALAR SUBQUERY 1
1|0|0|SCAN TABLE messages_fulltext VIRTUAL TABLE INDEX 2:
0|1|1|SEARCH TABLE threads AS t USING INDEX threads_message_id (message_id=?)
0|2|2|SEARCH TABLE folders AS f USING INTEGER PRIMARY KEY (rowid=?)
0|0|0|USE TEMP B-TREE FOR ORDER BY
```

query plan after:

```
0|0|0|SEARCH TABLE messages AS m USING INDEX msg_composite (deleted=? AND empty=?)
0|0|0|EXECUTE LIST SUBQUERY 1
1|0|0|SCAN TABLE messages_fulltext VIRTUAL TABLE INDEX 2:
0|1|1|SEARCH TABLE threads AS t USING INDEX threads_message_id (message_id=?)
0|2|2|SEARCH TABLE folders AS f USING INTEGER PRIMARY KEY (rowid=?)
0|0|0|USE TEMP B-TREE FOR ORDER BY
```

When I wrote this I assumed the EXISTS query would be efficiently optimized by way of the `docid = id` clause since the docid candidates should already have some selectivity. Turns out sqlite doesn't do that :(

This method (efficiently) builds a list of all document ids (with slightly worse selectivity) that match the given search term, and then selects from that list in the outer clause.

For two thousand messages in my mailbox, this change makes an empirical difference between "five seconds for search" to "instant search". Also, MessageListFragment has a quirk that clicking on a message reloads the query, which amplifyied this wait time to affect pretty much every click.