### PR TITLE
Don't try fallback authentication for non-authentication error responses

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/NegativeImapResponseException.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/NegativeImapResponseException.java
@@ -20,20 +20,24 @@ class NegativeImapResponseException extends MessagingException {
 
     public String getAlertText() {
         if (alertText == null) {
-            ImapResponse lastResponse = responses.get(responses.size() - 1);
+            ImapResponse lastResponse = getLastResponse();
             alertText = AlertResponse.getAlertText(lastResponse);
         }
         
         return alertText;
     }
-    
+
     public boolean wasByeResponseReceived() {
         for (ImapResponse response : responses) {
             if (response.getTag() == null && response.size() >= 1 && equalsIgnoreCase(response.get(0), Responses.BYE)) {
                 return true;
             }
         }
-        
+
         return false;
+    }
+
+    public ImapResponse getLastResponse() {
+        return responses.get(responses.size() - 1);
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ResponseCodeExtractor.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ResponseCodeExtractor.java
@@ -1,0 +1,19 @@
+package com.fsck.k9.mail.store.imap;
+
+
+class ResponseCodeExtractor {
+    public static final String AUTHENTICATION_FAILED = "AUTHENTICATIONFAILED";
+
+
+    private ResponseCodeExtractor() {
+    }
+
+    public static String getResponseCode(ImapResponse response) {
+        if (response.size() < 2 || !response.isList(1)) {
+            return null;
+        }
+
+        ImapList responseTextCode = response.getList(1);
+        return responseTextCode.size() != 1 ? null : responseTextCode.getString(0);
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ResponseCodeExtractorTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ResponseCodeExtractorTest.java
@@ -1,0 +1,38 @@
+package com.fsck.k9.mail.store.imap;
+
+
+import org.junit.Test;
+
+import static com.fsck.k9.mail.store.imap.ImapResponseHelper.createImapResponse;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+public class ResponseCodeExtractorTest {
+    @Test
+    public void getResponseCode_withResponseCode() throws Exception {
+        ImapResponse imapResponse = createImapResponse("x NO [AUTHENTICATIONFAILED] No sir");
+
+        String result = ResponseCodeExtractor.getResponseCode(imapResponse);
+
+        assertEquals("AUTHENTICATIONFAILED", result);
+    }
+
+    @Test
+    public void getResponseCode_withoutResponseCode() throws Exception {
+        ImapResponse imapResponse = createImapResponse("x NO Authentication failed");
+
+        String result = ResponseCodeExtractor.getResponseCode(imapResponse);
+
+        assertNull(result);
+    }
+
+    @Test
+    public void getResponseCode_withoutSingleItemResponse() throws Exception {
+        ImapResponse imapResponse = createImapResponse("x NO");
+
+        String result = ResponseCodeExtractor.getResponseCode(imapResponse);
+
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
If the server returns a response code like `UNAVAILABLE` there's no point in trying the fallback authentication method or notifying the user of an authentication failure.
Now we'll simply close the connection and throw the original `NegativeImapResponseException`.

See #2523