### PR TITLE
Update build/libraries/API/SDKs/Java/tools + basic runtime permissions (Android Studio 3.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.1.0-beta1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
     }
 }
@@ -21,4 +22,9 @@ subprojects {
             project.android.dexOptions.preDexLibraries = !rootProject.hasProperty('disablePreDex')
         }
     }
+}
+
+repositories {
+    google()
+    jcenter()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.2.20
+kotlinVersion=1.2.21
 androidCompileSdkVersion=27
 androidBuildToolsVersion=27.0.3
 androidSupportLibraryVersion=27.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,14 @@
-kotlinVersion=1.1.4-3
-androidCompileSdkVersion=25
-androidBuildToolsVersion=25.0.2
-androidSupportLibraryVersion=25.2.0
-timberVersion=4.5.1
+kotlinVersion=1.2.20
+androidCompileSdkVersion=27
+androidBuildToolsVersion=27.0.3
+androidSupportLibraryVersion=27.0.2
+androidSupportAnnotationsLibraryVersion=24.2.0
+timberVersion=4.6.0
 
 robolectricVersion=3.2.2
 junitVersion=4.12
 mockitoVersion=1.10.19
-okioVersion=1.11.0
-truthVersion=0.35
+okioVersion=1.13.0
+truthVersion=0.39
+
+android.enableD8=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip

--- a/k9mail-library/build.gradle
+++ b/k9mail-library/build.gradle
@@ -12,26 +12,27 @@ if (rootProject.testCoverage) {
 
 repositories {
     jcenter()
+    google()
 }
 
 dependencies {
-    compile 'org.apache.james:apache-mime4j-core:0.8.1'
-    compile 'org.apache.james:apache-mime4j-dom:0.8.1'
-    compile "com.squareup.okio:okio:${okioVersion}"
-    compile 'commons-io:commons-io:2.4'
-    compile 'com.jcraft:jzlib:1.0.7'
-    compile 'com.beetstra.jutf7:jutf7:1.0.0'
-    compile "com.android.support:support-annotations:${androidSupportLibraryVersion}"
-    compile "com.jakewharton.timber:timber:${timberVersion}"
+    implementation 'org.apache.james:apache-mime4j-core:0.8.1'
+    implementation 'org.apache.james:apache-mime4j-dom:0.8.1'
+    implementation "com.squareup.okio:okio:${okioVersion}"
+    implementation 'commons-io:commons-io:2.4'
+    implementation 'com.jcraft:jzlib:1.1.3'
+    implementation 'com.beetstra.jutf7:jutf7:1.0.0'
+    implementation "com.android.support:support-annotations:${androidSupportAnnotationsLibraryVersion}"
+    implementation "com.jakewharton.timber:timber:${timberVersion}"
 
-    androidTestCompile 'com.android.support.test:runner:0.4.1'
-    androidTestCompile 'com.madgag.spongycastle:pg:1.51.0.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.madgag.spongycastle:pg:1.54.0.0'
 
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
-    testCompile "org.robolectric:robolectric:${robolectricVersion}"
-    testCompile "junit:junit:${junitVersion}"
-    testCompile "com.google.truth:truth:${truthVersion}"
-    testCompile "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
+    testImplementation "org.robolectric:robolectric:${robolectricVersion}"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
 }
 
 android {
@@ -59,8 +60,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     packagingOptions {

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -11,41 +11,43 @@ if (rootProject.testCoverage) {
 }
 
 repositories {
+    google()
     jcenter()
 }
 
 //noinspection GroovyAssignabilityCheck
 configurations.all {
     resolutionStrategy {
-        force "com.android.support:support-annotations:${androidSupportLibraryVersion}"
+        force "com.android.support:support-annotations:${androidSupportAnnotationsLibraryVersion}"
     }
 }
 
 dependencies {
-    compile project(':k9mail-library')
-    compile project(':plugins:HoloColorPicker')
-    compile project(':plugins:openpgp-api-lib:openpgp-api')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
-    compile "com.squareup.okio:okio:${okioVersion}"
-    compile 'commons-io:commons-io:2.4'
-    compile "com.android.support:support-v4:${androidSupportLibraryVersion}"
-    compile 'org.jsoup:jsoup:1.11.2'
-    compile 'de.cketti.library.changelog:ckchangelog:1.2.1'
-    compile 'com.github.bumptech.glide:glide:3.6.1'
-    compile 'com.splitwise:tokenautocomplete:2.0.7'
-    compile 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.9.0'
-    compile 'com.github.amlcurran.showcaseview:library:5.4.1'
-    compile 'com.squareup.moshi:moshi:1.2.0'
-    compile "com.jakewharton.timber:timber:${timberVersion}"
-    compile 'net.jcip:jcip-annotations:1.0'
+    implementation project(':k9mail-library')
+    implementation project(':plugins:HoloColorPicker')
+    implementation project(':plugins:openpgp-api-lib:openpgp-api')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinVersion}"
+    implementation "com.squareup.okio:okio:${okioVersion}"
+    implementation 'commons-io:commons-io:2.4'
+    implementation "com.android.support:support-v4:${androidSupportLibraryVersion}"
+    implementation 'org.jsoup:jsoup:1.11.2'
+    implementation 'de.cketti.library.changelog:ckchangelog:1.2.2'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.splitwise:tokenautocomplete:2.0.7'
+    implementation 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.9.0'
+    implementation 'com.github.amlcurran.showcaseview:library:5.4.3'
+    implementation 'com.squareup.moshi:moshi:1.5.0'
+    implementation "com.jakewharton.timber:timber:${timberVersion}"
+    implementation 'net.jcip:jcip-annotations:1.0'
+    implementation 'org.apache.james:apache-mime4j-core:0.8.1'
+    implementation 'org.apache.james:apache-mime4j-dom:0.8.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-
-    testCompile "org.robolectric:robolectric:${robolectricVersion}"
-    testCompile "junit:junit:${junitVersion}"
-    testCompile "com.google.truth:truth:${truthVersion}"
-    testCompile "org.mockito:mockito-core:${mockitoVersion}"
-    testCompile "org.jdom:jdom2:2.0.6"
+    testImplementation "org.robolectric:robolectric:${robolectricVersion}"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.jdom:jdom2:2.0.6"
 }
 
 android {
@@ -60,7 +62,7 @@ android {
         versionName '5.500-SNAPSHOT'
 
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 27
 
         generatedDensities = ['mdpi', 'hdpi', 'xhdpi']
 
@@ -108,8 +110,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
@@ -1,9 +1,12 @@
 package com.fsck.k9.activity;
 
 import android.app.Activity;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.MotionEvent;
+import android.widget.Toast;
 
+import com.fsck.k9.R;
 import com.fsck.k9.activity.K9ActivityCommon.K9ActivityMagic;
 import com.fsck.k9.activity.misc.SwipeGestureDetector.OnSwipeGestureListener;
 
@@ -12,6 +15,8 @@ public abstract class K9Activity extends Activity implements K9ActivityMagic {
 
     private K9ActivityCommon mBase;
 
+    public static final int PERMISSIONS_REQUEST_READ_CONTACTS  = 1;
+    public static final int PERMISSIONS_REQUEST_WRITE_CONTACTS = 2;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -28,5 +33,25 @@ public abstract class K9Activity extends Activity implements K9ActivityMagic {
     @Override
     public void setupGestureDetector(OnSwipeGestureListener listener) {
         mBase.setupGestureDetector(listener);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           String permissions[], int[] grantResults) {
+        switch (requestCode) {
+            case PERMISSIONS_REQUEST_READ_CONTACTS:
+            case PERMISSIONS_REQUEST_WRITE_CONTACTS: {
+                // If request is cancelled, the result arrays are empty.
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+
+                    Toast.makeText(this, R.string.contact_permission_thanks,
+                            Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(this, R.string.contact_permission_request,
+                            Toast.LENGTH_LONG).show();
+                }
+            }
+        }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
@@ -15,8 +15,11 @@ public abstract class K9Activity extends Activity implements K9ActivityMagic {
 
     private K9ActivityCommon mBase;
 
-    public static final int PERMISSIONS_REQUEST_READ_CONTACTS  = 1;
+    public static final int PERMISSIONS_REQUEST_READ_CONTACTS = 1;
     public static final int PERMISSIONS_REQUEST_WRITE_CONTACTS = 2;
+    public static final int PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE = 3;
+    public static final int PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 4;
+
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -41,16 +44,29 @@ public abstract class K9Activity extends Activity implements K9ActivityMagic {
         switch (requestCode) {
             case PERMISSIONS_REQUEST_READ_CONTACTS:
             case PERMISSIONS_REQUEST_WRITE_CONTACTS: {
-                // If request is cancelled, the result arrays are empty.
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
 
                     Toast.makeText(this, R.string.contact_permission_thanks,
                             Toast.LENGTH_SHORT).show();
                 } else {
-                    Toast.makeText(this, R.string.contact_permission_request,
+                    Toast.makeText(this, R.string.permission_request,
                             Toast.LENGTH_LONG).show();
                 }
+                break;
+            }
+            case PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE:
+            case PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE: {
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+
+                    Toast.makeText(this, R.string.storage_permission_thanks,
+                            Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(this, R.string.permission_request,
+                            Toast.LENGTH_LONG).show();
+                }
+                break;
             }
         }
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1,14 +1,13 @@
 package com.fsck.k9.activity;
 
 
-import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
-
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.ActionBar;
 import android.app.AlertDialog;
@@ -21,6 +20,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
 import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -28,6 +28,8 @@ import android.os.Handler;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.TypedValue;
@@ -222,7 +224,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
+        checkPerms();
         if (UpgradeDatabases.actionUpgradeDatabases(this, getIntent())) {
             finish();
             return;
@@ -642,6 +644,16 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         updateFrom();
 
         updateMessageFormat();
+    }
+
+    private void checkPerms() {
+        if (ContextCompat.checkSelfPermission(this,
+                Manifest.permission.READ_CONTACTS)
+                != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.READ_CONTACTS},
+                    K9Activity.PERMISSIONS_REQUEST_READ_CONTACTS);
+        }
     }
 
     private void setTitle() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.activity;
 
 
+import android.Manifest;
 import java.util.Collection;
 import java.util.List;
 
@@ -14,12 +15,15 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import timber.log.Timber;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -235,6 +239,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         if (cl.isFirstRun()) {
             cl.getLogDialog().show();
         }
+        checkPerms();
     }
 
     @Override
@@ -498,6 +503,17 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         super.onPause();
 
         StorageManager.getInstance(getApplication()).removeListener(mStorageListener);
+    }
+
+
+    private void checkPerms() {
+        if (ContextCompat.checkSelfPermission(this,
+                Manifest.permission.READ_CONTACTS)
+                != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.READ_CONTACTS},
+                    K9Activity.PERMISSIONS_REQUEST_READ_CONTACTS);
+        }
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
@@ -5,10 +5,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import android.Manifest;
 import android.content.AsyncTaskLoader;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.database.AbstractCursor;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.ContactsContract;
@@ -16,6 +18,7 @@ import android.provider.ContactsContract.CommonDataKinds.Email;
 import android.provider.ContactsContract.Contacts;
 import android.provider.ContactsContract.Contacts.Data;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 
 import com.fsck.k9.R;
 import com.fsck.k9.mail.Address;
@@ -238,10 +241,68 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
     }
 
 
+    private Boolean hasPerm() {
+        return
+                ((ContextCompat.checkSelfPermission(getContext(),
+                Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED)
+                && ((ContextCompat.checkSelfPermission(getContext(),
+                        Manifest.permission.WRITE_CONTACTS) == PackageManager.PERMISSION_GRANTED)));
+
+    }
+
     private Cursor getNicknameCursor(String nickname) {
         nickname = "%" + nickname + "%";
 
         Uri queryUriForNickname = ContactsContract.Data.CONTENT_URI;
+        if (!hasPerm()) {
+            // return empty cursor
+            return new AbstractCursor() {
+                @Override
+                public int getCount() {
+                    return 0;
+                }
+
+                @Override
+                public String[] getColumnNames() {
+                    return new String[0];
+                }
+
+                @Override
+                public String getString(int column) {
+                    return null;
+                }
+
+                @Override
+                public short getShort(int column) {
+                    return 0;
+                }
+
+                @Override
+                public int getInt(int column) {
+                    return 0;
+                }
+
+                @Override
+                public long getLong(int column) {
+                    return 0;
+                }
+
+                @Override
+                public float getFloat(int column) {
+                    return 0;
+                }
+
+                @Override
+                public double getDouble(int column) {
+                    return 0;
+                }
+
+                @Override
+                public boolean isNull(int column) {
+                    return false;
+                }
+            };
+        }
 
         return contentResolver.query(queryUriForNickname,
                 PROJECTION_NICKNAME,
@@ -315,8 +376,10 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
         String selection = Contacts.DISPLAY_NAME_PRIMARY + " LIKE ? " +
                 " OR (" + Email.ADDRESS + " LIKE ? AND " + Data.MIMETYPE + " = '" + Email.CONTENT_ITEM_TYPE + "')";
         String[] selectionArgs = { query, query };
-        Cursor cursor = contentResolver.query(queryUri, PROJECTION, selection, selectionArgs, SORT_ORDER);
-
+        Cursor cursor = null;
+        if (hasPerm()) {
+            cursor = contentResolver.query(queryUri, PROJECTION, selection, selectionArgs, SORT_ORDER);
+        }
         if (cursor == null) {
             return false;
         }

--- a/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
@@ -1,14 +1,18 @@
 package com.fsck.k9.helper;
 
 
+import android.Manifest;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.database.AbstractCursor;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.ContactsContract;
 import timber.log.Timber;
 import android.provider.ContactsContract.CommonDataKinds.Photo;
+import android.support.v4.content.ContextCompat;
 
 import com.fsck.k9.mail.Address;
 
@@ -255,6 +259,14 @@ public class Contacts {
         }
     }
 
+    private Boolean hasPerm() {
+        return
+                ((ContextCompat.checkSelfPermission(mContext,
+                        Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED)
+                        && ((ContextCompat.checkSelfPermission(mContext,
+                        Manifest.permission.WRITE_CONTACTS) == PackageManager.PERMISSION_GRANTED)));
+    }
+
     /**
      * Return a {@link Cursor} instance that can be used to fetch information
      * about the contact with the given email address.
@@ -265,6 +277,55 @@ public class Contacts {
      */
     private Cursor getContactByAddress(final String address) {
         final Uri uri = Uri.withAppendedPath(ContactsContract.CommonDataKinds.Email.CONTENT_LOOKUP_URI, Uri.encode(address));
+        if (!hasPerm()) {
+            // return blank cursor
+            return new AbstractCursor() {
+                @Override
+                public int getCount() {
+                    return 0;
+                }
+
+                @Override
+                public String[] getColumnNames() {
+                    return new String[0];
+                }
+
+                @Override
+                public String getString(int column) {
+                    return null;
+                }
+
+                @Override
+                public short getShort(int column) {
+                    return 0;
+                }
+
+                @Override
+                public int getInt(int column) {
+                    return 0;
+                }
+
+                @Override
+                public long getLong(int column) {
+                    return 0;
+                }
+
+                @Override
+                public float getFloat(int column) {
+                    return 0;
+                }
+
+                @Override
+                public double getDouble(int column) {
+                    return 0;
+                }
+
+                @Override
+                public boolean isNull(int column) {
+                    return false;
+                }
+            };
+        } else
         return mContentResolver.query(
                 uri,
                 PROJECTION,

--- a/k9mail/src/main/java/com/fsck/k9/helper/FileBrowserHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/FileBrowserHelper.java
@@ -9,6 +9,8 @@ import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
+import android.os.FileUriExposedException;
 import android.text.InputType;
 import android.widget.EditText;
 
@@ -87,12 +89,23 @@ public class FileBrowserHelper {
             Intent intent = new Intent(intentAction);
             intent.setData(Uri.parse(uriPrefix + startPath.getPath()));
 
-            try {
-                c.startActivityForResult(intent, requestcode);
-                success = true;
-            } catch (ActivityNotFoundException e) {
-                // Try the next intent in the list
-                listIndex++;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                try {
+                    c.startActivityForResult(intent, requestcode);
+                    success = true;
+                    // note:  When Storage Access Framework is used, this won't be necessary.
+                } catch (ActivityNotFoundException | FileUriExposedException e) {
+                    // Try the next intent in the list
+                    listIndex++;
+                }
+            } else {
+                try {
+                    c.startActivityForResult(intent, requestcode);
+                    success = true;
+                } catch (ActivityNotFoundException e) {
+                    // Try the next intent in the list
+                    listIndex++;
+                }
             }
         } while (!success && (listIndex < PICK_DIRECTORY_INTENTS.length));
 

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationController.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationController.java
@@ -1,6 +1,8 @@
 package com.fsck.k9.notification;
 
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
@@ -10,6 +12,7 @@ import android.text.TextUtils;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
+import com.fsck.k9.R;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mailstore.LocalMessage;
@@ -36,6 +39,13 @@ public class NotificationController {
 
     public static NotificationController newInstance(Context context) {
         Context appContext = context.getApplicationContext();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            ((NotificationManager) appContext.getSystemService(Context.NOTIFICATION_SERVICE))
+                    .createNotificationChannel(new NotificationChannel
+                            (appContext.getString(R.string.k9_channel_id),
+                                    appContext.getString(R.string.k9_channel_description), NotificationManager.IMPORTANCE_DEFAULT));
+        }
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(appContext);
         return new NotificationController(appContext, notificationManager);
     }
@@ -159,6 +169,6 @@ public class NotificationController {
     }
 
     NotificationCompat.Builder createNotificationBuilder() {
-        return new NotificationCompat.Builder(context);
+        return new NotificationCompat.Builder(context, getContext().getString(R.string.k9_channel_id));
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -3,7 +3,7 @@ package com.fsck.k9.ui.messageview;
 
 import java.util.Collections;
 import java.util.Locale;
-
+import android.Manifest;
 import android.app.Activity;
 import android.app.DialogFragment;
 import android.app.DownloadManager;
@@ -13,11 +13,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
 import android.os.SystemClock;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.view.ContextThemeWrapper;
 import android.view.KeyEvent;
@@ -33,6 +36,7 @@ import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
 import com.fsck.k9.activity.ChooseFolder;
+import com.fsck.k9.activity.K9Activity;
 import com.fsck.k9.activity.MessageLoaderHelper;
 import com.fsck.k9.activity.MessageLoaderHelper.MessageLoaderCallbacks;
 import com.fsck.k9.activity.MessageReference;
@@ -828,12 +832,14 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
     @Override
     public void onSaveAttachment(AttachmentViewInfo attachment) {
+        checkPerms();
         currentAttachmentViewInfo = attachment;
         getAttachmentController(attachment).saveAttachment();
     }
 
     @Override
     public void onSaveAttachmentToUserProvidedDirectory(final AttachmentViewInfo attachment) {
+        checkPerms();
         currentAttachmentViewInfo = attachment;
         FileBrowserHelper.getInstance().showFileBrowserActivity(MessageViewFragment.this, null,
                 ACTIVITY_CHOOSE_DIRECTORY, new FileBrowserFailOverCallback() {
@@ -848,6 +854,17 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                     }
                 });
     }
+
+    private void checkPerms() {
+        if (ContextCompat.checkSelfPermission(getActivity(),
+                Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(getActivity(),
+                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    K9Activity.PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE);
+        }
+    }
+
 
     private AttachmentController getAttachmentController(AttachmentViewInfo attachment) {
         return new AttachmentController(mController, downloadManager, this, attachment);

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1288,6 +1288,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="k9_channel_description">All notifications</string>
 
     <!-- permissions -->
-    <string name="contact_permission_request">K-9 works best when this permission is granted.</string>
+    <string name="permission_request">K-9 works best when this permission is granted.</string>
     <string name="contact_permission_thanks">Your contact data is now available.</string>
+    <string name="storage_permission_thanks">You can now access external storage.</string>
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1286,4 +1286,8 @@ Please submit bug reports, contribute new features and ask questions at
     <!-- notification channel(s) -->
     <string name="k9_channel_id" translatable="false">k9_channel</string>
     <string name="k9_channel_description">All notifications</string>
+
+    <!-- permissions -->
+    <string name="contact_permission_request">K-9 works best when this permission is granted.</string>
+    <string name="contact_permission_thanks">Your contact data is now available.</string>
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1282,4 +1282,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="openpgp_enabled_error_back">Back</string>
     <string name="openpgp_enabled_error_disable">Disable Encryption</string>
     <string name="openpgp_encryption">OpenPGP Encryption</string>
+
+    <!-- notification channel(s) -->
+    <string name="k9_channel_id" translatable="false">k9_channel</string>
+    <string name="k9_channel_description">All notifications</string>
 </resources>

--- a/plugins/openpgp-api-lib/openpgp-api/build.gradle
+++ b/plugins/openpgp-api-lib/openpgp-api/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         versionCode 8
         versionName '9.0' // API-Version . minor
-        minSdkVersion 9
-        targetSdkVersion 22
+        minSdkVersion 14
+        targetSdkVersion 27
     }
 
     // Do not abort build if lint finds errors


### PR DESCRIPTION
I was annoyed by the inability to resize windows in my chromebook so I built K9 with the Android Studio 3.1 that went into beta today... and... now I can resize windows.

Note:  Google has also [announced that all apps in the Play store must update their targeted APIs starting in November 2018](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html).

![image](https://user-images.githubusercontent.com/528174/35610834-b42dd974-0617-11e8-88a6-940cee7b964f.png)

On the Chromebook, K9 is nice but the holo theme looks grey and dingy by modern standards.  Material design can be enabled with the changes in #3175.

WHAT THIS COMMIT HOPEFULLY DOES:

* Update gradle plugin to latest to date in Android Studio 3.1 beta 1
* Update gradle from 3.3 to 4.5.1 release
* Update target API from 22 to 27 (min now 14)
* Update to Java 1.8
* Enable new Dex compiler
* Use new "implementation" syntax in build.gradle
* Update (most?) non-testing google/3rd party libraries to latest
* Add simple default notification channel (for Android 8+ compatibility)
* Handle runtime permissions for contacts/storage

DOES NOT DO:
*  A material conversion (See #3175 for this)
*  Update most testImplementation libraries

Cheers!

Note:  Rolling build failed with "_....some licences have not been accepted_".  No big deal.