### PR TITLE
Fix ActivityListener crash due to concurrent modification

### DIFF
--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     compile 'com.github.amlcurran.showcaseview:library:5.4.1'
     compile 'com.squareup.moshi:moshi:1.2.0'
     compile "com.jakewharton.timber:timber:${timberVersion}"
+    compile 'net.jcip:jcip-annotations:1.0'
 
     androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -83,12 +83,13 @@ public class ActivityListener extends SimpleMessagingListener {
             } else {
                 displayName = loadingFolderName;
             }
-            if (account != null && account.getInboxFolderName() != null &&
-                    account.getInboxFolderName().equalsIgnoreCase(displayName)) {
-                displayName = context.getString(R.string.special_mailbox_name_inbox);
-            } else if (account != null && account.getOutboxFolderName() != null &&
-                    account.getOutboxFolderName().equals(displayName)) {
-                displayName = context.getString(R.string.special_mailbox_name_outbox);
+
+            if (account != null) {
+                if (displayName.equalsIgnoreCase(account.getInboxFolderName())) {
+                    displayName = context.getString(R.string.special_mailbox_name_inbox);
+                } else if (displayName.equalsIgnoreCase(account.getOutboxFolderName())) {
+                    displayName = context.getString(R.string.special_mailbox_name_outbox);
+                }
             }
 
             if (loadingHeaderFolderName != null) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.activity;
 
+
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
@@ -13,215 +14,203 @@ import com.fsck.k9.R;
 import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.service.MailService;
 
-public class ActivityListener extends SimpleMessagingListener {
-    private Account mAccount = null;
-    private String mLoadingFolderName = null;
-    private String mLoadingHeaderFolderName = null;
-    private String mLoadingAccountDescription = null;
-    private String mSendingAccountDescription = null;
-    private int mFolderCompleted = 0;
-    private int mFolderTotal = 0;
-    private String mProcessingAccountDescription = null;
-    private String mProcessingCommandTitle = null;
 
-    private BroadcastReceiver mTickReceiver = new BroadcastReceiver() {
+public class ActivityListener extends SimpleMessagingListener {
+    private Account account = null;
+    private String loadingFolderName = null;
+    private String loadingHeaderFolderName = null;
+    private String loadingAccountDescription = null;
+    private String sendingAccountDescription = null;
+    private int folderCompleted = 0;
+    private int folderTotal = 0;
+    private String processingAccountDescription = null;
+    private String processingCommandTitle = null;
+
+    private BroadcastReceiver tickReceiver = new BroadcastReceiver() {
         @Override
         public void onReceive(Context context, Intent intent) {
             informUserOfStatus();
         }
     };
 
+
     public String getOperation(Context context) {
-        if (mLoadingAccountDescription  != null
-                || mSendingAccountDescription != null
-                || mLoadingHeaderFolderName != null
-                || mProcessingAccountDescription != null) {
-
+        if (loadingAccountDescription != null ||
+                sendingAccountDescription != null ||
+                loadingHeaderFolderName != null ||
+                processingAccountDescription != null) {
             return getActionInProgressOperation(context);
+        }
 
-        } else {
-            long nextPollTime = MailService.getNextPollTime();
-            if (nextPollTime != -1) {
-                return context.getString(R.string.status_next_poll,
-                        DateUtils.getRelativeTimeSpanString(nextPollTime, System.currentTimeMillis(),
-                                DateUtils.MINUTE_IN_MILLIS, 0));
-            } else if (K9.isDebug() && MailService.isSyncDisabled()) {
-                if (MailService.hasNoConnectivity()) {
-                    return context.getString(R.string.status_no_network);
-                } else if (MailService.isSyncNoBackground()) {
-                    return context.getString(R.string.status_no_background);
-                } else if (MailService.isSyncBlocked()) {
-                    return context.getString(R.string.status_syncing_blocked);
-                } else if (MailService.isPollAndPushDisabled()) {
-                    return context.getString(R.string.status_poll_and_push_disabled);
-                } else {
-                    return context.getString(R.string.status_syncing_off);
-                }
-            } else if (MailService.isSyncDisabled()) {
-                return context.getString(R.string.status_syncing_off);
+        long nextPollTime = MailService.getNextPollTime();
+        if (nextPollTime != -1) {
+            CharSequence relativeTimeSpanString = DateUtils.getRelativeTimeSpanString(
+                    nextPollTime, System.currentTimeMillis(), DateUtils.MINUTE_IN_MILLIS, 0);
+            return context.getString(R.string.status_next_poll, relativeTimeSpanString);
+        } else if (K9.isDebug() && MailService.isSyncDisabled()) {
+            if (MailService.hasNoConnectivity()) {
+                return context.getString(R.string.status_no_network);
+            } else if (MailService.isSyncNoBackground()) {
+                return context.getString(R.string.status_no_background);
+            } else if (MailService.isSyncBlocked()) {
+                return context.getString(R.string.status_syncing_blocked);
+            } else if (MailService.isPollAndPushDisabled()) {
+                return context.getString(R.string.status_poll_and_push_disabled);
             } else {
-                return "";
+                return context.getString(R.string.status_syncing_off);
             }
+        } else if (MailService.isSyncDisabled()) {
+            return context.getString(R.string.status_syncing_off);
+        } else {
+            return "";
         }
     }
 
     private String getActionInProgressOperation(Context context) {
-        String progress = (mFolderTotal > 0 ?
-                context.getString(R.string.folder_progress, mFolderCompleted, mFolderTotal) : "");
+        String progress = folderTotal > 0 ?
+                context.getString(R.string.folder_progress, folderCompleted, folderTotal) : "";
 
-        if (mLoadingFolderName != null || mLoadingHeaderFolderName != null) {
+        if (loadingFolderName != null || loadingHeaderFolderName != null) {
             String displayName = null;
-            if (mLoadingHeaderFolderName != null) {
-                displayName = mLoadingHeaderFolderName;
-            } else if (mLoadingFolderName != null) {
-                displayName = mLoadingFolderName;
+            if (loadingHeaderFolderName != null) {
+                displayName = loadingHeaderFolderName;
+            } else if (loadingFolderName != null) {
+                displayName = loadingFolderName;
             }
-            if ((mAccount != null) && (mAccount.getInboxFolderName() != null)
-                    && mAccount.getInboxFolderName().equalsIgnoreCase(displayName)) {
+            if (account != null && account.getInboxFolderName() != null &&
+                    account.getInboxFolderName().equalsIgnoreCase(displayName)) {
                 displayName = context.getString(R.string.special_mailbox_name_inbox);
-            } else if ((mAccount != null) && (mAccount.getOutboxFolderName() != null)
-                    && mAccount.getOutboxFolderName().equals(displayName)) {
+            } else if (account != null && account.getOutboxFolderName() != null &&
+                    account.getOutboxFolderName().equals(displayName)) {
                 displayName = context.getString(R.string.special_mailbox_name_outbox);
             }
 
-            if (mLoadingHeaderFolderName != null) {
+            if (loadingHeaderFolderName != null) {
                 return context.getString(R.string.status_loading_account_folder_headers,
-                        mLoadingAccountDescription, displayName, progress);
+                        loadingAccountDescription, displayName, progress);
             } else {
                 return context.getString(R.string.status_loading_account_folder,
-                        mLoadingAccountDescription, displayName, progress);
+                        loadingAccountDescription, displayName, progress);
             }
-        }
-
-        else if (mSendingAccountDescription != null) {
-            return context.getString(R.string.status_sending_account, mSendingAccountDescription, progress);
-        } else if (mProcessingAccountDescription != null) {
-            return context.getString(R.string.status_processing_account, mProcessingAccountDescription,
-                    mProcessingCommandTitle != null ? mProcessingCommandTitle : "",
-                    progress);
+        } else if (sendingAccountDescription != null) {
+            return context.getString(R.string.status_sending_account, sendingAccountDescription, progress);
+        } else if (processingAccountDescription != null) {
+            return context.getString(R.string.status_processing_account, processingAccountDescription,
+                    processingCommandTitle != null ? processingCommandTitle : "", progress);
         } else {
             return "";
         }
     }
 
     public void onResume(Context context) {
-        context.registerReceiver(mTickReceiver, new IntentFilter(Intent.ACTION_TIME_TICK));
+        context.registerReceiver(tickReceiver, new IntentFilter(Intent.ACTION_TIME_TICK));
     }
 
     public void onPause(Context context) {
-        context.unregisterReceiver(mTickReceiver);
+        context.unregisterReceiver(tickReceiver);
     }
 
     public void informUserOfStatus() {
     }
 
     @Override
-    public void synchronizeMailboxFinished(
-        Account account,
-        String folder,
-        int totalMessagesInMailbox,
-        int numNewMessages) {
-        mLoadingAccountDescription = null;
-        mLoadingFolderName = null;
-        mAccount = null;
+    public void synchronizeMailboxFinished(Account account, String folder, int totalMessagesInMailbox,
+            int numNewMessages) {
+        loadingAccountDescription = null;
+        loadingFolderName = null;
+        this.account = null;
         informUserOfStatus();
     }
 
     @Override
     public void synchronizeMailboxStarted(Account account, String folder) {
-        mLoadingAccountDescription = account.getDescription();
-        mLoadingFolderName = folder;
-        mAccount = account;
-        mFolderCompleted = 0;
-        mFolderTotal = 0;
+        loadingAccountDescription = account.getDescription();
+        loadingFolderName = folder;
+        this.account = account;
+        folderCompleted = 0;
+        folderTotal = 0;
         informUserOfStatus();
     }
-
 
     @Override
     public void synchronizeMailboxHeadersStarted(Account account, String folder) {
-        mLoadingAccountDescription = account.getDescription();
-        mLoadingHeaderFolderName = folder;
+        loadingAccountDescription = account.getDescription();
+        loadingHeaderFolderName = folder;
         informUserOfStatus();
     }
-
 
     @Override
     public void synchronizeMailboxHeadersProgress(Account account, String folder, int completed, int total) {
-        mFolderCompleted = completed;
-        mFolderTotal = total;
+        folderCompleted = completed;
+        folderTotal = total;
         informUserOfStatus();
     }
 
     @Override
-    public void synchronizeMailboxHeadersFinished(Account account, String folder,
-            int total, int completed) {
-        mLoadingHeaderFolderName = null;
-        mFolderCompleted = 0;
-        mFolderTotal = 0;
+    public void synchronizeMailboxHeadersFinished(Account account, String folder, int total, int completed) {
+        loadingHeaderFolderName = null;
+        folderCompleted = 0;
+        folderTotal = 0;
         informUserOfStatus();
     }
-
 
     @Override
     public void synchronizeMailboxProgress(Account account, String folder, int completed, int total) {
-        mFolderCompleted = completed;
-        mFolderTotal = total;
+        folderCompleted = completed;
+        folderTotal = total;
         informUserOfStatus();
     }
 
     @Override
-    public void synchronizeMailboxFailed(Account account, String folder,
-                                         String message) {
-        mLoadingAccountDescription = null;
-        mLoadingHeaderFolderName = null;
-        mLoadingFolderName = null;
-        mAccount = null;
+    public void synchronizeMailboxFailed(Account account, String folder, String message) {
+        loadingAccountDescription = null;
+        loadingHeaderFolderName = null;
+        loadingFolderName = null;
+        this.account = null;
         informUserOfStatus();
-
     }
 
     @Override
     public void sendPendingMessagesStarted(Account account) {
-        mSendingAccountDescription = account.getDescription();
+        sendingAccountDescription = account.getDescription();
         informUserOfStatus();
     }
 
     @Override
     public void sendPendingMessagesCompleted(Account account) {
-        mSendingAccountDescription = null;
+        sendingAccountDescription = null;
         informUserOfStatus();
     }
 
     @Override
     public void sendPendingMessagesFailed(Account account) {
-        mSendingAccountDescription = null;
+        sendingAccountDescription = null;
         informUserOfStatus();
     }
 
     @Override
     public void pendingCommandsProcessing(Account account) {
-        mProcessingAccountDescription = account.getDescription();
-        mFolderCompleted = 0;
-        mFolderTotal = 0;
+        processingAccountDescription = account.getDescription();
+        folderCompleted = 0;
+        folderTotal = 0;
         informUserOfStatus();
     }
 
     @Override
     public void pendingCommandsFinished(Account account) {
-        mProcessingAccountDescription = null;
+        processingAccountDescription = null;
         informUserOfStatus();
     }
 
     @Override
     public void pendingCommandStarted(Account account, String commandTitle) {
-        mProcessingCommandTitle = commandTitle;
+        processingCommandTitle = commandTitle;
         informUserOfStatus();
     }
 
     @Override
     public void pendingCommandCompleted(Account account, String commandTitle) {
-        mProcessingCommandTitle = null;
+        processingCommandTitle = null;
         informUserOfStatus();
     }
 
@@ -241,12 +230,10 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     public int getFolderCompleted() {
-        return mFolderCompleted;
+        return folderCompleted;
     }
-
 
     public int getFolderTotal() {
-        return mFolderTotal;
+        return folderTotal;
     }
-
 }


### PR DESCRIPTION
`ActivityListener` accesses its field from both background threads and the main thread without locking. That leads to quite a few `NullPointerException`s for our users. This PR adds proper locking.

Fixes #2714