### PR TITLE
Disabling email signatures by default on account creation.

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -327,7 +327,7 @@ public class Account implements BaseAccount, StoreConfig {
         identities = new ArrayList<>();
 
         Identity identity = new Identity();
-        identity.setSignatureUse(true);
+        identity.setSignatureUse(false);
         identity.setSignature(context.getString(R.string.default_signature));
         identity.setDescription(context.getString(R.string.default_identity_description));
         identities.add(identity);


### PR DESCRIPTION
Several reasons why I'd like to see signatures disabled by default:
  -  Communication tools should never modify text content without the sender explicitly allowing it.
  -  Even having known about the default setting, I forget to change it when making new accounts. Suffice to say it's slightly irritating when I accidentally send the signature in an otherwise unfitting context (for work, organizing a funeral, love letters, etc.).

This patch simply sets the signatureUse to false instead of true when a new identity is created. The default signature string is still loaded in, and will appear if the user explicitly enables email signatures.

No additional unit tests fail, I tested this build on my phone, it appears to works as intended.