### PR TITLE
Prevent crash when parsing invalid base64 email address

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
@@ -2,12 +2,14 @@
 package com.fsck.k9.mail;
 
 import android.support.annotation.VisibleForTesting;
+
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
 
 import org.apache.james.mime4j.MimeException;
+import org.apache.james.mime4j.codec.DecodeMonitor;
 import org.apache.james.mime4j.codec.EncoderUtil;
 import org.apache.james.mime4j.dom.address.Mailbox;
 import org.apache.james.mime4j.dom.address.MailboxList;
@@ -29,7 +31,6 @@ public class Address implements Serializable {
     private String mAddress;
 
     private String mPersonal;
-
 
     public Address(Address address) {
         mAddress = address.mAddress;
@@ -142,7 +143,7 @@ public class Address implements Serializable {
         }
         List<Address> addresses = new ArrayList<>();
         try {
-            MailboxList parsedList =  DefaultAddressParser.DEFAULT.parseAddressList(addressList).flatten();
+            MailboxList parsedList =  DefaultAddressParser.DEFAULT.parseAddressList(addressList, DecodeMonitor.SILENT).flatten();
 
             for (int i = 0, count = parsedList.size(); i < count; i++) {
                 Mailbox mailbox = parsedList.get(i);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/AddressTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/AddressTest.java
@@ -180,4 +180,10 @@ public class AddressTest {
 
         assertNull(result);
     }
+
+    @Test
+    public void handlesInvalidBase64Encoding() throws Exception {
+        Address address = Address.parse("=?utf-8?b?invalid#?= <oops@example.com>")[0];
+        assertEquals("oops@example.com", address.getAddress());
+    }
 }


### PR DESCRIPTION
Skip invalid input; parse strictly otherwise.
Added a unit test for invalid base64 characters in mail/AddressTest.java

Fixes https://github.com/k9mail/k-9/issues/2846.

Note: This is a second pull request as the first was mistakenly made from jyn514/k9/master