### PR TITLE
Fix ImapConnectionTest failure

### DIFF
--- a/k9mail-library/src/test/java/com/fsck/k9/mail/helpers/KeyStoreProvider.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/helpers/KeyStoreProvider.java
@@ -1,0 +1,61 @@
+package com.fsck.k9.mail.helpers;
+
+
+import java.io.InputStream;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.cert.X509Certificate;
+
+
+public class KeyStoreProvider {
+    private static final String KEYSTORE_PASSWORD = "password";
+    private static final String KEYSTORE_RESOURCE = "/keystore.jks";
+    private static final String SERVER_CERTIFICATE_ALIAS = "mockimapserver";
+
+
+    private final KeyStore keyStore;
+
+
+    public static KeyStoreProvider getInstance() {
+        KeyStore keyStore = loadKeyStore();
+        return new KeyStoreProvider(keyStore);
+    }
+
+    private static KeyStore loadKeyStore() {
+        try {
+            KeyStore keyStore = KeyStore.getInstance("JKS");
+
+            InputStream keyStoreInputStream = KeyStoreProvider.class.getResourceAsStream(KEYSTORE_RESOURCE);
+            try {
+                keyStore.load(keyStoreInputStream, KEYSTORE_PASSWORD.toCharArray());
+            } finally {
+                keyStoreInputStream.close();
+            }
+
+            return keyStore;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private KeyStoreProvider(KeyStore keyStore) {
+        this.keyStore = keyStore;
+    }
+
+    public KeyStore getKeyStore() {
+        return keyStore;
+    }
+
+    public char[] getPassword() {
+        return KEYSTORE_PASSWORD.toCharArray();
+    }
+
+    public X509Certificate getServerCertificate() {
+        try {
+            KeyStore keyStore = loadKeyStore();
+            return (X509Certificate) keyStore.getCertificate(SERVER_CERTIFICATE_ALIAS);
+        } catch (KeyStoreException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/helpers/TestTrustedSocketFactory.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/helpers/TestTrustedSocketFactory.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.net.Socket;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
 
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
@@ -14,11 +15,23 @@ import javax.net.ssl.TrustManager;
 
 
 public class TestTrustedSocketFactory implements TrustedSocketFactory {
+    private final X509Certificate serverCertificate;
+
+
+    public static TestTrustedSocketFactory newInstance() {
+        X509Certificate serverCertificate = KeyStoreProvider.getInstance().getServerCertificate();
+        return new TestTrustedSocketFactory(serverCertificate);
+    }
+
+    private TestTrustedSocketFactory(X509Certificate serverCertificate) {
+        this.serverCertificate = serverCertificate;
+    }
+
     @Override
     public Socket createSocket(Socket socket, String host, int port, String clientCertificateAlias)
             throws NoSuchAlgorithmException, KeyManagementException, MessagingException, IOException {
 
-        TrustManager[] trustManagers = new TrustManager[] { new VeryTrustingTrustManager() };
+        TrustManager[] trustManagers = new TrustManager[] { new VeryTrustingTrustManager(serverCertificate) };
 
         SSLContext sslContext = SSLContext.getInstance("TLS");
         sslContext.init(null, trustManagers, null);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/helpers/VeryTrustingTrustManager.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/helpers/VeryTrustingTrustManager.java
@@ -10,6 +10,13 @@ import javax.net.ssl.X509TrustManager;
 
 @SuppressLint("TrustAllX509TrustManager")
 class VeryTrustingTrustManager implements X509TrustManager {
+    private final X509Certificate serverCertificate;
+
+
+    public VeryTrustingTrustManager(X509Certificate serverCertificate) {
+        this.serverCertificate = serverCertificate;
+    }
+
     @Override
     public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
         // Accept all certificates
@@ -22,7 +29,7 @@ class VeryTrustingTrustManager implements X509TrustManager {
 
     @Override
     public X509Certificate[] getAcceptedIssuers() {
-        return new X509Certificate[0];
+        return new X509Certificate[] { serverCertificate };
     }
 }
 

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -62,7 +62,7 @@ public class ImapConnectionTest {
     public void setUp() throws Exception {
         connectivityManager = mock(ConnectivityManager.class);
         oAuth2TokenProvider = createOAuth2TokenProvider();
-        socketFactory = new TestTrustedSocketFactory();
+        socketFactory = TestTrustedSocketFactory.newInstance();
 
         settings = new SimpleImapSettings();
         settings.setUsername(USERNAME);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/mockserver/MockImapServer.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/mockserver/MockImapServer.java
@@ -23,6 +23,7 @@ import java.util.zip.InflaterInputStream;
 
 import android.annotation.SuppressLint;
 
+import com.fsck.k9.mail.helpers.KeyStoreProvider;
 import com.jcraft.jzlib.JZlib;
 import com.jcraft.jzlib.ZOutputStream;
 import javax.net.ssl.KeyManagerFactory;
@@ -37,15 +38,13 @@ import org.apache.commons.io.IOUtils;
 
 @SuppressLint("NewApi")
 public class MockImapServer {
-    private static final String KEYSTORE_PASSWORD = "password";
-    private static final String KEYSTORE_RESOURCE = "/keystore.jks";
-
     private static final byte[] CRLF = { '\r', '\n' };
 
 
     private final Deque<ImapInteraction> interactions = new ConcurrentLinkedDeque<>();
     private final CountDownLatch waitForConnectionClosed = new CountDownLatch(1);
     private final CountDownLatch waitForAllExpectedCommands = new CountDownLatch(1);
+    private final KeyStoreProvider keyStoreProvider;
     private final Logger logger;
 
     private MockServerThread mockServerThread;
@@ -54,10 +53,11 @@ public class MockImapServer {
 
 
     public MockImapServer() {
-        this(new DefaultLogger());
+        this(KeyStoreProvider.getInstance(), new DefaultLogger());
     }
 
-    public MockImapServer(Logger logger) {
+    public MockImapServer(KeyStoreProvider keyStoreProvider, Logger logger) {
+        this.keyStoreProvider = keyStoreProvider;
         this.logger = logger;
     }
 
@@ -96,7 +96,7 @@ public class MockImapServer {
         port = serverSocket.getLocalPort();
 
         mockServerThread = new MockServerThread(serverSocket, interactions, waitForConnectionClosed,
-                waitForAllExpectedCommands, logger);
+                waitForAllExpectedCommands, logger, keyStoreProvider);
         mockServerThread.start();
     }
 
@@ -236,6 +236,7 @@ public class MockImapServer {
         private final CountDownLatch waitForConnectionClosed;
         private final CountDownLatch waitForAllExpectedCommands;
         private final Logger logger;
+        private final KeyStoreProvider keyStoreProvider;
 
         private volatile boolean shouldStop = false;
         private volatile Socket clientSocket;
@@ -246,13 +247,15 @@ public class MockImapServer {
 
 
         public MockServerThread(ServerSocket serverSocket, Deque<ImapInteraction> interactions,
-                CountDownLatch waitForConnectionClosed, CountDownLatch waitForAllExpectedCommands, Logger logger) {
+                CountDownLatch waitForConnectionClosed, CountDownLatch waitForAllExpectedCommands, Logger logger,
+                KeyStoreProvider keyStoreProvider) {
             super("MockImapServer");
             this.serverSocket = serverSocket;
             this.interactions = interactions;
             this.waitForConnectionClosed = waitForConnectionClosed;
             this.waitForAllExpectedCommands = waitForAllExpectedCommands;
             this.logger = logger;
+            this.keyStoreProvider = keyStoreProvider;
         }
 
         @Override
@@ -356,11 +359,11 @@ public class MockImapServer {
         private void upgradeToTls(Socket socket) throws KeyStoreException, IOException, NoSuchAlgorithmException,
                 CertificateException, UnrecoverableKeyException, KeyManagementException {
 
-            KeyStore keyStore = loadKeyStore();
+            KeyStore keyStore = keyStoreProvider.getKeyStore();
 
             String defaultAlgorithm = KeyManagerFactory.getDefaultAlgorithm();
             KeyManagerFactory keyManagerFactory = KeyManagerFactory.getInstance(defaultAlgorithm);
-            keyManagerFactory.init(keyStore, KEYSTORE_PASSWORD.toCharArray());
+            keyManagerFactory.init(keyStore, keyStoreProvider.getPassword());
 
             SSLContext sslContext = SSLContext.getInstance("TLS");
             sslContext.init(keyManagerFactory.getKeyManagers(), null, null);
@@ -373,20 +376,6 @@ public class MockImapServer {
 
             input = Okio.buffer(Okio.source(sslSocket.getInputStream()));
             output = Okio.buffer(Okio.sink(sslSocket.getOutputStream()));
-        }
-
-        private KeyStore loadKeyStore() throws KeyStoreException, IOException, NoSuchAlgorithmException,
-                CertificateException {
-            KeyStore keyStore = KeyStore.getInstance("JKS");
-
-            InputStream keyStoreInputStream = getClass().getResourceAsStream(KEYSTORE_RESOURCE);
-            try {
-                keyStore.load(keyStoreInputStream, KEYSTORE_PASSWORD.toCharArray());
-            } finally {
-                keyStoreInputStream.close();
-            }
-
-            return keyStore;
         }
 
         private void readAdditionalCommands() throws IOException {

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
@@ -52,7 +52,7 @@ public class SmtpTransportTest {
     
     @Before
     public void before() throws AuthenticationFailedException {
-        socketFactory = new TestTrustedSocketFactory();
+        socketFactory = TestTrustedSocketFactory.newInstance();
         oAuth2TokenProvider = mock(OAuth2TokenProvider.class);
         when(oAuth2TokenProvider.getToken(eq(USERNAME), anyInt()))
                 .thenReturn("oldToken").thenReturn("newToken");


### PR DESCRIPTION
Running tests outside of Android Studio started to fail for me with the following exception.

```
com.fsck.k9.mail.CertificateValidationException: java.security.cert.CertificateException: Certificates does not conform to algorithm constraints
	at com.fsck.k9.mail.store.imap.ImapConnection.handleSslException(ImapConnection.java:153)
	at com.fsck.k9.mail.store.imap.ImapConnection.open(ImapConnection.java:138)
	at com.fsck.k9.mail.store.imap.ImapConnectionTest.open_withStartTlsCapability_shouldIssueStartTlsCommand(ImapConnectionTest.java:669)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.robolectric.RobolectricTestRunner$HelperTestRunner$1.evaluate(RobolectricTestRunner.java:538)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.robolectric.RobolectricTestRunner$2.evaluate(RobolectricTestRunner.java:339)
	at org.robolectric.RobolectricTestRunner.runChild(RobolectricTestRunner.java:259)
	at org.robolectric.RobolectricTestRunner.runChild(RobolectricTestRunner.java:41)
	at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
	at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
	at org.robolectric.RobolectricTestRunner$1.evaluate(RobolectricTestRunner.java:199)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.runTestClass(JUnitTestClassExecuter.java:114)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.execute(JUnitTestClassExecuter.java:57)
	at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassProcessor.processTestClass(JUnitTestClassProcessor.java:66)
	at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
	at com.sun.proxy.$Proxy3.processTestClass(Unknown Source)
	at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:109)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:377)
	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:54)
	at org.gradle.internal.concurrent.StoppableExecutorImpl$1.run(StoppableExecutorImpl.java:40)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: javax.net.ssl.SSLHandshakeException: java.security.cert.CertificateException: Certificates does not conform to algorithm constraints
	at sun.security.ssl.Alerts.getSSLException(Alerts.java:192)
	at sun.security.ssl.SSLSocketImpl.fatal(SSLSocketImpl.java:1949)
	at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:302)
	at sun.security.ssl.Handshaker.fatalSE(Handshaker.java:296)
	at sun.security.ssl.ClientHandshaker.serverCertificate(ClientHandshaker.java:1514)
	at sun.security.ssl.ClientHandshaker.processMessage(ClientHandshaker.java:216)
	at sun.security.ssl.Handshaker.processLoop(Handshaker.java:1026)
	at sun.security.ssl.Handshaker.process_record(Handshaker.java:961)
	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:1062)
	at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1375)
	at sun.security.ssl.SSLSocketImpl.writeRecord(SSLSocketImpl.java:747)
	at sun.security.ssl.AppOutputStream.write(AppOutputStream.java:123)
	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
	at java.io.BufferedOutputStream.flush(BufferedOutputStream.java:140)
	at com.fsck.k9.mail.store.imap.ImapConnection.sendCommand(ImapConnection.java:774)
	at com.fsck.k9.mail.store.imap.ImapConnection.executeSimpleCommand(ImapConnection.java:727)
	at com.fsck.k9.mail.store.imap.ImapConnection.executeSimpleCommand(ImapConnection.java:716)
	at com.fsck.k9.mail.store.imap.ImapConnection.requestCapabilities(ImapConnection.java:291)
	at com.fsck.k9.mail.store.imap.ImapConnection.startTLS(ImapConnection.java:334)
	at com.fsck.k9.mail.store.imap.ImapConnection.upgradeToTls(ImapConnection.java:315)
	at com.fsck.k9.mail.store.imap.ImapConnection.upgradeToTlsIfNecessary(ImapConnection.java:299)
	at com.fsck.k9.mail.store.imap.ImapConnection.open(ImapConnection.java:125)
	... 47 more
Caused by: java.security.cert.CertificateException: Certificates does not conform to algorithm constraints
	at sun.security.ssl.AbstractTrustManagerWrapper.checkAlgorithmConstraints(SSLContextImpl.java:1120)
	at sun.security.ssl.AbstractTrustManagerWrapper.checkAdditionalTrust(SSLContextImpl.java:1044)
	at sun.security.ssl.AbstractTrustManagerWrapper.checkServerTrusted(SSLContextImpl.java:986)
	at sun.security.ssl.ClientHandshaker.serverCertificate(ClientHandshaker.java:1496)
	... 64 more
```

Returning the TLS certificate the mock server is using from `VeryTrustingTrustManager.getAcceptedIssuers()` is fixing this issue for me.
