### PR TITLE
Cleanup localstore classes

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
@@ -144,8 +144,6 @@ public abstract class Message implements Part, Body {
     @Override
     public abstract void setBody(Body body);
 
-    public abstract long getId();
-
     public abstract boolean hasAttachments();
 
     public abstract long getSize();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -689,11 +689,6 @@ public class MimeMessage extends Message {
     }
 
     @Override
-    public long getId() {
-        return Long.parseLong(mUid); //or maybe .mMessageId?
-    }
-
-    @Override
     public boolean hasAttachments() {
         return false;
     }

--- a/k9mail/src/main/java/com/fsck/k9/cache/EmailProviderCache.java
+++ b/k9mail/src/main/java/com/fsck/k9/cache/EmailProviderCache.java
@@ -126,7 +126,7 @@ public class EmailProviderCache {
     public void hideMessages(List<LocalMessage> messages) {
         synchronized (mHiddenMessageCache) {
             for (LocalMessage message : messages) {
-                long messageId = message.getId();
+                long messageId = message.getDatabaseId();
                 mHiddenMessageCache.put(messageId, message.getFolder().getId());
             }
         }
@@ -145,7 +145,7 @@ public class EmailProviderCache {
         synchronized (mHiddenMessageCache) {
             for (Message message : messages) {
                 LocalMessage localMessage = (LocalMessage) message;
-                long messageId = localMessage.getId();
+                long messageId = localMessage.getDatabaseId();
                 long folderId = ((LocalFolder) localMessage.getFolder()).getId();
                 Long hiddenInFolder = mHiddenMessageCache.get(messageId);
 

--- a/k9mail/src/main/java/com/fsck/k9/cache/EmailProviderCache.java
+++ b/k9mail/src/main/java/com/fsck/k9/cache/EmailProviderCache.java
@@ -127,7 +127,7 @@ public class EmailProviderCache {
         synchronized (mHiddenMessageCache) {
             for (LocalMessage message : messages) {
                 long messageId = message.getDatabaseId();
-                mHiddenMessageCache.put(messageId, message.getFolder().getId());
+                mHiddenMessageCache.put(messageId, message.getFolder().getDatabaseId());
             }
         }
 
@@ -146,7 +146,7 @@ public class EmailProviderCache {
             for (Message message : messages) {
                 LocalMessage localMessage = (LocalMessage) message;
                 long messageId = localMessage.getDatabaseId();
-                long folderId = ((LocalFolder) localMessage.getFolder()).getId();
+                long folderId = ((LocalFolder) localMessage.getFolder()).getDatabaseId();
                 Long hiddenInFolder = mHiddenMessageCache.get(messageId);
 
                 if (hiddenInFolder != null && hiddenInFolder.longValue() == folderId) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -305,7 +305,7 @@ public class MessagingController {
     }
 
     private boolean isMessageSuppressed(LocalMessage message) {
-        long messageId = message.getId();
+        long messageId = message.getDatabaseId();
         long folderId = message.getFolder().getId();
 
         EmailProviderCache cache = EmailProviderCache.getCache(message.getFolder().getAccountUuid(), context);
@@ -2511,7 +2511,7 @@ public class MessagingController {
         localFolder.open(Folder.OPEN_MODE_RW);
 
         LocalMessage message = localFolder.getMessage(uid);
-        if (message == null || message.getId() == 0) {
+        if (message == null || message.getDatabaseId() == 0) {
             throw new IllegalArgumentException("Message not found: folder=" + folderName + ", uid=" + uid);
         }
 
@@ -2530,7 +2530,7 @@ public class MessagingController {
             throws MessagingException {
 
         if (account.isMarkMessageAsReadOnView() && !message.isSet(Flag.SEEN)) {
-            List<Long> messageIds = Collections.singletonList(message.getId());
+            List<Long> messageIds = Collections.singletonList(message.getDatabaseId());
             setFlag(account, messageIds, Flag.SEEN, true);
 
             message.setFlagInternal(Flag.SEEN, true);
@@ -3996,7 +3996,7 @@ public class MessagingController {
     public long getId(Message message) {
         long id;
         if (message instanceof LocalMessage) {
-            id = message.getId();
+            id = ((LocalMessage) message).getDatabaseId();
         } else {
             Timber.w("MessagingController.getId() called without a LocalMessage");
             id = INVALID_MESSAGE_ID;

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -306,7 +306,7 @@ public class MessagingController {
 
     private boolean isMessageSuppressed(LocalMessage message) {
         long messageId = message.getDatabaseId();
-        long folderId = message.getFolder().getId();
+        long folderId = message.getFolder().getDatabaseId();
 
         EmailProviderCache cache = EmailProviderCache.getCache(message.getFolder().getAccountUuid(), context);
         return cache.isMessageHidden(messageId, folderId);
@@ -2721,7 +2721,7 @@ public class MessagingController {
             fp.add(FetchProfile.Item.BODY);
 
             Timber.i("Scanning folder '%s' (%d) for messages to send",
-                    account.getOutboxFolderName(), localFolder.getId());
+                    account.getOutboxFolderName(), localFolder.getDatabaseId());
 
             Transport transport = transportProvider.getTransport(K9.app, account);
 
@@ -2836,11 +2836,11 @@ public class MessagingController {
             message.setFlag(Flag.DELETED, true);
         } else {
             LocalFolder localSentFolder = localStore.getFolder(account.getSentFolderName());
-            Timber.i("Moving sent message to folder '%s' (%d)", account.getSentFolderName(), localSentFolder.getId());
+            Timber.i("Moving sent message to folder '%s' (%d)", account.getSentFolderName(), localSentFolder.getDatabaseId());
 
             localFolder.moveMessages(Collections.singletonList(message), localSentFolder);
 
-            Timber.i("Moved sent message to folder '%s' (%d)", account.getSentFolderName(), localSentFolder.getId());
+            Timber.i("Moved sent message to folder '%s' (%d)", account.getSentFolderName(), localSentFolder.getDatabaseId());
 
             PendingCommand command = PendingAppend.create(localSentFolder.getName(), message.getUid());
             queuePendingCommand(account, command);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalBodyPart.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalBodyPart.java
@@ -26,7 +26,7 @@ public class LocalBodyPart extends MimeBodyPart implements LocalPart {
     }
 
     @Override
-    public long getId() {
+    public long getPartId() {
         return messagePartId;
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -1046,7 +1046,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                                     "id %d currently in folder %s",
                                     lDestFolder.getId(),
                                     message.getUid(),
-                                    lMessage.getId(),
+                                    lMessage.getDatabaseId(),
                                     getName());
 
                             String newUid = K9.LOCAL_UID_PREFIX + UUID.randomUUID().toString();
@@ -1060,7 +1060,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
                             /*
                              * "Move" the message into the new folder
                              */
-                            long msgId = lMessage.getId();
+                            long msgId = lMessage.getDatabaseId();
                             String[] idArg = new String[] { Long.toString(msgId) };
 
                             ContentValues cv = new ContentValues();
@@ -1309,7 +1309,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
             LocalMessage oldMessage = getMessage(uid);
 
             if (oldMessage != null) {
-                oldMessageId = oldMessage.getId();
+                oldMessageId = oldMessage.getDatabaseId();
 
                 long oldRootMessagePartId = oldMessage.getMessagePartId();
                 deleteMessagePartsAndDataFromDisk(oldRootMessagePartId);
@@ -1689,7 +1689,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
             @Override
             public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                 db.update("messages", cv, "id = ?", new String[]
-                        { Long.toString(message.getId()) });
+                        { Long.toString(message.getDatabaseId()) });
                 return null;
             }
         });
@@ -1844,7 +1844,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     }
 
     void destroyMessage(LocalMessage localMessage) throws MessagingException {
-        destroyMessage(localMessage.getId(), localMessage.getMessagePartId(), localMessage.getMessageId());
+        destroyMessage(localMessage.getDatabaseId(), localMessage.getMessagePartId(), localMessage.getMessageId());
     }
 
     private void destroyMessage(final long messageId, final long messagePartId, final String messageIdHeader)

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -543,7 +543,7 @@ public class LocalFolder extends Folder<LocalMessage> {
 
     private String getPrefId(String name) {
         if (prefId == null) {
-            prefId = this.localStore.getUUid() + "." + name;
+            prefId = getAccount().getUuid() + "." + name;
         }
 
         return prefId;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -103,7 +103,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         super();
         this.localStore = localStore;
         this.folderName = name;
-        attachmentInfoExtractor = localStore.attachmentInfoExtractor;
+        attachmentInfoExtractor = localStore.getAttachmentInfoExtractor();
 
         if (getAccount().getInboxFolderName().equals(getName())) {
             syncClass =  FolderClass.FIRST_CLASS;
@@ -116,7 +116,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         super();
         this.localStore = localStore;
         this.folderId = id;
-        attachmentInfoExtractor = localStore.attachmentInfoExtractor;
+        attachmentInfoExtractor = localStore.getAttachmentInfoExtractor();
     }
 
     public long getId() {
@@ -152,7 +152,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         }
 
         try {
-            this.localStore.database.execute(false, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(false, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException {
                     Cursor cursor = null;
@@ -231,7 +231,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
     @Override
     public boolean exists() throws MessagingException {
-        return this.localStore.database.execute(false, new DbCallback<Boolean>() {
+        return this.localStore.getDatabase().execute(false, new DbCallback<Boolean>() {
             @Override
             public Boolean doDbWork(final SQLiteDatabase db) throws WrappedException {
                 Cursor cursor = null;
@@ -285,7 +285,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     @Override
     public int getMessageCount() throws MessagingException {
         try {
-            return this.localStore.database.execute(false, new DbCallback<Integer>() {
+            return this.localStore.getDatabase().execute(false, new DbCallback<Integer>() {
                 @Override
                 public Integer doDbWork(final SQLiteDatabase db) throws WrappedException {
                     try {
@@ -318,7 +318,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         }
 
         try {
-            return this.localStore.database.execute(false, new DbCallback<Integer>() {
+            return this.localStore.getDatabase().execute(false, new DbCallback<Integer>() {
                 @Override
                 public Integer doDbWork(final SQLiteDatabase db) throws WrappedException {
                     int unreadMessageCount = 0;
@@ -349,7 +349,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         }
 
         try {
-            return this.localStore.database.execute(false, new DbCallback<Integer>() {
+            return this.localStore.getDatabase().execute(false, new DbCallback<Integer>() {
                 @Override
                 public Integer doDbWork(final SQLiteDatabase db) throws WrappedException {
                     int flaggedMessageCount = 0;
@@ -449,7 +449,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
     private void updateFolderColumn(final String column, final Object value) throws MessagingException {
         try {
-            this.localStore.database.execute(false, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(false, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException {
                     try {
@@ -545,7 +545,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
     private String getPrefId(String name) {
         if (prefId == null) {
-            prefId = this.localStore.uUid + "." + name;
+            prefId = this.localStore.getUUid() + "." + name;
         }
 
         return prefId;
@@ -662,7 +662,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     public void fetch(final List<LocalMessage> messages, final FetchProfile fp, final MessageRetrievalListener<LocalMessage> listener)
     throws MessagingException {
         try {
-            this.localStore.database.execute(false, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(false, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException {
                     try {
@@ -806,7 +806,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
     public String getMessageUidById(final long id) throws MessagingException {
         try {
-            return this.localStore.database.execute(false, new DbCallback<String>() {
+            return this.localStore.getDatabase().execute(false, new DbCallback<String>() {
                 @Override
                 public String doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     try {
@@ -837,7 +837,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     @Override
     public LocalMessage getMessage(final String uid) throws MessagingException {
         try {
-            return this.localStore.database.execute(false, new DbCallback<LocalMessage>() {
+            return this.localStore.getDatabase().execute(false, new DbCallback<LocalMessage>() {
                 @Override
                 public LocalMessage doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     try {
@@ -875,7 +875,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
     public Map<String,Long> getAllMessagesAndEffectiveDates() throws MessagingException {
         try {
-            return  localStore.database.execute(false, new DbCallback<Map<String, Long>>() {
+            return  localStore.getDatabase().execute(false, new DbCallback<Map<String, Long>>() {
                 @Override
                 public Map<String, Long> doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     Cursor cursor = null;
@@ -917,7 +917,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     public List<LocalMessage> getMessages(final MessageRetrievalListener<LocalMessage> listener,
             final boolean includeDeleted) throws MessagingException {
         try {
-            return  localStore.database.execute(false, new DbCallback<List<LocalMessage>>() {
+            return  localStore.getDatabase().execute(false, new DbCallback<List<LocalMessage>>() {
                 @Override
                 public List<LocalMessage> doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     try {
@@ -943,7 +943,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
     public List<String> getAllMessageUids() throws MessagingException {
         try {
-            return  localStore.database.execute(false, new DbCallback<List<String>>() {
+            return  localStore.getDatabase().execute(false, new DbCallback<List<String>>() {
                 @Override
                 public List<String> doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     Cursor cursor = null;
@@ -1032,7 +1032,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         final Map<String, String> uidMap = new HashMap<>();
 
         try {
-            this.localStore.database.execute(false, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(false, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     try {
@@ -1157,7 +1157,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
      * @return The local version of the message. Never <code>null</code>.
      */
     public LocalMessage storeSmallMessage(final Message message, final Runnable runnable) throws MessagingException {
-        return this.localStore.database.execute(true, new DbCallback<LocalMessage>() {
+        return this.localStore.getDatabase().execute(true, new DbCallback<LocalMessage>() {
             @Override
             public LocalMessage doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                 try {
@@ -1193,7 +1193,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
     public void destroyMessages(final List<? extends Message> messages) {
         try {
-            this.localStore.database.execute(true, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(true, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     for (Message message : messages) {
@@ -1261,7 +1261,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         open(OPEN_MODE_RW);
         try {
             final Map<String, String> uidMap = new HashMap<>();
-            this.localStore.database.execute(true, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(true, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     try {
@@ -1646,7 +1646,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     public void addPartToMessage(final LocalMessage message, final Part part) throws MessagingException {
         open(OPEN_MODE_RW);
 
-        localStore.database.execute(false, new DbCallback<Void>() {
+        localStore.getDatabase().execute(false, new DbCallback<Void>() {
             @Override
             public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                 long messagePartId;
@@ -1685,7 +1685,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         open(OPEN_MODE_RW);
         final ContentValues cv = new ContentValues();
         cv.put("uid", message.getUid());
-        this.localStore.database.execute(false, new DbCallback<Void>() {
+        this.localStore.getDatabase().execute(false, new DbCallback<Void>() {
             @Override
             public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                 db.update("messages", cv, "id = ?", new String[]
@@ -1705,7 +1705,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
 
         // Use one transaction to set all flags
         try {
-            this.localStore.database.execute(true, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(true, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException,
                         UnavailableStorageException {
@@ -1764,7 +1764,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
         open(OPEN_MODE_RO);
 
         try {
-            this.localStore.database.execute(false, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(false, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException {
                     try {
@@ -1807,7 +1807,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     @Override
     public void delete(final boolean recurse) throws MessagingException {
         try {
-            this.localStore.database.execute(false, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(false, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     try {
@@ -1850,7 +1850,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     private void destroyMessage(final long messageId, final long messagePartId, final String messageIdHeader)
             throws MessagingException {
         try {
-            localStore.database.execute(true, new DbCallback<Void>() {
+            localStore.getDatabase().execute(true, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException,
                         UnavailableStorageException {
@@ -1995,7 +1995,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     }
 
     private void deleteMessageParts(final long rootMessagePartId) throws MessagingException {
-        localStore.database.execute(false, new DbCallback<Void>() {
+        localStore.getDatabase().execute(false, new DbCallback<Void>() {
             @Override
             public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                 db.delete("message_parts", "root = ?", new String[] { Long.toString(rootMessagePartId) });
@@ -2005,7 +2005,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     }
 
     private void deleteMessageDataFromDisk(final long rootMessagePartId) throws MessagingException {
-        localStore.database.execute(false, new DbCallback<Void>() {
+        localStore.getDatabase().execute(false, new DbCallback<Void>() {
             @Override
             public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                 deleteMessagePartsFromDisk(db, rootMessagePartId);
@@ -2063,7 +2063,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
      * framework to examine send date in lieu of internal date.</p>
      */
     public void updateLastUid() throws MessagingException {
-        Integer lastUid = this.localStore.database.execute(false, new DbCallback<Integer>() {
+        Integer lastUid = this.localStore.getDatabase().execute(false, new DbCallback<Integer>() {
             @Override
             public Integer doDbWork(final SQLiteDatabase db) {
                 Cursor cursor = null;
@@ -2089,7 +2089,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
     }
 
     public Long getOldestMessageDate() throws MessagingException {
-        return this.localStore.database.execute(false, new DbCallback<Long>() {
+        return this.localStore.getDatabase().execute(false, new DbCallback<Long>() {
             @Override
             public Long doDbWork(final SQLiteDatabase db) {
                 Cursor cursor = null;
@@ -2218,7 +2218,7 @@ public class LocalFolder extends Folder<LocalMessage> implements Serializable {
             throws MessagingException {
 
         try {
-            return this.localStore.database.execute(false, new DbCallback<List<Message>>() {
+            return this.localStore.getDatabase().execute(false, new DbCallback<List<Message>>() {
                 @Override
                 public List<Message> doDbWork(final SQLiteDatabase db) throws WrappedException {
                     try {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -9,7 +9,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -69,8 +68,7 @@ import org.apache.james.mime4j.util.MimeUtil;
 import timber.log.Timber;
 
 
-public class LocalFolder extends Folder<LocalMessage> implements Serializable {
-    private static final long serialVersionUID = -1973296520918624767L;
+public class LocalFolder extends Folder<LocalMessage> {
     private static final int MAX_BODY_SIZE_FOR_DATABASE = 16 * 1024;
     private static final long INVALID_MESSAGE_PART_ID = -1;
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -54,16 +54,16 @@ public class LocalMessage extends MimeMessage {
 
 
     void populateFromGetMessageCursor(Cursor cursor) throws MessagingException {
-        final String subject = cursor.getString(0);
+        final String subject = cursor.getString(LocalStore.MSG_INDEX_SUBJECT);
         this.setSubject(subject == null ? "" : subject);
 
-        Address[] from = Address.unpack(cursor.getString(1));
+        Address[] from = Address.unpack(cursor.getString(LocalStore.MSG_INDEX_SENDER_LIST));
         if (from.length > 0) {
             this.setFrom(from[0]);
         }
-        this.setInternalSentDate(new Date(cursor.getLong(2)));
-        this.setUid(cursor.getString(3));
-        String flagList = cursor.getString(4);
+        this.setInternalSentDate(new Date(cursor.getLong(LocalStore.MSG_INDEX_DATE)));
+        this.setUid(cursor.getString(LocalStore.MSG_INDEX_UID));
+        String flagList = cursor.getString(LocalStore.MSG_INDEX_FLAGS);
         if (flagList != null && flagList.length() > 0) {
             String[] flags = flagList.split(",");
 
@@ -79,39 +79,39 @@ public class LocalMessage extends MimeMessage {
                 }
             }
         }
-        this.databaseId = cursor.getLong(5);
-        this.setRecipients(RecipientType.TO, Address.unpack(cursor.getString(6)));
-        this.setRecipients(RecipientType.CC, Address.unpack(cursor.getString(7)));
-        this.setRecipients(RecipientType.BCC, Address.unpack(cursor.getString(8)));
-        this.setReplyTo(Address.unpack(cursor.getString(9)));
+        this.databaseId = cursor.getLong(LocalStore.MSG_INDEX_ID);
+        this.setRecipients(RecipientType.TO, Address.unpack(cursor.getString(LocalStore.MSG_INDEX_TO)));
+        this.setRecipients(RecipientType.CC, Address.unpack(cursor.getString(LocalStore.MSG_INDEX_CC)));
+        this.setRecipients(RecipientType.BCC, Address.unpack(cursor.getString(LocalStore.MSG_INDEX_BCC)));
+        this.setReplyTo(Address.unpack(cursor.getString(LocalStore.MSG_INDEX_REPLY_TO)));
 
-        this.attachmentCount = cursor.getInt(10);
-        this.setInternalDate(new Date(cursor.getLong(11)));
-        this.setMessageId(cursor.getString(12));
+        this.attachmentCount = cursor.getInt(LocalStore.MSG_INDEX_ATTACHMENT_COUNT);
+        this.setInternalDate(new Date(cursor.getLong(LocalStore.MSG_INDEX_INTERNAL_DATE)));
+        this.setMessageId(cursor.getString(LocalStore.MSG_INDEX_MESSAGE_ID_HEADER));
 
-        String previewTypeString = cursor.getString(24);
+        String previewTypeString = cursor.getString(LocalStore.MSG_INDEX_PREVIEW_TYPE);
         DatabasePreviewType databasePreviewType = DatabasePreviewType.fromDatabaseValue(previewTypeString);
         previewType = databasePreviewType.getPreviewType();
         if (previewType == PreviewType.TEXT) {
-            preview = cursor.getString(14);
+            preview = cursor.getString(LocalStore.MSG_INDEX_PREVIEW);
         } else {
             preview = "";
         }
 
         if (this.mFolder == null) {
-            LocalFolder f = new LocalFolder(this.localStore, cursor.getInt(13));
+            LocalFolder f = new LocalFolder(this.localStore, cursor.getInt(LocalStore.MSG_INDEX_FOLDER_ID));
             f.open(LocalFolder.OPEN_MODE_RW);
             this.mFolder = f;
         }
 
-        threadId = (cursor.isNull(15)) ? -1 : cursor.getLong(15);
-        rootId = (cursor.isNull(16)) ? -1 : cursor.getLong(16);
+        threadId = (cursor.isNull(LocalStore.MSG_INDEX_THREAD_ID)) ? -1 : cursor.getLong(LocalStore.MSG_INDEX_THREAD_ID);
+        rootId = (cursor.isNull(LocalStore.MSG_INDEX_THREAD_ROOT_ID)) ? -1 : cursor.getLong(LocalStore.MSG_INDEX_THREAD_ROOT_ID);
 
-        boolean deleted = (cursor.getInt(17) == 1);
-        boolean read = (cursor.getInt(18) == 1);
-        boolean flagged = (cursor.getInt(19) == 1);
-        boolean answered = (cursor.getInt(20) == 1);
-        boolean forwarded = (cursor.getInt(21) == 1);
+        boolean deleted = (cursor.getInt(LocalStore.MSG_INDEX_FLAG_DELETED) == 1);
+        boolean read = (cursor.getInt(LocalStore.MSG_INDEX_FLAG_READ) == 1);
+        boolean flagged = (cursor.getInt(LocalStore.MSG_INDEX_FLAG_FLAGGED) == 1);
+        boolean answered = (cursor.getInt(LocalStore.MSG_INDEX_FLAG_ANSWERED) == 1);
+        boolean forwarded = (cursor.getInt(LocalStore.MSG_INDEX_FLAG_FORWARDED) == 1);
 
         setFlagInternal(Flag.DELETED, deleted);
         setFlagInternal(Flag.SEEN, read);
@@ -119,10 +119,10 @@ public class LocalMessage extends MimeMessage {
         setFlagInternal(Flag.ANSWERED, answered);
         setFlagInternal(Flag.FORWARDED, forwarded);
 
-        setMessagePartId(cursor.getLong(22));
-        mimeType = cursor.getString(23);
+        setMessagePartId(cursor.getLong(LocalStore.MSG_INDEX_MESSAGE_PART_ID));
+        mimeType = cursor.getString(LocalStore.MSG_INDEX_MIME_TYPE);
 
-        byte[] header = cursor.getBlob(25);
+        byte[] header = cursor.getBlob(LocalStore.MSG_INDEX_HEADER_DATA);
         if (header != null) {
             MessageHeaderParser.parse(this, new ByteArrayInputStream(header));
         } else {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -29,7 +29,7 @@ import timber.log.Timber;
 public class LocalMessage extends MimeMessage {
     private final LocalStore localStore;
 
-    private long id;
+    private long databaseId;
     private long rootId;
     private long threadId;
     private long messagePartId;
@@ -79,7 +79,7 @@ public class LocalMessage extends MimeMessage {
                 }
             }
         }
-        this.id = cursor.getLong(5);
+        this.databaseId = cursor.getLong(5);
         this.setRecipients(RecipientType.TO, Address.unpack(cursor.getString(6)));
         this.setRecipients(RecipientType.CC, Address.unpack(cursor.getString(7)));
         this.setRecipients(RecipientType.BCC, Address.unpack(cursor.getString(8)));
@@ -246,9 +246,8 @@ public class LocalMessage extends MimeMessage {
         super.setFlag(flag, set);
     }
 
-    @Override
-    public long getId() {
-        return id;
+    public long getDatabaseId() {
+        return databaseId;
     }
 
     @Override
@@ -277,7 +276,7 @@ public class LocalMessage extends MimeMessage {
                     cv.put("answered", isSet(Flag.ANSWERED) ? 1 : 0);
                     cv.put("forwarded", isSet(Flag.FORWARDED) ? 1 : 0);
 
-                    db.update("messages", cv, "id = ?", new String[] { Long.toString(id) });
+                    db.update("messages", cv, "id = ?", new String[] { Long.toString(databaseId) });
 
                     return null;
                 }
@@ -311,7 +310,7 @@ public class LocalMessage extends MimeMessage {
                     cv.putNull("reply_to_list");
                     cv.putNull("message_part_id");
 
-                    db.update("messages", cv, "id = ?", new String[] { Long.toString(id) });
+                    db.update("messages", cv, "id = ?", new String[] { Long.toString(databaseId) });
 
                     try {
                         ((LocalFolder) mFolder).deleteMessagePartsAndDataFromDisk(messagePartId);
@@ -319,7 +318,7 @@ public class LocalMessage extends MimeMessage {
                         throw new WrappedException(e);
                     }
 
-                    getFolder().deleteFulltextIndexEntry(db, id);
+                    getFolder().deleteFulltextIndexEntry(db, databaseId);
 
                     return null;
                 }
@@ -343,7 +342,7 @@ public class LocalMessage extends MimeMessage {
                     ContentValues cv = new ContentValues();
                     cv.putNull("message_part_id");
 
-                    db.update("messages", cv, "id = ?", new String[] { Long.toString(id) });
+                    db.update("messages", cv, "id = ?", new String[] { Long.toString(databaseId) });
 
                     try {
                         ((LocalFolder) mFolder).deleteMessagePartsAndDataFromDisk(messagePartId);
@@ -380,7 +379,7 @@ public class LocalMessage extends MimeMessage {
         super.copy(message);
 
         message.messageReference = messageReference;
-        message.id = id;
+        message.databaseId = databaseId;
         message.attachmentCount = attachmentCount;
         message.subject = subject;
         message.preview = preview;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -257,7 +257,7 @@ public class LocalMessage extends MimeMessage {
     public void setFlag(final Flag flag, final boolean set) throws MessagingException {
 
         try {
-            this.localStore.database.execute(true, new DbCallback<Void>() {
+            this.localStore.getDatabase().execute(true, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     try {
@@ -297,7 +297,7 @@ public class LocalMessage extends MimeMessage {
      */
     private void delete() throws MessagingException {
         try {
-            localStore.database.execute(true, new DbCallback<Void>() {
+            localStore.getDatabase().execute(true, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
                     ContentValues cv = new ContentValues();
@@ -339,7 +339,7 @@ public class LocalMessage extends MimeMessage {
         }
 
         try {
-            localStore.database.execute(true, new DbCallback<Void>() {
+            localStore.getDatabase().execute(true, new DbCallback<Void>() {
                 @Override
                 public Void doDbWork(final SQLiteDatabase db) throws WrappedException, MessagingException {
                     ContentValues cv = new ContentValues();

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMimeMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMimeMessage.java
@@ -24,7 +24,7 @@ public class LocalMimeMessage extends MimeMessage implements LocalPart {
     }
 
     @Override
-    public long getId() {
+    public long getPartId() {
         return messagePartId;
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalPart.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalPart.java
@@ -3,7 +3,7 @@ package com.fsck.k9.mailstore;
 
 public interface LocalPart {
     String getAccountUuid();
-    long getId();
+    long getPartId();
     long getSize();
     LocalMessage getMessage();
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -9,7 +9,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -75,9 +74,7 @@ import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
  * Implements a SQLite database backed local store for Messages.
  * </pre>
  */
-public class LocalStore extends Store implements Serializable {
-    private static final long serialVersionUID = -5142141896809423072L;
-
+public class LocalStore extends Store {
     static final String[] EMPTY_STRING_ARRAY = new String[0];
     static final byte[] EMPTY_BYTE_ARRAY = new byte[0];
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -756,7 +756,7 @@ public class LocalStore extends Store implements Serializable {
 
             if (part instanceof LocalPart) {
                 LocalPart localBodyPart = (LocalPart) part;
-                if (localBodyPart.getId() == partId) {
+                if (localBodyPart.getPartId() == partId) {
                     return part;
                 }
             }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -103,6 +103,33 @@ public class LocalStore extends Store implements Serializable {
         "folder_id, preview, threads.id, threads.root, deleted, read, flagged, answered, " +
         "forwarded, message_part_id, messages.mime_type, preview_type, header ";
 
+    static final int MSG_INDEX_SUBJECT = 0;
+    static final int MSG_INDEX_SENDER_LIST = 1;
+    static final int MSG_INDEX_DATE = 2;
+    static final int MSG_INDEX_UID = 3;
+    static final int MSG_INDEX_FLAGS = 4;
+    static final int MSG_INDEX_ID = 5;
+    static final int MSG_INDEX_TO = 6;
+    static final int MSG_INDEX_CC = 7;
+    static final int MSG_INDEX_BCC = 8;
+    static final int MSG_INDEX_REPLY_TO = 9;
+    static final int MSG_INDEX_ATTACHMENT_COUNT = 10;
+    static final int MSG_INDEX_INTERNAL_DATE = 11;
+    static final int MSG_INDEX_MESSAGE_ID_HEADER = 12;
+    static final int MSG_INDEX_FOLDER_ID = 13;
+    static final int MSG_INDEX_PREVIEW = 14;
+    static final int MSG_INDEX_THREAD_ID = 15;
+    static final int MSG_INDEX_THREAD_ROOT_ID = 16;
+    static final int MSG_INDEX_FLAG_DELETED = 17;
+    static final int MSG_INDEX_FLAG_READ = 18;
+    static final int MSG_INDEX_FLAG_FLAGGED = 19;
+    static final int MSG_INDEX_FLAG_ANSWERED = 20;
+    static final int MSG_INDEX_FLAG_FORWARDED = 21;
+    static final int MSG_INDEX_MESSAGE_PART_ID = 22;
+    static final int MSG_INDEX_MIME_TYPE = 23;
+    static final int MSG_INDEX_PREVIEW_TYPE = 24;
+    static final int MSG_INDEX_HEADER_DATA = 25;
+
     static final String GET_FOLDER_COLS =
         "folders.id, name, visible_limit, last_updated, status, push_state, last_pushed, " +
         "integrate, top_group, poll_class, push_class, display_class, notify_class, more_messages";

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -188,7 +188,6 @@ public class LocalStore extends Store {
     private final AttachmentInfoExtractor attachmentInfoExtractor;
 
     private final Account account;
-    private final String uUid;
     private final LockableDatabase database;
 
     /**
@@ -207,7 +206,6 @@ public class LocalStore extends Store {
         attachmentInfoExtractor = AttachmentInfoExtractor.getInstance();
 
         this.account = account;
-        this.uUid = account.getUuid();
 
         database = new LockableDatabase(context, account.getUuid(), new StoreSchemaDefinition(this));
         database.setStorageProviderId(account.getLocalStorageProviderId());
@@ -270,10 +268,6 @@ public class LocalStore extends Store {
         return account;
     }
 
-    String getUUid() {
-        return uUid;
-    }
-
     protected Storage getStorage() {
         return Preferences.getPreferences(context).getStorage();
     }
@@ -282,7 +276,7 @@ public class LocalStore extends Store {
 
         final StorageManager storageManager = StorageManager.getInstance(context);
 
-        final File attachmentDirectory = storageManager.getAttachmentDirectory(uUid,
+        final File attachmentDirectory = storageManager.getAttachmentDirectory(account.getUuid(),
                                          database.getStorageProviderId());
 
         return database.execute(false, new DbCallback<Long>() {
@@ -298,7 +292,7 @@ public class LocalStore extends Store {
                     }
                 }
 
-                final File dbFile = storageManager.getDatabase(uUid, database.getStorageProviderId());
+                final File dbFile = storageManager.getDatabase(account.getUuid(), database.getStorageProviderId());
                 return dbFile.length() + attachmentLength;
             }
         });
@@ -468,7 +462,8 @@ public class LocalStore extends Store {
 
     private void deleteAllMessagePartsDataFromDisk() {
         final StorageManager storageManager = StorageManager.getInstance(context);
-        File attachmentDirectory = storageManager.getAttachmentDirectory(uUid, database.getStorageProviderId());
+        File attachmentDirectory = storageManager.getAttachmentDirectory(
+                account.getUuid(), database.getStorageProviderId());
         File[] files = attachmentDirectory.listFiles();
         if (files == null) {
             return;
@@ -897,7 +892,8 @@ public class LocalStore extends Store {
 
     File getAttachmentFile(String attachmentId) {
         final StorageManager storageManager = StorageManager.getInstance(context);
-        final File attachmentDirectory = storageManager.getAttachmentDirectory(uUid, database.getStorageProviderId());
+        final File attachmentDirectory = storageManager.getAttachmentDirectory(
+                account.getUuid(), database.getStorageProviderId());
         return new File(attachmentDirectory, attachmentId);
     }
 
@@ -999,7 +995,7 @@ public class LocalStore extends Store {
     }
 
     void notifyChange() {
-        Uri uri = Uri.withAppendedPath(EmailProvider.CONTENT_URI, "account/" + uUid + "/messages");
+        Uri uri = Uri.withAppendedPath(EmailProvider.CONTENT_URI, "account/" + account.getUuid() + "/messages");
         contentResolver.notifyChange(uri, null);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo55.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo55.java
@@ -9,7 +9,6 @@ import android.database.sqlite.SQLiteDatabase;
 import android.text.TextUtils;
 import timber.log.Timber;
 
-import com.fsck.k9.K9;
 import com.fsck.k9.mail.FetchProfile;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalFolder;
@@ -38,13 +37,13 @@ class MigrationTo55 {
 
                     String fulltext = fulltextCreator.createFulltext(localMessage);
                     if (!TextUtils.isEmpty(fulltext)) {
-                        Timber.d("fulltext for msg id %d is %d chars long", localMessage.getId(), fulltext.length());
+                        Timber.d("fulltext for msg id %d is %d chars long", localMessage.getDatabaseId(), fulltext.length());
                         cv.clear();
-                        cv.put("docid", localMessage.getId());
+                        cv.put("docid", localMessage.getDatabaseId());
                         cv.put("fulltext", fulltext);
                         db.insert("messages_fulltext", null, cv);
                     } else {
-                        Timber.d("no fulltext for msg id %d :(", localMessage.getId());
+                        Timber.d("no fulltext for msg id %d :(", localMessage.getDatabaseId());
                     }
                 }
             }

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -14,7 +14,6 @@ import timber.log.Timber;
 import android.support.annotation.WorkerThread;
 
 import com.fsck.k9.Globals;
-import com.fsck.k9.K9;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
@@ -64,7 +63,7 @@ public class AttachmentInfoExtractor {
         if (part instanceof LocalPart) {
             LocalPart localPart = (LocalPart) part;
             String accountUuid = localPart.getAccountUuid();
-            long messagePartId = localPart.getId();
+            long messagePartId = localPart.getPartId();
             size = localPart.getSize();
             isContentAvailable = part.getBody() != null;
             uri = AttachmentProvider.getAttachmentUri(accountUuid, messagePartId);

--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -358,13 +358,13 @@ public class MessageProvider extends ContentProvider {
     }
 
     /**
-     * Extracts the {@link LocalMessage#getId() ID} from the given {@link MessageInfoHolder}. The underlying
+     * Extracts the {@link LocalMessage#getDatabaseId() ID} from the given {@link MessageInfoHolder}. The underlying
      * {@link Message} is expected to be a {@link LocalMessage}.
      */
     public static class IdExtractor implements FieldExtractor<MessageInfoHolder, Long> {
         @Override
         public Long getField(MessageInfoHolder source) {
-            return source.message.getId();
+            return source.message.getDatabaseId();
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
@@ -5,7 +5,6 @@ import java.util.List;
 import timber.log.Timber;
 
 import com.fsck.k9.Account;
-import com.fsck.k9.K9;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mailstore.LocalFolder;
@@ -111,7 +110,7 @@ public class SqlQueryBuilder {
             LocalStore localStore = account.getLocalStore();
             LocalFolder folder = localStore.getFolder(folderName);
             folder.open(Folder.OPEN_MODE_RO);
-            folderId = folder.getId();
+            folderId = folder.getDatabaseId();
         } catch (MessagingException e) {
             //FIXME
             e.printStackTrace();

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -283,7 +283,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
 
         /* We hide the subject by default for each new message, and MessageTitleView might show
          * it later by calling showSubjectLine(). */
-        boolean newMessageShown = mMessage == null || mMessage.getId() != message.getId();
+        boolean newMessageShown = mMessage == null || !mMessage.getUid().equals(message.getUid());
         if (newMessageShown) {
             mSubjectView.setVisibility(GONE);
         }

--- a/k9mail/src/test/java/com/fsck/k9/cache/EmailProviderCacheTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/cache/EmailProviderCacheTest.java
@@ -42,7 +42,7 @@ public class EmailProviderCacheTest {
         cache = EmailProviderCache.getCache(UUID.randomUUID().toString(), RuntimeEnvironment.application);
         when(mockLocalMessage.getDatabaseId()).thenReturn(localMessageId);
         when(mockLocalMessage.getFolder()).thenReturn(mockLocalMessageFolder);
-        when(mockLocalMessageFolder.getId()).thenReturn(localMessageFolderId);
+        when(mockLocalMessageFolder.getDatabaseId()).thenReturn(localMessageFolderId);
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/cache/EmailProviderCacheTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/cache/EmailProviderCacheTest.java
@@ -40,7 +40,7 @@ public class EmailProviderCacheTest {
         MockitoAnnotations.initMocks(this);
 
         cache = EmailProviderCache.getCache(UUID.randomUUID().toString(), RuntimeEnvironment.application);
-        when(mockLocalMessage.getId()).thenReturn(localMessageId);
+        when(mockLocalMessage.getDatabaseId()).thenReturn(localMessageId);
         when(mockLocalMessage.getFolder()).thenReturn(mockLocalMessageFolder);
         when(mockLocalMessageFolder.getId()).thenReturn(localMessageFolderId);
     }

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -856,7 +856,7 @@ public class MessagingControllerTest {
         when(account.hasSentFolder()).thenReturn(true);
         when(account.getSentFolderName()).thenReturn(SENT_FOLDER_NAME);
         when(localStore.getFolder(SENT_FOLDER_NAME)).thenReturn(sentFolder);
-        when(sentFolder.getId()).thenReturn(1L);
+        when(sentFolder.getDatabaseId()).thenReturn(1L);
         when(localFolder.exists()).thenReturn(true);
         when(transportProvider.getTransport(appContext, account)).thenReturn(transport);
         when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(localMessageToSend1));

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MigrationTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MigrationTest.java
@@ -163,7 +163,7 @@ public class MigrationTest {
         localStore.getFolder("dev").fetch(Collections.singletonList(msg), fp, null);
 
         Assert.assertEquals("text/plain", msg.getMimeType());
-        Assert.assertEquals(2, msg.getId());
+        Assert.assertEquals(2, msg.getDatabaseId());
         Assert.assertEquals(13, msg.getHeaderNames().size());
         Assert.assertEquals(0, msg.getAttachmentCount());
 
@@ -229,7 +229,7 @@ public class MigrationTest {
         fp.add(FetchProfile.Item.BODY);
         localStore.getFolder("dev").fetch(Collections.singletonList(msg), fp, null);
 
-        Assert.assertEquals(3, msg.getId());
+        Assert.assertEquals(3, msg.getDatabaseId());
         Assert.assertEquals(8, msg.getHeaderNames().size());
         Assert.assertEquals("multipart/mixed", msg.getMimeType());
         Assert.assertEquals(1, msg.getHeader(MimeHeader.HEADER_CONTENT_TYPE).length);
@@ -301,7 +301,7 @@ public class MigrationTest {
         fp.add(FetchProfile.Item.BODY);
         localStore.getFolder("dev").fetch(Collections.singletonList(msg), fp, null);
 
-        Assert.assertEquals(4, msg.getId());
+        Assert.assertEquals(4, msg.getDatabaseId());
         Assert.assertEquals(8, msg.getHeaderNames().size());
         Assert.assertEquals("multipart/mixed", msg.getMimeType());
         Assert.assertEquals(2, msg.getAttachmentCount());
@@ -360,7 +360,7 @@ public class MigrationTest {
         fp.add(FetchProfile.Item.BODY);
         localStore.getFolder("dev").fetch(Collections.singletonList(msg), fp, null);
 
-        Assert.assertEquals(5, msg.getId());
+        Assert.assertEquals(5, msg.getDatabaseId());
         Assert.assertEquals(13, msg.getHeaderNames().size());
         Assert.assertEquals("multipart/encrypted", msg.getMimeType());
         Assert.assertEquals(2, msg.getAttachmentCount());
@@ -478,7 +478,7 @@ public class MigrationTest {
         fp.add(FetchProfile.Item.BODY);
         localStore.getFolder("dev").fetch(Collections.singletonList(msg), fp, null);
 
-        Assert.assertEquals(6, msg.getId());
+        Assert.assertEquals(6, msg.getDatabaseId());
         Assert.assertEquals(12, msg.getHeaderNames().size());
         Assert.assertEquals("text/plain", msg.getMimeType());
         Assert.assertEquals(0, msg.getAttachmentCount());
@@ -565,7 +565,7 @@ public class MigrationTest {
         fp.add(FetchProfile.Item.BODY);
         localStore.getFolder("dev").fetch(Collections.singletonList(msg), fp, null);
 
-        Assert.assertEquals(7, msg.getId());
+        Assert.assertEquals(7, msg.getDatabaseId());
         Assert.assertEquals(12, msg.getHeaderNames().size());
         Assert.assertEquals("text/plain", msg.getMimeType());
         Assert.assertEquals(0, msg.getAttachmentCount());
@@ -623,7 +623,7 @@ public class MigrationTest {
         fp.add(FetchProfile.Item.BODY);
         localStore.getFolder("dev").fetch(Collections.singletonList(msg), fp, null);
 
-        Assert.assertEquals(8, msg.getId());
+        Assert.assertEquals(8, msg.getDatabaseId());
         Assert.assertEquals(9, msg.getHeaderNames().size());
         Assert.assertEquals("multipart/alternative", msg.getMimeType());
         Assert.assertEquals(0, msg.getAttachmentCount());
@@ -688,7 +688,7 @@ public class MigrationTest {
         fp.add(FetchProfile.Item.BODY);
         localStore.getFolder("dev").fetch(Collections.singletonList(msg), fp, null);
 
-        Assert.assertEquals(9, msg.getId());
+        Assert.assertEquals(9, msg.getDatabaseId());
         Assert.assertEquals(11, msg.getHeaderNames().size());
         Assert.assertEquals("multipart/mixed", msg.getMimeType());
         Assert.assertEquals(1, msg.getAttachmentCount());

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
@@ -336,7 +336,7 @@ public class StoreSchemaDefinitionTest {
         LockableDatabase lockableDatabase = createLockableDatabase();
 
         LocalStore localStore = mock(LocalStore.class);
-        localStore.database = lockableDatabase;
+        when(localStore.getDatabase()).thenReturn(lockableDatabase);
         when(localStore.getContext()).thenReturn(context);
         when(localStore.getAccount()).thenReturn(account);
 


### PR DESCRIPTION
first three commits are purely IDE powered cleanup of the Local* classes, no semantic changes.

fourth commit renames the `id` field of LocalMessage to `databaseId`, to avoid confusion with `messageId` from the message header. this revealed another gem of our codebase: the base Message object already had the `getId` method, which in MimeMessage returns the message's uid parsed as a long, and is overridden by LocalMessage to return the database id. Luckily, getId is almost exclusively used on LocalMessage, which allows removing the getId method entirely without bigger problems.

fifth commit introduces constants to refer to columns for queries with GET_MESSAGE_COLS projection.

and the last removes the Serializable interface from LocalStore and LocalFolder, which we hopefully don't use anywhere (I couldn't find any)