### PR TITLE
Allow translation of 'more from sender' search name

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1279,7 +1279,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
     @Override
     public void showMoreFromSameSender(String senderAddress) {
-        LocalSearch tmpSearch = new LocalSearch("From " + senderAddress);
+        LocalSearch tmpSearch = new LocalSearch(getString(R.string.search_from_format, senderAddress));
         tmpSearch.addAccountUuids(mSearch.getAccountUuids());
         tmpSearch.and(SearchField.SENDER, senderAddress, Attribute.CONTAINS);
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -299,6 +299,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="message_additional_headers_retrieval_failed">The retrieval of additional headers from the database or mail server failed.</string>
 
     <string name="from_same_sender">More from this sender</string>
+    <string name="search_from_format">From <xliff:g id="sender">%s</xliff:g></string>
     <string name="debug_delete_local_body">Debug / Clear message body</string>
 
     <string name="message_discarded_toast">Message discarded</string>


### PR DESCRIPTION
Fixes part of #2941 


