### PR TITLE
remove namespace prefix from auto-configured special folder names (issue #701)

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -267,6 +267,15 @@ public class ImapStore extends RemoteStore {
                 combinedPrefix = null;
             }
 
+            String prefix = getCombinedPrefix();
+            int prefixLength = prefix.length();
+            if (prefixLength > 0 && decodedFolderName.startsWith(prefix)) {
+                if (K9MailLib.isDebug()) {
+                    Timber.d("Folder auto-configuration stripping prefix (%s) from folder name: %s", prefix, decodedFolderName);
+                }
+                decodedFolderName = decodedFolderName.substring(prefixLength);
+            }
+
             if (listResponse.hasAttribute("\\Archive") || listResponse.hasAttribute("\\All")) {
                 mStoreConfig.setArchiveFolderName(decodedFolderName);
                 if (K9MailLib.isDebug()) {


### PR DESCRIPTION
resolve issue #701 by removing namespace prefix from auto-configured special folder names

Tested with dovecot and prefix "INBOX." (see https://wiki.dovecot.org/Migration/Courier). Should also work with other prefixes or separators. The old behavior resulted in new folders named e.g. INBOX.INBOX.Sent