### PR TITLE
Fix HTML sanitation

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/message/html/HeadCleaner.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/html/HeadCleaner.java
@@ -35,7 +35,7 @@ class HeadCleaner {
     static class CleaningVisitor implements NodeVisitor {
         private final Element root;
         private Element destination;
-        private boolean skipChildren = false;
+        private Element elementToSkip;
 
 
         CleaningVisitor(Element root, Element destination) {
@@ -44,7 +44,7 @@ class HeadCleaner {
         }
 
         public void head(Node source, int depth) {
-            if (skipChildren) {
+            if (elementToSkip != null) {
                 return;
             }
 
@@ -59,7 +59,7 @@ class HeadCleaner {
                     destination.appendChild(destinationChild);
                     destination = destinationChild;
                 } else if (source != root) {
-                    skipChildren = true;
+                    elementToSkip = sourceElement;
                 }
             } else if (source instanceof TextNode) {
                 TextNode sourceText = (TextNode) source;
@@ -73,9 +73,10 @@ class HeadCleaner {
         }
 
         public void tail(Node source, int depth) {
-            if (source == destination) {
+            if (source == elementToSkip) {
+                elementToSkip = null;
+            } else if (source instanceof Element && isSafeTag(source)) {
                 destination = destination.parent();
-                skipChildren = false;
             }
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/message/html/HtmlSanitizer.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/html/HtmlSanitizer.java
@@ -15,6 +15,13 @@ public class HtmlSanitizer {
         Whitelist whitelist = Whitelist.relaxed()
                 .addTags("font", "hr", "ins", "del")
                 .addAttributes("table", "align", "bgcolor", "border", "cellpadding", "cellspacing", "width")
+                .addAttributes("tr", "align", "bgcolor", "valign")
+                .addAttributes("th",
+                        "align", "bgcolor", "colspan", "headers", "height", "nowrap", "rowspan", "scope", "sorted",
+                        "valign", "width")
+                .addAttributes("td",
+                        "align", "bgcolor", "colspan", "headers", "height", "nowrap", "rowspan", "scope", "valign",
+                        "width")
                 .addAttributes(":all", "class", "style", "id")
                 .addProtocols("img", "src", "http", "https", "cid", "data");
 

--- a/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
@@ -176,4 +176,17 @@ public class HtmlSanitizerTest {
 
         assertEquals(html, toCompactString(result));
     }
+
+    @Test
+    public void shouldKeepWhitelistedElementsInHeadAndSkipTheRest() {
+        String html = "<html><head>" +
+                "<title>remove this</title>" +
+                "<style>keep this</style>" +
+                "<script>remove this</script>" +
+                "</head></html>";
+
+        Document result = htmlSanitizer.sanitize(html);
+
+        assertEquals("<html><head><style>keep this</style></head><body></body></html>", toCompactString(result));
+    }
 }


### PR DESCRIPTION
Fixes bugs in `HeadCleaner` and adds (layout) attributes for `tr`, `th` and `td` tags to the whitelist.

Fixes #3034

