### PR TITLE
Use ProGuard to strip unused code in release builds

### DIFF
--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -74,6 +74,9 @@ android {
                 signingConfig signingConfigs.release
             }
 
+            minifyEnabled true
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+
             buildConfigField "boolean", "DEVELOPER_MODE", "false"
         }
 

--- a/k9mail/proguard-rules.pro
+++ b/k9mail/proguard-rules.pro
@@ -1,0 +1,23 @@
+# Add project specific ProGuard rules here.
+
+-dontobfuscate
+
+# Preserve the line number information for debugging stack traces.
+-keepattributes SourceFile,LineNumberTable
+
+# Library specific rules
+-dontnote android.net.http.*
+-dontnote org.apache.commons.codec.**
+-dontnote org.apache.http.**
+-dontnote com.squareup.moshi.**
+-dontnote com.github.amlcurran.showcaseview.**
+-dontnote de.cketti.safecontentresolver.**
+-dontnote com.tokenautocomplete.**
+
+-dontwarn okio.**
+-dontwarn com.squareup.moshi.**
+
+# Project specific rules
+-dontnote com.fsck.k9.PRNGFixes
+-dontnote com.fsck.k9.ui.messageview.**
+-dontnote com.fsck.k9.view.**


### PR DESCRIPTION
Smaller APKs are nice.

We'll probably want to configure Cloudbees to also test the release build variant. That way we'll hopefully catch cases where ProGuard removes code that is actually needed.