### PR TITLE
Split B-/Q-decoding and charset decoding into two different phases

### DIFF
--- a/k9mail-library/build.gradle
+++ b/k9mail-library/build.gradle
@@ -17,6 +17,7 @@ repositories {
 dependencies {
     compile 'org.apache.james:apache-mime4j-core:0.8.1'
     compile 'org.apache.james:apache-mime4j-dom:0.8.1'
+    compile "com.squareup.okio:okio:${okioVersion}"
     compile 'commons-io:commons-io:2.4'
     compile 'com.jcraft:jzlib:1.0.7'
     compile 'com.beetstra.jutf7:jutf7:1.0.0'
@@ -27,7 +28,6 @@ dependencies {
     androidTestCompile 'com.madgag.spongycastle:pg:1.51.0.0'
 
     testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
-    testCompile "com.squareup.okio:okio:${okioVersion}"
     testCompile "org.robolectric:robolectric:${robolectricVersion}"
     testCompile "junit:junit:${junitVersion}"
     testCompile "com.google.truth:truth:${truthVersion}"

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/DecoderUtilTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/DecoderUtilTest.java
@@ -119,7 +119,7 @@ public class DecoderUtilTest {
 
     @Test
     public void decodeEncodedWords_withInvalidBase64String_returnsEmptyString() {
-        assertInputDecodesToExpected("=?us-ascii?b?abc?=", "");
+        assertInputDecodesToExpected("=?us-ascii?b?ab#?=", "");
     }
 
     @Test
@@ -190,6 +190,12 @@ public class DecoderUtilTest {
     @Test
     public void decodeEncodedWords_withEncodedWordFollowedByEncodedWordWithDifferentCharset_shouldDecodeIndividually() {
         assertInputDecodesToExpected("=?us-ascii?Q?oh_no_?= =?utf-8?Q?=F0=9F=92=A9?=", "oh no 💩");
+    }
+
+    @Test
+    public void decodeEncodedWords_withTwoCompleteEncodedWords_shouldProvideBoth() {
+        assertInputDecodesToExpected("=?UTF-8?B?W+aWsOioguWWrl0g6aGn5a6iOiB4eHhAeHh4LmNvbSDmnInmlrDoqILllq46ICMyMDE4MA==?= " +
+                "=?UTF-8?B?MTE4MTIzNDU2Nzg=?=", "[新訂單] 顧客: xxx@xxx.com 有新訂單: #2018011812345678");
     }
 
     @Test


### PR DESCRIPTION
It is very unlikely that the Q-encoding or B-encoding is split across multiple encoded words. The common mistake is not taking charset encoding into account when creating multiple encoded words.
With this change we strip the Q-encoding/B-encoding of individual encoded words but do the charset decoding using the combined (decoded) bytes.

Fixes #3125

