### PR TITLE
Make some static fields final

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Throttle.java
+++ b/k9mail/src/main/java/com/fsck/k9/Throttle.java
@@ -37,7 +37,7 @@ import timber.log.Timber;
 public class Throttle {
     private static final int TIMEOUT_EXTEND_INTERVAL = 500;
 
-    private static Timer TIMER = new Timer();
+    private static final Timer TIMER = new Timer();
 
     private final Clock clock;
     private final Timer timer;

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -330,9 +330,9 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
     };
 
-    private static String ACCOUNT_STATS = "accountStats";
-    private static String STATE_UNREAD_COUNT = "unreadCount";
-    private static String SELECTED_CONTEXT_ACCOUNT = "selectedContextAccount";
+    private static final String ACCOUNT_STATS = "accountStats";
+    private static final String STATE_UNREAD_COUNT = "unreadCount";
+    private static final String SELECTED_CONTEXT_ACCOUNT = "selectedContextAccount";
     private static final String STATE_EXPORT_GLOBAL_SETTINGS = "exportGlobalSettings";
     private static final String STATE_EXPORT_ACCOUNTS = "exportAccountUuids";
 
@@ -1273,7 +1273,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         return true;
     }
 
-    private static String[][] USED_LIBRARIES = new String[][] {
+    private static final String[][] USED_LIBRARIES = new String[][] {
             new String[] {"Android Support Library", "https://developer.android.com/topic/libraries/support-library/index.html"},
             new String[] {"ckChangeLog", "https://github.com/cketti/ckChangeLog"},
             new String[] {"Commons IO", "http://commons.apache.org/io/"},

--- a/k9mail/src/main/java/com/fsck/k9/cache/TemporaryAttachmentStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/cache/TemporaryAttachmentStore.java
@@ -11,8 +11,8 @@ import com.fsck.k9.helper.FileHelper;
 
 
 public class TemporaryAttachmentStore {
-    private static String TEMPORARY_ATTACHMENT_DIRECTORY = "attachments";
-    private static long MAX_FILE_AGE = 12 * 60 * 60 * 1000;   // 12h
+    private static final String TEMPORARY_ATTACHMENT_DIRECTORY = "attachments";
+    private static final long MAX_FILE_AGE = 12 * 60 * 60 * 1000;   // 12h
 
     public static File getFile(Context context, String attachmentName) {
         File directory = getTemporaryAttachmentDirectory(context);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -94,7 +94,7 @@ public class LocalStore extends Store {
      * a String containing the columns getMessages expects to work with
      * in the correct order.
      */
-    static String GET_MESSAGES_COLS =
+    static final String GET_MESSAGES_COLS =
         "subject, sender_list, date, uid, flags, messages.id, to_list, cc_list, " +
         "bcc_list, reply_to_list, attachment_count, internal_date, messages.message_id, " +
         "folder_id, preview, threads.id, threads.root, deleted, read, flagged, answered, " +

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Storage.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Storage.java
@@ -26,8 +26,8 @@ public class Storage {
 
     private volatile ConcurrentMap<String, String> storage = new ConcurrentHashMap<String, String>();
 
-    private int DB_VERSION = 2;
-    private String DB_NAME = "preferences_storage";
+    private static final int DB_VERSION = 2;
+    private static final String DB_NAME = "preferences_storage";
 
     private ThreadLocal<ConcurrentMap<String, String>> workingStorage
     = new ThreadLocal<ConcurrentMap<String, String>>();

--- a/k9mail/src/main/java/com/fsck/k9/service/PollService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/PollService.java
@@ -15,8 +15,8 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class PollService extends CoreService {
-    private static String START_SERVICE = "com.fsck.k9.service.PollService.startService";
-    private static String STOP_SERVICE = "com.fsck.k9.service.PollService.stopService";
+    private static final String START_SERVICE = "com.fsck.k9.service.PollService.startService";
+    private static final String STOP_SERVICE = "com.fsck.k9.service.PollService.stopService";
 
     private Listener mListener = new Listener();
 

--- a/k9mail/src/main/java/com/fsck/k9/service/PushService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/PushService.java
@@ -6,8 +6,8 @@ import android.os.IBinder;
 import timber.log.Timber;
 
 public class PushService extends CoreService {
-    private static String START_SERVICE = "com.fsck.k9.service.PushService.startService";
-    private static String STOP_SERVICE = "com.fsck.k9.service.PushService.stopService";
+    private static final String START_SERVICE = "com.fsck.k9.service.PushService.startService";
+    private static final String STOP_SERVICE = "com.fsck.k9.service.PushService.stopService";
 
     public static void startService(Context context) {
         Intent i = new Intent();

--- a/k9mail/src/main/java/com/fsck/k9/service/SleepService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/SleepService.java
@@ -18,8 +18,8 @@ import static java.lang.Thread.currentThread;
 
 public class SleepService extends CoreService {
 
-    private static String ALARM_FIRED = "com.fsck.k9.service.SleepService.ALARM_FIRED";
-    private static String LATCH_ID = "com.fsck.k9.service.SleepService.LATCH_ID_EXTRA";
+    private static final String ALARM_FIRED = "com.fsck.k9.service.SleepService.ALARM_FIRED";
+    private static final String LATCH_ID = "com.fsck.k9.service.SleepService.LATCH_ID_EXTRA";
 
 
     private static ConcurrentHashMap<Integer, SleepDatum> sleepData = new ConcurrentHashMap<Integer, SleepDatum>();

--- a/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListRemoteViewFactory.java
+++ b/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListRemoteViewFactory.java
@@ -24,7 +24,7 @@ import com.fsck.k9.provider.MessageProvider;
 
 
 public class MessageListRemoteViewFactory implements RemoteViewsService.RemoteViewsFactory {
-    private static String[] MAIL_LIST_PROJECTIONS = {
+    private static final String[] MAIL_LIST_PROJECTIONS = {
             MessageProvider.MessageColumns.SENDER,
             MessageProvider.MessageColumns.SEND_DATE,
             MessageProvider.MessageColumns.SUBJECT,

--- a/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListWidgetProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListWidgetProvider.java
@@ -16,7 +16,7 @@ import com.fsck.k9.activity.MessageList;
 
 
 public class MessageListWidgetProvider extends AppWidgetProvider {
-    private static String ACTION_UPDATE_MESSAGE_LIST = "UPDATE_MESSAGE_LIST";
+    private static final String ACTION_UPDATE_MESSAGE_LIST = "UPDATE_MESSAGE_LIST";
 
 
     public static void triggerMessageListWidgetUpdate(Context context) {


### PR DESCRIPTION
Adding final prohibits modification and allows initialization of
primitive and String fields at compile time instead of runtime in
clinit:

https://developer.android.com/training/articles/perf-tips.html#UseFinal

Found via error-prone.
