### PR TITLE
Split synchronization code

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -40,7 +40,7 @@ import timber.log.Timber;
 import static com.fsck.k9.mail.store.imap.ImapUtility.getLastResponse;
 
 
-class ImapFolder extends Folder<ImapMessage> {
+public class ImapFolder extends Folder<ImapMessage> {
     private static final ThreadLocal<SimpleDateFormat> RFC3501_DATE = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapMessage.java
@@ -9,7 +9,7 @@ import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.MimeMessage;
 
 
-class ImapMessage extends MimeMessage {
+public class ImapMessage extends MimeMessage {
     ImapMessage(String uid, Folder folder) {
         this.mUid = uid;
         this.mFolder = folder;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -136,6 +136,10 @@ public class ImapStore extends RemoteStore {
         return combinedPrefix;
     }
 
+    public static boolean isStoreUriImap(String storeUri) {
+        return storeUri.startsWith("imap");
+    }
+
     @Override
     public List<ImapFolder> getPersonalNamespaces(boolean forceListAll) throws MessagingException {
         ImapConnection connection = getConnection();

--- a/k9mail/src/main/java/com/fsck/k9/controller/FlagSyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/FlagSyncHelper.java
@@ -109,7 +109,7 @@ class FlagSyncHelper<T extends Message> {
 
     private boolean syncFlags(LocalMessage localMessage, Message remoteMessage) throws MessagingException {
         boolean messageChanged = false;
-        if (localMessage == null || localMessage.isSet(Flag.DELETED)) {
+        if (localMessage == null) {
             return false;
         }
         if (remoteMessage.isSet(Flag.DELETED)) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/FlagSyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/FlagSyncHelper.java
@@ -1,0 +1,130 @@
+package com.fsck.k9.controller;
+
+
+import java.util.EnumSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import android.content.Context;
+import android.support.annotation.VisibleForTesting;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.activity.MessageReference;
+import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.mail.FetchProfile;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import com.fsck.k9.notification.NotificationController;
+import timber.log.Timber;
+
+
+class FlagSyncHelper<T extends Message> {
+
+    private static final Set<Flag> SYNC_FLAGS = EnumSet.of(Flag.SEEN, Flag.FLAGGED, Flag.ANSWERED, Flag.FORWARDED);
+
+    private final Context context;
+    private final MessagingController controller;
+    private final Contacts contacts;
+    private final NotificationController notificationController;
+    private final SyncHelper syncHelper;
+
+    public static FlagSyncHelper newInstance(Context context, MessagingController controller, SyncHelper syncHelper) {
+        Context appContext = context.getApplicationContext();
+        Contacts contacts = Contacts.getInstance(context);
+        NotificationController notificationController = NotificationController.newInstance(appContext);
+        return new FlagSyncHelper(appContext, controller, contacts, notificationController, syncHelper);
+    }
+
+    private FlagSyncHelper(Context context, MessagingController controller, Contacts contacts,
+            NotificationController notificationController, SyncHelper syncHelper) {
+        this.context = context;
+        this.controller = controller;
+        this.contacts = contacts;
+        this.notificationController = notificationController;
+        this.syncHelper = syncHelper;
+    }
+
+    void refreshLocalMessageFlags(final Account account, final Folder<T> remoteFolder, final LocalFolder localFolder,
+            List<T> syncFlagMessages) throws MessagingException {
+        final String folderName = remoteFolder.getName();
+        if (remoteFolder.supportsFetchingFlags()) {
+            Timber.d("SYNC: About to sync flags for %d remote messages for folder %s", syncFlagMessages.size(),
+                    folderName);
+
+            FetchProfile fp = new FetchProfile();
+            fp.add(FetchProfile.Item.FLAGS);
+
+            List<T> undeletedMessages = new LinkedList<>();
+            for (T message : syncFlagMessages) {
+                if (!message.isSet(Flag.DELETED)) {
+                    undeletedMessages.add(message);
+                }
+            }
+
+            remoteFolder.fetch(undeletedMessages, fp, null);
+
+            final AtomicInteger progress = new AtomicInteger(0);
+            int todo = syncFlagMessages.size();
+            for (Message remoteMessage : syncFlagMessages) {
+                processDownloadedFlags(account, localFolder, remoteMessage);
+                progress.incrementAndGet();
+                for (MessagingListener l : controller.getListeners()) {
+                    l.synchronizeMailboxProgress(account, folderName, progress.get(), todo);
+                }
+            }
+        }
+    }
+
+    @VisibleForTesting
+    void processDownloadedFlags(Account account, LocalFolder localFolder, Message remoteMessage)
+            throws MessagingException {
+        String folderName = localFolder.getName();
+        LocalMessage localMessage = localFolder.getMessage(remoteMessage.getUid());
+        boolean messageChanged = syncFlags(localMessage, remoteMessage);
+        if (messageChanged) {
+            boolean shouldBeNotifiedOf = false;
+            if (localMessage.isSet(Flag.DELETED) || syncHelper.isMessageSuppressed(localMessage, context)) {
+                for (MessagingListener l : controller.getListeners()) {
+                    l.synchronizeMailboxRemovedMessage(account, folderName, localMessage);
+                }
+            } else {
+                if (syncHelper.shouldNotifyForMessage(account, localFolder, localMessage, contacts)) {
+                    shouldBeNotifiedOf = true;
+                }
+            }
+
+            // we're only interested in messages that need removing
+            if (!shouldBeNotifiedOf) {
+                MessageReference messageReference = localMessage.makeMessageReference();
+                notificationController.removeNewMailNotification(account, messageReference);
+            }
+        }
+    }
+
+    private boolean syncFlags(LocalMessage localMessage, Message remoteMessage) throws MessagingException {
+        boolean messageChanged = false;
+        if (localMessage == null || localMessage.isSet(Flag.DELETED)) {
+            return false;
+        }
+        if (remoteMessage.isSet(Flag.DELETED)) {
+            if (localMessage.getFolder().syncRemoteDeletions()) {
+                localMessage.setFlag(Flag.DELETED, true);
+                messageChanged = true;
+            }
+        } else {
+            for (Flag flag : SYNC_FLAGS) {
+                if (remoteMessage.isSet(flag) != localMessage.isSet(flag)) {
+                    localMessage.setFlag(flag, remoteMessage.isSet(flag));
+                    messageChanged = true;
+                }
+            }
+        }
+        return messageChanged;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -62,7 +62,8 @@ class ImapSyncInteractor {
             } else {
                 imapFolder = getImapFolder(account, folderName);
 
-                if (!syncHelper.verifyOrCreateRemoteSpecialFolder(account, folderName, imapFolder, listener, controller)) {
+                if (!syncHelper.verifyOrCreateRemoteSpecialFolder(account, folderName, imapFolder, listener,
+                        controller)) {
                     return;
                 }
 
@@ -126,12 +127,12 @@ class ImapSyncInteractor {
             }
         } catch (Exception e) {
             Timber.e(e, "synchronizeMailbox");
-            // If we don't set the last checked, it can try too often during
-            // failure conditions
             String rootMessage = MessagingController.getRootCauseMessage(e);
             if (localFolder != null) {
                 try {
                     localFolder.setStatus(rootMessage);
+                    // If we don't set the last checked, it can try too often during
+                    // failure conditions
                     localFolder.setLastChecked(System.currentTimeMillis());
                 } catch (MessagingException me) {
                     Timber.e(e, "Could not set last checked on folder %s:%s",

--- a/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/ImapSyncInteractor.java
@@ -1,0 +1,180 @@
+package com.fsck.k9.controller;
+
+
+import com.fsck.k9.Account;
+import com.fsck.k9.Account.Expunge;
+import com.fsck.k9.mail.AuthenticationFailedException;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.Store;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.notification.NotificationController;
+import timber.log.Timber;
+
+
+class ImapSyncInteractor {
+
+    private final SyncHelper syncHelper;
+    private final FlagSyncHelper flagSyncHelper;
+    private final MessagingController controller;
+    private final MessageDownloader messageDownloader;
+    private final NotificationController notificationController;
+
+    ImapSyncInteractor(SyncHelper syncHelper, FlagSyncHelper flagSyncHelper, MessagingController controller,
+            MessageDownloader messageDownloader, NotificationController notificationController) {
+        this.syncHelper = syncHelper;
+        this.flagSyncHelper = flagSyncHelper;
+        this.controller = controller;
+        this.messageDownloader = messageDownloader;
+        this.notificationController = notificationController;
+    }
+
+    void performSync(Account account, String folderName, MessagingListener listener, Folder providedRemoteFolder) {
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxStarted(account, folderName);
+        }
+
+        Exception commandException = null;
+        LocalFolder localFolder = null;
+        ImapFolder imapFolder = null;
+
+        try {
+            Timber.d("SYNC: About to process pending commands for account %s", account.getDescription());
+
+            try {
+                controller.processPendingCommandsSynchronous(account);
+            } catch (Exception e) {
+                Timber.e(e, "Failure processing command, but allow message sync attempt");
+                commandException = e;
+            }
+
+            localFolder = getOpenedLocalFolder(account, folderName);
+            localFolder.updateLastUid();
+            if (providedRemoteFolder != null) {
+                if (providedRemoteFolder instanceof ImapFolder) {
+                    Timber.v("SYNC: using providedRemoteFolder %s", folderName);
+                    imapFolder = (ImapFolder) providedRemoteFolder;
+                } else {
+                    throw new IllegalArgumentException("A non-IMAP account was provided to ImapSyncInteractor");
+                }
+            } else {
+                imapFolder = getImapFolder(account, folderName);
+
+                if (!syncHelper.verifyOrCreateRemoteSpecialFolder(account, folderName, imapFolder, listener, controller)) {
+                    return;
+                }
+
+                Timber.v("SYNC: About to open remote folder %s", folderName);
+
+                if (Expunge.EXPUNGE_ON_POLL == account.getExpungePolicy()) {
+                    Timber.d("SYNC: Expunging folder %s:%s", account.getDescription(), folderName);
+                    imapFolder.expunge();
+                }
+                imapFolder.open(Folder.OPEN_MODE_RO);
+            }
+
+            notificationController.clearAuthenticationErrorNotification(account, true);
+
+            int remoteMessageCount = imapFolder.getMessageCount();
+            if (remoteMessageCount < 0) {
+                throw new IllegalStateException("Message count " + remoteMessageCount + " for folder " + folderName);
+            }
+
+            Timber.v("SYNC: Remote message count for folder %s is %d", folderName, remoteMessageCount);
+
+            int newMessages;
+            NonQresyncExtensionHandler handler = new NonQresyncExtensionHandler(syncHelper, flagSyncHelper,
+                    controller, messageDownloader);
+            newMessages = handler.continueSync(account, localFolder, imapFolder, listener);
+
+            int unreadMessageCount = localFolder.getUnreadMessageCount();
+            for (MessagingListener l : controller.getListeners()) {
+                l.folderStatusChanged(account, folderName, unreadMessageCount);
+            }
+
+            localFolder.setLastChecked(System.currentTimeMillis());
+            localFolder.setStatus(null);
+
+            Timber.d("Done synchronizing folder %s:%s @ %tc with %d new messages",
+                    account.getDescription(),
+                    folderName,
+                    System.currentTimeMillis(),
+                    newMessages);
+
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxFinished(account, folderName, imapFolder.getMessageCount(), newMessages);
+            }
+
+            if (commandException != null) {
+                String rootMessage = MessagingController.getRootCauseMessage(commandException);
+                Timber.e("Root cause failure in %s:%s was '%s'",
+                        account.getDescription(), folderName, rootMessage);
+                localFolder.setStatus(rootMessage);
+                for (MessagingListener l : controller.getListeners(listener)) {
+                    l.synchronizeMailboxFailed(account, folderName, rootMessage);
+                }
+            }
+
+            Timber.i("Done synchronizing folder %s:%s", account.getDescription(), folderName);
+
+        } catch (AuthenticationFailedException e) {
+            controller.handleAuthenticationFailure(account, true);
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxFailed(account, folderName, "Authentication failure");
+            }
+        } catch (Exception e) {
+            Timber.e(e, "synchronizeMailbox");
+            // If we don't set the last checked, it can try too often during
+            // failure conditions
+            String rootMessage = MessagingController.getRootCauseMessage(e);
+            if (localFolder != null) {
+                try {
+                    localFolder.setStatus(rootMessage);
+                    localFolder.setLastChecked(System.currentTimeMillis());
+                } catch (MessagingException me) {
+                    Timber.e(e, "Could not set last checked on folder %s:%s",
+                            account.getDescription(), localFolder.getName());
+                }
+            }
+
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxFailed(account, folderName, rootMessage);
+            }
+            controller.notifyUserIfCertificateProblem(account, e, true);
+            Timber.e("Failed synchronizing folder %s:%s @ %tc", account.getDescription(), folderName,
+                    System.currentTimeMillis());
+
+        } finally {
+            closeFolder(localFolder);
+            if (providedRemoteFolder == null) {
+                closeFolder(imapFolder);
+            }
+        }
+    }
+
+    private LocalFolder getOpenedLocalFolder(Account account, String folderName) throws MessagingException {
+        Timber.v("SYNC: About to get local folder %s and open it", folderName);
+        final LocalStore localStore = account.getLocalStore();
+        LocalFolder localFolder = localStore.getFolder(folderName);
+        localFolder.open(Folder.OPEN_MODE_RW);
+        return localFolder;
+    }
+
+    private ImapFolder getImapFolder(Account account, String folderName) throws MessagingException {
+        Store remoteStore = account.getRemoteStore();
+        Timber.v("SYNC: About to get remote IMAP folder %s", folderName);
+        Folder remoteFolder = remoteStore.getFolder(folderName);
+        if (!(remoteFolder instanceof ImapFolder)) {
+            throw new IllegalArgumentException("A non-IMAP account was provided to ImapSyncInteractor");
+        }
+        return  (ImapFolder) remoteFolder;
+    }
+
+    private void closeFolder(Folder folder) {
+        if (folder != null) {
+            folder.close();
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
@@ -1,0 +1,336 @@
+package com.fsck.k9.controller;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.Account.Expunge;
+import com.fsck.k9.K9;
+import com.fsck.k9.mail.AuthenticationFailedException;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Folder.FolderType;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.Store;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
+import com.fsck.k9.mailstore.LocalMessage;
+import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.notification.NotificationController;
+import timber.log.Timber;
+
+/* This class contains code that used to be present directly in the MessagingController. It used to represent a common
+synchronization mechanism for all types of accounts. Currently, it is used for synchronization of POP3 and WebDAV
+accounts only
+ */
+class LegacySyncInteractor {
+
+    private final MessagingController controller;
+    private final MessageDownloader messageDownloader;
+    private final NotificationController notificationController;
+
+    LegacySyncInteractor(MessagingController controller, MessageDownloader messageDownloader,
+            NotificationController notificationController) {
+        this.controller = controller;
+        this.messageDownloader = messageDownloader;
+        this.notificationController = notificationController;
+    }
+
+    void performSync(Account account, String folderName, MessagingListener listener, Folder<? extends Message> providedRemoteFolder) {
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxStarted(account, folderName);
+        }
+
+        Exception commandException = null;
+        LocalFolder localFolder = null;
+        Folder<? extends Message> remoteFolder = null;
+
+        try {
+            Timber.d("SYNC: About to process pending commands for account %s", account.getDescription());
+
+            try {
+                controller.processPendingCommandsSynchronous(account);
+            } catch (Exception e) {
+                Timber.e(e, "Failure processing command, but allow message sync attempt");
+                commandException = e;
+            }
+
+            /*
+             * Get the message list from the local store and create an index of
+             * the uids within the list.
+             */
+            Timber.v("SYNC: About to get local folder %s", folderName);
+
+            final LocalStore localStore = account.getLocalStore();
+            localFolder = localStore.getFolder(folderName);
+            localFolder.open(Folder.OPEN_MODE_RW);
+            localFolder.updateLastUid();
+            Map<String, Long> localUidMap = localFolder.getAllMessagesAndEffectiveDates();
+
+            if (providedRemoteFolder != null) {
+                Timber.v("SYNC: using providedRemoteFolder %s", folderName);
+                remoteFolder = providedRemoteFolder;
+            } else {
+                Store remoteStore = account.getRemoteStore();
+
+                Timber.v("SYNC: About to get remote folder %s", folderName);
+                remoteFolder = remoteStore.getFolder(folderName);
+
+                if (!verifyOrCreateRemoteSpecialFolder(account, folderName, remoteFolder, listener)) {
+                    return;
+                }
+
+
+                /*
+                 * Synchronization process:
+                 *
+                Open the folder
+                Upload any local messages that are marked as PENDING_UPLOAD (Drafts, Sent, Trash)
+                Get the message count
+                Get the list of the newest K9.DEFAULT_VISIBLE_LIMIT messages
+                getMessages(messageCount - K9.DEFAULT_VISIBLE_LIMIT, messageCount)
+                See if we have each message locally, if not fetch it's flags and envelope
+                Get and update the unread count for the folder
+                Update the remote flags of any messages we have locally with an internal date newer than the remote message.
+                Get the current flags for any messages we have locally but did not just download
+                Update local flags
+                For any message we have locally but not remotely, delete the local message to keep cache clean.
+                Download larger parts of any new messages.
+                (Optional) Download small attachments in the background.
+                 */
+
+                /*
+                 * Open the remote folder. This pre-loads certain metadata like message count.
+                 */
+                Timber.v("SYNC: About to open remote folder %s", folderName);
+
+                if (Expunge.EXPUNGE_ON_POLL == account.getExpungePolicy()) {
+                    Timber.d("SYNC: Expunging folder %s:%s", account.getDescription(), folderName);
+                    remoteFolder.expunge();
+                }
+                remoteFolder.open(Folder.OPEN_MODE_RO);
+            }
+
+            notificationController.clearAuthenticationErrorNotification(account, true);
+
+            /*
+             * Get the remote message count.
+             */
+            int remoteMessageCount = remoteFolder.getMessageCount();
+
+            int visibleLimit = localFolder.getVisibleLimit();
+
+            if (visibleLimit < 0) {
+                visibleLimit = K9.DEFAULT_VISIBLE_LIMIT;
+            }
+
+            final List<Message> remoteMessages = new ArrayList<>();
+            Map<String, Message> remoteUidMap = new HashMap<>();
+
+            Timber.v("SYNC: Remote message count for folder %s is %d", folderName, remoteMessageCount);
+
+            final Date earliestDate = account.getEarliestPollDate();
+            long earliestTimestamp = earliestDate != null ? earliestDate.getTime() : 0L;
+
+
+            int remoteStart = 1;
+            if (remoteMessageCount > 0) {
+                /* Message numbers start at 1.  */
+                if (visibleLimit > 0) {
+                    remoteStart = Math.max(0, remoteMessageCount - visibleLimit) + 1;
+                } else {
+                    remoteStart = 1;
+                }
+
+                Timber.v("SYNC: About to get messages %d through %d for folder %s",
+                        remoteStart, remoteMessageCount, folderName);
+
+                final AtomicInteger headerProgress = new AtomicInteger(0);
+                for (MessagingListener l : controller.getListeners(listener)) {
+                    l.synchronizeMailboxHeadersStarted(account, folderName);
+                }
+
+
+                List<? extends Message> remoteMessageArray =
+                        remoteFolder.getMessages(remoteStart, remoteMessageCount, earliestDate, null);
+
+                int messageCount = remoteMessageArray.size();
+
+                for (Message thisMess : remoteMessageArray) {
+                    headerProgress.incrementAndGet();
+                    for (MessagingListener l : controller.getListeners(listener)) {
+                        l.synchronizeMailboxHeadersProgress(account, folderName, headerProgress.get(), messageCount);
+                    }
+                    Long localMessageTimestamp = localUidMap.get(thisMess.getUid());
+                    if (localMessageTimestamp == null || localMessageTimestamp >= earliestTimestamp) {
+                        remoteMessages.add(thisMess);
+                        remoteUidMap.put(thisMess.getUid(), thisMess);
+                    }
+                }
+
+                Timber.v("SYNC: Got %d messages for folder %s", remoteUidMap.size(), folderName);
+
+                for (MessagingListener l : controller.getListeners(listener)) {
+                    l.synchronizeMailboxHeadersFinished(account, folderName, headerProgress.get(), remoteUidMap.size());
+                }
+
+            } else if (remoteMessageCount < 0) {
+                throw new Exception("Message count " + remoteMessageCount + " for folder " + folderName);
+            }
+
+            /*
+             * Remove any messages that are in the local store but no longer on the remote store or are too old
+             */
+            MoreMessages moreMessages = localFolder.getMoreMessages();
+            if (account.syncRemoteDeletions()) {
+                List<String> destroyMessageUids = new ArrayList<>();
+                for (String localMessageUid : localUidMap.keySet()) {
+                    if (remoteUidMap.get(localMessageUid) == null) {
+                        destroyMessageUids.add(localMessageUid);
+                    }
+                }
+
+                List<LocalMessage> destroyMessages = localFolder.getMessagesByUids(destroyMessageUids);
+                if (!destroyMessageUids.isEmpty()) {
+                    moreMessages = MoreMessages.UNKNOWN;
+
+                    localFolder.destroyMessages(destroyMessages);
+
+                    for (Message destroyMessage : destroyMessages) {
+                        for (MessagingListener l : controller.getListeners(listener)) {
+                            l.synchronizeMailboxRemovedMessage(account, folderName, destroyMessage);
+                        }
+                    }
+                }
+            }
+            // noinspection UnusedAssignment, free memory early? (better break up the method!)
+            localUidMap = null;
+
+            if (moreMessages == MoreMessages.UNKNOWN) {
+                updateMoreMessages(remoteFolder, localFolder, earliestDate, remoteStart);
+            }
+
+            /*
+             * Now we download the actual content of messages.
+             */
+            int newMessages = messageDownloader.downloadMessages(account, remoteFolder, localFolder,
+                    remoteMessages, false, true);
+
+            int unreadMessageCount = localFolder.getUnreadMessageCount();
+            for (MessagingListener l : controller.getListeners()) {
+                l.folderStatusChanged(account, folderName, unreadMessageCount);
+            }
+            /* Notify listeners that we're finally done. */
+
+            localFolder.setLastChecked(System.currentTimeMillis());
+            localFolder.setStatus(null);
+
+            Timber.d("Done synchronizing folder %s:%s @ %tc with %d new messages",
+                    account.getDescription(),
+                    folderName,
+                    System.currentTimeMillis(),
+                    newMessages);
+
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxFinished(account, folderName, remoteMessageCount, newMessages);
+            }
+
+
+            if (commandException != null) {
+                String rootMessage = MessagingController.getRootCauseMessage(commandException);
+                Timber.e("Root cause failure in %s:%s was '%s'",
+                        account.getDescription(), folderName, rootMessage);
+                localFolder.setStatus(rootMessage);
+                for (MessagingListener l : controller.getListeners(listener)) {
+                    l.synchronizeMailboxFailed(account, folderName, rootMessage);
+                }
+            }
+
+            Timber.i("Done synchronizing folder %s:%s", account.getDescription(), folderName);
+
+        } catch (AuthenticationFailedException e) {
+            controller.handleAuthenticationFailure(account, true);
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxFailed(account, folderName, "Authentication failure");
+            }
+        } catch (Exception e) {
+            Timber.e(e, "synchronizeMailbox");
+            // If we don't set the last checked, it can try too often during
+            // failure conditions
+            String rootMessage = MessagingController.getRootCauseMessage(e);
+            if (localFolder != null) {
+                try {
+                    localFolder.setStatus(rootMessage);
+                    localFolder.setLastChecked(System.currentTimeMillis());
+                } catch (MessagingException me) {
+                    Timber.e(e, "Could not set last checked on folder %s:%s",
+                            account.getDescription(), folderName);
+                }
+            }
+
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxFailed(account, folderName, rootMessage);
+            }
+            controller.notifyUserIfCertificateProblem(account, e, true);
+            Timber.e("Failed synchronizing folder %s:%s @ %tc", account.getDescription(), folderName,
+                    System.currentTimeMillis());
+
+        } finally {
+            closeFolder(localFolder);
+            if (providedRemoteFolder == null) {
+                closeFolder(remoteFolder);
+            }
+        }
+    }
+
+    /*
+     * If the folder is a "special" folder we need to see if it exists
+     * on the remote server. It if does not exist we'll try to create it. If we
+     * can't create we'll abort. This will happen on every single Pop3 folder as
+     * designed and on Imap folders during error conditions. This allows us
+     * to treat Pop3 and Imap the same in this code.
+     */
+    private boolean verifyOrCreateRemoteSpecialFolder(Account account, String folder, Folder remoteFolder,
+            MessagingListener listener) throws MessagingException {
+        if (folder.equals(account.getTrashFolderName()) ||
+                folder.equals(account.getSentFolderName()) ||
+                folder.equals(account.getDraftsFolderName())) {
+            if (!remoteFolder.exists()) {
+                if (!remoteFolder.create(FolderType.HOLDS_MESSAGES)) {
+                    for (MessagingListener l : controller.getListeners(listener)) {
+                        l.synchronizeMailboxFinished(account, folder, 0, 0);
+                    }
+
+                    Timber.i("Done synchronizing folder %s", folder);
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private void updateMoreMessages(Folder remoteFolder, LocalFolder localFolder, Date earliestDate, int remoteStart)
+            throws MessagingException, IOException {
+
+        if (remoteStart == 1) {
+            localFolder.setMoreMessages(MoreMessages.FALSE);
+        } else {
+            boolean moreMessagesAvailable = remoteFolder.areMoreMessagesAvailable(remoteStart, earliestDate);
+
+            MoreMessages newMoreMessages = (moreMessagesAvailable) ? MoreMessages.TRUE : MoreMessages.FALSE;
+            localFolder.setMoreMessages(newMoreMessages);
+        }
+    }
+
+    private void closeFolder(Folder folder) {
+        if (folder != null) {
+            folder.close();
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/LegacySyncInteractor.java
@@ -25,10 +25,11 @@ import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.notification.NotificationController;
 import timber.log.Timber;
 
-/* This class contains code that used to be present directly in the MessagingController. It used to represent a common
-synchronization mechanism for all types of accounts. Currently, it is used for synchronization of POP3 and WebDAV
-accounts only
- */
+/**
+ * This class contains code that used to be present directly in the MessagingController. It used to represent a common
+ * synchronization mechanism for all types of accounts. Currently, it is used for synchronization of POP3 and WebDAV
+ * accounts only.
+ **/
 class LegacySyncInteractor {
 
     private final MessagingController controller;

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessageDownloader.java
@@ -1,0 +1,492 @@
+package com.fsck.k9.controller;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import android.content.Context;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.AccountStats;
+import com.fsck.k9.K9;
+import com.fsck.k9.Preferences;
+import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.mail.BodyFactory;
+import com.fsck.k9.mail.DefaultBodyFactory;
+import com.fsck.k9.mail.FetchProfile;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessageRetrievalListener;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.Part;
+import com.fsck.k9.mail.internet.MessageExtractor;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import com.fsck.k9.mailstore.MessageRemovalListener;
+import com.fsck.k9.notification.NotificationController;
+import timber.log.Timber;
+
+
+class MessageDownloader {
+    private final Context context;
+    private final MessagingController controller;
+    private final Contacts contacts;
+    private final NotificationController notificationController;
+    private final SyncHelper syncHelper;
+
+    public static MessageDownloader newInstance(Context context, MessagingController controller, SyncHelper syncHelper) {
+        Context appContext = context.getApplicationContext();
+        Contacts contacts = Contacts.getInstance(context);
+        NotificationController notificationController = NotificationController.newInstance(appContext);
+        return new MessageDownloader(appContext, controller, contacts, notificationController, syncHelper);
+    }
+
+    private MessageDownloader(Context context, MessagingController controller, Contacts contacts,
+            NotificationController notificationController, SyncHelper syncHelper) {
+        this.context = context;
+        this.controller = controller;
+        this.contacts = contacts;
+        this.notificationController = notificationController;
+        this.syncHelper = syncHelper;
+    }
+
+    /**
+     * Fetches the messages described by inputMessages from the remote store and writes them to
+     * local storage.
+     *
+     * @param account
+     *         The account the remote store belongs to.
+     * @param remoteFolder
+     *         The remote folder to download messages from.
+     * @param localFolder
+     *         The {@link LocalFolder} instance corresponding to the remote folder.
+     * @param inputMessages
+     *         A list of message objects that store the UIDs of which messages to download.
+     * @param flagSyncOnly
+     *         Only flags will be fetched from the remote store if this is {@code true}.
+     * @param purgeToVisibleLimit
+     *         If true, local messages will be purged down to the limit of visible messages.
+     *
+     * @return The number of downloaded messages that are not flagged as {@link Flag#SEEN}.
+     *
+     * @throws MessagingException
+     */
+    int downloadMessages(final Account account, final Folder remoteFolder, final LocalFolder localFolder,
+            List<? extends Message> inputMessages, boolean flagSyncOnly, boolean purgeToVisibleLimit)
+            throws MessagingException {
+
+        final Date earliestDate = account.getEarliestPollDate();
+        Date downloadStarted = new Date(); // now
+
+        if (earliestDate != null) {
+            Timber.d("Only syncing messages after %s", earliestDate);
+        }
+        final String folderName = remoteFolder.getName();
+
+        int unreadBeforeStart = 0;
+        try {
+            AccountStats stats = account.getStats(context);
+            unreadBeforeStart = stats.unreadMessageCount;
+
+        } catch (MessagingException e) {
+            Timber.e(e, "Unable to getUnreadMessageCount for account: %s", account);
+        }
+
+        List<Message> syncFlagMessages = new ArrayList<>();
+        List<Message> unsyncedMessages = new ArrayList<>();
+        final AtomicInteger newMessages = new AtomicInteger(0);
+
+        List<Message> messages = new ArrayList<>(inputMessages);
+
+        for (Message message : messages) {
+            syncHelper.evaluateMessageForDownload(message, folderName, localFolder, remoteFolder, account,
+                    unsyncedMessages, syncFlagMessages, flagSyncOnly, controller);
+        }
+
+        final AtomicInteger progress = new AtomicInteger(0);
+        final int todo = unsyncedMessages.size();
+        for (MessagingListener l : controller.getListeners()) {
+            l.synchronizeMailboxProgress(account, folderName, progress.get(), todo);
+        }
+
+        Timber.d("SYNC: Have %d unsynced messages", unsyncedMessages.size());
+
+        messages.clear();
+        final List<Message> largeMessages = new ArrayList<>();
+        final List<Message> smallMessages = new ArrayList<>();
+        if (!unsyncedMessages.isEmpty()) {
+
+            /*
+             * Reverse the order of the messages. Depending on the server this may get us
+             * fetch results for newest to oldest. If not, no harm done.
+             */
+            Collections.sort(unsyncedMessages, new UidReverseComparator());
+            int visibleLimit = localFolder.getVisibleLimit();
+            int listSize = unsyncedMessages.size();
+
+            if ((visibleLimit > 0) && (listSize > visibleLimit)) {
+                unsyncedMessages = unsyncedMessages.subList(0, visibleLimit);
+            }
+
+            FetchProfile fp = new FetchProfile();
+            if (remoteFolder.supportsFetchingFlags()) {
+                fp.add(FetchProfile.Item.FLAGS);
+            }
+            fp.add(FetchProfile.Item.ENVELOPE);
+
+            Timber.d("SYNC: About to fetch %d unsynced messages for folder %s", unsyncedMessages.size(), folderName);
+
+            fetchUnsyncedMessages(account, remoteFolder, unsyncedMessages, smallMessages, largeMessages, progress, todo,
+                    fp);
+
+            String updatedPushState = localFolder.getPushState();
+            for (Message message : unsyncedMessages) {
+                String newPushState = remoteFolder.getNewPushState(updatedPushState, message);
+                if (newPushState != null) {
+                    updatedPushState = newPushState;
+                }
+            }
+            localFolder.setPushState(updatedPushState);
+
+            Timber.d("SYNC: Synced unsynced messages for folder %s", folderName);
+        }
+
+        Timber.d("SYNC: Have %d large messages and %d small messages out of %d unsynced messages",
+                largeMessages.size(), smallMessages.size(), unsyncedMessages.size());
+
+        unsyncedMessages.clear();
+        /*
+         * Grab the content of the small messages first. This is going to
+         * be very fast and at very worst will be a single up of a few bytes and a single
+         * download of 625k.
+         */
+        FetchProfile fp = new FetchProfile();
+        //TODO: Only fetch small and large messages if we have some
+        fp.add(FetchProfile.Item.BODY);
+        //        fp.add(FetchProfile.Item.FLAGS);
+        //        fp.add(FetchProfile.Item.ENVELOPE);
+        downloadSmallMessages(account, remoteFolder, localFolder, smallMessages, progress, unreadBeforeStart,
+                newMessages, todo, fp);
+        smallMessages.clear();
+        /*
+         * Now do the large messages that require more round trips.
+         */
+        fp = new FetchProfile();
+        fp.add(FetchProfile.Item.STRUCTURE);
+        downloadLargeMessages(account, remoteFolder, localFolder, largeMessages, progress, unreadBeforeStart,
+                newMessages, todo, fp);
+        largeMessages.clear();
+
+        Timber.d("SYNC: Synced remote messages for folder %s, %d new messages", folderName, newMessages.get());
+
+        FlagSyncHelper.newInstance(context, controller, syncHelper).refreshLocalMessageFlags(account, remoteFolder,
+                localFolder, syncFlagMessages);
+
+        Timber.d("SYNC: Synced remote messages for folder %s, %d new messages", folderName, newMessages.get());
+
+        if (purgeToVisibleLimit) {
+            localFolder.purgeToVisibleLimit(new MessageRemovalListener() {
+                @Override
+                public void messageRemoved(Message message) {
+                    for (MessagingListener l : controller.getListeners()) {
+                        l.synchronizeMailboxRemovedMessage(account, folderName, message);
+                    }
+                }
+
+            });
+        }
+
+        // If the oldest message seen on this sync is newer than
+        // the oldest message seen on the previous sync, then
+        // we want to move our high-water mark forward
+        // this is all here just for pop which only syncs inbox
+        // this would be a little wrong for IMAP (we'd want a folder-level pref, not an account level pref.)
+        // fortunately, we just don't care.
+        Long oldestMessageTime = localFolder.getOldestMessageDate();
+
+        if (oldestMessageTime != null) {
+            Date oldestExtantMessage = new Date(oldestMessageTime);
+            if (oldestExtantMessage.before(downloadStarted) &&
+                    oldestExtantMessage.after(new Date(account.getLatestOldMessageSeenTime()))) {
+                account.setLatestOldMessageSeenTime(oldestExtantMessage.getTime());
+                account.save(Preferences.getPreferences(context));
+            }
+
+        }
+        return newMessages.get();
+    }
+
+    private <T extends Message> void fetchUnsyncedMessages(final Account account, final Folder<T> remoteFolder,
+            List<T> unsyncedMessages,
+            final List<Message> smallMessages,
+            final List<Message> largeMessages,
+            final AtomicInteger progress,
+            final int todo,
+            FetchProfile fp) throws MessagingException {
+        final String folder = remoteFolder.getName();
+
+        final Date earliestDate = account.getEarliestPollDate();
+        remoteFolder.fetch(unsyncedMessages, fp,
+                new MessageRetrievalListener<T>() {
+                    @Override
+                    public void messageFinished(T message, int number, int ofTotal) {
+                        try {
+                            if (message.isSet(Flag.DELETED) || message.olderThan(earliestDate)) {
+                                if (K9.isDebug()) {
+                                    if (message.isSet(Flag.DELETED)) {
+                                        Timber.v("Newly downloaded message %s:%s:%s was marked deleted on server, " +
+                                                "skipping", account, folder, message.getUid());
+                                    } else {
+                                        Timber.d("Newly downloaded message %s is older than %s, skipping",
+                                                message.getUid(), earliestDate);
+                                    }
+                                }
+                                progress.incrementAndGet();
+                                for (MessagingListener l : controller.getListeners()) {
+                                    //TODO: This might be the source of poll count errors in the UI. Is todo always the
+                                    // same as ofTotal
+                                    l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
+                                }
+                                return;
+                            }
+
+                            if (account.getMaximumAutoDownloadMessageSize() > 0 &&
+                                    message.getSize() > account.getMaximumAutoDownloadMessageSize()) {
+                                largeMessages.add(message);
+                            } else {
+                                smallMessages.add(message);
+                            }
+                        } catch (Exception e) {
+                            Timber.e(e, "Error while storing downloaded message.");
+                        }
+                    }
+
+                    @Override
+                    public void messageStarted(String uid, int number, int ofTotal) {
+                    }
+
+                    @Override
+                    public void messagesFinished(int total) {
+                        // FIXME this method is almost never invoked by various Stores! Don't rely on it unless fixed!!
+                    }
+
+                });
+    }
+
+    private boolean shouldImportMessage(final Account account, final Message message,
+            final Date earliestDate) {
+
+        if (account.isSearchByDateCapable() && message.olderThan(earliestDate)) {
+            Timber.d("Message %s is older than %s, hence not saving", message.getUid(), earliestDate);
+            return false;
+        }
+        return true;
+    }
+
+    private <T extends Message> void downloadSmallMessages(final Account account, final Folder<T> remoteFolder,
+            final LocalFolder localFolder,
+            List<T> smallMessages,
+            final AtomicInteger progress,
+            final int unreadBeforeStart,
+            final AtomicInteger newMessages,
+            final int todo,
+            FetchProfile fp) throws MessagingException {
+        final String folder = remoteFolder.getName();
+
+        final Date earliestDate = account.getEarliestPollDate();
+
+        Timber.d("SYNC: Fetching %d small messages for folder %s", smallMessages.size(), folder);
+
+        remoteFolder.fetch(smallMessages,
+                fp, new MessageRetrievalListener<T>() {
+                    @Override
+                    public void messageFinished(final T message, int number, int ofTotal) {
+                        try {
+
+                            if (!shouldImportMessage(account, message, earliestDate)) {
+                                progress.incrementAndGet();
+
+                                return;
+                            }
+
+                            // Store the updated message locally
+                            final LocalMessage localMessage = localFolder.storeSmallMessage(message, new Runnable() {
+                                @Override
+                                public void run() {
+                                    progress.incrementAndGet();
+                                }
+                            });
+
+                            // Increment the number of "new messages" if the newly downloaded message is
+                            // not marked as read.
+                            if (!localMessage.isSet(Flag.SEEN)) {
+                                newMessages.incrementAndGet();
+                            }
+
+                            Timber.v("About to notify listeners that we got a new small message %s:%s:%s",
+                                    account, folder, message.getUid());
+
+                            // Update the listener with what we've found
+                            for (MessagingListener l : controller.getListeners()) {
+                                l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
+                                if (!localMessage.isSet(Flag.SEEN)) {
+                                    l.synchronizeMailboxNewMessage(account, folder, localMessage);
+                                }
+                            }
+                            // Send a notification of this message
+
+                            if (syncHelper.shouldNotifyForMessage(account, localFolder, message, contacts)) {
+                                // Notify with the localMessage so that we don't have to recalculate the content preview.
+                                notificationController.addNewMailNotification(account, localMessage, unreadBeforeStart);
+                            }
+
+                        } catch (MessagingException me) {
+                            Timber.e(me, "SYNC: fetch small messages");
+                        }
+                    }
+
+                    @Override
+                    public void messageStarted(String uid, int number, int ofTotal) {
+                    }
+
+                    @Override
+                    public void messagesFinished(int total) {
+                    }
+                });
+
+        Timber.d("SYNC: Done fetching small messages for folder %s", folder);
+    }
+
+    private <T extends Message> void downloadLargeMessages(final Account account, final Folder<T> remoteFolder,
+            final LocalFolder localFolder,
+            List<T> largeMessages,
+            final AtomicInteger progress,
+            final int unreadBeforeStart,
+            final AtomicInteger newMessages,
+            final int todo,
+            FetchProfile fp) throws MessagingException {
+        final String folder = remoteFolder.getName();
+        final Date earliestDate = account.getEarliestPollDate();
+
+        Timber.d("SYNC: Fetching large messages for folder %s", folder);
+
+        remoteFolder.fetch(largeMessages, fp, null);
+        for (T message : largeMessages) {
+
+            if (!shouldImportMessage(account, message, earliestDate)) {
+                progress.incrementAndGet();
+                continue;
+            }
+
+            if (message.getBody() == null) {
+                downloadSaneBody(account, remoteFolder, localFolder, message);
+            } else {
+                downloadPartial(remoteFolder, localFolder, message);
+            }
+
+            Timber.v("About to notify listeners that we got a new large message %s:%s:%s",
+                    account, folder, message.getUid());
+
+            // Update the listener with what we've found
+            progress.incrementAndGet();
+            // TODO do we need to re-fetch this here?
+            LocalMessage localMessage = localFolder.getMessage(message.getUid());
+            // Increment the number of "new messages" if the newly downloaded message is
+            // not marked as read.
+            if (!localMessage.isSet(Flag.SEEN)) {
+                newMessages.incrementAndGet();
+            }
+            for (MessagingListener l : controller.getListeners()) {
+                l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
+                if (!localMessage.isSet(Flag.SEEN)) {
+                    l.synchronizeMailboxNewMessage(account, folder, localMessage);
+                }
+            }
+            // Send a notification of this message
+            if (syncHelper.shouldNotifyForMessage(account, localFolder, message, contacts)) {
+                // Notify with the localMessage so that we don't have to recalculate the content preview.
+                notificationController.addNewMailNotification(account, localMessage, unreadBeforeStart);
+            }
+        }
+
+        Timber.d("SYNC: Done fetching large messages for folder %s", folder);
+    }
+
+    private void downloadPartial(Folder remoteFolder, LocalFolder localFolder, Message message)
+            throws MessagingException {
+        /*
+         * We have a structure to deal with, from which
+         * we can pull down the parts we want to actually store.
+         * Build a list of parts we are interested in. Text parts will be downloaded
+         * right now, attachments will be left for later.
+         */
+
+        Set<Part> viewables = MessageExtractor.collectTextParts(message);
+
+        /*
+         * Now download the parts we're interested in storing.
+         */
+        BodyFactory bodyFactory = new DefaultBodyFactory();
+        for (Part part : viewables) {
+            remoteFolder.fetchPart(message, part, null, bodyFactory);
+        }
+        // Store the updated message locally
+        localFolder.appendMessages(Collections.singletonList(message));
+
+        Message localMessage = localFolder.getMessage(message.getUid());
+
+        localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, true);
+    }
+
+    private void downloadSaneBody(Account account, Folder remoteFolder, LocalFolder localFolder, Message message)
+            throws MessagingException {
+        /*
+         * The provider was unable to get the structure of the message, so
+         * we'll download a reasonable portion of the messge and mark it as
+         * incomplete so the entire thing can be downloaded later if the user
+         * wishes to download it.
+         */
+        FetchProfile fp = new FetchProfile();
+        fp.add(FetchProfile.Item.BODY_SANE);
+                /*
+                 *  TODO a good optimization here would be to make sure that all Stores set
+                 *  the proper size after this fetch and compare the before and after size. If
+                 *  they equal we can mark this SYNCHRONIZED instead of PARTIALLY_SYNCHRONIZED
+                 */
+
+        remoteFolder.fetch(Collections.singletonList(message), fp, null);
+
+        // Store the updated message locally
+        localFolder.appendMessages(Collections.singletonList(message));
+
+        Message localMessage = localFolder.getMessage(message.getUid());
+
+
+        // Certain (POP3) servers give you the whole message even when you ask for only the first x Kb
+        if (!message.isSet(Flag.X_DOWNLOADED_FULL)) {
+                    /*
+                     * Mark the message as fully downloaded if the message size is smaller than
+                     * the account's autodownload size limit, otherwise mark as only a partial
+                     * download.  This will prevent the system from downloading the same message
+                     * twice.
+                     *
+                     * If there is no limit on autodownload size, that's the same as the message
+                     * being smaller than the max size
+                     */
+            if (account.getMaximumAutoDownloadMessageSize() == 0
+                    || message.getSize() < account.getMaximumAutoDownloadMessageSize()) {
+                localMessage.setFlag(Flag.X_DOWNLOADED_FULL, true);
+            } else {
+                // Set a flag indicating that the message has been partially downloaded and
+                // is ready for view.
+                localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, true);
+            }
+        }
+
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1,7 +1,6 @@
 package com.fsck.k9.controller;
 
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -62,9 +61,7 @@ import com.fsck.k9.controller.ProgressBodyFactory.ProgressListener;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.AuthenticationFailedException;
-import com.fsck.k9.mail.BodyFactory;
 import com.fsck.k9.mail.CertificateValidationException;
-import com.fsck.k9.mail.DefaultBodyFactory;
 import com.fsck.k9.mail.FetchProfile;
 import com.fsck.k9.mail.FetchProfile.Item;
 import com.fsck.k9.mail.Flag;
@@ -84,12 +81,11 @@ import com.fsck.k9.mail.internet.MessageExtractor;
 import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mail.power.TracingPowerManager;
 import com.fsck.k9.mail.power.TracingPowerManager.TracingWakeLock;
+import com.fsck.k9.mail.store.imap.ImapStore;
 import com.fsck.k9.mail.store.pop3.Pop3Store;
 import com.fsck.k9.mailstore.LocalFolder;
-import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
-import com.fsck.k9.mailstore.MessageRemovalListener;
 import com.fsck.k9.mailstore.UnavailableStorageException;
 import com.fsck.k9.notification.NotificationController;
 import com.fsck.k9.provider.EmailProvider;
@@ -130,6 +126,9 @@ public class MessagingController {
     private final Context context;
     private final Contacts contacts;
     private final NotificationController notificationController;
+    private final SyncHelper syncHelper;
+    private final FlagSyncHelper flagSyncHelper;
+    private final MessageDownloader messageDownloader;
 
     private final Thread controllerThread;
 
@@ -165,6 +164,9 @@ public class MessagingController {
         this.notificationController = notificationController;
         this.contacts = contacts;
         this.transportProvider = transportProvider;
+        syncHelper = SyncHelper.getInstance();
+        flagSyncHelper = FlagSyncHelper.newInstance(context, this, syncHelper);
+        messageDownloader = MessageDownloader.newInstance(context, this, syncHelper);
 
         controllerThread = new Thread(new Runnable() {
             @Override
@@ -294,14 +296,6 @@ public class MessagingController {
     private void unsuppressMessages(Account account, List<? extends Message> messages) {
         EmailProviderCache cache = EmailProviderCache.getCache(account.getUuid(), context);
         cache.unhideMessages(messages);
-    }
-
-    private boolean isMessageSuppressed(LocalMessage message) {
-        long messageId = message.getDatabaseId();
-        long folderId = message.getFolder().getDatabaseId();
-
-        EmailProviderCache cache = EmailProviderCache.getCache(message.getFolder().getAccountUuid(), context);
-        return cache.isMessageHidden(messageId, folderId);
     }
 
     private void setFlagInCache(final Account account, final List<Long> messageIds,
@@ -522,7 +516,7 @@ public class MessagingController {
 
                 @Override
                 public void messageFinished(LocalMessage message, int number, int ofTotal) {
-                    if (!isMessageSuppressed(message)) {
+                    if (!syncHelper.isMessageSuppressed(message, context)) {
                         List<LocalMessage> messages = new ArrayList<>();
 
                         messages.add(message);
@@ -715,290 +709,56 @@ public class MessagingController {
     /**
      * Start foreground synchronization of the specified folder. This is generally only called
      * by synchronizeMailbox.
-     * <p>
-     * TODO Break this method up into smaller chunks.
      */
     @VisibleForTesting
-    void synchronizeMailboxSynchronous(final Account account, final String folder, final MessagingListener listener,
-            Folder providedRemoteFolder) {
-        Folder remoteFolder = null;
-        LocalFolder tLocalFolder = null;
+    void synchronizeMailboxSynchronous(final Account account, final String folderName,
+            final MessagingListener listener, Folder providedRemoteFolder) {
 
-        Timber.i("Synchronizing folder %s:%s", account.getDescription(), folder);
+        /*
+         * Synchronization process:
+         *
+        Open the folder
+        Upload any local messages that are marked as PENDING_UPLOAD (Drafts, Sent, Trash)
+        Get the message count
+        Get the list of the newest K9.DEFAULT_VISIBLE_LIMIT messages
+        getMessages(messageCount - K9.DEFAULT_VISIBLE_LIMIT, messageCount)
+        See if we have each message locally, if not fetch it's flags and envelope
+        Get and update the unread count for the folder
+        Update the remote flags of any messages we have locally with an internal date newer than the remote message.
+        Get the current flags for any messages we have locally but did not just download
+        Update local flags
+        For any message we have locally but not remotely, delete the local message to keep cache clean.
+        Download larger parts of any new messages.
+        (Optional) Download small attachments in the background.
+         */
 
-        for (MessagingListener l : getListeners(listener)) {
-            l.synchronizeMailboxStarted(account, folder);
-        }
+        Timber.i("Synchronizing folder %s:%s", account.getDescription(), folderName);
+
         /*
          * We don't ever sync the Outbox
          */
-        if (folder.equals(account.getOutboxFolderName())) {
+        if (folderName.equals(account.getOutboxFolderName())) {
             for (MessagingListener l : getListeners(listener)) {
-                l.synchronizeMailboxFinished(account, folder, 0, 0);
+                l.synchronizeMailboxStarted(account, folderName);
+                l.synchronizeMailboxFinished(account, folderName, 0, 0);
             }
-
             return;
         }
 
-        Exception commandException = null;
-        try {
-            Timber.d("SYNC: About to process pending commands for account %s", account.getDescription());
-
-            try {
-                processPendingCommandsSynchronous(account);
-            } catch (Exception e) {
-                Timber.e(e, "Failure processing command, but allow message sync attempt");
-                commandException = e;
-            }
-
-            /*
-             * Get the message list from the local store and create an index of
-             * the uids within the list.
-             */
-            Timber.v("SYNC: About to get local folder %s", folder);
-
-            final LocalStore localStore = account.getLocalStore();
-            tLocalFolder = localStore.getFolder(folder);
-            final LocalFolder localFolder = tLocalFolder;
-            localFolder.open(Folder.OPEN_MODE_RW);
-            localFolder.updateLastUid();
-            Map<String, Long> localUidMap = localFolder.getAllMessagesAndEffectiveDates();
-
-            if (providedRemoteFolder != null) {
-                Timber.v("SYNC: using providedRemoteFolder %s", folder);
-                remoteFolder = providedRemoteFolder;
-            } else {
-                Store remoteStore = account.getRemoteStore();
-
-                Timber.v("SYNC: About to get remote folder %s", folder);
-                remoteFolder = remoteStore.getFolder(folder);
-
-                if (!verifyOrCreateRemoteSpecialFolder(account, folder, remoteFolder, listener)) {
-                    return;
-                }
-
-
-                /*
-                 * Synchronization process:
-                 *
-                Open the folder
-                Upload any local messages that are marked as PENDING_UPLOAD (Drafts, Sent, Trash)
-                Get the message count
-                Get the list of the newest K9.DEFAULT_VISIBLE_LIMIT messages
-                getMessages(messageCount - K9.DEFAULT_VISIBLE_LIMIT, messageCount)
-                See if we have each message locally, if not fetch it's flags and envelope
-                Get and update the unread count for the folder
-                Update the remote flags of any messages we have locally with an internal date newer than the remote message.
-                Get the current flags for any messages we have locally but did not just download
-                Update local flags
-                For any message we have locally but not remotely, delete the local message to keep cache clean.
-                Download larger parts of any new messages.
-                (Optional) Download small attachments in the background.
-                 */
-
-                /*
-                 * Open the remote folder. This pre-loads certain metadata like message count.
-                 */
-                Timber.v("SYNC: About to open remote folder %s", folder);
-
-                if (Expunge.EXPUNGE_ON_POLL == account.getExpungePolicy()) {
-                    Timber.d("SYNC: Expunging folder %s:%s", account.getDescription(), folder);
-                    remoteFolder.expunge();
-                }
-                remoteFolder.open(Folder.OPEN_MODE_RO);
-
-            }
-
-            notificationController.clearAuthenticationErrorNotification(account, true);
-
-            /*
-             * Get the remote message count.
-             */
-            int remoteMessageCount = remoteFolder.getMessageCount();
-
-            int visibleLimit = localFolder.getVisibleLimit();
-
-            if (visibleLimit < 0) {
-                visibleLimit = K9.DEFAULT_VISIBLE_LIMIT;
-            }
-
-            final List<Message> remoteMessages = new ArrayList<>();
-            Map<String, Message> remoteUidMap = new HashMap<>();
-
-            Timber.v("SYNC: Remote message count for folder %s is %d", folder, remoteMessageCount);
-
-            final Date earliestDate = account.getEarliestPollDate();
-            long earliestTimestamp = earliestDate != null ? earliestDate.getTime() : 0L;
-
-
-            int remoteStart = 1;
-            if (remoteMessageCount > 0) {
-                /* Message numbers start at 1.  */
-                if (visibleLimit > 0) {
-                    remoteStart = Math.max(0, remoteMessageCount - visibleLimit) + 1;
-                } else {
-                    remoteStart = 1;
-                }
-
-                Timber.v("SYNC: About to get messages %d through %d for folder %s",
-                        remoteStart, remoteMessageCount, folder);
-
-                final AtomicInteger headerProgress = new AtomicInteger(0);
-                for (MessagingListener l : getListeners(listener)) {
-                    l.synchronizeMailboxHeadersStarted(account, folder);
-                }
-
-
-                List<? extends Message> remoteMessageArray =
-                        remoteFolder.getMessages(remoteStart, remoteMessageCount, earliestDate, null);
-
-                int messageCount = remoteMessageArray.size();
-
-                for (Message thisMess : remoteMessageArray) {
-                    headerProgress.incrementAndGet();
-                    for (MessagingListener l : getListeners(listener)) {
-                        l.synchronizeMailboxHeadersProgress(account, folder, headerProgress.get(), messageCount);
-                    }
-                    Long localMessageTimestamp = localUidMap.get(thisMess.getUid());
-                    if (localMessageTimestamp == null || localMessageTimestamp >= earliestTimestamp) {
-                        remoteMessages.add(thisMess);
-                        remoteUidMap.put(thisMess.getUid(), thisMess);
-                    }
-                }
-
-                Timber.v("SYNC: Got %d messages for folder %s", remoteUidMap.size(), folder);
-
-                for (MessagingListener l : getListeners(listener)) {
-                    l.synchronizeMailboxHeadersFinished(account, folder, headerProgress.get(), remoteUidMap.size());
-                }
-
-            } else if (remoteMessageCount < 0) {
-                throw new Exception("Message count " + remoteMessageCount + " for folder " + folder);
-            }
-
-            /*
-             * Remove any messages that are in the local store but no longer on the remote store or are too old
-             */
-            MoreMessages moreMessages = localFolder.getMoreMessages();
-            if (account.syncRemoteDeletions()) {
-                List<String> destroyMessageUids = new ArrayList<>();
-                for (String localMessageUid : localUidMap.keySet()) {
-                    if (remoteUidMap.get(localMessageUid) == null) {
-                        destroyMessageUids.add(localMessageUid);
-                    }
-                }
-
-                List<LocalMessage> destroyMessages = localFolder.getMessagesByUids(destroyMessageUids);
-                if (!destroyMessageUids.isEmpty()) {
-                    moreMessages = MoreMessages.UNKNOWN;
-
-                    localFolder.destroyMessages(destroyMessages);
-
-                    for (Message destroyMessage : destroyMessages) {
-                        for (MessagingListener l : getListeners(listener)) {
-                            l.synchronizeMailboxRemovedMessage(account, folder, destroyMessage);
-                        }
-                    }
-                }
-            }
-            // noinspection UnusedAssignment, free memory early? (better break up the method!)
-            localUidMap = null;
-
-            if (moreMessages == MoreMessages.UNKNOWN) {
-                updateMoreMessages(remoteFolder, localFolder, earliestDate, remoteStart);
-            }
-
-            /*
-             * Now we download the actual content of messages.
-             */
-            int newMessages = downloadMessages(account, remoteFolder, localFolder, remoteMessages, false, true);
-
-            int unreadMessageCount = localFolder.getUnreadMessageCount();
-            for (MessagingListener l : getListeners()) {
-                l.folderStatusChanged(account, folder, unreadMessageCount);
-            }
-
-            /* Notify listeners that we're finally done. */
-
-            localFolder.setLastChecked(System.currentTimeMillis());
-            localFolder.setStatus(null);
-
-            Timber.d("Done synchronizing folder %s:%s @ %tc with %d new messages",
-                    account.getDescription(),
-                    folder,
-                    System.currentTimeMillis(),
-                    newMessages);
-
-            for (MessagingListener l : getListeners(listener)) {
-                l.synchronizeMailboxFinished(account, folder, remoteMessageCount, newMessages);
-            }
-
-
-            if (commandException != null) {
-                String rootMessage = getRootCauseMessage(commandException);
-                Timber.e("Root cause failure in %s:%s was '%s'",
-                        account.getDescription(), tLocalFolder.getName(), rootMessage);
-                localFolder.setStatus(rootMessage);
-                for (MessagingListener l : getListeners(listener)) {
-                    l.synchronizeMailboxFailed(account, folder, rootMessage);
-                }
-            }
-
-            Timber.i("Done synchronizing folder %s:%s", account.getDescription(), folder);
-
-        } catch (AuthenticationFailedException e) {
-            handleAuthenticationFailure(account, true);
-
-            for (MessagingListener l : getListeners(listener)) {
-                l.synchronizeMailboxFailed(account, folder, "Authentication failure");
-            }
-        } catch (Exception e) {
-            Timber.e(e, "synchronizeMailbox");
-            // If we don't set the last checked, it can try too often during
-            // failure conditions
-            String rootMessage = getRootCauseMessage(e);
-            if (tLocalFolder != null) {
-                try {
-                    tLocalFolder.setStatus(rootMessage);
-                    tLocalFolder.setLastChecked(System.currentTimeMillis());
-                } catch (MessagingException me) {
-                    Timber.e(e, "Could not set last checked on folder %s:%s",
-                            account.getDescription(), tLocalFolder.getName());
-                }
-            }
-
-            for (MessagingListener l : getListeners(listener)) {
-                l.synchronizeMailboxFailed(account, folder, rootMessage);
-            }
-            notifyUserIfCertificateProblem(account, e, true);
-            Timber.e("Failed synchronizing folder %s:%s @ %tc", account.getDescription(), folder,
-                    System.currentTimeMillis());
-
-        } finally {
-            if (providedRemoteFolder == null) {
-                closeFolder(remoteFolder);
-            }
-
-            closeFolder(tLocalFolder);
+        String storeUri = account.getStoreUri();
+        if (ImapStore.isStoreUriImap(storeUri)) {
+            ImapSyncInteractor syncInteractor = new ImapSyncInteractor(syncHelper, flagSyncHelper, this,
+                    messageDownloader, notificationController);
+            syncInteractor.performSync(account, folderName, listener, providedRemoteFolder);
+        } else {
+            LegacySyncInteractor syncInteractor = new LegacySyncInteractor(this, messageDownloader,
+                    notificationController);
+            syncInteractor.performSync(account, folderName, listener, providedRemoteFolder);
         }
-
     }
 
     void handleAuthenticationFailure(Account account, boolean incoming) {
         notificationController.showAuthenticationErrorNotification(account, incoming);
-    }
-
-    private void updateMoreMessages(Folder remoteFolder, LocalFolder localFolder, Date earliestDate, int remoteStart)
-            throws MessagingException, IOException {
-
-        if (remoteStart == 1) {
-            localFolder.setMoreMessages(MoreMessages.FALSE);
-        } else {
-            boolean moreMessagesAvailable = remoteFolder.areMoreMessagesAvailable(remoteStart, earliestDate);
-
-            MoreMessages newMoreMessages = (moreMessagesAvailable) ? MoreMessages.TRUE : MoreMessages.FALSE;
-            localFolder.setMoreMessages(newMoreMessages);
-        }
     }
 
     private static void closeFolder(Folder f) {
@@ -1007,602 +767,7 @@ public class MessagingController {
         }
     }
 
-    /*
-     * If the folder is a "special" folder we need to see if it exists
-     * on the remote server. It if does not exist we'll try to create it. If we
-     * can't create we'll abort. This will happen on every single Pop3 folder as
-     * designed and on Imap folders during error conditions. This allows us
-     * to treat Pop3 and Imap the same in this code.
-     */
-    private boolean verifyOrCreateRemoteSpecialFolder(Account account, String folder, Folder remoteFolder,
-            MessagingListener listener) throws MessagingException {
-        if (folder.equals(account.getTrashFolderName()) ||
-                folder.equals(account.getSentFolderName()) ||
-                folder.equals(account.getDraftsFolderName())) {
-            if (!remoteFolder.exists()) {
-                if (!remoteFolder.create(FolderType.HOLDS_MESSAGES)) {
-                    for (MessagingListener l : getListeners(listener)) {
-                        l.synchronizeMailboxFinished(account, folder, 0, 0);
-                    }
-
-                    Timber.i("Done synchronizing folder %s", folder);
-                    return false;
-                }
-            }
-        }
-        return true;
-    }
-
-    /**
-     * Fetches the messages described by inputMessages from the remote store and writes them to
-     * local storage.
-     *
-     * @param account
-     *         The account the remote store belongs to.
-     * @param remoteFolder
-     *         The remote folder to download messages from.
-     * @param localFolder
-     *         The {@link LocalFolder} instance corresponding to the remote folder.
-     * @param inputMessages
-     *         A list of messages objects that store the UIDs of which messages to download.
-     * @param flagSyncOnly
-     *         Only flags will be fetched from the remote store if this is {@code true}.
-     * @param purgeToVisibleLimit
-     *         If true, local messages will be purged down to the limit of visible messages.
-     *
-     * @return The number of downloaded messages that are not flagged as {@link Flag#SEEN}.
-     *
-     * @throws MessagingException
-     */
-    private int downloadMessages(final Account account, final Folder remoteFolder,
-            final LocalFolder localFolder, List<Message> inputMessages,
-            boolean flagSyncOnly, boolean purgeToVisibleLimit) throws MessagingException {
-
-        final Date earliestDate = account.getEarliestPollDate();
-        Date downloadStarted = new Date(); // now
-
-        if (earliestDate != null) {
-            Timber.d("Only syncing messages after %s", earliestDate);
-        }
-        final String folder = remoteFolder.getName();
-
-        int unreadBeforeStart = 0;
-        try {
-            AccountStats stats = account.getStats(context);
-            unreadBeforeStart = stats.unreadMessageCount;
-
-        } catch (MessagingException e) {
-            Timber.e(e, "Unable to getUnreadMessageCount for account: %s", account);
-        }
-
-        List<Message> syncFlagMessages = new ArrayList<>();
-        List<Message> unsyncedMessages = new ArrayList<>();
-        final AtomicInteger newMessages = new AtomicInteger(0);
-
-        List<Message> messages = new ArrayList<>(inputMessages);
-
-        for (Message message : messages) {
-            evaluateMessageForDownload(message, folder, localFolder, remoteFolder, account, unsyncedMessages,
-                    syncFlagMessages, flagSyncOnly);
-        }
-
-        final AtomicInteger progress = new AtomicInteger(0);
-        final int todo = unsyncedMessages.size() + syncFlagMessages.size();
-        for (MessagingListener l : getListeners()) {
-            l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
-        }
-
-        Timber.d("SYNC: Have %d unsynced messages", unsyncedMessages.size());
-
-        messages.clear();
-        final List<Message> largeMessages = new ArrayList<>();
-        final List<Message> smallMessages = new ArrayList<>();
-        if (!unsyncedMessages.isEmpty()) {
-
-            /*
-             * Reverse the order of the messages. Depending on the server this may get us
-             * fetch results for newest to oldest. If not, no harm done.
-             */
-            Collections.sort(unsyncedMessages, new UidReverseComparator());
-            int visibleLimit = localFolder.getVisibleLimit();
-            int listSize = unsyncedMessages.size();
-
-            if ((visibleLimit > 0) && (listSize > visibleLimit)) {
-                unsyncedMessages = unsyncedMessages.subList(0, visibleLimit);
-            }
-
-            FetchProfile fp = new FetchProfile();
-            if (remoteFolder.supportsFetchingFlags()) {
-                fp.add(FetchProfile.Item.FLAGS);
-            }
-            fp.add(FetchProfile.Item.ENVELOPE);
-
-            Timber.d("SYNC: About to fetch %d unsynced messages for folder %s", unsyncedMessages.size(), folder);
-
-            fetchUnsyncedMessages(account, remoteFolder, unsyncedMessages, smallMessages, largeMessages, progress, todo,
-                    fp);
-
-            String updatedPushState = localFolder.getPushState();
-            for (Message message : unsyncedMessages) {
-                String newPushState = remoteFolder.getNewPushState(updatedPushState, message);
-                if (newPushState != null) {
-                    updatedPushState = newPushState;
-                }
-            }
-            localFolder.setPushState(updatedPushState);
-
-            Timber.d("SYNC: Synced unsynced messages for folder %s", folder);
-        }
-
-        Timber.d("SYNC: Have %d large messages and %d small messages out of %d unsynced messages",
-                largeMessages.size(), smallMessages.size(), unsyncedMessages.size());
-
-        unsyncedMessages.clear();
-        /*
-         * Grab the content of the small messages first. This is going to
-         * be very fast and at very worst will be a single up of a few bytes and a single
-         * download of 625k.
-         */
-        FetchProfile fp = new FetchProfile();
-        //TODO: Only fetch small and large messages if we have some
-        fp.add(FetchProfile.Item.BODY);
-        //        fp.add(FetchProfile.Item.FLAGS);
-        //        fp.add(FetchProfile.Item.ENVELOPE);
-        downloadSmallMessages(account, remoteFolder, localFolder, smallMessages, progress, unreadBeforeStart,
-                newMessages, todo, fp);
-        smallMessages.clear();
-        /*
-         * Now do the large messages that require more round trips.
-         */
-        fp = new FetchProfile();
-        fp.add(FetchProfile.Item.STRUCTURE);
-        downloadLargeMessages(account, remoteFolder, localFolder, largeMessages, progress, unreadBeforeStart,
-                newMessages, todo, fp);
-        largeMessages.clear();
-
-        /*
-         * Refresh the flags for any messages in the local store that we didn't just
-         * download.
-         */
-
-        refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages, progress, todo);
-
-        Timber.d("SYNC: Synced remote messages for folder %s, %d new messages", folder, newMessages.get());
-
-        if (purgeToVisibleLimit) {
-            localFolder.purgeToVisibleLimit(new MessageRemovalListener() {
-                @Override
-                public void messageRemoved(Message message) {
-                    for (MessagingListener l : getListeners()) {
-                        l.synchronizeMailboxRemovedMessage(account, folder, message);
-                    }
-                }
-
-            });
-        }
-
-        // If the oldest message seen on this sync is newer than
-        // the oldest message seen on the previous sync, then
-        // we want to move our high-water mark forward
-        // this is all here just for pop which only syncs inbox
-        // this would be a little wrong for IMAP (we'd want a folder-level pref, not an account level pref.)
-        // fortunately, we just don't care.
-        Long oldestMessageTime = localFolder.getOldestMessageDate();
-
-        if (oldestMessageTime != null) {
-            Date oldestExtantMessage = new Date(oldestMessageTime);
-            if (oldestExtantMessage.before(downloadStarted) &&
-                    oldestExtantMessage.after(new Date(account.getLatestOldMessageSeenTime()))) {
-                account.setLatestOldMessageSeenTime(oldestExtantMessage.getTime());
-                account.save(Preferences.getPreferences(context));
-            }
-
-        }
-        return newMessages.get();
-    }
-
-    private void evaluateMessageForDownload(final Message message, final String folder,
-            final LocalFolder localFolder,
-            final Folder remoteFolder,
-            final Account account,
-            final List<Message> unsyncedMessages,
-            final List<Message> syncFlagMessages,
-            boolean flagSyncOnly) throws MessagingException {
-        if (message.isSet(Flag.DELETED)) {
-            Timber.v("Message with uid %s is marked as deleted", message.getUid());
-
-            syncFlagMessages.add(message);
-            return;
-        }
-
-        Message localMessage = localFolder.getMessage(message.getUid());
-
-        if (localMessage == null) {
-            if (!flagSyncOnly) {
-                if (!message.isSet(Flag.X_DOWNLOADED_FULL) && !message.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
-                    Timber.v("Message with uid %s has not yet been downloaded", message.getUid());
-
-                    unsyncedMessages.add(message);
-                } else {
-                    Timber.v("Message with uid %s is partially or fully downloaded", message.getUid());
-
-                    // Store the updated message locally
-                    localFolder.appendMessages(Collections.singletonList(message));
-
-                    localMessage = localFolder.getMessage(message.getUid());
-
-                    localMessage.setFlag(Flag.X_DOWNLOADED_FULL, message.isSet(Flag.X_DOWNLOADED_FULL));
-                    localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, message.isSet(Flag.X_DOWNLOADED_PARTIAL));
-
-                    for (MessagingListener l : getListeners()) {
-                        if (!localMessage.isSet(Flag.SEEN)) {
-                            l.synchronizeMailboxNewMessage(account, folder, localMessage);
-                        }
-                    }
-                }
-            }
-        } else if (!localMessage.isSet(Flag.DELETED)) {
-            Timber.v("Message with uid %s is present in the local store", message.getUid());
-
-            if (!localMessage.isSet(Flag.X_DOWNLOADED_FULL) && !localMessage.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
-                Timber.v("Message with uid %s is not downloaded, even partially; trying again", message.getUid());
-
-                unsyncedMessages.add(message);
-            } else {
-                String newPushState = remoteFolder.getNewPushState(localFolder.getPushState(), message);
-                if (newPushState != null) {
-                    localFolder.setPushState(newPushState);
-                }
-                syncFlagMessages.add(message);
-            }
-        } else {
-            Timber.v("Local copy of message with uid %s is marked as deleted", message.getUid());
-        }
-    }
-
-    private <T extends Message> void fetchUnsyncedMessages(final Account account, final Folder<T> remoteFolder,
-            List<T> unsyncedMessages,
-            final List<Message> smallMessages,
-            final List<Message> largeMessages,
-            final AtomicInteger progress,
-            final int todo,
-            FetchProfile fp) throws MessagingException {
-        final String folder = remoteFolder.getName();
-
-        final Date earliestDate = account.getEarliestPollDate();
-        remoteFolder.fetch(unsyncedMessages, fp,
-                new MessageRetrievalListener<T>() {
-                    @Override
-                    public void messageFinished(T message, int number, int ofTotal) {
-                        try {
-                            if (message.isSet(Flag.DELETED) || message.olderThan(earliestDate)) {
-                                if (K9.isDebug()) {
-                                    if (message.isSet(Flag.DELETED)) {
-                                        Timber.v("Newly downloaded message %s:%s:%s was marked deleted on server, " +
-                                                "skipping", account, folder, message.getUid());
-                                    } else {
-                                        Timber.d("Newly downloaded message %s is older than %s, skipping",
-                                                message.getUid(), earliestDate);
-                                    }
-                                }
-                                progress.incrementAndGet();
-                                for (MessagingListener l : getListeners()) {
-                                    //TODO: This might be the source of poll count errors in the UI. Is todo always the same as ofTotal
-                                    l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
-                                }
-                                return;
-                            }
-
-                            if (account.getMaximumAutoDownloadMessageSize() > 0 &&
-                                    message.getSize() > account.getMaximumAutoDownloadMessageSize()) {
-                                largeMessages.add(message);
-                            } else {
-                                smallMessages.add(message);
-                            }
-                        } catch (Exception e) {
-                            Timber.e(e, "Error while storing downloaded message.");
-                        }
-                    }
-
-                    @Override
-                    public void messageStarted(String uid, int number, int ofTotal) {
-                    }
-
-                    @Override
-                    public void messagesFinished(int total) {
-                        // FIXME this method is almost never invoked by various Stores! Don't rely on it unless fixed!!
-                    }
-
-                });
-    }
-
-    private boolean shouldImportMessage(final Account account, final Message message,
-            final Date earliestDate) {
-
-        if (account.isSearchByDateCapable() && message.olderThan(earliestDate)) {
-            Timber.d("Message %s is older than %s, hence not saving", message.getUid(), earliestDate);
-            return false;
-        }
-        return true;
-    }
-
-    private <T extends Message> void downloadSmallMessages(final Account account, final Folder<T> remoteFolder,
-            final LocalFolder localFolder,
-            List<T> smallMessages,
-            final AtomicInteger progress,
-            final int unreadBeforeStart,
-            final AtomicInteger newMessages,
-            final int todo,
-            FetchProfile fp) throws MessagingException {
-        final String folder = remoteFolder.getName();
-
-        final Date earliestDate = account.getEarliestPollDate();
-
-        Timber.d("SYNC: Fetching %d small messages for folder %s", smallMessages.size(), folder);
-
-        remoteFolder.fetch(smallMessages,
-                fp, new MessageRetrievalListener<T>() {
-                    @Override
-                    public void messageFinished(final T message, int number, int ofTotal) {
-                        try {
-
-                            if (!shouldImportMessage(account, message, earliestDate)) {
-                                progress.incrementAndGet();
-
-                                return;
-                            }
-
-                            // Store the updated message locally
-                            final LocalMessage localMessage = localFolder.storeSmallMessage(message, new Runnable() {
-                                @Override
-                                public void run() {
-                                    progress.incrementAndGet();
-                                }
-                            });
-
-                            // Increment the number of "new messages" if the newly downloaded message is
-                            // not marked as read.
-                            if (!localMessage.isSet(Flag.SEEN)) {
-                                newMessages.incrementAndGet();
-                            }
-
-                            Timber.v("About to notify listeners that we got a new small message %s:%s:%s",
-                                    account, folder, message.getUid());
-
-                            // Update the listener with what we've found
-                            for (MessagingListener l : getListeners()) {
-                                l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
-                                if (!localMessage.isSet(Flag.SEEN)) {
-                                    l.synchronizeMailboxNewMessage(account, folder, localMessage);
-                                }
-                            }
-                            // Send a notification of this message
-
-                            if (shouldNotifyForMessage(account, localFolder, message)) {
-                                // Notify with the localMessage so that we don't have to recalculate the content preview.
-                                notificationController.addNewMailNotification(account, localMessage, unreadBeforeStart);
-                            }
-
-                        } catch (MessagingException me) {
-                            Timber.e(me, "SYNC: fetch small messages");
-                        }
-                    }
-
-                    @Override
-                    public void messageStarted(String uid, int number, int ofTotal) {
-                    }
-
-                    @Override
-                    public void messagesFinished(int total) {
-                    }
-                });
-
-        Timber.d("SYNC: Done fetching small messages for folder %s", folder);
-    }
-
-    private <T extends Message> void downloadLargeMessages(final Account account, final Folder<T> remoteFolder,
-            final LocalFolder localFolder,
-            List<T> largeMessages,
-            final AtomicInteger progress,
-            final int unreadBeforeStart,
-            final AtomicInteger newMessages,
-            final int todo,
-            FetchProfile fp) throws MessagingException {
-        final String folder = remoteFolder.getName();
-        final Date earliestDate = account.getEarliestPollDate();
-
-        Timber.d("SYNC: Fetching large messages for folder %s", folder);
-
-        remoteFolder.fetch(largeMessages, fp, null);
-        for (T message : largeMessages) {
-
-            if (!shouldImportMessage(account, message, earliestDate)) {
-                progress.incrementAndGet();
-                continue;
-            }
-
-            if (message.getBody() == null) {
-                downloadSaneBody(account, remoteFolder, localFolder, message);
-            } else {
-                downloadPartial(remoteFolder, localFolder, message);
-            }
-
-            Timber.v("About to notify listeners that we got a new large message %s:%s:%s",
-                    account, folder, message.getUid());
-
-            // Update the listener with what we've found
-            progress.incrementAndGet();
-            // TODO do we need to re-fetch this here?
-            LocalMessage localMessage = localFolder.getMessage(message.getUid());
-            // Increment the number of "new messages" if the newly downloaded message is
-            // not marked as read.
-            if (!localMessage.isSet(Flag.SEEN)) {
-                newMessages.incrementAndGet();
-            }
-            for (MessagingListener l : getListeners()) {
-                l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
-                if (!localMessage.isSet(Flag.SEEN)) {
-                    l.synchronizeMailboxNewMessage(account, folder, localMessage);
-                }
-            }
-            // Send a notification of this message
-            if (shouldNotifyForMessage(account, localFolder, message)) {
-                // Notify with the localMessage so that we don't have to recalculate the content preview.
-                notificationController.addNewMailNotification(account, localMessage, unreadBeforeStart);
-            }
-        }
-
-        Timber.d("SYNC: Done fetching large messages for folder %s", folder);
-    }
-
-    private void downloadPartial(Folder remoteFolder, LocalFolder localFolder, Message message)
-            throws MessagingException {
-        /*
-         * We have a structure to deal with, from which
-         * we can pull down the parts we want to actually store.
-         * Build a list of parts we are interested in. Text parts will be downloaded
-         * right now, attachments will be left for later.
-         */
-
-        Set<Part> viewables = MessageExtractor.collectTextParts(message);
-
-        /*
-         * Now download the parts we're interested in storing.
-         */
-        BodyFactory bodyFactory = new DefaultBodyFactory();
-        for (Part part : viewables) {
-            remoteFolder.fetchPart(message, part, null, bodyFactory);
-        }
-        // Store the updated message locally
-        localFolder.appendMessages(Collections.singletonList(message));
-
-        Message localMessage = localFolder.getMessage(message.getUid());
-
-        // Set a flag indicating this message has been fully downloaded and can be
-        // viewed.
-        localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, true);
-    }
-
-    private void downloadSaneBody(Account account, Folder remoteFolder, LocalFolder localFolder, Message message)
-            throws MessagingException {
-        /*
-         * The provider was unable to get the structure of the message, so
-         * we'll download a reasonable portion of the messge and mark it as
-         * incomplete so the entire thing can be downloaded later if the user
-         * wishes to download it.
-         */
-        FetchProfile fp = new FetchProfile();
-        fp.add(FetchProfile.Item.BODY_SANE);
-                /*
-                 *  TODO a good optimization here would be to make sure that all Stores set
-                 *  the proper size after this fetch and compare the before and after size. If
-                 *  they equal we can mark this SYNCHRONIZED instead of PARTIALLY_SYNCHRONIZED
-                 */
-
-        remoteFolder.fetch(Collections.singletonList(message), fp, null);
-
-        // Store the updated message locally
-        localFolder.appendMessages(Collections.singletonList(message));
-
-        Message localMessage = localFolder.getMessage(message.getUid());
-
-
-        // Certain (POP3) servers give you the whole message even when you ask for only the first x Kb
-        if (!message.isSet(Flag.X_DOWNLOADED_FULL)) {
-                    /*
-                     * Mark the message as fully downloaded if the message size is smaller than
-                     * the account's autodownload size limit, otherwise mark as only a partial
-                     * download.  This will prevent the system from downloading the same message
-                     * twice.
-                     *
-                     * If there is no limit on autodownload size, that's the same as the message
-                     * being smaller than the max size
-                     */
-            if (account.getMaximumAutoDownloadMessageSize() == 0
-                    || message.getSize() < account.getMaximumAutoDownloadMessageSize()) {
-                localMessage.setFlag(Flag.X_DOWNLOADED_FULL, true);
-            } else {
-                // Set a flag indicating that the message has been partially downloaded and
-                // is ready for view.
-                localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, true);
-            }
-        }
-
-    }
-
-    private void refreshLocalMessageFlags(final Account account, final Folder remoteFolder,
-            final LocalFolder localFolder,
-            List<Message> syncFlagMessages,
-            final AtomicInteger progress,
-            final int todo
-    ) throws MessagingException {
-
-        final String folder = remoteFolder.getName();
-        if (remoteFolder.supportsFetchingFlags()) {
-            Timber.d("SYNC: About to sync flags for %d remote messages for folder %s", syncFlagMessages.size(), folder);
-
-            FetchProfile fp = new FetchProfile();
-            fp.add(FetchProfile.Item.FLAGS);
-
-            List<Message> undeletedMessages = new LinkedList<>();
-            for (Message message : syncFlagMessages) {
-                if (!message.isSet(Flag.DELETED)) {
-                    undeletedMessages.add(message);
-                }
-            }
-
-            remoteFolder.fetch(undeletedMessages, fp, null);
-            for (Message remoteMessage : syncFlagMessages) {
-                LocalMessage localMessage = localFolder.getMessage(remoteMessage.getUid());
-                boolean messageChanged = syncFlags(localMessage, remoteMessage);
-                if (messageChanged) {
-                    boolean shouldBeNotifiedOf = false;
-                    if (localMessage.isSet(Flag.DELETED) || isMessageSuppressed(localMessage)) {
-                        for (MessagingListener l : getListeners()) {
-                            l.synchronizeMailboxRemovedMessage(account, folder, localMessage);
-                        }
-                    } else {
-                        if (shouldNotifyForMessage(account, localFolder, localMessage)) {
-                            shouldBeNotifiedOf = true;
-                        }
-                    }
-
-                    // we're only interested in messages that need removing
-                    if (!shouldBeNotifiedOf) {
-                        MessageReference messageReference = localMessage.makeMessageReference();
-                        notificationController.removeNewMailNotification(account, messageReference);
-                    }
-                }
-                progress.incrementAndGet();
-                for (MessagingListener l : getListeners()) {
-                    l.synchronizeMailboxProgress(account, folder, progress.get(), todo);
-                }
-            }
-        }
-    }
-
-    private boolean syncFlags(LocalMessage localMessage, Message remoteMessage) throws MessagingException {
-        boolean messageChanged = false;
-        if (localMessage == null || localMessage.isSet(Flag.DELETED)) {
-            return false;
-        }
-        if (remoteMessage.isSet(Flag.DELETED)) {
-            if (localMessage.getFolder().syncRemoteDeletions()) {
-                localMessage.setFlag(Flag.DELETED, true);
-                messageChanged = true;
-            }
-        } else {
-            for (Flag flag : MessagingController.SYNC_FLAGS) {
-                if (remoteMessage.isSet(flag) != localMessage.isSet(flag)) {
-                    localMessage.setFlag(flag, remoteMessage.isSet(flag));
-                    messageChanged = true;
-                }
-            }
-        }
-        return messageChanged;
-    }
-
-    private String getRootCauseMessage(Throwable t) {
+    static String getRootCauseMessage(Throwable t) {
         Throwable rootCause = t;
         Throwable nextCause;
         do {
@@ -1653,7 +818,7 @@ public class MessagingController {
         });
     }
 
-    private void processPendingCommandsSynchronous(Account account) throws MessagingException {
+    void processPendingCommandsSynchronous(Account account) throws MessagingException {
         LocalStore localStore = account.getLocalStore();
         List<PendingCommand> commands = localStore.getPendingCommands();
 
@@ -2321,7 +1486,7 @@ public class MessagingController {
                 Message remoteMessage = remoteFolder.getMessage(uid);
 
                 if (loadPartialFromSearch) {
-                    downloadMessages(account, remoteFolder, localFolder,
+                    messageDownloader.downloadMessages(account, remoteFolder, localFolder,
                             Collections.singletonList(remoteMessage), false, false);
                 } else {
                     FetchProfile fp = new FetchProfile();
@@ -3514,7 +2679,7 @@ public class MessagingController {
                 Folder.FolderClass fDisplayClass = folder.getDisplayClass();
                 Folder.FolderClass fSyncClass = folder.getSyncClass();
 
-                if (modeMismatch(aDisplayMode, fDisplayClass)) {
+                if (syncHelper.modeMismatch(aDisplayMode, fDisplayClass)) {
                     // Never sync a folder that isn't displayed
                     /*
                     if (K9.DEBUG) {
@@ -3526,7 +2691,7 @@ public class MessagingController {
                     continue;
                 }
 
-                if (modeMismatch(aSyncMode, fSyncClass)) {
+                if (syncHelper.modeMismatch(aSyncMode, fSyncClass)) {
                     // Do not sync folders in the wrong class
                     /*
                     if (K9.DEBUG) {
@@ -3708,82 +2873,6 @@ public class MessagingController {
         });
     }
 
-
-    private boolean shouldNotifyForMessage(Account account, LocalFolder localFolder, Message message) {
-        // If we don't even have an account name, don't show the notification.
-        // (This happens during initial account setup)
-        if (account.getName() == null) {
-            return false;
-        }
-
-        // Do not notify if the user does not have notifications enabled or if the message has
-        // been read.
-        if (!account.isNotifyNewMail() || message.isSet(Flag.SEEN)) {
-            return false;
-        }
-
-        Account.FolderMode aDisplayMode = account.getFolderDisplayMode();
-        Account.FolderMode aNotifyMode = account.getFolderNotifyNewMailMode();
-        Folder.FolderClass fDisplayClass = localFolder.getDisplayClass();
-        Folder.FolderClass fNotifyClass = localFolder.getNotifyClass();
-
-        if (modeMismatch(aDisplayMode, fDisplayClass)) {
-            // Never notify a folder that isn't displayed
-            return false;
-        }
-
-        if (modeMismatch(aNotifyMode, fNotifyClass)) {
-            // Do not notify folders in the wrong class
-            return false;
-        }
-
-        // If the account is a POP3 account and the message is older than the oldest message we've
-        // previously seen, then don't notify about it.
-        if (account.getStoreUri().startsWith("pop3") &&
-                message.olderThan(new Date(account.getLatestOldMessageSeenTime()))) {
-            return false;
-        }
-
-        // No notification for new messages in Trash, Drafts, Spam or Sent folder.
-        // But do notify if it's the INBOX (see issue 1817).
-        Folder folder = message.getFolder();
-        if (folder != null) {
-            String folderName = folder.getName();
-            if (!account.getInboxFolderName().equals(folderName) &&
-                    (account.getTrashFolderName().equals(folderName)
-                            || account.getDraftsFolderName().equals(folderName)
-                            || account.getSpamFolderName().equals(folderName)
-                            || account.getSentFolderName().equals(folderName))) {
-                return false;
-            }
-        }
-
-        if (message.getUid() != null && localFolder.getLastUid() != null) {
-            try {
-                Integer messageUid = Integer.parseInt(message.getUid());
-                if (messageUid <= localFolder.getLastUid()) {
-                    Timber.d("Message uid is %s, max message uid is %s. Skipping notification.",
-                            messageUid, localFolder.getLastUid());
-                    return false;
-                }
-            } catch (NumberFormatException e) {
-                // Nothing to be done here.
-            }
-        }
-
-        // Don't notify if the sender address matches one of our identities and the user chose not
-        // to be notified for such messages.
-        if (account.isAnIdentity(message.getFrom()) && !account.isNotifySelfNewMail()) {
-            return false;
-        }
-
-        if (account.isNotifyContactsMailOnly() && !contacts.isAnyInContacts(message.getFrom())) {
-            return false;
-        }
-
-        return true;
-    }
-
     public void deleteAccount(Account account) {
         notificationController.clearNewMailNotifications(account);
         memorizingMessagingListener.removeAccount(account);
@@ -3839,17 +2928,6 @@ public class MessagingController {
         }
 
         return id;
-    }
-
-    private boolean modeMismatch(Account.FolderMode aMode, Folder.FolderClass fMode) {
-        return aMode == Account.FolderMode.NONE
-                || (aMode == Account.FolderMode.FIRST_CLASS &&
-                fMode != Folder.FolderClass.FIRST_CLASS)
-                || (aMode == Account.FolderMode.FIRST_AND_SECOND_CLASS &&
-                fMode != Folder.FolderClass.FIRST_CLASS &&
-                fMode != Folder.FolderClass.SECOND_CLASS)
-                || (aMode == Account.FolderMode.NOT_SECOND_CLASS &&
-                fMode == Folder.FolderClass.SECOND_CLASS);
     }
 
     private static AtomicInteger sequencing = new AtomicInteger(0);
@@ -3914,7 +2992,7 @@ public class MessagingController {
                 Folder.FolderClass fDisplayClass = folder.getDisplayClass();
                 Folder.FolderClass fPushClass = folder.getPushClass();
 
-                if (modeMismatch(aDisplayMode, fDisplayClass)) {
+                if (syncHelper.modeMismatch(aDisplayMode, fDisplayClass)) {
                     // Never push a folder that isn't displayed
                     /*
                     if (K9.DEBUG) {
@@ -3926,7 +3004,7 @@ public class MessagingController {
                     continue;
                 }
 
-                if (modeMismatch(aPushMode, fPushClass)) {
+                if (syncHelper.modeMismatch(aPushMode, fPushClass)) {
                     // Do not push folders in the wrong class
                     /*
                     if (K9.DEBUG) {
@@ -4013,7 +3091,8 @@ public class MessagingController {
                     localFolder.open(Folder.OPEN_MODE_RW);
 
                     account.setRingNotified(false);
-                    int newCount = downloadMessages(account, remoteFolder, localFolder, messages, flagSyncOnly, true);
+                    int newCount = messageDownloader.downloadMessages(account, remoteFolder, localFolder, messages,
+                            flagSyncOnly, true);
 
                     int unreadMessageCount = localFolder.getUnreadMessageCount();
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/NonQresyncExtensionHandler.java
@@ -1,0 +1,121 @@
+package com.fsck.k9.controller;
+
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mail.store.imap.ImapMessage;
+import com.fsck.k9.mailstore.LocalFolder;
+import timber.log.Timber;
+
+
+class NonQresyncExtensionHandler {
+
+    private final SyncHelper syncHelper;
+    private final FlagSyncHelper flagSyncHelper;
+    private final MessagingController controller;
+    private final MessageDownloader messageDownloader;
+
+    NonQresyncExtensionHandler(SyncHelper syncHelper, FlagSyncHelper flagSyncHelper, MessagingController controller,
+            MessageDownloader messageDownloader) {
+        this.syncHelper = syncHelper;
+        this.flagSyncHelper = flagSyncHelper;
+        this.controller = controller;
+        this.messageDownloader = messageDownloader;
+    }
+
+    int continueSync(Account account, LocalFolder localFolder, ImapFolder imapFolder, MessagingListener listener)
+            throws MessagingException, IOException {
+        Map<String, Long> localUidMap = localFolder.getAllMessagesAndEffectiveDates();
+        String folderName = localFolder.getName();
+        final List<ImapMessage> remoteMessages = new ArrayList<>();
+        Map<String, ImapMessage> remoteUidMap = new HashMap<>();
+
+        int remoteMessageCount = imapFolder.getMessageCount();
+        int remoteStart = syncHelper.getRemoteStart(localFolder, imapFolder);
+
+        Timber.v("SYNC: About to fetch UIDs for messages %d through %d in folder %s",
+                remoteStart, remoteMessageCount, folderName);
+
+        findRemoteMessagesToDownload(account, imapFolder, localUidMap, remoteMessages, remoteUidMap, remoteStart,
+                listener);
+
+        if (account.syncRemoteDeletions()) {
+            List<String> deletedUids = findDeletedMessageUids(localUidMap, remoteUidMap);
+            syncHelper.deleteLocalMessages(deletedUids, account, localFolder, controller, listener);
+        }
+
+        // noinspection UnusedAssignment, free memory early?
+        localUidMap = null;
+
+        List<Message> newMessages = new ArrayList<>();
+        List<Message> syncFlagMessages = new ArrayList<>();
+
+        for (Message message : remoteMessages) {
+            syncHelper.evaluateMessageForDownload(message, folderName, localFolder, imapFolder, account, newMessages,
+                    syncFlagMessages, false, controller);
+        }
+
+        syncHelper.updateMoreMessages(account, localFolder, imapFolder);
+        return messageDownloader.downloadMessages(account, imapFolder, localFolder, newMessages, false, true);
+    }
+
+    private void findRemoteMessagesToDownload(Account account, ImapFolder imapFolder,
+            Map<String, Long> localUidMap, List<ImapMessage> remoteMessages,
+            Map<String, ImapMessage> remoteUidMap, int remoteStart, MessagingListener listener)
+            throws MessagingException {
+        String folderName = imapFolder.getName();
+        final Date earliestDate = account.getEarliestPollDate();
+        long earliestTimestamp = earliestDate != null ? earliestDate.getTime() : 0L;
+        final AtomicInteger headerProgress = new AtomicInteger(0);
+        int remoteMessageCount = imapFolder.getMessageCount();
+
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxHeadersStarted(account, folderName);
+        }
+
+        List<ImapMessage> remoteMessageArray = new ArrayList<>();
+        if (remoteMessageCount > 0) {
+            remoteMessageArray = imapFolder.getMessages(remoteStart, remoteMessageCount, earliestDate, null);
+        }
+
+        int messageCount = remoteMessageArray.size();
+
+        for (ImapMessage thisMess : remoteMessageArray) {
+            headerProgress.incrementAndGet();
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxHeadersProgress(account, folderName, headerProgress.get(), messageCount);
+            }
+            Long localMessageTimestamp = localUidMap.get(thisMess.getUid());
+            if (localMessageTimestamp == null || localMessageTimestamp >= earliestTimestamp) {
+                remoteMessages.add(thisMess);
+                remoteUidMap.put(thisMess.getUid(), thisMess);
+            }
+        }
+
+        Timber.v("SYNC: Fetched %d message UIDs for folder %s", remoteUidMap.size(), folderName);
+
+        for (MessagingListener l : controller.getListeners(listener)) {
+            l.synchronizeMailboxHeadersFinished(account, folderName, headerProgress.get(), remoteUidMap.size());
+        }
+    }
+
+    private List<String> findDeletedMessageUids(Map<String, Long> localUidMap, Map<String, ImapMessage> remoteUidMap) {
+        List<String> deletedMessageUids = new ArrayList<>();
+        for (String localMessageUid : localUidMap.keySet()) {
+            if (remoteUidMap.get(localMessageUid) == null) {
+                deletedMessageUids.add(localMessageUid);
+            }
+        }
+        return deletedMessageUids;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
@@ -1,0 +1,262 @@
+package com.fsck.k9.controller;
+
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import android.content.Context;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9;
+import com.fsck.k9.cache.EmailProviderCache;
+import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Folder.FolderType;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalFolder.MoreMessages;
+import com.fsck.k9.mailstore.LocalMessage;
+import timber.log.Timber;
+
+
+class SyncHelper {
+
+    private static SyncHelper INSTANCE;
+
+    private SyncHelper() {
+    }
+
+    static SyncHelper getInstance() {
+        if (INSTANCE == null) {
+            INSTANCE = new SyncHelper();
+        }
+        return INSTANCE;
+    }
+
+    /*
+     * If the folder is a "special" folder we need to see if it exists
+     * on the remote server. It if does not exist we'll try to create it. If we
+     * can't create we'll abort. This will happen on every single Pop3 folder as
+     * designed and on Imap folders during error conditions. This allows us
+     * to treat Pop3 and Imap the same in this code.
+     */
+    boolean verifyOrCreateRemoteSpecialFolder(Account account, String folderName, Folder remoteFolder,
+            MessagingListener listener, MessagingController controller) throws MessagingException {
+        if ((folderName.equals(account.getTrashFolderName()) || folderName.equals(account.getSentFolderName()) ||
+                folderName.equals(account.getDraftsFolderName())) && !remoteFolder.exists() &&
+                !remoteFolder.create(FolderType.HOLDS_MESSAGES)) {
+            for (MessagingListener l : controller.getListeners(listener)) {
+                l.synchronizeMailboxFinished(account, folderName, 0, 0);
+            }
+
+            Timber.i("Done synchronizing folder %s", folderName);
+            return false;
+        }
+        return true;
+    }
+
+    int getRemoteStart(LocalFolder localFolder, Folder remoteFolder) throws MessagingException {
+        int remoteMessageCount = remoteFolder.getMessageCount();
+
+        int visibleLimit = localFolder.getVisibleLimit();
+        if (visibleLimit < 0) {
+            visibleLimit = K9.DEFAULT_VISIBLE_LIMIT;
+        }
+
+        int remoteStart;
+        /* Message numbers start at 1.  */
+        if (visibleLimit > 0) {
+            remoteStart = Math.max(0, remoteMessageCount - visibleLimit) + 1;
+        } else {
+            remoteStart = 1;
+        }
+        return remoteStart;
+    }
+
+    void deleteLocalMessages(List<String> deletedMessageUids, Account account, LocalFolder localFolder,
+            MessagingController controller, MessagingListener listener) throws IOException, MessagingException {
+        String folderName = localFolder.getName();
+        Timber.v("Deleting %d messages in the local cache that are not present in the remote mailbox for folder %s",
+                deletedMessageUids.size(), folderName);
+
+        if (!deletedMessageUids.isEmpty()) {
+            List<LocalMessage> destroyMessages = localFolder.getMessagesByUids(deletedMessageUids);
+            localFolder.destroyMessages(destroyMessages);
+
+            for (Message destroyMessage : destroyMessages) {
+                for (MessagingListener l : controller.getListeners(listener)) {
+                    l.synchronizeMailboxRemovedMessage(account, folderName, destroyMessage);
+                }
+            }
+        }
+    }
+
+    boolean isMessageSuppressed(LocalMessage message, Context context) {
+        long messageId = message.getDatabaseId();
+        long folderId = message.getFolder().getDatabaseId();
+
+        EmailProviderCache cache = EmailProviderCache.getCache(message.getFolder().getAccountUuid(), context);
+        return cache.isMessageHidden(messageId, folderId);
+    }
+
+    boolean modeMismatch(Account.FolderMode aMode, Folder.FolderClass fMode) {
+        return aMode == Account.FolderMode.NONE
+                || (aMode == Account.FolderMode.FIRST_CLASS &&
+                fMode != Folder.FolderClass.FIRST_CLASS)
+                || (aMode == Account.FolderMode.FIRST_AND_SECOND_CLASS &&
+                fMode != Folder.FolderClass.FIRST_CLASS &&
+                fMode != Folder.FolderClass.SECOND_CLASS)
+                || (aMode == Account.FolderMode.NOT_SECOND_CLASS &&
+                fMode == Folder.FolderClass.SECOND_CLASS);
+    }
+
+    void evaluateMessageForDownload(final Message message, final String folderName, final LocalFolder localFolder,
+            final Folder remoteFolder, final Account account, final List<Message> unsyncedMessages,
+            final List< Message> syncFlagMessages, boolean flagSyncOnly, MessagingController controller)
+            throws MessagingException {
+        if (message.isSet(Flag.DELETED)) {
+            Timber.v("Message with uid %s is marked as deleted", message.getUid());
+
+            syncFlagMessages.add(message);
+            return;
+        }
+
+        Message localMessage = localFolder.getMessageUidAndFlags(message.getUid());
+
+        if (localMessage == null) {
+            if (!flagSyncOnly) {
+                if (!message.isSet(Flag.X_DOWNLOADED_FULL) && !message.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
+                    Timber.v("Message with uid %s has not yet been downloaded", message.getUid());
+
+                    unsyncedMessages.add(message);
+                } else {
+                    Timber.v("Message with uid %s is partially or fully downloaded", message.getUid());
+
+                    // Store the updated message locally
+                    localFolder.appendMessages(Collections.singletonList(message));
+
+                    localMessage = localFolder.getMessage(message.getUid());
+
+                    localMessage.setFlag(Flag.X_DOWNLOADED_FULL, message.isSet(Flag.X_DOWNLOADED_FULL));
+                    localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, message.isSet(Flag.X_DOWNLOADED_PARTIAL));
+
+                    for (MessagingListener l : controller.getListeners()) {
+                        if (!localMessage.isSet(Flag.SEEN)) {
+                            l.synchronizeMailboxNewMessage(account, folderName, localMessage);
+                        }
+                    }
+                }
+            }
+        } else if (!localMessage.isSet(Flag.DELETED)) {
+            Timber.v("Message with uid %s is present in the local store", message.getUid());
+
+            if (!localMessage.isSet(Flag.X_DOWNLOADED_FULL) && !localMessage.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
+                Timber.v("Message with uid %s is not downloaded, even partially; trying again", message.getUid());
+
+                unsyncedMessages.add(message);
+            } else {
+                String newPushState = remoteFolder.getNewPushState(localFolder.getPushState(), message);
+                if (newPushState != null) {
+                    localFolder.setPushState(newPushState);
+                }
+                syncFlagMessages.add(message);
+            }
+        } else {
+            Timber.v("Local copy of message with uid %s is marked as deleted", message.getUid());
+        }
+    }
+
+    boolean shouldNotifyForMessage(Account account, LocalFolder localFolder, Message message, Contacts contacts) {
+        // If we don't even have an account name, don't show the notification.
+        // (This happens during initial account setup)
+        if (account.getName() == null) {
+            return false;
+        }
+
+        // Do not notify if the user does not have notifications enabled or if the message has
+        // been read.
+        if (!account.isNotifyNewMail() || message.isSet(Flag.SEEN)) {
+            return false;
+        }
+
+        Account.FolderMode aDisplayMode = account.getFolderDisplayMode();
+        Account.FolderMode aNotifyMode = account.getFolderNotifyNewMailMode();
+        Folder.FolderClass fDisplayClass = localFolder.getDisplayClass();
+        Folder.FolderClass fNotifyClass = localFolder.getNotifyClass();
+
+        if (modeMismatch(aDisplayMode, fDisplayClass)) {
+            // Never notify a folder that isn't displayed
+            return false;
+        }
+
+        if (modeMismatch(aNotifyMode, fNotifyClass)) {
+            // Do not notify folders in the wrong class
+            return false;
+        }
+
+        // If the account is a POP3 account and the message is older than the oldest message we've
+        // previously seen, then don't notify about it.
+        if (account.getStoreUri().startsWith("pop3") &&
+                message.olderThan(new Date(account.getLatestOldMessageSeenTime()))) {
+            return false;
+        }
+
+        // No notification for new messages in Trash, Drafts, Spam or Sent folder.
+        // But do notify if it's the INBOX (see issue 1817).
+        Folder folder = message.getFolder();
+        if (folder != null) {
+            String folderName = folder.getName();
+            if (!account.getInboxFolderName().equals(folderName) &&
+                    (account.getTrashFolderName().equals(folderName)
+                            || account.getDraftsFolderName().equals(folderName)
+                            || account.getSpamFolderName().equals(folderName)
+                            || account.getSentFolderName().equals(folderName))) {
+                return false;
+            }
+        }
+
+        if (message.getUid() != null && localFolder.getLastUid() != null) {
+            try {
+                Integer messageUid = Integer.parseInt(message.getUid());
+                if (messageUid <= localFolder.getLastUid()) {
+                    Timber.d("Message uid is %s, max message uid is %s. Skipping notification.",
+                            messageUid, localFolder.getLastUid());
+                    return false;
+                }
+            } catch (NumberFormatException e) {
+                // Nothing to be done here.
+            }
+        }
+
+        // Don't notify if the sender address matches one of our identities and the user chose not
+        // to be notified for such messages.
+        if (account.isAnIdentity(message.getFrom()) && !account.isNotifySelfNewMail()) {
+            return false;
+        }
+
+        if (account.isNotifyContactsMailOnly() && !contacts.isAnyInContacts(message.getFrom())) {
+            return false;
+        }
+
+        return true;
+    }
+
+    void updateMoreMessages(Account account, LocalFolder localFolder, Folder remoteFolder) throws IOException,
+            MessagingException {
+        final Date earliestDate = account.getEarliestPollDate();
+        int remoteStart = getRemoteStart(localFolder, remoteFolder);
+
+        if (remoteStart == 1) {
+            localFolder.setMoreMessages(MoreMessages.FALSE);
+        } else {
+            boolean moreMessagesAvailable = remoteFolder.areMoreMessagesAvailable(remoteStart, earliestDate);
+
+            MoreMessages newMoreMessages = (moreMessagesAvailable) ? MoreMessages.TRUE : MoreMessages.FALSE;
+            localFolder.setMoreMessages(newMoreMessages);
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SyncHelper.java
@@ -114,35 +114,35 @@ class SyncHelper {
                 fMode == Folder.FolderClass.SECOND_CLASS);
     }
 
-    void evaluateMessageForDownload(final Message message, final String folderName, final LocalFolder localFolder,
+    void evaluateMessageForDownload(final Message remoteMessage, final String folderName, final LocalFolder localFolder,
             final Folder remoteFolder, final Account account, final List<Message> unsyncedMessages,
             final List< Message> syncFlagMessages, boolean flagSyncOnly, MessagingController controller)
             throws MessagingException {
-        if (message.isSet(Flag.DELETED)) {
-            Timber.v("Message with uid %s is marked as deleted", message.getUid());
+        if (remoteMessage.isSet(Flag.DELETED)) {
+            Timber.v("Message with uid %s is marked as deleted", remoteMessage.getUid());
 
-            syncFlagMessages.add(message);
+            syncFlagMessages.add(remoteMessage);
             return;
         }
 
-        Message localMessage = localFolder.getMessageUidAndFlags(message.getUid());
+        Message localMessage = localFolder.getMessageUidAndFlags(remoteMessage.getUid());
 
         if (localMessage == null) {
             if (!flagSyncOnly) {
-                if (!message.isSet(Flag.X_DOWNLOADED_FULL) && !message.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
-                    Timber.v("Message with uid %s has not yet been downloaded", message.getUid());
+                if (!remoteMessage.isSet(Flag.X_DOWNLOADED_FULL) && !remoteMessage.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
+                    Timber.v("Message with uid %s has not yet been downloaded", remoteMessage.getUid());
 
-                    unsyncedMessages.add(message);
+                    unsyncedMessages.add(remoteMessage);
                 } else {
-                    Timber.v("Message with uid %s is partially or fully downloaded", message.getUid());
+                    Timber.v("Message with uid %s is partially or fully downloaded", remoteMessage.getUid());
 
                     // Store the updated message locally
-                    localFolder.appendMessages(Collections.singletonList(message));
+                    localFolder.appendMessages(Collections.singletonList(remoteMessage));
 
-                    localMessage = localFolder.getMessage(message.getUid());
+                    localMessage = localFolder.getMessage(remoteMessage.getUid());
 
-                    localMessage.setFlag(Flag.X_DOWNLOADED_FULL, message.isSet(Flag.X_DOWNLOADED_FULL));
-                    localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, message.isSet(Flag.X_DOWNLOADED_PARTIAL));
+                    localMessage.setFlag(Flag.X_DOWNLOADED_FULL, remoteMessage.isSet(Flag.X_DOWNLOADED_FULL));
+                    localMessage.setFlag(Flag.X_DOWNLOADED_PARTIAL, remoteMessage.isSet(Flag.X_DOWNLOADED_PARTIAL));
 
                     for (MessagingListener l : controller.getListeners()) {
                         if (!localMessage.isSet(Flag.SEEN)) {
@@ -152,21 +152,21 @@ class SyncHelper {
                 }
             }
         } else if (!localMessage.isSet(Flag.DELETED)) {
-            Timber.v("Message with uid %s is present in the local store", message.getUid());
+            Timber.v("Message with uid %s is present in the local store", remoteMessage.getUid());
 
             if (!localMessage.isSet(Flag.X_DOWNLOADED_FULL) && !localMessage.isSet(Flag.X_DOWNLOADED_PARTIAL)) {
-                Timber.v("Message with uid %s is not downloaded, even partially; trying again", message.getUid());
+                Timber.v("Message with uid %s is not downloaded, even partially; trying again", remoteMessage.getUid());
 
-                unsyncedMessages.add(message);
+                unsyncedMessages.add(remoteMessage);
             } else {
-                String newPushState = remoteFolder.getNewPushState(localFolder.getPushState(), message);
+                String newPushState = remoteFolder.getNewPushState(localFolder.getPushState(), remoteMessage);
                 if (newPushState != null) {
                     localFolder.setPushState(newPushState);
                 }
-                syncFlagMessages.add(message);
+                syncFlagMessages.add(remoteMessage);
             }
         } else {
-            Timber.v("Local copy of message with uid %s is marked as deleted", message.getUid());
+            Timber.v("Local copy of message with uid %s is marked as deleted", remoteMessage.getUid());
         }
     }
 

--- a/k9mail/src/test/java/com/fsck/k9/controller/FlagSyncHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/FlagSyncHelperTest.java
@@ -1,0 +1,205 @@
+package com.fsck.k9.controller;
+
+
+import java.util.List;
+
+import android.content.Context;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.mail.FetchProfile;
+import com.fsck.k9.mail.FetchProfile.Item;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.shadows.ShadowApplication;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+public class FlagSyncHelperTest {
+
+    private Account account;
+    private Folder remoteFolder;
+    private LocalFolder localFolder;
+    private MessagingListener listener;
+
+    private SyncHelper syncHelper;
+    private FlagSyncHelper flagSyncHelper;
+
+    @Before
+    public void setUp() {
+        account = mock(Account.class);
+        remoteFolder = mock(Folder.class);
+        localFolder = mock(LocalFolder.class);
+        Context appContext = ShadowApplication.getInstance().getApplicationContext();
+        MessagingController controller = mock(MessagingController.class);
+        listener = mock(MessagingListener.class);
+        when(controller.getListeners()).thenReturn(singleton(listener));
+
+        syncHelper = mock(SyncHelper.class);
+        flagSyncHelper = FlagSyncHelper.newInstance(appContext, controller, syncHelper);
+    }
+
+    @Test
+    public void refreshLocalMessageFlags_withSupportsFetchingFlagsTrue_shouldFetchAndProcessRemoteFlags()
+            throws Exception {
+        List<Message> syncFlagMessages = singletonList(createMessage(false));
+        FetchProfile flagsProfile = new FetchProfile();
+        flagsProfile.add(Item.FLAGS);
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
+
+        flagSyncHelper.refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages);
+
+        verify(remoteFolder).fetch(syncFlagMessages, flagsProfile, null);
+    }
+
+    @Test
+    public void refreshLocalMessageFlags_withSupportsFetchingFlagsFalse_shouldNotFetchRemoteFlags() throws Exception {
+        List<Message> syncFlagMessages = singletonList(createMessage(false));
+        FetchProfile flagsProfile = new FetchProfile();
+        flagsProfile.add(Item.FLAGS);
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+
+        flagSyncHelper.refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages);
+
+        verify(remoteFolder, never()).fetch(syncFlagMessages, flagsProfile, null);
+    }
+
+    @Test
+    public void refreshLocalMessageFlags_withDeletedMessages_shouldNotFetchFlagsForDeletedMessages() throws Exception {
+        Message nonDeletedMessage = createMessage(false);
+        Message deletedMessage = createMessage(true);
+        List<Message> syncFlagMessages = asList(nonDeletedMessage, deletedMessage);
+        FetchProfile flagsProfile = new FetchProfile();
+        flagsProfile.add(Item.FLAGS);
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
+
+        flagSyncHelper.refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages);
+
+        verify(remoteFolder).fetch(singletonList(nonDeletedMessage), flagsProfile, null);
+    }
+
+    @Test
+    public void refreshLocalMessageFlags_withListener_shouldCallListener() throws Exception {
+        List<Message> syncFlagMessages = singletonList(createMessage(false));
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
+
+        flagSyncHelper.refreshLocalMessageFlags(account, remoteFolder, localFolder, syncFlagMessages);
+
+        verify(listener).synchronizeMailboxProgress(account, localFolder.getName(), 1, 1);
+    }
+
+    @Test
+    public void processDownloadedFlags_withModifiedRemoteMessage_shouldUpdateLocalMessage() throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false);
+        when(remoteMessage.isSet(Flag.SEEN)).thenReturn(true);
+        when(localMessage.isSet(Flag.SEEN)).thenReturn(false);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(localMessage).setFlag(Flag.SEEN, true);
+    }
+
+    @Test
+    public void processDownloadedFlags_withDeletedLocalMessage_shouldNotUpdateLocalMessage() throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false);
+        when(remoteMessage.isSet(Flag.SEEN)).thenReturn(true);
+        when(localMessage.isSet(Flag.SEEN)).thenReturn(false);
+        when(localMessage.isSet(Flag.DELETED)).thenReturn(true);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(localMessage, never()).setFlag(any(Flag.class), anyBoolean());
+    }
+
+    @Test
+    public void processDownloadedFlags_withDeletedRemoteMessageAndSyncRemoteDeletionsTrue_shouldDeleteLocalMessage()
+            throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false);
+        when(remoteMessage.isSet(Flag.DELETED)).thenReturn(true);
+        when(localMessage.getFolder()).thenReturn(localFolder);
+        when(localFolder.syncRemoteDeletions()).thenReturn(true);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(localMessage).setFlag(Flag.DELETED, true);
+    }
+
+    @Test
+    public void processDownloadedFlags_withDeletedRemoteMessageAndSyncRemoteDeletionsFalse_shouldNotDeleteLocalMessage()
+            throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false);
+        when(remoteMessage.isSet(Flag.DELETED)).thenReturn(true);
+        when(localMessage.getFolder()).thenReturn(localFolder);
+        when(localFolder.syncRemoteDeletions()).thenReturn(false);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(localMessage, never()).setFlag(Flag.DELETED, true);
+    }
+
+    @Test
+    public void processDownloadedFlags_withModifiedRemoteMessageAndSuppressedLocalMessage_shouldNotifyListener()
+            throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(true);
+        when(remoteMessage.isSet(Flag.SEEN)).thenReturn(true);
+        when(localMessage.isSet(Flag.SEEN)).thenReturn(false);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(listener).synchronizeMailboxRemovedMessage(account, localFolder.getName(), localMessage);
+    }
+
+    @Test
+    public void processDownloadedFlags_withModifiedRemoteMessageAndNonSuppressedLocalMessage_shouldNotNotifyListener()
+            throws Exception {
+        Message remoteMessage = createMessage(false);
+        LocalMessage localMessage = createLocalMessageInFolder(false);
+        when(remoteMessage.isSet(Flag.SEEN)).thenReturn(true);
+        when(localMessage.isSet(Flag.SEEN)).thenReturn(false);
+
+        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
+
+        verify(listener, never()).synchronizeMailboxRemovedMessage(account, localFolder.getName(), localMessage);
+    }
+
+    private Message createMessage(boolean deletedFlagSet) {
+        Message message = mock(Message.class);
+        when(message.isSet(Flag.DELETED)).thenReturn(deletedFlagSet);
+        return message;
+    }
+
+    private LocalMessage createLocalMessageInFolder(boolean suppressed) throws MessagingException {
+        LocalMessage localMessage = mock(LocalMessage.class);
+        when(localFolder.getMessage(anyString())).thenReturn(localMessage);
+        when(syncHelper.isMessageSuppressed(eq(localMessage), any(Context.class))).thenReturn(suppressed);
+        when(syncHelper.shouldNotifyForMessage(eq(account), eq(localFolder), eq(localMessage), any(Contacts.class)))
+                .thenReturn(true);
+        return localMessage;
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/FlagSyncHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/FlagSyncHelperTest.java
@@ -25,7 +25,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.singleton;
 import static java.util.Collections.singletonList;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -119,19 +118,6 @@ public class FlagSyncHelperTest {
         flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
 
         verify(localMessage).setFlag(Flag.SEEN, true);
-    }
-
-    @Test
-    public void processDownloadedFlags_withDeletedLocalMessage_shouldNotUpdateLocalMessage() throws Exception {
-        Message remoteMessage = createMessage(false);
-        LocalMessage localMessage = createLocalMessageInFolder(false);
-        when(remoteMessage.isSet(Flag.SEEN)).thenReturn(true);
-        when(localMessage.isSet(Flag.SEEN)).thenReturn(false);
-        when(localMessage.isSet(Flag.DELETED)).thenReturn(true);
-
-        flagSyncHelper.processDownloadedFlags(account, localFolder, remoteMessage);
-
-        verify(localMessage, never()).setFlag(any(Flag.class), anyBoolean());
     }
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/ImapSyncInteractorTest.java
@@ -1,0 +1,153 @@
+package com.fsck.k9.controller;
+
+
+import com.fsck.k9.Account;
+import com.fsck.k9.Account.Expunge;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.RemoteStore;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.notification.NotificationController;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static java.util.Collections.singleton;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+public class ImapSyncInteractorTest {
+
+    private static final String FOLDER_NAME = "Folder";
+
+    private ImapSyncInteractor syncInteractor;
+
+    @Mock
+    private Account account;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private ImapFolder imapFolder;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private MessagingController controller;
+    @Mock
+    private FlagSyncHelper flagSyncHelper;
+    @Mock
+    private MessageDownloader messageDownloader;
+    @Mock
+    private NotificationController notificationController;
+    @Mock
+    private SyncHelper syncHelper;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        syncInteractor = new ImapSyncInteractor(syncHelper, flagSyncHelper, controller, messageDownloader,
+                notificationController);
+
+        configureLocalStoreWithFolder();
+        configureLocalFolder();
+        configureImapStoreWithFolder(imapFolder);
+        configureImapFolder();
+        when(syncHelper.verifyOrCreateRemoteSpecialFolder(account, FOLDER_NAME, imapFolder, listener, controller))
+                .thenReturn(true);
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+    }
+
+    @Test
+    public void performSync_withProcessPendingCommandsSynchronousThrowingException_shouldFinishWithError()
+            throws Exception {
+        doThrow(MessagingException.class).when(controller).processPendingCommandsSynchronous(account);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(listener).synchronizeMailboxFailed(eq(account), eq(FOLDER_NAME), anyString());
+    }
+    @Test
+    public void performSync_withImapFolder_shouldFinishWithoutError() throws Exception {
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(listener).synchronizeMailboxFinished(eq(account), eq(FOLDER_NAME), anyInt(), anyInt());
+    }
+
+    @Test
+    public void performSync_withNonImapFolder_shouldFinishWithError() throws Exception {
+        configureImapStoreWithFolder(mock(Folder.class));
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(listener).synchronizeMailboxFailed(eq(account), eq(FOLDER_NAME), anyString());
+    }
+
+    @Test
+    public void performSync_withRemoteFolderCreationFailed_shouldExitWithoutOpeningRemoteFolder() throws Exception {
+        when(syncHelper.verifyOrCreateRemoteSpecialFolder(account, FOLDER_NAME, imapFolder, listener, controller))
+                .thenReturn(false);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(imapFolder, never()).open(anyInt());
+    }
+
+    @Test
+    public void performSync_withAccountNotSetToExpungeOnPoll_shouldNotExpungeRemoteFolder() throws Exception {
+        when(account.getExpungePolicy()).thenReturn(Expunge.EXPUNGE_MANUALLY);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(imapFolder, never()).expunge();
+    }
+
+    @Test
+    public void performSync_withNegativeMessageCount_shouldFinishWithError() throws Exception {
+        when(imapFolder.getMessageCount()).thenReturn(-1);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(listener).synchronizeMailboxFailed(eq(account), eq(FOLDER_NAME), anyString());
+    }
+
+    @Test
+    public void performSync_afterCompletion_shouldCloseFolders() throws Exception {
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(localFolder).close();
+        verify(imapFolder).close();
+    }
+
+    private void configureLocalStoreWithFolder() throws MessagingException {
+        LocalStore localStore = mock(LocalStore.class);
+        when(account.getLocalStore()).thenReturn(localStore);
+        when(localStore.getFolder(FOLDER_NAME)).thenReturn(localFolder);
+    }
+
+    private void configureLocalFolder() throws Exception {
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+    }
+
+    private void configureImapStoreWithFolder(Folder folder) throws MessagingException {
+        RemoteStore remoteStore = mock(RemoteStore.class);
+        when(account.getRemoteStore()).thenReturn(remoteStore);
+        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(folder);
+    }
+
+    private void configureImapFolder() throws Exception {
+        when(imapFolder.getName()).thenReturn(FOLDER_NAME);
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/LegacySyncInteractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/LegacySyncInteractorTest.java
@@ -1,0 +1,233 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessageRetrievalListener;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.RemoteStore;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.notification.NotificationController;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonMap;
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+public class LegacySyncInteractorTest {
+
+    private static final String FOLDER_NAME = "Folder";
+
+    private LegacySyncInteractor syncInteractor;
+
+    @Mock
+    private Account account;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private Folder remoteFolder;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private MessagingController controller;
+    @Mock
+    private MessageDownloader messageDownloader;
+    @Mock
+    private NotificationController notificationController;
+    @Captor
+    private ArgumentCaptor<List<Message>> messageListCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+        syncInteractor = new LegacySyncInteractor(controller, messageDownloader, notificationController);
+
+        configureLocalStoreWithFolder();
+        configureRemoteStoreWithFolder();
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+    }
+
+    @Test
+    public void performSync_withOneMessageInRemoteFolder_shouldFinishWithoutError() throws Exception {
+        messageCountInRemoteFolder(1);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(listener).synchronizeMailboxFinished(account, FOLDER_NAME, 1, 0);
+    }
+
+    @Test
+    public void performSync_withEmptyRemoteFolder_shouldFinishWithoutError() throws Exception {
+        messageCountInRemoteFolder(0);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(listener).synchronizeMailboxFinished(account, FOLDER_NAME, 0, 0);
+    }
+
+    @Test
+    public void performSync_withNegativeMessageCountInRemoteFolder_shouldFinishWithError() throws Exception {
+        messageCountInRemoteFolder(-1);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(listener).synchronizeMailboxFailed(account, FOLDER_NAME,
+                "Exception: Message count -1 for folder Folder");
+    }
+
+    @Test
+    public void performSync_shouldOpenRemoteFolderFromStore() throws Exception {
+        messageCountInRemoteFolder(1);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(remoteFolder).open(Folder.OPEN_MODE_RO);
+    }
+
+    @Test
+    public void performSync_withAccountPolicySetToExpungeOnPoll_shouldExpungeRemoteFolder() throws Exception {
+        messageCountInRemoteFolder(1);
+        when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_ON_POLL);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(remoteFolder).expunge();
+    }
+
+    @Test
+    public void performSync_withAccountPolicySetToExpungeManually_shouldNotExpungeRemoteFolder() throws Exception {
+        messageCountInRemoteFolder(1);
+        when(account.getExpungePolicy()).thenReturn(Account.Expunge.EXPUNGE_MANUALLY);
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(remoteFolder, never()).expunge();
+    }
+
+    @Test
+    public void performSync_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfDeletedMessages() throws Exception {
+        messageCountInRemoteFolder(0);
+        LocalMessage localCopyOfRemoteDeletedMessage = mock(LocalMessage.class);
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(singletonMap("1", 0L));
+        when(localFolder.getMessagesByUids(any(List.class)))
+                .thenReturn(Collections.singletonList(localCopyOfRemoteDeletedMessage));
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(localFolder).destroyMessages(messageListCaptor.capture());
+        assertEquals(localCopyOfRemoteDeletedMessage, messageListCaptor.getValue().get(0));
+    }
+
+    @Test
+    public void performSync_withAccountSetToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfExistingMessagesAfterEarliestPollDate()
+            throws Exception {
+        messageCountInRemoteFolder(1);
+        Date dateOfEarliestPoll = new Date();
+        LocalMessage localMessage = localMessageWithCopyOnServer();
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(account.getEarliestPollDate()).thenReturn(dateOfEarliestPoll);
+        when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(false);
+        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(localMessage));
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
+    }
+
+    @Test
+    public void performSync_withAccountSetToSyncRemoteDeletions_shouldDeleteLocalCopiesOfExistingMessagesBeforeEarliestPollDate()
+            throws Exception {
+        messageCountInRemoteFolder(1);
+        LocalMessage localMessage = localMessageWithCopyOnServer();
+        Date dateOfEarliestPoll = new Date();
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(account.getEarliestPollDate()).thenReturn(dateOfEarliestPoll);
+        when(localMessage.olderThan(dateOfEarliestPoll)).thenReturn(true);
+        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(singletonMap("1", 0L));
+        when(localFolder.getMessagesByUids(any(List.class))).thenReturn(Collections.singletonList(localMessage));
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(localFolder).destroyMessages(messageListCaptor.capture());
+        assertEquals(localMessage, messageListCaptor.getValue().get(0));
+    }
+
+    @Test
+    public void performSync_withAccountSetNotToSyncRemoteDeletions_shouldNotDeleteLocalCopiesOfMessages()
+            throws Exception {
+        messageCountInRemoteFolder(0);
+        LocalMessage remoteDeletedMessage = mock(LocalMessage.class);
+        when(account.syncRemoteDeletions()).thenReturn(false);
+        when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(remoteDeletedMessage));
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(localFolder, never()).destroyMessages(messageListCaptor.capture());
+    }
+
+    @Test
+    public void performSync_shouldDownloadUnsyncedMessagesAndSyncLocalMessageFlags() throws Exception {
+        messageCountInRemoteFolder(1);
+        localMessageWithCopyOnServer();
+
+        syncInteractor.performSync(account, FOLDER_NAME, listener, null);
+
+        verify(messageDownloader).downloadMessages(eq(account), eq(remoteFolder), eq(localFolder),
+                messageListCaptor.capture(), eq(false), eq(true));
+        assertEquals(messageListCaptor.getValue().size(), 1);
+    }
+
+    private void configureLocalStoreWithFolder() throws MessagingException {
+        LocalStore localStore = mock(LocalStore.class);
+        when(account.getLocalStore()).thenReturn(localStore);
+        when(localStore.getFolder(FOLDER_NAME)).thenReturn(localFolder);
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+    }
+
+    private void configureRemoteStoreWithFolder() throws MessagingException {
+        RemoteStore remoteStore = mock(RemoteStore.class);
+        when(account.getRemoteStore()).thenReturn(remoteStore);
+        when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
+        when(remoteFolder.getName()).thenReturn(FOLDER_NAME);
+    }
+
+    private void messageCountInRemoteFolder(int value) throws MessagingException {
+        when(remoteFolder.getMessageCount()).thenReturn(value);
+    }
+
+    private LocalMessage localMessageWithCopyOnServer() throws MessagingException {
+        String messageUid = "UID";
+        Message remoteMessage = mock(Message.class);
+        LocalMessage localMessage = mock(LocalMessage.class);
+
+        when(remoteMessage.getUid()).thenReturn(messageUid);
+        when(localMessage.getUid()).thenReturn(messageUid);
+        when(remoteFolder.getMessages(anyInt(), anyInt(), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(Collections.singletonList(remoteMessage));
+        return localMessage;
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessageDownloaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessageDownloaderTest.java
@@ -1,0 +1,196 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Date;
+import java.util.List;
+
+import android.content.Context;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.AccountStats;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.FetchProfile;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessageRetrievalListener;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.robolectric.shadows.ShadowApplication;
+import org.robolectric.shadows.ShadowLog;
+
+import static java.util.Collections.singletonList;
+import static junit.framework.TestCase.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+public class MessageDownloaderTest {
+
+    private static final String FOLDER_NAME = "Folder";
+    private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;
+
+    private MessageDownloader messageDownloader;
+
+    @Mock
+    private Account account;
+    @Mock
+    private Folder remoteFolder;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private MessagingController controller;
+    @Mock
+    private SyncHelper syncHelper;
+    @Mock
+    private Message unsyncedRemoteMessage;
+    @Captor
+    private ArgumentCaptor<FetchProfile> fetchProfileCaptor;
+
+    @Before
+    public void setUp() throws MessagingException {
+        ShadowLog.stream = System.out;
+        MockitoAnnotations.initMocks(this);
+        Context context = ShadowApplication.getInstance().getApplicationContext();
+
+        messageDownloader = MessageDownloader.newInstance(context, controller, syncHelper);
+
+        when(account.getStats(any(Context.class))).thenReturn(mock(AccountStats.class));
+        when(account.getMaximumAutoDownloadMessageSize()).thenReturn(MAXIMUM_SMALL_MESSAGE_SIZE);
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(remoteFolder.getName()).thenReturn(FOLDER_NAME);
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Message remoteMessage = invocation.getArgumentAt(0, Message.class);
+                List<Message> unsyncedMessages = invocation.getArgumentAt(5, List.class);
+                unsyncedMessages.add(remoteMessage);
+                return null;
+            }
+        }).when(syncHelper).evaluateMessageForDownload(any(Message.class), eq(FOLDER_NAME), eq(localFolder),
+                eq(remoteFolder), eq(account), any(List.class), any(List.class), eq(false), eq(controller));
+    }
+
+    @Test
+    public void downloadMessages_withAccountSupportingFetchingFlags_shouldFetchUnsychronizedMessagesEnvelopeAndFlags()
+            throws Exception {
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(true);
+
+        messageDownloader.downloadMessages(account, remoteFolder, localFolder, singletonList(unsyncedRemoteMessage), false,
+                true);
+
+        verify(remoteFolder, atLeastOnce()).fetch(anyList(), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
+        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.FLAGS));
+        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
+        assertEquals(2, fetchProfileCaptor.getAllValues().get(0).size());
+    }
+
+    @Test
+    public void downloadMessages_withAccountNotSupportingFetchingFlags_shouldFetchUnsychronizedMessagesEnvelope()
+            throws Exception {
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+
+        messageDownloader.downloadMessages(account, remoteFolder, localFolder, singletonList(unsyncedRemoteMessage), false,
+                true);
+
+        verify(remoteFolder, atLeastOnce()).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(0).size());
+        assertTrue(fetchProfileCaptor.getAllValues().get(0).contains(FetchProfile.Item.ENVELOPE));
+    }
+
+    @Test
+    public void downloadMessages_withUnsyncedNewSmallMessage_shouldFetchBodyOfSmallMessage()
+            throws Exception {
+        Message smallMessage = buildSmallNewMessage();
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+        respondToFetchEnvelopesWithMessage(smallMessage);
+
+        messageDownloader.downloadMessages(account, remoteFolder, localFolder, singletonList(smallMessage), false,
+                true);
+
+        verify(remoteFolder, atLeast(2)).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(1).size());
+        assertTrue(fetchProfileCaptor.getAllValues().get(1).contains(FetchProfile.Item.BODY));
+    }
+
+    @Test
+    public void downloadMessages_withUnsyncedNewLargeMessage_shouldFetchStructureAndLimitedBodyOfLargeMessage()
+            throws Exception {
+        final Message largeMessage = buildLargeNewMessage();
+        when(remoteFolder.supportsFetchingFlags()).thenReturn(false);
+        respondToFetchEnvelopesWithMessage(largeMessage);
+        when(localFolder.appendMessages(anyList())).then(new Answer<Object>() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                when(localFolder.getMessage(anyString())).thenReturn(mock(LocalMessage.class));
+                return null;
+            }
+        });
+        when(localFolder.getMessage(anyString())).thenReturn(mock(LocalMessage.class));
+
+        messageDownloader.downloadMessages(account, remoteFolder, localFolder, singletonList(largeMessage), false,
+                true);
+
+        verify(remoteFolder, atLeast(4)).fetch(any(List.class), fetchProfileCaptor.capture(),
+                any(MessageRetrievalListener.class));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(2).size());
+        assertEquals(FetchProfile.Item.STRUCTURE, fetchProfileCaptor.getAllValues().get(2).get(0));
+        assertEquals(1, fetchProfileCaptor.getAllValues().get(3).size());
+        assertEquals(FetchProfile.Item.BODY_SANE, fetchProfileCaptor.getAllValues().get(3).get(0));
+    }
+
+    private Message buildSmallNewMessage() {
+        Message message = mock(Message.class);
+        when(message.olderThan(any(Date.class))).thenReturn(false);
+        when(message.getSize()).thenReturn((long) MAXIMUM_SMALL_MESSAGE_SIZE);
+        return message;
+    }
+
+    private Message buildLargeNewMessage() {
+        Message message = mock(Message.class);
+        when(message.olderThan(any(Date.class))).thenReturn(false);
+        when(message.getSize()).thenReturn((long) (MAXIMUM_SMALL_MESSAGE_SIZE + 1));
+        return message;
+    }
+
+    private void respondToFetchEnvelopesWithMessage(final Message message) throws MessagingException {
+        doAnswer(new Answer() {
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                FetchProfile fetchProfile = (FetchProfile) invocation.getArguments()[1];
+                if (invocation.getArguments()[2] != null) {
+                    MessageRetrievalListener listener = (MessageRetrievalListener) invocation.getArguments()[2];
+                    if (fetchProfile.contains(FetchProfile.Item.ENVELOPE)) {
+                        listener.messageStarted("UID", 1, 1);
+                        listener.messageFinished(message, 1, 1);
+                        listener.messagesFinished(1);
+                    }
+                }
+                return null;
+            }
+        }).when(remoteFolder).fetch(any(List.class), any(FetchProfile.class), any(MessageRetrievalListener.class));
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/NonQresyncExtensionHandlerTest.java
@@ -1,0 +1,176 @@
+package com.fsck.k9.controller;
+
+
+import java.util.Date;
+import java.util.List;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessageRetrievalListener;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.store.imap.ImapFolder;
+import com.fsck.k9.mail.store.imap.ImapMessage;
+import com.fsck.k9.mailstore.LocalFolder;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static java.util.Collections.singletonMap;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyList;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+public class NonQresyncExtensionHandlerTest {
+
+    private static final String FOLDER_NAME = "Folder";
+    private static final String NEW_MESSAGE_UID = "2";
+    private static final String OLD_MESSAGE_UID = "1";
+
+    private NonQresyncExtensionHandler extensionHandler;
+
+    @Mock
+    private Account account;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private ImapFolder imapFolder;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private MessagingController controller;
+    @Mock
+    private ImapMessage remoteNewMessage;
+    @Mock
+    private ImapMessage remoteOldMessage;
+    @Mock
+    private MessageDownloader messageDownloader;
+    @Mock
+    private FlagSyncHelper flagSyncHelper;
+    @Mock
+    private SyncHelper syncHelper;
+    @Captor
+    private ArgumentCaptor<List<String>> deletedUidsCaptor;
+    @Captor
+    private ArgumentCaptor<List<ImapMessage>> downloadMessagesCaptor;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        extensionHandler = new NonQresyncExtensionHandler(syncHelper, flagSyncHelper, controller, messageDownloader);
+
+        configureLocalFolder();
+        configureImapFolder();
+        configureRemainingMocks();
+    }
+
+    @Test
+    public void continueSync_shouldNotifyListenersOfHeaderSynchronization() throws Exception {
+        when(account.syncRemoteDeletions()).thenReturn(true);
+
+        extensionHandler.continueSync(account, localFolder, imapFolder, listener);
+
+        verify(listener).synchronizeMailboxHeadersStarted(account, FOLDER_NAME);
+        verify(listener).synchronizeMailboxHeadersProgress(account, FOLDER_NAME, 1, 2);
+        verify(listener).synchronizeMailboxHeadersProgress(account, FOLDER_NAME, 2, 2);
+        verify(listener).synchronizeMailboxHeadersFinished(account, FOLDER_NAME, 2, 2);
+    }
+
+    @Test
+    public void continueSync_withSyncRemoteDeletionsSetToTrue_shouldDeleteLocalCopiesOfDeletedMessages()
+            throws Exception {
+        when(account.syncRemoteDeletions()).thenReturn(true);
+        when(imapFolder.getMessages(eq(1), eq(2), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(singletonList(remoteNewMessage));
+
+        extensionHandler.continueSync(account, localFolder, imapFolder, listener);
+
+        verify(syncHelper).deleteLocalMessages(deletedUidsCaptor.capture(), eq(account), eq(localFolder),
+                eq(controller), eq(listener));
+        assertEquals(deletedUidsCaptor.getValue(), singletonList(OLD_MESSAGE_UID));
+    }
+
+    @Test
+    public void continueSync_withSyncRemoteDeletionsSetToFalse_shouldNotDeleteLocalCopiesOfDeletedMessages()
+            throws Exception {
+        when(account.syncRemoteDeletions()).thenReturn(false);
+        when(imapFolder.getMessages(eq(1), eq(2), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(singletonList(remoteNewMessage));
+
+        extensionHandler.continueSync(account, localFolder, imapFolder, listener);
+
+        verify(syncHelper, never()).deleteLocalMessages(anyList(), eq(account), eq(localFolder), eq(controller),
+                eq(listener));
+    }
+
+    @Test
+    public void continueSync_shouldDownloadNewMessages() throws Exception {
+        extensionHandler.continueSync(account, localFolder, imapFolder, listener);
+
+        verify(messageDownloader).downloadMessages(eq(account), eq(imapFolder), eq(localFolder),
+                downloadMessagesCaptor.capture(), eq(false), eq(true));
+        assertEquals(downloadMessagesCaptor.getValue(), singletonList(remoteNewMessage));
+    }
+
+    private void configureLocalFolder() throws MessagingException {
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(localFolder.getMessage(NEW_MESSAGE_UID)).thenReturn(null);
+        when(localFolder.getAllMessagesAndEffectiveDates()).thenReturn(singletonMap(OLD_MESSAGE_UID, 0L));
+    }
+
+    private void configureImapFolder() throws MessagingException {
+        when(imapFolder.getName()).thenReturn(FOLDER_NAME);
+        when(imapFolder.getMessageCount()).thenReturn(2);
+        when(imapFolder.getMessages(eq(1), eq(2), any(Date.class), any(MessageRetrievalListener.class)))
+                .thenReturn(asList(remoteNewMessage, remoteOldMessage));
+    }
+
+    private void configureRemainingMocks() throws MessagingException {
+        when(remoteNewMessage.getUid()).thenReturn(NEW_MESSAGE_UID);
+        when(remoteOldMessage.getUid()).thenReturn(OLD_MESSAGE_UID);
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                List<Message> unsyncedMessages = (List) args[5];
+                unsyncedMessages.add(remoteNewMessage);
+                return null;
+            }
+        }).when(syncHelper).evaluateMessageForDownload(eq(remoteNewMessage), eq(FOLDER_NAME), eq(localFolder),
+                eq(imapFolder), eq(account), any(List.class), any(List.class), eq(false), eq(controller));
+
+        doAnswer(new Answer() {
+            @Override
+            public Object answer(InvocationOnMock invocation) throws Throwable {
+                Object[] args = invocation.getArguments();
+                List<Message> flagSyncMessages = (List) args[6];
+                flagSyncMessages.add(remoteOldMessage);
+                return null;
+            }
+        }).when(syncHelper).evaluateMessageForDownload(eq(remoteOldMessage), eq(FOLDER_NAME), eq(localFolder),
+                eq(imapFolder), eq(account), any(List.class), any(List.class), eq(false), eq(controller));
+
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+        when(syncHelper.getRemoteStart(localFolder, imapFolder)).thenReturn(1);
+        when(account.getDisplayCount()).thenReturn(2);
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/SyncHelperTest.java
@@ -1,0 +1,140 @@
+package com.fsck.k9.controller;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTestRunner;
+import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Folder.FolderType;
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mailstore.LocalFolder;
+import com.fsck.k9.mailstore.LocalMessage;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import static java.util.Collections.singleton;
+import static java.util.Collections.singletonList;
+import static junit.framework.TestCase.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@SuppressWarnings("unchecked")
+@RunWith(K9RobolectricTestRunner.class)
+public class SyncHelperTest {
+
+    private static final String FOLDER_NAME = "Folder";
+
+    private SyncHelper syncHelper;
+
+    @Mock
+    private Account account;
+    @Mock
+    private LocalFolder localFolder;
+    @Mock
+    private Folder remoteFolder;
+    @Mock
+    private MessagingListener listener;
+    @Mock
+    private MessagingController controller;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+
+        syncHelper = SyncHelper.getInstance();
+
+        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(remoteFolder.getName()).thenReturn(FOLDER_NAME);
+        when(controller.getListeners(listener)).thenReturn(singleton(listener));
+    }
+
+    @Test
+    public void verifyOrCreateRemoteSpecialFolder_withUnavailableRemoteFolder_shouldTryToCreateRemoteFolder()
+            throws Exception {
+        when(account.getTrashFolderName()).thenReturn("Trash");
+        when(remoteFolder.exists()).thenReturn(false);
+
+        syncHelper.verifyOrCreateRemoteSpecialFolder(account, "Trash", remoteFolder, listener, controller);
+
+        verify(remoteFolder).create(FolderType.HOLDS_MESSAGES);
+    }
+
+    @Test
+    public void verifyOrCreateRemoteSpecialFolder_withFolderCreationFailed_shouldNotifyListeners() throws Exception {
+        String folderName = "Trash";
+        when(account.getTrashFolderName()).thenReturn(folderName);
+        when(remoteFolder.exists()).thenReturn(false);
+        when(remoteFolder.create(FolderType.HOLDS_MESSAGES)).thenReturn(false);
+
+        syncHelper.verifyOrCreateRemoteSpecialFolder(account, folderName, remoteFolder, listener, controller);
+
+        verify(listener).synchronizeMailboxFinished(account, folderName, 0, 0);
+    }
+
+    @Test
+    public void getRemoteStart() throws Exception {
+        when(remoteFolder.getMessageCount()).thenReturn(152);
+        when(localFolder.getVisibleLimit()).thenReturn(100);
+
+        int remoteStart = syncHelper.getRemoteStart(localFolder, remoteFolder);
+
+        assertEquals(remoteStart, 53);
+    }
+
+    @Test
+    public void deleteLocalMessages_withDeletedMessages_shouldNotifyListeners() throws Exception {
+        LocalMessage destroyedMessage = mock(LocalMessage.class);
+        when(localFolder.getMessagesByUids(singletonList("1"))).thenReturn(singletonList(destroyedMessage));
+
+        syncHelper.deleteLocalMessages(singletonList("1"), account, localFolder, controller, listener);
+
+        verify(listener).synchronizeMailboxRemovedMessage(account, FOLDER_NAME, destroyedMessage);
+    }
+
+    @Test
+    public void evaluateMessageForDownload_withoutLocalCopy_shouldAddMessageToUnsyncedMessagesList() throws Exception {
+        Message message = createRemoteMessage(false);
+        List<Message> unsyncedMessages = new ArrayList<>(0);
+        List<Message> syncFlagMessages = new ArrayList<>(0);
+
+        syncHelper.evaluateMessageForDownload(message, FOLDER_NAME, localFolder, remoteFolder, account, unsyncedMessages,
+                syncFlagMessages, false, controller);
+
+        assertEquals(singletonList(message), unsyncedMessages);
+    }
+
+    @Test
+    public void evaluateMessageForDownload_withLocalCopy_shouldAddMessageToSyncFlagMessagesList() throws Exception {
+        Message message = createRemoteMessage(true);
+        List<Message> unsyncedMessages = new ArrayList<>(0);
+        List<Message> syncFlagMessages = new ArrayList<>(0);
+
+        syncHelper.evaluateMessageForDownload(message, FOLDER_NAME, localFolder, remoteFolder, account, unsyncedMessages,
+                syncFlagMessages, false, controller);
+
+        assertEquals(singletonList(message), syncFlagMessages);
+    }
+
+    private Message createRemoteMessage(boolean availableLocally) throws MessagingException {
+        String uid = "1";
+        Message remoteMessage = mock(Message.class);
+        when(remoteMessage.getUid()).thenReturn(uid);
+        if (availableLocally) {
+            LocalMessage localMessage = mock(LocalMessage.class);
+            when(localMessage.isSet(Flag.X_DOWNLOADED_FULL)).thenReturn(true);
+            when(localFolder.getMessageUidAndFlags(uid)).thenReturn(localMessage);
+        } else {
+            when(localFolder.getMessage(uid)).thenReturn(null);
+        }
+        return remoteMessage;
+    }
+}


### PR DESCRIPTION
This is the first PR towards supporting CONDSTORE and QRESYNC.

This PR splits `synchronizeMailboxSynchronous` in `MessagingController` into two pathways(`ImapSyncInteractor` and `LegacySyncInteractor`) depending on whether the protocol is IMAP or non-IMAP. 

`ImapSyncInteractor` contains code that is copied over from `synchronizeMailboxSynchronous` and then split into multiple classes (`SyncHelper`, `FlagSyncHelper` and `MessageDownloader`).

`LegacySyncInteractor` contains code directly copied over from `synchronizeMailboxSynchronous`.