### PR TITLE
Use translatable string for Cryptography preference

### DIFF
--- a/k9mail/src/main/res/xml/global_preferences.xml
+++ b/k9mail/src/main/res/xml/global_preferences.xml
@@ -412,7 +412,7 @@
     </PreferenceScreen>
 
     <PreferenceScreen
-        android:title="Cryptography"
+        android:title="@string/account_settings_crypto"
         android:key="crypto">
 
         <org.openintents.openpgp.util.OpenPgpAppPreference


### PR DESCRIPTION
Fixes part of #2941 
