### PR TITLE
Rewrite IMAP IDLE

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
@@ -113,7 +113,7 @@ public abstract class Folder<T extends Message> {
 
     public abstract String getUidFromMessageId(Message message) throws MessagingException;
 
-    public void expunge() throws MessagingException
+    public void expunge(List<Long> knownDeletedUids) throws MessagingException
         {}
 
     /**

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
@@ -4,6 +4,7 @@ package com.fsck.k9.mail.store.imap;
 class Capabilities {
     public static final String IDLE = "IDLE";
     public static final String CONDSTORE = "CONDSTORE";
+    public static final String UID_PLUS = "UIDPLUS";
     public static final String SASL_IR = "SASL-IR";
     public static final String AUTH_XOAUTH2 = "AUTH=XOAUTH2";
     public static final String AUTH_CRAM_MD5 = "AUTH=CRAM-MD5";

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
@@ -18,4 +18,5 @@ public class Commands {
     public static final String UID_STORE = "UID STORE";
     public static final String UID_FETCH = "UID FETCH";
     public static final String UID_COPY = "UID COPY";
+    public static final String UID_EXPUNGE = "UID EXPUNGE";
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -695,6 +695,10 @@ public class ImapConnection {
         return capabilities.contains(Capabilities.IDLE);
     }
 
+    boolean isUidPlusCapable() {
+        return capabilities.contains(Capabilities.UID_PLUS);
+    }
+
     public void close() {
         open = false;
         stacktraceForClose = new Exception();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidExpungeCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidExpungeCommand.java
@@ -1,0 +1,51 @@
+package com.fsck.k9.mail.store.imap.selectedstate.command;
+
+
+import java.io.IOException;
+
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.imap.Commands;
+import com.fsck.k9.mail.store.imap.ImapConnection;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mail.store.imap.selectedstate.response.SelectedStateResponse;
+
+
+public class UidExpungeCommand extends FolderSelectedStateCommand {
+
+    private UidExpungeCommand() {
+    }
+
+    @Override
+    String createCommandString() {
+        return String.format("%s %s", Commands.UID_EXPUNGE, createCombinedIdString()).trim();
+    }
+
+    @Override
+    public SelectedStateResponse execute(ImapConnection connection, ImapFolder folder) throws MessagingException {
+        try {
+            executeInternal(connection, folder);
+            return null;
+        } catch (IOException ioe) {
+            throw folder.ioExceptionHandler(connection, ioe);
+        }
+
+    }
+
+    @Override
+    Builder newBuilder() {
+        return new Builder();
+    }
+
+    public static class Builder extends FolderSelectedStateCommand.Builder<UidExpungeCommand, Builder> {
+
+        @Override
+        UidExpungeCommand createCommand() {
+            return new UidExpungeCommand();
+        }
+
+        @Override
+        Builder createBuilder() {
+            return this;
+        }
+    }
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidSearchCommand.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/selectedstate/command/UidSearchCommand.java
@@ -21,6 +21,7 @@ import com.fsck.k9.mail.store.imap.selectedstate.response.UidSearchResponse;
 
 public class UidSearchCommand extends FolderSelectedStateCommand {
     private boolean useUids;
+    private boolean excludeGivenUids;
     private String queryString;
     private String messageId;
     private boolean performFullTextSearch;
@@ -35,6 +36,9 @@ public class UidSearchCommand extends FolderSelectedStateCommand {
     @Override
     String createCommandString() {
         StringBuilder builder = new StringBuilder(Commands.UID_SEARCH).append(" ");
+        if (excludeGivenUids) {
+            builder.append("NOT ");
+        }
         if (useUids) {
             builder.append("UID ");
         }
@@ -126,7 +130,7 @@ public class UidSearchCommand extends FolderSelectedStateCommand {
     @Override
     Builder newBuilder() {
         return new Builder()
-                .useUids(useUids)
+                .useUids(useUids, excludeGivenUids)
                 .queryString(queryString)
                 .messageId(messageId)
                 .performFullTextSearch(performFullTextSearch)
@@ -138,8 +142,9 @@ public class UidSearchCommand extends FolderSelectedStateCommand {
 
     public static class Builder extends FolderSelectedStateCommand.Builder<UidSearchCommand, Builder> {
 
-        public Builder useUids(boolean useUids) {
+        public Builder useUids(boolean useUids, boolean exclude) {
             command.useUids = useUids;
+            command.excludeGivenUids = exclude;
             return builder;
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -971,6 +971,42 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         }
     }
 
+    public List<Long> getDeletedMessageUids() throws MessagingException {
+        try {
+            return  localStore.database.execute(false, new DbCallback<List<Long>>() {
+                @Override
+                public List<Long> doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
+                    Cursor cursor = null;
+                    ArrayList<Long> result = new ArrayList<>();
+
+                    try {
+                        open(OPEN_MODE_RO);
+
+                        cursor = db.rawQuery(
+                                "SELECT uid " +
+                                        "FROM messages " +
+                                        "WHERE empty = 0 AND deleted = 1 AND " +
+                                        "folder_id = ? ORDER BY date DESC",
+                                new String[] { Long.toString(mFolderId) });
+
+                        while (cursor.moveToNext()) {
+                            Long uid = Long.parseLong(cursor.getString(0));
+                            result.add(uid);
+                        }
+                    } catch (MessagingException e) {
+                        throw new WrappedException(e);
+                    } finally {
+                        Utility.closeQuietly(cursor);
+                    }
+
+                    return result;
+                }
+            });
+        } catch (WrappedException e) {
+            throw(MessagingException) e.getCause();
+        }
+    }
+
     public List<LocalMessage> getMessagesByUids(@NonNull List<String> uids) throws MessagingException {
         open(OPEN_MODE_RW);
         List<LocalMessage> messages = new ArrayList<>();


### PR DESCRIPTION
This PR builds upon the changes made to `ImapFolderPusher` in PR #2607 by

- Removing all the code that processes the various IDLE responses 
- Making it not extend `ImapFolder` anymore
- Not sending DONE and IDLE commands whenever a useful response is received through IDLE