### PR TITLE
Show error if encryption is enabled but no key is configured

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -349,8 +349,8 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
         Toast.makeText(activity, R.string.error_crypto_provider_ui_required, Toast.LENGTH_LONG).show();
     }
 
-    public void showErrorMissingSignKey() {
-        Toast.makeText(activity, R.string.compose_error_no_signing_key, Toast.LENGTH_LONG).show();
+    public void showErrorNoKeyConfigured() {
+        Toast.makeText(activity, R.string.compose_error_no_key_configured, Toast.LENGTH_LONG).show();
     }
 
     public void showErrorInlineAttach() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -624,7 +624,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                     return;
                 }
 
-                if (currentCryptoStatus.isEncryptionEnabledError()) {
+                if (currentCryptoStatus.isEncryptionEnabled() && !currentCryptoStatus.allRecipientsCanEncrypt()) {
                     recipientMvpView.showOpenPgpEnabledErrorDialog(false);
                     return;
                 }
@@ -687,6 +687,9 @@ public class RecipientPresenter implements PermissionPingCallback {
                 break;
             case PROVIDER_ERROR:
                 recipientMvpView.showErrorOpenPgpConnection();
+                break;
+            case KEY_CONFIG_ERROR:
+                recipientMvpView.showErrorNoKeyConfigured();
                 break;
             default:
                 throw new AssertionError("not all error states handled, this is a bug!");
@@ -894,7 +897,7 @@ public class RecipientPresenter implements PermissionPingCallback {
             return;
         }
         if (enableEncryption) {
-            if (!cachedCryptoStatus.canEncrypt()) {
+            if (!cachedCryptoStatus.allRecipientsCanEncrypt()) {
                 onCryptoModeChanged(CryptoMode.CHOICE_ENABLED);
                 recipientMvpView.showOpenPgpEnabledErrorDialog(true);
             } else if (cachedCryptoStatus.canEncryptAndIsMutual()) {

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -87,20 +87,22 @@ public class PgpMessageBuilder extends MessageBuilder {
             throw new IllegalStateException("PgpMessageBuilder must have cryptoStatus set before building!");
         }
 
+        Long openPgpKeyId = cryptoStatus.getOpenPgpKeyId();
         try {
-            if (!cryptoStatus.isProviderStateOk()) {
-                throw new MessagingException("OpenPGP Provider is not ready!");
-            }
-
             currentProcessedMimeMessage = build();
         } catch (MessagingException me) {
             queueMessageBuildException(me);
             return;
         }
 
-        Long openPgpKeyId = cryptoStatus.getOpenPgpKeyId();
         if (openPgpKeyId == null) {
-            throw new IllegalArgumentException("PgpMessageBuilder requires a configured key id!");
+            queueMessageBuildSuccess(currentProcessedMimeMessage);
+            return;
+        }
+
+        if (!cryptoStatus.isProviderStateOk()) {
+            queueMessageBuildException(new MessagingException("OpenPGP Provider is not ready!"));
+            return;
         }
 
         Address address = currentProcessedMimeMessage.getFrom()[0];

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1146,7 +1146,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="address_type_other">Other</string>
     <string name="address_type_mobile">Mobile</string>
     <string name="compose_error_no_draft_folder">No Drafts folder configured for this account!</string>
-    <string name="compose_error_no_signing_key">No key configured for signing! Please check your settings.</string>
+    <string name="compose_error_no_key_configured">No key configured for this account! Check your settings.</string>
     <string name="crypto_mode_disabled">Don\'t encrypt</string>
     <string name="crypto_mode_opportunistic">Encrypt if possible</string>
     <string name="crypto_mode_private">Encrypt</string>


### PR DESCRIPTION
This brings back an error that I inadvertently dropped somewhere along the way, but that is actually very important: Refuse to send a message while encryption is enabled and no key is configured.