### PR TITLE
Tidy up K9's variable naming to match code style

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -100,10 +100,10 @@ public class K9 extends Application {
      * This will be {@code true} once the initialization is complete and {@link #notifyObservers()}
      * was called.
      * Afterwards calls to {@link #registerApplicationAware(com.fsck.k9.K9.ApplicationAware)} will
-     * immediately call {@link com.fsck.k9.K9.ApplicationAware#initializeComponent(K9)} for the
+     * immediately call {@link com.fsck.k9.K9.ApplicationAware#initializeComponent(Application)} for the
      * supplied argument.
      */
-    private static boolean sInitialized = false;
+    private static boolean initialized = false;
 
     public enum BACKGROUND_OPS {
         ALWAYS, NEVER, WHEN_CHECKED_AUTO_SYNC
@@ -154,18 +154,18 @@ public class K9 extends Application {
      * @see #checkCachedDatabaseVersion()
      * @see #setDatabasesUpToDate(boolean)
      */
-    private static SharedPreferences sDatabaseVersionCache;
+    private static SharedPreferences databaseVersionCache;
 
-    private static boolean mAnimations = true;
+    private static boolean animations = true;
 
-    private static boolean mConfirmDelete = false;
-    private static boolean mConfirmDiscardMessage = true;
-    private static boolean mConfirmDeleteStarred = false;
-    private static boolean mConfirmSpam = false;
-    private static boolean mConfirmDeleteFromNotification = true;
-    private static boolean mConfirmMarkAllRead = true;
+    private static boolean confirmDelete = false;
+    private static boolean confirmDiscardMessage = true;
+    private static boolean confirmDeleteStarred = false;
+    private static boolean confirmSpam = false;
+    private static boolean confirmDeleteFromNotification = true;
+    private static boolean confirmMarkAllRead = true;
 
-    private static NotificationHideSubject sNotificationHideSubject = NotificationHideSubject.NEVER;
+    private static NotificationHideSubject notificationHideSubject = NotificationHideSubject.NEVER;
 
     /**
      * Controls when to hide the subject in the notification area.
@@ -176,7 +176,7 @@ public class K9 extends Application {
         NEVER
     }
 
-    private static NotificationQuickDelete sNotificationQuickDelete = NotificationQuickDelete.NEVER;
+    private static NotificationQuickDelete notificationQuickDelete = NotificationQuickDelete.NEVER;
 
     /**
      * Controls behaviour of delete button in notifications.
@@ -207,62 +207,62 @@ public class K9 extends Application {
         WHEN_IN_LANDSCAPE
     }
 
-    private static boolean mMessageListCheckboxes = true;
-    private static boolean mMessageListStars = true;
-    private static int mMessageListPreviewLines = 2;
+    private static boolean messageListCheckboxes = true;
+    private static boolean messageListStars = true;
+    private static int messageListPreviewLines = 2;
 
-    private static boolean mShowCorrespondentNames = true;
-    private static boolean mMessageListSenderAboveSubject = false;
-    private static boolean mShowContactName = false;
-    private static boolean mChangeContactNameColor = false;
-    private static int mContactNameColor = 0xff00008f;
-    private static boolean sShowContactPicture = true;
-    private static boolean mMessageViewFixedWidthFont = false;
-    private static boolean mMessageViewReturnToList = false;
-    private static boolean mMessageViewShowNext = false;
+    private static boolean showCorrespondentNames = true;
+    private static boolean messageListSenderAboveSubject = false;
+    private static boolean showContactName = false;
+    private static boolean changeContactNameColor = false;
+    private static int contactNameColor = 0xff00008f;
+    private static boolean showContactPicture = true;
+    private static boolean messageViewFixedWidthFont = false;
+    private static boolean messageViewReturnToList = false;
+    private static boolean messageViewShowNext = false;
 
-    private static boolean mGesturesEnabled = true;
-    private static boolean mUseVolumeKeysForNavigation = false;
-    private static boolean mUseVolumeKeysForListNavigation = false;
-    private static boolean mStartIntegratedInbox = false;
-    private static boolean mMeasureAccounts = true;
-    private static boolean mCountSearchMessages = true;
-    private static boolean mHideSpecialAccounts = false;
-    private static boolean mAutofitWidth;
-    private static boolean mQuietTimeEnabled = false;
-    private static boolean mNotificationDuringQuietTimeEnabled = true;
-    private static String mQuietTimeStarts = null;
-    private static String mQuietTimeEnds = null;
-    private static String mAttachmentDefaultPath = "";
-    private static boolean mWrapFolderNames = false;
-    private static boolean mHideUserAgent = false;
-    private static boolean mHideTimeZone = false;
+    private static boolean gesturesEnabled = true;
+    private static boolean useVolumeKeysForNavigation = false;
+    private static boolean useVolumeKeysForListNavigation = false;
+    private static boolean startIntegratedInbox = false;
+    private static boolean measureAccounts = true;
+    private static boolean countSearchMessages = true;
+    private static boolean hideSpecialAccounts = false;
+    private static boolean autofitWidth;
+    private static boolean quietTimeEnabled = false;
+    private static boolean notificationDuringQuietTimeEnabled = true;
+    private static String quietTimeStarts = null;
+    private static String quietTimeEnds = null;
+    private static String attachmentDefaultPath = "";
+    private static boolean wrapFolderNames = false;
+    private static boolean hideUserAgent = false;
+    private static boolean hideTimeZone = false;
 
-    private static String sOpenPgpProvider = "";
-    private static boolean sOpenPgpSupportSignOnly = false;
+    private static String openPgpProvider = "";
+    private static boolean openPgpSupportSignOnly = false;
 
-    private static SortType mSortType;
-    private static Map<SortType, Boolean> mSortAscending = new HashMap<SortType, Boolean>();
+    private static SortType sortType;
+    private static Map<SortType, Boolean> sortAscending = new HashMap<SortType, Boolean>();
 
-    private static boolean sUseBackgroundAsUnreadIndicator = true;
-    private static boolean sThreadedViewEnabled = true;
-    private static SplitViewMode sSplitViewMode = SplitViewMode.NEVER;
-    private static boolean sColorizeMissingContactPictures = true;
+    private static boolean useBackgroundAsUnreadIndicator = true;
+    private static boolean threadedViewEnabled = true;
+    private static SplitViewMode splitViewMode = SplitViewMode.NEVER;
+    private static boolean colorizeMissingContactPictures = true;
 
-    private static boolean sMessageViewArchiveActionVisible = false;
-    private static boolean sMessageViewDeleteActionVisible = true;
-    private static boolean sMessageViewMoveActionVisible = false;
-    private static boolean sMessageViewCopyActionVisible = false;
-    private static boolean sMessageViewSpamActionVisible = false;
+    private static boolean messageViewArchiveActionVisible = false;
+    private static boolean messageViewDeleteActionVisible = true;
+    private static boolean messageViewMoveActionVisible = false;
+    private static boolean messageViewCopyActionVisible = false;
+    private static boolean messageViewSpamActionVisible = false;
 
-    private static int sPgpInlineDialogCounter;
-    private static int sPgpSignOnlyDialogCounter;
+    private static int pgpInlineDialogCounter;
+    private static int pgpSignOnlyDialogCounter;
 
 
     /**
      * @see #areDatabasesUpToDate()
      */
-    private static boolean sDatabasesUpToDate = false;
+    private static boolean databasesUpToDate = false;
 
     /**
      * For use when displaying that no folder is selected
@@ -447,38 +447,38 @@ public class K9 extends Application {
         editor.putBoolean("enableDebugLogging", K9.DEBUG);
         editor.putBoolean("enableSensitiveLogging", K9.DEBUG_SENSITIVE);
         editor.putString("backgroundOperations", K9.backgroundOps.name());
-        editor.putBoolean("animations", mAnimations);
-        editor.putBoolean("gesturesEnabled", mGesturesEnabled);
-        editor.putBoolean("useVolumeKeysForNavigation", mUseVolumeKeysForNavigation);
-        editor.putBoolean("useVolumeKeysForListNavigation", mUseVolumeKeysForListNavigation);
-        editor.putBoolean("autofitWidth", mAutofitWidth);
-        editor.putBoolean("quietTimeEnabled", mQuietTimeEnabled);
-        editor.putBoolean("notificationDuringQuietTimeEnabled", mNotificationDuringQuietTimeEnabled);
-        editor.putString("quietTimeStarts", mQuietTimeStarts);
-        editor.putString("quietTimeEnds", mQuietTimeEnds);
+        editor.putBoolean("animations", animations);
+        editor.putBoolean("gesturesEnabled", gesturesEnabled);
+        editor.putBoolean("useVolumeKeysForNavigation", useVolumeKeysForNavigation);
+        editor.putBoolean("useVolumeKeysForListNavigation", useVolumeKeysForListNavigation);
+        editor.putBoolean("autofitWidth", autofitWidth);
+        editor.putBoolean("quietTimeEnabled", quietTimeEnabled);
+        editor.putBoolean("notificationDuringQuietTimeEnabled", notificationDuringQuietTimeEnabled);
+        editor.putString("quietTimeStarts", quietTimeStarts);
+        editor.putString("quietTimeEnds", quietTimeEnds);
 
-        editor.putBoolean("startIntegratedInbox", mStartIntegratedInbox);
-        editor.putBoolean("measureAccounts", mMeasureAccounts);
-        editor.putBoolean("countSearchMessages", mCountSearchMessages);
-        editor.putBoolean("messageListSenderAboveSubject", mMessageListSenderAboveSubject);
-        editor.putBoolean("hideSpecialAccounts", mHideSpecialAccounts);
-        editor.putBoolean("messageListStars", mMessageListStars);
-        editor.putInt("messageListPreviewLines", mMessageListPreviewLines);
-        editor.putBoolean("messageListCheckboxes", mMessageListCheckboxes);
-        editor.putBoolean("showCorrespondentNames", mShowCorrespondentNames);
-        editor.putBoolean("showContactName", mShowContactName);
-        editor.putBoolean("showContactPicture", sShowContactPicture);
-        editor.putBoolean("changeRegisteredNameColor", mChangeContactNameColor);
-        editor.putInt("registeredNameColor", mContactNameColor);
-        editor.putBoolean("messageViewFixedWidthFont", mMessageViewFixedWidthFont);
-        editor.putBoolean("messageViewReturnToList", mMessageViewReturnToList);
-        editor.putBoolean("messageViewShowNext", mMessageViewShowNext);
-        editor.putBoolean("wrapFolderNames", mWrapFolderNames);
-        editor.putBoolean("hideUserAgent", mHideUserAgent);
-        editor.putBoolean("hideTimeZone", mHideTimeZone);
+        editor.putBoolean("startIntegratedInbox", startIntegratedInbox);
+        editor.putBoolean("measureAccounts", measureAccounts);
+        editor.putBoolean("countSearchMessages", countSearchMessages);
+        editor.putBoolean("messageListSenderAboveSubject", messageListSenderAboveSubject);
+        editor.putBoolean("hideSpecialAccounts", hideSpecialAccounts);
+        editor.putBoolean("messageListStars", messageListStars);
+        editor.putInt("messageListPreviewLines", messageListPreviewLines);
+        editor.putBoolean("messageListCheckboxes", messageListCheckboxes);
+        editor.putBoolean("showCorrespondentNames", showCorrespondentNames);
+        editor.putBoolean("showContactName", showContactName);
+        editor.putBoolean("showContactPicture", showContactPicture);
+        editor.putBoolean("changeRegisteredNameColor", changeContactNameColor);
+        editor.putInt("registeredNameColor", contactNameColor);
+        editor.putBoolean("messageViewFixedWidthFont", messageViewFixedWidthFont);
+        editor.putBoolean("messageViewReturnToList", messageViewReturnToList);
+        editor.putBoolean("messageViewShowNext", messageViewShowNext);
+        editor.putBoolean("wrapFolderNames", wrapFolderNames);
+        editor.putBoolean("hideUserAgent", hideUserAgent);
+        editor.putBoolean("hideTimeZone", hideTimeZone);
 
-        editor.putString("openPgpProvider", sOpenPgpProvider);
-        editor.putBoolean("openPgpSupportSignOnly", sOpenPgpSupportSignOnly);
+        editor.putString("openPgpProvider", openPgpProvider);
+        editor.putBoolean("openPgpSupportSignOnly", openPgpSupportSignOnly);
 
         editor.putString("language", language);
         editor.putInt("theme", theme.ordinal());
@@ -486,34 +486,34 @@ public class K9 extends Application {
         editor.putInt("messageComposeTheme", composerTheme.ordinal());
         editor.putBoolean("fixedMessageViewTheme", useFixedMessageTheme);
 
-        editor.putBoolean("confirmDelete", mConfirmDelete);
-        editor.putBoolean("confirmDiscardMessage", mConfirmDiscardMessage);
-        editor.putBoolean("confirmDeleteStarred", mConfirmDeleteStarred);
-        editor.putBoolean("confirmSpam", mConfirmSpam);
-        editor.putBoolean("confirmDeleteFromNotification", mConfirmDeleteFromNotification);
-        editor.putBoolean("confirmMarkAllRead", mConfirmMarkAllRead);
+        editor.putBoolean("confirmDelete", confirmDelete);
+        editor.putBoolean("confirmDiscardMessage", confirmDiscardMessage);
+        editor.putBoolean("confirmDeleteStarred", confirmDeleteStarred);
+        editor.putBoolean("confirmSpam", confirmSpam);
+        editor.putBoolean("confirmDeleteFromNotification", confirmDeleteFromNotification);
+        editor.putBoolean("confirmMarkAllRead", confirmMarkAllRead);
 
-        editor.putString("sortTypeEnum", mSortType.name());
-        editor.putBoolean("sortAscending", mSortAscending.get(mSortType));
+        editor.putString("sortTypeEnum", sortType.name());
+        editor.putBoolean("sortAscending", sortAscending.get(sortType));
 
-        editor.putString("notificationHideSubject", sNotificationHideSubject.toString());
-        editor.putString("notificationQuickDelete", sNotificationQuickDelete.toString());
+        editor.putString("notificationHideSubject", notificationHideSubject.toString());
+        editor.putString("notificationQuickDelete", notificationQuickDelete.toString());
         editor.putString("lockScreenNotificationVisibility", sLockScreenNotificationVisibility.toString());
 
-        editor.putString("attachmentdefaultpath", mAttachmentDefaultPath);
-        editor.putBoolean("useBackgroundAsUnreadIndicator", sUseBackgroundAsUnreadIndicator);
-        editor.putBoolean("threadedView", sThreadedViewEnabled);
-        editor.putString("splitViewMode", sSplitViewMode.name());
-        editor.putBoolean("colorizeMissingContactPictures", sColorizeMissingContactPictures);
+        editor.putString("attachmentdefaultpath", attachmentDefaultPath);
+        editor.putBoolean("useBackgroundAsUnreadIndicator", useBackgroundAsUnreadIndicator);
+        editor.putBoolean("threadedView", threadedViewEnabled);
+        editor.putString("splitViewMode", splitViewMode.name());
+        editor.putBoolean("colorizeMissingContactPictures", colorizeMissingContactPictures);
 
-        editor.putBoolean("messageViewArchiveActionVisible", sMessageViewArchiveActionVisible);
-        editor.putBoolean("messageViewDeleteActionVisible", sMessageViewDeleteActionVisible);
-        editor.putBoolean("messageViewMoveActionVisible", sMessageViewMoveActionVisible);
-        editor.putBoolean("messageViewCopyActionVisible", sMessageViewCopyActionVisible);
-        editor.putBoolean("messageViewSpamActionVisible", sMessageViewSpamActionVisible);
+        editor.putBoolean("messageViewArchiveActionVisible", messageViewArchiveActionVisible);
+        editor.putBoolean("messageViewDeleteActionVisible", messageViewDeleteActionVisible);
+        editor.putBoolean("messageViewMoveActionVisible", messageViewMoveActionVisible);
+        editor.putBoolean("messageViewCopyActionVisible", messageViewCopyActionVisible);
+        editor.putBoolean("messageViewSpamActionVisible", messageViewSpamActionVisible);
 
-        editor.putInt("pgpInlineDialogCounter", sPgpInlineDialogCounter);
-        editor.putInt("pgpSignOnlyDialogCounter", sPgpSignOnlyDialogCounter);
+        editor.putInt("pgpInlineDialogCounter", pgpInlineDialogCounter);
+        editor.putInt("pgpSignOnlyDialogCounter", pgpSignOnlyDialogCounter);
 
         fontSizes.save(editor);
     }
@@ -659,9 +659,9 @@ public class K9 extends Application {
      * @see #areDatabasesUpToDate()
      */
     public void checkCachedDatabaseVersion() {
-        sDatabaseVersionCache = getSharedPreferences(DATABASE_VERSION_CACHE, MODE_PRIVATE);
+        databaseVersionCache = getSharedPreferences(DATABASE_VERSION_CACHE, MODE_PRIVATE);
 
-        int cachedVersion = sDatabaseVersionCache.getInt(KEY_LAST_ACCOUNT_DATABASE_VERSION, 0);
+        int cachedVersion = databaseVersionCache.getInt(KEY_LAST_ACCOUNT_DATABASE_VERSION, 0);
 
         if (cachedVersion >= LocalStore.DB_VERSION) {
             K9.setDatabasesUpToDate(false);
@@ -680,71 +680,71 @@ public class K9 extends Application {
         Storage storage = prefs.getStorage();
         setDebug(storage.getBoolean("enableDebugLogging", BuildConfig.DEVELOPER_MODE));
         DEBUG_SENSITIVE = storage.getBoolean("enableSensitiveLogging", false);
-        mAnimations = storage.getBoolean("animations", true);
-        mGesturesEnabled = storage.getBoolean("gesturesEnabled", false);
-        mUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false);
-        mUseVolumeKeysForListNavigation = storage.getBoolean("useVolumeKeysForListNavigation", false);
-        mStartIntegratedInbox = storage.getBoolean("startIntegratedInbox", false);
-        mMeasureAccounts = storage.getBoolean("measureAccounts", true);
-        mCountSearchMessages = storage.getBoolean("countSearchMessages", true);
-        mHideSpecialAccounts = storage.getBoolean("hideSpecialAccounts", false);
-        mMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false);
-        mMessageListCheckboxes = storage.getBoolean("messageListCheckboxes", false);
-        mMessageListStars = storage.getBoolean("messageListStars", true);
-        mMessageListPreviewLines = storage.getInt("messageListPreviewLines", 2);
+        animations = storage.getBoolean("animations", true);
+        gesturesEnabled = storage.getBoolean("gesturesEnabled", false);
+        useVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false);
+        useVolumeKeysForListNavigation = storage.getBoolean("useVolumeKeysForListNavigation", false);
+        startIntegratedInbox = storage.getBoolean("startIntegratedInbox", false);
+        measureAccounts = storage.getBoolean("measureAccounts", true);
+        countSearchMessages = storage.getBoolean("countSearchMessages", true);
+        hideSpecialAccounts = storage.getBoolean("hideSpecialAccounts", false);
+        messageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false);
+        messageListCheckboxes = storage.getBoolean("messageListCheckboxes", false);
+        messageListStars = storage.getBoolean("messageListStars", true);
+        messageListPreviewLines = storage.getInt("messageListPreviewLines", 2);
 
-        mAutofitWidth = storage.getBoolean("autofitWidth", true);
+        autofitWidth = storage.getBoolean("autofitWidth", true);
 
-        mQuietTimeEnabled = storage.getBoolean("quietTimeEnabled", false);
-        mNotificationDuringQuietTimeEnabled = storage.getBoolean("notificationDuringQuietTimeEnabled", true);
-        mQuietTimeStarts = storage.getString("quietTimeStarts", "21:00");
-        mQuietTimeEnds = storage.getString("quietTimeEnds", "7:00");
+        quietTimeEnabled = storage.getBoolean("quietTimeEnabled", false);
+        notificationDuringQuietTimeEnabled = storage.getBoolean("notificationDuringQuietTimeEnabled", true);
+        quietTimeStarts = storage.getString("quietTimeStarts", "21:00");
+        quietTimeEnds = storage.getString("quietTimeEnds", "7:00");
 
-        mShowCorrespondentNames = storage.getBoolean("showCorrespondentNames", true);
-        mShowContactName = storage.getBoolean("showContactName", false);
-        sShowContactPicture = storage.getBoolean("showContactPicture", true);
-        mChangeContactNameColor = storage.getBoolean("changeRegisteredNameColor", false);
-        mContactNameColor = storage.getInt("registeredNameColor", 0xff00008f);
-        mMessageViewFixedWidthFont = storage.getBoolean("messageViewFixedWidthFont", false);
-        mMessageViewReturnToList = storage.getBoolean("messageViewReturnToList", false);
-        mMessageViewShowNext = storage.getBoolean("messageViewShowNext", false);
-        mWrapFolderNames = storage.getBoolean("wrapFolderNames", false);
-        mHideUserAgent = storage.getBoolean("hideUserAgent", false);
-        mHideTimeZone = storage.getBoolean("hideTimeZone", false);
+        showCorrespondentNames = storage.getBoolean("showCorrespondentNames", true);
+        showContactName = storage.getBoolean("showContactName", false);
+        showContactPicture = storage.getBoolean("showContactPicture", true);
+        changeContactNameColor = storage.getBoolean("changeRegisteredNameColor", false);
+        contactNameColor = storage.getInt("registeredNameColor", 0xff00008f);
+        messageViewFixedWidthFont = storage.getBoolean("messageViewFixedWidthFont", false);
+        messageViewReturnToList = storage.getBoolean("messageViewReturnToList", false);
+        messageViewShowNext = storage.getBoolean("messageViewShowNext", false);
+        wrapFolderNames = storage.getBoolean("wrapFolderNames", false);
+        hideUserAgent = storage.getBoolean("hideUserAgent", false);
+        hideTimeZone = storage.getBoolean("hideTimeZone", false);
 
-        sOpenPgpProvider = storage.getString("openPgpProvider", NO_OPENPGP_PROVIDER);
-        sOpenPgpSupportSignOnly = storage.getBoolean("openPgpSupportSignOnly", false);
+        openPgpProvider = storage.getString("openPgpProvider", NO_OPENPGP_PROVIDER);
+        openPgpSupportSignOnly = storage.getBoolean("openPgpSupportSignOnly", false);
 
-        mConfirmDelete = storage.getBoolean("confirmDelete", false);
-        mConfirmDiscardMessage = storage.getBoolean("confirmDiscardMessage", true);
-        mConfirmDeleteStarred = storage.getBoolean("confirmDeleteStarred", false);
-        mConfirmSpam = storage.getBoolean("confirmSpam", false);
-        mConfirmDeleteFromNotification = storage.getBoolean("confirmDeleteFromNotification", true);
-        mConfirmMarkAllRead = storage.getBoolean("confirmMarkAllRead", true);
+        confirmDelete = storage.getBoolean("confirmDelete", false);
+        confirmDiscardMessage = storage.getBoolean("confirmDiscardMessage", true);
+        confirmDeleteStarred = storage.getBoolean("confirmDeleteStarred", false);
+        confirmSpam = storage.getBoolean("confirmSpam", false);
+        confirmDeleteFromNotification = storage.getBoolean("confirmDeleteFromNotification", true);
+        confirmMarkAllRead = storage.getBoolean("confirmMarkAllRead", true);
 
         try {
             String value = storage.getString("sortTypeEnum", Account.DEFAULT_SORT_TYPE.name());
-            mSortType = SortType.valueOf(value);
+            sortType = SortType.valueOf(value);
         } catch (Exception e) {
-            mSortType = Account.DEFAULT_SORT_TYPE;
+            sortType = Account.DEFAULT_SORT_TYPE;
         }
 
         boolean sortAscending = storage.getBoolean("sortAscending", Account.DEFAULT_SORT_ASCENDING);
-        mSortAscending.put(mSortType, sortAscending);
+        K9.sortAscending.put(sortType, sortAscending);
 
         String notificationHideSubject = storage.getString("notificationHideSubject", null);
         if (notificationHideSubject == null) {
             // If the "notificationHideSubject" setting couldn't be found, the app was probably
             // updated. Look for the old "keyguardPrivacy" setting and map it to the new enum.
-            sNotificationHideSubject = (storage.getBoolean("keyguardPrivacy", false)) ?
+            K9.notificationHideSubject = (storage.getBoolean("keyguardPrivacy", false)) ?
                     NotificationHideSubject.WHEN_LOCKED : NotificationHideSubject.NEVER;
         } else {
-            sNotificationHideSubject = NotificationHideSubject.valueOf(notificationHideSubject);
+            K9.notificationHideSubject = NotificationHideSubject.valueOf(notificationHideSubject);
         }
 
         String notificationQuickDelete = storage.getString("notificationQuickDelete", null);
         if (notificationQuickDelete != null) {
-            sNotificationQuickDelete = NotificationQuickDelete.valueOf(notificationQuickDelete);
+            K9.notificationQuickDelete = NotificationQuickDelete.valueOf(notificationQuickDelete);
         }
 
         String lockScreenNotificationVisibility = storage.getString("lockScreenNotificationVisibility", null);
@@ -754,13 +754,13 @@ public class K9 extends Application {
 
         String splitViewMode = storage.getString("splitViewMode", null);
         if (splitViewMode != null) {
-            sSplitViewMode = SplitViewMode.valueOf(splitViewMode);
+            K9.splitViewMode = SplitViewMode.valueOf(splitViewMode);
         }
 
-        mAttachmentDefaultPath = storage.getString("attachmentdefaultpath",
+        attachmentDefaultPath = storage.getString("attachmentdefaultpath",
                 Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS).toString());
-        sUseBackgroundAsUnreadIndicator = storage.getBoolean("useBackgroundAsUnreadIndicator", true);
-        sThreadedViewEnabled = storage.getBoolean("threadedView", true);
+        useBackgroundAsUnreadIndicator = storage.getBoolean("useBackgroundAsUnreadIndicator", true);
+        threadedViewEnabled = storage.getBoolean("threadedView", true);
         fontSizes.load(storage);
 
         try {
@@ -771,16 +771,16 @@ public class K9 extends Application {
             setBackgroundOps(BACKGROUND_OPS.WHEN_CHECKED_AUTO_SYNC);
         }
 
-        sColorizeMissingContactPictures = storage.getBoolean("colorizeMissingContactPictures", true);
+        colorizeMissingContactPictures = storage.getBoolean("colorizeMissingContactPictures", true);
 
-        sMessageViewArchiveActionVisible = storage.getBoolean("messageViewArchiveActionVisible", false);
-        sMessageViewDeleteActionVisible = storage.getBoolean("messageViewDeleteActionVisible", true);
-        sMessageViewMoveActionVisible = storage.getBoolean("messageViewMoveActionVisible", false);
-        sMessageViewCopyActionVisible = storage.getBoolean("messageViewCopyActionVisible", false);
-        sMessageViewSpamActionVisible = storage.getBoolean("messageViewSpamActionVisible", false);
+        messageViewArchiveActionVisible = storage.getBoolean("messageViewArchiveActionVisible", false);
+        messageViewDeleteActionVisible = storage.getBoolean("messageViewDeleteActionVisible", true);
+        messageViewMoveActionVisible = storage.getBoolean("messageViewMoveActionVisible", false);
+        messageViewCopyActionVisible = storage.getBoolean("messageViewCopyActionVisible", false);
+        messageViewSpamActionVisible = storage.getBoolean("messageViewSpamActionVisible", false);
 
-        sPgpInlineDialogCounter = storage.getInt("pgpInlineDialogCounter", 0);
-        sPgpSignOnlyDialogCounter = storage.getInt("pgpSignOnlyDialogCounter", 0);
+        pgpInlineDialogCounter = storage.getInt("pgpInlineDialogCounter", 0);
+        pgpSignOnlyDialogCounter = storage.getInt("pgpSignOnlyDialogCounter", 0);
 
         K9.setK9Language(storage.getString("language", ""));
 
@@ -817,7 +817,7 @@ public class K9 extends Application {
                 }
             }
 
-            sInitialized = true;
+            initialized = true;
             observers.clear();
         }
     }
@@ -830,7 +830,7 @@ public class K9 extends Application {
      */
     public static void registerApplicationAware(final ApplicationAware component) {
         synchronized (observers) {
-            if (sInitialized) {
+            if (initialized) {
                 component.initializeComponent(K9.app);
             } else if (!observers.contains(component)) {
                 observers.add(component);
@@ -927,76 +927,76 @@ public class K9 extends Application {
     }
 
     public static boolean gesturesEnabled() {
-        return mGesturesEnabled;
+        return gesturesEnabled;
     }
 
     public static void setGesturesEnabled(boolean gestures) {
-        mGesturesEnabled = gestures;
+        gesturesEnabled = gestures;
     }
 
     public static boolean useVolumeKeysForNavigationEnabled() {
-        return mUseVolumeKeysForNavigation;
+        return useVolumeKeysForNavigation;
     }
 
     public static void setUseVolumeKeysForNavigation(boolean volume) {
-        mUseVolumeKeysForNavigation = volume;
+        useVolumeKeysForNavigation = volume;
     }
 
     public static boolean useVolumeKeysForListNavigationEnabled() {
-        return mUseVolumeKeysForListNavigation;
+        return useVolumeKeysForListNavigation;
     }
 
     public static void setUseVolumeKeysForListNavigation(boolean enabled) {
-        mUseVolumeKeysForListNavigation = enabled;
+        useVolumeKeysForListNavigation = enabled;
     }
 
     public static boolean autofitWidth() {
-        return mAutofitWidth;
+        return autofitWidth;
     }
 
     public static void setAutofitWidth(boolean autofitWidth) {
-        mAutofitWidth = autofitWidth;
+        K9.autofitWidth = autofitWidth;
     }
 
     public static boolean getQuietTimeEnabled() {
-        return mQuietTimeEnabled;
+        return quietTimeEnabled;
     }
 
     public static void setQuietTimeEnabled(boolean quietTimeEnabled) {
-        mQuietTimeEnabled = quietTimeEnabled;
+        K9.quietTimeEnabled = quietTimeEnabled;
     }
 
     public static boolean isNotificationDuringQuietTimeEnabled() {
-        return mNotificationDuringQuietTimeEnabled;
+        return notificationDuringQuietTimeEnabled;
     }
 
     public static void setNotificationDuringQuietTimeEnabled(boolean notificationDuringQuietTimeEnabled) {
-        mNotificationDuringQuietTimeEnabled = notificationDuringQuietTimeEnabled;
+        K9.notificationDuringQuietTimeEnabled = notificationDuringQuietTimeEnabled;
     }
 
     public static String getQuietTimeStarts() {
-        return mQuietTimeStarts;
+        return quietTimeStarts;
     }
 
     public static void setQuietTimeStarts(String quietTimeStarts) {
-        mQuietTimeStarts = quietTimeStarts;
+        K9.quietTimeStarts = quietTimeStarts;
     }
 
     public static String getQuietTimeEnds() {
-        return mQuietTimeEnds;
+        return quietTimeEnds;
     }
 
     public static void setQuietTimeEnds(String quietTimeEnds) {
-        mQuietTimeEnds = quietTimeEnds;
+        K9.quietTimeEnds = quietTimeEnds;
     }
 
 
     public static boolean isQuietTime() {
-        if (!mQuietTimeEnabled) {
+        if (!quietTimeEnabled) {
             return false;
         }
 
-        QuietTimeChecker quietTimeChecker = new QuietTimeChecker(Clock.INSTANCE, mQuietTimeStarts, mQuietTimeEnds);
+        QuietTimeChecker quietTimeChecker = new QuietTimeChecker(Clock.INSTANCE, quietTimeStarts, quietTimeEnds);
         return quietTimeChecker.isQuietTime();
     }
 
@@ -1010,106 +1010,106 @@ public class K9 extends Application {
     }
 
     public static boolean startIntegratedInbox() {
-        return mStartIntegratedInbox;
+        return startIntegratedInbox;
     }
 
     public static void setStartIntegratedInbox(boolean startIntegratedInbox) {
-        mStartIntegratedInbox = startIntegratedInbox;
+        K9.startIntegratedInbox = startIntegratedInbox;
     }
 
     public static boolean showAnimations() {
-        return mAnimations;
+        return animations;
     }
 
     public static void setAnimations(boolean animations) {
-        mAnimations = animations;
+        K9.animations = animations;
     }
 
     public static int messageListPreviewLines() {
-        return mMessageListPreviewLines;
+        return messageListPreviewLines;
     }
 
     public static void setMessageListPreviewLines(int lines) {
-        mMessageListPreviewLines = lines;
+        messageListPreviewLines = lines;
     }
 
     public static boolean messageListCheckboxes() {
-        return mMessageListCheckboxes;
+        return messageListCheckboxes;
     }
 
     public static void setMessageListCheckboxes(boolean checkboxes) {
-        mMessageListCheckboxes = checkboxes;
+        messageListCheckboxes = checkboxes;
     }
 
     public static boolean messageListStars() {
-        return mMessageListStars;
+        return messageListStars;
     }
 
     public static void setMessageListStars(boolean stars) {
-        mMessageListStars = stars;
+        messageListStars = stars;
     }
 
     public static boolean showCorrespondentNames() {
-        return mShowCorrespondentNames;
+        return showCorrespondentNames;
     }
 
      public static boolean messageListSenderAboveSubject() {
-         return mMessageListSenderAboveSubject;
+         return messageListSenderAboveSubject;
      }
 
     public static void setMessageListSenderAboveSubject(boolean sender) {
-         mMessageListSenderAboveSubject = sender;
+         messageListSenderAboveSubject = sender;
     }
     public static void setShowCorrespondentNames(boolean showCorrespondentNames) {
-        mShowCorrespondentNames = showCorrespondentNames;
+        K9.showCorrespondentNames = showCorrespondentNames;
     }
 
     public static boolean showContactName() {
-        return mShowContactName;
+        return showContactName;
     }
 
     public static void setShowContactName(boolean showContactName) {
-        mShowContactName = showContactName;
+        K9.showContactName = showContactName;
     }
 
     public static boolean changeContactNameColor() {
-        return mChangeContactNameColor;
+        return changeContactNameColor;
     }
 
     public static void setChangeContactNameColor(boolean changeContactNameColor) {
-        mChangeContactNameColor = changeContactNameColor;
+        K9.changeContactNameColor = changeContactNameColor;
     }
 
     public static int getContactNameColor() {
-        return mContactNameColor;
+        return contactNameColor;
     }
 
     public static void setContactNameColor(int contactNameColor) {
-        mContactNameColor = contactNameColor;
+        K9.contactNameColor = contactNameColor;
     }
 
     public static boolean messageViewFixedWidthFont() {
-        return mMessageViewFixedWidthFont;
+        return messageViewFixedWidthFont;
     }
 
     public static void setMessageViewFixedWidthFont(boolean fixed) {
-        mMessageViewFixedWidthFont = fixed;
+        messageViewFixedWidthFont = fixed;
     }
 
     public static boolean messageViewReturnToList() {
-        return mMessageViewReturnToList;
+        return messageViewReturnToList;
     }
 
     public static void setMessageViewReturnToList(boolean messageViewReturnToList) {
-        mMessageViewReturnToList = messageViewReturnToList;
+        K9.messageViewReturnToList = messageViewReturnToList;
     }
 
     public static boolean messageViewShowNext() {
-        return mMessageViewShowNext;
+        return messageViewShowNext;
     }
 
     public static void setMessageViewShowNext(boolean messageViewShowNext) {
-        mMessageViewShowNext = messageViewShowNext;
+        K9.messageViewShowNext = messageViewShowNext;
     }
 
     public static FontSizes getFontSizes() {
@@ -1117,91 +1117,91 @@ public class K9 extends Application {
     }
 
     public static boolean measureAccounts() {
-        return mMeasureAccounts;
+        return measureAccounts;
     }
 
     public static void setMeasureAccounts(boolean measureAccounts) {
-        mMeasureAccounts = measureAccounts;
+        K9.measureAccounts = measureAccounts;
     }
 
     public static boolean countSearchMessages() {
-        return mCountSearchMessages;
+        return countSearchMessages;
     }
 
     public static void setCountSearchMessages(boolean countSearchMessages) {
-        mCountSearchMessages = countSearchMessages;
+        K9.countSearchMessages = countSearchMessages;
     }
 
     public static boolean isHideSpecialAccounts() {
-        return mHideSpecialAccounts;
+        return hideSpecialAccounts;
     }
 
     public static void setHideSpecialAccounts(boolean hideSpecialAccounts) {
-        mHideSpecialAccounts = hideSpecialAccounts;
+        K9.hideSpecialAccounts = hideSpecialAccounts;
     }
 
     public static boolean confirmDelete() {
-        return mConfirmDelete;
+        return confirmDelete;
     }
 
     public static void setConfirmDelete(final boolean confirm) {
-        mConfirmDelete = confirm;
+        confirmDelete = confirm;
     }
 
     public static boolean confirmDeleteStarred() {
-        return mConfirmDeleteStarred;
+        return confirmDeleteStarred;
     }
 
     public static void setConfirmDeleteStarred(final boolean confirm) {
-        mConfirmDeleteStarred = confirm;
+        confirmDeleteStarred = confirm;
     }
 
     public static boolean confirmSpam() {
-        return mConfirmSpam;
+        return confirmSpam;
     }
 
     public static boolean confirmDiscardMessage() {
-        return mConfirmDiscardMessage;
+        return confirmDiscardMessage;
     }
 
     public static void setConfirmSpam(final boolean confirm) {
-        mConfirmSpam = confirm;
+        confirmSpam = confirm;
     }
 
     public static void setConfirmDiscardMessage(final boolean confirm) {
-        mConfirmDiscardMessage = confirm;
+        confirmDiscardMessage = confirm;
     }
 
     public static boolean confirmDeleteFromNotification() {
-        return mConfirmDeleteFromNotification;
+        return confirmDeleteFromNotification;
     }
 
     public static void setConfirmDeleteFromNotification(final boolean confirm) {
-        mConfirmDeleteFromNotification = confirm;
+        confirmDeleteFromNotification = confirm;
     }
 
     public static boolean confirmMarkAllRead() {
-        return mConfirmMarkAllRead;
+        return confirmMarkAllRead;
     }
 
     public static void setConfirmMarkAllRead(final boolean confirm) {
-        mConfirmMarkAllRead = confirm;
+        confirmMarkAllRead = confirm;
     }
 
     public static NotificationHideSubject getNotificationHideSubject() {
-        return sNotificationHideSubject;
+        return notificationHideSubject;
     }
 
     public static void setNotificationHideSubject(final NotificationHideSubject mode) {
-        sNotificationHideSubject = mode;
+        notificationHideSubject = mode;
     }
 
     public static NotificationQuickDelete getNotificationQuickDeleteBehaviour() {
-        return sNotificationQuickDelete;
+        return notificationQuickDelete;
     }
 
     public static void setNotificationQuickDeleteBehaviour(final NotificationQuickDelete mode) {
-        sNotificationQuickDelete = mode;
+        notificationQuickDelete = mode;
     }
 
     public static LockScreenNotificationVisibility getLockScreenNotificationVisibility() {
@@ -1213,167 +1213,167 @@ public class K9 extends Application {
     }
 
     public static boolean wrapFolderNames() {
-        return mWrapFolderNames;
+        return wrapFolderNames;
     }
     public static void setWrapFolderNames(final boolean state) {
-        mWrapFolderNames = state;
+        wrapFolderNames = state;
     }
 
     public static boolean hideUserAgent() {
-        return mHideUserAgent;
+        return hideUserAgent;
     }
     public static void setHideUserAgent(final boolean state) {
-        mHideUserAgent = state;
+        hideUserAgent = state;
     }
 
     public static boolean hideTimeZone() {
-        return mHideTimeZone;
+        return hideTimeZone;
     }
     public static void setHideTimeZone(final boolean state) {
-        mHideTimeZone = state;
+        hideTimeZone = state;
     }
 
     public static boolean isOpenPgpProviderConfigured() {
-        return !NO_OPENPGP_PROVIDER.equals(sOpenPgpProvider);
+        return !NO_OPENPGP_PROVIDER.equals(openPgpProvider);
     }
 
     public static String getOpenPgpProvider() {
-        return sOpenPgpProvider;
+        return openPgpProvider;
     }
 
     public static void setOpenPgpProvider(String openPgpProvider) {
-        sOpenPgpProvider = openPgpProvider;
+        K9.openPgpProvider = openPgpProvider;
     }
 
     public static boolean getOpenPgpSupportSignOnly() {
-        return sOpenPgpSupportSignOnly;
+        return openPgpSupportSignOnly;
     }
 
     public static void setOpenPgpSupportSignOnly(boolean supportSignOnly) {
-        sOpenPgpSupportSignOnly = supportSignOnly;
+        openPgpSupportSignOnly = supportSignOnly;
     }
 
     public static String getAttachmentDefaultPath() {
-        return mAttachmentDefaultPath;
+        return attachmentDefaultPath;
     }
 
     public static void setAttachmentDefaultPath(String attachmentDefaultPath) {
-        K9.mAttachmentDefaultPath = attachmentDefaultPath;
+        K9.attachmentDefaultPath = attachmentDefaultPath;
     }
 
     public static synchronized SortType getSortType() {
-        return mSortType;
+        return sortType;
     }
 
     public static synchronized void setSortType(SortType sortType) {
-        mSortType = sortType;
+        K9.sortType = sortType;
     }
 
     public static synchronized boolean isSortAscending(SortType sortType) {
-        if (mSortAscending.get(sortType) == null) {
-            mSortAscending.put(sortType, sortType.isDefaultAscending());
+        if (sortAscending.get(sortType) == null) {
+            sortAscending.put(sortType, sortType.isDefaultAscending());
         }
-        return mSortAscending.get(sortType);
+        return sortAscending.get(sortType);
     }
 
     public static synchronized void setSortAscending(SortType sortType, boolean sortAscending) {
-        mSortAscending.put(sortType, sortAscending);
+        K9.sortAscending.put(sortType, sortAscending);
     }
 
     public static synchronized boolean useBackgroundAsUnreadIndicator() {
-        return sUseBackgroundAsUnreadIndicator;
+        return useBackgroundAsUnreadIndicator;
     }
 
     public static synchronized void setUseBackgroundAsUnreadIndicator(boolean enabled) {
-        sUseBackgroundAsUnreadIndicator = enabled;
+        useBackgroundAsUnreadIndicator = enabled;
     }
 
     public static synchronized boolean isThreadedViewEnabled() {
-        return sThreadedViewEnabled;
+        return threadedViewEnabled;
     }
 
     public static synchronized void setThreadedViewEnabled(boolean enable) {
-        sThreadedViewEnabled = enable;
+        threadedViewEnabled = enable;
     }
 
     public static synchronized SplitViewMode getSplitViewMode() {
-        return sSplitViewMode;
+        return splitViewMode;
     }
 
     public static synchronized void setSplitViewMode(SplitViewMode mode) {
-        sSplitViewMode = mode;
+        splitViewMode = mode;
     }
 
     public static boolean showContactPicture() {
-        return sShowContactPicture;
+        return showContactPicture;
     }
 
     public static void setShowContactPicture(boolean show) {
-        sShowContactPicture = show;
+        showContactPicture = show;
     }
 
     public static boolean isColorizeMissingContactPictures() {
-        return sColorizeMissingContactPictures;
+        return colorizeMissingContactPictures;
     }
 
     public static void setColorizeMissingContactPictures(boolean enabled) {
-        sColorizeMissingContactPictures = enabled;
+        colorizeMissingContactPictures = enabled;
     }
 
     public static boolean isMessageViewArchiveActionVisible() {
-        return sMessageViewArchiveActionVisible;
+        return messageViewArchiveActionVisible;
     }
 
     public static void setMessageViewArchiveActionVisible(boolean visible) {
-        sMessageViewArchiveActionVisible = visible;
+        messageViewArchiveActionVisible = visible;
     }
 
     public static boolean isMessageViewDeleteActionVisible() {
-        return sMessageViewDeleteActionVisible;
+        return messageViewDeleteActionVisible;
     }
 
     public static void setMessageViewDeleteActionVisible(boolean visible) {
-        sMessageViewDeleteActionVisible = visible;
+        messageViewDeleteActionVisible = visible;
     }
 
     public static boolean isMessageViewMoveActionVisible() {
-        return sMessageViewMoveActionVisible;
+        return messageViewMoveActionVisible;
     }
 
     public static void setMessageViewMoveActionVisible(boolean visible) {
-        sMessageViewMoveActionVisible = visible;
+        messageViewMoveActionVisible = visible;
     }
 
     public static boolean isMessageViewCopyActionVisible() {
-        return sMessageViewCopyActionVisible;
+        return messageViewCopyActionVisible;
     }
 
     public static void setMessageViewCopyActionVisible(boolean visible) {
-        sMessageViewCopyActionVisible = visible;
+        messageViewCopyActionVisible = visible;
     }
 
     public static boolean isMessageViewSpamActionVisible() {
-        return sMessageViewSpamActionVisible;
+        return messageViewSpamActionVisible;
     }
 
     public static void setMessageViewSpamActionVisible(boolean visible) {
-        sMessageViewSpamActionVisible = visible;
+        messageViewSpamActionVisible = visible;
     }
 
     public static int getPgpInlineDialogCounter() {
-        return sPgpInlineDialogCounter;
+        return pgpInlineDialogCounter;
     }
 
     public static void setPgpInlineDialogCounter(int pgpInlineDialogCounter) {
-        K9.sPgpInlineDialogCounter = pgpInlineDialogCounter;
+        K9.pgpInlineDialogCounter = pgpInlineDialogCounter;
     }
 
     public static int getPgpSignOnlyDialogCounter() {
-        return sPgpSignOnlyDialogCounter;
+        return pgpSignOnlyDialogCounter;
     }
 
     public static void setPgpSignOnlyDialogCounter(int pgpSignOnlyDialogCounter) {
-        K9.sPgpSignOnlyDialogCounter = pgpSignOnlyDialogCounter;
+        K9.pgpSignOnlyDialogCounter = pgpSignOnlyDialogCounter;
     }
 
     /**
@@ -1388,7 +1388,7 @@ public class K9 extends Application {
      *         {@code false}, otherwise.
      */
     public static synchronized boolean areDatabasesUpToDate() {
-        return sDatabasesUpToDate;
+        return databasesUpToDate;
     }
 
     /**
@@ -1401,10 +1401,10 @@ public class K9 extends Application {
      * @see #areDatabasesUpToDate()
      */
     public static synchronized void setDatabasesUpToDate(boolean save) {
-        sDatabasesUpToDate = true;
+        databasesUpToDate = true;
 
         if (save) {
-            Editor editor = sDatabaseVersionCache.edit();
+            Editor editor = databaseVersionCache.edit();
             editor.putInt(KEY_LAST_ACCOUNT_DATABASE_VERSION, LocalStore.DB_VERSION);
             editor.apply();
         }


### PR DESCRIPTION
Just repeated use of IDE refactor renaming. No change in behaviour.