### PR TITLE
Added a check for showing correspondent name to RecipientSelectView

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -32,6 +32,7 @@ import android.widget.ListPopupWindow;
 import android.widget.ListView;
 import android.widget.TextView;
 
+import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.activity.AlternateRecipientAdapter;
 import com.fsck.k9.activity.AlternateRecipientAdapter.AlternateRecipientListener;
@@ -605,7 +606,8 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         }
 
         public String getDisplayNameOrAddress() {
-            String displayName = getDisplayName();
+            final String displayName = K9.showCorrespondentNames() ? getDisplayName() : null;
+    
             if (displayName != null) {
                 return displayName;
             }


### PR DESCRIPTION
To resolve issue https://github.com/k9mail/k-9/issues/3012, I added a check on the "Show correspondent names" setting in RecipientSelectView.getDisplayNameOrAddress().

This check will now let this method return the full address or display name of the recipient based on the user settings. This only affects the view in the "To/CC/BCC" fields in MessageCompose before it is clicked. All other elements remain the same. 
If no display name is available, the method still falls back to address, regardless of the user settings.

I tested: 
- That it works in To/CC/BCC in both a new composition and a reply
- That it does not affect the popup view when the RecipientSelectView is clicked
    - The display name is still displayed correctly here, as well as all address (no changed behavior)
- The typed address is shown in the view, not the "first" from the expanded view
