### PR TITLE
Updated dependency versions and targetSDK

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,10 @@
 buildscript {
     repositories {
         jcenter()
+        maven {
+            url 'https://maven.google.com/'
+            name 'Google'
+        }
     }
 
     dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.0.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.1.4-3
+kotlinVersion=1.1.51
 androidCompileSdkVersion=25
 androidBuildToolsVersion=25.0.2
 androidSupportLibraryVersion=25.2.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlinVersion=1.1.51
 androidCompileSdkVersion=25
-androidBuildToolsVersion=25.0.2
+androidBuildToolsVersion=27.0.0
 androidSupportLibraryVersion=25.2.0
 timberVersion=4.5.1
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlinVersion=1.1.51
 androidCompileSdkVersion=25
 androidBuildToolsVersion=27.0.0
-androidSupportLibraryVersion=25.2.0
+androidSupportLibraryVersion=26.0.0
 timberVersion=4.5.1
 
 robolectricVersion=3.2.2

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Mar 11 00:40:32 EET 2017
+#Sat Nov 04 16:33:11 EDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/k9mail-library/build.gradle
+++ b/k9mail-library/build.gradle
@@ -12,6 +12,10 @@ if (rootProject.testCoverage) {
 
 repositories {
     jcenter()
+    maven {
+        url 'https://maven.google.com/'
+        name 'Google'
+    }
 }
 
 dependencies {
@@ -23,7 +27,7 @@ dependencies {
     compile "com.android.support:support-annotations:${androidSupportLibraryVersion}"
     compile "com.jakewharton.timber:timber:${timberVersion}"
 
-    androidTestCompile 'com.android.support.test:runner:0.4.1'
+    androidTestCompile 'com.android.support.test:runner:1.0.1'
     androidTestCompile 'com.madgag.spongycastle:pg:1.51.0.0'
 
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -12,6 +12,10 @@ if (rootProject.testCoverage) {
 
 repositories {
     jcenter()
+    maven {
+        url 'https://maven.google.com/'
+        name 'Google'
+    }
 }
 
 //noinspection GroovyAssignabilityCheck
@@ -30,15 +34,15 @@ dependencies {
     compile "com.android.support:support-v4:${androidSupportLibraryVersion}"
     compile 'org.jsoup:jsoup:1.10.2'
     compile 'de.cketti.library.changelog:ckchangelog:1.2.1'
-    compile 'com.github.bumptech.glide:glide:3.6.1'
-    compile 'com.splitwise:tokenautocomplete:2.0.7'
+    compile 'com.github.bumptech.glide:glide:3.7.0'
+    compile 'com.splitwise:tokenautocomplete:2.0.8'
     compile 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.9.0'
     compile 'com.github.amlcurran.showcaseview:library:5.4.1'
     compile 'com.squareup.moshi:moshi:1.2.0'
     compile "com.jakewharton.timber:timber:${timberVersion}"
     compile 'net.jcip:jcip-annotations:1.0'
 
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
+    androidTestCompile 'com.android.support.test.espresso:espresso-core:3.0.1'
 
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
     testCompile "org.robolectric:robolectric:${robolectricVersion}"
@@ -60,7 +64,7 @@ android {
         versionName '5.303-SNAPSHOT'
 
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 26
 
         generatedDensities = ['mdpi', 'hdpi', 'xhdpi']
 


### PR DESCRIPTION
targetSdkVersion: 22 -> 26
kotlin: 1.1.4-3 -> 1.1.51
build tools: 25.0.2 -> 27.0.0
test runner: 0.4.1 -> 1.0.1
expresso-core: 2.2.2 -> 3.0.1
splitwise autocomplete: 2.0.7 -> 2.0.8
glide: 3.6.1 -> 3.7.0
