### PR TITLE
Fix retrieval of contact photos

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
@@ -31,7 +31,8 @@ public class Contacts {
     protected static final String PROJECTION[] = {
             ContactsContract.CommonDataKinds.Email._ID,
             ContactsContract.Contacts.DISPLAY_NAME,
-            ContactsContract.CommonDataKinds.Email.CONTACT_ID
+            ContactsContract.CommonDataKinds.Email.CONTACT_ID,
+            Photo.PHOTO_URI
     };
 
     /**
@@ -238,7 +239,10 @@ public class Contacts {
                 if (!c.moveToFirst()) {
                     return null;
                 }
-                final String uriString = c.getString(c.getColumnIndex(Photo.PHOTO_URI));
+                int columnIndex = c.getColumnIndex(Photo.PHOTO_URI);
+                final String uriString = c.getString(columnIndex);
+                if (uriString == null)
+                    return null;
                 return Uri.parse(uriString);
             } catch (IllegalStateException e) {
                 return null;


### PR DESCRIPTION
Add the PHOTO_URI column to the projection so it's actually there when we come to look for it 

This allows actual fetching of contact photos on my device and stops the:

`Failed to read row 0, column -1 from a CursorWindow` messages in the logs.


