### PR TITLE
Prefer encrypt setting

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -220,6 +220,7 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean stripSignature;
     private boolean syncRemoteDeletions;
     private long pgpCryptoKey;
+    private boolean autocryptPreferEncryptMutual;
     private boolean markMessageAsReadOnView;
     private boolean alwaysShowCcBcc;
     private boolean allowRemoteSearch;
@@ -1642,6 +1643,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public void setCryptoKey(long keyId) {
         pgpCryptoKey = keyId;
+    }
+
+    public boolean getAutocryptPreferEncryptMutual() {
+        return autocryptPreferEncryptMutual;
+    }
+
+    public void setAutocryptPreferEncryptMutual(boolean autocryptPreferEncryptMutual) {
+        this.autocryptPreferEncryptMutual = autocryptPreferEncryptMutual;
     }
 
     public boolean allowRemoteSearch() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -84,7 +84,7 @@ public class ComposeCryptoStatus {
             case NO_CHOICE:
                 if (recipientAutocryptStatusType == RecipientAutocryptStatusType.NO_RECIPIENTS) {
                     return CryptoStatusDisplayType.NO_CHOICE_EMPTY;
-                } else if (canEncryptAndIsMutual()) {
+                } else if (canEncryptAndIsMutualDefault()) {
                     if (recipientAutocryptStatusType.isConfirmed()) {
                         return CryptoStatusDisplayType.NO_CHOICE_MUTUAL_TRUSTED;
                     } else {
@@ -136,7 +136,7 @@ public class ComposeCryptoStatus {
         }
 
         boolean isExplicitlyEnabled = (cryptoMode == CryptoMode.CHOICE_ENABLED);
-        boolean isMutualAndNotDisabled = (cryptoMode != CryptoMode.CHOICE_DISABLED && canEncryptAndIsMutual());
+        boolean isMutualAndNotDisabled = (cryptoMode != CryptoMode.CHOICE_DISABLED && canEncryptAndIsMutualDefault());
         return isExplicitlyEnabled || isMutualAndNotDisabled;
     }
 
@@ -168,8 +168,16 @@ public class ComposeCryptoStatus {
         return recipientAddresses.length > 0;
     }
 
-    boolean canEncryptAndIsMutual() {
-        return allRecipientsCanEncrypt() && preferEncryptMutual && recipientAutocryptStatus.type.isMutual();
+    public boolean isSenderPreferEncryptMutual() {
+        return preferEncryptMutual;
+    }
+
+    private boolean isRecipientsPreferEncryptMutual() {
+        return recipientAutocryptStatus.type.isMutual();
+    }
+
+    boolean canEncryptAndIsMutualDefault() {
+        return allRecipientsCanEncrypt() && isSenderPreferEncryptMutual() && isRecipientsPreferEncryptMutual();
     }
 
     boolean hasAutocryptPendingIntent() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -400,7 +400,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                 .setCryptoProviderState(cryptoProviderState)
                 .setCryptoMode(currentCryptoMode)
                 .setEnablePgpInline(cryptoEnablePgpInline)
-                .setPreferEncryptMutual(false) // TODO introduce a setting
+                .setPreferEncryptMutual(account.getAutocryptPreferEncryptMutual())
                 .setRecipients(getAllRecipients())
                 .setOpenPgpKeyId(accountCryptoKey)
                 .build();
@@ -640,7 +640,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                     if (currentCryptoStatus.hasAutocryptPendingIntent()) {
                         recipientMvpView.launchUserInteractionPendingIntent(
                                 currentCryptoStatus.getAutocryptPendingIntent(), REQUEST_CODE_AUTOCRYPT);
-                    } else if (currentCryptoStatus.canEncryptAndIsMutual()) {
+                    } else if (currentCryptoStatus.canEncryptAndIsMutualDefault()) {
                         onCryptoModeChanged(CryptoMode.CHOICE_DISABLED);
                     } else {
                         onCryptoModeChanged(CryptoMode.CHOICE_ENABLED);
@@ -648,7 +648,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                     return;
                 }
 
-                if (currentCryptoMode == CryptoMode.CHOICE_DISABLED && !currentCryptoStatus.canEncryptAndIsMutual()) {
+                if (currentCryptoMode == CryptoMode.CHOICE_DISABLED && !currentCryptoStatus.canEncryptAndIsMutualDefault()) {
                     onCryptoModeChanged(CryptoMode.CHOICE_ENABLED);
                     return;
                 }
@@ -902,14 +902,14 @@ public class RecipientPresenter implements PermissionPingCallback {
             if (!cachedCryptoStatus.allRecipientsCanEncrypt()) {
                 onCryptoModeChanged(CryptoMode.CHOICE_ENABLED);
                 recipientMvpView.showOpenPgpEnabledErrorDialog(true);
-            } else if (cachedCryptoStatus.canEncryptAndIsMutual()) {
+            } else if (cachedCryptoStatus.canEncryptAndIsMutualDefault()) {
                 onCryptoModeChanged(CryptoMode.NO_CHOICE);
             } else {
                 recipientMvpView.showOpenPgpEncryptExplanationDialog();
                 onCryptoModeChanged(CryptoMode.CHOICE_ENABLED);
             }
         } else {
-            if (cachedCryptoStatus.canEncryptAndIsMutual()) {
+            if (cachedCryptoStatus.canEncryptAndIsMutualDefault()) {
                 onCryptoModeChanged(CryptoMode.CHOICE_DISABLED);
             } else {
                 onCryptoModeChanged(CryptoMode.NO_CHOICE);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -112,6 +112,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private static final String PREFERENCE_SYNC_REMOTE_DELETIONS = "account_sync_remote_deletetions";
     private static final String PREFERENCE_CRYPTO = "crypto";
     private static final String PREFERENCE_CRYPTO_KEY = "crypto_key";
+    private static final String PREFERENCE_AUTOCRYPT_PREFER_ENCRYPT = "autocrypt_prefer_encrypt";
     private static final String PREFERENCE_CLOUD_SEARCH_ENABLED = "remote_search_enabled";
     private static final String PREFERENCE_REMOTE_SEARCH_NUM_RESULTS = "account_remote_search_num_results";
     private static final String PREFERENCE_REMOTE_SEARCH_FULL_TEXT = "account_remote_search_full_text";
@@ -178,7 +179,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private ListPreference mMaxPushFolders;
     private boolean hasPgpCrypto = false;
     private OpenPgpKeyPreference pgpCryptoKey;
-    private CheckBoxPreference pgpSupportSignOnly;
+    private CheckBoxPreference autocryptPreferEncryptMutual;
 
     private PreferenceScreen searchScreen;
     private CheckBoxPreference cloudSearchEnabled;
@@ -711,6 +712,9 @@ public class AccountSettings extends K9PreferenceActivity {
             });
 
             cryptoMenu.setOnPreferenceClickListener(null);
+
+            autocryptPreferEncryptMutual = (CheckBoxPreference) findPreference(PREFERENCE_AUTOCRYPT_PREFER_ENCRYPT);
+            autocryptPreferEncryptMutual.setChecked(account.getAutocryptPreferEncryptMutual());
         } else {
             cryptoMenu.setSummary(R.string.account_settings_no_openpgp_provider_configured);
             cryptoMenu.setOnPreferenceClickListener(new OnPreferenceClickListener() {
@@ -791,6 +795,7 @@ public class AccountSettings extends K9PreferenceActivity {
         } else {
             account.setCryptoKey(Account.NO_OPENPGP_KEY);
         }
+        account.setAutocryptPreferEncryptMutual(autocryptPreferEncryptMutual.isChecked());
 
         // In webdav account we use the exact folder name also for inbox,
         // since it varies because of internationalization

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -113,8 +113,8 @@ public class PgpMessageBuilder extends MessageBuilder {
         byte[] keyData = autocryptOpenPgpApiInteractor.getKeyMaterialForKeyId(
                 openPgpApi, openPgpKeyId, address.getAddress());
         if (keyData != null) {
-            autocryptOperations.addAutocryptHeaderToMessage(
-                    currentProcessedMimeMessage, keyData, address.getAddress(), false);
+            autocryptOperations.addAutocryptHeaderToMessage(currentProcessedMimeMessage, keyData,
+                    address.getAddress(), cryptoStatus.isSenderPreferEncryptMutual());
         }
 
         startOrContinueBuildMessage(null);

--- a/k9mail/src/main/java/com/fsck/k9/ui/dialog/AutocryptPreferEncryptDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/dialog/AutocryptPreferEncryptDialog.java
@@ -1,0 +1,69 @@
+package com.fsck.k9.ui.dialog;
+
+
+import android.annotation.SuppressLint;
+import android.app.AlertDialog;
+import android.app.Dialog;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.text.method.LinkMovementMethod;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.View.OnClickListener;
+import android.widget.CheckBox;
+import android.widget.TextView;
+
+import com.fsck.k9.R;
+
+
+public class AutocryptPreferEncryptDialog extends AlertDialog implements OnClickListener {
+
+    private final CheckBox preferEncryptCheckbox;
+    private final OnPreferEncryptChangedListener onPreferEncryptChangedListener;
+
+    private boolean preferEncryptEnabled;
+
+    public AutocryptPreferEncryptDialog(Context context, boolean preferEncryptEnabled,
+            OnPreferEncryptChangedListener onPreferEncryptChangedListener) {
+        super(context);
+
+        this.onPreferEncryptChangedListener = onPreferEncryptChangedListener;
+        this.preferEncryptEnabled = preferEncryptEnabled;
+
+        LayoutInflater inflater = LayoutInflater.from(context);
+
+        @SuppressLint("InflateParams")
+        View contentView = inflater.inflate(R.layout.dialog_autocrypt_prefer_encrypt, null);
+
+        preferEncryptCheckbox = (CheckBox) contentView.findViewById(R.id.prefer_encrypt_check);
+        preferEncryptCheckbox.setChecked(preferEncryptEnabled);
+
+        contentView.findViewById(R.id.prefer_encrypt).setOnClickListener(this);
+
+        // TODO add autocrypt logo?
+        // setIcon(R.drawable.autocrypt);
+        setView(contentView);
+        setButton(Dialog.BUTTON_NEUTRAL, context.getString(R.string.done_action), new OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialogInterface, int i) {
+                cancel();
+            }
+        });
+    }
+
+    @Override
+    public void onClick(View v) {
+        toggleCheck();
+    }
+
+    private void toggleCheck() {
+        preferEncryptEnabled = !preferEncryptEnabled;
+        preferEncryptCheckbox.setChecked(preferEncryptEnabled);
+
+        onPreferEncryptChangedListener.onPreferEncryptChanged(preferEncryptEnabled);
+    }
+
+    public interface OnPreferEncryptChangedListener {
+        void onPreferEncryptChanged(boolean enabled);
+    }
+}

--- a/k9mail/src/main/res/layout/dialog_autocrypt_prefer_encrypt.xml
+++ b/k9mail/src/main/res/layout/dialog_autocrypt_prefer_encrypt.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="24dp"
+            android:layout_marginRight="24dp"
+            android:layout_marginTop="24dp"
+            android:layout_marginBottom="20dp"
+            android:text="@string/dialog_autocrypt_mutual_title"
+            style="?android:textAppearanceLarge" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="24dp"
+            android:layout_marginRight="24dp"
+            android:text="@string/dialog_autocrypt_mutual_description_1" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="12dp"
+            android:paddingLeft="24dp"
+            android:paddingRight="24dp"
+            android:gravity="center_vertical"
+            android:minHeight="?android:listPreferredItemHeight"
+            android:orientation="horizontal"
+            android:background="?android:selectableItemBackground"
+            android:id="@+id/prefer_encrypt">
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:text="@string/dialog_autocrypt_mutual_description_2" />
+
+            <CheckBox
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:id="@+id/prefer_encrypt_check"
+                android:clickable="false"
+                />
+
+        </LinearLayout>
+
+    </LinearLayout>
+
+</ScrollView>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1282,7 +1282,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="openpgp_enabled_error_back">Back</string>
     <string name="openpgp_enabled_error_disable">Disable Encryption</string>
     <string name="openpgp_encryption">OpenPGP Encryption</string>
-    <string name="account_settings_crypto_prefer_encrypt">Encryption preference</string>
-    <string name="account_settings_crypto_prefer_encrypt_on">By default when replying to encrypted, or if all recipients also checked this option</string>
-    <string name="account_settings_crypto_prefer_encrypt_off">By default, when replying to encrypted messages</string>
+
+    <string name="account_settings_crypto_prefer_encrypt">Autocrypt mutual mode</string>
+    <string name="dialog_autocrypt_mutual_title">Autocrypt mutual mode</string>
+    <string name="dialog_autocrypt_mutual_description_1">Messages will normally be encrypted by choice, or when replying to an encrypted message.</string>
+    <string name="dialog_autocrypt_mutual_description_2">If both sender and recipients enable mutual mode, encryption will be enabled by default.</string>
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1282,4 +1282,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="openpgp_enabled_error_back">Back</string>
     <string name="openpgp_enabled_error_disable">Disable Encryption</string>
     <string name="openpgp_encryption">OpenPGP Encryption</string>
+    <string name="account_settings_crypto_prefer_encrypt">Encryption preference</string>
+    <string name="account_settings_crypto_prefer_encrypt_on">By default when replying to encrypted, or if all recipients also checked this option</string>
+    <string name="account_settings_crypto_prefer_encrypt_off">By default, when replying to encrypted messages</string>
 </resources>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -479,12 +479,11 @@
             android:key="crypto_key"
             android:title="@string/account_settings_crypto_key" />
 
-        <CheckBoxPreference
+        <Preference
             android:key="autocrypt_prefer_encrypt"
             android:title="@string/account_settings_crypto_prefer_encrypt"
-            android:summaryOn="@string/account_settings_crypto_prefer_encrypt_on"
-            android:summaryOff="@string/account_settings_crypto_prefer_encrypt_off"
             />
+
     </PreferenceScreen>
 
 </PreferenceScreen>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -479,6 +479,12 @@
             android:key="crypto_key"
             android:title="@string/account_settings_crypto_key" />
 
+        <CheckBoxPreference
+            android:key="autocrypt_prefer_encrypt"
+            android:title="@string/account_settings_crypto_prefer_encrypt"
+            android:summaryOn="@string/account_settings_crypto_prefer_encrypt_on"
+            android:summaryOff="@string/account_settings_crypto_prefer_encrypt_off"
+            />
     </PreferenceScreen>
 
 </PreferenceScreen>


### PR DESCRIPTION
Adds a setting that enables Autocrypt's `prefer-encrypt=mutual`. The logic is trivial since it was already there, the hard part is the wording I guess. I'm ok with this for a first attempt, but there is probably room for improvement. In a way, the goal is to get the user *not* to just blindly enable this setting, like any variant of "Prefer encryption" or "Encrypt by default" would do.