### PR TITLE
Fix: import/export maintains account order

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -155,7 +156,7 @@ public class SettingsExporter {
             Set<String> exportAccounts;
             if (accountUuids == null) {
                 List<Account> accounts = preferences.getAccounts();
-                exportAccounts = new HashSet<>();
+                exportAccounts = new LinkedHashSet<>();
                 for (Account account : accounts) {
                     exportAccounts.add(account.getUuid());
                 }

--- a/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -7,6 +7,7 @@ import java.io.InputStreamReader;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -804,7 +805,7 @@ public class SettingsImporter {
                 String element = xpp.getName();
                 if (SettingsExporter.ACCOUNT_ELEMENT.equals(element)) {
                     if (accounts == null) {
-                        accounts = new HashMap<>();
+                        accounts = new LinkedHashMap<>();
                     }
 
                     ImportedAccount account = parseAccount(xpp, accountUuids, overview);


### PR DESCRIPTION
Resolves #2969 

As suggested by @cketti 
* Changed `HashSet` to `LinkedHashSet` in `SettingsExporter` for storing accounts in order.
* Changed `HashMap` to `LinkedHashMap` in `SettingsImporter` for importing accounts in order.