### PR TITLE
Html Sanitization: Update JSoup, test iframe removal & allow center

### DIFF
--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -28,7 +28,7 @@ dependencies {
     compile "com.squareup.okio:okio:${okioVersion}"
     compile 'commons-io:commons-io:2.4'
     compile "com.android.support:support-v4:${androidSupportLibraryVersion}"
-    compile 'org.jsoup:jsoup:1.10.2'
+    compile 'org.jsoup:jsoup:1.11.2'
     compile 'de.cketti.library.changelog:ckchangelog:1.2.1'
     compile 'com.github.bumptech.glide:glide:3.6.1'
     compile 'com.splitwise:tokenautocomplete:2.0.7'

--- a/k9mail/src/main/java/com/fsck/k9/message/html/HtmlSanitizer.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/html/HtmlSanitizer.java
@@ -13,7 +13,7 @@ public class HtmlSanitizer {
 
     HtmlSanitizer() {
         Whitelist whitelist = Whitelist.relaxed()
-                .addTags("font", "hr", "ins", "del")
+                .addTags("font", "hr", "ins", "del", "center")
                 .addAttributes("font", "color", "face", "size")
                 .addAttributes("table", "align", "background", "bgcolor", "border", "cellpadding", "cellspacing",
                         "width")

--- a/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
@@ -189,4 +189,15 @@ public class HtmlSanitizerTest {
 
         assertEquals("<html><head><style>keep this</style></head><body></body></html>", toCompactString(result));
     }
+
+    @Test
+    public void shouldRemoveIFrames() {
+        String html = "<html><body>" +
+                "<iframe src=\"http://www.google.com\" />" +
+                "</body></html>";
+
+        Document result = htmlSanitizer.sanitize(html);
+
+        assertEquals("<html><head></head><body></body></html>", toCompactString(result));
+    }
 }

--- a/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
@@ -200,4 +200,17 @@ public class HtmlSanitizerTest {
 
         assertEquals("<html><head></head><body></body></html>", toCompactString(result));
     }
+
+    @Test
+    public void shouldKeepFormattingTags() {
+        String html = "<html><body>" +
+                "<center><font face=\"Arial\" color=\"red\" size=\"12\">A</font></center>" +
+                "</body></html>";
+
+        Document result = htmlSanitizer.sanitize(html);
+
+        assertEquals("<html><head></head><body>" +
+                "<center><font face=\"Arial\" color=\"red\" size=\"12\">A</font></center>" +
+                "</body></html>", toCompactString(result));
+    }
 }


### PR DESCRIPTION
Validates that changes in #2518 removed iframes. Finishes #846

Updating JSoup to newer version to fix JSoup's handling of self-closing tags (without this the test fails because it doesn't handle the self-closing iframe tag. See https://github.com/jhy/jsoup/blob/master/CHANGES#L139





  