### PR TITLE
don't default to prefer-encrypt mutual

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -25,6 +25,7 @@ public class ComposeCryptoStatus {
     private Long openPgpKeyId;
     private String[] recipientAddresses;
     private boolean enablePgpInline;
+    private boolean preferEncryptMutual;
     private CryptoMode cryptoMode;
     private RecipientAutocryptStatus recipientAutocryptStatus;
 
@@ -83,7 +84,7 @@ public class ComposeCryptoStatus {
             case NO_CHOICE:
                 if (recipientAutocryptStatusType == RecipientAutocryptStatusType.NO_RECIPIENTS) {
                     return CryptoStatusDisplayType.NO_CHOICE_EMPTY;
-                } else if (recipientAutocryptStatusType.canEncrypt() && recipientAutocryptStatusType.isMutual()) { // TODO check own "mutual" status
+                } else if (canEncryptAndIsMutual()) {
                     if (recipientAutocryptStatusType.isConfirmed()) {
                         return CryptoStatusDisplayType.NO_CHOICE_MUTUAL_TRUSTED;
                     } else {
@@ -168,7 +169,7 @@ public class ComposeCryptoStatus {
     }
 
     boolean canEncryptAndIsMutual() {
-        return allRecipientsCanEncrypt() && recipientAutocryptStatus.type.isMutual();
+        return allRecipientsCanEncrypt() && preferEncryptMutual && recipientAutocryptStatus.type.isMutual();
     }
 
     boolean hasAutocryptPendingIntent() {
@@ -186,6 +187,7 @@ public class ComposeCryptoStatus {
         private Long openPgpKeyId;
         private List<Recipient> recipients;
         private Boolean enablePgpInline;
+        private Boolean preferEncryptMutual;
 
         public ComposeCryptoStatusBuilder setCryptoProviderState(CryptoProviderState cryptoProviderState) {
             this.cryptoProviderState = cryptoProviderState;
@@ -212,6 +214,11 @@ public class ComposeCryptoStatus {
             return this;
         }
 
+        public ComposeCryptoStatusBuilder setPreferEncryptMutual(boolean preferEncryptMutual) {
+            this.preferEncryptMutual = preferEncryptMutual;
+            return this;
+        }
+
         public ComposeCryptoStatus build() {
             if (cryptoProviderState == null) {
                 throw new AssertionError("cryptoProviderState must be set!");
@@ -225,6 +232,9 @@ public class ComposeCryptoStatus {
             if (enablePgpInline == null) {
                 throw new AssertionError("enablePgpInline must be set!");
             }
+            if (preferEncryptMutual == null) {
+                throw new AssertionError("preferEncryptMutual must be set!");
+            }
 
             ArrayList<String> recipientAddresses = new ArrayList<>();
             for (Recipient recipient : recipients) {
@@ -237,6 +247,7 @@ public class ComposeCryptoStatus {
             result.recipientAddresses = recipientAddresses.toArray(new String[0]);
             result.openPgpKeyId = openPgpKeyId;
             result.enablePgpInline = enablePgpInline;
+            result.preferEncryptMutual = preferEncryptMutual;
             return result;
         }
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -400,6 +400,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                 .setCryptoProviderState(cryptoProviderState)
                 .setCryptoMode(currentCryptoMode)
                 .setEnablePgpInline(cryptoEnablePgpInline)
+                .setPreferEncryptMutual(false) // TODO introduce a setting
                 .setRecipients(getAllRecipients())
                 .setOpenPgpKeyId(accountCryptoKey)
                 .build();

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -546,6 +546,7 @@ public class PgpMessageBuilderTest {
     private ComposeCryptoStatusBuilder createDefaultComposeCryptoStatusBuilder() {
         return new ComposeCryptoStatusBuilder()
                 .setEnablePgpInline(false)
+                .setPreferEncryptMutual(false)
                 .setOpenPgpKeyId(TEST_KEY_ID)
                 .setRecipients(new ArrayList<Recipient>())
                 .setCryptoProviderState(CryptoProviderState.OK);


### PR DESCRIPTION
I left this TODO in the autocrypt-compose PR and kind of forgot about it. It's a fairly simple change, basically it just adds a boolean value to the conjunction in `canEncryptAndIsMutual` from the builder. The value is always false at the moment, but will become a setting at some point.