### PR TITLE
Security Warnings

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
@@ -20,13 +20,16 @@ public final class CryptoResultAnnotation {
     private final OpenPgpSignatureResult openPgpSignatureResult;
     private final OpenPgpError openPgpError;
     private final PendingIntent openPgpPendingIntent;
+    private final PendingIntent openPgpInsecureWarningPendingIntent;
 
     private final CryptoResultAnnotation encapsulatedResult;
 
     private CryptoResultAnnotation(@NonNull CryptoError errorType, MimeBodyPart replacementData,
             OpenPgpDecryptionResult openPgpDecryptionResult,
             OpenPgpSignatureResult openPgpSignatureResult,
-            PendingIntent openPgpPendingIntent, OpenPgpError openPgpError) {
+            PendingIntent openPgpPendingIntent,
+            PendingIntent openPgpInsecureWarningPendingIntent,
+            OpenPgpError openPgpError) {
         this.errorType = errorType;
         this.replacementData = replacementData;
 
@@ -34,6 +37,7 @@ public final class CryptoResultAnnotation {
         this.openPgpSignatureResult = openPgpSignatureResult;
         this.openPgpPendingIntent = openPgpPendingIntent;
         this.openPgpError = openPgpError;
+        this.openPgpInsecureWarningPendingIntent = openPgpInsecureWarningPendingIntent;
 
         this.encapsulatedResult = null;
     }
@@ -49,6 +53,7 @@ public final class CryptoResultAnnotation {
         this.openPgpDecryptionResult = annotation.openPgpDecryptionResult;
         this.openPgpSignatureResult = annotation.openPgpSignatureResult;
         this.openPgpPendingIntent = annotation.openPgpPendingIntent;
+        this.openPgpInsecureWarningPendingIntent = annotation.openPgpInsecureWarningPendingIntent;
         this.openPgpError = annotation.openPgpError;
 
         this.encapsulatedResult = encapsulatedResult;
@@ -56,30 +61,31 @@ public final class CryptoResultAnnotation {
 
 
     public static CryptoResultAnnotation createOpenPgpResultAnnotation(OpenPgpDecryptionResult decryptionResult,
-            OpenPgpSignatureResult signatureResult, PendingIntent pendingIntent, MimeBodyPart replacementPart) {
+            OpenPgpSignatureResult signatureResult, PendingIntent pendingIntent,
+            PendingIntent insecureWarningPendingIntent, MimeBodyPart replacementPart) {
         return new CryptoResultAnnotation(CryptoError.OPENPGP_OK, replacementPart,
-                decryptionResult, signatureResult, pendingIntent, null);
+                decryptionResult, signatureResult, pendingIntent, insecureWarningPendingIntent, null);
     }
 
     public static CryptoResultAnnotation createErrorAnnotation(CryptoError error, MimeBodyPart replacementData) {
         if (error == CryptoError.OPENPGP_OK) {
             throw new AssertionError("CryptoError must be actual error state!");
         }
-        return new CryptoResultAnnotation(error, replacementData, null, null, null, null);
+        return new CryptoResultAnnotation(error, replacementData, null, null, null, null, null);
     }
 
     public static CryptoResultAnnotation createOpenPgpCanceledAnnotation() {
-        return new CryptoResultAnnotation(CryptoError.OPENPGP_UI_CANCELED, null, null, null, null, null);
+        return new CryptoResultAnnotation(CryptoError.OPENPGP_UI_CANCELED, null, null, null, null, null, null);
     }
 
     public static CryptoResultAnnotation createOpenPgpSignatureErrorAnnotation(
             OpenPgpError error, MimeBodyPart replacementData) {
         return new CryptoResultAnnotation(
-                CryptoError.OPENPGP_SIGNED_API_ERROR, replacementData, null, null, null, error);
+                CryptoError.OPENPGP_SIGNED_API_ERROR, replacementData, null, null, null, null, error);
     }
 
     public static CryptoResultAnnotation createOpenPgpEncryptionErrorAnnotation(OpenPgpError error) {
-        return new CryptoResultAnnotation(CryptoError.OPENPGP_ENCRYPTED_API_ERROR, null, null, null, null, error);
+        return new CryptoResultAnnotation(CryptoError.OPENPGP_ENCRYPTED_API_ERROR, null, null, null, null, null, error);
     }
 
     public boolean isOpenPgpResult() {
@@ -115,6 +121,11 @@ public final class CryptoResultAnnotation {
     @Nullable
     public PendingIntent getOpenPgpPendingIntent() {
         return openPgpPendingIntent;
+    }
+
+    @Nullable
+    public PendingIntent getOpenPgpInsecureWarningPendingIntent() {
+        return openPgpInsecureWarningPendingIntent;
     }
 
     @Nullable

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
@@ -130,6 +130,10 @@ public final class CryptoResultAnnotation {
         return openPgpPendingIntent;
     }
 
+    public boolean hasOpenPgpInsecureWarningPendingIntent() {
+        return openPgpInsecureWarningPendingIntent != null;
+    }
+
     @Nullable
     public PendingIntent getOpenPgpInsecureWarningPendingIntent() {
         return openPgpInsecureWarningPendingIntent;
@@ -170,7 +174,6 @@ public final class CryptoResultAnnotation {
     public CryptoResultAnnotation getEncapsulatedResult() {
         return encapsulatedResult;
     }
-
 
     public enum CryptoError {
         OPENPGP_OK,

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
@@ -21,6 +21,7 @@ public final class CryptoResultAnnotation {
     private final OpenPgpError openPgpError;
     private final PendingIntent openPgpPendingIntent;
     private final PendingIntent openPgpInsecureWarningPendingIntent;
+    private final boolean overrideCryptoWarning;
 
     private final CryptoResultAnnotation encapsulatedResult;
 
@@ -29,7 +30,8 @@ public final class CryptoResultAnnotation {
             OpenPgpSignatureResult openPgpSignatureResult,
             PendingIntent openPgpPendingIntent,
             PendingIntent openPgpInsecureWarningPendingIntent,
-            OpenPgpError openPgpError) {
+            OpenPgpError openPgpError,
+            boolean overrideCryptoWarning) {
         this.errorType = errorType;
         this.replacementData = replacementData;
 
@@ -38,6 +40,7 @@ public final class CryptoResultAnnotation {
         this.openPgpPendingIntent = openPgpPendingIntent;
         this.openPgpError = openPgpError;
         this.openPgpInsecureWarningPendingIntent = openPgpInsecureWarningPendingIntent;
+        this.overrideCryptoWarning = overrideCryptoWarning;
 
         this.encapsulatedResult = null;
     }
@@ -55,6 +58,7 @@ public final class CryptoResultAnnotation {
         this.openPgpPendingIntent = annotation.openPgpPendingIntent;
         this.openPgpInsecureWarningPendingIntent = annotation.openPgpInsecureWarningPendingIntent;
         this.openPgpError = annotation.openPgpError;
+        this.overrideCryptoWarning = annotation.overrideCryptoWarning;
 
         this.encapsulatedResult = encapsulatedResult;
     }
@@ -62,30 +66,33 @@ public final class CryptoResultAnnotation {
 
     public static CryptoResultAnnotation createOpenPgpResultAnnotation(OpenPgpDecryptionResult decryptionResult,
             OpenPgpSignatureResult signatureResult, PendingIntent pendingIntent,
-            PendingIntent insecureWarningPendingIntent, MimeBodyPart replacementPart) {
+            PendingIntent insecureWarningPendingIntent, MimeBodyPart replacementPart,
+            boolean overrideCryptoWarning) {
         return new CryptoResultAnnotation(CryptoError.OPENPGP_OK, replacementPart,
-                decryptionResult, signatureResult, pendingIntent, insecureWarningPendingIntent, null);
+                decryptionResult, signatureResult, pendingIntent, insecureWarningPendingIntent, null,
+                overrideCryptoWarning);
     }
 
     public static CryptoResultAnnotation createErrorAnnotation(CryptoError error, MimeBodyPart replacementData) {
         if (error == CryptoError.OPENPGP_OK) {
             throw new AssertionError("CryptoError must be actual error state!");
         }
-        return new CryptoResultAnnotation(error, replacementData, null, null, null, null, null);
+        return new CryptoResultAnnotation(error, replacementData, null, null, null, null, null, false);
     }
 
     public static CryptoResultAnnotation createOpenPgpCanceledAnnotation() {
-        return new CryptoResultAnnotation(CryptoError.OPENPGP_UI_CANCELED, null, null, null, null, null, null);
+        return new CryptoResultAnnotation(CryptoError.OPENPGP_UI_CANCELED, null, null, null, null, null, null, false);
     }
 
     public static CryptoResultAnnotation createOpenPgpSignatureErrorAnnotation(
             OpenPgpError error, MimeBodyPart replacementData) {
         return new CryptoResultAnnotation(
-                CryptoError.OPENPGP_SIGNED_API_ERROR, replacementData, null, null, null, null, error);
+                CryptoError.OPENPGP_SIGNED_API_ERROR, replacementData, null, null, null, null, error, false);
     }
 
     public static CryptoResultAnnotation createOpenPgpEncryptionErrorAnnotation(OpenPgpError error) {
-        return new CryptoResultAnnotation(CryptoError.OPENPGP_ENCRYPTED_API_ERROR, null, null, null, null, null, error);
+        return new CryptoResultAnnotation(
+                CryptoError.OPENPGP_ENCRYPTED_API_ERROR, null, null, null, null, null, error, false);
     }
 
     public boolean isOpenPgpResult() {
@@ -145,6 +152,10 @@ public final class CryptoResultAnnotation {
     @Nullable
     public MimeBodyPart getReplacementData() {
         return replacementData;
+    }
+
+    public boolean isOverrideSecurityWarning() {
+        return overrideCryptoWarning;
     }
 
     @NonNull

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
@@ -251,6 +251,7 @@ public class MessageCryptoHelper {
             decryptIntent.putExtra(OpenPgpApi.EXTRA_SENDER_ADDRESS, from[0].getAddress());
         }
 
+        decryptIntent.putExtra(OpenPgpApi.EXTRA_SUPPORT_OVERRIDE_CRYPTO_WARNING, true);
         decryptIntent.putExtra(OpenPgpApi.EXTRA_DECRYPTION_RESULT, cachedDecryptionResult);
 
         return decryptIntent;
@@ -515,9 +516,11 @@ public class MessageCryptoHelper {
                 currentCryptoResult.getParcelableExtra(OpenPgpApi.RESULT_SIGNATURE);
         PendingIntent pendingIntent = currentCryptoResult.getParcelableExtra(OpenPgpApi.RESULT_INTENT);
         PendingIntent insecureWarningPendingIntent = currentCryptoResult.getParcelableExtra(OpenPgpApi.RESULT_INSECURE_DETAIL_INTENT);
+        boolean overrideCryptoWarning = currentCryptoResult.getBooleanExtra(
+                OpenPgpApi.RESULT_OVERRIDE_CRYPTO_WARNING, false);
 
-        CryptoResultAnnotation resultAnnotation = CryptoResultAnnotation.createOpenPgpResultAnnotation(
-                decryptionResult, signatureResult, pendingIntent, insecureWarningPendingIntent, outputPart);
+        CryptoResultAnnotation resultAnnotation = CryptoResultAnnotation.createOpenPgpResultAnnotation(decryptionResult,
+                signatureResult, pendingIntent, insecureWarningPendingIntent, outputPart, overrideCryptoWarning);
 
         onCryptoOperationSuccess(resultAnnotation);
     }

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
@@ -514,9 +514,10 @@ public class MessageCryptoHelper {
         OpenPgpSignatureResult signatureResult =
                 currentCryptoResult.getParcelableExtra(OpenPgpApi.RESULT_SIGNATURE);
         PendingIntent pendingIntent = currentCryptoResult.getParcelableExtra(OpenPgpApi.RESULT_INTENT);
+        PendingIntent insecureWarningPendingIntent = currentCryptoResult.getParcelableExtra(OpenPgpApi.RESULT_INSECURE_DETAIL_INTENT);
 
         CryptoResultAnnotation resultAnnotation = CryptoResultAnnotation.createOpenPgpResultAnnotation(
-                decryptionResult, signatureResult, pendingIntent, outputPart);
+                decryptionResult, signatureResult, pendingIntent, insecureWarningPendingIntent, outputPart);
 
         onCryptoOperationSuccess(resultAnnotation);
     }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/CryptoInfoDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/CryptoInfoDialog.java
@@ -28,6 +28,7 @@ import com.fsck.k9.view.ThemeUtils;
 
 public class CryptoInfoDialog extends DialogFragment {
     public static final String ARG_DISPLAY_STATUS = "display_status";
+    public static final String ARG_HAS_SECURITY_WARNING = "has_security_warning";
     public static final int ICON_ANIM_DELAY = 400;
     public static final int ICON_ANIM_DURATION = 350;
 
@@ -46,11 +47,12 @@ public class CryptoInfoDialog extends DialogFragment {
     private TextView bottomText;
 
 
-    public static CryptoInfoDialog newInstance(MessageCryptoDisplayStatus displayStatus) {
+    public static CryptoInfoDialog newInstance(MessageCryptoDisplayStatus displayStatus, boolean hasSecurityWarning) {
         CryptoInfoDialog frag = new CryptoInfoDialog();
 
         Bundle args = new Bundle();
         args.putString(ARG_DISPLAY_STATUS, displayStatus.toString());
+        args.putBoolean(ARG_HAS_SECURITY_WARNING, hasSecurityWarning);
         frag.setArguments(args);
 
         return frag;
@@ -85,7 +87,19 @@ public class CryptoInfoDialog extends DialogFragment {
                 dismiss();
             }
         });
-        if (displayStatus.hasAssociatedKey()) {
+        boolean hasSecurityWarning = getArguments().getBoolean(ARG_HAS_SECURITY_WARNING);
+        if (hasSecurityWarning) {
+            b.setNeutralButton(R.string.crypto_info_view_security_warning, new OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialogInterface, int i) {
+                    Fragment frag = getTargetFragment();
+                    if (! (frag instanceof OnClickShowCryptoKeyListener)) {
+                        throw new AssertionError("Displaying activity must implement OnClickShowCryptoKeyListener!");
+                    }
+                    ((OnClickShowCryptoKeyListener) frag).onClickShowSecurityWarning();
+                }
+            });
+        } else if (displayStatus.hasAssociatedKey()) {
             b.setNeutralButton(R.string.crypto_info_view_key, new OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialogInterface, int i) {
@@ -190,5 +204,6 @@ public class CryptoInfoDialog extends DialogFragment {
 
     public interface OnClickShowCryptoKeyListener {
         void onClickShowCryptoKey();
+        void onClickShowSecurityWarning();
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -122,6 +122,7 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
             }
 
             case ENCRYPTED_ERROR:
+            case ENCRYPTED_INSECURE:
             case UNSUPPORTED_ENCRYPTED: {
                 Drawable providerIcon = getOpenPgpApiProviderIcon(messageView.getContext());
                 if (messageViewInfo.cryptoResultAnnotation.hasReplacementData()) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -72,6 +72,10 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
             return false;
         }
 
+        if (cryptoResultAnnotation.isOverrideSecurityWarning()) {
+            overrideCryptoWarning = true;
+        }
+
         messageView.getMessageHeaderView().setCryptoStatus(displayStatus);
 
         switch (displayStatus) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -129,10 +129,23 @@ public class MessageTopView extends LinearLayout {
     }
 
     public void showMessageCryptoWarning(final MessageViewInfo messageViewInfo, Drawable providerIcon,
-            @StringRes int warningTextRes) {
+            @StringRes int warningTextRes, boolean showDetailButton) {
         resetAndPrepareMessageView(messageViewInfo);
         View view = mInflater.inflate(R.layout.message_content_crypto_warning, containerView, false);
         setCryptoProviderIcon(providerIcon, view);
+
+        View detailButton = view.findViewById(R.id.crypto_warning_details);
+        if(showDetailButton) {
+            detailButton.setVisibility(View.VISIBLE);
+            detailButton.setOnClickListener(new OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    messageCryptoPresenter.onClickShowCryptoWarningDetails();
+                }
+            });
+        } else {
+            detailButton.setVisibility(View.GONE);
+        }
 
         view.findViewById(R.id.crypto_warning_override).setOnClickListener(new OnClickListener() {
             @Override

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -689,8 +689,8 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         }
 
         @Override
-        public void showCryptoInfoDialog(MessageCryptoDisplayStatus displayStatus) {
-            CryptoInfoDialog dialog = CryptoInfoDialog.newInstance(displayStatus);
+        public void showCryptoInfoDialog(MessageCryptoDisplayStatus displayStatus, boolean hasSecurityWarning) {
+            CryptoInfoDialog dialog = CryptoInfoDialog.newInstance(displayStatus, hasSecurityWarning);
             dialog.setTargetFragment(MessageViewFragment.this, 0);
             dialog.show(getFragmentManager(), "crypto_info_dialog");
         }
@@ -706,6 +706,11 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
             startOpenPgpChooserActivity();
         }
     };
+
+    @Override
+    public void onClickShowSecurityWarning() {
+        messageCryptoPresenter.onClickShowCryptoWarningDetails();
+    }
 
     @Override
     public void onClickShowCryptoKey() {

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
@@ -125,6 +125,12 @@ public enum MessageCryptoDisplayStatus {
             R.string.crypto_msg_encrypted_error
     ),
 
+    ENCRYPTED_INSECURE (
+            R.attr.openpgp_red,
+            R.drawable.status_lock_error,
+            R.string.crypto_msg_encrypted_insecure
+    ),
+
     INCOMPLETE_ENCRYPTED (
             R.attr.openpgp_black,
             R.drawable.status_lock_opportunistic,
@@ -254,7 +260,7 @@ public enum MessageCryptoDisplayStatus {
                 return getStatusForPgpEncryptedResult(signatureResult);
 
             case OpenPgpDecryptionResult.RESULT_INSECURE:
-                return ENCRYPTED_ERROR;
+                return ENCRYPTED_INSECURE;
         }
 
         throw new AssertionError("all cases must be handled, this is a bug!");

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
@@ -254,7 +254,6 @@ public enum MessageCryptoDisplayStatus {
                 return getStatusForPgpEncryptedResult(signatureResult);
 
             case OpenPgpDecryptionResult.RESULT_INSECURE:
-                // TODO handle better?
                 return ENCRYPTED_ERROR;
         }
 

--- a/k9mail/src/main/res/layout/message_content_crypto_warning.xml
+++ b/k9mail/src/main/res/layout/message_content_crypto_warning.xml
@@ -46,6 +46,12 @@
     <Button
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:id="@+id/crypto_warning_details"
+        android:text="@string/messageview_crypto_warning_details"/>
+
+    <Button
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
         android:id="@+id/crypto_warning_override"
         android:text="@string/messageview_crypto_warning_show_anyway"/>
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1194,6 +1194,7 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="crypto_info_ok">OK</string>
     <string name="crypto_info_view_key">View Signer</string>
+    <string name="crypto_info_view_security_warning">Details</string>
     <string name="locked_attach_unlock">Unlock</string>
     <string name="locked_attach_unencrypted">This part was not encrypted, and may be insecure.</string>
     <string name="locked_attach_title">Unprotected Attachment</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1167,6 +1167,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="crypto_msg_disabled">Message is not encrypted</string>
 
     <string name="crypto_msg_encrypted_error">Message is encrypted, but there was a decryption error.</string>
+    <string name="crypto_msg_encrypted_insecure">Message is encrypted but insecure!</string>
     <string name="crypto_msg_signed_error">Message is signed, but the signature could not be verified.</string>
     <string name="crypto_msg_encrypted_no_provider">Message is encrypted, but no crypto app is configured.</string>
     <string name="crypto_msg_unsupported_encrypted">Message is encrypted, but in an unsupported format.</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1230,4 +1230,5 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="mail_list_widget_text">K-9 Message List</string>
     <string name="mail_list_widget_loading">Loading messages…</string>
     <string name="fetching_folders_failed">Fetching folder list failed</string>
+    <string name="messageview_crypto_warning_details">Show Details</string>
 </resources>

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
@@ -263,10 +263,12 @@ public class OpenPgpApi {
     public static final String EXTRA_PROGRESS_MESSENGER = "progress_messenger";
     public static final String EXTRA_DATA_LENGTH = "data_length";
     public static final String EXTRA_SENDER_ADDRESS = "sender_address";
+    public static final String EXTRA_SUPPORT_OVERRIDE_CRYPTO_WARNING = "support_override_crpto_warning";
     public static final String RESULT_SIGNATURE = "signature";
     public static final String RESULT_DECRYPTION = "decryption";
     public static final String RESULT_METADATA = "metadata";
     public static final String RESULT_INSECURE_DETAIL_INTENT = "insecure_detail_intent";
+    public static final String RESULT_OVERRIDE_CRYPTO_WARNING = "override_crypto_warning";
     // This will be the charset which was specified in the headers of ascii armored input, if any
     public static final String RESULT_CHARSET = "charset";
 

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
@@ -266,6 +266,7 @@ public class OpenPgpApi {
     public static final String RESULT_SIGNATURE = "signature";
     public static final String RESULT_DECRYPTION = "decryption";
     public static final String RESULT_METADATA = "metadata";
+    public static final String RESULT_INSECURE_DETAIL_INTENT = "insecure_detail_intent";
     // This will be the charset which was specified in the headers of ascii armored input, if any
     public static final String RESULT_CHARSET = "charset";
 


### PR DESCRIPTION
This PR adds support for the security warning api improvements from https://github.com/open-keychain/open-keychain/pull/2097, see also there for screenshots.

Besides better error reporting, this also adds an option to suppress errors, i.e. skip displaying the security warning before a message is displayed. This addresses the problem that insecure keys would persistently cause warnings.

This change should be perfectly forward and backward compatible.