### PR TITLE
for Downloading complete message removes star #2475

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2464,7 +2464,7 @@ public class MessagingController {
                 // Get the remote message and fully download it
                 Message remoteMessage = remoteFolder.getMessage(uid);
 
-                if (loadPartialFromSearch) {
+                if (!loadPartialFromSearch) {
                     downloadMessages(account, remoteFolder, localFolder,
                             Collections.singletonList(remoteMessage), false, false);
                 } else {


### PR DESCRIPTION
Changed loadMessageRemoteSynchronous method so that it runs downloadMessages method when loadMessageRemote method is called.

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


