### PR TITLE
Add toast when folder fetch fails

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapResponseParser.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapResponseParser.java
@@ -477,7 +477,7 @@ class ImapResponseParser {
 
     private void checkTokenIsString(Object token) throws IOException {
         if (!(token instanceof String)) {
-            throw new IOException("Unexpected non-string token: " + token);
+            throw new IOException("Unexpected non-string token: " + token.getClass().getSimpleName() + " - " + token);
         }
     }
 }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapResponseParserTest.java
@@ -384,6 +384,14 @@ public class ImapResponseParserTest {
         assertEquals("[FolderName]", response.get(3));
     }
 
+    @Test(expected = IOException.class)
+    public void testListResponseContainingFolderNameContainingBracketsThrowsException() throws Exception {
+        ImapResponseParser parser = createParser(
+                "* LIST (\\NoInferiors) \"/\" Root/Folder/Subfolder()\r\n");
+
+        parser.readResponse();
+    }
+
     @Test
     public void readResponseShouldReadWholeListResponseLine() throws Exception {
         ImapResponseParser parser = createParser("* LIST (\\HasNoChildren) \".\" [FolderName]\r\n" +
@@ -417,7 +425,7 @@ public class ImapResponseParserTest {
             parser.readResponse();
             fail("Expected exception");
         } catch (IOException e) {
-            assertEquals("Unexpected non-string token: [1, 2]", e.getMessage());
+            assertEquals("Unexpected non-string token: ImapList - [1, 2]", e.getMessage());
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -706,8 +706,8 @@ public class FolderList extends K9ListActivity {
             @Override
             public void listFoldersFailed(Account account, String message) {
                 if (account.equals(mAccount)) {
-
                     mHandler.progress(false);
+                    Toast.makeText(context, R.string.fetching_folders_failed, Toast.LENGTH_SHORT).show();
                 }
                 super.listFoldersFailed(account, message);
             }

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1229,4 +1229,5 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="mail_list_widget_text">K-9 Message List</string>
     <string name="mail_list_widget_loading">Loading messages…</string>
+    <string name="fetching_folders_failed">Fetching folder list failed</string>
 </resources>


### PR DESCRIPTION
Improve behaviour seen in #2474 - display a Toast when fetching the list of folders fails.

Also, a test for this kind of issue to validate we follow the spec here.

