### PR TITLE
Removed unthrown exceptions from method signatures

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/CharsetSupport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/CharsetSupport.java
@@ -30,7 +30,7 @@ public class CharsetSupport {
     };
 
 
-    public static void setCharset(String charset, Part part) throws MessagingException {
+    public static void setCharset(String charset, Part part) {
         part.setHeader(MimeHeader.HEADER_CONTENT_TYPE,
                 part.getMimeType() + ";\r\n charset=" + getExternalCharset(charset));
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/JisSupport.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/JisSupport.java
@@ -67,7 +67,7 @@ class JisSupport {
     }
 
 
-    private static String getJisVariantFromReceivedHeaders(Part message) throws MessagingException {
+    private static String getJisVariantFromReceivedHeaders(Part message) {
         String[] receivedHeaders = message.getHeader("Received");
         if (receivedHeaders.length == 0) {
             return null;
@@ -91,7 +91,7 @@ class JisSupport {
         return null;
     }
 
-    private static String getJisVariantFromFromHeaders(Message message) throws MessagingException {
+    private static String getJisVariantFromFromHeaders(Message message) {
         Address addresses[] = message.getFrom();
         if (addresses == null || addresses.length == 0) {
             return null;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
@@ -66,7 +66,7 @@ class ImapFolderPusher extends ImapFolder {
         }
     }
 
-    public void refresh() throws IOException, MessagingException {
+    public void refresh() {
         if (idling) {
             wakeLock.acquire(PUSH_WAKE_LOCK_TIMEOUT);
             idleStopper.stopIdle();

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
@@ -40,7 +40,7 @@ public class WebDavSocketFactory implements LayeredSocketFactory {
 
     public Socket connectSocket(Socket sock, String host, int port,
             InetAddress localAddress, int localPort, HttpParams params)
-            throws IOException, ConnectTimeoutException {
+            throws IOException {
         return mSchemeSocketFactory.connectSocket(sock, host, port, localAddress, localPort, params);
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -312,7 +312,7 @@ public class WebDavStore extends RemoteStore {
         return folder;
     }
 
-    private Folder getSendSpoolFolder() throws MessagingException {
+    private Folder getSendSpoolFolder() {
         if (sendFolder == null) {
             sendFolder = getFolder(WebDavConstants.DAV_MAIL_SEND_FOLDER);
         }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/ListHeadersTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/ListHeadersTest.java
@@ -114,7 +114,7 @@ public class ListHeadersTest {
         assertEquals(emailAddress, result[0].getAddress());
     }
 
-    private MimeMessage buildMimeMessageWithListPostValue(String... values) throws MessagingException {
+    private MimeMessage buildMimeMessageWithListPostValue(String... values) {
         MimeMessage message = new MimeMessage();
         for (String value : values) {
             message.addHeader("List-Post", value);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapConnectionTest.java
@@ -1008,7 +1008,7 @@ public class ImapConnectionTest {
         server.output("2 OK [CAPABILITY " + postAuthCapabilities + "] LOGIN completed");
     }
 
-    private OAuth2TokenProvider createOAuth2TokenProvider() throws AuthenticationFailedException {
+    private OAuth2TokenProvider createOAuth2TokenProvider() {
         return new OAuth2TokenProvider() {
             private int invalidationCount = 0;
 
@@ -1025,7 +1025,7 @@ public class ImapConnectionTest {
                         return XOAUTH_ANOTHER_TOKEN;
                     }
                     default: {
-                        throw new AssertionError("Ran out of auth tokens. invalidateToken() called too often?");
+                        throw new AuthenticationFailedException("Ran out of auth tokens. invalidateToken() called too often?");
                     }
                 }
             }

--- a/k9mail/src/androidTest/java/com/fsck/k9/provider/EmailProviderTest.java
+++ b/k9mail/src/androidTest/java/com/fsck/k9/provider/EmailProviderTest.java
@@ -34,7 +34,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
         super(EmailProvider.class, EmailProvider.AUTHORITY);
     }
 
-    private void buildMessages() throws MessagingException {
+    private void buildMessages() {
         message = new MimeMessage();
         message.setSubject("Test Subject");
         message.setSentDate(new GregorianCalendar(2016, 1, 2).getTime(), false);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -1522,7 +1522,7 @@ public class LocalFolder extends Folder<LocalMessage> {
         }
     }
 
-    private void messageMarkerToContentValues(ContentValues cv) throws MessagingException {
+    private void messageMarkerToContentValues(ContentValues cv) {
         cv.put("data_location", DataLocation.CHILD_PART_CONTAINS_DATA);
     }
 
@@ -1592,7 +1592,7 @@ public class LocalFolder extends Folder<LocalMessage> {
     }
 
     private long decodeAndCountBytes(File file, String encoding, long fallbackValue)
-            throws MessagingException, IOException {
+            throws IOException {
         InputStream inputStream = new FileInputStream(file);
         try {
             return decodeAndCountBytes(inputStream, encoding, fallbackValue);
@@ -2132,8 +2132,7 @@ public class LocalFolder extends Folder<LocalMessage> {
         });
     }
 
-    private ThreadInfo doMessageThreading(SQLiteDatabase db, Message message)
-            throws MessagingException {
+    private ThreadInfo doMessageThreading(SQLiteDatabase db, Message message) {
         long rootId = -1;
         long parentId = -1;
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMimeMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMimeMessage.java
@@ -1,7 +1,6 @@
 package com.fsck.k9.mailstore;
 
 
-import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.MimeMessage;
 
 
@@ -10,8 +9,7 @@ public class LocalMimeMessage extends MimeMessage implements LocalPart {
     private final LocalMessage message;
     private final long messagePartId;
 
-    public LocalMimeMessage(String accountUuid, LocalMessage message, long messagePartId)
-            throws MessagingException {
+    public LocalMimeMessage(String accountUuid, LocalMessage message, long messagePartId) {
         super();
         this.accountUuid = accountUuid;
         this.message = message;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MimePartStreamParser.java
@@ -69,8 +69,7 @@ public class MimePartStreamParser {
         private final MimeBodyPart decryptedRootPart;
         private final Stack<Object> stack = new Stack<>();
 
-        public PartBuilder(FileFactory fileFactory, MimeBodyPart decryptedRootPart)
-                throws MessagingException {
+        public PartBuilder(FileFactory fileFactory, MimeBodyPart decryptedRootPart) {
             this.fileFactory = fileFactory;
             this.decryptedRootPart = decryptedRootPart;
         }

--- a/k9mail/src/main/java/com/fsck/k9/message/quote/HtmlQuoteCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/quote/HtmlQuoteCreator.java
@@ -46,7 +46,7 @@ public class HtmlQuoteCreator {
      * @throws MessagingException
      */
     public static InsertableHtmlContent quoteOriginalHtmlMessage(Resources resources, Message originalMessage,
-            String messageBody, QuoteStyle quoteStyle) throws MessagingException {
+            String messageBody, QuoteStyle quoteStyle) {
         InsertableHtmlContent insertable = findInsertionPoints(messageBody);
 
         String sentDate = QuoteHelper.getSentDateText(resources, originalMessage);

--- a/k9mail/src/main/java/com/fsck/k9/message/quote/TextQuoteCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/quote/TextQuoteCreator.java
@@ -25,7 +25,7 @@ public class TextQuoteCreator {
      * @return Quoted text.
      * @throws MessagingException
      */
-    public static String quoteOriginalTextMessage(Resources resources, Message originalMessage, String messageBody, QuoteStyle quoteStyle, String prefix) throws MessagingException {
+    public static String quoteOriginalTextMessage(Resources resources, Message originalMessage, String messageBody, QuoteStyle quoteStyle, String prefix) {
         String body = messageBody == null ? "" : messageBody;
         String sentDate = QuoteHelper.getSentDateText(resources, originalMessage);
         if (quoteStyle == QuoteStyle.PREFIX) {

--- a/k9mail/src/main/java/com/fsck/k9/provider/DecryptedFileProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/DecryptedFileProvider.java
@@ -56,7 +56,7 @@ public class DecryptedFileProvider extends FileProvider {
 
     @Nullable
     public static Uri getUriForProvidedFile(@NonNull Context context, File file,
-            @Nullable String encoding, @Nullable String mimeType) throws IOException {
+            @Nullable String encoding, @Nullable String mimeType) {
         try {
             Uri.Builder uriBuilder = FileProvider.getUriForFile(context, AUTHORITY, file).buildUpon();
             if (mimeType != null) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
@@ -417,7 +417,7 @@ public class MessageCryptoHelper {
         });
     }
 
-    private OpenPgpDataSource getDataSourceForSignedData(final Part signedPart) throws IOException {
+    private OpenPgpDataSource getDataSourceForSignedData(final Part signedPart) {
         return new OpenPgpDataSource() {
             @Override
             public void writeTo(OutputStream os) throws IOException {
@@ -433,7 +433,7 @@ public class MessageCryptoHelper {
         };
     }
 
-    private OpenPgpDataSource getDataSourceForEncryptedOrInlineData() throws IOException {
+    private OpenPgpDataSource getDataSourceForEncryptedOrInlineData() {
         return new OpenPgpApi.OpenPgpDataSource() {
             @Override
             public Long getSizeForProgress() {
@@ -479,7 +479,7 @@ public class MessageCryptoHelper {
         };
     }
 
-    private OpenPgpDataSink<MimeBodyPart> getDataSinkForDecryptedData() throws IOException {
+    private OpenPgpDataSink<MimeBodyPart> getDataSinkForDecryptedData() {
         return new OpenPgpDataSink<MimeBodyPart>() {
             @Override
             @WorkerThread

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -433,8 +433,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
        }
     }
 
-    private List<HeaderEntry> getAdditionalHeaders(final Message message)
-    throws MessagingException {
+    private List<HeaderEntry> getAdditionalHeaders(final Message message) {
         List<HeaderEntry> additionalHeaders = new LinkedList<HeaderEntry>();
 
         Set<String> headerNames = new LinkedHashSet<String>(message.getHeaderNames());

--- a/k9mail/src/test/java/com/fsck/k9/message/MessageCreationHelper.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/MessageCreationHelper.java
@@ -51,7 +51,7 @@ public class MessageCreationHelper {
         return createMessage(mimeType, null);
     }
 
-    private static Message createMessage(String mimeType, Body body) throws MessagingException {
+    private static Message createMessage(String mimeType, Body body) {
         MimeMessage message = new MimeMessage();
         message.setBody(body);
         message.setHeader(MimeHeader.HEADER_CONTENT_TYPE, mimeType);
@@ -59,7 +59,7 @@ public class MessageCreationHelper {
         return message;
     }
 
-    private static MimeMultipart createMultipartBody(String mimeType, BodyPart[] parts) throws MessagingException {
+    private static MimeMultipart createMultipartBody(String mimeType, BodyPart[] parts) {
         MimeMultipart multipart = new MimeMultipart(mimeType, "boundary");
         for (BodyPart part : parts) {
             multipart.addBodyPart(part);

--- a/k9mail/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.java
@@ -165,7 +165,7 @@ public class NotificationContentCreatorTest {
         return new MessageReference(ACCOUNT_UUID, FOLDER_NAME, UID, null);
     }
 
-    private LocalMessage createFakeLocalMessage(MessageReference messageReference) throws Exception {
+    private LocalMessage createFakeLocalMessage(MessageReference messageReference) {
         LocalMessage message = mock(LocalMessage.class);
 
         when(message.makeMessageReference()).thenReturn(messageReference);

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/ParcelFileDescriptorUtil.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/ParcelFileDescriptorUtil.java
@@ -47,8 +47,7 @@ public class ParcelFileDescriptorUtil {
         return readSide;
     }
 
-    public static TransferThread pipeTo(OutputStream outputStream, ParcelFileDescriptor output)
-            throws IOException {
+    public static TransferThread pipeTo(OutputStream outputStream, ParcelFileDescriptor output) {
 
         AutoCloseInputStream InputStream = new AutoCloseInputStream(output);
         TransferThread t = new TransferThread(InputStream, outputStream);
@@ -93,7 +92,7 @@ public class ParcelFileDescriptorUtil {
     }
 
     public static <T> DataSinkTransferThread<T> asyncPipeToDataSink(
-            OpenPgpDataSink<T> dataSink, ParcelFileDescriptor output) throws IOException {
+            OpenPgpDataSink<T> dataSink, ParcelFileDescriptor output) {
         InputStream inputStream = new BufferedInputStream(new AutoCloseInputStream(output));
         DataSinkTransferThread<T> dataSinkTransferThread =
                 new DataSinkTransferThread<T>(dataSink, inputStream);


### PR DESCRIPTION
Removed `throws someException` from many methods and constructors
if said exception was never thrown.

For OAuth2TokenProvider.getToken(), changed exception thrown to
match method signature (AssertionError -> AuthenticationFailedException)