### PR TITLE
Remove custom attachment permission

### DIFF
--- a/k9mail/src/main/AndroidManifest.xml
+++ b/k9mail/src/main/AndroidManifest.xml
@@ -27,14 +27,6 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <permission
-        android:name="${applicationId}.permission.READ_ATTACHMENT"
-        android:description="@string/read_attachment_desc"
-        android:label="@string/read_attachment_label"
-        android:permissionGroup="android.permission-group.MESSAGES"
-        android:protectionLevel="dangerous"/>
-    <uses-permission android:name="${applicationId}.permission.READ_ATTACHMENT"/>
-
-    <permission
         android:name="${applicationId}.permission.REMOTE_CONTROL"
         android:description="@string/remote_control_desc"
         android:label="@string/remote_control_label"
@@ -423,10 +415,8 @@
         <provider
             android:name=".provider.AttachmentProvider"
             android:authorities="${applicationId}.attachmentprovider"
-            android:exported="true"
-            android:grantUriPermissions="true"
-            android:multiprocess="true"
-            android:readPermission="${applicationId}.permission.READ_ATTACHMENT">
+            android:exported="false"
+            android:grantUriPermissions="true">
             
             <meta-data
                 android:name="de.cketti.safecontentresolver.ALLOW_INTERNAL_ACCESS"

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -79,8 +79,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="app_libraries">We\'re using the following third-party libraries: <xliff:g id="app_libraries_list">%s</xliff:g></string>
     <string name="app_emoji_icons">Emoji icons: <xliff:g id="app_emoji_icons_link">%s</xliff:g></string>
 
-    <string name="read_attachment_label">Read Email attachments</string>
-    <string name="read_attachment_desc">Allows this application to read your Email attachments.</string>
     <string name="read_messages_label">Read Emails</string>
     <string name="read_messages_desc">Allows this application to read your Emails.</string>
     <string name="delete_messages_label">Delete Emails</string>


### PR DESCRIPTION
As far as I can tell we never expose the attachment URI without also granting access via the `grantUriPermissions` mechanism. A custom permission needlessly exposes our `AttachmentProvider` to third-party apps.