### PR TITLE
Change ChooseFolder to not perform a display name to folder name lookup

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -282,6 +282,10 @@ public class ChooseFolder extends K9ListActivity {
                 if (mHideCurrentFolder && name.equals(mFolder)) {
                     continue;
                 }
+                if (account.getOutboxFolderName().equals(name)) {
+                    continue;
+                }
+
                 Folder.FolderClass fMode = folder.getDisplayClass();
 
                 if ((aMode == FolderMode.FIRST_CLASS &&
@@ -335,7 +339,7 @@ public class ChooseFolder extends K9ListActivity {
                     if (mAccount.getInboxFolderName().equals(name)) {
                         folderList.add(getString(R.string.special_mailbox_name_inbox));
                         mHeldInbox = name;
-                    } else if (!account.getOutboxFolderName().equals(name)) {
+                    } else {
                         folderList.add(name);
                     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -298,6 +298,11 @@ public class ChooseFolder extends K9ListActivity {
                     continue;
                 }
 
+                if (account.getInboxFolderName().equals(name)) {
+                    mHeldInbox = name;
+                    name = getString(R.string.special_mailbox_name_inbox);
+                }
+
                 if (folder.isInTopGroup()) {
                     topFolders.add(name);
                 } else {
@@ -316,15 +321,15 @@ public class ChooseFolder extends K9ListActivity {
             Collections.sort(topFolders, comparator);
             Collections.sort(newFolders, comparator);
 
-            List<String> localFolders = new ArrayList<String>(newFolders.size() +
+            final List<String> folderList = new ArrayList<String>(newFolders.size() +
                     topFolders.size() + ((mShowOptionNone) ? 1 : 0));
 
             if (mShowOptionNone) {
-                localFolders.add(K9.FOLDER_NONE);
+                folderList.add(K9.FOLDER_NONE);
             }
 
-            localFolders.addAll(topFolders);
-            localFolders.addAll(newFolders);
+            folderList.addAll(topFolders);
+            folderList.addAll(newFolders);
 
             int selectedFolder = -1;
 
@@ -332,17 +337,9 @@ public class ChooseFolder extends K9ListActivity {
              * We're not allowed to change the adapter from a background thread, so we collect the
              * folder names and update the adapter in the UI thread (see finally block).
              */
-            final List<String> folderList = new ArrayList<String>();
             try {
                 int position = 0;
-                for (String name : localFolders) {
-                    if (mAccount.getInboxFolderName().equals(name)) {
-                        folderList.add(getString(R.string.special_mailbox_name_inbox));
-                        mHeldInbox = name;
-                    } else {
-                        folderList.add(name);
-                    }
-
+                for (String name : folderList) {
                     if (mSelectFolder != null) {
                         /*
                          * Never select EXTRA_CUR_FOLDER (mFolder) if EXTRA_SEL_FOLDER
@@ -351,9 +348,11 @@ public class ChooseFolder extends K9ListActivity {
 
                         if (name.equals(mSelectFolder)) {
                             selectedFolder = position;
+                            break;
                         }
                     } else if (name.equals(mFolder)) {
                         selectedFolder = position;
+                        break;
                     }
                     position++;
                 }


### PR DESCRIPTION
`ChooseFolder` displays the Inbox using a localized string. Previously when the user clicked an item we read the display text from the `TextView`, compared that to the localized display name and replaced it with the "real" Inbox name when they match. Otherwise the text from the `TextView` is used directly.

I introduced the class `FolderDisplayData` that holds both the folder display name and the "internal" folder name. That allowed me to get rid of the display name to folder name mapping.
