### PR TITLE
Show the name of each account imported

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -1565,12 +1565,11 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
         @Override
         protected String generateMessage(Accounts activity) {
-            // TODO: localization
 
             StringBuilder result = new StringBuilder();
             for (AccountDescriptionPair account : mImportResults.importedAccounts) {
-                result.append("Imported ").append(account.original.name)
-                        .append(" as ").append(account.imported.name).append('\n');
+                result.append(activity.getString(R.string.settings_import_single_success, account.original.name, account.imported.name));
+                result.append('\n');
             }
             int imported = mImportResults.importedAccounts.size();
             String accounts = activity.getResources().getQuantityString(

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -1565,12 +1565,18 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
         @Override
         protected String generateMessage(Accounts activity) {
-            //TODO: display names of imported accounts (name from file *and* possibly new name)
+            // TODO: localization
 
+            StringBuilder result = new StringBuilder();
+            for (AccountDescriptionPair account : mImportResults.importedAccounts) {
+                result.append("Imported ").append(account.original.name)
+                        .append(" as ").append(account.imported.name).append('\n');
+            }
             int imported = mImportResults.importedAccounts.size();
             String accounts = activity.getResources().getQuantityString(
                                   R.plurals.settings_import_accounts, imported, imported);
-            return activity.getString(R.string.settings_import_success, accounts, mFilename);
+            result.append(activity.getString(R.string.settings_import_success, accounts, mFilename));
+            return result.toString();
         }
 
         @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -1565,12 +1565,14 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
         @Override
         protected String generateMessage(Accounts activity) {
-
             StringBuilder result = new StringBuilder();
             for (AccountDescriptionPair account : mImportResults.importedAccounts) {
-                result.append(activity.getString(R.string.settings_import_single_success, account.original.name, account.imported.name));
+                result.append(activity.getString(R.string.settings_import_account_imported_as,
+                        account.original.name, account.imported.name));
                 result.append('\n');
             }
+            result.append('\n');
+
             int imported = mImportResults.importedAccounts.size();
             String accounts = activity.getResources().getQuantityString(
                                   R.plurals.settings_import_accounts, imported, imported);

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -988,6 +988,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="settings_export_success_generic">Settings successfully exported</string>
     <string name="settings_import_global_settings_success">Imported global settings from <xliff:g id="filename">%s</xliff:g></string>
     <string name="settings_import_success">Imported <xliff:g id="accounts">%s</xliff:g> from <xliff:g id="filename">%s</xliff:g></string>
+    <string name="settings_import_single_success">Imported <xliff:g id="account.original.name">%s</xliff:g> as <xliff:g id="account.imported.name">%s</xliff:g></string>
     <plurals name="settings_import_accounts">
         <item quantity="one">1 account</item>
         <item quantity="other"><xliff:g id="numAccounts">%s</xliff:g> accounts</item>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -988,7 +988,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="settings_export_success_generic">Settings successfully exported</string>
     <string name="settings_import_global_settings_success">Imported global settings from <xliff:g id="filename">%s</xliff:g></string>
     <string name="settings_import_success">Imported <xliff:g id="accounts">%s</xliff:g> from <xliff:g id="filename">%s</xliff:g></string>
-    <string name="settings_import_single_success">Imported <xliff:g id="account.original.name">%s</xliff:g> as <xliff:g id="account.imported.name">%s</xliff:g></string>
+    <string name="settings_import_account_imported_as">Imported <xliff:g id="original_account_name">%s</xliff:g> as <xliff:g id="account_name_after_import">%s</xliff:g></string>
     <plurals name="settings_import_accounts">
         <item quantity="one">1 account</item>
         <item quantity="other"><xliff:g id="numAccounts">%s</xliff:g> accounts</item>


### PR DESCRIPTION
For each account, show `Imported <old account> as <new account>`.

Does not currently support localization.

Replaces `// TODO: show each account imported (and possibly old name)` with `// TODO: localization`.
