### PR TITLE
Return actual root part of message in MessageViewInfo (fixes #3004)

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
@@ -37,10 +37,10 @@ public class MessageViewInfo {
         this.extraAttachments = extraAttachments;
     }
 
-    static MessageViewInfo createWithExtractedContent(Message message, boolean isMessageIncomplete,
+    static MessageViewInfo createWithExtractedContent(Message message, Part rootPart, boolean isMessageIncomplete,
             String text, List<AttachmentViewInfo> attachments, AttachmentResolver attachmentResolver) {
         return new MessageViewInfo(
-                message, isMessageIncomplete, message, text, attachments, null, attachmentResolver, null,
+                message, isMessageIncomplete, rootPart, text, attachments, null, attachmentResolver, null,
                 Collections.<AttachmentViewInfo>emptyList());
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -124,7 +124,7 @@ public class MessageViewInfoExtractor {
                 !message.isSet(Flag.X_DOWNLOADED_FULL) || MessageExtractor.hasMissingParts(message);
 
         return MessageViewInfo.createWithExtractedContent(
-                message, isMessageIncomplete, viewable.html, attachmentInfos, attachmentResolver);
+                message, contentPart, isMessageIncomplete, viewable.html, attachmentInfos, attachmentResolver);
     }
 
     private ViewableExtractedText extractViewableAndAttachments(List<Part> parts,

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -406,6 +406,8 @@ public class MessageViewInfoExtractorTest {
 
         assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
         assertSame(annotation, messageViewInfo.cryptoResultAnnotation);
+        assertSame(message, messageViewInfo.message);
+        assertSame(message, messageViewInfo.rootPart);
         assertTrue(messageViewInfo.attachments.isEmpty());
         assertTrue(messageViewInfo.extraAttachments.isEmpty());
     }
@@ -427,6 +429,8 @@ public class MessageViewInfoExtractorTest {
 
         assertEquals("<pre class=\"k9mail\">replacement text</pre>", messageViewInfo.text);
         assertSame(annotation, messageViewInfo.cryptoResultAnnotation);
+        assertSame(message, messageViewInfo.message);
+        assertSame(replacementPart, messageViewInfo.rootPart);
         assertTrue(messageViewInfo.attachments.isEmpty());
         assertTrue(messageViewInfo.extraAttachments.isEmpty());
     }


### PR DESCRIPTION
This fixes #3004, which was a bug that snuck into #2777 where the actual content part wasn't correctly passed to the quotation logic. Sigh.