### PR TITLE
Rename fragment.getLayoutInflater for Android O+

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
@@ -74,7 +74,7 @@ public class MessageListAdapter extends CursorAdapter {
 
     @Override
     public View newView(Context context, Cursor cursor, ViewGroup parent) {
-        View view = fragment.getLayoutInflater().inflate(R.layout.message_list_item, parent, false);
+        View view = fragment.getK9LayoutInflater().inflate(R.layout.message_list_item, parent, false);
 
         MessageViewHolder holder = new MessageViewHolder(fragment);
         holder.date = (TextView) view.findViewById(R.id.date);

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -2913,7 +2913,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         return (isRemoteSearchAllowed() || isCheckMailAllowed());
     }
 
-    LayoutInflater getLayoutInflater() {
+    LayoutInflater getK9LayoutInflater() {
         return layoutInflater;
     }
 }


### PR DESCRIPTION
- This method name is a duplicate of a final method in class
`Landroid/app/Fragment`. Renaming it resolves the conflict and fixes the
crash on my Android O device.

Fixes #2540 

PS - If the name is no good, please let me know an alternative, and I'll update it.