### PR TITLE
Fix: Contact nicknames always on top #3178

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
@@ -2,6 +2,8 @@ package com.fsck.k9.activity.compose;
 
 
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +37,8 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
     private static final int INDEX_EMAIL_CUSTOM_LABEL = 5;
     private static final int INDEX_CONTACT_ID = 6;
     private static final int INDEX_PHOTO_URI = 7;
+    private static final int INDEX_TIMES_CONTACTED = 8;
+    private static final int INDEX_KEY_PRIMARY = 9;
 
     private static final String[] PROJECTION = {
             ContactsContract.CommonDataKinds.Email._ID,
@@ -44,7 +48,9 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
             ContactsContract.CommonDataKinds.Email.TYPE,
             ContactsContract.CommonDataKinds.Email.LABEL,
             ContactsContract.CommonDataKinds.Email.CONTACT_ID,
-            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
+            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
+            ContactsContract.CommonDataKinds.Email.TIMES_CONTACTED,
+            ContactsContract.Contacts.SORT_KEY_PRIMARY
     };
 
     private static final String SORT_ORDER = "" +
@@ -260,6 +266,21 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
         foundValidCursor |= fillContactDataFromNameAndEmail(query, recipients, recipientMap);
 
         if (foundValidCursor) {
+            Collections.sort(recipients, new Comparator<Recipient>() {
+                @Override
+                public int compare(Recipient o1, Recipient o2) {
+
+                    int x = o2.getTimesContacted();
+                    int y = o1.getTimesContacted();
+
+                    int compTimesContacted = (x < y) ? -1 : ((x == y) ? 0 : 1);
+                    if (compTimesContacted != 0){
+                        return compTimesContacted;
+                    }
+                    return  o2.getKeyPrimary().compareTo(o1.getKeyPrimary());
+                }
+            });
+
             registerContentObserver();
         }
 
@@ -374,6 +395,10 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
                 }
             }
             Recipient recipient = new Recipient(name, email, addressLabel, contactId, lookupKey);
+            recipient.setTimesContacted(cursor.getInt(INDEX_TIMES_CONTACTED));
+            recipient.setKeyPrimary(cursor.getString(INDEX_KEY_PRIMARY));
+
+
             if (recipient.isValidEmailAddress()) {
 
                 recipient.photoThumbnailUri = cursor.isNull(INDEX_PHOTO_URI) ? null : Uri.parse(cursor.getString(INDEX_PHOTO_URI));

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
@@ -163,7 +163,7 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
     }
 
     private void fillContactDataFromCryptoProvider(String query, List<Recipient> recipients,
-                                                   Map<String, Recipient> recipientMap) {
+            Map<String, Recipient> recipientMap) {
         Cursor cursor;
         try {
             Uri queryUri = Uri.parse("content://" + cryptoProvider + ".provider.exported/autocrypt_status");
@@ -197,7 +197,7 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
     }
 
     private void fillContactDataFromAddresses(Address[] addresses, List<Recipient> recipients,
-                                              Map<String, Recipient> recipientMap) {
+            Map<String, Recipient> recipientMap) {
         for (Address address : addresses) {
             // TODO actually query contacts - not sure if this is possible in a single query tho :(
             Recipient recipient = new Recipient(address);
@@ -207,7 +207,7 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
     }
 
     private void fillContactDataFromEmailContentUri(Uri contactUri, List<Recipient> recipients,
-                                                    Map<String, Recipient> recipientMap) {
+            Map<String, Recipient> recipientMap) {
         Cursor cursor = contentResolver.query(contactUri, PROJECTION, null, null, null);
 
         if (cursor == null) {
@@ -218,7 +218,7 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
     }
 
     private void fillContactDataFromLookupKey(Uri lookupKeyUri, List<Recipient> recipients,
-                                              Map<String, Recipient> recipientMap) {
+            Map<String, Recipient> recipientMap) {
         // We could use the contact id from the URI directly, but getting it from the lookup key is safer
         Uri contactContentUri = Contacts.lookupContact(contentResolver, lookupKeyUri);
         if (contactContentUri == null) {
@@ -259,14 +259,14 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
 
     @SuppressWarnings("ConstantConditions")
     private void fillContactDataFromQuery(String query, List<Recipient> recipients,
-                                          Map<String, Recipient> recipientMap) {
+            Map<String, Recipient> recipientMap) {
 
         boolean foundValidCursor = false;
         foundValidCursor |= fillContactDataFromNickname(query, recipients, recipientMap);
         foundValidCursor |= fillContactDataFromNameAndEmail(query, recipients, recipientMap);
 
         if (foundValidCursor) {
-            //nicknames should be sorted as the others - timesContacted,keyPrimary
+            //nicknames should be sorted as the others - by timesContacted,keyPrimary
             Collections.sort(recipients, new Comparator<Recipient>() {
                 @Override
                 public int compare(Recipient o1, Recipient o2) {
@@ -275,10 +275,10 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
                     int y = o1.getTimesContacted();
 
                     int compTimesContacted = (x < y) ? -1 : ((x == y) ? 0 : 1);
-                    if (compTimesContacted != 0){
+                    if (compTimesContacted != 0) {
                         return compTimesContacted;
                     }
-                    return  o2.getKeyPrimary().compareTo(o1.getKeyPrimary());
+                    return o2.getKeyPrimary().compareTo(o1.getKeyPrimary());
                 }
             });
 
@@ -296,7 +296,7 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
 
     @SuppressWarnings("ConstantConditions")
     private boolean fillContactDataFromNickname(String nickname, List<Recipient> recipients,
-                                                Map<String, Recipient> recipientMap) {
+            Map<String, Recipient> recipientMap) {
 
         boolean hasContact = false;
 
@@ -329,7 +329,7 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
 
 
     private boolean fillContactDataFromNameAndEmail(String query, List<Recipient> recipients,
-                                                    Map<String, Recipient> recipientMap) {
+            Map<String, Recipient> recipientMap) {
         query = "%" + query + "%";
 
         Uri queryUri = Email.CONTENT_URI;
@@ -350,12 +350,12 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
     }
 
     private void fillContactDataFromCursor(Cursor cursor, List<Recipient> recipients,
-                                           Map<String, Recipient> recipientMap) {
+            Map<String, Recipient> recipientMap) {
         fillContactDataFromCursor(cursor, recipients, recipientMap, null);
     }
 
     private void fillContactDataFromCursor(Cursor cursor, List<Recipient> recipients,
-                                           Map<String, Recipient> recipientMap, @Nullable String prefilledName) {
+            Map<String, Recipient> recipientMap, @Nullable String prefilledName) {
 
         while (cursor.moveToNext()) {
             String name = prefilledName != null ? prefilledName : cursor.getString(INDEX_NAME);
@@ -402,7 +402,8 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
 
             if (recipient.isValidEmailAddress()) {
 
-                recipient.photoThumbnailUri = cursor.isNull(INDEX_PHOTO_URI) ? null : Uri.parse(cursor.getString(INDEX_PHOTO_URI));
+                recipient.photoThumbnailUri =
+                        cursor.isNull(INDEX_PHOTO_URI) ? null : Uri.parse(cursor.getString(INDEX_PHOTO_URI));
                 recipientMap.put(email, recipient);
                 recipients.add(recipient);
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
@@ -266,6 +266,7 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
         foundValidCursor |= fillContactDataFromNameAndEmail(query, recipients, recipientMap);
 
         if (foundValidCursor) {
+            //nicknames should be sorted as the others - timesContacted,keyPrimary
             Collections.sort(recipients, new Comparator<Recipient>() {
                 @Override
                 public int compare(Recipient o1, Recipient o2) {

--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -583,8 +583,6 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         public Address address;
 
         public String addressLabel;
-        private int timesContacted;
-        private String keyPrimary;
 
         @Nullable // null if the contact has no photo. transient because we serialize this manually, see below.
         public transient Uri photoThumbnailUri;
@@ -696,22 +694,6 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
                 String uriString = ois.readUTF();
                 photoThumbnailUri = Uri.parse(uriString);
             }
-        }
-
-        public void setTimesContacted(int timesContacted) {
-            this.timesContacted = timesContacted;
-        }
-
-        public int getTimesContacted() {
-            return timesContacted;
-        }
-
-        public void setKeyPrimary(String keyPrimary) {
-            this.keyPrimary = keyPrimary;
-        }
-
-        public String getKeyPrimary() {
-            return keyPrimary;
         }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -583,6 +583,8 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         public Address address;
 
         public String addressLabel;
+        private int timesContacted;
+        private String keyPrimary;
 
         @Nullable // null if the contact has no photo. transient because we serialize this manually, see below.
         public transient Uri photoThumbnailUri;
@@ -694,6 +696,22 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
                 String uriString = ois.readUTF();
                 photoThumbnailUri = Uri.parse(uriString);
             }
+        }
+
+        public void setTimesContacted(int timesContacted) {
+            this.timesContacted = timesContacted;
+        }
+
+        public int getTimesContacted() {
+            return timesContacted;
+        }
+
+        public void setKeyPrimary(String keyPrimary) {
+            this.keyPrimary = keyPrimary;
+        }
+
+        public String getKeyPrimary() {
+            return keyPrimary;
         }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -583,6 +583,8 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         public Address address;
 
         public String addressLabel;
+        private int timesContacted;
+        private String keyPrimary;
 
         @Nullable // null if the contact has no photo. transient because we serialize this manually, see below.
         public transient Uri photoThumbnailUri;
@@ -607,7 +609,7 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
 
         public String getDisplayNameOrAddress() {
             final String displayName = K9.showCorrespondentNames() ? getDisplayName() : null;
-    
+
             if (displayName != null) {
                 return displayName;
             }
@@ -694,6 +696,22 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
                 String uriString = ois.readUTF();
                 photoThumbnailUri = Uri.parse(uriString);
             }
+        }
+
+        public void setTimesContacted(int timesContacted) {
+            this.timesContacted = timesContacted;
+        }
+
+        public int getTimesContacted() {
+            return timesContacted;
+        }
+
+        public void setKeyPrimary(String keyPrimary) {
+            this.keyPrimary = keyPrimary;
+        }
+
+        public String getKeyPrimary() {
+            return keyPrimary;
         }
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
@@ -40,15 +40,28 @@ public class RecipientLoaderTest {
             ContactsContract.CommonDataKinds.Email.TYPE,
             ContactsContract.CommonDataKinds.Email.LABEL,
             ContactsContract.CommonDataKinds.Email.CONTACT_ID,
-            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
+            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
+            ContactsContract.CommonDataKinds.Email.TIMES_CONTACTED,
+            ContactsContract.Contacts.SORT_KEY_PRIMARY
     };
     static final String[] PROJECTION_CRYPTO_ADDRESSES = { "address", "uid_address" };
     static final String[] PROJECTION_CRYPTO_STATUS = { "address", "uid_key_status", "autocrypt_key_status" };
     static final Address CONTACT_ADDRESS_1 = Address.parse("Contact Name <address@example.org>")[0];
     static final Address CONTACT_ADDRESS_2 = Address.parse("Other Contact Name <address_two@example.org>")[0];
-    static final String[] CONTACT_1 = new String[] {"0", "Bob", "bob", "bob@host.com", ""+TYPE_HOME, null, "1", null};
-    static final String[] CONTACT_NO_EMAIL = new String[] {"0", "Bob", "bob", null, ""+TYPE_HOME, null, "1", null};
+    static final String TYPE = ""+TYPE_HOME;
+    static final String[] CONTACT_1 = new String[] {"0", "Bob", "bob", "bob@host.com", TYPE, null, "1", null, "100", "Bob"};
+    static final String[] CONTACT_NO_EMAIL = new String[] {"0", "Bob", "bob", null, TYPE, null, "1", null, "10", "Bob_noMail"};
+    static final String[] CONTACT_WITH_NICKNAME_NOT_CONTACTED = new String[] {"0", "Eve_notContacted", "eve_notContacted", "eve_notContacted@host.com", TYPE, null, "2", null, "0", "Eve"};
+    static final String[] NICKNAME_NOT_CONTACTED = new String[]{"2", "Eves_Nickname_Bob"};
+
     static final String QUERYSTRING = "querystring";
+
+
+    private static final String[] PROJECTION_NICKNAME = {
+            ContactsContract.Data.CONTACT_ID,
+            ContactsContract.CommonDataKinds.Nickname.NAME
+    };
+
 
 
     Context context;
@@ -172,6 +185,34 @@ public class RecipientLoaderTest {
                         any(String.class))).thenReturn(cursor);
     }
 
+    private void setupNicknameContactProvider(String queriedAddress, String[]... contactsWithNickname) {
+        MatrixCursor cursor = new MatrixCursor(PROJECTION_NICKNAME);
+        for (String[] contact : contactsWithNickname) {
+            cursor.addRow(contact);
+        }
+        when(contentResolver
+                .query(eq(ContactsContract.Data.CONTENT_URI),
+                        aryEq(PROJECTION_NICKNAME),
+                        any(String.class),
+                        any(String[].class),
+                        any(String.class))).thenReturn(cursor);
+
+
+    }
+
+
+    private void setupContactProviderForId(String id, String[]... contacts) {
+        MatrixCursor cursor = new MatrixCursor(PROJECTION);
+        for (String[] contact : contacts) {
+            cursor.addRow(contact);
+        }
+        when(contentResolver
+                .query(eq( Email.CONTENT_URI),
+                        aryEq(PROJECTION),
+                        any(String.class),
+                        aryEq(new String[] { id}),
+                        any(String.class))).thenReturn(cursor);
+    }
     @Test
     public void queryContactProvider() throws Exception {
         RecipientLoader recipientLoader = new RecipientLoader(context, CRYPTO_PROVIDER, QUERYSTRING);
@@ -192,5 +233,23 @@ public class RecipientLoaderTest {
         List<Recipient> recipients = recipientLoader.loadInBackground();
 
         assertEquals(0, recipients.size());
+    }
+
+
+    /**
+     * Nickname should be sorted as querying others (more times contacted first)
+     */
+    @Test
+    public void queryContactProvider_sortByContactedForNickname() throws Exception {
+        RecipientLoader recipientLoader = new RecipientLoader(context, null, QUERYSTRING);
+        setupContactProvider("%" + QUERYSTRING + "%", CONTACT_1);
+        setupNicknameContactProvider("%" + QUERYSTRING + "%", NICKNAME_NOT_CONTACTED);
+        setupContactProviderForId(NICKNAME_NOT_CONTACTED[0], CONTACT_WITH_NICKNAME_NOT_CONTACTED);
+
+        List<Recipient> recipients = recipientLoader.loadInBackground();
+
+        assertEquals(2, recipients.size());
+        assertEquals("bob@host.com", recipients.get(0).address.getAddress());
+        assertEquals("eve_notContacted@host.com", recipients.get(1).address.getAddress());
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
@@ -48,11 +48,15 @@ public class RecipientLoaderTest {
     static final String[] PROJECTION_CRYPTO_STATUS = { "address", "uid_key_status", "autocrypt_key_status" };
     static final Address CONTACT_ADDRESS_1 = Address.parse("Contact Name <address@example.org>")[0];
     static final Address CONTACT_ADDRESS_2 = Address.parse("Other Contact Name <address_two@example.org>")[0];
-    static final String TYPE = ""+TYPE_HOME;
-    static final String[] CONTACT_1 = new String[] {"0", "Bob", "bob", "bob@host.com", TYPE, null, "1", null, "100", "Bob"};
-    static final String[] CONTACT_NO_EMAIL = new String[] {"0", "Bob", "bob", null, TYPE, null, "1", null, "10", "Bob_noMail"};
-    static final String[] CONTACT_WITH_NICKNAME_NOT_CONTACTED = new String[] {"0", "Eve_notContacted", "eve_notContacted", "eve_notContacted@host.com", TYPE, null, "2", null, "0", "Eve"};
-    static final String[] NICKNAME_NOT_CONTACTED = new String[]{"2", "Eves_Nickname_Bob"};
+    static final String TYPE = "" + TYPE_HOME;
+    static final String[] CONTACT_1 =
+            new String[] { "0", "Bob", "bob", "bob@host.com", TYPE, null, "1", null, "100", "Bob" };
+    static final String[] CONTACT_NO_EMAIL =
+            new String[] { "0", "Bob", "bob", null, TYPE, null, "1", null, "10", "Bob_noMail" };
+    static final String[] CONTACT_WITH_NICKNAME_NOT_CONTACTED =
+            new String[] { "0", "Eve_notContacted", "eve_notContacted", "eve_notContacted@host.com", TYPE, null, "2",
+                    null, "0", "Eve" };
+    static final String[] NICKNAME_NOT_CONTACTED = new String[] { "2", "Eves_Nickname_Bob" };
 
     static final String QUERYSTRING = "querystring";
 
@@ -61,7 +65,6 @@ public class RecipientLoaderTest {
             ContactsContract.Data.CONTACT_ID,
             ContactsContract.CommonDataKinds.Nickname.NAME
     };
-
 
 
     Context context;
@@ -205,12 +208,13 @@ public class RecipientLoaderTest {
             cursor.addRow(contact);
         }
         when(contentResolver
-                .query(eq( Email.CONTENT_URI),
+                .query(eq(Email.CONTENT_URI),
                         aryEq(PROJECTION),
                         any(String.class),
-                        aryEq(new String[] { id}),
+                        aryEq(new String[] { id }),
                         any(String.class))).thenReturn(cursor);
     }
+
     @Test
     public void queryContactProvider() throws Exception {
         RecipientLoader recipientLoader = new RecipientLoader(context, CRYPTO_PROVIDER, QUERYSTRING);

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
@@ -1,8 +1,6 @@
 package com.fsck.k9.activity.compose;
 
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import android.content.ContentResolver;
@@ -25,7 +23,6 @@ import static android.provider.ContactsContract.CommonDataKinds.Email.TYPE_HOME;
 import static org.junit.Assert.*;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,23 +40,19 @@ public class RecipientLoaderTest {
             ContactsContract.CommonDataKinds.Email.TYPE,
             ContactsContract.CommonDataKinds.Email.LABEL,
             ContactsContract.CommonDataKinds.Email.CONTACT_ID,
-            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
+            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
+            ContactsContract.CommonDataKinds.Email.TIMES_CONTACTED,
+            ContactsContract.Contacts.SORT_KEY_PRIMARY
     };
     static final String[] PROJECTION_CRYPTO_ADDRESSES = { "address", "uid_address" };
     static final String[] PROJECTION_CRYPTO_STATUS = { "address", "uid_key_status", "autocrypt_key_status" };
     static final Address CONTACT_ADDRESS_1 = Address.parse("Contact Name <address@example.org>")[0];
     static final Address CONTACT_ADDRESS_2 = Address.parse("Other Contact Name <address_two@example.org>")[0];
-    static final String[] CONTACT_1 = new String[] {"0", "Bob", "bob", "bob@host.com", ""+TYPE_HOME, null, "1", null};
-    static final String[] CONTACT_NO_EMAIL = new String[] {"0", "Bob", "bob", null, ""+TYPE_HOME, null, "1", null};
-
-    static final String CONTACT_ID_NOT_CONTACTED ="2";
-    static final String CONTACT_ID_CONTACTED ="3";
-    static final String[] CONTACT_WITH_NICKNAME_NOT_CONTACTED = new String[] {"0", "Eve_notContacted", "eve_notContacted", "eve_notContacted@host.com", ""+TYPE_HOME, null, CONTACT_ID_NOT_CONTACTED, null};
-    static final String[] CONTACT_WITH_NICKNAME_CONTACTED = new String[] {"0", "Jule", "jule", "jule@host.com", ""+TYPE_HOME, null, CONTACT_ID_CONTACTED, null};
-
-
-    static final String[] NICKNAME_NOT_CONTACTED = new String[]{CONTACT_ID_NOT_CONTACTED, "Eves_Nickname_Bob"};
-    static final String[] NICKNAME_CONTACTED = new String[]{CONTACT_ID_CONTACTED, "Jules_Nickname_Bob"};
+    static final String TYPE = ""+TYPE_HOME;
+    static final String[] CONTACT_1 = new String[] {"0", "Bob", "bob", "bob@host.com", TYPE, null, "1", null, "100", "Bob"};
+    static final String[] CONTACT_NO_EMAIL = new String[] {"0", "Bob", "bob", null, TYPE, null, "1", null, "10", "Bob_noMail"};
+    static final String[] CONTACT_WITH_NICKNAME_NOT_CONTACTED = new String[] {"0", "Eve_notContacted", "eve_notContacted", "eve_notContacted@host.com", TYPE, null, "2", null, "0", "Eve"};
+    static final String[] NICKNAME_NOT_CONTACTED = new String[]{"2", "Eves_Nickname_Bob"};
 
     static final String QUERYSTRING = "querystring";
 
@@ -179,20 +172,16 @@ public class RecipientLoaderTest {
                         any(String.class))).thenReturn(cursorCryptoStatus);
     }
 
-    private void setupContactProvider(String queriedAddress, List<String> additionalIds, String[]... contacts) {
+    private void setupContactProvider(String queriedAddress, String[]... contacts) {
         MatrixCursor cursor = new MatrixCursor(PROJECTION);
         for (String[] contact : contacts) {
             cursor.addRow(contact);
         }
-        List<String> parameters = new ArrayList<>();
-        parameters.add(queriedAddress);
-        parameters.add(queriedAddress);
-        parameters.addAll(additionalIds);
         when(contentResolver
                 .query(eq(Email.CONTENT_URI),
                         aryEq(PROJECTION),
                         any(String.class),
-                        aryEq(parameters.toArray(new String[parameters.size()])),
+                        aryEq(new String[] { queriedAddress, queriedAddress }),
                         any(String.class))).thenReturn(cursor);
     }
 
@@ -207,12 +196,27 @@ public class RecipientLoaderTest {
                         any(String.class),
                         any(String[].class),
                         any(String.class))).thenReturn(cursor);
+
+
     }
 
+
+    private void setupContactProviderForId(String id, String[]... contacts) {
+        MatrixCursor cursor = new MatrixCursor(PROJECTION);
+        for (String[] contact : contacts) {
+            cursor.addRow(contact);
+        }
+        when(contentResolver
+                .query(eq( Email.CONTENT_URI),
+                        aryEq(PROJECTION),
+                        any(String.class),
+                        aryEq(new String[] { id}),
+                        any(String.class))).thenReturn(cursor);
+    }
     @Test
     public void queryContactProvider() throws Exception {
         RecipientLoader recipientLoader = new RecipientLoader(context, CRYPTO_PROVIDER, QUERYSTRING);
-        setupContactProvider("%" + QUERYSTRING + "%", Collections.EMPTY_LIST, CONTACT_1);
+        setupContactProvider("%" + QUERYSTRING + "%", CONTACT_1);
 
         List<Recipient> recipients = recipientLoader.loadInBackground();
 
@@ -224,9 +228,7 @@ public class RecipientLoaderTest {
     @Test
     public void queryContactProvider_ignoresRecipientWithNoEmail() throws Exception {
         RecipientLoader recipientLoader = new RecipientLoader(context, CRYPTO_PROVIDER, QUERYSTRING);
-        List<String> additionalIds = new ArrayList<>();
-        additionalIds.add(CONTACT_ID_NOT_CONTACTED);
-        setupContactProvider("%" + QUERYSTRING + "%", additionalIds, CONTACT_NO_EMAIL);
+        setupContactProvider("%" + QUERYSTRING + "%", CONTACT_NO_EMAIL);
 
         List<Recipient> recipients = recipientLoader.loadInBackground();
 
@@ -240,32 +242,14 @@ public class RecipientLoaderTest {
     @Test
     public void queryContactProvider_sortByContactedForNickname() throws Exception {
         RecipientLoader recipientLoader = new RecipientLoader(context, null, QUERYSTRING);
-        List<String> additionalIds = new ArrayList<>();
-        additionalIds.add(CONTACT_ID_NOT_CONTACTED);
-        setupContactProvider("%" + QUERYSTRING + "%", additionalIds, CONTACT_1, CONTACT_WITH_NICKNAME_NOT_CONTACTED);
+        setupContactProvider("%" + QUERYSTRING + "%", CONTACT_1);
         setupNicknameContactProvider("%" + QUERYSTRING + "%", NICKNAME_NOT_CONTACTED);
+        setupContactProviderForId(NICKNAME_NOT_CONTACTED[0], CONTACT_WITH_NICKNAME_NOT_CONTACTED);
 
         List<Recipient> recipients = recipientLoader.loadInBackground();
 
         assertEquals(2, recipients.size());
         assertEquals("bob@host.com", recipients.get(0).address.getAddress());
         assertEquals("eve_notContacted@host.com", recipients.get(1).address.getAddress());
-    }
-
-    @Test
-    public void queryContactProvider_sortByContactedForNickname1() throws Exception {
-        RecipientLoader recipientLoader = new RecipientLoader(context, null, QUERYSTRING);
-        List<String> additionalIds = new ArrayList<>();
-        additionalIds.add(CONTACT_ID_NOT_CONTACTED);
-        additionalIds.add(CONTACT_ID_CONTACTED);
-        setupContactProvider("%" + QUERYSTRING + "%", additionalIds, CONTACT_1, CONTACT_WITH_NICKNAME_CONTACTED, CONTACT_WITH_NICKNAME_NOT_CONTACTED);
-        setupNicknameContactProvider("%" + QUERYSTRING + "%", NICKNAME_NOT_CONTACTED, NICKNAME_CONTACTED);
-
-        List<Recipient> recipients = recipientLoader.loadInBackground();
-
-        assertEquals(3, recipients.size());
-        assertEquals("bob@host.com", recipients.get(0).address.getAddress());
-        assertEquals("jule@host.com", recipients.get(1).address.getAddress());
-        assertEquals("eve_notContacted@host.com", recipients.get(2).address.getAddress());
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
@@ -1,8 +1,6 @@
 package com.fsck.k9.activity.compose;
 
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 import android.content.ContentResolver;
@@ -25,7 +23,6 @@ import static android.provider.ContactsContract.CommonDataKinds.Email.TYPE_HOME;
 import static org.junit.Assert.*;
 import static org.mockito.AdditionalMatchers.aryEq;
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -43,23 +40,19 @@ public class RecipientLoaderTest {
             ContactsContract.CommonDataKinds.Email.TYPE,
             ContactsContract.CommonDataKinds.Email.LABEL,
             ContactsContract.CommonDataKinds.Email.CONTACT_ID,
-            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI
+            ContactsContract.Contacts.PHOTO_THUMBNAIL_URI,
+            ContactsContract.CommonDataKinds.Email.TIMES_CONTACTED,
+            ContactsContract.Contacts.SORT_KEY_PRIMARY
     };
     static final String[] PROJECTION_CRYPTO_ADDRESSES = { "address", "uid_address" };
     static final String[] PROJECTION_CRYPTO_STATUS = { "address", "uid_key_status", "autocrypt_key_status" };
     static final Address CONTACT_ADDRESS_1 = Address.parse("Contact Name <address@example.org>")[0];
     static final Address CONTACT_ADDRESS_2 = Address.parse("Other Contact Name <address_two@example.org>")[0];
-    static final String[] CONTACT_1 = new String[] {"0", "Bob", "bob", "bob@host.com", ""+TYPE_HOME, null, "1", null};
-    static final String[] CONTACT_NO_EMAIL = new String[] {"0", "Bob", "bob", null, ""+TYPE_HOME, null, "1", null};
-
-    static final String CONTACT_ID_NOT_CONTACTED ="2";
-    static final String CONTACT_ID_CONTACTED ="3";
-    static final String[] CONTACT_WITH_NICKNAME_NOT_CONTACTED = new String[] {"0", "Eve_notContacted", "eve_notContacted", "eve_notContacted@host.com", ""+TYPE_HOME, null, CONTACT_ID_NOT_CONTACTED, null};
-    static final String[] CONTACT_WITH_NICKNAME_CONTACTED = new String[] {"0", "Jule", "jule", "jule@host.com", ""+TYPE_HOME, null, CONTACT_ID_CONTACTED, null};
-
-
-    static final String[] NICKNAME_NOT_CONTACTED = new String[]{CONTACT_ID_NOT_CONTACTED, "Eves_Nickname_Bob"};
-    static final String[] NICKNAME_CONTACTED = new String[]{CONTACT_ID_CONTACTED, "Jules_Nickname_Bob"};
+    static final String TYPE = ""+TYPE_HOME;
+    static final String[] CONTACT_1 = new String[] {"0", "Bob", "bob", "bob@host.com", TYPE, null, "1", null, "100", "Bob"};
+    static final String[] CONTACT_NO_EMAIL = new String[] {"0", "Bob", "bob", null, TYPE, null, "1", null, "10", "Bob_noMail"};
+    static final String[] CONTACT_WITH_NICKNAME_NOT_CONTACTED = new String[] {"0", "Eve_notContacted", "eve_notContacted", "eve_notContacted@host.com", TYPE, null, "2", null, "0", "Eve"};
+    static final String[] NICKNAME_NOT_CONTACTED = new String[]{"2", "Eves_Nickname_Bob"};
 
     static final String QUERYSTRING = "querystring";
 
@@ -179,20 +172,16 @@ public class RecipientLoaderTest {
                         any(String.class))).thenReturn(cursorCryptoStatus);
     }
 
-    private void setupContactProvider(String queriedAddress, List<String> additionalIds, String[]... contacts) {
+    private void setupContactProvider(String queriedAddress, String[]... contacts) {
         MatrixCursor cursor = new MatrixCursor(PROJECTION);
         for (String[] contact : contacts) {
             cursor.addRow(contact);
         }
-        List<String> parameters = new ArrayList<>();
-        parameters.add(queriedAddress);
-        parameters.add(queriedAddress);
-        parameters.addAll(additionalIds);
         when(contentResolver
                 .query(eq(Email.CONTENT_URI),
                         aryEq(PROJECTION),
                         any(String.class),
-                        aryEq(parameters.toArray(new String[parameters.size()])),
+                        aryEq(new String[] { queriedAddress, queriedAddress }),
                         any(String.class))).thenReturn(cursor);
     }
 
@@ -209,10 +198,23 @@ public class RecipientLoaderTest {
                         any(String.class))).thenReturn(cursor);
     }
 
+
+    private void setupContactProviderForId(String id, String[]... contacts) {
+        MatrixCursor cursor = new MatrixCursor(PROJECTION);
+        for (String[] contact : contacts) {
+            cursor.addRow(contact);
+        }
+        when(contentResolver
+                .query(eq( Email.CONTENT_URI),
+                        aryEq(PROJECTION),
+                        any(String.class),
+                        aryEq(new String[] { id}),
+                        any(String.class))).thenReturn(cursor);
+    }
     @Test
     public void queryContactProvider() throws Exception {
         RecipientLoader recipientLoader = new RecipientLoader(context, CRYPTO_PROVIDER, QUERYSTRING);
-        setupContactProvider("%" + QUERYSTRING + "%", Collections.EMPTY_LIST, CONTACT_1);
+        setupContactProvider("%" + QUERYSTRING + "%", CONTACT_1);
 
         List<Recipient> recipients = recipientLoader.loadInBackground();
 
@@ -224,9 +226,7 @@ public class RecipientLoaderTest {
     @Test
     public void queryContactProvider_ignoresRecipientWithNoEmail() throws Exception {
         RecipientLoader recipientLoader = new RecipientLoader(context, CRYPTO_PROVIDER, QUERYSTRING);
-        List<String> additionalIds = new ArrayList<>();
-        additionalIds.add(CONTACT_ID_NOT_CONTACTED);
-        setupContactProvider("%" + QUERYSTRING + "%", additionalIds, CONTACT_NO_EMAIL);
+        setupContactProvider("%" + QUERYSTRING + "%", CONTACT_NO_EMAIL);
 
         List<Recipient> recipients = recipientLoader.loadInBackground();
 
@@ -240,32 +240,14 @@ public class RecipientLoaderTest {
     @Test
     public void queryContactProvider_sortByContactedForNickname() throws Exception {
         RecipientLoader recipientLoader = new RecipientLoader(context, null, QUERYSTRING);
-        List<String> additionalIds = new ArrayList<>();
-        additionalIds.add(CONTACT_ID_NOT_CONTACTED);
-        setupContactProvider("%" + QUERYSTRING + "%", additionalIds, CONTACT_1, CONTACT_WITH_NICKNAME_NOT_CONTACTED);
+        setupContactProvider("%" + QUERYSTRING + "%", CONTACT_1);
         setupNicknameContactProvider("%" + QUERYSTRING + "%", NICKNAME_NOT_CONTACTED);
+        setupContactProviderForId(NICKNAME_NOT_CONTACTED[0], CONTACT_WITH_NICKNAME_NOT_CONTACTED);
 
         List<Recipient> recipients = recipientLoader.loadInBackground();
 
         assertEquals(2, recipients.size());
         assertEquals("bob@host.com", recipients.get(0).address.getAddress());
         assertEquals("eve_notContacted@host.com", recipients.get(1).address.getAddress());
-    }
-
-    @Test
-    public void queryContactProvider_sortByContactedForNickname1() throws Exception {
-        RecipientLoader recipientLoader = new RecipientLoader(context, null, QUERYSTRING);
-        List<String> additionalIds = new ArrayList<>();
-        additionalIds.add(CONTACT_ID_NOT_CONTACTED);
-        additionalIds.add(CONTACT_ID_CONTACTED);
-        setupContactProvider("%" + QUERYSTRING + "%", additionalIds, CONTACT_1, CONTACT_WITH_NICKNAME_CONTACTED, CONTACT_WITH_NICKNAME_NOT_CONTACTED);
-        setupNicknameContactProvider("%" + QUERYSTRING + "%", NICKNAME_NOT_CONTACTED, NICKNAME_CONTACTED);
-
-        List<Recipient> recipients = recipientLoader.loadInBackground();
-
-        assertEquals(3, recipients.size());
-        assertEquals("bob@host.com", recipients.get(0).address.getAddress());
-        assertEquals("jule@host.com", recipients.get(1).address.getAddress());
-        assertEquals("eve_notContacted@host.com", recipients.get(2).address.getAddress());
     }
 }


### PR DESCRIPTION
Fix for "Contact nicknames always on top #3178"

correct sort for contacts with Nickname (contacts with matching Nicknames were always at the top, ignoring times contacted), seems to be introduced with adding Nicknames

