### PR TITLE
Tidy up the usage of 'e-mail' in non-translated source text

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -15,7 +15,7 @@ import com.fsck.k9.message.AutocryptStatusInteractor.RecipientAutocryptStatusTyp
 import com.fsck.k9.view.RecipientSelectView.Recipient;
 
 /** This is an immutable object which contains all relevant metadata entered
- * during e-mail composition to apply cryptographic operations before sending
+ * during email composition to apply cryptographic operations before sending
  * or saving as draft.
  */
 public class ComposeCryptoStatus {

--- a/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
@@ -92,7 +92,7 @@ public class Contacts {
         contactIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         contactIntent.setData(contactUri);
 
-        // Pass along full E-mail string for possible create dialog
+        // Pass along full email string for possible create dialog
         contactIntent.putExtra(ContactsContract.Intents.EXTRA_CREATE_DESCRIPTION,
                 email.toString());
 

--- a/k9mail/src/main/java/com/fsck/k9/search/SearchAccount.java
+++ b/k9mail/src/main/java/com/fsck/k9/search/SearchAccount.java
@@ -10,7 +10,7 @@ import com.fsck.k9.search.SearchSpecification.SearchField;
 
 /**
  * This class is basically a wrapper around a LocalSearch. It allows to expose it as
- * an account. This is a meta-account containing all the e-mail that matches the search.
+ * an account. This is a meta-account containing all the email that matches the search.
  */
 public class SearchAccount implements BaseAccount {
     public static final String ALL_MESSAGES = "all_messages";

--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -91,7 +91,7 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         alternatesAdapter = new AlternateRecipientAdapter(context, this);
         alternatesPopup.setAdapter(alternatesAdapter);
 
-        // don't allow duplicates, based on equality of recipient objects, which is e-mail addresses
+        // don't allow duplicates, based on equality of recipient objects, which is email addresses
         allowDuplicates(false);
 
         // if a token is completed, pick an entry based on best guess.

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1275,7 +1275,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="enable_encryption">Enable Encryption</string>
     <string name="disable_encryption">Disable Encryption</string>
     <string name="openpgp_description_text1">Encrypting messages ensures they can be read by the recipient, and nobody else.</string>
-    <string name="openpgp_description_text3">Encryption will only show up if supported by all recipients, and they must have sent you an e-mail before.</string>
+    <string name="openpgp_description_text3">Encryption will only show up if supported by all recipients, and they must have sent you an email before.</string>
     <string name="openpgp_description_text2">Toggle encryption by clicking this icon.</string>
     <string name="openpgp_enabled_error_gotit">Got it</string>
     <string name="openpgp_enabled_error_back">Back</string>


### PR DESCRIPTION
`grep -rni "e-mail" k9mail/src/ | grep -v "values\-" | grep -v "test"`

There's only one that's actually visible, the rest are comments.

Thanks to #3086 

