### PR TITLE
Crypto status dryrun

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -647,12 +647,11 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             builder = SimpleMessageBuilder.newInstance();
         }
 
+        recipientPresenter.builderSetProperties(builder);
+
         builder.setSubject(Utility.stripNewLines(subjectView.getText().toString()))
                 .setSentDate(new Date())
                 .setHideTimeZone(K9.hideTimeZone())
-                .setTo(recipientPresenter.getToAddresses())
-                .setCc(recipientPresenter.getCcAddresses())
-                .setBcc(recipientPresenter.getBccAddresses())
                 .setInReplyTo(repliedToMessageId)
                 .setReferences(referencedMessageIds)
                 .setRequestReadReceipt(requestReadReceipt)

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -116,8 +116,12 @@ public class AttachmentPresenter {
     }
 
     public void onClickAddAttachment(RecipientPresenter recipientPresenter) {
-        AttachErrorState maybeAttachErrorState =
-                recipientPresenter.getCurrentCryptoStatus().getAttachErrorStateOrNull();
+        ComposeCryptoStatus currentCachedCryptoStatus = recipientPresenter.getCurrentCachedCryptoStatus();
+        if (currentCachedCryptoStatus == null) {
+            return;
+        }
+
+        AttachErrorState maybeAttachErrorState = currentCachedCryptoStatus.getAttachErrorStateOrNull();
         if (maybeAttachErrorState != null) {
             recipientPresenter.showPgpAttachError(maybeAttachErrorState);
             return;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -320,6 +320,10 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
         Toast.makeText(activity, R.string.error_contact_address_not_found, Toast.LENGTH_LONG).show();
     }
 
+    public void showErrorOpenPgpRetrieveStatus() {
+        Toast.makeText(activity, R.string.error_recipient_crypto_retrieve, Toast.LENGTH_LONG).show();
+    }
+
     public void showErrorOpenPgpConnection() {
         Toast.makeText(activity, R.string.error_crypto_provider_connect, Toast.LENGTH_LONG).show();
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -19,7 +19,6 @@ import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
-import timber.log.Timber;
 import android.view.Menu;
 
 import com.fsck.k9.Account;
@@ -29,6 +28,7 @@ import com.fsck.k9.R;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.AttachErrorState;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.ComposeCryptoStatusBuilder;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.SendErrorState;
+import com.fsck.k9.activity.compose.RecipientMvpView.CryptoStatusDisplayType;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.helper.MailTo;
 import com.fsck.k9.helper.ReplyToParser;
@@ -47,6 +47,7 @@ import org.openintents.openpgp.util.OpenPgpApi;
 import org.openintents.openpgp.util.OpenPgpApi.PermissionPingCallback;
 import org.openintents.openpgp.util.OpenPgpServiceConnection;
 import org.openintents.openpgp.util.OpenPgpServiceConnection.OnBound;
+import timber.log.Timber;
 
 
 public class RecipientPresenter implements PermissionPingCallback {
@@ -392,7 +393,11 @@ public class RecipientPresenter implements PermissionPingCallback {
             @Override
             protected void onPostExecute(ComposeCryptoStatus composeCryptoStatus) {
                 cachedCryptoStatus = composeCryptoStatus;
-                recipientMvpView.showCryptoStatus(composeCryptoStatus.getCryptoStatusDisplayType());
+                CryptoStatusDisplayType cryptoStatusDisplayType = composeCryptoStatus.getCryptoStatusDisplayType();
+                if (cryptoStatusDisplayType == CryptoStatusDisplayType.ERROR) {
+                    recipientMvpView.showErrorOpenPgpRetrieveStatus();
+                }
+                recipientMvpView.showCryptoStatus(cryptoStatusDisplayType);
                 recipientMvpView.showCryptoSpecialMode(composeCryptoStatus.getCryptoSpecialModeDisplayType());
             }
         }.execute();

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -11,7 +11,7 @@ import android.content.Intent;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import timber.log.Timber;
+import android.support.annotation.WorkerThread;
 
 import com.fsck.k9.Globals;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus;
@@ -35,6 +35,7 @@ import org.apache.james.mime4j.util.MimeUtil;
 import org.openintents.openpgp.OpenPgpError;
 import org.openintents.openpgp.util.OpenPgpApi;
 import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
+import timber.log.Timber;
 
 
 public class PgpMessageBuilder extends MessageBuilder {
@@ -327,6 +328,7 @@ public class PgpMessageBuilder extends MessageBuilder {
         this.cryptoStatus = cryptoStatus;
     }
 
+    @WorkerThread
     public CryptoProviderDryRunStatus retrieveCryptoProviderRecipientStatus() {
         boolean shouldSign = cryptoStatus.isSigningEnabled();
         boolean shouldEncrypt = cryptoStatus.isEncryptionEnabled();

--- a/k9mail/src/main/res/layout/message_compose_recipients.xml
+++ b/k9mail/src/main/res/layout/message_compose_recipients.xml
@@ -110,7 +110,7 @@
             tools:visibility="visible"
             android:inAnimation="@anim/fade_in"
             android:outAnimation="@anim/fade_out"
-            custom:previewInitialChild="2">
+            custom:previewInitialChild="7">
 
             <ImageView
                 android:layout_width="wrap_content"
@@ -245,6 +245,14 @@
                     />
 
             </FrameLayout>
+
+            <ImageView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:src="@drawable/status_lock_opportunistic"
+                android:tint="?attr/openpgp_grey"
+                />
 
         </com.fsck.k9.view.ToolableViewAnimator>
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1233,4 +1233,5 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="mail_list_widget_loading">Loading messages…</string>
     <string name="fetching_folders_failed">Fetching folder list failed</string>
     <string name="messageview_crypto_warning_details">Show Details</string>
+    <string name="error_recipient_crypto_retrieve">Error retrieving recipient status from OpenPGP provider!</string>
 </resources>

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
@@ -45,6 +45,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
+@SuppressWarnings("ConstantConditions")
 @RunWith(K9RobolectricTestRunner.class)
 @Config(shadows = {ShadowOpenPgpAsyncTask.class})
 public class RecipientPresenterTest {
@@ -77,7 +78,7 @@ public class RecipientPresenterTest {
 
         recipientPresenter = new RecipientPresenter(
                 context, loaderManager, recipientMvpView, account, composePgpInlineDecider, replyToParser, listener);
-        recipientPresenter.updateCryptoStatus();
+        recipientPresenter.asyncUpdateCryptoStatus();
 
         noUserIdsResultIntent = new Intent();
         noUserIdsResultIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
@@ -120,7 +121,7 @@ public class RecipientPresenterTest {
 
     @Test
     public void getCurrentCryptoStatus_withoutCryptoProvider() throws Exception {
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.UNCONFIGURED, status.getCryptoStatusDisplayType());
         assertEquals(CryptoSpecialModeDisplayType.NONE, status.getCryptoSpecialModeDisplayType());
@@ -133,7 +134,8 @@ public class RecipientPresenterTest {
     public void getCurrentCryptoStatus_withCryptoProvider() throws Exception {
         setupCryptoProvider(noUserIdsResultIntent);
 
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.OPPORTUNISTIC_EMPTY, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -145,7 +147,8 @@ public class RecipientPresenterTest {
         setupCryptoProvider(noUserIdsResultIntent);
 
         recipientPresenter.onCryptoModeChanged(CryptoMode.OPPORTUNISTIC);
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.OPPORTUNISTIC_EMPTY, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -160,7 +163,8 @@ public class RecipientPresenterTest {
         setupCryptoProvider(resultIntent);
 
         recipientPresenter.onCryptoModeChanged(CryptoMode.OPPORTUNISTIC);
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.OPPORTUNISTIC_UNTRUSTED, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -176,7 +180,8 @@ public class RecipientPresenterTest {
         setupCryptoProvider(resultIntent);
 
         recipientPresenter.onCryptoModeChanged(CryptoMode.OPPORTUNISTIC);
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.OPPORTUNISTIC_NOKEY, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -192,7 +197,8 @@ public class RecipientPresenterTest {
         setupCryptoProvider(resultIntent);
 
         recipientPresenter.onCryptoModeChanged(CryptoMode.PRIVATE);
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.PRIVATE_NOKEY, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -207,7 +213,8 @@ public class RecipientPresenterTest {
         setupCryptoProvider(resultIntent);
 
         recipientPresenter.onCryptoModeChanged(CryptoMode.OPPORTUNISTIC);
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.OPPORTUNISTIC_TRUSTED, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -219,7 +226,8 @@ public class RecipientPresenterTest {
         setupCryptoProvider(noUserIdsResultIntent);
 
         recipientPresenter.onCryptoModeChanged(CryptoMode.DISABLE);
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.DISABLED, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -231,7 +239,8 @@ public class RecipientPresenterTest {
         setupCryptoProvider(noUserIdsResultIntent);
 
         recipientPresenter.onCryptoModeChanged(CryptoMode.PRIVATE);
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.PRIVATE_EMPTY, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -243,7 +252,8 @@ public class RecipientPresenterTest {
         setupCryptoProvider(noUserIdsResultIntent);
 
         recipientPresenter.onMenuSetSignOnly(true);
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.SIGN_ONLY, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -256,7 +266,8 @@ public class RecipientPresenterTest {
         setupCryptoProvider(noUserIdsResultIntent);
 
         recipientPresenter.onMenuSetPgpInline(true);
-        ComposeCryptoStatus status = recipientPresenter.getCurrentCryptoStatus();
+        Robolectric.getBackgroundThreadScheduler().runOneTask();
+        ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.OPPORTUNISTIC_EMPTY, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
@@ -334,7 +345,7 @@ public class RecipientPresenterTest {
         Robolectric.getBackgroundThreadScheduler().pause();
         recipientPresenter.setOpenPgpServiceConnection(openPgpServiceConnection, CRYPTO_PROVIDER);
         recipientPresenter.onSwitchAccount(account);
-        recipientPresenter.updateCryptoStatus();
+        recipientPresenter.asyncUpdateCryptoStatus();
         Robolectric.getBackgroundThreadScheduler().runOneTask();
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -275,7 +275,6 @@ public class PgpMessageBuilderTest {
 
         Intent expectedApiIntent = new Intent(OpenPgpApi.ACTION_SIGN_AND_ENCRYPT);
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
-        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, new long[] { TEST_SELF_ENCRYPT_KEY_ID });
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_ENCRYPT_OPPORTUNISTIC, false);
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, cryptoStatus.getRecipientAddresses());
@@ -328,7 +327,6 @@ public class PgpMessageBuilderTest {
 
         Intent expectedApiIntent = new Intent(OpenPgpApi.ACTION_SIGN_AND_ENCRYPT);
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
-        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, new long[] { TEST_SELF_ENCRYPT_KEY_ID });
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_ENCRYPT_OPPORTUNISTIC, false);
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, cryptoStatus.getRecipientAddresses());

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
@@ -230,6 +230,8 @@ public class OpenPgpApi {
     public static final String EXTRA_USER_IDS = "user_ids";
     public static final String EXTRA_KEY_IDS = "key_ids";
     public static final String EXTRA_SIGN_KEY_ID = "sign_key_id";
+    public static final String EXTRA_DRY_RUN = "dry_run";
+    public static final String RESULT_KEYS_CONFIRMED = "keys_confirmed";
     // optional extras:
     public static final String EXTRA_PASSPHRASE = "passphrase";
     public static final String EXTRA_ORIGINAL_FILENAME = "original_filename";


### PR DESCRIPTION
This PR changes how the crypto status icon is displayed and most importantly, calls out to OpenKeychain to retrieve information about the state of selected recipients.

This comes with a cost in complexity since that call is made asynchronously, and there is a new "weird state" where the status is not yet retrieved and the user presses "send". However this should be so rare that it should never come up in practice, which is why I silently abort the user interaction rather than add even more complexity to handle it.

From OpenKeychain's side, the mechanism works as a "dry run" for sign+encrypt, following the same codepath as a regular sign+encrypt operation but aborting the process once all metadata is gathered, returning with a status. This requires a development version of OpenKeychain that includes this PR: https://github.com/open-keychain/open-keychain/pull/2088. I will push for a beta release with that included to make this easier to test.

Sadly, it's not possible to be compatible with older openkeychain versions here unless I keep the old crypto status mechanism around, which I really don't want to do. The plan is to release this in OpenKeychain earlier than K-9 and just error out for older versions.