### PR TITLE
add learn more to autocrypt mutual dialog

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/dialog/AutocryptPreferEncryptDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/dialog/AutocryptPreferEncryptDialog.java
@@ -35,6 +35,9 @@ public class AutocryptPreferEncryptDialog extends AlertDialog implements OnClick
         @SuppressLint("InflateParams")
         View contentView = inflater.inflate(R.layout.dialog_autocrypt_prefer_encrypt, null);
 
+        TextView learnMoreText = (TextView) contentView.findViewById(R.id.prefer_encrypt_learn_more);
+        makeTextViewLinksClickable(learnMoreText);
+
         preferEncryptCheckbox = (CheckBox) contentView.findViewById(R.id.prefer_encrypt_check);
         preferEncryptCheckbox.setChecked(preferEncryptEnabled);
 
@@ -65,5 +68,9 @@ public class AutocryptPreferEncryptDialog extends AlertDialog implements OnClick
 
     public interface OnPreferEncryptChangedListener {
         void onPreferEncryptChanged(boolean enabled);
+    }
+
+    private void makeTextViewLinksClickable(TextView textView) {
+        textView.setMovementMethod(LinkMovementMethod.getInstance());
     }
 }

--- a/k9mail/src/main/res/layout/dialog_autocrypt_prefer_encrypt.xml
+++ b/k9mail/src/main/res/layout/dialog_autocrypt_prefer_encrypt.xml
@@ -28,7 +28,6 @@
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="12dp"
             android:paddingLeft="24dp"
             android:paddingRight="24dp"
             android:gravity="center_vertical"
@@ -51,6 +50,15 @@
                 />
 
         </LinearLayout>
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginLeft="24dp"
+            android:layout_marginRight="24dp"
+            android:layout_marginBottom="20dp"
+            android:id="@+id/prefer_encrypt_learn_more"
+            android:text="@string/dialog_autocrypt_mutual_learn_more" />
 
     </LinearLayout>
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1289,4 +1289,5 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="dialog_autocrypt_mutual_title">Autocrypt mutual mode</string>
     <string name="dialog_autocrypt_mutual_description_1">Messages will normally be encrypted by choice, or when replying to an encrypted message.</string>
     <string name="dialog_autocrypt_mutual_description_2">If both sender and recipients enable mutual mode, encryption will be enabled by default.</string>
+    <string name="dialog_autocrypt_mutual_learn_more">You can <a href="https://k9mail.github.io/2018/02/26/OpenPGP-Considerations-Part-III-Autocrypt.html">click here</a> to learn more.</string>
 </resources>


### PR DESCRIPTION
Adding a link to the [autocrypt/mutual](https://k9mail.github.io/2018/02/26/OpenPGP-Considerations-Part-III-Autocrypt.html) blog post from the prefer-encrypt=mutual dialog.

Unfortunately, I'm not sure if and how we could localize this...