### PR TITLE
Add test for IMAP FETCH BODYSTRUCTURE

### DIFF
--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -835,6 +835,23 @@ public class ImapFolderTest {
     }
 
     @Test
+    public void fetch_withStructureFetchProfile_shouldSetContentType() throws Exception {
+        ImapFolder folder = createFolder("Folder");
+        prepareImapFolderForOpen(OPEN_MODE_RO);
+        folder.open(OPEN_MODE_RO);
+        String bodyStructure = "(\"TEXT\" \"PLAIN\" (\"CHARSET\" \"US-ASCII\") NIL NIL \"7BIT\" 2279 48)";
+        when(imapConnection.readResponse(any(ImapResponseCallback.class)))
+                .thenReturn(createImapResponse("* 1 FETCH (BODYSTRUCTURE "+bodyStructure+" UID 1)"))
+                .thenReturn(createImapResponse("x OK"));
+        List<ImapMessage> messages = createImapMessages("1");
+        FetchProfile fetchProfile = createFetchProfile(Item.STRUCTURE);
+
+        folder.fetch(messages, fetchProfile, null);
+
+        verify(messages.get(0)).setHeader(MimeHeader.HEADER_CONTENT_TYPE, "text/plain;\r\n CHARSET=\"US-ASCII\"");
+    }
+
+    @Test
     public void fetch_withBodySaneFetchProfile_shouldIssueRespectiveCommand() throws Exception {
         ImapFolder folder = createFolder("Folder");
         prepareImapFolderForOpen(OPEN_MODE_RO);


### PR DESCRIPTION
A fairly basic test for code surrounding #2966 (doesn't fix the bug). Just verifying the behaviour we already have - parsing a sample header.

The example BODYSTRUCTURE itself I took from the IMAP RFC -  https://tools.ietf.org/html/rfc3501 page 74.