### PR TITLE
Autocrypt gossip

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptGossipHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptGossipHeader.java
@@ -1,0 +1,64 @@
+package com.fsck.k9.autocrypt;
+
+
+import java.util.Arrays;
+
+import android.support.annotation.NonNull;
+
+
+class AutocryptGossipHeader {
+    static final String AUTOCRYPT_GOSSIP_HEADER = "Autocrypt-Gossip";
+
+    private static final String AUTOCRYPT_PARAM_ADDR = "addr";
+    private static final String AUTOCRYPT_PARAM_KEY_DATA = "keydata";
+
+
+    @NonNull
+    private final byte[] keyData;
+    @NonNull
+    private final String addr;
+
+    AutocryptGossipHeader(@NonNull String addr, @NonNull byte[] keyData) {
+        this.addr = addr;
+        this.keyData = keyData;
+    }
+
+    String toRawHeaderString() {
+        StringBuilder builder = new StringBuilder();
+
+        builder.append(AutocryptGossipHeader.AUTOCRYPT_GOSSIP_HEADER).append(": ");
+        builder.append(AutocryptGossipHeader.AUTOCRYPT_PARAM_ADDR).append('=').append(addr).append("; ");
+        builder.append(AutocryptGossipHeader.AUTOCRYPT_PARAM_KEY_DATA).append('=');
+        builder.append(AutocryptHeader.createFoldedBase64KeyData(keyData));
+
+        return builder.toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        AutocryptGossipHeader that = (AutocryptGossipHeader) o;
+
+        if (!Arrays.equals(keyData, that.keyData)) {
+            return false;
+        }
+        if (!addr.equals(that.addr)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Arrays.hashCode(keyData);
+        result = 31 * result + addr.hashCode();
+        return result;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptGossipHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptGossipHeader.java
@@ -14,9 +14,9 @@ class AutocryptGossipHeader {
 
 
     @NonNull
-    private final byte[] keyData;
+    final byte[] keyData;
     @NonNull
-    private final String addr;
+    final String addr;
 
     AutocryptGossipHeader(@NonNull String addr, @NonNull byte[] keyData) {
         this.addr = addr;

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptGossipHeaderParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptGossipHeaderParser.java
@@ -1,0 +1,93 @@
+package com.fsck.k9.autocrypt;
+
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
+
+import com.fsck.k9.mail.Part;
+import com.fsck.k9.mail.internet.MimeUtility;
+import okio.ByteString;
+import timber.log.Timber;
+
+
+class AutocryptGossipHeaderParser {
+    private static final AutocryptGossipHeaderParser INSTANCE = new AutocryptGossipHeaderParser();
+
+
+    public static AutocryptGossipHeaderParser getInstance() {
+        return INSTANCE;
+    }
+
+    private AutocryptGossipHeaderParser() { }
+
+
+    List<AutocryptGossipHeader> getAllAutocryptGossipHeaders(Part part) {
+        String[] headers = part.getHeader(AutocryptGossipHeader.AUTOCRYPT_GOSSIP_HEADER);
+        List<AutocryptGossipHeader> autocryptHeaders = parseAllAutocryptGossipHeaders(headers);
+
+        return Collections.unmodifiableList(autocryptHeaders);
+    }
+
+    @Nullable
+    @VisibleForTesting
+    AutocryptGossipHeader parseAutocryptGossipHeader(String headerValue) {
+        Map<String,String> parameters = MimeUtility.getAllHeaderParameters(headerValue);
+
+        String type = parameters.remove(AutocryptHeader.AUTOCRYPT_PARAM_TYPE);
+        if (type != null && !type.equals(AutocryptHeader.AUTOCRYPT_TYPE_1)) {
+            Timber.e("autocrypt: unsupported type parameter %s", type);
+            return null;
+        }
+
+        String base64KeyData = parameters.remove(AutocryptHeader.AUTOCRYPT_PARAM_KEY_DATA);
+        if (base64KeyData == null) {
+            Timber.e("autocrypt: missing key parameter");
+            return null;
+        }
+
+        ByteString byteString = ByteString.decodeBase64(base64KeyData);
+        if (byteString == null) {
+            Timber.e("autocrypt: error parsing base64 data");
+            return null;
+        }
+
+        String addr = parameters.remove(AutocryptHeader.AUTOCRYPT_PARAM_ADDR);
+        if (addr == null) {
+            Timber.e("autocrypt: no to header!");
+            return null;
+        }
+
+        if (hasCriticalParameters(parameters)) {
+            return null;
+        }
+
+        return new AutocryptGossipHeader(addr, byteString.toByteArray());
+    }
+
+    private boolean hasCriticalParameters(Map<String, String> parameters) {
+        for (String parameterName : parameters.keySet()) {
+            if (parameterName != null && !parameterName.startsWith("_")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @NonNull
+    private List<AutocryptGossipHeader> parseAllAutocryptGossipHeaders(String[] headers) {
+        ArrayList<AutocryptGossipHeader> autocryptHeaders = new ArrayList<>();
+        for (String header : headers) {
+            AutocryptGossipHeader autocryptHeader = parseAutocryptGossipHeader(header);
+            if (autocryptHeader != null) {
+                autocryptHeaders.add(autocryptHeader);
+            }
+        }
+        return autocryptHeaders;
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptGossipHeaderParser.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptGossipHeaderParser.java
@@ -84,9 +84,11 @@ class AutocryptGossipHeaderParser {
         ArrayList<AutocryptGossipHeader> autocryptHeaders = new ArrayList<>();
         for (String header : headers) {
             AutocryptGossipHeader autocryptHeader = parseAutocryptGossipHeader(header);
-            if (autocryptHeader != null) {
-                autocryptHeaders.add(autocryptHeader);
+            if (autocryptHeader == null) {
+                Timber.e("Encountered malformed autocrypt-gossip header - skipping!");
+                continue;
             }
+            autocryptHeaders.add(autocryptHeader);
         }
         return autocryptHeaders;
     }

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptHeader.java
@@ -54,39 +54,26 @@ class AutocryptHeader {
                     .append('=').append(AutocryptHeader.AUTOCRYPT_PREFER_ENCRYPT_MUTUAL).append("; ");
         }
         builder.append(AutocryptHeader.AUTOCRYPT_PARAM_KEY_DATA).append("=");
-
-        appendBase64KeyData(builder);
+        builder.append(createFoldedBase64KeyData(keyData));
 
         return builder.toString();
     }
 
-    private void appendBase64KeyData(StringBuilder builder) {
+    static String createFoldedBase64KeyData(byte[] keyData) {
         String base64KeyData = ByteString.of(keyData).base64();
+        StringBuilder result = new StringBuilder();
 
-        int base64Length = base64KeyData.length();
-        int lineLengthBeforeKeyData = builder.length();
-        int dataLengthInFirstLine = HEADER_LINE_LENGTH -lineLengthBeforeKeyData;
-
-        boolean keyDataFitsInFirstLine = dataLengthInFirstLine > 0 && base64Length < dataLengthInFirstLine;
-        if (keyDataFitsInFirstLine) {
-            builder.append(base64KeyData, 0, base64Length);
-            return;
-        }
-
-        if (dataLengthInFirstLine > 0) {
-            builder.append(base64KeyData, 0, dataLengthInFirstLine).append("\r\n ");
-        } else {
-            builder.append("\r\n ");
-            dataLengthInFirstLine = 0;
-        }
-
-        for (int i = dataLengthInFirstLine; i < base64Length; i += HEADER_LINE_LENGTH) {
+        for (int i = 0, base64Length = base64KeyData.length(); i < base64Length; i += HEADER_LINE_LENGTH) {
             if (i + HEADER_LINE_LENGTH <= base64Length) {
-                builder.append(base64KeyData, i, i + HEADER_LINE_LENGTH).append("\r\n ");
+                result.append("\r\n ");
+                result.append(base64KeyData, i, i + HEADER_LINE_LENGTH);
             } else {
-                builder.append(base64KeyData, i, base64Length);
+                result.append("\r\n ");
+                result.append(base64KeyData, i, base64Length);
             }
         }
+
+        return result.toString();
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOpenPgpApiInteractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOpenPgpApiInteractor.java
@@ -16,13 +16,23 @@ public class AutocryptOpenPgpApiInteractor {
 
     private AutocryptOpenPgpApiInteractor() { }
 
-    public byte[] getKeyMaterialFromApi(OpenPgpApi openPgpApi, long keyId, String minimizeForUserId) {
-        Intent retreiveKeyIntent = new Intent(OpenPgpApi.ACTION_GET_KEY);
-        retreiveKeyIntent.putExtra(OpenPgpApi.EXTRA_KEY_ID, keyId);
-        retreiveKeyIntent.putExtra(OpenPgpApi.EXTRA_MINIMIZE, true);
-        retreiveKeyIntent.putExtra(OpenPgpApi.EXTRA_MINIMIZE_USER_ID, minimizeForUserId);
+    public byte[] getKeyMaterialForKeyId(OpenPgpApi openPgpApi, long keyId, String minimizeForUserId) {
+        Intent retrieveKeyIntent = new Intent(OpenPgpApi.ACTION_GET_KEY);
+        retrieveKeyIntent.putExtra(OpenPgpApi.EXTRA_KEY_ID, keyId);
+        return getKeyMaterialFromApi(openPgpApi, retrieveKeyIntent, minimizeForUserId);
+    }
+
+    public byte[] getKeyMaterialForUserId(OpenPgpApi openPgpApi, String userId) {
+        Intent retrieveKeyIntent = new Intent(OpenPgpApi.ACTION_GET_KEY);
+        retrieveKeyIntent.putExtra(OpenPgpApi.EXTRA_USER_ID, userId);
+        return getKeyMaterialFromApi(openPgpApi, retrieveKeyIntent, userId);
+    }
+
+    private byte[] getKeyMaterialFromApi(OpenPgpApi openPgpApi, Intent retrieveKeyIntent, String userId) {
+        retrieveKeyIntent.putExtra(OpenPgpApi.EXTRA_MINIMIZE, true);
+        retrieveKeyIntent.putExtra(OpenPgpApi.EXTRA_MINIMIZE_USER_ID, userId);
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        Intent result = openPgpApi.executeApi(retreiveKeyIntent, (InputStream) null, baos);
+        Intent result = openPgpApi.executeApi(retrieveKeyIntent, (InputStream) null, baos);
 
         if (result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR) ==
                 OpenPgpApi.RESULT_CODE_SUCCESS) {

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOperations.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOperations.java
@@ -7,6 +7,7 @@ import java.util.Date;
 import android.content.Intent;
 
 import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.internet.MimeBodyPart;
 import org.openintents.openpgp.AutocryptPeerUpdate;
 import org.openintents.openpgp.util.OpenPgpApi;
 
@@ -60,4 +61,10 @@ public class AutocryptOperations {
         message.addRawHeader(AutocryptHeader.AUTOCRYPT_HEADER, rawAutocryptHeader);
     }
 
+    public void addAutocryptGossipHeaderToPart(MimeBodyPart part, byte[] keyData, String autocryptAddress) {
+        AutocryptGossipHeader autocryptGossipHeader = new AutocryptGossipHeader(autocryptAddress, keyData);
+        String rawAutocryptHeader = autocryptGossipHeader.toRawHeaderString();
+
+        part.addRawHeader(AutocryptGossipHeader.AUTOCRYPT_GOSSIP_HEADER, rawAutocryptHeader);
+    }
 }

--- a/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOperations.java
+++ b/k9mail/src/main/java/com/fsck/k9/autocrypt/AutocryptOperations.java
@@ -1,12 +1,18 @@
 package com.fsck.k9.autocrypt;
 
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
+import java.util.List;
 
 import android.content.Intent;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
 
+import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.Message.RecipientType;
 import com.fsck.k9.mail.internet.MimeBodyPart;
 import org.openintents.openpgp.AutocryptPeerUpdate;
 import org.openintents.openpgp.util.OpenPgpApi;
@@ -14,16 +20,20 @@ import org.openintents.openpgp.util.OpenPgpApi;
 
 public class AutocryptOperations {
     private final AutocryptHeaderParser autocryptHeaderParser;
+    private final AutocryptGossipHeaderParser autocryptGossipHeaderParser;
 
 
     public static AutocryptOperations getInstance() {
         AutocryptHeaderParser autocryptHeaderParser = AutocryptHeaderParser.getInstance();
-        return new AutocryptOperations(autocryptHeaderParser);
+        AutocryptGossipHeaderParser autocryptGossipHeaderParser = AutocryptGossipHeaderParser.getInstance();
+        return new AutocryptOperations(autocryptHeaderParser, autocryptGossipHeaderParser);
     }
 
 
-    private AutocryptOperations(AutocryptHeaderParser autocryptHeaderParser) {
+    private AutocryptOperations(AutocryptHeaderParser autocryptHeaderParser,
+            AutocryptGossipHeaderParser autocryptGossipHeaderParser) {
         this.autocryptHeaderParser = autocryptHeaderParser;
+        this.autocryptGossipHeaderParser = autocryptGossipHeaderParser;
     }
 
     public boolean addAutocryptPeerUpdateToIntentIfPresent(Message currentMessage, Intent intent) {
@@ -48,8 +58,90 @@ public class AutocryptOperations {
         return true;
     }
 
+    public boolean addAutocryptGossipUpdateToIntentIfPresent(Message message, MimeBodyPart decryptedPart, Intent intent) {
+        Bundle updates = createGossipUpdateBundle(message, decryptedPart);
+
+        if (updates == null) {
+            return false;
+        }
+
+        intent.putExtra(OpenPgpApi.EXTRA_AUTOCRYPT_PEER_GOSSIP_UPDATES, updates);
+        return true;
+    }
+
+    @Nullable
+    private Bundle createGossipUpdateBundle(Message message, MimeBodyPart decryptedPart) {
+        List<String> gossipAcceptedAddresses = getGossipAcceptedAddresses(message);
+        if (gossipAcceptedAddresses.isEmpty()) {
+            return null;
+        }
+
+        List<AutocryptGossipHeader> autocryptGossipHeaders =
+                autocryptGossipHeaderParser.getAllAutocryptGossipHeaders(decryptedPart);
+        if (autocryptGossipHeaders.isEmpty()) {
+            return null;
+        }
+
+        Date messageDate = message.getSentDate();
+        Date internalDate = message.getInternalDate();
+        Date effectiveDate = messageDate.before(internalDate) ? messageDate : internalDate;
+
+        return createGossipUpdateBundle(gossipAcceptedAddresses, autocryptGossipHeaders, effectiveDate);
+    }
+
+    @Nullable
+    private Bundle createGossipUpdateBundle(List<String> gossipAcceptedAddresses,
+            List<AutocryptGossipHeader> autocryptGossipHeaders, Date effectiveDate) {
+        Bundle updates = new Bundle();
+        for (AutocryptGossipHeader autocryptGossipHeader : autocryptGossipHeaders) {
+            boolean isAcceptedAddress = gossipAcceptedAddresses.contains(autocryptGossipHeader.addr.toLowerCase());
+            if (!isAcceptedAddress) {
+                continue;
+            }
+
+            AutocryptPeerUpdate update = AutocryptPeerUpdate.create(autocryptGossipHeader.keyData, effectiveDate, false);
+            updates.putParcelable(autocryptGossipHeader.addr, update);
+        }
+        if (updates.isEmpty()) {
+            return null;
+        }
+        return updates;
+    }
+
+    private List<String> getGossipAcceptedAddresses(Message message) {
+        ArrayList<String> result = new ArrayList<>();
+
+        addRecipientsToList(result, message, RecipientType.TO);
+        addRecipientsToList(result, message, RecipientType.CC);
+        removeRecipientsFromList(result, message, RecipientType.DELIVERED_TO);
+
+        return Collections.unmodifiableList(result);
+    }
+
+    private void addRecipientsToList(ArrayList<String> result, Message message, RecipientType recipientType) {
+        for (Address address : message.getRecipients(recipientType)) {
+            String addr = address.getAddress();
+            if (addr != null) {
+                result.add(addr.toLowerCase());
+            }
+        }
+    }
+
+    private void removeRecipientsFromList(ArrayList<String> result, Message message, RecipientType recipientType) {
+        for (Address address : message.getRecipients(recipientType)) {
+            String addr = address.getAddress();
+            if (addr != null) {
+                result.remove(addr);
+            }
+        }
+    }
+
     public boolean hasAutocryptHeader(Message currentMessage) {
         return currentMessage.getHeader(AutocryptHeader.AUTOCRYPT_HEADER).length > 0;
+    }
+
+    public boolean hasAutocryptGossipHeader(MimeBodyPart part) {
+        return part.getHeader(AutocryptGossipHeader.AUTOCRYPT_GOSSIP_HEADER).length > 0;
     }
 
     public void addAutocryptHeaderToMessage(Message message, byte[] keyData,

--- a/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptGossipHeaderParserTest.kt
+++ b/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptGossipHeaderParserTest.kt
@@ -1,0 +1,96 @@
+package com.fsck.k9.autocrypt
+
+
+import com.fsck.k9.mail.filter.Base64
+import com.fsck.k9.mailstore.MimePartStreamParser
+import org.junit.Assert.*
+import org.junit.Test
+
+
+class AutocryptGossipHeaderParserTest {
+    val GOSSIP_DATA_BOB = Base64.decodeBase64(
+            """mQGNBFoBt74BDAC8AMsjPY17kxodbfmHah38ZQipY0yfuo97WUBs2jeiFYlQdunPANi5VMgbAX+H
+     Mq1XoBRs6qW+WpX8Uj11mu22c57BTUXJRbRr4TnTuuOQmT0egwFDe3x8vHSFmcf9OzG8iKR9ftUE
+     +F2ewrzzmm3XY8hy7QeUgBfClZVA6A3rsX4gGawjDo6ZRBbYwckINgGX/vQk6rGs""".toByteArray())
+
+    val GOSSIP_HEADER_BOB = """addr=bob@autocrypt.example; keydata=
+ mQGNBFoBt74BDAC8AMsjPY17kxodbfmHah38ZQipY0yfuo97WUBs2jeiFYlQdunPANi5VMgbAX+H
+ Mq1XoBRs6qW+WpX8Uj11mu22c57BTUXJRbRr4TnTuuOQmT0egwFDe3x8vHSFmcf9OzG8iKR9ftUE
+ +F2ewrzzmm3XY8hy7QeUgBfClZVA6A3rsX4gGawjDo6ZRBbYwckINgGX/vQk6rGs"""
+
+    val GOSSIP_RAW_HEADER_BOB = "Autocrypt-Gossip: $GOSSIP_HEADER_BOB".replace("\n", "\r\n")
+
+    // Example from Autocrypt 1.0 appendix
+    val GOSSIP_PART = """Autocrypt-Gossip: $GOSSIP_HEADER_BOB
+Autocrypt-Gossip: addr=carol@autocrypt.example; keydata=
+ mQGNBFoBt8oBDADGqfZ6PqW05hUEO1dkKm+ixJXnbVriPz2tRkAqT7lTF4KBGitxo4IPv9RPIjJR
+ UMUo89ddyqQfiwKxdFCMDqFDnVRWlDaM+r8sauNJoIFwtTFuvUpkFeCI5gYvneEIIbf1r3Xx1pf5
+ Iy9qsd5eg/4Vvc2AezUv+A6p2DUNHgFMX2FfDus+EPO0wgeWbNaV601aE7UhyugB
+Content-Type: text/plain
+
+Hi Bob and Carol,
+
+I wanted to introduce the two of you to each other.
+
+I hope you are both doing well!  You can now both "reply all" here,
+and the thread will remain encrypted.
+
+Regards,
+Alice
+""".replace("\n", "\r\n")
+
+    private val autocryptGossipHeaderParser = AutocryptGossipHeaderParser.getInstance()
+
+    @Test
+    fun parseFromPart() {
+        val gossipPart = MimePartStreamParser.parse(null, GOSSIP_PART.byteInputStream())
+        val allAutocryptGossipHeaders = autocryptGossipHeaderParser.getAllAutocryptGossipHeaders(gossipPart)
+
+        assertEquals("text/plain", gossipPart.mimeType)
+        assertEquals(2, allAutocryptGossipHeaders.size)
+        assertEquals("bob@autocrypt.example", allAutocryptGossipHeaders[0].addr)
+        assertEquals("carol@autocrypt.example", allAutocryptGossipHeaders[1].addr)
+        assertArrayEquals(GOSSIP_DATA_BOB, allAutocryptGossipHeaders[0].keyData)
+    }
+
+    @Test
+    fun parseString() {
+        val gossipHeader = autocryptGossipHeaderParser.parseAutocryptGossipHeader(GOSSIP_HEADER_BOB)
+
+        gossipHeader!!
+        assertArrayEquals(GOSSIP_DATA_BOB, gossipHeader.keyData)
+        assertEquals(GOSSIP_RAW_HEADER_BOB, gossipHeader.toRawHeaderString())
+    }
+
+    @Test
+    fun parseHeader_missingKeydata() {
+        val gossipHeader = autocryptGossipHeaderParser.parseAutocryptGossipHeader(
+                "addr=CDEF")
+
+        assertNull(gossipHeader)
+    }
+
+    @Test
+    fun parseHeader_unknownCritical() {
+        val gossipHeader = autocryptGossipHeaderParser.parseAutocryptGossipHeader(
+                "addr=bawb; somecritical=value; keydata=aGk")
+
+        assertNull(gossipHeader)
+    }
+
+    @Test
+    fun parseHeader_unknownNonCritical() {
+        val gossipHeader = autocryptGossipHeaderParser.parseAutocryptGossipHeader(
+                "addr=bawb; _somenoncritical=value; keydata=aGk")
+
+        assertNotNull(gossipHeader)
+    }
+
+    @Test
+    fun parseHeader_brokenBase64() {
+        val gossipHeader = autocryptGossipHeaderParser.parseAutocryptGossipHeader(
+                "addr=bawb; _somenoncritical=value; keydata=X")
+
+        assertNull(gossipHeader)
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderTest.java
@@ -5,17 +5,15 @@ import java.util.HashMap;
 
 import org.junit.Test;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
 
 
 @SuppressWarnings("WeakerAccess")
 public class AutocryptHeaderTest {
     static final HashMap<String, String> PARAMETERS = new HashMap<>();
     static final String ADDR = "addr";
-    static final String ADDR_LONG = "veryveryverylongaddressthatspansmorethanalinelengthintheheader";
     static final byte[] KEY_DATA = ("theseare120charactersxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" +
             "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx").getBytes();
-    static final byte[] KEY_DATA_SHORT = ("theseare15chars").getBytes();
     static final boolean IS_PREFER_ENCRYPT_MUTUAL = true;
 
 
@@ -24,19 +22,7 @@ public class AutocryptHeaderTest {
         AutocryptHeader autocryptHeader = new AutocryptHeader(PARAMETERS, ADDR, KEY_DATA, IS_PREFER_ENCRYPT_MUTUAL);
         String autocryptHeaderString = autocryptHeader.toRawHeaderString();
 
-        String expected = "Autocrypt: addr=addr; prefer-encrypt=mutual; keydata=dGhlc2VhcmUxMjBjaGFyYWN\r\n" +
-                " 0ZXJzeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh\r\n" +
-                " 4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4";
-        assertEquals(expected, autocryptHeaderString);
-    }
-
-    @Test
-    public void toRawHeaderString_withLongAddress_returnsExpected() throws Exception {
-        AutocryptHeader autocryptHeader = new AutocryptHeader(PARAMETERS,
-                ADDR_LONG, KEY_DATA, IS_PREFER_ENCRYPT_MUTUAL);
-        String autocryptHeaderString = autocryptHeader.toRawHeaderString();
-
-        String expected = "Autocrypt: addr=veryveryverylongaddressthatspansmorethanalinelengthintheheader; prefer-encrypt=mutual; keydata=\r\n" +
+        String expected = "Autocrypt: addr=addr; prefer-encrypt=mutual; keydata=\r\n" +
                 " dGhlc2VhcmUxMjBjaGFyYWN0ZXJzeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4\r\n" +
                 " eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4\r\n" +
                 " eHh4eHh4";
@@ -44,12 +30,14 @@ public class AutocryptHeaderTest {
     }
 
     @Test
-    public void toRawHeaderString_withShortData_returnsExpected() throws Exception {
-        AutocryptHeader autocryptHeader = new AutocryptHeader(PARAMETERS,
-                ADDR, KEY_DATA_SHORT, IS_PREFER_ENCRYPT_MUTUAL);
+    public void gossip_toRawHeaderString_returnsExpected() throws Exception {
+        AutocryptGossipHeader autocryptHeader = new AutocryptGossipHeader(ADDR, KEY_DATA);
         String autocryptHeaderString = autocryptHeader.toRawHeaderString();
 
-        String expected = "Autocrypt: addr=addr; prefer-encrypt=mutual; keydata=dGhlc2VhcmUxNWNoYXJz";
+        String expected = "Autocrypt-Gossip: addr=addr; keydata=\r\n" +
+                " dGhlc2VhcmUxMjBjaGFyYWN0ZXJzeHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4\r\n" +
+                " eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4eHh4\r\n" +
+                " eHh4eHh4";
         assertEquals(expected, autocryptHeaderString);
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -80,7 +80,7 @@ public class PgpMessageBuilderTest {
 
     @Before
     public void setUp() throws Exception {
-        when(autocryptOpenPgpApiInteractor.getKeyMaterialFromApi(openPgpApi, TEST_KEY_ID, SENDER_EMAIL))
+        when(autocryptOpenPgpApiInteractor.getKeyMaterialForKeyId(openPgpApi, TEST_KEY_ID, SENDER_EMAIL))
                 .thenReturn(AUTOCRYPT_KEY_MATERIAL);
     }
 

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -331,6 +331,66 @@ public class PgpMessageBuilderTest {
     }
 
     @Test
+    public void buildEncrypt__checkGossip() throws MessagingException {
+        ComposeCryptoStatus cryptoStatus = cryptoStatusBuilder
+                .setCryptoMode(CryptoMode.CHOICE_ENABLED)
+                .setRecipients(Arrays.asList(
+                        new Recipient("alice", "alice@example.org", "alice", -1, "key"),
+                        new Recipient("bob", "bob@example.org", "bob", -1, "key2")))
+                .build();
+        pgpMessageBuilder.setCryptoStatus(cryptoStatus);
+
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+        when(openPgpApi.executeApi(any(Intent.class), any(OpenPgpDataSource.class), any(OutputStream.class))).thenReturn(returnIntent);
+        pgpMessageBuilder.buildAsync(mock(Callback.class));
+
+        verify(autocryptOpenPgpApiInteractor).getKeyMaterialForUserId(same(openPgpApi), eq("alice@example.org"));
+        verify(autocryptOpenPgpApiInteractor).getKeyMaterialForUserId(same(openPgpApi), eq("bob@example.org"));
+    }
+
+    @Test
+    public void buildEncrypt__checkGossip__filterBcc() throws MessagingException {
+        ComposeCryptoStatus cryptoStatus = cryptoStatusBuilder
+                .setCryptoMode(CryptoMode.CHOICE_ENABLED)
+                .setRecipients(Arrays.asList(
+                        new Recipient("alice", "alice@example.org", "alice", -1, "key"),
+                        new Recipient("bob", "bob@example.org", "bob", -1, "key2"),
+                        new Recipient("carol", "carol@example.org", "carol", -1, "key3")))
+                .build();
+        pgpMessageBuilder.setCryptoStatus(cryptoStatus);
+        pgpMessageBuilder.setBcc(Collections.singletonList(new Address("carol@example.org")));
+
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+        when(openPgpApi.executeApi(any(Intent.class), any(OpenPgpDataSource.class), any(OutputStream.class))).thenReturn(returnIntent);
+        pgpMessageBuilder.buildAsync(mock(Callback.class));
+
+        verify(autocryptOpenPgpApiInteractor).getKeyMaterialForUserId(same(openPgpApi), eq("alice@example.org"));
+        verify(autocryptOpenPgpApiInteractor).getKeyMaterialForUserId(same(openPgpApi), eq("bob@example.org"));
+    }
+
+    @Test
+    public void buildEncrypt__checkGossip__filterBccSingleRecipient() throws MessagingException {
+        ComposeCryptoStatus cryptoStatus = cryptoStatusBuilder
+                .setCryptoMode(CryptoMode.CHOICE_ENABLED)
+                .setRecipients(Arrays.asList(
+                        new Recipient("alice", "alice@example.org", "alice", -1, "key"),
+                        new Recipient("carol", "carol@example.org", "carol", -1, "key3")))
+                .build();
+        pgpMessageBuilder.setCryptoStatus(cryptoStatus);
+        pgpMessageBuilder.setBcc(Collections.singletonList(new Address("carol@example.org")));
+
+        Intent returnIntent = new Intent();
+        returnIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
+        when(openPgpApi.executeApi(any(Intent.class), any(OpenPgpDataSource.class), any(OutputStream.class))).thenReturn(returnIntent);
+        pgpMessageBuilder.buildAsync(mock(Callback.class));
+
+        verify(autocryptOpenPgpApiInteractor).getKeyMaterialForKeyId(any(OpenPgpApi.class), any(Long.class), any(String.class));
+        verifyNoMoreInteractions(autocryptOpenPgpApiInteractor);
+    }
+
+    @Test
     public void buildEncrypt__shouldSucceed() throws MessagingException {
         ComposeCryptoStatus cryptoStatus = cryptoStatusBuilder
                 .setCryptoMode(CryptoMode.CHOICE_ENABLED)

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
@@ -308,6 +308,7 @@ public class OpenPgpApi {
     // UPDATE_AUTOCRYPT_PEER
     public static final String EXTRA_AUTOCRYPT_PEER_ID = "autocrypt_peer_id";
     public static final String EXTRA_AUTOCRYPT_PEER_UPDATE = "autocrypt_peer_update";
+    public static final String EXTRA_AUTOCRYPT_PEER_GOSSIP_UPDATES = "autocrypt_peer_gossip_updates";
 
     // INTERNAL, must not be used
     public static final String EXTRA_CALL_UUID1 = "call_uuid1";


### PR DESCRIPTION
This adds support for receiving and sending Autocrypt-Gossip headers. It's still a WIP PR, I'm currently working on the OpenKeychain before finishing this.

It depends on https://github.com/open-keychain/open-keychain/pull/2253, which changes the Autocrypt logic quite a bit to work according to Autocrypt 1.0 spec.

All of this is both forward-compatible (newer openkeychain is compatible to current k9), and backward-compatible (newer k9 works with old openkeychain, but silently fails sending or receiving gossip).