### PR TITLE
Do nothing in ImapConnection.close() if connection is not open

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -715,6 +715,10 @@ class ImapConnection {
     }
 
     public void close() {
+        if (!open) {
+            return;
+        }
+
         open = false;
         stacktraceForClose = new Exception();
 


### PR DESCRIPTION
Under certain circumstances `ImapFolderPusher` can call `ImapConnection.close()` twice. When using compression this will lead to a `NullPointerException` inside `ZOutputStream.close()`.
We're ignoring all exceptions when closing a connection. So this shouldn't be a problem. But (early versions of?) Android 8.1 shipped with a bug in ART that shuts down the VM when a `NullPointerException` is triggered from AOT/JIT(?) compiled code that uses a certain optimization. And we're unlucky enough to trigger this bug.

Not closing the streams more than once should work around this bug.

Fixes #2931