### PR TITLE
Removed deprecated members, classes, and APIs

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -72,10 +72,6 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         MessageViewFragmentListener, OnBackStackChangedListener, OnSwipeGestureListener,
         OnSwitchCompleteListener {
 
-    @Deprecated
-    //TODO: Remove after 2017-09-11
-    private static final String EXTRA_SEARCH_OLD = "search";
-
     private static final String EXTRA_SEARCH = "search_bytes";
     private static final String EXTRA_NO_THREADING = "no_threading";
 
@@ -434,9 +430,6 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                     mSearch.addAccountUuid(LocalSearch.ALL_ACCOUNTS);
                 }
             }
-        } else if (intent.hasExtra(EXTRA_SEARCH_OLD)) {
-            mSearch = intent.getParcelableExtra(EXTRA_SEARCH_OLD);
-            mNoThreading = intent.getBooleanExtra(EXTRA_NO_THREADING, false);
         } else {
             // regular LocalSearch object was passed
             mSearch = intent.hasExtra(EXTRA_SEARCH) ?


### PR DESCRIPTION
Members:
Removed MessageList.EXTRA_SEARCH_OLD (and its reference in a search)
Removed MessageProvider.INCREMENT (and its reference in a search)

Classes:
Removed unused class MessageProvider.IncrementExtractor
Removed DownloadImageTask; replaced only reference with android.DownloadManager

APIs:
Replaced OpenPgpApi.ACTION_SIGN with ACTION_CLEARTEXT_SIGN
Removed MessageWebView.setVerticalScrollbarOverlay (does nothing from API 23 onward)