### PR TITLE
Upgrade MIME4J to latest release

### DIFF
--- a/k9mail-library/build.gradle
+++ b/k9mail-library/build.gradle
@@ -14,8 +14,8 @@ repositories {
 }
 
 dependencies {
-    compile 'org.apache.james:apache-mime4j-core:0.7.2'
-    compile 'org.apache.james:apache-mime4j-dom:0.7.2'
+    compile 'org.apache.james:apache-mime4j-core:0.8.1'
+    compile 'org.apache.james:apache-mime4j-dom:0.8.1'
     compile 'commons-io:commons-io:2.4'
     compile 'com.jcraft:jzlib:1.0.7'
     compile 'com.beetstra.jutf7:jutf7:1.0.0'

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
@@ -19,8 +19,7 @@ import android.text.util.Rfc822Token;
 import android.text.util.Rfc822Tokenizer;
 
 public class Address implements Serializable {
-    private static final Pattern ATOM = Pattern.compile(
-            "^(?:[a-zA-Z0-9!#$%&'*+\\-/=?^_`{|}~]|\\s)+$");
+    private static final Pattern ATOM = Pattern.compile("^(?:[a-zA-Z0-9!#$%&'*+\\-/=?^_`{|}~]|\\s)+$");
 
     /**
      * Immutable empty {@link Address} array
@@ -145,7 +144,7 @@ public class Address implements Serializable {
         try {
             MailboxList parsedList =  DefaultAddressParser.DEFAULT.parseAddressList(addressList).flatten();
 
-                for (int i = 0, count = parsedList.size(); i < count; i++) {
+            for (int i = 0, count = parsedList.size(); i < count; i++) {
                 Mailbox mailbox = parsedList.get(i);
                 addresses.add(new Address(mailbox.getLocalPart() + "@" + mailbox.getDomain(), mailbox.getName(), false));
             }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
@@ -11,7 +11,7 @@ import org.apache.james.mime4j.MimeException;
 import org.apache.james.mime4j.codec.EncoderUtil;
 import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.dom.address.MailboxList;
-import org.apache.james.mime4j.field.address.AddressBuilder;
+import org.apache.james.mime4j.field.address.DefaultAddressParser;
 import timber.log.Timber;
 
 import android.text.TextUtils;
@@ -19,7 +19,8 @@ import android.text.util.Rfc822Token;
 import android.text.util.Rfc822Tokenizer;
 
 public class Address implements Serializable {
-    private static final Pattern ATOM = Pattern.compile("^(?:[a-zA-Z0-9!#$%&'*+\\-/=?^_`{|}~]|\\s)+$");
+    private static final Pattern ATOM = Pattern.compile(
+            "^(?:[a-zA-Z0-9!#$%&'*+\\-/=?^_`{|}~]|\\s)+$");
 
     /**
      * Immutable empty {@link Address} array
@@ -140,18 +141,13 @@ public class Address implements Serializable {
         if (TextUtils.isEmpty(addressList)) {
             return EMPTY_ADDRESS_ARRAY;
         }
-        List<Address> addresses = new ArrayList<Address>();
+        List<Address> addresses = new ArrayList<>();
         try {
-            MailboxList parsedList =  AddressBuilder.DEFAULT.parseAddressList(addressList).flatten();
+            MailboxList parsedList =  DefaultAddressParser.DEFAULT.parseAddressList(addressList).flatten();
 
-            for (int i = 0, count = parsedList.size(); i < count; i++) {
-                org.apache.james.mime4j.dom.address.Address address = parsedList.get(i);
-                if (address instanceof Mailbox) {
-                    Mailbox mailbox = (Mailbox) address;
-                    addresses.add(new Address(mailbox.getLocalPart() + "@" + mailbox.getDomain(), mailbox.getName(), false));
-                } else {
-                    Timber.e("Unknown address type from Mime4J: %s", address.getClass().toString());
-                }
+                for (int i = 0, count = parsedList.size(); i < count; i++) {
+                Mailbox mailbox = parsedList.get(i);
+                addresses.add(new Address(mailbox.getLocalPart() + "@" + mailbox.getDomain(), mailbox.getName(), false));
             }
         } catch (MimeException pe) {
             Timber.e(pe, "MimeException in Address.parse()");

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/EncoderUtil.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/EncoderUtil.java
@@ -5,6 +5,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
 import java.util.BitSet;
 
+import org.apache.james.mime4j.Charsets;
 import org.apache.james.mime4j.util.CharsetUtil;
 
 /**
@@ -159,13 +160,13 @@ class EncoderUtil {
         for (int index = 0; index < len; index++) {
             char ch = text.charAt(index);
             if (ch > 0xff) {
-                return CharsetUtil.UTF_8;
+                return Charsets.UTF_8;
             }
             if (ch > 0x7f) {
                 ascii = false;
             }
         }
-        return ascii ? CharsetUtil.US_ASCII : CharsetUtil.ISO_8859_1;
+        return ascii ? Charsets.US_ASCII : Charsets.ISO_8859_1;
     }
 
     private static Encoding determineEncoding(byte[] bytes) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -103,11 +103,14 @@ public class MimeMessage extends Message {
 
         mBody = null;
 
-        MimeConfig.Builder configBuilder = new MimeConfig.Builder();
-        configBuilder.setMaxHeaderLen(-1); // The default is a mere 10k
-        configBuilder.setMaxLineLen(-1); // The default is 1000 characters. Some MUAs generate
-        // REALLY long References: headers
-        configBuilder.setMaxHeaderCount(-1); // Disable the check for header count.
+        MimeConfig.Builder configBuilder = new MimeConfig.Builder()
+                // The default is a mere 10k
+                .setMaxHeaderLen(-1)
+                // The default is 1000 characters. Some MUAs generate
+                // REALLY long References: headers
+                .setMaxLineLen(-1)
+                // Disable the check for header count.
+                .setMaxHeaderCount(-1);
         MimeStreamParser parser = new MimeStreamParser(configBuilder.build());
         parser.setContentHandler(new MimeMessageBuilder(new DefaultBodyFactory()));
         if (recurse) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -36,7 +36,6 @@ import org.apache.james.mime4j.parser.MimeStreamParser;
 import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
-import org.apache.james.mime4j.stream.MimeConfig.Builder;
 
 
 /**
@@ -103,15 +102,16 @@ public class MimeMessage extends Message {
 
         mBody = null;
 
-        MimeConfig.Builder configBuilder = new MimeConfig.Builder()
+        MimeConfig parserConfig = new MimeConfig.Builder()
                 // The default is a mere 10k
                 .setMaxHeaderLen(-1)
-                // The default is 1000 characters. Some MUAs generate
-                // REALLY long References: headers
+                // The default is 1000 characters. Some MUAs generate REALLY long References: headers
                 .setMaxLineLen(-1)
                 // Disable the check for header count.
-                .setMaxHeaderCount(-1);
-        MimeStreamParser parser = new MimeStreamParser(configBuilder.build());
+                .setMaxHeaderCount(-1)
+                .build();
+
+        MimeStreamParser parser = new MimeStreamParser(parserConfig);
         parser.setContentHandler(new MimeMessageBuilder(new DefaultBodyFactory()));
         if (recurse) {
             parser.setRecurse();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -36,6 +36,7 @@ import org.apache.james.mime4j.parser.MimeStreamParser;
 import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
+import org.apache.james.mime4j.stream.MimeConfig.Builder;
 
 
 /**
@@ -102,12 +103,12 @@ public class MimeMessage extends Message {
 
         mBody = null;
 
-        MimeConfig parserConfig  = new MimeConfig();
-        parserConfig.setMaxHeaderLen(-1); // The default is a mere 10k
-        parserConfig.setMaxLineLen(-1); // The default is 1000 characters. Some MUAs generate
+        MimeConfig.Builder configBuilder = new MimeConfig.Builder();
+        configBuilder.setMaxHeaderLen(-1); // The default is a mere 10k
+        configBuilder.setMaxLineLen(-1); // The default is 1000 characters. Some MUAs generate
         // REALLY long References: headers
-        parserConfig.setMaxHeaderCount(-1); // Disable the check for header count.
-        MimeStreamParser parser = new MimeStreamParser(parserConfig);
+        configBuilder.setMaxHeaderCount(-1); // Disable the check for header count.
+        MimeStreamParser parser = new MimeStreamParser(configBuilder.build());
         parser.setContentHandler(new MimeMessageBuilder(new DefaultBodyFactory()));
         if (recurse) {
             parser.setRecurse();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/message/MessageHeaderParser.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/message/MessageHeaderParser.java
@@ -30,11 +30,11 @@ public class MessageHeaderParser {
     }
 
     private static MimeStreamParser getMimeStreamParser() {
-        MimeConfig parserConfig = new MimeConfig();
+        MimeConfig.Builder parserConfig = new MimeConfig.Builder();
         parserConfig.setMaxHeaderLen(-1);
         parserConfig.setMaxLineLen(-1);
         parserConfig.setMaxHeaderCount(-1);
-        return new MimeStreamParser(parserConfig);
+        return new MimeStreamParser(parserConfig.build());
     }
 
     private static class MessageHeaderParserContentHandler implements ContentHandler {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/message/MessageHeaderParser.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/message/MessageHeaderParser.java
@@ -30,11 +30,13 @@ public class MessageHeaderParser {
     }
 
     private static MimeStreamParser getMimeStreamParser() {
-        MimeConfig.Builder parserConfig = new MimeConfig.Builder()
-            .setMaxHeaderLen(-1)
-            .setMaxLineLen(-1)
-            .setMaxHeaderCount(-1);
-        return new MimeStreamParser(parserConfig.build());
+        MimeConfig parserConfig = new MimeConfig.Builder()
+                .setMaxHeaderLen(-1)
+                .setMaxLineLen(-1)
+                .setMaxHeaderCount(-1)
+                .build();
+
+        return new MimeStreamParser(parserConfig);
     }
 
     private static class MessageHeaderParserContentHandler implements ContentHandler {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/message/MessageHeaderParser.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/message/MessageHeaderParser.java
@@ -30,10 +30,10 @@ public class MessageHeaderParser {
     }
 
     private static MimeStreamParser getMimeStreamParser() {
-        MimeConfig.Builder parserConfig = new MimeConfig.Builder();
-        parserConfig.setMaxHeaderLen(-1);
-        parserConfig.setMaxLineLen(-1);
-        parserConfig.setMaxHeaderCount(-1);
+        MimeConfig.Builder parserConfig = new MimeConfig.Builder()
+            .setMaxHeaderLen(-1)
+            .setMaxLineLen(-1)
+            .setMaxHeaderCount(-1);
         return new MimeStreamParser(parserConfig.build());
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
@@ -31,12 +31,13 @@ public class MimePartStreamParser {
             throws MessagingException, IOException {
         MimeBodyPart parsedRootPart = new MimeBodyPart();
 
-        MimeConfig.Builder parserConfig  = new MimeConfig.Builder();
-        parserConfig.setMaxHeaderLen(-1);
-        parserConfig.setMaxLineLen(-1);
-        parserConfig.setMaxHeaderCount(-1);
+        MimeConfig parserConfig  = new MimeConfig.Builder()
+                .setMaxHeaderLen(-1)
+                .setMaxLineLen(-1)
+                .setMaxHeaderCount(-1)
+                .build();
 
-        MimeStreamParser parser = new MimeStreamParser(parserConfig.build());
+        MimeStreamParser parser = new MimeStreamParser(parserConfig);
         parser.setContentHandler(new PartBuilder(fileFactory, parsedRootPart));
         parser.setRecurse();
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
@@ -31,12 +31,12 @@ public class MimePartStreamParser {
             throws MessagingException, IOException {
         MimeBodyPart parsedRootPart = new MimeBodyPart();
 
-        MimeConfig parserConfig  = new MimeConfig();
+        MimeConfig.Builder parserConfig  = new MimeConfig.Builder();
         parserConfig.setMaxHeaderLen(-1);
         parserConfig.setMaxLineLen(-1);
         parserConfig.setMaxHeaderCount(-1);
 
-        MimeStreamParser parser = new MimeStreamParser(parserConfig);
+        MimeStreamParser parser = new MimeStreamParser(parserConfig.build());
         parser.setContentHandler(new PartBuilder(fileFactory, parsedRootPart));
         parser.setRecurse();
 


### PR DESCRIPTION
This updates us to the latest (still old) release of Apache MIME4J. It's a pretty minimal change in terms of code. It'll probably need a reasonable amount of testing.

Unfortunately it doesn't add the internationalisation stuff.

See change-list: https://gist.github.com/philipwhiuk/7d4bcf994b3a3247cf7e3819356d7241

