### PR TITLE
Autocrypt header attach

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -125,7 +125,9 @@ public class ComposeCryptoStatus {
     }
 
     public boolean shouldUsePgpMessageBuilder() {
-        return cryptoProviderState != CryptoProviderState.UNCONFIGURED && (isEncryptionEnabled() || isSignOnly());
+        return cryptoProviderState != CryptoProviderState.UNCONFIGURED &&
+                cryptoProviderState != CryptoProviderState.ERROR &&
+                openPgpKeyId != null;
     }
 
     public boolean isEncryptionEnabled() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -125,9 +125,8 @@ public class ComposeCryptoStatus {
     }
 
     public boolean shouldUsePgpMessageBuilder() {
-        return cryptoProviderState != CryptoProviderState.UNCONFIGURED &&
-                cryptoProviderState != CryptoProviderState.ERROR &&
-                openPgpKeyId != null;
+        // CryptoProviderState.ERROR will be handled as an actual error, see SendErrorState
+        return cryptoProviderState != CryptoProviderState.UNCONFIGURED && openPgpKeyId != null;
     }
 
     public boolean isEncryptionEnabled() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -22,16 +22,15 @@ public class ComposeCryptoStatus {
 
 
     private CryptoProviderState cryptoProviderState;
-    private Long signingKeyId;
-    private Long selfEncryptKeyId;
+    private Long openPgpKeyId;
     private String[] recipientAddresses;
     private boolean enablePgpInline;
     private CryptoMode cryptoMode;
     private RecipientAutocryptStatus recipientAutocryptStatus;
 
 
-    public Long getSigningKeyId() {
-        return signingKeyId;
+    public Long getOpenPgpKeyId() {
+        return openPgpKeyId;
     }
 
     CryptoStatusDisplayType getCryptoStatusDisplayType() {
@@ -187,8 +186,7 @@ public class ComposeCryptoStatus {
 
         private CryptoProviderState cryptoProviderState;
         private CryptoMode cryptoMode;
-        private Long signingKeyId;
-        private Long selfEncryptKeyId;
+        private Long openPgpKeyId;
         private List<Recipient> recipients;
         private Boolean enablePgpInline;
 
@@ -202,13 +200,8 @@ public class ComposeCryptoStatus {
             return this;
         }
 
-        public ComposeCryptoStatusBuilder setSigningKeyId(Long signingKeyId) {
-            this.signingKeyId = signingKeyId;
-            return this;
-        }
-
-        public ComposeCryptoStatusBuilder setSelfEncryptId(Long selfEncryptKeyId) {
-            this.selfEncryptKeyId = selfEncryptKeyId;
+        public ComposeCryptoStatusBuilder setOpenPgpKeyId(Long openPgpKeyId) {
+            this.openPgpKeyId = openPgpKeyId;
             return this;
         }
 
@@ -245,8 +238,7 @@ public class ComposeCryptoStatus {
             result.cryptoProviderState = cryptoProviderState;
             result.cryptoMode = cryptoMode;
             result.recipientAddresses = recipientAddresses.toArray(new String[0]);
-            result.signingKeyId = signingKeyId;
-            result.selfEncryptKeyId = selfEncryptKeyId;
+            result.openPgpKeyId = openPgpKeyId;
             result.enablePgpInline = enablePgpInline;
             return result;
         }
@@ -257,8 +249,7 @@ public class ComposeCryptoStatus {
         result.cryptoProviderState = cryptoProviderState;
         result.cryptoMode = cryptoMode;
         result.recipientAddresses = recipientAddresses;
-        result.signingKeyId = signingKeyId;
-        result.selfEncryptKeyId = selfEncryptKeyId;
+        result.openPgpKeyId = openPgpKeyId;
         result.enablePgpInline = enablePgpInline;
         result.recipientAutocryptStatus = recipientAutocryptStatusType;
         return result;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -400,8 +400,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                 .setCryptoMode(currentCryptoMode)
                 .setEnablePgpInline(cryptoEnablePgpInline)
                 .setRecipients(getAllRecipients())
-                .setSigningKeyId(accountCryptoKey)
-                .setSelfEncryptId(accountCryptoKey)
+                .setOpenPgpKeyId(accountCryptoKey)
                 .build();
 
         final String[] recipientAddresses = composeCryptoStatus.getRecipientAddresses();

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
@@ -12,7 +12,7 @@ import okio.ByteString;
 class AutocryptHeader {
     static final String AUTOCRYPT_HEADER = "Autocrypt";
 
-    static final String AUTOCRYPT_PARAM_TO = "addr";
+    static final String AUTOCRYPT_PARAM_ADDR = "addr";
     static final String AUTOCRYPT_PARAM_KEY_DATA = "keydata";
 
     static final String AUTOCRYPT_PARAM_TYPE = "type";
@@ -46,7 +46,7 @@ class AutocryptHeader {
         }
 
         String autocryptHeaderString = AutocryptHeader.AUTOCRYPT_HEADER + ": ";
-        autocryptHeaderString += AutocryptHeader.AUTOCRYPT_PARAM_TO + "=" + addr + ";";
+        autocryptHeaderString += AutocryptHeader.AUTOCRYPT_PARAM_ADDR + "=" + addr + ";";
         if (isPreferEncryptMutual) {
             autocryptHeaderString += AutocryptHeader.AUTOCRYPT_PARAM_PREFER_ENCRYPT + "=" +
                     AutocryptHeader.AUTOCRYPT_PREFER_ENCRYPT_MUTUAL + ";";

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
@@ -3,6 +3,8 @@ package com.fsck.k9.autocrypt;
 
 import java.util.Map;
 
+import okio.ByteString;
+
 
 class AutocryptHeader {
     static final String AUTOCRYPT_HEADER = "Autocrypt";
@@ -16,6 +18,8 @@ class AutocryptHeader {
     static final String AUTOCRYPT_PARAM_PREFER_ENCRYPT = "prefer-encrypt";
     static final String AUTOCRYPT_PREFER_ENCRYPT_MUTUAL = "mutual";
 
+    private static final int HEADER_LINE_LENGTH = 76;
+
 
     final byte[] keyData;
     final String addr;
@@ -27,5 +31,31 @@ class AutocryptHeader {
         this.addr = addr;
         this.keyData = keyData;
         this.isPreferEncryptMutual = isPreferEncryptMutual;
+    }
+
+    String toRawHeaderString() {
+        if (!parameters.isEmpty()) {
+            throw new UnsupportedOperationException("arbitrary parameters not supported");
+        }
+
+        String autocryptHeaderString = AutocryptHeader.AUTOCRYPT_HEADER + ": ";
+        autocryptHeaderString += AutocryptHeader.AUTOCRYPT_PARAM_TO + "=" + addr + ";";
+        if (isPreferEncryptMutual) {
+            autocryptHeaderString += AutocryptHeader.AUTOCRYPT_PARAM_PREFER_ENCRYPT + "=" +
+                    AutocryptHeader.AUTOCRYPT_PREFER_ENCRYPT_MUTUAL + ";";
+        }
+        autocryptHeaderString += AutocryptHeader.AUTOCRYPT_PARAM_KEY_DATA + "=" + ByteString.of(keyData).base64();
+
+        StringBuilder headerLines = new StringBuilder();
+        int autocryptHeaderLength = autocryptHeaderString.length();
+        for (int i = 0; i < autocryptHeaderLength; i += HEADER_LINE_LENGTH) {
+            if (i + HEADER_LINE_LENGTH <= autocryptHeaderLength) {
+                headerLines.append(autocryptHeaderString, i, i + HEADER_LINE_LENGTH).append("\n ");
+            } else {
+                headerLines.append(autocryptHeaderString, i, autocryptHeaderLength);
+            }
+        }
+
+        return headerLines.toString();
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
@@ -1,7 +1,10 @@
 package com.fsck.k9.autocrypt;
 
 
+import java.util.Arrays;
 import java.util.Map;
+
+import android.support.annotation.NonNull;
 
 import okio.ByteString;
 
@@ -21,12 +24,16 @@ class AutocryptHeader {
     private static final int HEADER_LINE_LENGTH = 76;
 
 
+    @NonNull
     final byte[] keyData;
+    @NonNull
     final String addr;
+    @NonNull
     final Map<String,String> parameters;
     final boolean isPreferEncryptMutual;
 
-    AutocryptHeader(Map<String, String> parameters, String addr, byte[] keyData, boolean isPreferEncryptMutual) {
+    AutocryptHeader(@NonNull Map<String, String> parameters, @NonNull String addr,
+            @NonNull byte[] keyData, boolean isPreferEncryptMutual) {
         this.parameters = parameters;
         this.addr = addr;
         this.keyData = keyData;
@@ -57,5 +64,41 @@ class AutocryptHeader {
         }
 
         return headerLines.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AutocryptHeader that = (AutocryptHeader) o;
+
+        if (isPreferEncryptMutual != that.isPreferEncryptMutual) {
+            return false;
+        }
+        if (!Arrays.equals(keyData, that.keyData)) {
+            return false;
+        }
+        if (!addr.equals(that.addr)) {
+            return false;
+        }
+        if (!parameters.equals(that.parameters)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(keyData);
+        result = 31 * result + addr.hashCode();
+        result = 31 * result + parameters.hashCode();
+        result = 31 * result + (isPreferEncryptMutual ? 1 : 0);
+        return result;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
@@ -57,7 +57,7 @@ class AutocryptHeader {
         int autocryptHeaderLength = autocryptHeaderString.length();
         for (int i = 0; i < autocryptHeaderLength; i += HEADER_LINE_LENGTH) {
             if (i + HEADER_LINE_LENGTH <= autocryptHeaderLength) {
-                headerLines.append(autocryptHeaderString, i, i + HEADER_LINE_LENGTH).append("\n ");
+                headerLines.append(autocryptHeaderString, i, i + HEADER_LINE_LENGTH).append("\r\n ");
             } else {
                 headerLines.append(autocryptHeaderString, i, autocryptHeaderLength);
             }

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeaderParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeaderParser.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.internet.MimeUtility;
@@ -34,7 +35,8 @@ class AutocryptHeaderParser {
     }
 
     @Nullable
-    private AutocryptHeader parseAutocryptHeader(String headerValue) {
+    @VisibleForTesting
+    AutocryptHeader parseAutocryptHeader(String headerValue) {
         Map<String,String> parameters = MimeUtility.getAllHeaderParameters(headerValue);
 
         String type = parameters.remove(AutocryptHeader.AUTOCRYPT_PARAM_TYPE);

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeaderParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeaderParser.java
@@ -57,7 +57,7 @@ class AutocryptHeaderParser {
             return null;
         }
 
-        String to = parameters.remove(AutocryptHeader.AUTOCRYPT_PARAM_TO);
+        String to = parameters.remove(AutocryptHeader.AUTOCRYPT_PARAM_ADDR);
         if (to == null) {
             Timber.e("autocrypt: no to header!");
             return null;

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOpenPgpApiInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOpenPgpApiInteractor.java
@@ -1,0 +1,34 @@
+package com.fsck.k9.autocrypt;
+
+
+import java.io.ByteArrayOutputStream;
+import java.io.InputStream;
+
+import android.content.Intent;
+
+import org.openintents.openpgp.util.OpenPgpApi;
+
+
+public class AutocryptOpenPgpApiInteractor {
+    public static AutocryptOpenPgpApiInteractor getInstance() {
+        return new AutocryptOpenPgpApiInteractor();
+    }
+
+    private AutocryptOpenPgpApiInteractor() { }
+
+    public byte[] getKeyMaterialFromApi(OpenPgpApi openPgpApi, long keyId, String minimizeForUserId) {
+        Intent retreiveKeyIntent = new Intent(OpenPgpApi.ACTION_GET_KEY);
+        retreiveKeyIntent.putExtra(OpenPgpApi.EXTRA_KEY_ID, keyId);
+        retreiveKeyIntent.putExtra(OpenPgpApi.EXTRA_MINIMIZE, true);
+        retreiveKeyIntent.putExtra(OpenPgpApi.EXTRA_MINIMIZE_USER_ID, minimizeForUserId);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Intent result = openPgpApi.executeApi(retreiveKeyIntent, (InputStream) null, baos);
+
+        if (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR) ==
+                OpenPgpApi.RESULT_CODE_SUCCESS) {
+            return baos.toByteArray();
+        } else{
+            return null;
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOperations.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOperations.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.autocrypt;
 
 
+import java.util.Collections;
 import java.util.Date;
 
 import android.content.Intent;
@@ -49,4 +50,14 @@ public class AutocryptOperations {
     public boolean hasAutocryptHeader(Message currentMessage) {
         return currentMessage.getHeader(AutocryptHeader.AUTOCRYPT_HEADER).length > 0;
     }
+
+    public void addAutocryptHeaderToMessage(Message message, byte[] keyData,
+            String autocryptAddress, boolean preferEncryptMutual) {
+        AutocryptHeader autocryptHeader = new AutocryptHeader(
+                Collections.<String,String>emptyMap(), autocryptAddress, keyData, preferEncryptMutual);
+        String rawAutocryptHeader = autocryptHeader.toRawHeaderString();
+
+        message.addRawHeader(AutocryptHeader.AUTOCRYPT_HEADER, rawAutocryptHeader);
+    }
+
 }

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -135,12 +135,19 @@ public class PgpMessageBuilder extends MessageBuilder {
     @NonNull
     private Intent buildOpenPgpApiIntent(boolean shouldSign, boolean shouldEncrypt, boolean isPgpInlineMode) {
         Intent pgpApiIntent;
+
+        Long openPgpKeyId = cryptoStatus.getOpenPgpKeyId();
         if (shouldEncrypt) {
             if (!shouldSign) {
                 throw new IllegalStateException("encrypt-only is not supported at this point and should never happen!");
             }
             // pgpApiIntent = new Intent(shouldSign ? OpenPgpApi.ACTION_SIGN_AND_ENCRYPT : OpenPgpApi.ACTION_ENCRYPT);
             pgpApiIntent = new Intent(OpenPgpApi.ACTION_SIGN_AND_ENCRYPT);
+
+            if (openPgpKeyId != null) {
+                long[] selfEncryptIds = { openPgpKeyId };
+                pgpApiIntent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, selfEncryptIds);
+            }
 
             if(!isDraft()) {
                 pgpApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, cryptoStatus.getRecipientAddresses());
@@ -151,7 +158,7 @@ public class PgpMessageBuilder extends MessageBuilder {
         }
 
         if (shouldSign) {
-            pgpApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, cryptoStatus.getSigningKeyId());
+            pgpApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, openPgpKeyId);
         }
 
         pgpApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
@@ -148,7 +148,7 @@ public class RecipientPresenterTest {
 
         assertEquals(CryptoStatusDisplayType.NO_CHOICE_EMPTY, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
-        assertFalse(status.shouldUsePgpMessageBuilder());
+        assertTrue(status.shouldUsePgpMessageBuilder());
     }
 
     @Test
@@ -161,7 +161,7 @@ public class RecipientPresenterTest {
 
         assertEquals(CryptoStatusDisplayType.NO_CHOICE_AVAILABLE, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
-        assertFalse(status.shouldUsePgpMessageBuilder());
+        assertTrue(status.shouldUsePgpMessageBuilder());
     }
 
     @Test
@@ -174,7 +174,7 @@ public class RecipientPresenterTest {
 
         assertEquals(CryptoStatusDisplayType.NO_CHOICE_AVAILABLE_TRUSTED, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
-        assertFalse(status.shouldUsePgpMessageBuilder());
+        assertTrue(status.shouldUsePgpMessageBuilder());
     }
 
     @Test
@@ -187,7 +187,7 @@ public class RecipientPresenterTest {
 
         assertEquals(CryptoStatusDisplayType.NO_CHOICE_UNAVAILABLE, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
-        assertFalse(status.shouldUsePgpMessageBuilder());
+        assertTrue(status.shouldUsePgpMessageBuilder());
     }
 
     @Test
@@ -217,7 +217,7 @@ public class RecipientPresenterTest {
 
         assertEquals(CryptoStatusDisplayType.CHOICE_DISABLED_UNTRUSTED, status.getCryptoStatusDisplayType());
         assertTrue(status.isProviderStateOk());
-        assertFalse(status.shouldUsePgpMessageBuilder());
+        assertTrue(status.shouldUsePgpMessageBuilder());
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderParserTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderParserTest.java
@@ -105,6 +105,18 @@ public class AutocryptHeaderParserTest {
         assertEquals("ignore", autocryptHeader.parameters.get("_monkey"));
     }
 
+    @Test
+    public void parseAutocryptHeader_toRawHeaderString() throws Exception {
+        MimeMessage message = parseFromResource("autocrypt/rsa2048-simple.eml");
+        AutocryptHeader autocryptHeader = autocryptHeaderParser.getValidAutocryptHeader(message);
+
+        String headerValue = autocryptHeader.toRawHeaderString();
+        headerValue = headerValue.substring("Autocrypt: ".length());
+        AutocryptHeader parsedAutocryptHeader = autocryptHeaderParser.parseAutocryptHeader(headerValue);
+
+        assertEquals(autocryptHeader, parsedAutocryptHeader);
+    }
+
     private MimeMessage parseFromResource(String resourceName) throws IOException, MessagingException {
         InputStream inputStream = readFromResourceFile(resourceName);
         return MimeMessage.parseMimeMessage(inputStream, false);

--- a/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderTest.java
@@ -1,0 +1,39 @@
+package com.fsck.k9.autocrypt;
+
+
+import java.util.HashMap;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+@SuppressWarnings("WeakerAccess")
+public class AutocryptHeaderTest {
+    static final HashMap<String, String> PARAMETERS = new HashMap<>();
+    static final String ADDR = "addr";
+    static final byte[] KEY_DATA = ("theseare120charactersxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
+            "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx").getBytes();
+    static final boolean IS_PREFER_ENCRYPT_MUTUAL = true;
+
+
+    private AutocryptHeader autocryptHeader;
+
+
+    @Before
+    public void setUp() throws Exception {
+        autocryptHeader = new AutocryptHeader(PARAMETERS, ADDR, KEY_DATA, IS_PREFER_ENCRYPT_MUTUAL);
+    }
+
+
+    @Test
+    public void toRawHeaderString_returnsExpected() throws Exception {
+        String autocryptHeaderString = autocryptHeader.toRawHeaderString();
+
+        String expected = "Autocrypt: addr=addr;prefer-encrypt=mutual;keydata=dGhlc2VhcmUxMjBjaGFyYWN0Z\n" +
+                " XJzeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4e\n" +
+                " Hh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4";
+        assertEquals(expected, autocryptHeaderString);
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderTest.java
@@ -13,27 +13,44 @@ import static org.junit.Assert.*;
 public class AutocryptHeaderTest {
     static final HashMap<String, String> PARAMETERS = new HashMap<>();
     static final String ADDR = "addr";
+    static final String ADDR_LONG = "veryveryverylongaddressthatspansmorethanalinelengthintheheader";
     static final byte[] KEY_DATA = ("theseare120charactersxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
             "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx").getBytes();
+    static final byte[] KEY_DATA_SHORT = ("theseare15chars").getBytes();
     static final boolean IS_PREFER_ENCRYPT_MUTUAL = true;
-
-
-    private AutocryptHeader autocryptHeader;
-
-
-    @Before
-    public void setUp() throws Exception {
-        autocryptHeader = new AutocryptHeader(PARAMETERS, ADDR, KEY_DATA, IS_PREFER_ENCRYPT_MUTUAL);
-    }
 
 
     @Test
     public void toRawHeaderString_returnsExpected() throws Exception {
+        AutocryptHeader autocryptHeader = new AutocryptHeader(PARAMETERS, ADDR, KEY_DATA, IS_PREFER_ENCRYPT_MUTUAL);
         String autocryptHeaderString = autocryptHeader.toRawHeaderString();
 
-        String expected = "Autocrypt: addr=addr;prefer-encrypt=mutual;keydata=dGhlc2VhcmUxMjBjaGFyYWN0Z\r\n" +
-                " XJzeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4e\r\n" +
-                " Hh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4";
+        String expected = "Autocrypt: addr=addr; prefer-encrypt=mutual; keydata=dGhlc2VhcmUxMjBjaGFyYWN\r\n" +
+                " 0ZXJzeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh\r\n" +
+                " 4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4";
+        assertEquals(expected, autocryptHeaderString);
+    }
+
+    @Test
+    public void toRawHeaderString_withLongAddress_returnsExpected() throws Exception {
+        AutocryptHeader autocryptHeader = new AutocryptHeader(PARAMETERS,
+                ADDR_LONG, KEY_DATA, IS_PREFER_ENCRYPT_MUTUAL);
+        String autocryptHeaderString = autocryptHeader.toRawHeaderString();
+
+        String expected = "Autocrypt: addr=veryveryverylongaddressthatspansmorethanalinelengthintheheader; prefer-encrypt=mutual; keydata=\r\n" +
+                " dGhlc2VhcmUxMjBjaGFyYWN0ZXJzeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4\r\n" +
+                " eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4\r\n" +
+                " eHh4eHh4";
+        assertEquals(expected, autocryptHeaderString);
+    }
+
+    @Test
+    public void toRawHeaderString_withShortData_returnsExpected() throws Exception {
+        AutocryptHeader autocryptHeader = new AutocryptHeader(PARAMETERS,
+                ADDR, KEY_DATA_SHORT, IS_PREFER_ENCRYPT_MUTUAL);
+        String autocryptHeaderString = autocryptHeader.toRawHeaderString();
+
+        String expected = "Autocrypt: addr=addr; prefer-encrypt=mutual; keydata=dGhlc2VhcmUxNWNoYXJz";
         assertEquals(expected, autocryptHeaderString);
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderTest.java
@@ -31,8 +31,8 @@ public class AutocryptHeaderTest {
     public void toRawHeaderString_returnsExpected() throws Exception {
         String autocryptHeaderString = autocryptHeader.toRawHeaderString();
 
-        String expected = "Autocrypt: addr=addr;prefer-encrypt=mutual;keydata=dGhlc2VhcmUxMjBjaGFyYWN0Z\n" +
-                " XJzeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4e\n" +
+        String expected = "Autocrypt: addr=addr;prefer-encrypt=mutual;keydata=dGhlc2VhcmUxMjBjaGFyYWN0Z\r\n" +
+                " XJzeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4e\r\n" +
                 " Hh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4";
         assertEquals(expected, autocryptHeaderString);
     }

--- a/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptOperationsHelper.java
+++ b/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptOperationsHelper.java
@@ -1,0 +1,23 @@
+package com.fsck.k9.autocrypt;
+
+
+import com.fsck.k9.mail.internet.MimeMessage;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertArrayEquals;
+
+
+public class AutocryptOperationsHelper {
+    private static AutocryptHeaderParser INSTANCE = AutocryptHeaderParser.getInstance();
+
+    public static void assertMessageHasAutocryptHeader(
+            MimeMessage message, String addr, boolean isPreferEncryptMutual, byte[] keyData) {
+        AutocryptHeader autocryptHeader = INSTANCE.getValidAutocryptHeader(message);
+
+        assertNotNull(autocryptHeader);
+        assertEquals(addr, autocryptHeader.addr);
+        assertEquals(isPreferEncryptMutual, autocryptHeader.isPreferEncryptMutual);
+        assertArrayEquals(keyData, autocryptHeader.keyData);
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -62,8 +62,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(K9RobolectricTestRunner.class)
 public class PgpMessageBuilderTest {
-    private static final long TEST_SIGN_KEY_ID = 123L;
-    private static final long TEST_SELF_ENCRYPT_KEY_ID = 234L;
+    private static final long TEST_KEY_ID = 123L;
     private static final String TEST_MESSAGE_TEXT = "message text with a ☭ CCCP symbol";
 
 
@@ -126,7 +125,7 @@ public class PgpMessageBuilderTest {
         pgpMessageBuilder.buildAsync(mockCallback);
 
         Intent expectedIntent = new Intent(OpenPgpApi.ACTION_DETACHED_SIGN);
-        expectedIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
+        expectedIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_KEY_ID);
         expectedIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
         assertIntentEqualsActionAndExtras(expectedIntent, capturedApiIntent.getValue());
 
@@ -267,7 +266,8 @@ public class PgpMessageBuilderTest {
         pgpMessageBuilder.buildAsync(mockCallback);
 
         Intent expectedApiIntent = new Intent(OpenPgpApi.ACTION_SIGN_AND_ENCRYPT);
-        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_KEY_ID);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, new long[] { TEST_KEY_ID });
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, cryptoStatus.getRecipientAddresses());
         assertIntentEqualsActionAndExtras(expectedApiIntent, capturedApiIntent.getValue());
@@ -318,7 +318,8 @@ public class PgpMessageBuilderTest {
         pgpMessageBuilder.buildAsync(mockCallback);
 
         Intent expectedApiIntent = new Intent(OpenPgpApi.ACTION_SIGN_AND_ENCRYPT);
-        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_KEY_ID);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_KEY_IDS, new long[] { TEST_KEY_ID });
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_USER_IDS, cryptoStatus.getRecipientAddresses());
         assertIntentEqualsActionAndExtras(expectedApiIntent, capturedApiIntent.getValue());
@@ -354,7 +355,7 @@ public class PgpMessageBuilderTest {
         pgpMessageBuilder.buildAsync(mockCallback);
 
         Intent expectedApiIntent = new Intent(OpenPgpApi.ACTION_SIGN);
-        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_SIGN_KEY_ID);
+        expectedApiIntent.putExtra(OpenPgpApi.EXTRA_SIGN_KEY_ID, TEST_KEY_ID);
         expectedApiIntent.putExtra(OpenPgpApi.EXTRA_REQUEST_ASCII_ARMOR, true);
         assertIntentEqualsActionAndExtras(expectedApiIntent, capturedApiIntent.getValue());
 
@@ -455,8 +456,7 @@ public class PgpMessageBuilderTest {
     private ComposeCryptoStatusBuilder createDefaultComposeCryptoStatusBuilder() {
         return new ComposeCryptoStatusBuilder()
                 .setEnablePgpInline(false)
-                .setSigningKeyId(TEST_SIGN_KEY_ID)
-                .setSelfEncryptId(TEST_SELF_ENCRYPT_KEY_ID)
+                .setOpenPgpKeyId(TEST_KEY_ID)
                 .setRecipients(new ArrayList<Recipient>())
                 .setCryptoProviderState(CryptoProviderState.OK);
     }
@@ -543,11 +543,11 @@ public class PgpMessageBuilderTest {
             }
             if (intentExtra instanceof long[]) {
                 if (!Arrays.equals((long[]) intentExtra, (long[]) expectedExtra)) {
-                    Assert.assertArrayEquals((long[]) expectedExtra, (long[]) intentExtra);
+                    Assert.assertArrayEquals("error in " + key, (long[]) expectedExtra, (long[]) intentExtra);
                 }
             } else {
                 if (!intentExtra.equals(expectedExtra)) {
-                    Assert.assertEquals(expectedExtra, intentExtra);
+                    Assert.assertEquals("error in " + key, expectedExtra, intentExtra);
                 }
             }
         }


### PR DESCRIPTION
This PR implements the sending part of the [autocrypt](https://autocrypt.org) spec. It relies on the minimize feature of the autocrypt PR in OpenKeychain https://github.com/open-keychain/open-keychain/pull/2127, and attaches the user's key in the appropriate format to outgoing messages in the Autocrypt header.

This is a purely technical PR that doesn't touch on UI, see #2608 for the GUI aspect.