### PR TITLE
Restore scroll position of message view

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -371,7 +371,7 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
     }
 
     public void displayMessageViewContainer(MessageViewInfo messageViewInfo,
-            final OnRenderingFinishedListener onRenderingFinishedListener, boolean automaticallyLoadPictures,
+            final OnLoadFinishedListener onLoadFinishedListener, boolean automaticallyLoadPictures,
             boolean hideUnsignedTextDivider, AttachmentViewCallback attachmentCallback) {
 
         this.attachmentCallback = attachmentCallback;
@@ -406,7 +406,7 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
         OnPageFinishedListener onPageFinishedListener = new OnPageFinishedListener() {
             @Override
             public void onPageFinished() {
-                onRenderingFinishedListener.onLoadFinished();
+                onLoadFinishedListener.onLoadFinished();
             }
         };
 
@@ -591,7 +591,7 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
         }
     }
 
-    interface OnRenderingFinishedListener {
+    interface OnLoadFinishedListener {
         void onLoadFinished();
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -39,6 +39,7 @@ import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.view.MessageHeader.OnLayoutChangedListener;
 import com.fsck.k9.view.MessageWebView;
 import com.fsck.k9.view.MessageWebView.OnPageFinishedListener;
+import com.fsck.k9.view.MessageWebView.OnRenderingFinishedListener;
 
 
 public class MessageContainerView extends LinearLayout implements OnLayoutChangedListener, OnCreateContextMenuListener {
@@ -371,7 +372,7 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
     }
 
     public void displayMessageViewContainer(MessageViewInfo messageViewInfo,
-            final OnLoadFinishedListener onLoadFinishedListener, boolean automaticallyLoadPictures,
+            final OnLoadFinishedListener onLoadFinishedListener, final OnRenderingFinishedListener onRenderingFinishedListener, boolean automaticallyLoadPictures,
             boolean hideUnsignedTextDivider, AttachmentViewCallback attachmentCallback) {
 
         this.attachmentCallback = attachmentCallback;
@@ -412,6 +413,7 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
 
         displayHtmlContentWithInlineAttachments(
                 textToDisplay, messageViewInfo.attachmentResolver, onPageFinishedListener);
+        mMessageContentView.setOnRenderingFinishedListener(onRenderingFinishedListener);
 
         if (!TextUtils.isEmpty(messageViewInfo.extraText)) {
             unsignedTextContainer.setVisibility(View.VISIBLE);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -25,7 +25,7 @@ import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mailstore.MessageViewInfo;
-import com.fsck.k9.ui.messageview.MessageContainerView.OnRenderingFinishedListener;
+import com.fsck.k9.ui.messageview.MessageContainerView.OnLoadFinishedListener;
 import com.fsck.k9.view.MessageHeader;
 import com.fsck.k9.view.ThemeUtils;
 import com.fsck.k9.view.ToolableViewAnimator;
@@ -116,7 +116,7 @@ public class MessageTopView extends LinearLayout {
         containerView.addView(view);
 
         boolean hideUnsignedTextDivider = !K9.getOpenPgpSupportSignOnly();
-        view.displayMessageViewContainer(messageViewInfo, new OnRenderingFinishedListener() {
+        view.displayMessageViewContainer(messageViewInfo, new OnLoadFinishedListener() {
             @Override
             public void onLoadFinished() {
                 displayViewOnLoadFinished(true);

--- a/k9mail/src/main/java/com/fsck/k9/view/NonLockingScrollView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/NonLockingScrollView.java
@@ -157,6 +157,26 @@ public class NonLockingScrollView extends ScrollView {
         }
     }
 
+    private int getContentHeight() {
+        final View child = getChildAt(0);
+        return (child != null) ? child.getHeight() : 0;
+    }
+
+    public float getRelativeScrollY() {
+        final int contentHeight = getContentHeight();
+        final int scrollY = getScrollY();
+        if (scrollY <= contentHeight) {
+            return ((float) scrollY) / ((float) contentHeight);
+        }
+        return 1;
+    }
+
+    public void setRelativeScrollY(float relScrollY) {
+        final int contentHeight = getContentHeight();
+        final int scrollY = (int) (contentHeight * relScrollY);
+        scrollTo(getScrollX(), scrollY);
+    }
+
     class HierarchyTreeChangeListener implements OnHierarchyChangeListener {
         @Override
         public void onChildViewAdded(View parent, View child) {

--- a/k9mail/src/main/res/layout/message.xml
+++ b/k9mail/src/main/res/layout/message.xml
@@ -13,7 +13,8 @@
     <com.fsck.k9.view.NonLockingScrollView
         android:layout_width="fill_parent"
         android:layout_height="0dp"
-        android:layout_weight="1">
+        android:layout_weight="1"
+        android:id="@+id/non_locking_scroll_view">
 
         <LinearLayout
             android:orientation="vertical"


### PR DESCRIPTION
Here is a first attempt at issue #1720. For now it only deals with the vertical scroll position. Horizontal scrolling is maintained by another class and restoring it did not seem to be so important for a start.

Since the `MessageContainerView` does not yet exist at the time of `onRestoreInstanceState`, I have put saving and restoring into the `MessageTopView`. (This overlaps a bit with PR #2716: Both add save/restore to the `MessageTopView`.)

The biggest problem was to find out when rendering the message is _really_ finished. `WebViewClient.onPageFinished` may be called too soon; `WebView.PictureListener.onNewPicture` and `WebView.capturePicture` are deprecated and appear to be the wrong thing to do for scrolling. There are some suggestions on the web, but all that I tried fired too soon in some cases. I ended up using `Throttle` to wait a few ms after the last invocation of `invalidate` with a content height > 0. That does not feel good. Better ideas are welcome!

For the relative scroll position, I divide the absolute scroll position by the content height. On restore I multiply the relative position by the possibly changed content hight. This seems to be straight forward, but is just an approximation, since the layout of the rendered content may depend on the width of the display. For a "slim" message with only short lines or a fixed layout this restores what is shown at the top. For messages that need line folding or such, the restored position may be off target.

Any feedback is welcome. And in the worst case this PR just serves to rule out a few ideas.