### PR TITLE
Stop refresh animation on pause

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -664,6 +664,13 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         localBroadcastManager.unregisterReceiver(cacheBroadcastReceiver);
         activityListener.onPause(getActivity());
         messagingController.removeListener(activityListener);
+
+        // Workaround for Android bug https://issuetracker.google.com/issues/37008170
+        if (swipeRefreshLayout != null) {
+            swipeRefreshLayout.setRefreshing(false);
+            swipeRefreshLayout.destroyDrawingCache();
+            swipeRefreshLayout.clearAnimation();
+        }
     }
 
     /**

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -664,13 +664,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         localBroadcastManager.unregisterReceiver(cacheBroadcastReceiver);
         activityListener.onPause(getActivity());
         messagingController.removeListener(activityListener);
-
-        // Workaround for Android bug https://issuetracker.google.com/issues/37008170
-        if (swipeRefreshLayout != null) {
-            swipeRefreshLayout.setRefreshing(false);
-            swipeRefreshLayout.destroyDrawingCache();
-            swipeRefreshLayout.clearAnimation();
-        }
     }
 
     /**
@@ -2267,6 +2260,14 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 Timber.e(e, "Could not abort remote search before going back");
             }
         }
+
+        // Workaround for Android bug https://issuetracker.google.com/issues/37008170
+        if (swipeRefreshLayout != null) {
+            swipeRefreshLayout.setRefreshing(false);
+            swipeRefreshLayout.destroyDrawingCache();
+            swipeRefreshLayout.clearAnimation();
+        }
+
         super.onStop();
     }
 


### PR DESCRIPTION
Workaround for [Android bug 37008170](https://issuetracker.google.com/issues/37008170); resolves issue #2788.

The bug causes trouble when replacing a fragment while SwipeRefreshLayout shows the refresh animation. In K-9 this kicks in when either opening a message thread or doing "More from this sender" from the message list.

This PR implements the workaround in the `MessageListFragment` as suggested here:
https://stackoverflow.com/questions/27057449/when-switch-fragment-with-swiperefreshlayout-during-refreshing-fragment-freezes/27073879#27073879