### PR TITLE
Fix screen orientation messages selection issue (Fixing issue #2605)

### DIFF
--- a/k9mail/src/main/AndroidManifest.xml
+++ b/k9mail/src/main/AndroidManifest.xml
@@ -204,7 +204,7 @@
 
         <activity
             android:name=".activity.MessageList"
-            android:configChanges="locale"
+            android:configChanges="locale|orientation|screenSize|keyboardHidden"
             android:launchMode="singleTop"
             android:uiOptions="splitActionBarWhenNarrow">
             <intent-filter>

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1616,4 +1616,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
             }
         }
     }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+    }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1617,8 +1617,4 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         }
     }
 
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-    }
 }


### PR DESCRIPTION
Fix screen orientation issue when messages are selected in "unified box" . Fixing issue #2605 