### PR TITLE
Address now logs an error if given bad arguments

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
@@ -64,7 +64,7 @@ public class Address implements Serializable {
                     mPersonal = (personal == null) ? null : personal.trim();
                 }
             } else {
-                Timber.e(new IllegalArgumentException(), "address " + address + " is invalid");
+                Timber.e("Invalid address: %s", address);
             }
         } else {
             mAddress = address;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Address.java
@@ -64,7 +64,7 @@ public class Address implements Serializable {
                     mPersonal = (personal == null) ? null : personal.trim();
                 }
             } else {
-                // This should be an error
+                Timber.e(new IllegalArgumentException(), "address " + address + " is invalid");
             }
         } else {
             mAddress = address;


### PR DESCRIPTION
This is in response to this comment (replaced in this commit):

    // This should be an error		
