### PR TITLE
persist dialog counters

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -21,6 +21,7 @@ import android.content.SharedPreferences;
 import android.content.SharedPreferences.Editor;
 import android.content.pm.PackageManager;
 import android.net.Uri;
+import android.os.AsyncTask;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Looper;
@@ -1433,6 +1434,20 @@ public class K9 extends Application {
         if (enableDebugLogging) {
             Timber.plant(new DebugTree());
         }
+    }
+
+    public static void saveSettingsAsync() {
+        new AsyncTask<Void,Void,Void>() {
+            @Override
+            protected Void doInBackground(Void... voids) {
+                Preferences prefs = Preferences.getPreferences(app);
+                StorageEditor editor = prefs.getStorage().edit();
+                save(editor);
+                editor.commit();
+
+                return null;
+            }
+        }.execute();
     }
 
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -756,6 +756,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         int pgpInlineDialogCounter = K9.getPgpInlineDialogCounter();
         if (pgpInlineDialogCounter < PGP_DIALOG_DISPLAY_THRESHOLD) {
             K9.setPgpInlineDialogCounter(pgpInlineDialogCounter + 1);
+            K9.saveSettingsAsync();
             return true;
         }
         return false;
@@ -765,6 +766,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         int pgpSignOnlyDialogCounter = K9.getPgpSignOnlyDialogCounter();
         if (pgpSignOnlyDialogCounter < PGP_DIALOG_DISPLAY_THRESHOLD) {
             K9.setPgpSignOnlyDialogCounter(pgpSignOnlyDialogCounter + 1);
+            K9.saveSettingsAsync();
             return true;
         }
         return false;


### PR DESCRIPTION
Simple fix: the counters for displayed warning dialogs (openpgp inline and sign-only) were set, but not persisted. I added a simple fire-and-forget method to persist those.