### PR TITLE
Subfolders implementation

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
@@ -17,6 +17,10 @@ public abstract class Folder<T extends Message> {
     public static final int OPEN_MODE_RW=0;
     public static final int OPEN_MODE_RO=1;
 
+    public String getParentId() {
+        return null;
+    }
+
     // NONE is obsolete, it will be translated to NO_CLASS for display and to INHERITED for sync and push
     public enum FolderClass {
         NONE, NO_CLASS, INHERITED, FIRST_CLASS, SECOND_CLASS
@@ -79,6 +83,12 @@ public abstract class Folder<T extends Message> {
      * @return true if the folder exists
      */
     public abstract boolean exists() throws MessagingException;
+
+    /**
+     * This should not perform a network request
+     * @return whether the folder is able to contain subfolders.
+     */
+    public abstract boolean canHaveSubFolders();
 
     /**
      * This should not perform a network request.

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
@@ -17,9 +17,10 @@ public abstract class Folder<T extends Message> {
     public static final int OPEN_MODE_RW=0;
     public static final int OPEN_MODE_RO=1;
 
-    public String getParentId() {
-        return null;
-    }
+    /**
+     * @return The ID of the parent folder.
+     */
+    public abstract String getParentId();
 
     // NONE is obsolete, it will be translated to NO_CLASS for display and to INHERITED for sync and push
     public enum FolderClass {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Store.java
@@ -28,12 +28,12 @@ public abstract class Store {
     /**
      * Request a list of folders. This can perform a network request.
      */
-    @NonNull public abstract List <? extends Folder > getFolders(boolean forceListAll) throws MessagingException;
+    @NonNull public abstract List<? extends Folder> getFolders(boolean forceListAll) throws MessagingException;
 
     /**
      * Request a list of folders. This can perform a network request.
      */
-    @NonNull public abstract List <? extends Folder > getSubFolders(String parentFolderId, boolean forceListAll) throws MessagingException;
+    @NonNull public abstract List<? extends Folder> getSubFolders(String parentFolderId, boolean forceListAll) throws MessagingException;
 
     /**
      * Verify that the settings provided for the store can be used succesfuly.

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Store.java
@@ -28,7 +28,12 @@ public abstract class Store {
     /**
      * Request a list of folders. This can perform a network request.
      */
-    @NonNull public abstract List <? extends Folder > getPersonalNamespaces(boolean forceListAll) throws MessagingException;
+    @NonNull public abstract List <? extends Folder > getFolders(boolean forceListAll) throws MessagingException;
+
+    /**
+     * Request a list of folders. This can perform a network request.
+     */
+    @NonNull public abstract List <? extends Folder > getSubFolders(String parentFolderId, boolean forceListAll) throws MessagingException;
 
     /**
      * Verify that the settings provided for the store can be used succesfuly.

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -71,6 +71,7 @@ class ImapFolder extends Folder<ImapMessage> {
     protected Map<Long, String> msgSeqUidMap = new ConcurrentHashMap<Long, String>();
     private final FolderNameCodec folderNameCodec;
     private final String id;
+    private final String parentId;
     private final String name;
     private int mode;
     private volatile boolean exists;
@@ -86,7 +87,8 @@ class ImapFolder extends Folder<ImapMessage> {
         super();
         this.store = store;
         this.id = id;
-        this.name = id;
+        this.parentId = store.getParentId("id");
+        this.name = store.getFolderName(id);
         this.folderNameCodec = folderNameCodec;
     }
 
@@ -244,6 +246,11 @@ class ImapFolder extends Folder<ImapMessage> {
     }
 
     @Override
+    public String getParentId() {
+        return store.getParentId(id);
+    }
+
+    @Override
     public String getName() {
         return name;
     }
@@ -299,6 +306,12 @@ class ImapFolder extends Folder<ImapMessage> {
                 store.releaseConnection(connection);
             }
         }
+    }
+
+    @Override
+    public boolean canHaveSubFolders() {
+        //TODO: Use the output of LIST/LSUB to define this.
+        return true;
     }
 
     @Override

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -87,7 +87,7 @@ class ImapFolder extends Folder<ImapMessage> {
         super();
         this.store = store;
         this.id = id;
-        this.parentId = store.getParentId("id");
+        this.parentId = store.getParentId(id);
         this.name = store.getFolderName(id);
         this.folderNameCodec = folderNameCodec;
     }
@@ -247,7 +247,7 @@ class ImapFolder extends Folder<ImapMessage> {
 
     @Override
     public String getParentId() {
-        return store.getParentId(id);
+        return parentId;
     }
 
     @Override

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -150,7 +150,7 @@ public class ImapStore extends RemoteStore {
         List<ImapFolder> subFolders = new ArrayList<>();
 
         for (ImapFolder folder: folders) {
-            if (!folder.getId().equals(parentFolderId) && folder.getId().startsWith(parentFolderId)) {
+            if (folder.getId().startsWith(parentFolderId) && folder.getId().length() != parentFolderId.length()) {
                 subFolders.add(folder);
             }
         }
@@ -434,7 +434,7 @@ public class ImapStore extends RemoteStore {
         if (pathDelimiter == null || id.lastIndexOf(pathDelimiter) == -1) {
             return id;
         } else {
-            return id.substring(id.lastIndexOf(pathDelimiter)+pathDelimiter.length());
+            return id.substring(id.lastIndexOf(pathDelimiter) + pathDelimiter.length());
         }
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -138,7 +138,28 @@ public class ImapStore extends RemoteStore {
     }
 
     @Override
-    @NonNull public List<ImapFolder> getPersonalNamespaces(boolean forceListAll) throws MessagingException {
+    @NonNull
+    public List<ImapFolder> getFolders(boolean forceListAll) throws MessagingException {
+        return getPersonalNamespaces(forceListAll);
+    }
+
+    @Override
+    @NonNull
+    public List<ImapFolder> getSubFolders(final String parentFolderId, boolean forceListAll) throws MessagingException {
+        List<ImapFolder> folders = getPersonalNamespaces(forceListAll);
+        List<ImapFolder> subFolders = new ArrayList<>();
+
+        for (ImapFolder folder: folders) {
+            if (!folder.getId().equals(parentFolderId) && folder.getId().startsWith(parentFolderId)) {
+                subFolders.add(folder);
+            }
+        }
+
+        return subFolders;
+    }
+
+    @NonNull
+    public List<ImapFolder> getPersonalNamespaces(boolean forceListAll) throws MessagingException {
         ImapConnection connection = getConnection();
 
         try {
@@ -399,6 +420,22 @@ public class ImapStore extends RemoteStore {
     @Override
     public Pusher getPusher(PushReceiver receiver) {
         return new ImapPusher(this, receiver);
+    }
+
+    String getParentId(@NonNull String id) {
+        if (pathDelimiter == null || id.lastIndexOf(pathDelimiter) == -1) {
+            return "";
+        } else {
+            return id.substring(0, id.lastIndexOf(pathDelimiter));
+        }
+    }
+
+    public String getFolderName(String id) {
+        if (pathDelimiter == null || id.lastIndexOf(pathDelimiter) == -1) {
+            return id;
+        } else {
+            return id.substring(id.lastIndexOf(pathDelimiter)+pathDelimiter.length());
+        }
     }
 
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
@@ -121,6 +121,11 @@ class Pop3Folder extends Folder<Pop3Message> {
     }
 
     @Override
+    public boolean canHaveSubFolders() {
+        return false;
+    }
+
+    @Override
     public int getMessageCount() {
         return messageCount;
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
@@ -51,6 +51,11 @@ class Pop3Folder extends Folder<Pop3Message> {
     }
 
     @Override
+    public String getParentId() {
+        return null;
+    }
+
+    @Override
     public synchronized void open(int mode) throws MessagingException {
         if (isOpen()) {
             return;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -10,6 +10,7 @@ import com.fsck.k9.mail.store.RemoteStore;
 import com.fsck.k9.mail.store.StoreConfig;
 
 import java.net.*;
+import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.HashMap;
 import java.util.List;
@@ -200,10 +201,16 @@ public class Pop3Store extends RemoteStore {
     }
 
     @Override
-    @NonNull public List <Pop3Folder> getPersonalNamespaces(boolean forceListAll) throws MessagingException {
+    @NonNull public List <Pop3Folder> getFolders(boolean forceListAll) throws MessagingException {
         List<Pop3Folder> folders = new LinkedList<>();
         folders.add(getFolder(mStoreConfig.getInboxFolderId()));
         return folders;
+    }
+
+    @NonNull
+    @Override
+    public List<? extends Folder> getSubFolders(String parentFolderId, boolean forceListAll) throws MessagingException {
+        return new ArrayList<>();
     }
 
     @Override

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -714,7 +714,7 @@ class WebDavFolder extends Folder<WebDavMessage> {
     @Override
     public boolean equals(Object o) {
         if (o instanceof WebDavFolder) {
-            return ((WebDavFolder) o).name.equals(name);
+            return ((WebDavFolder) o).id.equals(id);
         }
         return super.equals(o);
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -51,6 +51,7 @@ import static com.fsck.k9.mail.helper.UrlEncodingHelper.encodeUtf8;
 
  */
 class WebDavFolder extends Folder<WebDavMessage> {
+    private String id;
     private String name;
     private String folderUrl;
     private boolean mIsOpen = false;
@@ -62,10 +63,10 @@ class WebDavFolder extends Folder<WebDavMessage> {
         return store;
     }
 
-    public WebDavFolder(WebDavStore nStore, String name) {
+    public WebDavFolder(WebDavStore nStore, String id) {
         super();
         store = nStore;
-        this.name = name;
+        this.id = id;
         buildFolderUrl();
     }
 
@@ -207,12 +208,18 @@ class WebDavFolder extends Folder<WebDavMessage> {
 
     @Override
     public String getId() {
-        return this.name;
+        return this.id;
+    }
+
+    @Override
+    public String getParentId() {
+        return id.split("/", 2)[0];
     }
 
     @Override
     public String getName() {
-        return this.name;
+        String[] idParts = id.split("/");
+        return idParts[idParts.length-1];
     }
 
     @Override

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -221,6 +221,11 @@ class WebDavFolder extends Folder<WebDavMessage> {
     }
 
     @Override
+    public boolean canHaveSubFolders() {
+        throw new UnsupportedOperationException("Not yet implemented");
+    }
+
+    @Override
     public void close() {
         this.messageCount = 0;
         this.unreadMessageCount = 0;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -42,17 +42,14 @@ import static com.fsck.k9.mail.helper.UrlEncodingHelper.encodeUtf8;
  * A folder is referenced by an ID and a name.
  *
  * In the ImapFolder, the ID is the path including / separators.
- * The name is also currently the full path including separators.
+ * The name the final portion of the path.
  *
  * ID: "Folder/Subfolder"
- * Name: "Folder/Subfolder"
+ * Name: "Subfolder"
  *
- * TODO: Implement child-parent relationship for folders and make the name just the child name (e.g. Subfolder)
-
  */
 class WebDavFolder extends Folder<WebDavMessage> {
     private String id;
-    private String name;
     private String folderUrl;
     private boolean mIsOpen = false;
     private int messageCount = 0;
@@ -72,7 +69,7 @@ class WebDavFolder extends Folder<WebDavMessage> {
 
     private void buildFolderUrl() {
         String encodedName;
-        String[] urlParts = this.name.split("/");
+        String[] urlParts = this.id.split("/");
         String url = "";
         for (int i = 0, count = urlParts.length; i < count; i++) {
             if (i != 0) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -174,7 +174,7 @@ public class WebDavStore extends RemoteStore {
 
     @Override
     @NonNull
-    public List<? extends Folder> getPersonalNamespaces(boolean forceListAll) throws MessagingException {
+    public List<? extends Folder> getFolders(boolean forceListAll) throws MessagingException {
         List<Folder> folderList = new LinkedList<>();
         /*
          * We have to check authentication here so we have the proper URL stored
@@ -240,6 +240,12 @@ public class WebDavStore extends RemoteStore {
         }
 
         return folderList;
+    }
+
+    @NonNull
+    @Override
+    public List<? extends Folder> getSubFolders(String parentFolderId, boolean forceListAll) throws MessagingException {
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/MessageTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/MessageTest.java
@@ -370,6 +370,11 @@ public class MessageTest {
         String id;
 
         @Override
+        public String getParentId() {
+            return null;
+        }
+
+        @Override
         public void open(int mode) throws MessagingException {}
 
         @Override

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/MessageTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/MessageTest.java
@@ -396,6 +396,11 @@ public class MessageTest {
         }
 
         @Override
+        public boolean canHaveSubFolders() {
+            return false;
+        }
+
+        @Override
         public int getMessageCount() throws MessagingException {
             return 0;
         }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -807,7 +807,7 @@ public class ImapFolderTest {
 
         folder.fetch(null, fetchProfile, null);
 
-        verifyNoMoreInteractions(imapStore);
+        verifyNoMoreInteractions(imapConnection);
     }
 
     @Test
@@ -817,7 +817,7 @@ public class ImapFolderTest {
 
         folder.fetch(Collections.<ImapMessage>emptyList(), fetchProfile, null);
 
-        verifyNoMoreInteractions(imapStore);
+        verifyNoMoreInteractions(imapConnection);
     }
 
     @Test

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
@@ -147,7 +147,7 @@ public class ImapStoreTest {
         when(imapConnection.executeSimpleCommand("LIST \"\" \"*\"")).thenReturn(imapResponses);
         imapStore.enqueueImapConnection(imapConnection);
 
-        List<? extends Folder> result = imapStore.getPersonalNamespaces(true);
+        List<? extends Folder> result = imapStore.getFolders(true);
 
         assertNotNull(result);
         assertEquals(Sets.newSet("INBOX", "Folder.SubFolder"), extractFolderIds(result));
@@ -168,7 +168,7 @@ public class ImapStoreTest {
         when(imapConnection.executeSimpleCommand("LIST \"\" \"pathPrefix/*\"")).thenReturn(imapResponses);
         imapStore.enqueueImapConnection(imapConnection);
 
-        List<? extends Folder> result = imapStore.getPersonalNamespaces(true);
+        List<? extends Folder> result = imapStore.getFolders(true);
 
         assertNotNull(result);
         assertEquals(Sets.newSet("INBOX", "Folder.SubFolder"), extractFolderIds(result));
@@ -187,7 +187,7 @@ public class ImapStoreTest {
         when(imapConnection.executeSimpleCommand("LIST \"\" \"*\"")).thenReturn(imapResponses);
         imapStore.enqueueImapConnection(imapConnection);
 
-        List<? extends Folder> result = imapStore.getPersonalNamespaces(false);
+        List<? extends Folder> result = imapStore.getFolders(false);
 
         assertNotNull(result);
         assertEquals(Sets.newSet("INBOX", "Folder.SubFolder"), extractFolderIds(result));
@@ -215,7 +215,7 @@ public class ImapStoreTest {
         when(imapConnection.executeSimpleCommand("LIST \"\" \"*\"")).thenReturn(imapResponses);
         imapStore.enqueueImapConnection(imapConnection);
 
-        List<? extends Folder> result = imapStore.getPersonalNamespaces(false);
+        List<? extends Folder> result = imapStore.getFolders(false);
 
         assertNotNull(result);
         assertEquals(Sets.newSet("INBOX", "Folder.SubFolder"), extractFolderIds(result));
@@ -228,7 +228,7 @@ public class ImapStoreTest {
         when(imapConnection.executeSimpleCommand(anyString())).thenReturn(imapResponses);
         imapStore.enqueueImapConnection(imapConnection);
 
-        imapStore.getPersonalNamespaces(true);
+        imapStore.getFolders(true);
 
         verify(imapConnection, never()).close();
     }
@@ -240,12 +240,19 @@ public class ImapStoreTest {
         imapStore.enqueueImapConnection(imapConnection);
 
         try {
-            imapStore.getPersonalNamespaces(true);
+            imapStore.getFolders(true);
             fail("Expected exception");
         } catch (MessagingException ignored) {
         }
 
         verify(imapConnection).close();
+    }
+
+    @Test
+    public void getParentId_shouldReturnCorrectValue() {
+        String result = imapStore.getParentId("Folder.SubFolder");
+
+        assertEquals("Folder", result);
     }
 
     @Test
@@ -333,7 +340,6 @@ public class ImapStoreTest {
 
         return folderNames;
     }
-
 
     private static class TestImapStore extends ImapStore {
         private Deque<ImapConnection> imapConnections = new ArrayDeque<>();

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3FolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3FolderTest.java
@@ -6,8 +6,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 
 import com.fsck.k9.mail.FetchProfile;
@@ -20,6 +18,8 @@ import com.fsck.k9.mail.internet.BinaryTempFileBody;
 import com.fsck.k9.mail.store.StoreConfig;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -36,18 +36,21 @@ import static org.mockito.Mockito.when;
 
 
 public class Pop3FolderTest {
+
+    @Mock
     private Pop3Store mockStore;
+    @Mock
     private Pop3Connection mockConnection;
+    @Mock
     private StoreConfig mockStoreConfig;
+    @Mock
     private MessageRetrievalListener<Pop3Message> mockListener;
+
     private Pop3Folder folder;
 
     @Before
     public void before() throws MessagingException {
-        mockStore = mock(Pop3Store.class);
-        mockConnection = mock(Pop3Connection.class);
-        mockStoreConfig = mock(StoreConfig.class);
-        mockListener = mock(MessageRetrievalListener.class);
+        MockitoAnnotations.initMocks(this);
         when(mockStore.getConfig()).thenReturn(mockStoreConfig);
         when(mockStoreConfig.getInboxFolderId()).thenReturn("Inbox");
         when(mockStore.createConnection()).thenReturn(mockConnection);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3StoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3StoreTest.java
@@ -185,7 +185,7 @@ public class Pop3StoreTest {
 
     @Test
     public void getPersonalNamespace_shouldReturnListConsistingOfInbox() throws Exception {
-        List<Pop3Folder> folders = store.getPersonalNamespaces(true);
+        List<Pop3Folder> folders = store.getFolders(true);
 
         assertEquals(1, folders.size());
         assertEquals("Inbox", folders.get(0).getId());

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
@@ -255,7 +255,7 @@ public class WebDavStoreTest {
         configureHttpResponses(UNAUTHORIZED_401_RESPONSE, OK_200_RESPONSE, createOkPropfindResponse(),
                 createOkSearchResponse());
 
-        webDavStore.getPersonalNamespaces(true);
+        webDavStore.getFolders(true);
 
         List<HttpGeneric> requests = requestCaptor.getAllValues();
         assertEquals(4, requests.size()); // AUTH + 2
@@ -269,7 +269,7 @@ public class WebDavStoreTest {
         configureHttpResponses(UNAUTHORIZED_401_RESPONSE, OK_200_RESPONSE, createOkPropfindResponse(),
                 createOkSearchResponse());
 
-        webDavStore.getPersonalNamespaces(true);
+        webDavStore.getFolders(true);
 
         verify(storeConfig).setInboxFolderId("Inbox");
     }
@@ -281,7 +281,7 @@ public class WebDavStoreTest {
         configureHttpResponses(UNAUTHORIZED_401_RESPONSE, OK_200_RESPONSE, createOkPropfindResponse(),
                 createOkSearchResponse());
 
-        webDavStore.getPersonalNamespaces(true);
+        webDavStore.getFolders(true);
 
         List<HttpGeneric> requests = requestCaptor.getAllValues();
         assertEquals(4, requests.size()); // AUTH + SPECIALFOLDERS + 1
@@ -295,7 +295,7 @@ public class WebDavStoreTest {
         configureHttpResponses(UNAUTHORIZED_401_RESPONSE, OK_200_RESPONSE, createOkPropfindResponse(),
                 createOkSearchResponse());
 
-        List<? extends Folder> folders = webDavStore.getPersonalNamespaces(true);
+        List<? extends Folder> folders = webDavStore.getFolders(true);
 
         List<HttpGeneric> requests = requestCaptor.getAllValues();
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/AccountList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/AccountList.java
@@ -115,7 +115,6 @@ public abstract class AccountList extends K9ListActivity implements OnItemClickL
             } else {
                 view = getLayoutInflater().inflate(R.layout.accounts_item, parent, false);
                 view.findViewById(R.id.active_icons).setVisibility(View.GONE);
-                view.findViewById(R.id.folders).setVisibility(View.GONE);
             }
 
             AccountViewHolder holder = (AccountViewHolder) view.getTag();

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -1841,14 +1841,15 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
             if (account instanceof SearchAccount) {
                 holder.folders.setVisibility(View.GONE);
-            } else {
+            } else if (account instanceof Account) {
                 holder.folders.setVisibility(View.VISIBLE);
                 holder.folders.setOnClickListener(new OnClickListener() {
                     public void onClick(View v) {
                         FolderList.actionHandleAccount(Accounts.this, (Account)account);
-
                     }
                 });
+            } else {
+                Timber.e("Unhandled account type:" + account.getClass().getName());
             }
 
             return view;

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -42,6 +42,7 @@ public class ChooseFolder extends K9ListActivity {
     public static final String EXTRA_SHOW_CURRENT = "com.fsck.k9.ChooseFolder_showcurrent";
     public static final String EXTRA_SHOW_FOLDER_NONE = "com.fsck.k9.ChooseFolder_showOptionNone";
     public static final String EXTRA_SHOW_DISPLAYABLE_ONLY = "com.fsck.k9.ChooseFolder_showDisplayableOnly";
+    public static final String EXTRA_SHOW_AS_TREE_STRUCTURE = "com.fsck.k9.ChooseFolder_showAsTreeStructure";
 
 
     String mFolderId;
@@ -78,6 +79,7 @@ public class ChooseFolder extends K9ListActivity {
     boolean mHideCurrentFolder = true;
     boolean mShowOptionNone = false;
     boolean mShowDisplayableOnly = false;
+    boolean mShowAsTreeStructure = false;
 
     /**
      * What folders to display.<br/>
@@ -123,6 +125,9 @@ public class ChooseFolder extends K9ListActivity {
         if (intent.getStringExtra(EXTRA_SHOW_DISPLAYABLE_ONLY) != null) {
             mShowDisplayableOnly = true;
         }
+        if (intent.getStringExtra(EXTRA_SHOW_AS_TREE_STRUCTURE) != null) {
+            mShowAsTreeStructure = true;
+        }
         if (mFolderId == null)
             mFolderId = "";
 
@@ -163,7 +168,7 @@ public class ChooseFolder extends K9ListActivity {
         });
     }
 
-    class ChooseFolderHandler extends Handler {
+    private class ChooseFolderHandler extends Handler {
         private static final int MSG_PROGRESS = 1;
         private static final int MSG_SET_SELECTED_FOLDER = 2;
 
@@ -188,7 +193,7 @@ public class ChooseFolder extends K9ListActivity {
             sendMessage(msg);
         }
 
-        public void setSelectedFolder(int position) {
+        void setSelectedFolder(int position) {
             android.os.Message msg = new android.os.Message();
             msg.what = MSG_SET_SELECTED_FOLDER;
             msg.arg1 = position;

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -1124,11 +1124,11 @@ public class FolderList extends K9ListActivity {
             }
             mFontSizes.setViewTextSize(holder.folderStatus, mFontSizes.getFolderStatus());
 
-            final FolderViewHolder viewHolder = holder;
             view.setOnClickListener(new OnClickListener() {
                 @Override
                 public void onClick(View v) {
-                    onOpenFolder(viewHolder.folderId);
+                    ListView listView = (ListView) v.getParent();
+                    listView.getOnItemClickListener().onItemClick(listView, v, listView.indexOfChild(v), v.getId());
                 }
             });
             return view;

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -1009,7 +1009,7 @@ public class AccountSettings extends K9PreferenceActivity {
         @Override
         protected Void doInBackground(Void... params) {
             try {
-                folders = account.getLocalStore().getPersonalNamespaces(false);
+                folders = account.getLocalStore().getFolders(false);
             } catch (Exception e) {
                 /// this can't be checked in
             }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -89,6 +89,7 @@ public class LocalFolder extends Folder<LocalMessage> {
 
     private String remoteId = null;
     private String name = null;
+    private String parentRemoteId = null;
     private long databaseId = -1;
     private int visibleLimit = -1;
     private String prefId = null;
@@ -202,6 +203,7 @@ public class LocalFolder extends Folder<LocalMessage> {
         databaseId = cursor.getInt(LocalStore.FOLDER_ID_INDEX);
         localStore.setFolderByDatabaseId(databaseId, this);
         remoteId = cursor.getString(LocalStore.FOLDER_REMOTE_ID_INDEX);
+        parentRemoteId = cursor.getString(LocalStore.FOLDER_PARENT_REMOTE_ID_INDEX);
         localStore.setFolderByRemoteId(remoteId, this);
         name = cursor.getString(LocalStore.FOLDER_NAME_INDEX);
         visibleLimit = cursor.getInt(LocalStore.FOLDER_VISIBLE_LIMIT_INDEX);
@@ -242,6 +244,11 @@ public class LocalFolder extends Folder<LocalMessage> {
     }
 
     @Override
+    public String getParentId() {
+        return parentRemoteId;
+    }
+
+    @Override
     public String getName() {
         return name;
     }
@@ -266,6 +273,12 @@ public class LocalFolder extends Folder<LocalMessage> {
                 }
             }
         });
+    }
+
+    @Override
+    public boolean canHaveSubFolders() {
+        //TODO: Update based on the remote folder
+        return true;
     }
 
     @Override
@@ -398,6 +411,16 @@ public class LocalFolder extends Folder<LocalMessage> {
             throw new WrappedException(e);
         }
         updateFolderColumn("name", name);
+    }
+
+    public void setParentId(@NonNull String parentRemoteId) throws MessagingException {
+        try {
+            open(OPEN_MODE_RW);
+            this.parentRemoteId = parentRemoteId;
+        } catch (MessagingException e) {
+            throw new WrappedException(e);
+        }
+        updateFolderColumn("parentRemoteId", parentRemoteId);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -81,6 +81,7 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
         db.execSQL("CREATE TABLE folders (" +
                 "id INTEGER PRIMARY KEY," +
                 "remoteId TEXT, " +
+                "parentRemoteId TEXT, " +
                 "name TEXT, " +
                 "last_updated INTEGER, " +
                 "unread_count INTEGER, " +

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo42.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo42.java
@@ -22,7 +22,7 @@ class MigrationTo42 {
             long startTime = SystemClock.elapsedRealtime();
             StorageEditor editor = storage.edit();
 
-            List<? extends Folder > folders = localStore.getPersonalNamespaces(true);
+            List<? extends Folder > folders = localStore.getFolders(true);
             for (Folder folder : folders) {
                 if (folder instanceof LocalFolder) {
                     LocalFolder lFolder = (LocalFolder)folder;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo62.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo62.java
@@ -1,0 +1,30 @@
+
+package com.fsck.k9.mailstore.migrations;
+
+
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+
+
+class MigrationTo62 {
+
+    static void addFolderParentRemoteId(SQLiteDatabase db) {
+        if (!columnExists(db, "folders", "parentRemoteId")) {
+            db.execSQL("ALTER TABLE folders ADD parentRemoteId TEXT");
+        }
+    }
+
+    private static boolean columnExists(SQLiteDatabase db, String table, String columnName) {
+        Cursor columnCursor = db.rawQuery("PRAGMA table_info(" + table + ")", null);
+        boolean foundColumn = false;
+        while (columnCursor.moveToNext()) {
+            String currentColumnName = columnCursor.getString(1);
+            if (currentColumnName.equals(columnName)) {
+                foundColumn = true;
+                break;
+            }
+        }
+        columnCursor.close();
+        return foundColumn;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
@@ -77,6 +77,8 @@ public class Migrations {
                 MigrationTo60.migratePendingCommands(db);
             case 60:
                 MigrationTo61.addFolderRemoteId(db);
+            case 61:
+                MigrationTo62.addFolderParentRemoteId(db);
         }
     }
 }

--- a/k9mail/src/main/res/layout/accounts_folders_icons.xml
+++ b/k9mail/src/main/res/layout/accounts_folders_icons.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/active_icons"
     android:layout_width="wrap_content"
     android:layout_height="match_parent"
@@ -30,7 +31,9 @@
             android:layout_height="wrap_content"
             android:singleLine="true"
             android:ellipsize="end"
-            android:textAppearance="?android:attr/textAppearanceLarge" />
+            android:textAppearance="?android:attr/textAppearanceLarge"
+            tools:text="10"
+        />
 
     </LinearLayout>
 
@@ -56,7 +59,42 @@
             android:layout_height="wrap_content"
             android:singleLine="true"
             android:ellipsize="end"
-            android:textAppearance="?android:attr/textAppearanceLarge"/>
+            android:textAppearance="?android:attr/textAppearanceLarge"
+            tools:text="1"/>
+
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/folder_button_wrapper"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_toRightOf="@id/new_message_count_wrapper"
+        android:layout_toEndOf="@id/new_message_count_wrapper"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        >
+
+        <View
+            android:layout_width="1dp"
+            android:layout_height="match_parent"
+            android:layout_marginLeft="2dip"
+            android:layout_marginRight="4dip"
+            android:background="?android:attr/dividerVertical" />
+
+        <ImageButton
+            android:id="@+id/folders"
+            android:gravity="center_vertical"
+            android:focusable="false"
+            android:layout_marginRight="43dip"
+            android:src="?attr/iconFolder"
+            android:background="?android:attr/selectableItemBackground"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:padding="8dp"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:contentDescription="@string/folders_title"
+            />
 
     </LinearLayout>
 

--- a/k9mail/src/main/res/layout/accounts_item.xml
+++ b/k9mail/src/main/res/layout/accounts_item.xml
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout
-        android:id="@+id/accounts_item_layout"
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:minHeight="?android:attr/listPreferredItemHeight"
-        android:orientation="horizontal"
-        android:descendantFocusability="blocksDescendants"
-        android:gravity="center_vertical">
+    android:id="@+id/accounts_item_layout"
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeight"
+    android:orientation="horizontal"
+    android:descendantFocusability="blocksDescendants"
+    android:gravity="center_vertical"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <View
             android:id="@+id/chip"
@@ -33,7 +34,9 @@
                 android:singleLine="true"
                 android:ellipsize="end"
                 android:textColor="?android:attr/textColorPrimary"
-                android:textAppearance="?android:attr/textAppearanceMedium"/>
+                android:textAppearance="?android:attr/textAppearanceMedium"
+                tools:text="Main"
+            />
 
         <TextView
                 android:id="@+id/email"
@@ -42,39 +45,11 @@
                 android:singleLine="true"
                 android:ellipsize="end"
                 android:textColor="?android:attr/textColorSecondary"
-                android:textAppearance="?android:attr/textAppearanceSmall"/>
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                tools:text="Email"
+            />
 
     </LinearLayout>
 
     <include layout="@layout/accounts_folders_icons"/>
-
-    <LinearLayout
-            android:id="@+id/folder_button_wrapper"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            >
-
-        <View
-                android:layout_width="1dp"
-                android:layout_height="match_parent"
-                android:layout_marginLeft="2dip"
-                android:layout_marginRight="4dip"
-                android:background="?android:attr/dividerVertical" />
-
-        <ImageButton
-                android:id="@+id/folders"
-                android:gravity="center_vertical"
-                android:focusable="false"
-                android:layout_marginRight="3dip"
-                android:src="?attr/iconFolder"
-                android:background="?android:attr/selectableItemBackground"
-                android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
-                android:padding="8dp"
-                android:paddingLeft="16dp"
-                android:paddingRight="16dp"
-                />
-
-    </LinearLayout>
 </LinearLayout>

--- a/k9mail/src/main/res/layout/folder_list_item.xml
+++ b/k9mail/src/main/res/layout/folder_list_item.xml
@@ -2,6 +2,7 @@
 <LinearLayout
         android:id="@+id/folder_list_item_layout"
         xmlns:android="http://schemas.android.com/apk/res/android"
+        xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:minHeight="?android:attr/listPreferredItemHeight"
@@ -25,7 +26,6 @@
             android:orientation="vertical"
             android:gravity="center_vertical"
             android:paddingBottom="2dip"
-
             android:paddingLeft="6dip">
 
         <TextView
@@ -33,7 +33,9 @@
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:textColor="?android:attr/textColorPrimary"
-                android:textAppearance="?android:attr/textAppearanceLarge"/>
+                android:textAppearance="?android:attr/textAppearanceLarge"
+                tools:text="Folder"
+            />
 
         <TextView
                 android:id="@+id/folder_status"
@@ -42,7 +44,9 @@
                 android:singleLine="true"
                 android:ellipsize="end"
                 android:textColor="?android:attr/textColorTertiary"
-                android:textAppearance="?android:attr/textAppearanceSmall"/>
+                android:textAppearance="?android:attr/textAppearanceSmall"
+                tools:text="Refreshed 2 hours ago (Push active)"
+            />
 
     </LinearLayout>
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -89,6 +89,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="about_title_fmt">About <xliff:g id="app_name">%s</xliff:g></string>
     <string name="accounts_title">Accounts</string>
     <string name="folders_title">Folders</string>
+    <string name="subfolders_title">Folders - <xliff:g id="parent_folder">%s</xliff:g></string>
     <string name="advanced">Advanced</string>
 
     <string name="message_list_title"><xliff:g id="account">%s</xliff:g>:<xliff:g id="folder">%s</xliff:g> </string>

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -216,7 +216,7 @@ public class MessagingControllerTest {
     @Test
     public void listFoldersSynchronous_shouldNotifyTheListenerListingStarted() throws MessagingException {
         List<LocalFolder> folders = Collections.singletonList(localFolder);
-        when(localStore.getPersonalNamespaces(false)).thenReturn(folders);
+        when(localStore.getFolders(false)).thenReturn(folders);
 
         controller.listFoldersSynchronous(account, false, listener);
 
@@ -226,7 +226,7 @@ public class MessagingControllerTest {
     @Test
     public void listFoldersSynchronous_shouldNotifyTheListenerOfTheListOfFolders() throws MessagingException {
         List<LocalFolder> folders = Collections.singletonList(localFolder);
-        when(localStore.getPersonalNamespaces(false)).thenReturn(folders);
+        when(localStore.getFolders(false)).thenReturn(folders);
 
         controller.listFoldersSynchronous(account, false, listener);
 
@@ -236,7 +236,7 @@ public class MessagingControllerTest {
 
     @Test
     public void listFoldersSynchronous_shouldNotifyFailureOnException() throws MessagingException {
-        when(localStore.getPersonalNamespaces(false)).thenThrow(new MessagingException("Test"));
+        when(localStore.getFolders(false)).thenThrow(new MessagingException("Test"));
 
         controller.listFoldersSynchronous(account, true, listener);
 
@@ -245,7 +245,7 @@ public class MessagingControllerTest {
 
     @Test
     public void listFoldersSynchronous_shouldNotNotifyFinishedAfterFailure() throws MessagingException {
-        when(localStore.getPersonalNamespaces(false)).thenThrow(new MessagingException("Test"));
+        when(localStore.getFolders(false)).thenThrow(new MessagingException("Test"));
 
         controller.listFoldersSynchronous(account, true, listener);
 
@@ -255,7 +255,7 @@ public class MessagingControllerTest {
     @Test
     public void listFoldersSynchronous_shouldNotifyFinishedAfterSuccess() throws MessagingException {
         List<LocalFolder> folders = Collections.singletonList(localFolder);
-        when(localStore.getPersonalNamespaces(false)).thenReturn(folders);
+        when(localStore.getFolders(false)).thenReturn(folders);
 
         controller.listFoldersSynchronous(account, false, listener);
 
@@ -268,7 +268,7 @@ public class MessagingControllerTest {
         LocalFolder newLocalFolder = mock(LocalFolder.class);
 
         List<Folder> folders = Collections.singletonList(remoteFolder);
-        when(remoteStore.getPersonalNamespaces(false)).thenAnswer(createAnswer(folders));
+        when(remoteStore.getFolders(false)).thenAnswer(createAnswer(folders));
         when(remoteFolder.getId()).thenReturn("NewFolder");
         when(localStore.getFolder("NewFolder")).thenReturn(newLocalFolder);
 
@@ -282,10 +282,10 @@ public class MessagingControllerTest {
         configureRemoteStoreWithFolder();
         LocalFolder oldLocalFolder = mock(LocalFolder.class);
         when(oldLocalFolder.getId()).thenReturn("OldLocalFolder");
-        when(localStore.getPersonalNamespaces(false))
+        when(localStore.getFolders(false))
                 .thenReturn(Collections.singletonList(oldLocalFolder));
         List<Folder> folders = Collections.emptyList();
-        when(remoteStore.getPersonalNamespaces(false)).thenAnswer(createAnswer(folders));
+        when(remoteStore.getFolders(false)).thenAnswer(createAnswer(folders));
 
         controller.refreshRemoteSynchronous(account, listener);
 
@@ -295,10 +295,10 @@ public class MessagingControllerTest {
     @Test
     public void refreshRemoteSynchronous_shouldNotDeleteFoldersOnRemote() throws MessagingException {
         configureRemoteStoreWithFolder();
-        when(localStore.getPersonalNamespaces(false))
+        when(localStore.getFolders(false))
                 .thenReturn(Collections.singletonList(localFolder));
         List<Folder> folders = Collections.singletonList(remoteFolder);
-        when(remoteStore.getPersonalNamespaces(false)).thenAnswer(createAnswer(folders));
+        when(remoteStore.getFolders(false)).thenAnswer(createAnswer(folders));
 
         controller.refreshRemoteSynchronous(account, listener);
 
@@ -311,10 +311,10 @@ public class MessagingControllerTest {
         LocalFolder missingSpecialFolder = mock(LocalFolder.class);
         when(account.isSpecialFolder("Outbox")).thenReturn(true);
         when(missingSpecialFolder.getId()).thenReturn("Outbox");
-        when(localStore.getPersonalNamespaces(false))
+        when(localStore.getFolders(false))
                 .thenReturn(Collections.singletonList(missingSpecialFolder));
         List<Folder> folders = Collections.emptyList();
-        when(remoteStore.getPersonalNamespaces(false)).thenAnswer(createAnswer(folders));
+        when(remoteStore.getFolders(false)).thenAnswer(createAnswer(folders));
 
         controller.refreshRemoteSynchronous(account, listener);
 
@@ -334,7 +334,7 @@ public class MessagingControllerTest {
     public void refreshRemoteSynchronous_shouldProvideFolderList() throws MessagingException {
         configureRemoteStoreWithFolder();
         List<LocalFolder> folders = Collections.singletonList(localFolder);
-        when(localStore.getPersonalNamespaces(false)).thenReturn(folders);
+        when(localStore.getFolders(false)).thenReturn(folders);
 
         controller.refreshRemoteSynchronous(account, listener);
 
@@ -345,7 +345,7 @@ public class MessagingControllerTest {
     public void refreshRemoteSynchronous_shouldNotifyFinishedAfterSuccess() throws MessagingException {
         configureRemoteStoreWithFolder();
         List<LocalFolder> folders = Collections.singletonList(localFolder);
-        when(localStore.getPersonalNamespaces(false)).thenReturn(folders);
+        when(localStore.getFolders(false)).thenReturn(folders);
 
         controller.refreshRemoteSynchronous(account, listener);
 
@@ -355,7 +355,7 @@ public class MessagingControllerTest {
     @Test
     public void refreshRemoteSynchronous_shouldNotNotifyFinishedAfterFailure() throws MessagingException {
         configureRemoteStoreWithFolder();
-        when(localStore.getPersonalNamespaces(false)).thenThrow(new MessagingException("Test"));
+        when(localStore.getFolders(false)).thenThrow(new MessagingException("Test"));
 
         controller.refreshRemoteSynchronous(account, listener);
 
@@ -937,7 +937,7 @@ public class MessagingControllerTest {
         when(localStore.getFolder(FOLDER_ID)).thenReturn(localFolder);
         when(localFolder.getId()).thenReturn(FOLDER_ID);
         when(localStore.getFolder(K9.ERROR_FOLDER_ID)).thenReturn(errorFolder);
-        when(localStore.getPersonalNamespaces(false)).thenReturn(Collections.singletonList(localFolder));
+        when(localStore.getFolders(false)).thenReturn(Collections.singletonList(localFolder));
     }
 
     private void configureRemoteStoreWithFolder() throws MessagingException {


### PR DESCRIPTION
This is the diff against the remoteFolderId branch, which it relies on heavily.

Implements #630

Does not implement checking for \Noinferiors from RFC 2060 or any of RFC3348. Implementing this would improve user experience but is probably not mandatory. 

Unlike the remote folders PR this one's a bit more experimental. A lot of it is hand-wavy design and some investigation into what the ticket requires. When the redesign happens then that will obviously require this feature to be re-written.