### PR TITLE
Don't ignore preamble and epilogue in decrypted messages

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.mailstore;
 
 
+import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -134,12 +135,18 @@ public class MimePartStreamParser {
 
         @Override
         public void preamble(InputStream is) throws MimeException, IOException {
-            // Do nothing
+            expect(MimeMultipart.class);
+            ByteArrayOutputStream preamble = new ByteArrayOutputStream();
+            IOUtils.copy(is, preamble);
+            ((MimeMultipart)stack.peek()).setPreamble(preamble.toByteArray());
         }
 
         @Override
         public void epilogue(InputStream is) throws MimeException, IOException {
-            // Do nothing
+            expect(MimeMultipart.class);
+            ByteArrayOutputStream epilogue = new ByteArrayOutputStream();
+            IOUtils.copy(is, epilogue);
+            ((MimeMultipart) stack.peek()).setEpilogue(epilogue.toByteArray());
         }
 
         @Override
@@ -173,6 +180,13 @@ public class MimePartStreamParser {
         @Override
         public void raw(InputStream is) throws MimeException, IOException {
             throw new IllegalStateException("Not implemented");
+        }
+
+        private void expect(Class<?> c) {
+            if (!c.isInstance(stack.peek())) {
+                throw new IllegalStateException("Internal stack error: " + "Expected '"
+                        + c.getName() + "' found '" + stack.peek().getClass().getName() + "'");
+            }
         }
     }
 }


### PR DESCRIPTION
I received an email that had one empty line as an epilogue, ignoring that headers broke signature verification. The implementation was correct in `MimeMessage`, I just copied that over. Not the nicest fix, but the one that touches the least amount of code.