### PR TITLE
Revert to old way of replacing ASCII lines with <hr> tag

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/message/html/HtmlConverter.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/html/HtmlConverter.java
@@ -5,7 +5,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
-import java.util.regex.Pattern;
 
 import android.text.Annotation;
 import android.text.Editable;
@@ -179,11 +178,6 @@ public class HtmlConverter {
             "style=\"margin: 0pt 0pt 1ex 0.8ex; border-left: 1px solid $$COLOR$$; padding-left: 1ex;\">";
     private static final String HTML_BLOCKQUOTE_END = "</blockquote>";
     private static final String HTML_NEWLINE = "<br />";
-    private static final Pattern ASCII_PATTERN_FOR_HR = Pattern.compile(
-            "(^|\\Q" + HTML_NEWLINE + "\\E)\\s*((\\Q" + HTML_NEWLINE + "\\E)*" +
-            "((((\\Q" + HTML_NEWLINE + "\\E){0,2}([-=_]{3,})(\\Q" + HTML_NEWLINE +
-            "\\E){0,2})|(([-=_]{2,} ?)(8&lt;|<gt>8|%&lt;|<gt>%)" +
-            "( ?[-=_]{2,})))+(\\Q" + HTML_NEWLINE + "\\E|$)))");
 
     /**
      * Convert a text string into an HTML document.
@@ -276,7 +270,7 @@ public class HtmlConverter {
                    HTML_BLOCKQUOTE_END + "$1"
                );
 
-        text = ASCII_PATTERN_FOR_HR.matcher(text).replaceAll("<hr>");
+        text = text.replaceAll("\\s*([-=_]{30,}+)\\s*", "<hr>");
 
         StringBuffer sb = new StringBuffer(text.length() + TEXT_TO_HTML_EXTRA_BUFFER_LENGTH);
 

--- a/k9mail/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 
 import com.fsck.k9.K9RobolectricTestRunner;
 import org.apache.commons.io.IOUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.annotation.Config;
@@ -194,6 +195,7 @@ public class HtmlConverterTest {
     }
 
     @Test
+    @Ignore("Disabled due to temporary fix for issue #3018")
     public void issue2259Spec() {
         String text = "text\n" +
                 "---------------------------\n" +
@@ -225,6 +227,7 @@ public class HtmlConverterTest {
     }
 
     @Test
+    @Ignore("Disabled due to temporary fix for issue #3018")
     public void mergeConsecutiveBreaksIntoOne() {
         String text = "hello\n------------\n---------------\nfoo bar";
         String result = HtmlConverter.textToHtml(text);
@@ -260,6 +263,7 @@ public class HtmlConverterTest {
     }
 
     @Test
+    @Ignore("Disabled due to temporary fix for issue #3018")
     public void anyTripletIsHRuledOut() {
         String text = "--=\n-=-\n===\n___\n\n";
         String result = HtmlConverter.textToHtml(text);
@@ -267,6 +271,7 @@ public class HtmlConverterTest {
     }
 
     @Test
+    @Ignore("Disabled due to temporary fix for issue #3018")
     public void replaceSpaceSeparatedDashesWithHR() {
         String text = "hello\n---------------------------\nfoo bar";
         String result = HtmlConverter.textToHtml(text);
@@ -274,6 +279,7 @@ public class HtmlConverterTest {
     }
 
     @Test
+    @Ignore("Disabled due to temporary fix for issue #3018")
     public void replacementWithHRAtBeginning() {
         String text = "---------------------------\nfoo bar";
         String result = HtmlConverter.textToHtml(text);
@@ -281,6 +287,7 @@ public class HtmlConverterTest {
     }
 
     @Test
+    @Ignore("Disabled due to temporary fix for issue #3018")
     public void replacementWithHRAtEnd() {
         String text = "hello\n__________________________________";
         String result = HtmlConverter.textToHtml(text);
@@ -288,6 +295,7 @@ public class HtmlConverterTest {
     }
 
     @Test
+    @Ignore("Disabled due to temporary fix for issue #3018")
     public void replacementOfScissorsByHR() {
         String text = "hello\n-- %< -------------- >8 --\nworld\n";
         String result = HtmlConverter.textToHtml(text);


### PR DESCRIPTION
The regular expression we were using was causing the HTML conversion to take forever for some messages.
I want to fix this properly by rewriting the text to HTML conversion. But for now we need a quick fix.

Fixes #3018