### PR TITLE
Case sensitive folder name comparisons

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -1370,7 +1370,7 @@ class ImapFolder extends Folder<ImapMessage> {
     public boolean equals(Object other) {
         if (other instanceof ImapFolder) {
             ImapFolder otherFolder = (ImapFolder) other;
-            return otherFolder.getName().equalsIgnoreCase(getName());
+            return otherFolder.getName().equals(getName());
         }
 
         return super.equals(other);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -392,7 +392,7 @@ class ImapFolder extends Folder<ImapMessage> {
             return;
         }
 
-        if (trashFolderName == null || getName().equalsIgnoreCase(trashFolderName)) {
+        if (trashFolderName == null || getName().equals(trashFolderName)) {
             setFlags(messages, Collections.singleton(Flag.DELETED), true);
         } else {
             ImapFolder remoteTrashFolder = getStore().getFolder(trashFolderName);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -41,6 +41,7 @@ import static com.fsck.k9.mail.store.imap.ImapUtility.getLastResponse;
 
 
 class ImapFolder extends Folder<ImapMessage> {
+    static final String INBOX = "INBOX";
     private static final ThreadLocal<SimpleDateFormat> RFC3501_DATE = new ThreadLocal<SimpleDateFormat>() {
         @Override
         protected SimpleDateFormat initialValue() {
@@ -78,7 +79,7 @@ class ImapFolder extends Folder<ImapMessage> {
     private String getPrefixedName() throws MessagingException {
         String prefixedName = "";
 
-        if (!store.getStoreConfig().getInboxFolderName().equalsIgnoreCase(name)) {
+        if (!INBOX.equalsIgnoreCase(name)) {
             ImapConnection connection;
             synchronized (this) {
                 if (this.connection == null) {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -197,7 +197,7 @@ public class ImapStore extends RemoteStore {
                 combinedPrefix = null;
             }
 
-            if (folder.equalsIgnoreCase(mStoreConfig.getInboxFolderName())) {
+            if (ImapFolder.INBOX.equalsIgnoreCase(folder)) {
                 continue;
             } else if (folder.equals(mStoreConfig.getOutboxFolderName())) {
                 /*
@@ -216,12 +216,14 @@ public class ImapStore extends RemoteStore {
             }
         }
 
-        folderNames.add(mStoreConfig.getInboxFolderName());
+        folderNames.add(ImapFolder.INBOX);
 
         return folderNames;
     }
 
     void autoconfigureFolders(final ImapConnection connection) throws IOException, MessagingException {
+        mStoreConfig.setInboxFolderName(ImapFolder.INBOX);
+
         if (!connection.hasCapability(Capabilities.SPECIAL_USE)) {
             if (K9MailLib.isDebug()) {
                 Timber.d("No detected folder auto-configuration methods.");

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
@@ -31,6 +31,9 @@ import static com.fsck.k9.mail.store.pop3.Pop3Commands.*;
  * POP3 only supports one folder, "Inbox". So the folder name is the ID here.
  */
 class Pop3Folder extends Folder<Pop3Message> {
+    static final String INBOX = "INBOX";
+
+
     private Pop3Store pop3Store;
     private Map<String, Pop3Message> uidToMsgMap = new HashMap<>();
     @SuppressLint("UseSparseArrays")
@@ -44,10 +47,6 @@ class Pop3Folder extends Folder<Pop3Message> {
         super();
         this.pop3Store = pop3Store;
         this.name = name;
-
-        if (this.name.equalsIgnoreCase(pop3Store.getConfig().getInboxFolderName())) {
-            this.name = pop3Store.getConfig().getInboxFolderName();
-        }
     }
 
     @Override
@@ -56,7 +55,7 @@ class Pop3Folder extends Folder<Pop3Message> {
             return;
         }
 
-        if (!name.equalsIgnoreCase(pop3Store.getConfig().getInboxFolderName())) {
+        if (!INBOX.equals(name)) {
             throw new MessagingException("Folder does not exist");
         }
 
@@ -113,7 +112,7 @@ class Pop3Folder extends Folder<Pop3Message> {
 
     @Override
     public boolean exists() throws MessagingException {
-        return name.equalsIgnoreCase(pop3Store.getConfig().getInboxFolderName());
+        return INBOX.equals(name);
     }
 
     @Override

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -201,13 +201,15 @@ public class Pop3Store extends RemoteStore {
     @Override
     public List<Pop3Folder> getPersonalNamespaces(boolean forceListAll) throws MessagingException {
         List<Pop3Folder> folders = new LinkedList<>();
-        folders.add(getFolder(mStoreConfig.getInboxFolderName()));
+        folders.add(getFolder(Pop3Folder.INBOX));
         return folders;
     }
 
     @Override
     public void checkSettings() throws MessagingException {
-        Pop3Folder folder = new Pop3Folder(this, mStoreConfig.getInboxFolderName());
+        mStoreConfig.setInboxFolderName(Pop3Folder.INBOX);
+
+        Pop3Folder folder = new Pop3Folder(this, Pop3Folder.INBOX);
         try {
             folder.open(Folder.OPEN_MODE_RW);
             folder.requestUidl();

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3FolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3FolderTest.java
@@ -6,8 +6,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.List;
 
 import com.fsck.k9.mail.FetchProfile;
@@ -49,10 +47,10 @@ public class Pop3FolderTest {
         mockStoreConfig = mock(StoreConfig.class);
         mockListener = mock(MessageRetrievalListener.class);
         when(mockStore.getConfig()).thenReturn(mockStoreConfig);
-        when(mockStoreConfig.getInboxFolderName()).thenReturn("Inbox");
+        when(mockStoreConfig.getInboxFolderName()).thenReturn(Pop3Folder.INBOX);
         when(mockStore.createConnection()).thenReturn(mockConnection);
         when(mockConnection.executeSimpleCommand(Pop3Commands.STAT_COMMAND)).thenReturn("+OK 10 0");
-        folder = new Pop3Folder(mockStore, "Inbox");
+        folder = new Pop3Folder(mockStore, Pop3Folder.INBOX);
         BinaryTempFileBody.setTempDirectory(new File(System.getProperty("java.io.tmpdir")));
     }
 

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3StoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3StoreTest.java
@@ -66,7 +66,7 @@ public class Pop3StoreTest {
     public void setUp() throws Exception {
         //Using a SSL socket allows us to mock it
         when(mockStoreConfig.getStoreUri()).thenReturn("pop3+ssl+://PLAIN:user:password@server:12345");
-        when(mockStoreConfig.getInboxFolderName()).thenReturn("Inbox");
+        when(mockStoreConfig.getInboxFolderName()).thenReturn(Pop3Folder.INBOX);
         when(mockTrustedSocketFactory.createSocket(null, "server", 12345, null)).thenReturn(mockSocket);
         when(mockSocket.isConnected()).thenReturn(true);
         when(mockSocket.isClosed()).thenReturn(false);
@@ -187,7 +187,7 @@ public class Pop3StoreTest {
         List<Pop3Folder> folders = store.getPersonalNamespaces(true);
 
         assertEquals(1, folders.size());
-        assertEquals("Inbox", folders.get(0).getName());
+        assertEquals("INBOX", folders.get(0).getName());
     }
 
     @Test
@@ -247,7 +247,7 @@ public class Pop3StoreTest {
         when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(response.getBytes("UTF-8")));
         ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
         when(mockSocket.getOutputStream()).thenReturn(byteArrayOutputStream);
-        Pop3Folder folder = store.getFolder("Inbox");
+        Pop3Folder folder = store.getFolder(Pop3Folder.INBOX);
 
         folder.open(Folder.OPEN_MODE_RW);
 
@@ -262,7 +262,7 @@ public class Pop3StoreTest {
                 CAPA_RESPONSE +
                 AUTH_PLAIN_FAILED_RESPONSE;
         when(mockSocket.getInputStream()).thenReturn(new ByteArrayInputStream(response.getBytes("UTF-8")));
-        Pop3Folder folder = store.getFolder("Inbox");
+        Pop3Folder folder = store.getFolder(Pop3Folder.INBOX);
 
         folder.open(Folder.OPEN_MODE_RW);
     }

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -1075,7 +1075,7 @@ public class Account implements BaseAccount, StoreConfig {
     }
 
     public boolean isSpecialFolder(String folderName) {
-        return (folderName != null && (folderName.equalsIgnoreCase(getInboxFolderName()) ||
+        return (folderName != null && (folderName.equals(getInboxFolderName()) ||
                 folderName.equals(getTrashFolderName()) ||
                 folderName.equals(getDraftsFolderName()) ||
                 folderName.equals(getArchiveFolderName()) ||
@@ -1097,7 +1097,7 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has a drafts folder set.
      */
     public synchronized boolean hasDraftsFolder() {
-        return !K9.FOLDER_NONE.equalsIgnoreCase(draftsFolderName);
+        return !K9.FOLDER_NONE.equals(draftsFolderName);
     }
 
     public synchronized String getSentFolderName() {
@@ -1113,7 +1113,7 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has a sent folder set.
      */
     public synchronized boolean hasSentFolder() {
-        return !K9.FOLDER_NONE.equalsIgnoreCase(sentFolderName);
+        return !K9.FOLDER_NONE.equals(sentFolderName);
     }
 
 
@@ -1130,7 +1130,7 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has a trash folder set.
      */
     public synchronized boolean hasTrashFolder() {
-        return !K9.FOLDER_NONE.equalsIgnoreCase(trashFolderName);
+        return !K9.FOLDER_NONE.equals(trashFolderName);
     }
 
     public synchronized String getArchiveFolderName() {
@@ -1146,7 +1146,7 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has an archive folder set.
      */
     public synchronized boolean hasArchiveFolder() {
-        return !K9.FOLDER_NONE.equalsIgnoreCase(archiveFolderName);
+        return !K9.FOLDER_NONE.equals(archiveFolderName);
     }
 
     public synchronized String getSpamFolderName() {
@@ -1162,7 +1162,7 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has a spam folder set.
      */
     public synchronized boolean hasSpamFolder() {
-        return !K9.FOLDER_NONE.equalsIgnoreCase(spamFolderName);
+        return !K9.FOLDER_NONE.equals(spamFolderName);
     }
 
     public synchronized String getOutboxFolderName() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -85,9 +85,9 @@ public class ActivityListener extends SimpleMessagingListener {
             }
 
             if (account != null) {
-                if (displayName.equalsIgnoreCase(account.getInboxFolderName())) {
+                if (displayName.equals(account.getInboxFolderName())) {
                     displayName = context.getString(R.string.special_mailbox_name_inbox);
-                } else if (displayName.equalsIgnoreCase(account.getOutboxFolderName())) {
+                } else if (displayName.equals(account.getOutboxFolderName())) {
                     displayName = context.getString(R.string.special_mailbox_name_outbox);
                 }
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -279,10 +279,7 @@ public class ChooseFolder extends K9ListActivity {
             for (Folder folder : folders) {
                 String name = folder.getName();
 
-                // Inbox needs to be compared case-insensitively
-                if (mHideCurrentFolder && (name.equals(mFolder) || (
-                        mAccount.getInboxFolderName().equalsIgnoreCase(mFolder) &&
-                        mAccount.getInboxFolderName().equalsIgnoreCase(name)))) {
+                if (mHideCurrentFolder && name.equals(mFolder)) {
                     continue;
                 }
                 Folder.FolderClass fMode = folder.getDisplayClass();
@@ -335,7 +332,7 @@ public class ChooseFolder extends K9ListActivity {
             try {
                 int position = 0;
                 for (String name : localFolders) {
-                    if (mAccount.getInboxFolderName().equalsIgnoreCase(name)) {
+                    if (mAccount.getInboxFolderName().equals(name)) {
                         folderList.add(getString(R.string.special_mailbox_name_inbox));
                         mHeldInbox = name;
                     } else if (!account.getOutboxFolderName().equals(name)) {
@@ -351,9 +348,7 @@ public class ChooseFolder extends K9ListActivity {
                         if (name.equals(mSelectFolder)) {
                             selectedFolder = position;
                         }
-                    } else if (name.equals(mFolder) || (
-                            mAccount.getInboxFolderName().equalsIgnoreCase(mFolder) &&
-                            mAccount.getInboxFolderName().equalsIgnoreCase(name))) {
+                    } else if (name.equals(mFolder)) {
                         selectedFolder = position;
                     }
                     position++;

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
@@ -121,8 +121,7 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
                     context.getString(R.string.special_mailbox_name_drafts_fmt), name);
         } else if (name.equals(account.getOutboxFolderName())) {
             displayName = context.getString(R.string.special_mailbox_name_outbox);
-        // FIXME: We really shouldn't do a case-insensitive comparison here
-        } else if (name.equalsIgnoreCase(account.getInboxFolderName())) {
+        } else if (name.equals(account.getInboxFolderName())) {
             displayName = context.getString(R.string.special_mailbox_name_inbox);
         } else {
             displayName = name;

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -989,7 +989,7 @@ public class AccountSettings extends K9PreferenceActivity {
     }
 
     private String translateFolder(String in) {
-        if (account.getInboxFolderName().equalsIgnoreCase(in)) {
+        if (account.getInboxFolderName().equals(in)) {
             return getString(R.string.special_mailbox_name_inbox);
         } else {
             return in;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -917,7 +917,7 @@ public class LocalStore extends Store {
                     if (account.isSpecialFolder(name)) {
                         prefHolder.inTopGroup = true;
                         prefHolder.displayClass = LocalFolder.FolderClass.FIRST_CLASS;
-                        if (name.equalsIgnoreCase(account.getInboxFolderName())) {
+                        if (name.equals(account.getInboxFolderName())) {
                             prefHolder.integrate = true;
                             prefHolder.notifyClass = LocalFolder.FolderClass.FIRST_CLASS;
                             prefHolder.pushClass = LocalFolder.FolderClass.FIRST_CLASS;
@@ -925,8 +925,7 @@ public class LocalStore extends Store {
                             prefHolder.pushClass = LocalFolder.FolderClass.INHERITED;
 
                         }
-                        if (name.equalsIgnoreCase(account.getInboxFolderName()) ||
-                                name.equalsIgnoreCase(account.getDraftsFolderName())) {
+                        if (name.equals(account.getInboxFolderName()) || name.equals(account.getDraftsFolderName())) {
                             prefHolder.syncClass = LocalFolder.FolderClass.FIRST_CLASS;
                         } else {
                             prefHolder.syncClass = LocalFolder.FolderClass.NO_CLASS;

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionService.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionService.java
@@ -233,7 +233,7 @@ public class NotificationActionService extends CoreService {
 
     private boolean isMovePossible(MessagingController controller, Account account,
             String destinationFolderName) {
-        boolean isSpecialFolderConfigured = !K9.FOLDER_NONE.equalsIgnoreCase(destinationFolderName);
+        boolean isSpecialFolderConfigured = !K9.FOLDER_NONE.equals(destinationFolderName);
 
         return isSpecialFolderConfigured && controller.isMoveCapable(account);
     }

--- a/k9mail/src/main/java/com/fsck/k9/notification/WearNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/WearNotifications.java
@@ -240,7 +240,7 @@ class WearNotifications extends BaseNotifications {
     }
 
     private boolean isMovePossible(Account account, String destinationFolderName) {
-        if (K9.FOLDER_NONE.equalsIgnoreCase(destinationFolderName)) {
+        if (K9.FOLDER_NONE.equals(destinationFolderName)) {
             return false;
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -301,7 +301,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
             return;
         }
 
-        if (K9.FOLDER_NONE.equalsIgnoreCase(dstFolder)) {
+        if (K9.FOLDER_NONE.equals(dstFolder)) {
             return;
         }
 


### PR DESCRIPTION
This makes all folder name comparisons outside of the IMAP classes case sensitive.

Luckily, we have always used "INBOX" as Inbox folder name for POP3 and IMAP. So there's no need for a database migration fixing up the folders table.

Fixes #632


