### PR TITLE
Fixed import/export of crypto settings

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -285,10 +285,10 @@ public class GlobalSettings {
         s.put("pgpSignOnlyDialogCounter", Settings.versions(
                 new V(45, new IntegerRangeSetting(0, Integer.MAX_VALUE, 0))
         ));
-        s.put("openpgpProvider", Settings.versions(
+        s.put("openPgpProvider", Settings.versions(
                 new V(46, new StringSetting(K9.NO_OPENPGP_PROVIDER))
         ));
-        s.put("openpgpSupportSignOnly", Settings.versions(
+        s.put("openPgpSupportSignOnly", Settings.versions(
                 new V(47, new BooleanSetting(false))
         ));
 


### PR DESCRIPTION
Fixes #2503, there was a mismatch between 'openpgpSupportSignOnly' in GlobalSettings vs. 'openPgpSupportSignOnly' in K9. 
Since the Crypto-option menu has not arrived at the stable build, I don't think a SettingUpgrader to delete the lowercase-option from setting storages/exported setting files is needed. 

