### PR TITLE
Added outlook alike date separators in the messagelist.

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -211,6 +211,7 @@ public class K9 extends Application {
 
     private static boolean mMessageListCheckboxes = true;
     private static boolean mMessageListStars = true;
+    private static boolean mMessageListGroups = true;
     private static int mMessageListPreviewLines = 2;
 
     private static boolean mShowCorrespondentNames = true;
@@ -465,6 +466,7 @@ public class K9 extends Application {
         editor.putBoolean("messageListSenderAboveSubject", mMessageListSenderAboveSubject);
         editor.putBoolean("hideSpecialAccounts", mHideSpecialAccounts);
         editor.putBoolean("messageListStars", mMessageListStars);
+        editor.putBoolean("messageListGroups", mMessageListGroups);
         editor.putInt("messageListPreviewLines", mMessageListPreviewLines);
         editor.putBoolean("messageListCheckboxes", mMessageListCheckboxes);
         editor.putBoolean("showCorrespondentNames", mShowCorrespondentNames);
@@ -693,6 +695,7 @@ public class K9 extends Application {
         mMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false);
         mMessageListCheckboxes = storage.getBoolean("messageListCheckboxes", false);
         mMessageListStars = storage.getBoolean("messageListStars", true);
+        mMessageListGroups = storage.getBoolean("messageListGroups", true);
         mMessageListPreviewLines = storage.getInt("messageListPreviewLines", 2);
 
         mAutofitWidth = storage.getBoolean("autofitWidth", true);
@@ -1082,6 +1085,14 @@ public class K9 extends Application {
 
     public static void setMessageListStars(boolean stars) {
         mMessageListStars = stars;
+    }
+
+    public static boolean messageListGroups() {
+        return mMessageListGroups;
+    }
+
+    public static void setMessageListGroups(boolean groups) {
+        mMessageListGroups = groups;
     }
 
     public static boolean showCorrespondentNames() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -72,6 +72,7 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_MESSAGELIST_PREVIEW_LINES = "messagelist_preview_lines";
     private static final String PREFERENCE_MESSAGELIST_SENDER_ABOVE_SUBJECT = "messagelist_sender_above_subject";
     private static final String PREFERENCE_MESSAGELIST_STARS = "messagelist_stars";
+    private static final String PREFERENCE_MESSAGELIST_GROUPS = "messagelist_groups";
     private static final String PREFERENCE_MESSAGELIST_SHOW_CORRESPONDENT_NAMES = "messagelist_show_correspondent_names";
     private static final String PREFERENCE_MESSAGELIST_SHOW_CONTACT_NAME = "messagelist_show_contact_name";
     private static final String PREFERENCE_MESSAGELIST_CONTACT_NAME_COLOR = "messagelist_contact_name_color";
@@ -138,6 +139,7 @@ public class Prefs extends K9PreferenceActivity {
     private CheckBoxPreference mSenderAboveSubject;
     private CheckBoxPreference mCheckboxes;
     private CheckBoxPreference mStars;
+    private CheckBoxPreference mGroups;
     private CheckBoxPreference mShowCorrespondentNames;
     private CheckBoxPreference mShowContactName;
     private CheckBoxPreference mChangeContactNameColor;
@@ -274,6 +276,9 @@ public class Prefs extends K9PreferenceActivity {
 
         mStars = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_STARS);
         mStars.setChecked(K9.messageListStars());
+
+        mGroups = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_GROUPS);
+        mGroups.setChecked(K9.messageListGroups());
 
         mShowCorrespondentNames = (CheckBoxPreference)findPreference(PREFERENCE_MESSAGELIST_SHOW_CORRESPONDENT_NAMES);
         mShowCorrespondentNames.setChecked(K9.showCorrespondentNames());
@@ -513,6 +518,7 @@ public class Prefs extends K9PreferenceActivity {
         K9.setMessageListPreviewLines(Integer.parseInt(mPreviewLines.getValue()));
         K9.setMessageListCheckboxes(mCheckboxes.isChecked());
         K9.setMessageListStars(mStars.isChecked());
+        K9.setMessageListGroups(mGroups.isChecked());
         K9.setShowCorrespondentNames(mShowCorrespondentNames.isChecked());
         K9.setMessageListSenderAboveSubject(mSenderAboveSubject.isChecked());
         K9.setShowContactName(mShowContactName.isChecked());

--- a/k9mail/src/main/java/com/fsck/k9/fragment/DateGroups.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/DateGroups.java
@@ -118,7 +118,8 @@ public class DateGroups {
             messageDate.setTimeInMillis(date);
 
             long dateDifference = daysBetween(messageDate, Calendar.getInstance());
-            int monthDifference = Calendar.getInstance().get( Calendar.MONTH) - messageDate.get( Calendar.MONTH );
+            int monthDifference = ( Calendar.getInstance().get( Calendar.YEAR) + Calendar.getInstance().get( Calendar.MONTH) ) -
+                    ( messageDate.get( Calendar.YEAR ) + messageDate.get( Calendar.MONTH ) );
 
             if (dateDifference == DATE_TODAY) {
                 category = GROUP_TODAY;

--- a/k9mail/src/main/java/com/fsck/k9/fragment/DateGroups.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/DateGroups.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.fsck.k9.fragment;
+
+import android.content.Context;
+import android.database.Cursor;
+import android.widget.CursorAdapter;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.R;
+import static com.fsck.k9.fragment.MLFProjectionInfo.DATE_COLUMN;
+import static com.fsck.k9.fragment.MLFProjectionInfo.INTERNAL_DATE_COLUMN;
+
+import java.util.Calendar;
+
+
+/**
+ * A class to calculate the catagory of the date
+ */
+public class DateGroups {
+
+    private static final int GROUP_NONE                 = 0;
+    private static final int GROUP_TODAY                = 1;
+    private static final int GROUP_YESTERDAY            = 2;
+    private static final int GROUP_DAY_BEFORE_YESTERDAY = 3;
+    private static final int GROUP_LAST_WEEK            = 11;
+    private static final int GROUP_TWO_WEEKS_AGO        = 12;
+    private static final int GROUP_THREE_WEEKS_AGO      = 13;
+    private static final int GROUP_LAST_MONTH           = 14;
+    private static final int GROUP_OLDER                = 15;
+
+    private String dateGroupNames[] = new String[20];
+
+    private int[] dateGroupIds = null;
+    private Account.SortType sortType;
+    private CursorAdapter cursorAdapter = null;
+
+    DateGroups(Context context, MessageListAdapter adapter, Account.SortType sorttype ) {
+
+        sortType = sorttype;
+        cursorAdapter = adapter;
+
+        dateGroupNames[GROUP_TODAY] = context.getString(R.string.message_list_separator_today);
+        dateGroupNames[GROUP_YESTERDAY] = context.getString(R.string.message_list_separator_yesterday);
+        dateGroupNames[GROUP_DAY_BEFORE_YESTERDAY] = context.getString(R.string.message_list_separator_day_before_yesterday);
+        dateGroupNames[GROUP_LAST_WEEK] = context.getString(R.string.message_list_separator_last_week);
+        dateGroupNames[GROUP_TWO_WEEKS_AGO] = context.getString(R.string.message_list_separator_two_weeks);
+        dateGroupNames[GROUP_THREE_WEEKS_AGO] = context.getString(R.string.message_list_separator_three_weeks);
+        dateGroupNames[GROUP_LAST_MONTH] = context.getString(R.string.message_list_separator_last_month);
+        dateGroupNames[GROUP_OLDER] = context.getString(R.string.message_list_separator_older);
+    }
+
+    void addDateGroups( int[] groups ){
+        dateGroupIds = groups;
+    }
+
+    String getDateGroupName(int position) {
+        String groupName;
+        Cursor cursor = (Cursor) cursorAdapter.getItem(position);
+
+        if ((dateGroupIds[position] > GROUP_DAY_BEFORE_YESTERDAY) && (dateGroupIds[position] < GROUP_LAST_WEEK)) {
+            if (sortType == Account.SortType.SORT_ARRIVAL) {
+                groupName = (String) android.text.format.DateFormat.format("EEEE", cursor.getLong(INTERNAL_DATE_COLUMN));
+            } else {
+                groupName = (String) android.text.format.DateFormat.format("EEEE", cursor.getLong(DATE_COLUMN));
+            }
+        } else {
+            groupName = dateGroupNames[dateGroupIds[position]];
+        }
+
+        return groupName;
+    }
+
+    private int getSundayOffset()
+    {
+        int sundayOffset = 0;
+        Calendar calendar = Calendar.getInstance();
+        for (int j = 0; j < 7; j++) {
+            calendar.add(Calendar.DATE, -1);
+            if (calendar.get(Calendar.DAY_OF_WEEK) == Calendar.SUNDAY) {
+                sundayOffset = j + 1;
+                break;
+            }
+        }
+        return sundayOffset;
+    }
+
+    int getDateGroup(long date) {
+        final int DATE_TODAY                = 0;
+        final int DATE_YESTERDAY            = 1;
+        final int DATE_DAY_BEFORE_YESTERDAY = 2;
+        final int DATE_START_OF_WEEKDAYS    = 3;
+        final int DATE_LAST_WEEK            = 7;
+        final int DATE_TWO_WEEKS_AGO        = 14;
+        final int DATE_THREE_WEEKS_AGO      = 21;
+        final int DATE_LAST_MONTH           = 1;
+
+        if (date != 0) {
+            int category = 0;
+
+            int sundayOffset = getSundayOffset();
+
+            Calendar messageDate = Calendar.getInstance();
+            messageDate.setTimeInMillis(date);
+
+            long dateDifference = daysBetween(messageDate, Calendar.getInstance());
+            int monthDifference = Calendar.getInstance().get( Calendar.MONTH) - messageDate.get( Calendar.MONTH );
+
+            if (dateDifference == DATE_TODAY) {
+                category = GROUP_TODAY;
+            } else if (dateDifference == DATE_YESTERDAY) {
+                category = GROUP_YESTERDAY;
+            } else if (dateDifference == DATE_DAY_BEFORE_YESTERDAY) {
+                category = GROUP_DAY_BEFORE_YESTERDAY;
+            } else if ((sundayOffset > 1) && (dateDifference <= sundayOffset)) {
+                category = messageDate.get(Calendar.DAY_OF_WEEK) + DATE_START_OF_WEEKDAYS;
+            } else if ((dateDifference - sundayOffset) < DATE_LAST_WEEK) {
+                category = GROUP_LAST_WEEK;
+            } else if ((dateDifference - sundayOffset) < DATE_TWO_WEEKS_AGO) {
+                category = GROUP_TWO_WEEKS_AGO;
+            } else if ((dateDifference - sundayOffset) < DATE_THREE_WEEKS_AGO) {
+                category = GROUP_THREE_WEEKS_AGO;
+            } else if (monthDifference == DATE_LAST_MONTH) {
+                category = GROUP_LAST_MONTH;
+            } else {
+                category = GROUP_OLDER;
+            }
+            return category;
+        }
+        return GROUP_NONE;
+    }
+
+    private final static long MILLISECS_PER_DAY = 24 * 60 * 60 * 1000;
+
+    private long daysBetween(Calendar a, Calendar b) {
+        if (a.get(Calendar.ERA) == b.get(Calendar.ERA) && a.get(Calendar.YEAR) == b.get(Calendar.YEAR)
+                && a.get(Calendar.DAY_OF_YEAR) == b.get(Calendar.DAY_OF_YEAR)) {
+            return 0;
+        }
+        Calendar a2 = (Calendar) a.clone();
+        Calendar b2 = (Calendar) b.clone();
+        a2.set(Calendar.HOUR_OF_DAY, 0);
+        a2.set(Calendar.MINUTE, 0);
+        a2.set(Calendar.SECOND, 0);
+        a2.set(Calendar.MILLISECOND, 0);
+        b2.set(Calendar.HOUR_OF_DAY, 0);
+        b2.set(Calendar.MINUTE, 0);
+        b2.set(Calendar.SECOND, 0);
+        b2.set(Calendar.MILLISECOND, 0);
+        long diff = a2.getTimeInMillis() - b2.getTimeInMillis();
+        long days = diff / MILLISECS_PER_DAY;
+        return Math.abs(days);
+    }
+
+}

--- a/k9mail/src/main/java/com/fsck/k9/fragment/DateGroups.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/DateGroups.java
@@ -26,6 +26,7 @@ import static com.fsck.k9.fragment.MLFProjectionInfo.DATE_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.INTERNAL_DATE_COLUMN;
 
 import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
 
 
 /**
@@ -145,8 +146,6 @@ public class DateGroups {
         return GROUP_NONE;
     }
 
-    private final static long MILLISECS_PER_DAY = 24 * 60 * 60 * 1000;
-
     private long daysBetween(Calendar a, Calendar b) {
         if (a.get(Calendar.ERA) == b.get(Calendar.ERA) && a.get(Calendar.YEAR) == b.get(Calendar.YEAR)
                 && a.get(Calendar.DAY_OF_YEAR) == b.get(Calendar.DAY_OF_YEAR)) {
@@ -163,7 +162,7 @@ public class DateGroups {
         b2.set(Calendar.SECOND, 0);
         b2.set(Calendar.MILLISECOND, 0);
         long diff = a2.getTimeInMillis() - b2.getTimeInMillis();
-        long days = diff / MILLISECS_PER_DAY;
+        long days = TimeUnit.MILLISECONDS.toDays(diff);
         return Math.abs(days);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
@@ -27,6 +27,7 @@ import com.fsck.k9.mail.Address;
 import com.fsck.k9.mailstore.DatabasePreviewType;
 import com.fsck.k9.ui.ContactBadge;
 
+import static com.fsck.k9.K9.messageListGroups;
 import static com.fsck.k9.fragment.MLFProjectionInfo.ANSWERED_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.CC_LIST_COLUMN;
@@ -54,7 +55,6 @@ public class MessageListAdapter extends CursorAdapter {
     private Drawable mForwardedAnsweredIcon;
     private FontSizes fontSizes = K9.getFontSizes();
     private Account.SortType mSortType;
-    private Context mContext;
 
     MessageListAdapter(MessageListFragment fragment) {
         super(fragment.getActivity(), null, 0);
@@ -83,8 +83,6 @@ public class MessageListAdapter extends CursorAdapter {
         MessageViewHolder holder = new MessageViewHolder(fragment);
         holder.date = (TextView) view.findViewById(R.id.date);
         holder.chip = view.findViewById(R.id.chip);
-
-        mContext = context;
 
         if (fragment.previewLines == 0 && fragment.contactsPictureLoader == null) {
             view.findViewById(R.id.preview).setVisibility(View.GONE);
@@ -174,62 +172,24 @@ public class MessageListAdapter extends CursorAdapter {
         TextView separatorText = (TextView) view.findViewById(R.id.separatorText);
         TextView separatorDate = (TextView) view.findViewById(R.id.separatorDate);
 
-        // MessageInfoHolder message = (MessageInfoHolder) getItem(
-        // cursor.getPosition() );
-
         boolean showSeparators = false;
-
-        if ((mSortType == Account.SortType.SORT_DATE) ||
-                (mSortType == Account.SortType.SORT_ARRIVAL)) {
-            showSeparators = true;
+        if ( messageListGroups() ) {
+            if ((mSortType == Account.SortType.SORT_DATE) ||
+                    (mSortType == Account.SortType.SORT_ARRIVAL)) {
+                showSeparators = true;
+            }
         }
 
         if (showSeparators) {
             int pos = cursor.getPosition();
-            int[] categorizedMessages = fragment.getCategorizedMessages();
-            int dateCategory = categorizedMessages[pos];
 
-            if (mSortType == Account.SortType.SORT_DATE) {
-                displayDate = DateUtils.getRelativeTimeSpanString(context, cursor.getLong(DATE_COLUMN));
-            } else if (mSortType == Account.SortType.SORT_ARRIVAL) {
-                displayDate = DateUtils.getRelativeTimeSpanString(context, cursor.getLong(INTERNAL_DATE_COLUMN));
-            }
+            String describeDate = fragment.dateGroup.getDateGroupName( pos );
 
-            if (!datesDone) {
-                dateCategories[1] = mContext.getString(R.string.message_list_separator_today);
-                dateCategories[2] = mContext.getString(R.string.message_list_separator_yesterday);
-                dateCategories[3] = mContext.getString(R.string.message_list_separator_day_before_yesterday);
-
-                // dateCategories[3] = (String)
-                // android.text.format.DateFormat.format("EEEE",
-                // message.compareDate );
-
-                dateCategories[11] = mContext.getString(R.string.message_list_separator_last_week);
-                dateCategories[12] = mContext.getString(R.string.message_list_separator_two_weeks);
-                dateCategories[13] = mContext.getString(R.string.message_list_separator_three_weeks);
-                dateCategories[14] = mContext.getString(R.string.message_list_separator_older);
-                ;
-
-                datesDone = true;
-            }
-
-            // if ( K9.messageListSeparators() && showSeparators )
-            if (dateCategory > 0) {
-                String describeDate = null;
-
-                if ((dateCategory > 3) && (dateCategory <= 10)) {
-                    if (mSortType == Account.SortType.SORT_ARRIVAL) {
-                        describeDate = (String) android.text.format.DateFormat.format("EEEE", cursor.getLong(INTERNAL_DATE_COLUMN));
-                    } else {
-                        describeDate = (String) android.text.format.DateFormat.format("EEEE", cursor.getLong(DATE_COLUMN));
-                    }
-                } else {
-                    describeDate = dateCategories[dateCategory];
-                }
+            if ( describeDate != null ) {
 
                 java.text.DateFormat df = android.text.format.DateFormat.getDateFormat(context);
 
-                separatorText.setText(describeDate);
+                separatorText.setText( describeDate );
 
                 int res = R.attr.messageListSeparatorBackgroundColor;
                 TypedValue backColor = new TypedValue();
@@ -259,8 +219,6 @@ public class MessageListAdapter extends CursorAdapter {
             separatorText.setVisibility(View.GONE);
             separatorDate.setVisibility(View.GONE);
         }
-
-
 
         boolean read = (cursor.getInt(READ_COLUMN) == 1);
         boolean flagged = (cursor.getInt(FLAGGED_COLUMN) == 1);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -162,6 +162,9 @@ public class GlobalSettings {
         s.put("messageListStars", Settings.versions(
                 new V(1, new BooleanSetting(true))
         ));
+        s.put("messageListGroups", Settings.versions(
+                new V(1, new BooleanSetting(true))
+        ));
         s.put("messageViewFixedWidthFont", Settings.versions(
                 new V(1, new BooleanSetting(false))
         ));

--- a/k9mail/src/main/res/layout/message_list_item.xml
+++ b/k9mail/src/main/res/layout/message_list_item.xml
@@ -1,5 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/item_wrapper"
+    android:layout_width="fill_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical" >
+
+    <LinearLayout
+        android:id="@+id/separator_wrapper"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal" >
+
+        <TextView
+            android:id="@+id/separatorText"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.8"
+            android:gravity="left"
+            android:visibility="gone"
+            android:paddingLeft="32dp"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+        <TextView
+            android:id="@+id/separatorDate"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="0.2"
+            android:gravity="right"
+            android:visibility="gone"
+            android:paddingRight="32dp"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
+
+    </LinearLayout>
+
+    <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:orientation="horizontal"
@@ -179,5 +213,6 @@
 
     </RelativeLayout>
 
+</LinearLayout>
 
 </LinearLayout>

--- a/k9mail/src/main/res/values-de/strings.xml
+++ b/k9mail/src/main/res/values-de/strings.xml
@@ -210,6 +210,17 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="debug_enable_sensitive_logging_title">Vertrauliche Informationen protokollieren</string>
   <string name="debug_enable_sensitive_logging_summary">Anmeldepasswörter bei Verbindungsaufbau protokollieren.</string>
   <string name="message_list_load_more_messages_action">Weitere Nachrichten laden</string>
+
+  <!-- Date separators -->
+  <string name="message_list_separator_today">Heute</string>
+  <string name="message_list_separator_yesterday">Gestern</string>
+  <string name="message_list_separator_day_before_yesterday">Vorgestern</string>
+  <string name="message_list_separator_last_week">Letzte Woche</string>
+  <string name="message_list_separator_two_weeks">Vor Zwei Wochen</string>
+  <string name="message_list_separator_three_weeks">Vor Drei Wochen</string>
+  <string name="message_list_separator_last_month">last month</string>
+  <string name="message_list_separator_older">Älter</string>
+
   <string name="message_to_fmt">An:<xliff:g id="counterParty">%s</xliff:g></string>
   <string name="message_compose_subject_hint">Betreff</string>
   <string name="message_compose_content_hint">Nachrichtentext</string>

--- a/k9mail/src/main/res/values-fr/strings.xml
+++ b/k9mail/src/main/res/values-fr/strings.xml
@@ -210,6 +210,17 @@ jusqu\'à <xliff:g id="messages_to_load">%d</xliff:g> de plus</string>
   <string name="debug_enable_sensitive_logging_title">Journaliser les informations délicates</string>
   <string name="debug_enable_sensitive_logging_summary">Pourrait inclure les mots de passe dans les journaux.</string>
   <string name="message_list_load_more_messages_action">Charger plus de messages</string>
+
+  <!-- Date separators -->
+  <string name="message_list_separator_today">aujourd\'hui</string>
+  <string name="message_list_separator_yesterday">hier</string>
+  <string name="message_list_separator_day_before_yesterday">avant-hier</string>
+  <string name="message_list_separator_last_week">semaine dernière</string>
+  <string name="message_list_separator_two_weeks">deux semaines avant</string>
+  <string name="message_list_separator_three_weeks">trois semaines avant</string>
+  <string name="message_list_separator_last_month">mois dernier</string>
+  <string name="message_list_separator_older">plus tôt</string>
+
   <string name="message_to_fmt">À\u00A0: <xliff:g id="counterParty">%s</xliff:g></string>
   <string name="message_compose_subject_hint">Objet</string>
   <string name="message_compose_content_hint">Texte du message</string>

--- a/k9mail/src/main/res/values-nl/strings.xml
+++ b/k9mail/src/main/res/values-nl/strings.xml
@@ -257,6 +257,8 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   <string name="message_saved_toast">Bericht opgeslagen als concept</string>
   <string name="global_settings_flag_label">Bericht sterren</string>
   <string name="global_settings_flag_summary">Sterren geven gemarkeerde berichten aan</string>
+  <string name="global_settings_groups_label">Toon datumgroepen</string>
+  <string name="global_settings_groups_summary">Groepeer berichten op datum (bijv. gisteren, vorige week) als de berichten gesorteerd zijn op datum</string>
   <string name="global_settings_checkbox_label">Multi-selecteer selectieboxen</string>
   <string name="global_settings_checkbox_summary">Laat altijd multi-selecteer selectieboxen zien</string>
   <string name="global_settings_preview_lines_label">Preview regels</string>

--- a/k9mail/src/main/res/values-nl/strings.xml
+++ b/k9mail/src/main/res/values-nl/strings.xml
@@ -205,6 +205,17 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   <string name="debug_enable_sensitive_logging_title">Log gevoelige informatie</string>
   <string name="debug_enable_sensitive_logging_summary">Kan wachtwoorden laten zien in logs.</string>
   <string name="message_list_load_more_messages_action">Laad meer berichten</string>
+
+  <!-- Date separators -->
+  <string name="message_list_separator_today">vandaag</string>
+  <string name="message_list_separator_yesterday">gisteren</string>
+  <string name="message_list_separator_day_before_yesterday">eergisteren</string>
+  <string name="message_list_separator_last_week">vorige week</string>
+  <string name="message_list_separator_two_weeks">twee weken geleden</string>
+  <string name="message_list_separator_three_weeks">drie weken geleden</string>
+  <string name="message_list_separator_last_month">vorige maand</string>
+  <string name="message_list_separator_older">ouder</string>
+
   <string name="message_to_fmt">Aan:<xliff:g id="counterParty">%s</xliff:g></string>
   <string name="message_compose_subject_hint">Onderwerp</string>
   <string name="message_compose_content_hint">Bericht tekst</string>

--- a/k9mail/src/main/res/values/attrs.xml
+++ b/k9mail/src/main/res/values/attrs.xml
@@ -49,6 +49,8 @@
         <attr name="messageListActiveItemBackgroundColor" format="reference|color"/>
         <attr name="messageListDividerColor" format="reference|color"/>
         <attr name="messageListCheckbox" format="reference"/>
+        <attr name="messageListSeparatorBackgroundColor" format="reference|color"/>
+        <attr name="messageListSeparatorForegroundColor" format="reference|color"/>
         <attr name="messageViewBackgroundColor" format="reference|color"/>
         <attr name="messageViewAttachmentBackground" format="reference"/>
         <attr name="messageComposeAddContactImage" format="reference"/>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -294,6 +294,17 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="message_view_toast_unable_to_display_message">Unable to display message</string>
     <string name="message_view_sender_label">via %1$s</string>
 
+    <!-- Date separators -->
+    <string name="message_list_separator_today">today</string>
+    <string name="message_list_separator_yesterday">yesterday</string>
+    <string name="message_list_separator_day_before_yesterday">day before yesterday</string>
+    <string name="message_list_separator_last_week">last week</string>
+    <string name="message_list_separator_two_weeks">two weeks ago</string>
+    <string name="message_list_separator_three_weeks">three weeks ago</string>
+    <string name="message_list_separator_earlier_this_month">earlier this month</string>
+    <string name="message_list_separator_last_month">last month</string>
+    <string name="message_list_separator_older">older</string>
+
     <!-- NOTE: The following message refers to strings with id account_setup_incoming_save_all_headers_label and account_setup_incoming_title -->
     <string name="message_no_additional_headers_available">All headers have been downloaded, but there are no additional headers to show.</string>
     <string name="message_additional_headers_retrieval_failed">The retrieval of additional headers from the database or mail server failed.</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -317,6 +317,8 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="global_settings_flag_label">Show stars</string>
     <string name="global_settings_flag_summary">Stars indicate flagged messages</string>
+    <string name="global_settings_groups_label">Show dategroups</string>
+    <string name="global_settings_groups_summary">Group messages by date (e.g. yesterday, last week) if the messages are sorted by date</string>
     <string name="global_settings_checkbox_label">Multi-select checkboxes</string>
     <string name="global_settings_checkbox_summary">Always show multi-select checkboxes</string>
     <string name="global_settings_preview_lines_label">Preview lines</string>

--- a/k9mail/src/main/res/values/themes.xml
+++ b/k9mail/src/main/res/values/themes.xml
@@ -56,6 +56,8 @@
         <item name="messageListActiveItemBackgroundColor">#ff2ea7d1</item>
         <item name="messageListDividerColor">#ffcccccc</item>
         <item name="messageListCheckbox">@drawable/btn_check_message_list_light</item>
+        <item name="messageListSeparatorForegroundColor">#f9f7f7</item>
+        <item name="messageListSeparatorBackgroundColor">#4d4d4d</item>
         <item name="messageViewBackgroundColor">#ffffffff</item>
         <item name="messageViewAttachmentBackground">@drawable/attachment_text_box_light</item>
         <item name="messageComposeAddContactImage">@drawable/ic_button_add_contact_light</item>
@@ -122,6 +124,8 @@
         <item name="messageListActiveItemBackgroundColor">#ff33b5e5</item>
         <item name="messageListDividerColor">#ff333333</item>
         <item name="messageListCheckbox">@drawable/btn_check_message_list_dark</item>
+        <item name="messageListSeparatorForegroundColor">#f9f9f9</item>
+        <item name="messageListSeparatorBackgroundColor">#FF606060</item>
         <item name="messageViewBackgroundColor">#000000</item>
         <item name="messageViewAttachmentBackground">@drawable/attachment_text_box_dark</item>
         <item name="messageComposeAddContactImage">@drawable/ic_button_add_contact_dark</item>

--- a/k9mail/src/main/res/xml/global_preferences.xml
+++ b/k9mail/src/main/res/xml/global_preferences.xml
@@ -147,6 +147,12 @@
 
             <CheckBoxPreference
                 android:persistent="false"
+                android:key="messagelist_groups"
+                android:title="@string/global_settings_groups_label"
+                android:summary="@string/global_settings_groups_summary" />
+
+            <CheckBoxPreference
+                android:persistent="false"
                 android:key="messagelist_checkboxes"
                 android:title="@string/global_settings_checkbox_label"
                 android:summary="@string/global_settings_checkbox_summary" />


### PR DESCRIPTION
Date separators show when messagelist is sorted on date or on arrival
Will be pleased to add a preference to toggle this behaviour
but first must be sure you like this and will use this in k9

I only added the translations for English, French, German and Dutch. Other languages are beyond my knowledge.

![omail_messages_light](https://user-images.githubusercontent.com/6112759/32702368-845af0ac-c7e6-11e7-8744-77ddbd0e0bdc.png)

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


