### PR TITLE
Add tel, sip, bitcoin, ethereum and rtsp URIs to the whitelist for links

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/message/html/HtmlSanitizer.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/html/HtmlSanitizer.java
@@ -25,7 +25,8 @@ public class HtmlSanitizer {
                         "align", "bgcolor", "colspan", "headers", "height", "nowrap", "rowspan", "scope", "valign",
                         "width")
                 .addAttributes(":all", "class", "style", "id")
-                .addProtocols("img", "src", "http", "https", "cid", "data");
+                .addProtocols("img", "src", "http", "https", "cid", "data")
+                .addProtocols("a", "href", "tel", "sip", "bitcoin", "ethereum", "rtsp");
 
         cleaner = new Cleaner(whitelist);
         headCleaner = new HeadCleaner();

--- a/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
@@ -213,4 +213,25 @@ public class HtmlSanitizerTest {
                 "<center><font face=\"Arial\" color=\"red\" size=\"12\">A</font></center>" +
                 "</body></html>", toCompactString(result));
     }
+
+    @Test
+    public void shouldKeepUris() {
+        String html = "<html><body>" +
+                "<a href=\"tel:00442079460111\">Telephone</a>" +
+                "<a href=\"sip:user@example.com\">SIP</a>" +
+                "<a href=\"bitcoin:12A1MyfXbW6RhdRAZEqofac5jCQQjwEPBu\">Bitcoin</a>" +
+                "<a href=\"ethereum:0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7\">Ethereum</a>" +
+                "<a href=\"rtsp://example.com/media.mp4\">RTSP</a>" +
+                "</body></html>";
+
+        Document result = htmlSanitizer.sanitize(html);
+
+        assertEquals("<html><head></head><body>" +
+                "<a href=\"tel:00442079460111\">Telephone</a>" +
+                "<a href=\"sip:user@example.com\">SIP</a>" +
+                "<a href=\"bitcoin:12A1MyfXbW6RhdRAZEqofac5jCQQjwEPBu\">Bitcoin</a>" +
+                "<a href=\"ethereum:0x89205A3A3b2A69De6Dbf7f01ED13B2108B2c43e7\">Ethereum</a>" +
+                "<a href=\"rtsp://example.com/media.mp4\">RTSP</a>" +
+                "</body></html>", toCompactString(result));
+    }
 }

--- a/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/html/HtmlSanitizerTest.java
@@ -217,6 +217,9 @@ public class HtmlSanitizerTest {
     @Test
     public void shouldKeepUris() {
         String html = "<html><body>" +
+                "<a href=\"http://example.com/index.html\">HTTP</a>" +
+                "<a href=\"https://example.com/default.html\">HTTPS</a>" +
+                "<a href=\"mailto:user@example.com\">Mailto</a>" +
                 "<a href=\"tel:00442079460111\">Telephone</a>" +
                 "<a href=\"sip:user@example.com\">SIP</a>" +
                 "<a href=\"bitcoin:12A1MyfXbW6RhdRAZEqofac5jCQQjwEPBu\">Bitcoin</a>" +
@@ -227,6 +230,9 @@ public class HtmlSanitizerTest {
         Document result = htmlSanitizer.sanitize(html);
 
         assertEquals("<html><head></head><body>" +
+                "<a href=\"http://example.com/index.html\">HTTP</a>" +
+                "<a href=\"https://example.com/default.html\">HTTPS</a>" +
+                "<a href=\"mailto:user@example.com\">Mailto</a>" +
                 "<a href=\"tel:00442079460111\">Telephone</a>" +
                 "<a href=\"sip:user@example.com\">SIP</a>" +
                 "<a href=\"bitcoin:12A1MyfXbW6RhdRAZEqofac5jCQQjwEPBu\">Bitcoin</a>" +


### PR DESCRIPTION
Fixes #3065 and adds all other protocols we linkify to the whitelist as well.
