### PR TITLE
add tests for MessageCryptoHelper

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
@@ -57,7 +57,7 @@ public abstract class Message implements Part, Body {
         final int MULTIPLIER = 31;
 
         int result = 1;
-        result = MULTIPLIER * result + mFolder.getName().hashCode();
+        result = MULTIPLIER * result + (mFolder != null ? mFolder.getName().hashCode() : 0);
         result = MULTIPLIER * result + mUid.hashCode();
         return result;
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -13,6 +13,8 @@ import android.os.Parcelable;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.UiThread;
+
+import com.fsck.k9.ui.crypto.OpenPgpApiFactory;
 import timber.log.Timber;
 
 import com.fsck.k9.Account;
@@ -268,7 +270,7 @@ public class MessageLoaderHelper {
             messageCryptoHelper = retainCryptoHelperFragment.getData();
         }
         if (messageCryptoHelper == null || messageCryptoHelper.isConfiguredForOutdatedCryptoProvider()) {
-            messageCryptoHelper = new MessageCryptoHelper(context);
+            messageCryptoHelper = new MessageCryptoHelper(context, new OpenPgpApiFactory());
             retainCryptoHelperFragment.setData(messageCryptoHelper);
         }
         messageCryptoHelper.asyncStartOrResumeProcessingMessage(

--- a/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
+++ b/k9mail/src/main/java/com/fsck/k9/crypto/MessageDecryptVerifier.java
@@ -200,11 +200,9 @@ public class MessageDecryptVerifier {
             if (body instanceof Multipart) {
                 Multipart multi = (Multipart) body;
                 BodyPart signatureBody = multi.getBodyPart(1);
-                if (isSameMimeType(signatureBody.getMimeType(), APPLICATION_PGP_SIGNATURE)) {
-                    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-                    signatureBody.getBody().writeTo(bos);
-                    return bos.toByteArray();
-                }
+                ByteArrayOutputStream bos = new ByteArrayOutputStream();
+                signatureBody.getBody().writeTo(bos);
+                return bos.toByteArray();
             }
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/OpenPgpApiFactory.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/OpenPgpApiFactory.java
@@ -1,0 +1,14 @@
+package com.fsck.k9.ui.crypto;
+
+
+import android.content.Context;
+
+import org.openintents.openpgp.util.OpenPgpApi;
+import org.openintents.openpgp.IOpenPgpService2;
+
+
+public class OpenPgpApiFactory {
+    OpenPgpApi createOpenPgpApi(Context context, IOpenPgpService2 service) {
+        return new OpenPgpApi(context, service);
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/ui/crypto/MessageCryptoHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/ui/crypto/MessageCryptoHelperTest.java
@@ -1,0 +1,259 @@
+package com.fsck.k9.ui.crypto;
+
+
+import java.io.OutputStream;
+
+import android.app.PendingIntent;
+import android.content.Context;
+import android.content.Intent;
+
+import com.fsck.k9.K9;
+import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.Body;
+import com.fsck.k9.mail.BodyPart;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.Multipart;
+import com.fsck.k9.mail.internet.MimeBodyPart;
+import com.fsck.k9.mail.internet.MimeMessage;
+import com.fsck.k9.mail.internet.MimeMultipart;
+import com.fsck.k9.mail.internet.TextBody;
+import com.fsck.k9.mailstore.CryptoResultAnnotation;
+import com.fsck.k9.mailstore.CryptoResultAnnotation.CryptoError;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.openintents.openpgp.IOpenPgpService2;
+import org.openintents.openpgp.OpenPgpDecryptionResult;
+import org.openintents.openpgp.OpenPgpSignatureResult;
+import org.openintents.openpgp.util.OpenPgpApi;
+import org.openintents.openpgp.util.OpenPgpApi.IOpenPgpSinkResultCallback;
+import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSink;
+import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertSame;
+import static junit.framework.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 21)
+public class MessageCryptoHelperTest {
+    private MessageCryptoHelper messageCryptoHelper;
+    private OpenPgpApi openPgpApi;
+    private Intent capturedApiIntent;
+    private IOpenPgpSinkResultCallback capturedCallback;
+    private MessageCryptoCallback messageCryptoCallback;
+
+
+    @Before
+    public void setUp() throws Exception {
+        openPgpApi = mock(OpenPgpApi.class);
+
+        K9.setOpenPgpProvider("org.example.dummy");
+
+        OpenPgpApiFactory openPgpApiFactory = mock(OpenPgpApiFactory.class);
+        when(openPgpApiFactory.createOpenPgpApi(any(Context.class), any(IOpenPgpService2.class))).thenReturn(openPgpApi);
+        messageCryptoHelper = new MessageCryptoHelper(RuntimeEnvironment.application, openPgpApiFactory);
+        messageCryptoCallback = mock(MessageCryptoCallback.class);
+    }
+
+    @Test
+    public void textPlain() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setUid("msguid");
+        message.setHeader("Content-Type", "text/plain");
+
+        MessageCryptoCallback messageCryptoCallback = mock(MessageCryptoCallback.class);
+        messageCryptoHelper.asyncStartOrResumeProcessingMessage(message, messageCryptoCallback, null);
+
+        ArgumentCaptor<MessageCryptoAnnotations> captor = ArgumentCaptor.forClass(MessageCryptoAnnotations.class);
+        verify(messageCryptoCallback).onCryptoOperationsFinished(captor.capture());
+        MessageCryptoAnnotations annotations = captor.getValue();
+        assertTrue(annotations.isEmpty());
+        verifyNoMoreInteractions(messageCryptoCallback);
+    }
+
+    @Test
+    public void multipartSigned__withNullBody__shouldReturnSignedIncomplete() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setUid("msguid");
+        message.setHeader("Content-Type", "multipart/signed");
+
+        MessageCryptoCallback messageCryptoCallback = mock(MessageCryptoCallback.class);
+        messageCryptoHelper.asyncStartOrResumeProcessingMessage(message, messageCryptoCallback, null);
+
+        assertPartAnnotationHasState(message, messageCryptoCallback, CryptoError.OPENPGP_SIGNED_BUT_INCOMPLETE, null,
+                null, null, null);
+    }
+
+    @Test
+    public void multipartEncrypted__withNullBody__shouldReturnEncryptedIncomplete() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setUid("msguid");
+        message.setHeader("Content-Type", "multipart/encrypted");
+
+        MessageCryptoCallback messageCryptoCallback = mock(MessageCryptoCallback.class);
+        messageCryptoHelper.asyncStartOrResumeProcessingMessage(message, messageCryptoCallback, null);
+
+        assertPartAnnotationHasState(
+                message, messageCryptoCallback, CryptoError.OPENPGP_ENCRYPTED_BUT_INCOMPLETE, null, null, null, null);
+    }
+
+    @Test
+    public void multipartEncrypted__withUnknownProtocol__shouldReturnEncryptedUnsupported() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setUid("msguid");
+        message.setHeader("Content-Type", "multipart/encrypted; protocol=\"unknown protocol\"");
+        message.setBody(new MimeMultipart("multipart/encrypted", "--------"));
+
+        MessageCryptoCallback messageCryptoCallback = mock(MessageCryptoCallback.class);
+        messageCryptoHelper.asyncStartOrResumeProcessingMessage(message, messageCryptoCallback, null);
+
+        assertPartAnnotationHasState(message, messageCryptoCallback, CryptoError.ENCRYPTED_BUT_UNSUPPORTED, null, null,
+                null, null);
+    }
+
+    @Test
+    public void multipartSigned__withUnknownProtocol__shouldReturnSignedUnsupported() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setUid("msguid");
+        message.setHeader("Content-Type", "multipart/signed; protocol=\"unknown protocol\"");
+        message.setBody(new MimeMultipart("multipart/encrypted", "--------"));
+
+        MessageCryptoCallback messageCryptoCallback = mock(MessageCryptoCallback.class);
+        messageCryptoHelper.asyncStartOrResumeProcessingMessage(message, messageCryptoCallback, null);
+
+        assertPartAnnotationHasState(message, messageCryptoCallback, CryptoError.SIGNED_BUT_UNSUPPORTED, null, null,
+                null, null);
+    }
+
+    @Test
+    public void multipartSigned__shouldCallOpenPgpApiAsync() throws Exception {
+        BodyPart signedBodyPart = spy(new MimeBodyPart(new TextBody("text")));
+        BodyPart signatureBodyPart = new MimeBodyPart(new TextBody("text"));
+
+        Multipart messageBody = new MimeMultipart("boundary1");
+        messageBody.addBodyPart(signedBodyPart);
+        messageBody.addBodyPart(signatureBodyPart);
+
+        MimeMessage message = new MimeMessage();
+        message.setUid("msguid");
+        message.setHeader("Content-Type", "multipart/signed; protocol=\"application/pgp-signature\"");
+        message.setFrom(Address.parse("Test <test@example.org>")[0]);
+        message.setBody(messageBody);
+
+        OutputStream outputStream = mock(OutputStream.class);
+
+
+        processSignedMessageAndCaptureMocks(message, signedBodyPart, outputStream);
+
+
+        assertEquals(OpenPgpApi.ACTION_DECRYPT_VERIFY, capturedApiIntent.getAction());
+        assertEquals("test@example.org", capturedApiIntent.getStringExtra(OpenPgpApi.EXTRA_SENDER_ADDRESS));
+    }
+
+    @Test
+    public void multipartEncrypted__shouldCallOpenPgpApiAsync() throws Exception {
+        BodyPart dummyBodyPart = new MimeBodyPart(new TextBody("text"));
+        Body encryptedBody = spy(new TextBody("encrypted data"));
+        BodyPart encryptedBodyPart = spy(new MimeBodyPart(encryptedBody));
+
+        Multipart messageBody = new MimeMultipart("boundary1");
+        messageBody.addBodyPart(dummyBodyPart);
+        messageBody.addBodyPart(encryptedBodyPart);
+
+        MimeMessage message = new MimeMessage();
+        message.setUid("msguid");
+        message.setHeader("Content-Type", "multipart/encrypted; protocol=\"application/pgp-encrypted\"");
+        message.setFrom(Address.parse("Test <test@example.org>")[0]);
+        message.setBody(messageBody);
+
+        OutputStream outputStream = mock(OutputStream.class);
+
+        Intent resultIntent = new Intent();
+        resultIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+        OpenPgpDecryptionResult decryptionResult = mock(OpenPgpDecryptionResult.class);
+        resultIntent.putExtra(OpenPgpApi.RESULT_DECRYPTION, decryptionResult);
+        OpenPgpSignatureResult signatureResult = mock(OpenPgpSignatureResult.class);
+        resultIntent.putExtra(OpenPgpApi.RESULT_SIGNATURE, signatureResult);
+        PendingIntent pendingIntent = mock(PendingIntent.class);
+        resultIntent.putExtra(OpenPgpApi.RESULT_INTENT, pendingIntent);
+
+
+        processEncryptedMessageAndCaptureMocks(message, encryptedBody, outputStream);
+
+        MimeBodyPart decryptedPart = new MimeBodyPart(new TextBody("text"));
+        capturedCallback.onReturn(resultIntent, decryptedPart);
+
+
+        assertEquals(OpenPgpApi.ACTION_DECRYPT_VERIFY, capturedApiIntent.getAction());
+        assertEquals("test@example.org", capturedApiIntent.getStringExtra(OpenPgpApi.EXTRA_SENDER_ADDRESS));
+        assertPartAnnotationHasState(message, messageCryptoCallback, CryptoError.OPENPGP_OK, decryptedPart,
+                decryptionResult, signatureResult, pendingIntent);
+    }
+
+    private void processEncryptedMessageAndCaptureMocks(Message message, Body encryptedBody, OutputStream outputStream)
+            throws Exception {
+        messageCryptoHelper.asyncStartOrResumeProcessingMessage(message, messageCryptoCallback, null);
+
+        ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+        ArgumentCaptor<OpenPgpDataSource> dataSourceCaptor = ArgumentCaptor.forClass(OpenPgpDataSource.class);
+        ArgumentCaptor<IOpenPgpSinkResultCallback> callbackCaptor = ArgumentCaptor.forClass(IOpenPgpSinkResultCallback.class);
+        verify(openPgpApi).executeApiAsync(intentCaptor.capture(), dataSourceCaptor.capture(),
+                any(OpenPgpDataSink.class), callbackCaptor.capture());
+
+        capturedApiIntent = intentCaptor.getValue();
+        capturedCallback = callbackCaptor.getValue();
+
+        OpenPgpDataSource dataSource = dataSourceCaptor.getValue();
+        dataSource.writeTo(outputStream);
+        verify(encryptedBody).writeTo(outputStream);
+    }
+
+    private void processSignedMessageAndCaptureMocks(Message message, BodyPart signedBodyPart,
+            OutputStream outputStream) throws Exception {
+        messageCryptoHelper.asyncStartOrResumeProcessingMessage(message, messageCryptoCallback, null);
+
+        ArgumentCaptor<Intent> intentCaptor = ArgumentCaptor.forClass(Intent.class);
+        ArgumentCaptor<OpenPgpDataSource> dataSourceCaptor = ArgumentCaptor.forClass(OpenPgpDataSource.class);
+        ArgumentCaptor<IOpenPgpSinkResultCallback> callbackCaptor = ArgumentCaptor.forClass(IOpenPgpSinkResultCallback.class);
+        verify(openPgpApi).executeApiAsync(intentCaptor.capture(), dataSourceCaptor.capture(),
+                callbackCaptor.capture());
+
+        capturedApiIntent = intentCaptor.getValue();
+        capturedCallback = callbackCaptor.getValue();
+
+        OpenPgpDataSource dataSource = dataSourceCaptor.getValue();
+        dataSource.writeTo(outputStream);
+        verify(signedBodyPart).writeTo(outputStream);
+    }
+
+    private void assertPartAnnotationHasState(Message message, MessageCryptoCallback messageCryptoCallback,
+            CryptoError cryptoErrorState, MimeBodyPart replacementPart, OpenPgpDecryptionResult openPgpDecryptionResult,
+            OpenPgpSignatureResult openPgpSignatureResult, PendingIntent openPgpPendingIntent) {
+        ArgumentCaptor<MessageCryptoAnnotations> captor = ArgumentCaptor.forClass(MessageCryptoAnnotations.class);
+        verify(messageCryptoCallback).onCryptoOperationsFinished(captor.capture());
+        MessageCryptoAnnotations annotations = captor.getValue();
+        CryptoResultAnnotation cryptoResultAnnotation = annotations.get(message);
+        assertEquals(cryptoErrorState, cryptoResultAnnotation.getErrorType());
+        if (replacementPart != null) {
+            assertSame(replacementPart, cryptoResultAnnotation.getReplacementData());
+        }
+        assertSame(openPgpDecryptionResult, cryptoResultAnnotation.getOpenPgpDecryptionResult());
+        assertSame(openPgpSignatureResult, cryptoResultAnnotation.getOpenPgpSignatureResult());
+        assertSame(openPgpPendingIntent, cryptoResultAnnotation.getOpenPgpPendingIntent());
+        verifyNoMoreInteractions(messageCryptoCallback);
+    }
+
+}


### PR DESCRIPTION
This class has been criminally undertested, which came back to bite me in the autocrypt branches once too often. So here's a bunch of tests to check basic functionality. Also includes a bunch of related changes to make testing easier.