### PR TITLE
Use read-only access for polling

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -801,11 +801,11 @@ public class MessagingController {
                  */
                 Timber.v("SYNC: About to open remote folder %s", folder);
 
-                remoteFolder.open(Folder.OPEN_MODE_RW);
                 if (Expunge.EXPUNGE_ON_POLL == account.getExpungePolicy()) {
                     Timber.d("SYNC: Expunging folder %s:%s", account.getDescription(), folder);
                     remoteFolder.expunge();
                 }
+                remoteFolder.open(Folder.OPEN_MODE_RO);
 
             }
 

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -661,7 +661,7 @@ public class MessagingControllerTest {
 
         controller.synchronizeMailboxSynchronous(account, FOLDER_NAME, listener, null);
 
-        verify(remoteFolder).open(Folder.OPEN_MODE_RW);
+        verify(remoteFolder).open(Folder.OPEN_MODE_RO);
     }
 
     @Test


### PR DESCRIPTION
Addressing issue #2772, this PR changes K-9 to use read-only access when polling for new messages. This avoids deleting the IMAP flag `\Recent` from new messages before they are opened for reading. For push notification on new messages, K-9 already uses read-only access.