### PR TITLE
Fix MessageList.onRestoreInstanceState()

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -535,6 +535,8 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
     @Override
     public void onRestoreInstanceState(Bundle savedInstanceState) {
+        super.onRestoreInstanceState(savedInstanceState);
+
         mMessageListWasDisplayed = savedInstanceState.getBoolean(STATE_MESSAGE_LIST_WAS_DISPLAYED);
         mFirstBackStackId = savedInstanceState.getInt(STATE_FIRST_BACK_STACK_ID);
     }


### PR DESCRIPTION
I don't know if the previous behavior was causing any issues in K-9 Mail. I stumbled over this while working on a fork.