### PR TITLE
Use sensible shortcut keys (fixes #3057) (ANDROID STUDIO 3.1)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,11 @@
 buildscript {
     repositories {
         jcenter()
+        google()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.1.0-beta1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}"
     }
 }
@@ -21,4 +22,9 @@ subprojects {
             project.android.dexOptions.preDexLibraries = !rootProject.hasProperty('disablePreDex')
         }
     }
+}
+
+repositories {
+    google()
+    jcenter()
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-kotlinVersion=1.2.20
+kotlinVersion=1.2.21
 androidCompileSdkVersion=27
 androidBuildToolsVersion=27.0.3
 androidSupportLibraryVersion=27.0.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,14 @@
-kotlinVersion=1.1.4-3
-androidCompileSdkVersion=25
-androidBuildToolsVersion=25.0.2
-androidSupportLibraryVersion=25.2.0
-timberVersion=4.5.1
+kotlinVersion=1.2.20
+androidCompileSdkVersion=27
+androidBuildToolsVersion=27.0.3
+androidSupportLibraryVersion=27.0.2
+androidSupportAnnotationsLibraryVersion=24.2.0
+timberVersion=4.6.0
 
 robolectricVersion=3.2.2
 junitVersion=4.12
 mockitoVersion=1.10.19
-okioVersion=1.11.0
-truthVersion=0.35
+okioVersion=1.13.0
+truthVersion=0.39
+
+android.enableD8=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.5-all.zip

--- a/k9mail-library/build.gradle
+++ b/k9mail-library/build.gradle
@@ -12,26 +12,27 @@ if (rootProject.testCoverage) {
 
 repositories {
     jcenter()
+    google()
 }
 
 dependencies {
-    compile 'org.apache.james:apache-mime4j-core:0.8.1'
-    compile 'org.apache.james:apache-mime4j-dom:0.8.1'
-    compile "com.squareup.okio:okio:${okioVersion}"
-    compile 'commons-io:commons-io:2.4'
-    compile 'com.jcraft:jzlib:1.0.7'
-    compile 'com.beetstra.jutf7:jutf7:1.0.0'
-    compile "com.android.support:support-annotations:${androidSupportLibraryVersion}"
-    compile "com.jakewharton.timber:timber:${timberVersion}"
+    implementation 'org.apache.james:apache-mime4j-core:0.8.1'
+    implementation 'org.apache.james:apache-mime4j-dom:0.8.1'
+    implementation "com.squareup.okio:okio:${okioVersion}"
+    implementation 'commons-io:commons-io:2.4'
+    implementation 'com.jcraft:jzlib:1.1.3'
+    implementation 'com.beetstra.jutf7:jutf7:1.0.0'
+    implementation "com.android.support:support-annotations:${androidSupportAnnotationsLibraryVersion}"
+    implementation "com.jakewharton.timber:timber:${timberVersion}"
 
-    androidTestCompile 'com.android.support.test:runner:0.4.1'
-    androidTestCompile 'com.madgag.spongycastle:pg:1.51.0.0'
+    androidTestImplementation 'com.android.support.test:runner:1.0.1'
+    androidTestImplementation 'com.madgag.spongycastle:pg:1.54.0.0'
 
-    testCompile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
-    testCompile "org.robolectric:robolectric:${robolectricVersion}"
-    testCompile "junit:junit:${junitVersion}"
-    testCompile "com.google.truth:truth:${truthVersion}"
-    testCompile "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
+    testImplementation "org.robolectric:robolectric:${robolectricVersion}"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
 }
 
 android {
@@ -59,8 +60,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 
     packagingOptions {

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -11,41 +11,43 @@ if (rootProject.testCoverage) {
 }
 
 repositories {
+    google()
     jcenter()
 }
 
 //noinspection GroovyAssignabilityCheck
 configurations.all {
     resolutionStrategy {
-        force "com.android.support:support-annotations:${androidSupportLibraryVersion}"
+        force "com.android.support:support-annotations:${androidSupportAnnotationsLibraryVersion}"
     }
 }
 
 dependencies {
-    compile project(':k9mail-library')
-    compile project(':plugins:HoloColorPicker')
-    compile project(':plugins:openpgp-api-lib:openpgp-api')
-    compile "org.jetbrains.kotlin:kotlin-stdlib-jre7:${kotlinVersion}"
-    compile "com.squareup.okio:okio:${okioVersion}"
-    compile 'commons-io:commons-io:2.4'
-    compile "com.android.support:support-v4:${androidSupportLibraryVersion}"
-    compile 'org.jsoup:jsoup:1.11.2'
-    compile 'de.cketti.library.changelog:ckchangelog:1.2.1'
-    compile 'com.github.bumptech.glide:glide:3.6.1'
-    compile 'com.splitwise:tokenautocomplete:2.0.7'
-    compile 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.9.0'
-    compile 'com.github.amlcurran.showcaseview:library:5.4.1'
-    compile 'com.squareup.moshi:moshi:1.2.0'
-    compile "com.jakewharton.timber:timber:${timberVersion}"
-    compile 'net.jcip:jcip-annotations:1.0'
+    implementation project(':k9mail-library')
+    implementation project(':plugins:HoloColorPicker')
+    implementation project(':plugins:openpgp-api-lib:openpgp-api')
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlinVersion}"
+    implementation "com.squareup.okio:okio:${okioVersion}"
+    implementation 'commons-io:commons-io:2.4'
+    implementation "com.android.support:support-v4:${androidSupportLibraryVersion}"
+    implementation 'org.jsoup:jsoup:1.11.2'
+    implementation 'de.cketti.library.changelog:ckchangelog:1.2.2'
+    implementation 'com.github.bumptech.glide:glide:3.7.0'
+    implementation 'com.splitwise:tokenautocomplete:2.0.7'
+    implementation 'de.cketti.safecontentresolver:safe-content-resolver-v14:0.9.0'
+    implementation 'com.github.amlcurran.showcaseview:library:5.4.3'
+    implementation 'com.squareup.moshi:moshi:1.5.0'
+    implementation "com.jakewharton.timber:timber:${timberVersion}"
+    implementation 'net.jcip:jcip-annotations:1.0'
+    implementation 'org.apache.james:apache-mime4j-core:0.8.1'
+    implementation 'org.apache.james:apache-mime4j-dom:0.8.1'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 
-    androidTestCompile 'com.android.support.test.espresso:espresso-core:2.2.2'
-
-    testCompile "org.robolectric:robolectric:${robolectricVersion}"
-    testCompile "junit:junit:${junitVersion}"
-    testCompile "com.google.truth:truth:${truthVersion}"
-    testCompile "org.mockito:mockito-core:${mockitoVersion}"
-    testCompile "org.jdom:jdom2:2.0.6"
+    testImplementation "org.robolectric:robolectric:${robolectricVersion}"
+    testImplementation "junit:junit:${junitVersion}"
+    testImplementation "com.google.truth:truth:${truthVersion}"
+    testImplementation "org.mockito:mockito-core:${mockitoVersion}"
+    testImplementation "org.jdom:jdom2:2.0.6"
 }
 
 android {
@@ -60,7 +62,7 @@ android {
         versionName '5.500-SNAPSHOT'
 
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 27
 
         generatedDensities = ['mdpi', 'hdpi', 'xhdpi']
 
@@ -108,8 +110,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_7
-        targetCompatibility JavaVersion.VERSION_1_7
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
 }
 

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation "com.squareup.okio:okio:${okioVersion}"
     implementation 'commons-io:commons-io:2.4'
     implementation "com.android.support:support-v4:${androidSupportLibraryVersion}"
+    implementation "com.android.support:appcompat-v7:${androidSupportLibraryVersion}"
     implementation 'org.jsoup:jsoup:1.11.2'
     implementation 'de.cketti.library.changelog:ckchangelog:1.2.2'
     implementation 'com.github.bumptech.glide:glide:3.7.0'

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -2,20 +2,6 @@
 package com.fsck.k9.activity;
 
 
-import java.io.FileNotFoundException;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.ArrayList;
-import java.util.Calendar;
-import java.util.EnumSet;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
-
-import android.app.ActionBar;
 import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Application;
@@ -33,6 +19,7 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+import android.support.v7.app.ActionBar;
 import android.text.Editable;
 import android.text.TextWatcher;
 import android.util.SparseBooleanArray;
@@ -94,6 +81,20 @@ import com.fsck.k9.search.SearchAccount;
 import com.fsck.k9.search.SearchSpecification.Attribute;
 import com.fsck.k9.search.SearchSpecification.SearchField;
 import com.fsck.k9.view.ColorChip;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
 import de.cketti.library.changelog.ChangeLog;
 import timber.log.Timber;
 
@@ -415,7 +416,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         }
 
         requestWindowFeature(Window.FEATURE_PROGRESS);
-        actionBar = getActionBar();
+        actionBar = getSupportActionBar();
         initializeActionBar();
         setContentView(R.layout.accounts);
         ListView listView = getListView();
@@ -532,7 +533,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
      * Save the reference to a currently displayed dialog or a running AsyncTask (if available).
      */
     @Override
-    public Object onRetainNonConfigurationInstance() {
+    public Object onRetainCustomNonConfigurationInstance() {
         Object retain = null;
         if (nonConfigurationInstance != null && nonConfigurationInstance.retain()) {
             retain = nonConfigurationInstance;

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -7,12 +7,12 @@ import java.util.List;
 import java.util.Locale;
 
 import android.annotation.SuppressLint;
-import android.app.ActionBar;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.PowerManager;
+import android.support.v7.app.ActionBar;
 import android.text.TextUtils.TruncateAt;
 import android.text.format.DateUtils;
 import timber.log.Timber;
@@ -260,7 +260,7 @@ public class FolderList extends K9ListActivity {
         }
 
         actionBarProgressView = getActionBarProgressView();
-        actionBar = getActionBar();
+        actionBar = getSupportActionBar();
         initializeActionBar();
         setContentView(R.layout.folder_list);
         listView = getListView();
@@ -360,7 +360,7 @@ public class FolderList extends K9ListActivity {
     }
 
 
-    @Override public Object onRetainNonConfigurationInstance() {
+    @Override public Object onRetainCustomNonConfigurationInstance() {
         return (adapter == null) ? null : adapter.mFolders;
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
@@ -1,8 +1,8 @@
 package com.fsck.k9.activity;
 
-import android.app.Activity;
 import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.support.v7.app.AppCompatActivity;
 import android.view.MotionEvent;
 import android.widget.Toast;
 
@@ -11,7 +11,7 @@ import com.fsck.k9.activity.K9ActivityCommon.K9ActivityMagic;
 import com.fsck.k9.activity.misc.SwipeGestureDetector.OnSwipeGestureListener;
 
 
-public abstract class K9Activity extends Activity implements K9ActivityMagic {
+public abstract class K9Activity extends AppCompatActivity implements K9ActivityMagic {
 
     private K9ActivityCommon mBase;
 
@@ -60,10 +60,10 @@ public abstract class K9Activity extends Activity implements K9ActivityMagic {
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
 
-                    Toast.makeText(this, R.string.storage_permission_thanks,
+                    Toast.makeText(this, R.string.contact_permission_thanks,
                             Toast.LENGTH_SHORT).show();
                 } else {
-                    Toast.makeText(this, R.string.permission_request,
+                    Toast.makeText(this, R.string.storage_permission_thanks,
                             Toast.LENGTH_LONG).show();
                 }
                 break;

--- a/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
@@ -1,9 +1,12 @@
 package com.fsck.k9.activity;
 
 import android.app.Activity;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.view.MotionEvent;
+import android.widget.Toast;
 
+import com.fsck.k9.R;
 import com.fsck.k9.activity.K9ActivityCommon.K9ActivityMagic;
 import com.fsck.k9.activity.misc.SwipeGestureDetector.OnSwipeGestureListener;
 
@@ -12,6 +15,8 @@ public abstract class K9Activity extends Activity implements K9ActivityMagic {
 
     private K9ActivityCommon mBase;
 
+    public static final int PERMISSIONS_REQUEST_READ_CONTACTS  = 1;
+    public static final int PERMISSIONS_REQUEST_WRITE_CONTACTS = 2;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -28,5 +33,25 @@ public abstract class K9Activity extends Activity implements K9ActivityMagic {
     @Override
     public void setupGestureDetector(OnSwipeGestureListener listener) {
         mBase.setupGestureDetector(listener);
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode,
+                                           String permissions[], int[] grantResults) {
+        switch (requestCode) {
+            case PERMISSIONS_REQUEST_READ_CONTACTS:
+            case PERMISSIONS_REQUEST_WRITE_CONTACTS: {
+                // If request is cancelled, the result arrays are empty.
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+
+                    Toast.makeText(this, R.string.contact_permission_thanks,
+                            Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(this, R.string.contact_permission_request,
+                            Toast.LENGTH_LONG).show();
+                }
+            }
+        }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/K9Activity.java
@@ -15,8 +15,11 @@ public abstract class K9Activity extends Activity implements K9ActivityMagic {
 
     private K9ActivityCommon mBase;
 
-    public static final int PERMISSIONS_REQUEST_READ_CONTACTS  = 1;
+    public static final int PERMISSIONS_REQUEST_READ_CONTACTS = 1;
     public static final int PERMISSIONS_REQUEST_WRITE_CONTACTS = 2;
+    public static final int PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE = 3;
+    public static final int PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 4;
+
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -41,16 +44,29 @@ public abstract class K9Activity extends Activity implements K9ActivityMagic {
         switch (requestCode) {
             case PERMISSIONS_REQUEST_READ_CONTACTS:
             case PERMISSIONS_REQUEST_WRITE_CONTACTS: {
-                // If request is cancelled, the result arrays are empty.
                 if (grantResults.length > 0
                         && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
 
                     Toast.makeText(this, R.string.contact_permission_thanks,
                             Toast.LENGTH_SHORT).show();
                 } else {
-                    Toast.makeText(this, R.string.contact_permission_request,
+                    Toast.makeText(this, R.string.permission_request,
                             Toast.LENGTH_LONG).show();
                 }
+                break;
+            }
+            case PERMISSIONS_REQUEST_READ_EXTERNAL_STORAGE:
+            case PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE: {
+                if (grantResults.length > 0
+                        && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+
+                    Toast.makeText(this, R.string.storage_permission_thanks,
+                            Toast.LENGTH_SHORT).show();
+                } else {
+                    Toast.makeText(this, R.string.permission_request,
+                            Toast.LENGTH_LONG).show();
+                }
+                break;
             }
         }
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/K9ListActivity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/K9ListActivity.java
@@ -1,10 +1,10 @@
 package com.fsck.k9.activity;
 
-import android.app.ListActivity;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.widget.AdapterView;
+import android.widget.ListAdapter;
 import android.widget.ListView;
 
 import com.fsck.k9.K9;
@@ -12,9 +12,11 @@ import com.fsck.k9.activity.K9ActivityCommon.K9ActivityMagic;
 import com.fsck.k9.activity.misc.SwipeGestureDetector.OnSwipeGestureListener;
 
 
-public abstract class K9ListActivity extends ListActivity implements K9ActivityMagic {
+public abstract class K9ListActivity extends K9Activity implements K9ActivityMagic {
 
     private K9ActivityCommon base;
+    protected ListAdapter adapter;
+    protected ListView list;
 
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -43,7 +45,7 @@ public abstract class K9ListActivity extends ListActivity implements K9ActivityM
         // Shortcuts that work no matter what is selected
         if (K9.useVolumeKeysForListNavigationEnabled() &&
                 (keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
-                keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)) {
+                        keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)) {
 
             final ListView listView = getListView();
 
@@ -70,10 +72,25 @@ public abstract class K9ListActivity extends ListActivity implements K9ActivityM
         // Swallow these events too to avoid the audible notification of a volume change
         if (K9.useVolumeKeysForListNavigationEnabled() &&
                 (keyCode == KeyEvent.KEYCODE_VOLUME_UP ||
-                keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)) {
+                        keyCode == KeyEvent.KEYCODE_VOLUME_DOWN)) {
             return true;
         }
 
         return super.onKeyUp(keyCode, event);
+    }
+
+    protected ListView getListView() {
+        if (list == null) {
+            list = (ListView) findViewById(android.R.id.list);
+        }
+        return list;
+    }
+
+    protected void setListAdapter(ListAdapter listAdapter) {
+        if (list == null) {
+            list = (ListView) findViewById(android.R.id.list);
+        }
+        list.setAdapter(listAdapter);
+        adapter = listAdapter;
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1,14 +1,13 @@
 package com.fsck.k9.activity;
 
 
-import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
-
+import android.Manifest;
 import android.annotation.SuppressLint;
 import android.app.ActionBar;
 import android.app.AlertDialog;
@@ -21,6 +20,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
 import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
@@ -28,6 +28,8 @@ import android.os.Handler;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.TypedValue;
@@ -222,7 +224,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
+        checkPerms();
         if (UpgradeDatabases.actionUpgradeDatabases(this, getIntent())) {
             finish();
             return;
@@ -642,6 +644,16 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         updateFrom();
 
         updateMessageFormat();
+    }
+
+    private void checkPerms() {
+        if (ContextCompat.checkSelfPermission(this,
+                Manifest.permission.READ_CONTACTS)
+                != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.READ_CONTACTS},
+                    K9Activity.PERMISSIONS_REQUEST_READ_CONTACTS);
+        }
     }
 
     private void setTitle() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1,17 +1,8 @@
 package com.fsck.k9.activity;
 
 
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.regex.Pattern;
 import android.Manifest;
 import android.annotation.SuppressLint;
-import android.app.ActionBar;
-import android.app.AlertDialog;
-import android.app.AlertDialog.Builder;
 import android.app.Dialog;
 import android.app.PendingIntent;
 import android.content.Context;
@@ -30,6 +21,8 @@ import android.support.annotation.Nullable;
 import android.support.annotation.StringRes;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.text.TextUtils;
 import android.text.TextWatcher;
 import android.util.TypedValue;
@@ -102,7 +95,16 @@ import com.fsck.k9.search.LocalSearch;
 import com.fsck.k9.ui.EolConvertingEditText;
 import com.fsck.k9.ui.compose.QuotedMessageMvpView;
 import com.fsck.k9.ui.compose.QuotedMessagePresenter;
+
 import org.openintents.openpgp.util.OpenPgpApi;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Pattern;
+
 import timber.log.Timber;
 
 
@@ -614,7 +616,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     }
 
     @Override
-    public Object onRetainNonConfigurationInstance() {
+    public Object onRetainCustomNonConfigurationInstance() {
         if (currentMessageBuilder != null) {
             currentMessageBuilder.detachCallback();
         }
@@ -1154,7 +1156,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                         (K9.getK9Theme() == K9.Theme.LIGHT) ?
                                 R.style.Theme_K9_Dialog_Light :
                                 R.style.Theme_K9_Dialog_Dark);
-                Builder builder = new AlertDialog.Builder(context);
+                AlertDialog.Builder builder = new AlertDialog.Builder(context);
                 builder.setTitle(R.string.send_as);
                 final IdentityAdapter adapter = new IdentityAdapter(context);
                 builder.setAdapter(adapter, new DialogInterface.OnClickListener() {
@@ -1666,7 +1668,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     };
 
     private void initializeActionBar() {
-        ActionBar actionBar = getActionBar();
+        ActionBar actionBar = getSupportActionBar();
         actionBar.setDisplayHomeAsUpEnabled(true);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.activity;
 
 
+import android.Manifest;
 import java.util.Collection;
 import java.util.List;
 
@@ -14,12 +15,15 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
+import android.content.pm.PackageManager;
 import android.content.res.Configuration;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
 import timber.log.Timber;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -235,6 +239,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         if (cl.isFirstRun()) {
             cl.getLogDialog().show();
         }
+        checkPerms();
     }
 
     @Override
@@ -498,6 +503,17 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         super.onPause();
 
         StorageManager.getInstance(getApplication()).removeListener(mStorageListener);
+    }
+
+
+    private void checkPerms() {
+        if (ContextCompat.checkSelfPermission(this,
+                Manifest.permission.READ_CONTACTS)
+                != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(this,
+                    new String[]{Manifest.permission.READ_CONTACTS},
+                    K9Activity.PERMISSIONS_REQUEST_READ_CONTACTS);
+        }
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -639,13 +639,31 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
                 break;
             }
-            case KeyEvent.KEYCODE_C: {
-                messageListFragment.onCompose();
+            case KeyEvent.KEYCODE_N:{
+                if (event.isCtrlPressed()) {
+                    messageListFragment.onCompose();
+                }
+                return true;
+            }
+            case KeyEvent.KEYCODE_M:{
+                if (event.isCtrlPressed()) {
+                    if (event.isShiftPressed()) {
+                        if (displayMode == DisplayMode.MESSAGE_LIST) {
+                            messageListFragment.onMove();
+                        } else if (messageViewFragment != null) {
+                            messageViewFragment.onMove();
+                        }
+                    } else {
+                        messageListFragment.onCompose();
+                    }
+                }
                 return true;
             }
             case KeyEvent.KEYCODE_Q: {
-                if (messageListFragment != null && messageListFragment.isSingleAccountMode()) {
-                    onShowFolderList();
+                if (event.isCtrlPressed()) {
+                    if (messageListFragment != null && messageListFragment.isSingleAccountMode()) {
+                        onShowFolderList();
+                    }
                 }
                 return true;
             }
@@ -657,8 +675,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 messageListFragment.onReverseSort();
                 return true;
             }
-            case KeyEvent.KEYCODE_DEL:
-            case KeyEvent.KEYCODE_D: {
+            case KeyEvent.KEYCODE_DEL:{
                 if (displayMode == DisplayMode.MESSAGE_LIST) {
                     messageListFragment.onDelete();
                 } else if (messageViewFragment != null) {
@@ -666,11 +683,11 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 }
                 return true;
             }
-            case KeyEvent.KEYCODE_S: {
+            case KeyEvent.KEYCODE_SPACE: {
                 messageListFragment.toggleMessageSelect();
                 return true;
             }
-            case KeyEvent.KEYCODE_G: {
+            case KeyEvent.KEYCODE_S: {
                 if (displayMode == DisplayMode.MESSAGE_LIST) {
                     messageListFragment.onToggleFlagged();
                 } else if (messageViewFragment != null) {
@@ -678,15 +695,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 }
                 return true;
             }
-            case KeyEvent.KEYCODE_M: {
-                if (displayMode == DisplayMode.MESSAGE_LIST) {
-                    messageListFragment.onMove();
-                } else if (messageViewFragment != null) {
-                    messageViewFragment.onMove();
-                }
-                return true;
-            }
-            case KeyEvent.KEYCODE_V: {
+            case KeyEvent.KEYCODE_A: {
                 if (displayMode == DisplayMode.MESSAGE_LIST) {
                     messageListFragment.onArchive();
                 } else if (messageViewFragment != null) {
@@ -694,49 +703,51 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 }
                 return true;
             }
-            case KeyEvent.KEYCODE_Y: {
-                if (displayMode == DisplayMode.MESSAGE_LIST) {
-                    messageListFragment.onCopy();
-                } else if (messageViewFragment != null) {
-                    messageViewFragment.onCopy();
-                }
-                return true;
-            }
-            case KeyEvent.KEYCODE_Z: {
-                if (displayMode == DisplayMode.MESSAGE_LIST) {
-                    messageListFragment.onToggleRead();
-                } else if (messageViewFragment != null) {
-                    messageViewFragment.onToggleRead();
-                }
-                return true;
-            }
-            case KeyEvent.KEYCODE_F: {
-                if (messageViewFragment != null) {
-                    messageViewFragment.onForward();
-                }
-                return true;
-            }
-            case KeyEvent.KEYCODE_A: {
-                if (messageViewFragment != null) {
-                    messageViewFragment.onReplyAll();
+            case KeyEvent.KEYCODE_C: {
+                if (event.isCtrlPressed()) {
+                    if (displayMode == DisplayMode.MESSAGE_LIST) {
+                        messageListFragment.onCopy();
+                    } else if (messageViewFragment != null) {
+                        messageViewFragment.onCopy();
+                    }
                 }
                 return true;
             }
             case KeyEvent.KEYCODE_R: {
-                if (messageViewFragment != null) {
-                    messageViewFragment.onReply();
+                if (event.isCtrlPressed()) {
+                    if (event.isShiftPressed()) {
+                        if (messageViewFragment != null) {
+                            messageViewFragment.onReplyAll();
+                        } else {
+                            if (messageViewFragment != null) {
+                                messageViewFragment.onReply();
+                            }
+                        }
+                    } else {
+                        if (displayMode == DisplayMode.MESSAGE_LIST) {
+                            messageListFragment.onToggleRead();
+                        } else if (messageViewFragment != null) {
+                            messageViewFragment.onToggleRead();
+                        }
+                    }
                 }
                 return true;
             }
-            case KeyEvent.KEYCODE_J:
-            case KeyEvent.KEYCODE_P: {
+            case KeyEvent.KEYCODE_L: {
+                if (event.isCtrlPressed()) {
+                    if (messageViewFragment != null) {
+                        messageViewFragment.onForward();
+                    }
+                }
+                return true;
+            }
+            case KeyEvent.KEYCODE_B:{
                 if (messageViewFragment != null) {
                     showPreviousMessage();
                 }
                 return true;
             }
-            case KeyEvent.KEYCODE_N:
-            case KeyEvent.KEYCODE_K: {
+            case KeyEvent.KEYCODE_F:{
                 if (messageViewFragment != null) {
                     showNextMessage();
                 }
@@ -747,7 +758,10 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 messageViewFragment.zoom(event);
                 return true;
             }*/
-            case KeyEvent.KEYCODE_H: {
+            case KeyEvent.KEYCODE_H:
+            case KeyEvent.KEYCODE_HELP:
+            case KeyEvent.KEYCODE_SLASH:
+                {
                 Toast toast;
                 if (displayMode == DisplayMode.MESSAGE_LIST) {
                     toast = Toast.makeText(this, R.string.message_list_help_key, Toast.LENGTH_LONG);

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -2,11 +2,7 @@ package com.fsck.k9.activity;
 
 
 import android.Manifest;
-import java.util.Collection;
-import java.util.List;
-
 import android.annotation.SuppressLint;
-import android.app.ActionBar;
 import android.app.FragmentManager;
 import android.app.FragmentManager.OnBackStackChangedListener;
 import android.app.FragmentTransaction;
@@ -21,9 +17,9 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
-import timber.log.Timber;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.content.ContextCompat;
+import android.support.v7.app.ActionBar;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
 import android.view.Menu;
@@ -64,7 +60,12 @@ import com.fsck.k9.view.MessageHeader;
 import com.fsck.k9.view.MessageTitleView;
 import com.fsck.k9.view.ViewSwitcher;
 import com.fsck.k9.view.ViewSwitcher.OnSwitchCompleteListener;
+
+import java.util.Collection;
+import java.util.List;
+
 import de.cketti.library.changelog.ChangeLog;
+import timber.log.Timber;
 
 
 /**
@@ -551,7 +552,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     }
 
     private void initializeActionBar() {
-        actionBar = getActionBar();
+        actionBar = getSupportActionBar();
 
         actionBar.setDisplayShowCustomEnabled(true);
         actionBar.setCustomView(R.layout.actionbar_custom);

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
@@ -5,10 +5,12 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-
+import android.Manifest;
 import android.content.AsyncTaskLoader;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.pm.PackageManager;
+import android.database.AbstractCursor;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.ContactsContract;
@@ -16,6 +18,7 @@ import android.provider.ContactsContract.CommonDataKinds.Email;
 import android.provider.ContactsContract.Contacts;
 import android.provider.ContactsContract.Contacts.Data;
 import android.support.annotation.Nullable;
+import android.support.v4.content.ContextCompat;
 
 import com.fsck.k9.R;
 import com.fsck.k9.mail.Address;
@@ -238,10 +241,68 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
     }
 
 
+    private Boolean hasPerm() {
+        return
+                ((ContextCompat.checkSelfPermission(getContext(),
+                Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED)
+                && ((ContextCompat.checkSelfPermission(getContext(),
+                        Manifest.permission.WRITE_CONTACTS) == PackageManager.PERMISSION_GRANTED)));
+
+    }
+
     private Cursor getNicknameCursor(String nickname) {
         nickname = "%" + nickname + "%";
 
         Uri queryUriForNickname = ContactsContract.Data.CONTENT_URI;
+        if (!hasPerm()) {
+            // return empty cursor
+            return new AbstractCursor() {
+                @Override
+                public int getCount() {
+                    return 0;
+                }
+
+                @Override
+                public String[] getColumnNames() {
+                    return new String[0];
+                }
+
+                @Override
+                public String getString(int column) {
+                    return null;
+                }
+
+                @Override
+                public short getShort(int column) {
+                    return 0;
+                }
+
+                @Override
+                public int getInt(int column) {
+                    return 0;
+                }
+
+                @Override
+                public long getLong(int column) {
+                    return 0;
+                }
+
+                @Override
+                public float getFloat(int column) {
+                    return 0;
+                }
+
+                @Override
+                public double getDouble(int column) {
+                    return 0;
+                }
+
+                @Override
+                public boolean isNull(int column) {
+                    return false;
+                }
+            };
+        }
 
         return contentResolver.query(queryUriForNickname,
                 PROJECTION_NICKNAME,
@@ -315,8 +376,10 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
         String selection = Contacts.DISPLAY_NAME_PRIMARY + " LIKE ? " +
                 " OR (" + Email.ADDRESS + " LIKE ? AND " + Data.MIMETYPE + " = '" + Email.CONTENT_ITEM_TYPE + "')";
         String[] selectionArgs = { query, query };
-        Cursor cursor = contentResolver.query(queryUri, PROJECTION, selection, selectionArgs, SORT_ORDER);
-
+        Cursor cursor = null;
+        if (hasPerm()) {
+            cursor = contentResolver.query(queryUri, PROJECTION, selection, selectionArgs, SORT_ORDER);
+        }
         if (cursor == null) {
             return false;
         }

--- a/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/Contacts.java
@@ -1,14 +1,18 @@
 package com.fsck.k9.helper;
 
 
+import android.Manifest;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.database.AbstractCursor;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.ContactsContract;
 import timber.log.Timber;
 import android.provider.ContactsContract.CommonDataKinds.Photo;
+import android.support.v4.content.ContextCompat;
 
 import com.fsck.k9.mail.Address;
 
@@ -255,6 +259,14 @@ public class Contacts {
         }
     }
 
+    private Boolean hasPerm() {
+        return
+                ((ContextCompat.checkSelfPermission(mContext,
+                        Manifest.permission.READ_CONTACTS) == PackageManager.PERMISSION_GRANTED)
+                        && ((ContextCompat.checkSelfPermission(mContext,
+                        Manifest.permission.WRITE_CONTACTS) == PackageManager.PERMISSION_GRANTED)));
+    }
+
     /**
      * Return a {@link Cursor} instance that can be used to fetch information
      * about the contact with the given email address.
@@ -265,6 +277,55 @@ public class Contacts {
      */
     private Cursor getContactByAddress(final String address) {
         final Uri uri = Uri.withAppendedPath(ContactsContract.CommonDataKinds.Email.CONTENT_LOOKUP_URI, Uri.encode(address));
+        if (!hasPerm()) {
+            // return blank cursor
+            return new AbstractCursor() {
+                @Override
+                public int getCount() {
+                    return 0;
+                }
+
+                @Override
+                public String[] getColumnNames() {
+                    return new String[0];
+                }
+
+                @Override
+                public String getString(int column) {
+                    return null;
+                }
+
+                @Override
+                public short getShort(int column) {
+                    return 0;
+                }
+
+                @Override
+                public int getInt(int column) {
+                    return 0;
+                }
+
+                @Override
+                public long getLong(int column) {
+                    return 0;
+                }
+
+                @Override
+                public float getFloat(int column) {
+                    return 0;
+                }
+
+                @Override
+                public double getDouble(int column) {
+                    return 0;
+                }
+
+                @Override
+                public boolean isNull(int column) {
+                    return false;
+                }
+            };
+        } else
         return mContentResolver.query(
                 uri,
                 PROJECTION,

--- a/k9mail/src/main/java/com/fsck/k9/helper/FileBrowserHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/FileBrowserHelper.java
@@ -9,6 +9,8 @@ import android.content.ActivityNotFoundException;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
+import android.os.FileUriExposedException;
 import android.text.InputType;
 import android.widget.EditText;
 
@@ -87,12 +89,23 @@ public class FileBrowserHelper {
             Intent intent = new Intent(intentAction);
             intent.setData(Uri.parse(uriPrefix + startPath.getPath()));
 
-            try {
-                c.startActivityForResult(intent, requestcode);
-                success = true;
-            } catch (ActivityNotFoundException e) {
-                // Try the next intent in the list
-                listIndex++;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                try {
+                    c.startActivityForResult(intent, requestcode);
+                    success = true;
+                    // note:  When Storage Access Framework is used, this won't be necessary.
+                } catch (ActivityNotFoundException | FileUriExposedException e) {
+                    // Try the next intent in the list
+                    listIndex++;
+                }
+            } else {
+                try {
+                    c.startActivityForResult(intent, requestcode);
+                    success = true;
+                } catch (ActivityNotFoundException e) {
+                    // Try the next intent in the list
+                    listIndex++;
+                }
             }
         } while (!success && (listIndex < PICK_DIRECTORY_INTENTS.length));
 

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationController.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationController.java
@@ -1,6 +1,8 @@
 package com.fsck.k9.notification;
 
 
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
 import android.net.Uri;
 import android.os.Build;
@@ -10,6 +12,7 @@ import android.text.TextUtils;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
+import com.fsck.k9.R;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mailstore.LocalMessage;
@@ -36,6 +39,13 @@ public class NotificationController {
 
     public static NotificationController newInstance(Context context) {
         Context appContext = context.getApplicationContext();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            ((NotificationManager) appContext.getSystemService(Context.NOTIFICATION_SERVICE))
+                    .createNotificationChannel(new NotificationChannel
+                            (appContext.getString(R.string.k9_channel_id),
+                                    appContext.getString(R.string.k9_channel_description), NotificationManager.IMPORTANCE_DEFAULT));
+        }
         NotificationManagerCompat notificationManager = NotificationManagerCompat.from(appContext);
         return new NotificationController(appContext, notificationManager);
     }
@@ -159,6 +169,6 @@ public class NotificationController {
     }
 
     NotificationCompat.Builder createNotificationBuilder() {
-        return new NotificationCompat.Builder(context);
+        return new NotificationCompat.Builder(context, getContext().getString(R.string.k9_channel_id));
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/ui/EolConvertingEditText.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/EolConvertingEditText.java
@@ -1,15 +1,15 @@
 package com.fsck.k9.ui;
 
 import android.content.Context;
+import android.support.v7.widget.AppCompatEditText;
 import android.util.AttributeSet;
-import android.widget.EditText;
 
 /**
  * An {@link android.widget.EditText} extension with methods that convert line endings from
  * {@code \r\n} to {@code \n} and back again when setting and getting text.
  *
  */
-public class EolConvertingEditText extends EditText {
+public class EolConvertingEditText extends AppCompatEditText {
 
     public EolConvertingEditText(Context context, AttributeSet attrs) {
         super(context, attrs);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -3,7 +3,7 @@ package com.fsck.k9.ui.messageview;
 
 import java.util.Collections;
 import java.util.Locale;
-
+import android.Manifest;
 import android.app.Activity;
 import android.app.DialogFragment;
 import android.app.DownloadManager;
@@ -13,11 +13,14 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
+import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
 import android.os.SystemClock;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.text.TextUtils;
 import android.view.ContextThemeWrapper;
 import android.view.KeyEvent;
@@ -33,6 +36,7 @@ import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
 import com.fsck.k9.activity.ChooseFolder;
+import com.fsck.k9.activity.K9Activity;
 import com.fsck.k9.activity.MessageLoaderHelper;
 import com.fsck.k9.activity.MessageLoaderHelper.MessageLoaderCallbacks;
 import com.fsck.k9.activity.MessageReference;
@@ -828,12 +832,14 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
     @Override
     public void onSaveAttachment(AttachmentViewInfo attachment) {
+        checkPerms();
         currentAttachmentViewInfo = attachment;
         getAttachmentController(attachment).saveAttachment();
     }
 
     @Override
     public void onSaveAttachmentToUserProvidedDirectory(final AttachmentViewInfo attachment) {
+        checkPerms();
         currentAttachmentViewInfo = attachment;
         FileBrowserHelper.getInstance().showFileBrowserActivity(MessageViewFragment.this, null,
                 ACTIVITY_CHOOSE_DIRECTORY, new FileBrowserFailOverCallback() {
@@ -848,6 +854,17 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                     }
                 });
     }
+
+    private void checkPerms() {
+        if (ContextCompat.checkSelfPermission(getActivity(),
+                Manifest.permission.WRITE_EXTERNAL_STORAGE)
+                != PackageManager.PERMISSION_GRANTED) {
+            ActivityCompat.requestPermissions(getActivity(),
+                    new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    K9Activity.PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE);
+        }
+    }
+
 
     private AttachmentController getAttachmentController(AttachmentViewInfo attachment) {
         return new AttachmentController(mController, downloadManager, this, attachment);

--- a/k9mail/src/main/res/layout/edit_identity.xml
+++ b/k9mail/src/main/res/layout/edit_identity.xml
@@ -18,6 +18,7 @@
         <EditText
             android:id="@+id/description"
             android:singleLine="true"
+			android:inputType="text"
             android:layout_height="wrap_content"
             android:layout_width="fill_parent" 
             android:hint="@string/edit_identity_description_hint"
@@ -31,6 +32,7 @@
         <EditText
             android:id="@+id/name"
             android:singleLine="true"
+			android:inputType="text"
             android:layout_height="wrap_content"
             android:layout_width="fill_parent" 
             android:hint="@string/edit_identity_name_hint"

--- a/k9mail/src/main/res/menu/accounts_option.xml
+++ b/k9mail/src/main/res/menu/accounts_option.xml
@@ -1,28 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item
         android:id="@+id/search"
         android:icon="?attr/iconActionSearch"
-        android:showAsAction="always"
-        android:title="@string/search_action"/>
+        android:title="@string/search_action"
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/check_mail"
         android:alphabeticShortcut="r"
         android:icon="?attr/iconActionRefresh"
-        android:showAsAction="always"
-        android:title="@string/check_mail_action"/>
+        android:title="@string/check_mail_action"
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/compose"
         android:alphabeticShortcut="c"
         android:icon="?attr/iconActionCompose"
-        android:showAsAction="always"
-        android:title="@string/compose_action"/>
+        android:title="@string/compose_action"
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/add_new_account"
         android:icon="?attr/iconActionAdd"
-        android:showAsAction="ifRoom"
-        android:title="@string/add_account_action"/>
+        android:title="@string/add_account_action"
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/about"
         android:icon="?attr/iconActionAbout"
@@ -43,7 +44,7 @@
     <item
         android:id="@+id/edit_prefs"
         android:icon="?attr/iconActionSettings"
-        android:showAsAction="never"
-        android:title="@string/preferences_action"/>
+        android:title="@string/preferences_action"
+        app:showAsAction="never" />
 
 </menu>

--- a/k9mail/src/main/res/menu/folder_list_option.xml
+++ b/k9mail/src/main/res/menu/folder_list_option.xml
@@ -1,28 +1,29 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android" >
     <item
         android:id="@+id/search"
         android:icon="?attr/iconActionSearch"
-        android:showAsAction="always"
-        android:title="@string/search_action"/>
+        android:title="@string/search_action"
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/filter_folders"
         android:icon="?attr/iconActionSearchFolder"
-        android:showAsAction="always|collapseActionView"
         android:title="@string/filter_folders_action"
-        android:actionViewClass="android.widget.SearchView"/>
+        app:showAsAction="ifRoom|collapseActionView"
+        app:actionViewClass="android.widget.SearchView" />
     <item
         android:id="@+id/check_mail"
         android:alphabeticShortcut="r"
         android:icon="?attr/iconActionRefresh"
-        android:showAsAction="always"
-        android:title="@string/check_mail_action"/>
+        android:title="@string/check_mail_action"
+        app:showAsAction="always" />
     <item
         android:id="@+id/compose"
         android:alphabeticShortcut="c"
         android:icon="?attr/iconActionCompose"
-        android:showAsAction="always"
-        android:title="@string/compose_action"/>
+        android:title="@string/compose_action"
+        app:showAsAction="always" />
     <item
         android:icon="?attr/iconFolder"
         android:title="@string/folder_list_display_mode_label">
@@ -52,8 +53,8 @@
         android:title="@string/empty_trash_action"/>
     <item
         android:id="@+id/compact"
-        android:showAsAction="never"
-        android:title="@string/compact_action"/>
+        android:title="@string/compact_action"
+        app:showAsAction="never" />
     <item
         android:id="@+id/list_folders"
         android:icon="?attr/iconActionRefresh"
@@ -61,8 +62,8 @@
     <item
         android:id="@+id/settings"
         android:icon="?attr/iconActionSettings"
-        android:showAsAction="never"
-        android:title="@string/preferences_action">
+        android:title="@string/preferences_action"
+        app:showAsAction="never">
         <menu>
             <item
                 android:id="@+id/account_settings"

--- a/k9mail/src/main/res/menu/folder_select_option.xml
+++ b/k9mail/src/main/res/menu/folder_select_option.xml
@@ -1,12 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <item
         android:id="@+id/filter_folders"
-        android:actionViewClass="android.widget.SearchView"
         android:icon="?attr/iconActionSearchFolder"
-        android:showAsAction="always|collapseActionView"
-        android:title="@string/filter_folders_action"/>
+        android:title="@string/filter_folders_action"
+        app:actionViewClass="android.widget.SearchView"
+        app:showAsAction="always|collapseActionView" />
     <item
         android:id="@+id/display_all"
         android:title="@string/folder_list_display_mode_all"/>

--- a/k9mail/src/main/res/menu/message_compose_option.xml
+++ b/k9mail/src/main/res/menu/message_compose_option.xml
@@ -1,19 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/add_attachment"
         android:alphabeticShortcut="n"
         android:title="@string/add_attachment_action"
         android:icon="?attr/iconActionAddAttachment"
-        android:showAsAction="always"
-    />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/send"
         android:alphabeticShortcut="s"
         android:title="@string/send_action"
         android:icon="?attr/iconActionSend"
-        android:showAsAction="always"
-    />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/add_from_contacts"
         android:alphabeticShortcut="a"
@@ -41,36 +40,30 @@
         android:id="@+id/openpgp_encrypt_enable"
         android:alphabeticShortcut="c"
         android:title="@string/enable_encryption"
-        android:showAsAction="never"
-        />
+        app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_encrypt_disable"
         android:alphabeticShortcut="c"
         android:title="@string/disable_encryption"
-        android:showAsAction="never"
-        />
+        app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_sign_only"
         android:alphabeticShortcut="g"
         android:title="@string/enable_sign_only"
-        android:showAsAction="never"
-        />
+        app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_sign_only_disable"
         android:alphabeticShortcut="g"
         android:title="@string/disable_sign_only"
-        android:showAsAction="never"
-        />
+        app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_inline_enable"
         android:alphabeticShortcut="i"
         android:title="@string/enable_inline_pgp"
-        android:showAsAction="never"
-        />
+        app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_inline_disable"
         android:alphabeticShortcut="i"
         android:title="@string/disable_inline_pgp"
-        android:showAsAction="never"
-        />
+        app:showAsAction="never" />
 </menu>

--- a/k9mail/src/main/res/menu/message_compose_option.xml
+++ b/k9mail/src/main/res/menu/message_compose_option.xml
@@ -1,65 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/add_attachment"
-        android:alphabeticShortcut="n"
-        android:title="@string/add_attachment_action"
+        android:alphabeticShortcut="a"
         android:icon="?attr/iconActionAddAttachment"
+        android:title="@string/add_attachment_action"
+        app:alphabeticModifiers="CTRL|SHIFT"
         app:showAsAction="ifRoom" />
     <item
         android:id="@+id/send"
-        android:alphabeticShortcut="s"
-        android:title="@string/send_action"
+        android:alphabeticShortcut="\\n"
         android:icon="?attr/iconActionSend"
-        app:showAsAction="ifRoom" />
+        android:title="@string/send_action"
+        app:alphabeticModifiers="CTRL"
+        app:showAsAction="always" />
     <item
         android:id="@+id/add_from_contacts"
-        android:alphabeticShortcut="a"
+        android:alphabeticShortcut="p"
         android:title="@string/add_from_contacts"
-    />
+        app:alphabeticModifiers="CTRL" />
     <item
         android:id="@+id/save"
-        android:alphabeticShortcut="d"
-        android:title="@string/save_draft_action"
+        android:alphabeticShortcut="s"
         android:icon="?attr/iconActionSave"
-        />
+        android:title="@string/save_draft_action"
+        app:alphabeticModifiers="CTRL" />
     <item
         android:id="@+id/discard"
         android:alphabeticShortcut="q"
-        android:title="@string/discard_action"
         android:icon="?attr/iconActionCancel"
-    />
+        android:title="@string/discard_action"
+        app:alphabeticModifiers="CTRL" />
     <item
         android:id="@+id/read_receipt"
         android:alphabeticShortcut="r"
-        android:title="@string/read_receipt"
         android:icon="?attr/iconActionRequestReadReceipt"
-    />
+        android:title="@string/read_receipt"
+        app:alphabeticModifiers="CTRL" />
     <item
         android:id="@+id/openpgp_encrypt_enable"
         android:alphabeticShortcut="c"
         android:title="@string/enable_encryption"
+        app:alphabeticModifiers="CTRL|SHIFT"
         app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_encrypt_disable"
         android:alphabeticShortcut="c"
         android:title="@string/disable_encryption"
+        app:alphabeticModifiers="CTRL|SHIFT"
+
         app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_sign_only"
-        android:alphabeticShortcut="g"
+        android:alphabeticShortcut="s"
         android:title="@string/enable_sign_only"
+        app:alphabeticModifiers="CTRL|SHIFT"
         app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_sign_only_disable"
-        android:alphabeticShortcut="g"
+        android:alphabeticShortcut="s"
         android:title="@string/disable_sign_only"
+        app:alphabeticModifiers="CTRL|SHIFT"
         app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_inline_enable"
         android:alphabeticShortcut="i"
         android:title="@string/enable_inline_pgp"
+        app:alphabeticModifiers="CTRL|SHIFT"
         app:showAsAction="never" />
     <item
         android:id="@+id/openpgp_inline_disable"

--- a/k9mail/src/main/res/menu/message_list_context.xml
+++ b/k9mail/src/main/res/menu/message_list_context.xml
@@ -1,35 +1,31 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/delete"
         android:title="@string/delete_action"
-        android:showAsAction="always"
         android:icon="?attr/iconActionDelete"
-    />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/mark_as_read"
         android:title="@string/mark_as_read_action"
-        android:showAsAction="always"
         android:icon="?attr/iconActionMarkAsRead"
-    />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/mark_as_unread"
         android:title="@string/mark_as_unread_action"
-        android:showAsAction="always"
         android:icon="?attr/iconActionMarkAsUnread"
-    />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/archive"
         android:title="@string/archive_action"
-        android:showAsAction="always"
         android:icon="?attr/iconActionArchive"
-    />
+        app:showAsAction="always" />
     <item
         android:id="@+id/move"
         android:title="@string/move_action"
-        android:showAsAction="ifRoom"
         android:icon="?attr/iconActionMove"
-    />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/copy"
         android:title="@string/copy_action"
@@ -38,25 +34,21 @@
     <item
         android:id="@+id/flag"
         android:title="@string/flag_action"
-        android:showAsAction="ifRoom"
         android:icon="?attr/iconActionFlag"
-    />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/unflag"
         android:title="@string/unflag_action"
-        android:showAsAction="ifRoom"
         android:icon="?attr/iconActionUnflag"
-    />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/spam"
         android:title="@string/spam_action"
-        android:showAsAction="ifRoom"
         android:icon="?attr/iconActionSpam"
-    />
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/select_all"
         android:icon="?attr/iconActionSelectAll"
-        android:showAsAction="never"
         android:title="@string/batch_select_all"
-    />
+        app:showAsAction="never" />
 </menu>

--- a/k9mail/src/main/res/menu/message_list_option.xml
+++ b/k9mail/src/main/res/menu/message_list_option.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android" >
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android" >
 
     <!--
     The comments preceding the (top level) menu items denote which part of the combined message
@@ -15,78 +16,76 @@
         android:id="@+id/previous_message"
         android:title="@string/previous_action"
         android:icon="?attr/iconActionPreviousMessage"
-        android:showAsAction="always"
-    />
+        app:showAsAction="ifRoom" />
 
     <!-- MessageView -->
     <item
         android:id="@+id/next_message"
         android:title="@string/next_action"
         android:icon="?attr/iconActionNextMessage"
-        android:showAsAction="always"
-    />
+        app:showAsAction="ifRoom" />
 
     <!-- MessageList -->
     <item
         android:id="@+id/search"
         android:icon="?attr/iconActionSearch"
-        android:showAsAction="always"
-        android:title="@string/search_action"/>
+        android:title="@string/search_action"
+        app:showAsAction="ifRoom" />
 
     <!-- MessageList -->
     <item
         android:id="@+id/search_remote"
         android:icon="?attr/iconActionRemoteSearch"
-        android:showAsAction="always"
         android:title="@string/action_remote_search"
-        android:visible="false"/>
+        android:visible="false"
+        app:showAsAction="ifRoom" />
 
     <!-- MessageList -->
     <item
         android:id="@+id/check_mail"
         android:alphabeticShortcut="r"
         android:icon="?attr/iconActionRefresh"
-        android:showAsAction="always"
-        android:title="@string/check_mail_action"/>
+        android:title="@string/check_mail_action"
+        app:showAsAction="ifRoom" />
 
     <!-- MessageView -->
     <item
         android:id="@+id/delete"
         android:alphabeticShortcut="q"
         android:icon="?attr/iconActionDelete"
-        android:showAsAction="always"
-        android:title="@string/delete_action"/>
+        android:title="@string/delete_action"
+        app:showAsAction="always" />
     <!-- MessageView -->
     <item
         android:id="@+id/archive"
         android:icon="?attr/iconActionArchive"
-        android:showAsAction="ifRoom"
-        android:title="@string/archive_action"/>
+        android:title="@string/archive_action"
+        app:showAsAction="ifRoom" />
     <!-- MessageView -->
     <item
         android:id="@+id/spam"
         android:icon="?attr/iconActionSpam"
-        android:showAsAction="ifRoom"
-        android:title="@string/spam_action"/>
+        android:title="@string/spam_action"
+        app:showAsAction="ifRoom" />
     <!-- MessageView -->
     <item
         android:id="@+id/move"
         android:icon="?attr/iconActionMove"
-        android:showAsAction="ifRoom"
-        android:title="@string/move_action"/>
+        android:title="@string/move_action"
+        app:showAsAction="ifRoom" />
     <!-- MessageView -->
     <item
         android:id="@+id/copy"
         android:icon="?attr/iconActionCopy"
-        android:showAsAction="ifRoom"
-        android:title="@string/copy_action"/>
+        android:title="@string/copy_action"
+        app:showAsAction="ifRoom" />
 
     <!-- MessageView -->
     <item
         android:id="@+id/single_message_options"
         android:icon="?attr/iconActionSingleMessageOptions"
-        android:showAsAction="ifRoom"
-        android:title="@string/single_message_options_action">
+        android:title="@string/single_message_options_action"
+        app:showAsAction="ifRoom">
         <menu>
             <item
                 android:id="@+id/reply"
@@ -110,8 +109,8 @@
     <item
         android:id="@+id/refile"
         android:icon="?attr/iconActionSingleMessageOptions"
-        android:showAsAction="never"
-        android:title="@string/refile_action">
+        android:title="@string/refile_action"
+        app:showAsAction="never">
         <menu>
             <item
                 android:id="@+id/refile_archive"
@@ -137,23 +136,23 @@
     <item
         android:id="@+id/toggle_unread"
         android:alphabeticShortcut="u"
-        android:showAsAction="never"
-        android:title="@string/mark_as_unread_action"/>
+        android:title="@string/mark_as_unread_action"
+        app:showAsAction="never" />
 
     <item android:id="@+id/show_headers"
-          android:showAsAction="never"
-          android:title="@string/show_headers_action"/>
+        android:title="@string/show_headers_action"
+        app:showAsAction="never" />
 
     <item android:id="@+id/hide_headers"
-          android:showAsAction="never"
-          android:title="@string/hide_headers_action"/>
+        android:title="@string/hide_headers_action"
+        app:showAsAction="never" />
 
     <!-- MessageList -->
     <item
         android:id="@+id/set_sort"
         android:icon="?attr/iconActionSort"
-        android:showAsAction="ifRoom"
-        android:title="@string/sort_by">
+        android:title="@string/sort_by"
+        app:showAsAction="ifRoom">
         <menu>
             <item
                 android:id="@+id/set_sort_date"
@@ -184,51 +183,51 @@
         android:id="@+id/compose"
         android:alphabeticShortcut="c"
         android:icon="?attr/iconActionCompose"
-        android:showAsAction="ifRoom"
-        android:title="@string/compose_action"/>
+        android:title="@string/compose_action"
+        app:showAsAction="ifRoom" />
 
     <!-- MessageList -->
     <item
         android:id="@+id/select_all"
         android:icon="?attr/iconActionSelectAll"
-        android:showAsAction="never"
-        android:title="@string/batch_select_all"/>
+        android:title="@string/batch_select_all"
+        app:showAsAction="never" />
 
     <!-- MessageList -->
     <item
         android:id="@+id/mark_all_as_read"
-        android:showAsAction="never"
-        android:title="@string/mark_all_as_read"/>
+        android:title="@string/mark_all_as_read"
+        app:showAsAction="never" />
 
     <!-- MessageList -->
     <item
         android:id="@+id/send_messages"
         android:alphabeticShortcut="r"
         android:icon="?attr/iconActionUpload"
-        android:showAsAction="never"
-        android:title="@string/send_messages_action"/>
+        android:title="@string/send_messages_action"
+        app:showAsAction="never" />
 
     <!-- MessageList -->
     <item
         android:id="@+id/expunge"
-        android:showAsAction="never"
-        android:title="@string/expunge_action"/>
+        android:title="@string/expunge_action"
+        app:showAsAction="never" />
 
     <!-- MessageView -->
     <item
         android:id="@+id/select_text"
-        android:showAsAction="never"
-        android:title="@string/select_text_action"/>
+        android:title="@string/select_text_action"
+        app:showAsAction="never" />
 
     <!-- MessageView -->
     <item
         android:id="@+id/toggle_message_view_theme"
-        android:showAsAction="never"
-        android:title="@string/message_view_theme_action_dark"/>
+        android:title="@string/message_view_theme_action_dark"
+        app:showAsAction="never" />
     <item
         android:id="@+id/show_folder_list"
-        android:showAsAction="never"
-        android:title="@string/folders_title" />
+        android:title="@string/folders_title"
+        app:showAsAction="never" />
     <!-- always -->
     <item
         android:id="@+id/settings"

--- a/k9mail/src/main/res/menu/unread_widget_option.xml
+++ b/k9mail/src/main/res/menu/unread_widget_option.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/done"
         android:title="@string/unread_widget_action_done"
-        android:showAsAction="always"
         android:icon="?attr/iconActionSave"
-        />
+        app:showAsAction="always" />
 </menu>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -794,9 +794,41 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_setup_failed_dlg_invalid_certificate_accept">Accept Key</string>
     <string name="account_setup_failed_dlg_invalid_certificate_reject">Reject Key</string>
 
-    <string name="message_view_help_key">Del (or D) - Delete\nR - Reply\nA - Reply All\nC - Compose\nF - Forward\nM - Move\nV - Archive\nY - Copy\nZ - Mark (Un)read\nG - Star\nO - Sort type\nI - Sort order\nQ - Return to Folders\nS - Select/deselect\nJ or P - Previous Message\nK or N - Next Message</string>
     <string name="message_list_help_key">Del (or D) - Delete\nC - Compose\nM - Move\nV - Archive\nY - Copy\nZ - Mark (Un)read\nG - Star\nO - Sort type\nI - Sort order\nQ - Return to Folders\nS - Select/deselect</string>
-
+    <string name="message_view_help_key">
+        CTRL-N, CTRL-M - Compose a new message\n
+        CTRL-R - Reply\n
+        CTRL-SHIFT-R - Reply all\n
+        CTRL-L - Forward email\n
+        DEL - Delete selected mail/thread\n
+        SPACE - Select/Deselect message\n
+        S - Toggle star\n
+        R - Toggle read status\n
+        CTRL-SHIFT-M - Move to another folder\n
+        A - archive selected\n
+        CTRL-C - Copy to another folder\n
+        F - Next message\n
+        B - Previous message\n
+        O - Cycle sort order\n
+        I - Cycle sort type\n
+        H, /, ? - This help</string>
+    <string name="message_composition_help_key">
+        CTRL-SHIFT-A - New attachment\n
+        CTRL-ENTER - Send now\n
+        CTRL-P - Add from Contacts\n
+        CTRL-S Save drafts\n
+        CTRL-Q - Quit/discard\n
+        CTRL-R - Read request read receipt\n
+        CTRL-SHIFT-C - Toggle encryption\n
+        CTRL-SHIFT-S - Toggle openpgp signature\n
+        CTRL-SHIFT-I - Enable/Disable inline PGP\n
+        CTRL-A Select all\n
+        CTRL-C Copy\n
+        CTRL-X Cut\n
+        CTRL-V Paste\n
+        CTRL-Z Undo\n
+        CTRL-SHIFT-Z Redo
+    </string>
     <string name="folder_list_help_key">1 - Display only 1st Class folders\n2 - Display 1st and 2nd Class folders\n3 - Display all except 2nd Class folders\n4 - Display all folders\nQ - Return to Accounts\nS - Edit Account Settings</string>
 
     <string name="folder_list_filter_hint">Folder name contains</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1288,6 +1288,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="k9_channel_description">All notifications</string>
 
     <!-- permissions -->
-    <string name="contact_permission_request">K-9 works best when this permission is granted.</string>
+    <string name="permission_request">K-9 works best when this permission is granted.</string>
     <string name="contact_permission_thanks">Your contact data is now available.</string>
+    <string name="storage_permission_thanks">You can now access external storage.</string>
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1286,4 +1286,8 @@ Please submit bug reports, contribute new features and ask questions at
     <!-- notification channel(s) -->
     <string name="k9_channel_id" translatable="false">k9_channel</string>
     <string name="k9_channel_description">All notifications</string>
+
+    <!-- permissions -->
+    <string name="contact_permission_request">K-9 works best when this permission is granted.</string>
+    <string name="contact_permission_thanks">Your contact data is now available.</string>
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1282,4 +1282,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="openpgp_enabled_error_back">Back</string>
     <string name="openpgp_enabled_error_disable">Disable Encryption</string>
     <string name="openpgp_encryption">OpenPGP Encryption</string>
+
+    <!-- notification channel(s) -->
+    <string name="k9_channel_id" translatable="false">k9_channel</string>
+    <string name="k9_channel_description">All notifications</string>
 </resources>

--- a/k9mail/src/main/res/values/styles.xml
+++ b/k9mail/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:tools="http://schemas.android.com/tools">
 
-    <style name="Theme.K9Dialog" parent="@android:Theme.Light">
+    <style name="Theme.K9Dialog" parent="Theme.AppCompat.Light">
         <item name="android:windowFrame">@null</item>
         <item name="android:windowBackground">@drawable/popup_background</item>
         <item name="android:windowTitleStyle">?android:attr/textAppearanceLargeInverse</item>
@@ -14,7 +14,7 @@
       Fix a bug with AutoCompleteTextView
       See https://code.google.com/p/android/issues/detail?id=5237
     -->
-    <style name="Widget.K9.AutoCompleteTextView" parent="@android:style/Widget.AutoCompleteTextView">
+    <style name="Widget.K9.AutoCompleteTextView" parent="Widget.AppCompat.AutoCompleteTextView">
         <item name="android:textColor">@android:color/primary_text_light</item>
     </style>
 

--- a/k9mail/src/main/res/values/themes.xml
+++ b/k9mail/src/main/res/values/themes.xml
@@ -6,8 +6,8 @@
     </style>
 
     <!-- Empty base themes that can be easily replaced by RRO (Runtime Resource Overlay) themes -->
-    <style name="Theme.K9.Light.Base" parent="@android:style/Theme.Holo.Light" />
-    <style name="Theme.K9.Dark.Base" parent="@android:style/Theme.Holo" />
+    <style name="Theme.K9.Light.Base" parent="Theme.AppCompat.Light" />
+    <style name="Theme.K9.Dark.Base" parent="Theme.AppCompat" />
 
     <style name="Theme.K9.Light.Common" parent="Theme.K9.Light.Base">
         <item name="iconFolder">@drawable/folder_light</item>
@@ -152,7 +152,7 @@
         <item name="backgroundColorChooseAccountHeader">#404040</item>
     </style>
 
-    <style name="Theme.K9.Dialog.Translucent.Dark" parent="@android:style/Theme.Holo.Dialog">
+    <style name="Theme.K9.Dialog.Translucent.Dark" parent="Theme.AppCompat.Dialog">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowIsTranslucent">true</item>
@@ -165,7 +165,7 @@
         <item name="tintColorBulletPointNeutral">#bbb</item>
     </style>
 
-    <style name="Theme.K9.Dialog.Translucent.Light" parent="@android:style/Theme.Holo.Light.Dialog">
+    <style name="Theme.K9.Dialog.Translucent.Light" parent="Theme.AppCompat.Light.Dialog">
         <item name="android:windowBackground">@android:color/transparent</item>
         <item name="android:colorBackgroundCacheHint">@null</item>
         <item name="android:windowIsTranslucent">true</item>

--- a/plugins/openpgp-api-lib/openpgp-api/build.gradle
+++ b/plugins/openpgp-api-lib/openpgp-api/build.gradle
@@ -8,8 +8,8 @@ android {
     defaultConfig {
         versionCode 8
         versionName '9.0' // API-Version . minor
-        minSdkVersion 9
-        targetSdkVersion 22
+        minSdkVersion 14
+        targetSdkVersion 27
     }
 
     // Do not abort build if lint finds errors


### PR DESCRIPTION
See Issue #3057 for discussion, but this creates shortcut keys that are
intuitive in a desktop (chromebook) or hard keyboard setting.  Aside from
using traditional ctrl-modifiers to take important actions, the keys are
chosen to not clobber over native Android EditText behavior such as copy,
paste, select, navigate, undo/redo, etc.  The specific changes are in the
strings.xml.  Of note, the ctrl-RETURN to send doesn't function on my
chromebook, but I did do it according to the documentation, so it's very
possible this is a an issue with the framework itself.

**Modifier key support required compat views, which in turn required
more recent APIs, which in turn required the latest Android Studio stuff.**
So this commit is built over my previous compatibility changes to the
Android 3.1 build environment.  (PR #3159, PR #3175, etc.)
