### PR TITLE
Fix #3032 - add count to string for replacement

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -1343,7 +1343,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 handler.updateFooter(context.getResources().getQuantityString(R.plurals.remote_search_downloading_limited,
                         maxResults, maxResults, numResults));
             } else {
-                handler.updateFooter(context.getResources().getQuantityString(R.plurals.remote_search_downloading, numResults));
+                handler.updateFooter(context.getResources().getQuantityString(R.plurals.remote_search_downloading,
+                        numResults, numResults));
             }
             fragmentListener.setMessageListProgress(Window.PROGRESS_START);
         }


### PR DESCRIPTION
Fixes #3032 - need to add the count twice, first for the pluralisation second for the string replacement parameter.