### PR TITLE
Updated dependency versions and targetSDK

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-kotlinVersion=1.1.4-3
+kotlinVersion=1.1.51
 androidCompileSdkVersion=25
-androidBuildToolsVersion=25.0.2
+androidBuildToolsVersion=27.0.0
 androidSupportLibraryVersion=25.2.0
 timberVersion=4.5.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlinVersion=1.1.51
 androidCompileSdkVersion=25
-androidBuildToolsVersion=27.0.0
+androidBuildToolsVersion=25.0.2
 androidSupportLibraryVersion=25.2.0
 timberVersion=4.5.1
 

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -12,6 +12,7 @@ if (rootProject.testCoverage) {
 
 repositories {
     jcenter()
+    google()
 }
 
 //noinspection GroovyAssignabilityCheck
@@ -22,30 +23,30 @@ configurations.all {
 }
 
 dependencies {
-    compile project(':k9mail-library')
-    compile project(':plugins:HoloColorPicker')
-    compile project(':plugins:openpgp-api-lib:openpgp-api')
-    compile "com.squareup.okio:okio:${okioVersion}"
-    compile 'commons-io:commons-io:2.4'
-    compile "com.android.support:support-v4:${androidSupportLibraryVersion}"
-    compile 'org.jsoup:jsoup:1.10.2'
-    compile 'de.cketti.library.changelog:ckchangelog:1.2.1'
-    compile 'com.github.bumptech.glide:glide:3.6.1'
-    compile 'com.splitwise:tokenautocomplete:2.0.7'
-    compile 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.9.0'
-    compile 'com.github.amlcurran.showcaseview:library:5.4.1'
-    compile 'com.squareup.moshi:moshi:1.2.0'
-    compile "com.jakewharton.timber:timber:${timberVersion}"
-    compile 'net.jcip:jcip-annotations:1.0'
+    implementation project(':k9mail-library')
+    implementation project(':plugins:HoloColorPicker')
+    implementation project(':plugins:openpgp-api-lib:openpgp-api')
+    implementation "com.squareup.okio:okio:${okioVersion}"
+    implementation 'commons-io:commons-io:2.4'
+    implementation "com.android.support:support-v4:${androidSupportLibraryVersion}"
+    implementation 'org.jsoup:jsoup:1.10.2'
+    implementation 'de.cketti.library.changelog:ckchangelog:1.2.1'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.splitwise:tokenautocomplete:2.0.8'
+    implementation 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.9.0'
+    implementation 'com.github.amlcurran.showcaseview:library:5.4.1'
+    implementation 'com.squareup.moshi:moshi:1.2.0'
+    implementation "com.jakewharton.timber:timber:${timberVersion}"
+    implementation 'net.jcip:jcip-annotations:1.0'
 
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
-    testCompile "org.robolectric:robolectric:${robolectricVersion}"
-    testCompile "junit:junit:${junitVersion}"
-    testCompile "com.google.truth:truth:${truthVersion}"
-    testCompile "org.mockito:mockito-core:${mockitoVersion}"
-    testCompile "org.jdom:jdom2:2.0.6"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
+    testImplementation "org.robolectric:robolectric:${robolectricVersion}"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.jdom:jdom2:2.0.6"
 }
 
 android {
@@ -60,7 +61,7 @@ android {
         versionName '5.303-SNAPSHOT'
 
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 26
 
         generatedDensities = ['mdpi', 'hdpi', 'xhdpi']
 


### PR DESCRIPTION
Changed compile -> implementation and so on for
testCompile, andoidTestCompile

targetSdkVersion: 22 -> 26
kotlin: 1.1.4-3 -> 1.1.51
build tools: 25.0.2 -> 27.0.0
expresso-core: 2.2.2 -> 3.0.1
splitwise autocomplete: 2.0.7 -> 2.0.8
glide: 3.6.1 -> 3.7.0
