### PR TITLE
Add server_id column to folders table

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
@@ -99,10 +99,10 @@ public abstract class Folder<T extends Message> {
         return null;
     }
 
-    public void delete(List<? extends Message> msgs, String trashFolderName) throws MessagingException {
+    public void delete(List<? extends Message> msgs, String trashFolder) throws MessagingException {
         for (Message message : msgs) {
             Message myMessage = getMessage(message.getUid());
-            myMessage.delete(trashFolderName);
+            myMessage.delete(trashFolder);
         }
     }
 
@@ -140,7 +140,7 @@ public abstract class Folder<T extends Message> {
 
     public abstract void delete(boolean recurse) throws MessagingException;
 
-    public abstract String getName();
+    public abstract String getServerId();
 
     /**
      * @param oldPushState
@@ -161,7 +161,7 @@ public abstract class Folder<T extends Message> {
 
     @Override
     public String toString() {
-        return getName();
+        return getServerId();
     }
 
     public long getLastChecked() {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Folder.java
@@ -142,6 +142,8 @@ public abstract class Folder<T extends Message> {
 
     public abstract String getServerId();
 
+    public abstract String getName();
+
     /**
      * @param oldPushState
      * @param message

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Message.java
@@ -49,7 +49,7 @@ public abstract class Message implements Part, Body {
         }
         Message other = (Message)o;
         return (getUid().equals(other.getUid())
-                && getFolder().getName().equals(other.getFolder().getName()));
+                && getFolder().getServerId().equals(other.getFolder().getServerId()));
     }
 
     @Override
@@ -57,7 +57,7 @@ public abstract class Message implements Part, Body {
         final int MULTIPLIER = 31;
 
         int result = 1;
-        result = MULTIPLIER * result + (mFolder != null ? mFolder.getName().hashCode() : 0);
+        result = MULTIPLIER * result + (mFolder != null ? mFolder.getServerId().hashCode() : 0);
         result = MULTIPLIER * result + mUid.hashCode();
         return result;
     }
@@ -148,7 +148,7 @@ public abstract class Message implements Part, Body {
 
     public abstract long getSize();
 
-    public void delete(String trashFolderName) throws MessagingException {}
+    public void delete(String trashFolder) throws MessagingException {}
 
     /*
      * TODO Refactor Flags at some point to be able to store user defined flags.

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/PushReceiver.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/PushReceiver.java
@@ -12,9 +12,9 @@ public interface PushReceiver {
     void messagesArrived(Folder folder, List<Message> mess);
     void messagesFlagsChanged(Folder folder, List<Message> mess);
     void messagesRemoved(Folder folder, List<Message> mess);
-    String getPushState(String folderName);
+    String getPushState(String folderServerId);
     void pushError(String errorMessage, Exception e);
     void authenticationFailed();
-    void setPushActive(String folderName, boolean enabled);
+    void setPushActive(String folderServerId, boolean enabled);
     void sleep(TracingWakeLock wakeLock, long millis);
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Pusher.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Pusher.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 
 public interface Pusher {
-    public void start(List<String> folderNames);
+    public void start(List<String> folderServerIds);
     public void refresh();
     public void stop();
     /**

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
@@ -10,17 +10,17 @@ public interface StoreConfig {
     boolean subscribedFoldersOnly();
     boolean useCompression(NetworkType type);
 
-    String getInboxFolderName();
-    String getOutboxFolderName();
-    String getDraftsFolderName();
+    String getInboxFolder();
+    String getOutboxFolder();
+    String getDraftsFolder();
 
-    void setArchiveFolderName(String name);
-    void setDraftsFolderName(String name);
-    void setTrashFolderName(String name);
-    void setSpamFolderName(String name);
-    void setSentFolderName(String name);
-    void setAutoExpandFolderName(String name);
-    void setInboxFolderName(String name);
+    void setArchiveFolder(String name);
+    void setDraftsFolder(String name);
+    void setTrashFolder(String name);
+    void setSpamFolder(String name);
+    void setSentFolder(String name);
+    void setAutoExpandFolder(String name);
+    void setInboxFolder(String name);
 
     int getMaximumAutoDownloadMessageSize();
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -228,6 +228,11 @@ class ImapFolder extends Folder<ImapMessage> {
         return name;
     }
 
+    @Override
+    public String getName() {
+        return name;
+    }
+
     private boolean exists(String escapedFolderName) throws MessagingException {
         try {
             // Since we don't care about RECENT, we'll use that for the check, because we're checking

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapMessage.java
@@ -30,7 +30,7 @@ class ImapMessage extends MimeMessage {
     }
 
     @Override
-    public void delete(String trashFolderName) throws MessagingException {
-        getFolder().delete(Collections.singletonList(this), trashFolderName);
+    public void delete(String trashFolder) throws MessagingException {
+        getFolder().delete(Collections.singletonList(this), trashFolder);
     }
 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapPusher.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapPusher.java
@@ -25,13 +25,13 @@ class ImapPusher implements Pusher {
     }
 
     @Override
-    public void start(List<String> folderNames) {
+    public void start(List<String> folderServerIds) {
         synchronized (folderPushers) {
             stop();
 
             setLastRefresh(currentTimeMillis());
 
-            for (String folderName : folderNames) {
+            for (String folderName : folderServerIds) {
                 ImapFolderPusher pusher = createImapFolderPusher(folderName);
                 folderPushers.add(pusher);
 
@@ -47,7 +47,7 @@ class ImapPusher implements Pusher {
                 try {
                     folderPusher.refresh();
                 } catch (Exception e) {
-                    Timber.e(e, "Got exception while refreshing for %s", folderPusher.getName());
+                    Timber.e(e, "Got exception while refreshing for %s", folderPusher.getServerId());
                 }
             }
         }
@@ -63,12 +63,12 @@ class ImapPusher implements Pusher {
             for (ImapFolderPusher folderPusher : folderPushers) {
                 try {
                     if (K9MailLib.isDebug()) {
-                        Timber.i("Requesting stop of IMAP folderPusher %s", folderPusher.getName());
+                        Timber.i("Requesting stop of IMAP folderPusher %s", folderPusher.getServerId());
                     }
 
                     folderPusher.stop();
                 } catch (Exception e) {
-                    Timber.e(e, "Got exception while stopping %s", folderPusher.getName());
+                    Timber.e(e, "Got exception while stopping %s", folderPusher.getServerId());
                 }
             }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -199,7 +199,7 @@ public class ImapStore extends RemoteStore {
 
             if (ImapFolder.INBOX.equalsIgnoreCase(folder)) {
                 continue;
-            } else if (folder.equals(mStoreConfig.getOutboxFolderName())) {
+            } else if (folder.equals(mStoreConfig.getOutboxFolder())) {
                 /*
                  * There is a folder on the server with the same name as our local
                  * outbox. Until we have a good plan to deal with this situation
@@ -222,7 +222,7 @@ public class ImapStore extends RemoteStore {
     }
 
     void autoconfigureFolders(final ImapConnection connection) throws IOException, MessagingException {
-        mStoreConfig.setInboxFolderName(ImapFolder.INBOX);
+        mStoreConfig.setInboxFolder(ImapFolder.INBOX);
 
         if (!connection.hasCapability(Capabilities.SPECIAL_USE)) {
             if (K9MailLib.isDebug()) {
@@ -262,27 +262,27 @@ public class ImapStore extends RemoteStore {
             }
 
             if (listResponse.hasAttribute("\\Archive") || listResponse.hasAttribute("\\All")) {
-                mStoreConfig.setArchiveFolderName(decodedFolderName);
+                mStoreConfig.setArchiveFolder(decodedFolderName);
                 if (K9MailLib.isDebug()) {
                     Timber.d("Folder auto-configuration detected Archive folder: %s", decodedFolderName);
                 }
             } else if (listResponse.hasAttribute("\\Drafts")) {
-                mStoreConfig.setDraftsFolderName(decodedFolderName);
+                mStoreConfig.setDraftsFolder(decodedFolderName);
                 if (K9MailLib.isDebug()) {
                     Timber.d("Folder auto-configuration detected Drafts folder: %s", decodedFolderName);
                 }
             } else if (listResponse.hasAttribute("\\Sent")) {
-                mStoreConfig.setSentFolderName(decodedFolderName);
+                mStoreConfig.setSentFolder(decodedFolderName);
                 if (K9MailLib.isDebug()) {
                     Timber.d("Folder auto-configuration detected Sent folder: %s", decodedFolderName);
                 }
             } else if (listResponse.hasAttribute("\\Junk")) {
-                mStoreConfig.setSpamFolderName(decodedFolderName);
+                mStoreConfig.setSpamFolder(decodedFolderName);
                 if (K9MailLib.isDebug()) {
                     Timber.d("Folder auto-configuration detected Spam folder: %s", decodedFolderName);
                 }
             } else if (listResponse.hasAttribute("\\Trash")) {
-                mStoreConfig.setTrashFolderName(decodedFolderName);
+                mStoreConfig.setTrashFolder(decodedFolderName);
                 if (K9MailLib.isDebug()) {
                     Timber.d("Folder auto-configuration detected Trash folder: %s", decodedFolderName);
                 }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
@@ -106,6 +106,11 @@ class Pop3Folder extends Folder<Pop3Message> {
     }
 
     @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
     public boolean create(FolderType type) throws MessagingException {
         return false;
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Folder.java
@@ -101,7 +101,7 @@ class Pop3Folder extends Folder<Pop3Message> {
     }
 
     @Override
-    public String getName() {
+    public String getServerId() {
         return name;
     }
 
@@ -523,7 +523,7 @@ class Pop3Folder extends Folder<Pop3Message> {
     }
 
     @Override
-    public void delete(List<? extends Message> msgs, String trashFolderName) throws MessagingException {
+    public void delete(List<? extends Message> msgs, String trashFolder) throws MessagingException {
         setFlags(msgs, Collections.singleton(Flag.DELETED), true);
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Message.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Message.java
@@ -26,7 +26,7 @@ class Pop3Message extends MimeMessage {
     }
 
     @Override
-    public void delete(String trashFolderName) throws MessagingException {
+    public void delete(String trashFolder) throws MessagingException {
         //  try
         //  {
         //  Poor POP3 users, we can't copy the message to the Trash folder, but they still want a delete

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -207,7 +207,7 @@ public class Pop3Store extends RemoteStore {
 
     @Override
     public void checkSettings() throws MessagingException {
-        mStoreConfig.setInboxFolderName(Pop3Folder.INBOX);
+        mStoreConfig.setInboxFolder(Pop3Folder.INBOX);
 
         Pop3Folder folder = new Pop3Folder(this, Pop3Folder.INBOX);
         try {

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -193,7 +193,7 @@ public class Pop3Store extends RemoteStore {
         Pop3Folder folder = mFolders.get(name);
         if (folder == null) {
             folder = new Pop3Folder(this, name);
-            mFolders.put(folder.getName(), folder);
+            mFolders.put(folder.getServerId(), folder);
         }
         return folder;
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -200,6 +200,11 @@ class WebDavFolder extends Folder<WebDavMessage> {
     }
 
     @Override
+    public String getName() {
+        return this.mName;
+    }
+
+    @Override
     public boolean exists() {
         return true;
     }

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -94,19 +94,19 @@ class WebDavFolder extends Folder<WebDavMessage> {
 
     @Override
     public Map<String, String> copyMessages(List<? extends Message> messages, Folder folder) throws MessagingException {
-        moveOrCopyMessages(messages, folder.getName(), false);
+        moveOrCopyMessages(messages, folder.getServerId(), false);
         return null;
     }
 
     @Override
     public Map<String, String> moveMessages(List<? extends Message> messages, Folder folder) throws MessagingException {
-        moveOrCopyMessages(messages, folder.getName(), true);
+        moveOrCopyMessages(messages, folder.getServerId(), true);
         return null;
     }
 
     @Override
-    public void delete(List<? extends Message> msgs, String trashFolderName) throws MessagingException {
-        moveOrCopyMessages(msgs, trashFolderName, true);
+    public void delete(List<? extends Message> msgs, String trashFolder) throws MessagingException {
+        moveOrCopyMessages(msgs, trashFolder, true);
     }
 
     private void moveOrCopyMessages(List<? extends Message> messages, String folderName, boolean isMove)
@@ -195,7 +195,7 @@ class WebDavFolder extends Folder<WebDavMessage> {
     }
 
     @Override
-    public String getName() {
+    public String getServerId() {
         return this.mName;
     }
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavMessage.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavMessage.java
@@ -96,10 +96,10 @@ class WebDavMessage extends MimeMessage {
     }
 
     @Override
-    public void delete(String trashFolderName) throws MessagingException {
+    public void delete(String trashFolder) throws MessagingException {
         WebDavFolder wdFolder = (WebDavFolder) getFolder();
-        Timber.i("Deleting message by moving to %s", trashFolderName);
-        wdFolder.moveMessages(Collections.singletonList(this), wdFolder.getStore().getFolder(trashFolderName));
+        Timber.i("Deleting message by moving to %s", trashFolder);
+        wdFolder.moveMessages(Collections.singletonList(this), wdFolder.getStore().getFolder(trashFolder));
     }
 
     @Override

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -190,23 +190,23 @@ public class WebDavStore extends RemoteStore {
         Map<String, String> specialFoldersMap = dataset.getSpecialFolderToUrl();
         String folderName = getFolderName(specialFoldersMap.get(WebDavConstants.DAV_MAIL_INBOX_FOLDER));
         if (folderName != null) {
-            mStoreConfig.setAutoExpandFolderName(folderName);
-            mStoreConfig.setInboxFolderName(folderName);
+            mStoreConfig.setAutoExpandFolder(folderName);
+            mStoreConfig.setInboxFolder(folderName);
         }
 
         folderName = getFolderName(specialFoldersMap.get(WebDavConstants.DAV_MAIL_DRAFTS_FOLDER));
         if (folderName != null) {
-            mStoreConfig.setDraftsFolderName(folderName);
+            mStoreConfig.setDraftsFolder(folderName);
         }
 
         folderName = getFolderName(specialFoldersMap.get(WebDavConstants.DAV_MAIL_TRASH_FOLDER));
         if (folderName != null) {
-            mStoreConfig.setTrashFolderName(folderName);
+            mStoreConfig.setTrashFolder(folderName);
         }
 
         folderName = getFolderName(specialFoldersMap.get(WebDavConstants.DAV_MAIL_SPAM_FOLDER));
         if (folderName != null) {
-            mStoreConfig.setSpamFolderName(folderName);
+            mStoreConfig.setSpamFolder(folderName);
         }
 
         // K-9 Mail's outbox is a special local folder and different from Exchange/WebDAV's outbox.
@@ -218,7 +218,7 @@ public class WebDavStore extends RemoteStore {
 
         folderName = getFolderName(specialFoldersMap.get(WebDavConstants.DAV_MAIL_SENT_FOLDER));
         if (folderName != null) {
-            mStoreConfig.setSentFolderName(folderName);
+            mStoreConfig.setSentFolder(folderName);
         }
 
         /*
@@ -978,7 +978,7 @@ public class WebDavStore extends RemoteStore {
 
     @Override
     public void sendMessages(List<? extends Message> messages) throws MessagingException {
-        WebDavFolder tmpFolder = getFolder(mStoreConfig.getDraftsFolderName());
+        WebDavFolder tmpFolder = getFolder(mStoreConfig.getDraftsFolder());
         try {
             tmpFolder.open(Folder.OPEN_MODE_RW);
             List<? extends Message> retMessages = tmpFolder.appendWebDavMessages(messages);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -74,7 +74,7 @@ public class ImapFolderTest {
         BinaryTempFileBody.setTempDirectory(RuntimeEnvironment.application.getCacheDir());
         imapStore = mock(ImapStore.class);
         storeConfig = mock(StoreConfig.class);
-        when(storeConfig.getInboxFolderName()).thenReturn("INBOX");
+        when(storeConfig.getInboxFolder()).thenReturn("INBOX");
         when(imapStore.getCombinedPrefix()).thenReturn("");
         when(imapStore.getStoreConfig()).thenReturn(storeConfig);
 

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
@@ -113,11 +113,11 @@ public class ImapStoreTest {
 
         imapStore.autoconfigureFolders(imapConnection);
 
-        verify(storeConfig).setDraftsFolderName("[Gmail]/Drafts");
-        verify(storeConfig).setSentFolderName("[Gmail]/Sent Mail");
-        verify(storeConfig).setSpamFolderName("[Gmail]/Spam");
-        verify(storeConfig).setTrashFolderName("[Gmail]/Trash");
-        verify(storeConfig).setArchiveFolderName("[Gmail]/All Mail");
+        verify(storeConfig).setDraftsFolder("[Gmail]/Drafts");
+        verify(storeConfig).setSentFolder("[Gmail]/Sent Mail");
+        verify(storeConfig).setSpamFolder("[Gmail]/Spam");
+        verify(storeConfig).setTrashFolder("[Gmail]/Trash");
+        verify(storeConfig).setArchiveFolder("[Gmail]/All Mail");
     }
 
     @Test
@@ -149,11 +149,11 @@ public class ImapStoreTest {
         imapStore.autoconfigureFolders(imapConnection);
 
         assertEquals("INBOX.", imapStore.getCombinedPrefix());
-        verify(storeConfig).setDraftsFolderName("Drafts");
-        verify(storeConfig).setSentFolderName("Sent");
-        verify(storeConfig).setSpamFolderName("Spam");
-        verify(storeConfig).setTrashFolderName("Trash");
-        verify(storeConfig).setArchiveFolderName("Archive");
+        verify(storeConfig).setDraftsFolder("Drafts");
+        verify(storeConfig).setSentFolder("Sent");
+        verify(storeConfig).setSpamFolder("Spam");
+        verify(storeConfig).setTrashFolder("Trash");
+        verify(storeConfig).setArchiveFolder("Archive");
     }
 
     @Test
@@ -359,7 +359,7 @@ public class ImapStoreTest {
 
     private StoreConfig createStoreConfig() {
         StoreConfig storeConfig = mock(StoreConfig.class);
-        when(storeConfig.getInboxFolderName()).thenReturn("INBOX");
+        when(storeConfig.getInboxFolder()).thenReturn("INBOX");
         when(storeConfig.getStoreUri()).thenReturn("imap://user:password@imap.example.org");
 
         return storeConfig;

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
@@ -368,7 +368,7 @@ public class ImapStoreTest {
     private Set<String> extractFolderNames(List<? extends Folder> folders) {
         Set<String> folderNames = new HashSet<>(folders.size());
         for (Folder folder : folders) {
-            folderNames.add(folder.getName());
+            folderNames.add(folder.getServerId());
         }
 
         return folderNames;

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3FolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3FolderTest.java
@@ -47,7 +47,7 @@ public class Pop3FolderTest {
         mockStoreConfig = mock(StoreConfig.class);
         mockListener = mock(MessageRetrievalListener.class);
         when(mockStore.getConfig()).thenReturn(mockStoreConfig);
-        when(mockStoreConfig.getInboxFolderName()).thenReturn(Pop3Folder.INBOX);
+        when(mockStoreConfig.getInboxFolder()).thenReturn(Pop3Folder.INBOX);
         when(mockStore.createConnection()).thenReturn(mockConnection);
         when(mockConnection.executeSimpleCommand(Pop3Commands.STAT_COMMAND)).thenReturn("+OK 10 0");
         folder = new Pop3Folder(mockStore, Pop3Folder.INBOX);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3StoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3StoreTest.java
@@ -66,7 +66,7 @@ public class Pop3StoreTest {
     public void setUp() throws Exception {
         //Using a SSL socket allows us to mock it
         when(mockStoreConfig.getStoreUri()).thenReturn("pop3+ssl+://PLAIN:user:password@server:12345");
-        when(mockStoreConfig.getInboxFolderName()).thenReturn(Pop3Folder.INBOX);
+        when(mockStoreConfig.getInboxFolder()).thenReturn(Pop3Folder.INBOX);
         when(mockTrustedSocketFactory.createSocket(null, "server", 12345, null)).thenReturn(mockSocket);
         when(mockSocket.isConnected()).thenReturn(true);
         when(mockSocket.isClosed()).thenReturn(false);

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3StoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/pop3/Pop3StoreTest.java
@@ -179,7 +179,7 @@ public class Pop3StoreTest {
     public void getFolder_shouldReturnFolderWithCorrectName() throws Exception {
         Pop3Folder folder = store.getFolder("TestFolder");
 
-        assertEquals("TestFolder", folder.getName());
+        assertEquals("TestFolder", folder.getServerId());
     }
 
     @Test
@@ -187,7 +187,7 @@ public class Pop3StoreTest {
         List<Pop3Folder> folders = store.getPersonalNamespaces(true);
 
         assertEquals(1, folders.size());
-        assertEquals("INBOX", folders.get(0).getName());
+        assertEquals("INBOX", folders.get(0).getServerId());
     }
 
     @Test

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavMessageTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavMessageTest.java
@@ -30,7 +30,7 @@ public class WebDavMessageTest {
     @Before
     public void before() {
         MockitoAnnotations.initMocks(this);
-        when(mockFolder.getName()).thenReturn("Inbox");
+        when(mockFolder.getServerId()).thenReturn("Inbox");
         when(mockFolder.getUrl()).thenReturn("http://example.org/Inbox");
         message = new WebDavMessage("message1", mockFolder);
     }

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
@@ -271,7 +271,7 @@ public class WebDavStoreTest {
 
         webDavStore.getPersonalNamespaces(true);
 
-        verify(storeConfig).setInboxFolderName("Inbox");
+        verify(storeConfig).setInboxFolder("Inbox");
     }
 
     @Test
@@ -379,7 +379,7 @@ public class WebDavStoreTest {
 
     private StoreConfig createStoreConfig(String storeUri) {
         StoreConfig storeConfig = mock(StoreConfig.class);
-        when(storeConfig.getInboxFolderName()).thenReturn("INBOX");
+        when(storeConfig.getInboxFolder()).thenReturn("INBOX");
         when(storeConfig.getStoreUri()).thenReturn(storeUri);
         return storeConfig;
     }

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -821,14 +821,14 @@ public class Account implements BaseAccount, StoreConfig {
         return stats;
     }
 
-    public int getFolderUnreadCount(Context context, String folderName) throws MessagingException {
+    public int getFolderUnreadCount(Context context, String folderServerId) throws MessagingException {
         if (!isAvailable(context)) {
             return 0;
         }
 
         int unreadMessageCount = 0;
 
-        Cursor cursor = loadUnreadCountForFolder(context, folderName);
+        Cursor cursor = loadUnreadCountForFolder(context, folderServerId);
         try {
             if (cursor != null && cursor.moveToFirst()) {
                 unreadMessageCount = cursor.getInt(0);
@@ -840,7 +840,7 @@ public class Account implements BaseAccount, StoreConfig {
         return unreadMessageCount;
     }
 
-    private Cursor loadUnreadCountForFolder(Context context, String folderName) {
+    private Cursor loadUnreadCountForFolder(Context context, String folderServerId) {
         ContentResolver cr = context.getContentResolver();
 
         Uri uri = Uri.withAppendedPath(EmailProvider.CONTENT_URI,
@@ -851,7 +851,7 @@ public class Account implements BaseAccount, StoreConfig {
         };
 
         LocalSearch search = new LocalSearch();
-        search.addAllowedFolder(folderName);
+        search.addAllowedFolder(folderServerId);
 
         // Use the LocalSearch instance to create a WHERE clause to query the content provider
         StringBuilder query = new StringBuilder();
@@ -1073,14 +1073,14 @@ public class Account implements BaseAccount, StoreConfig {
         this.deletePolicy = deletePolicy;
     }
 
-    public boolean isSpecialFolder(String folderName) {
-        return (folderName != null && (folderName.equals(getInboxFolder()) ||
-                folderName.equals(getTrashFolder()) ||
-                folderName.equals(getDraftsFolder()) ||
-                folderName.equals(getArchiveFolder()) ||
-                folderName.equals(getSpamFolder()) ||
-                folderName.equals(getOutboxFolder()) ||
-                folderName.equals(getSentFolder())));
+    public boolean isSpecialFolder(String folderServerId) {
+        return (folderServerId != null && (folderServerId.equals(getInboxFolder()) ||
+                folderServerId.equals(getTrashFolder()) ||
+                folderServerId.equals(getDraftsFolder()) ||
+                folderServerId.equals(getArchiveFolder()) ||
+                folderServerId.equals(getSpamFolder()) ||
+                folderServerId.equals(getOutboxFolder()) ||
+                folderServerId.equals(getSentFolder())));
     }
 
     public synchronized String getDraftsFolder() {
@@ -1688,8 +1688,8 @@ public class Account implements BaseAccount, StoreConfig {
         return lastSelectedFolder;
     }
 
-    public synchronized void setLastSelectedFolder(String folderName) {
-        lastSelectedFolder = folderName;
+    public synchronized void setLastSelectedFolder(String folderServerId) {
+        lastSelectedFolder = folderServerId;
     }
 
     public synchronized NotificationSetting getNotificationSetting() {
@@ -1842,9 +1842,9 @@ public class Account implements BaseAccount, StoreConfig {
         search.or(new SearchCondition(SearchField.FOLDER, Attribute.EQUALS, getInboxFolder()));
     }
 
-    private void excludeSpecialFolder(LocalSearch search, String folderName) {
-        if (folderName != null && !K9.FOLDER_NONE.equals(folderName)) {
-            search.and(SearchField.FOLDER, folderName, Attribute.NOT_EQUALS);
+    private void excludeSpecialFolder(LocalSearch search, String folderServerId) {
+        if (folderServerId != null && !K9.FOLDER_NONE.equals(folderServerId)) {
+            search.and(SearchField.FOLDER, folderServerId, Attribute.NOT_EQUALS);
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -179,13 +179,13 @@ public class Account implements BaseAccount, StoreConfig {
     private FolderMode folderNotifyNewMailMode;
     private boolean notifySelfNewMail;
     private boolean notifyContactsMailOnly;
-    private String inboxFolderName;
-    private String draftsFolderName;
-    private String sentFolderName;
-    private String trashFolderName;
-    private String archiveFolderName;
-    private String spamFolderName;
-    private String autoExpandFolderName;
+    private String inboxFolder;
+    private String draftsFolder;
+    private String sentFolder;
+    private String trashFolder;
+    private String archiveFolder;
+    private String spamFolder;
+    private String autoExpandFolder;
     private FolderMode folderDisplayMode;
     private FolderMode folderSyncMode;
     private FolderMode folderPushMode;
@@ -249,7 +249,7 @@ public class Account implements BaseAccount, StoreConfig {
      * Note: For now this value isn't persisted. So it will be reset when
      *       K-9 Mail is restarted.
      */
-    private String lastSelectedFolderName = null;
+    private String lastSelectedFolder = null;
 
     private List<Identity> identities;
 
@@ -297,8 +297,8 @@ public class Account implements BaseAccount, StoreConfig {
         showPictures = ShowPictures.NEVER;
         isSignatureBeforeQuotedText = false;
         expungePolicy = Expunge.EXPUNGE_IMMEDIATELY;
-        autoExpandFolderName = INBOX;
-        inboxFolderName = INBOX;
+        autoExpandFolder = INBOX;
+        inboxFolder = INBOX;
         maxPushFolders = 10;
         chipColor = pickColor(context);
         goToUnreadMessageSearch = false;
@@ -398,12 +398,12 @@ public class Account implements BaseAccount, StoreConfig {
         notifyContactsMailOnly = storage.getBoolean(accountUuid + ".notifyContactsMailOnly", false);
         notifySync = storage.getBoolean(accountUuid + ".notifyMailCheck", false);
         deletePolicy =  DeletePolicy.fromInt(storage.getInt(accountUuid + ".deletePolicy", DeletePolicy.NEVER.setting));
-        inboxFolderName = storage.getString(accountUuid + ".inboxFolderName", INBOX);
-        draftsFolderName = storage.getString(accountUuid + ".draftsFolderName", "Drafts");
-        sentFolderName = storage.getString(accountUuid + ".sentFolderName", "Sent");
-        trashFolderName = storage.getString(accountUuid + ".trashFolderName", "Trash");
-        archiveFolderName = storage.getString(accountUuid + ".archiveFolderName", "Archive");
-        spamFolderName = storage.getString(accountUuid + ".spamFolderName", "Spam");
+        inboxFolder = storage.getString(accountUuid + ".inboxFolderName", INBOX);
+        draftsFolder = storage.getString(accountUuid + ".draftsFolderName", "Drafts");
+        sentFolder = storage.getString(accountUuid + ".sentFolderName", "Sent");
+        trashFolder = storage.getString(accountUuid + ".trashFolderName", "Trash");
+        archiveFolder = storage.getString(accountUuid + ".archiveFolderName", "Archive");
+        spamFolder = storage.getString(accountUuid + ".spamFolderName", "Spam");
         expungePolicy = getEnumStringPref(storage, accountUuid + ".expungePolicy", Expunge.EXPUNGE_IMMEDIATELY);
         syncRemoteDeletions = storage.getBoolean(accountUuid + ".syncRemoteDeletions", true);
 
@@ -429,7 +429,7 @@ public class Account implements BaseAccount, StoreConfig {
             compressionMap.put(type, useCompression);
         }
 
-        autoExpandFolderName = storage.getString(accountUuid + ".autoExpandFolderName", INBOX);
+        autoExpandFolder = storage.getString(accountUuid + ".autoExpandFolderName", INBOX);
 
         accountNumber = storage.getInt(accountUuid + ".accountNumber", 0);
 
@@ -688,13 +688,13 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(accountUuid + ".notifyContactsMailOnly", notifyContactsMailOnly);
         editor.putBoolean(accountUuid + ".notifyMailCheck", notifySync);
         editor.putInt(accountUuid + ".deletePolicy", deletePolicy.setting);
-        editor.putString(accountUuid + ".inboxFolderName", inboxFolderName);
-        editor.putString(accountUuid + ".draftsFolderName", draftsFolderName);
-        editor.putString(accountUuid + ".sentFolderName", sentFolderName);
-        editor.putString(accountUuid + ".trashFolderName", trashFolderName);
-        editor.putString(accountUuid + ".archiveFolderName", archiveFolderName);
-        editor.putString(accountUuid + ".spamFolderName", spamFolderName);
-        editor.putString(accountUuid + ".autoExpandFolderName", autoExpandFolderName);
+        editor.putString(accountUuid + ".inboxFolderName", inboxFolder);
+        editor.putString(accountUuid + ".draftsFolderName", draftsFolder);
+        editor.putString(accountUuid + ".sentFolderName", sentFolder);
+        editor.putString(accountUuid + ".trashFolderName", trashFolder);
+        editor.putString(accountUuid + ".archiveFolderName", archiveFolder);
+        editor.putString(accountUuid + ".spamFolderName", spamFolder);
+        editor.putString(accountUuid + ".autoExpandFolderName", autoExpandFolder);
         editor.putInt(accountUuid + ".accountNumber", accountNumber);
         editor.putString(accountUuid + ".sortTypeEnum", sortType.name());
         editor.putBoolean(accountUuid + ".sortAscending", sortAscending.get(sortType));
@@ -1074,21 +1074,21 @@ public class Account implements BaseAccount, StoreConfig {
     }
 
     public boolean isSpecialFolder(String folderName) {
-        return (folderName != null && (folderName.equals(getInboxFolderName()) ||
-                folderName.equals(getTrashFolderName()) ||
-                folderName.equals(getDraftsFolderName()) ||
-                folderName.equals(getArchiveFolderName()) ||
-                folderName.equals(getSpamFolderName()) ||
-                folderName.equals(getOutboxFolderName()) ||
-                folderName.equals(getSentFolderName())));
+        return (folderName != null && (folderName.equals(getInboxFolder()) ||
+                folderName.equals(getTrashFolder()) ||
+                folderName.equals(getDraftsFolder()) ||
+                folderName.equals(getArchiveFolder()) ||
+                folderName.equals(getSpamFolder()) ||
+                folderName.equals(getOutboxFolder()) ||
+                folderName.equals(getSentFolder())));
     }
 
-    public synchronized String getDraftsFolderName() {
-        return draftsFolderName;
+    public synchronized String getDraftsFolder() {
+        return draftsFolder;
     }
 
-    public synchronized void setDraftsFolderName(String name) {
-        draftsFolderName = name;
+    public synchronized void setDraftsFolder(String name) {
+        draftsFolder = name;
     }
 
     /**
@@ -1096,15 +1096,15 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has a drafts folder set.
      */
     public synchronized boolean hasDraftsFolder() {
-        return !K9.FOLDER_NONE.equals(draftsFolderName);
+        return !K9.FOLDER_NONE.equals(draftsFolder);
     }
 
-    public synchronized String getSentFolderName() {
-        return sentFolderName;
+    public synchronized String getSentFolder() {
+        return sentFolder;
     }
 
-    public synchronized void setSentFolderName(String name) {
-        sentFolderName = name;
+    public synchronized void setSentFolder(String name) {
+        sentFolder = name;
     }
 
     /**
@@ -1112,16 +1112,16 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has a sent folder set.
      */
     public synchronized boolean hasSentFolder() {
-        return !K9.FOLDER_NONE.equals(sentFolderName);
+        return !K9.FOLDER_NONE.equals(sentFolder);
     }
 
 
-    public synchronized String getTrashFolderName() {
-        return trashFolderName;
+    public synchronized String getTrashFolder() {
+        return trashFolder;
     }
 
-    public synchronized void setTrashFolderName(String name) {
-        trashFolderName = name;
+    public synchronized void setTrashFolder(String name) {
+        trashFolder = name;
     }
 
     /**
@@ -1129,15 +1129,15 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has a trash folder set.
      */
     public synchronized boolean hasTrashFolder() {
-        return !K9.FOLDER_NONE.equals(trashFolderName);
+        return !K9.FOLDER_NONE.equals(trashFolder);
     }
 
-    public synchronized String getArchiveFolderName() {
-        return archiveFolderName;
+    public synchronized String getArchiveFolder() {
+        return archiveFolder;
     }
 
-    public synchronized void setArchiveFolderName(String archiveFolderName) {
-        this.archiveFolderName = archiveFolderName;
+    public synchronized void setArchiveFolder(String archiveFolder) {
+        this.archiveFolder = archiveFolder;
     }
 
     /**
@@ -1145,15 +1145,15 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has an archive folder set.
      */
     public synchronized boolean hasArchiveFolder() {
-        return !K9.FOLDER_NONE.equals(archiveFolderName);
+        return !K9.FOLDER_NONE.equals(archiveFolder);
     }
 
-    public synchronized String getSpamFolderName() {
-        return spamFolderName;
+    public synchronized String getSpamFolder() {
+        return spamFolder;
     }
 
-    public synchronized void setSpamFolderName(String name) {
-        spamFolderName = name;
+    public synchronized void setSpamFolder(String name) {
+        spamFolder = name;
     }
 
     /**
@@ -1161,19 +1161,19 @@ public class Account implements BaseAccount, StoreConfig {
      * @return true if account has a spam folder set.
      */
     public synchronized boolean hasSpamFolder() {
-        return !K9.FOLDER_NONE.equals(spamFolderName);
+        return !K9.FOLDER_NONE.equals(spamFolder);
     }
 
-    public synchronized String getOutboxFolderName() {
+    public String getOutboxFolder() {
         return OUTBOX;
     }
 
-    public synchronized String getAutoExpandFolderName() {
-        return autoExpandFolderName;
+    public synchronized String getAutoExpandFolder() {
+        return autoExpandFolder;
     }
 
-    public synchronized void setAutoExpandFolderName(String name) {
-        autoExpandFolderName = name;
+    public synchronized void setAutoExpandFolder(String name) {
+        autoExpandFolder = name;
     }
 
     public synchronized int getAccountNumber() {
@@ -1668,12 +1668,12 @@ public class Account implements BaseAccount, StoreConfig {
         remoteSearchNumResults = (val >= 0 ? val : 0);
     }
 
-    public String getInboxFolderName() {
-        return inboxFolderName;
+    public String getInboxFolder() {
+        return inboxFolder;
     }
 
-    public void setInboxFolderName(String name) {
-        this.inboxFolderName = name;
+    public void setInboxFolder(String name) {
+        this.inboxFolder = name;
     }
 
     public synchronized boolean syncRemoteDeletions() {
@@ -1684,12 +1684,12 @@ public class Account implements BaseAccount, StoreConfig {
         this.syncRemoteDeletions = syncRemoteDeletions;
     }
 
-    public synchronized String getLastSelectedFolderName() {
-        return lastSelectedFolderName;
+    public synchronized String getLastSelectedFolder() {
+        return lastSelectedFolder;
     }
 
-    public synchronized void setLastSelectedFolderName(String folderName) {
-        lastSelectedFolderName = folderName;
+    public synchronized void setLastSelectedFolder(String folderName) {
+        lastSelectedFolder = folderName;
     }
 
     public synchronized NotificationSetting getNotificationSetting() {
@@ -1810,12 +1810,12 @@ public class Account implements BaseAccount, StoreConfig {
      *         The {@code LocalSearch} instance to modify.
      */
     public void excludeSpecialFolders(LocalSearch search) {
-        excludeSpecialFolder(search, getTrashFolderName());
-        excludeSpecialFolder(search, getDraftsFolderName());
-        excludeSpecialFolder(search, getSpamFolderName());
-        excludeSpecialFolder(search, getOutboxFolderName());
-        excludeSpecialFolder(search, getSentFolderName());
-        search.or(new SearchCondition(SearchField.FOLDER, Attribute.EQUALS, getInboxFolderName()));
+        excludeSpecialFolder(search, getTrashFolder());
+        excludeSpecialFolder(search, getDraftsFolder());
+        excludeSpecialFolder(search, getSpamFolder());
+        excludeSpecialFolder(search, getOutboxFolder());
+        excludeSpecialFolder(search, getSentFolder());
+        search.or(new SearchCondition(SearchField.FOLDER, Attribute.EQUALS, getInboxFolder()));
     }
 
     /**
@@ -1836,10 +1836,10 @@ public class Account implements BaseAccount, StoreConfig {
      *         The {@code LocalSearch} instance to modify.
      */
     public void excludeUnwantedFolders(LocalSearch search) {
-        excludeSpecialFolder(search, getTrashFolderName());
-        excludeSpecialFolder(search, getSpamFolderName());
-        excludeSpecialFolder(search, getOutboxFolderName());
-        search.or(new SearchCondition(SearchField.FOLDER, Attribute.EQUALS, getInboxFolderName()));
+        excludeSpecialFolder(search, getTrashFolder());
+        excludeSpecialFolder(search, getSpamFolder());
+        excludeSpecialFolder(search, getOutboxFolder());
+        search.or(new SearchCondition(SearchField.FOLDER, Attribute.EQUALS, getInboxFolder()));
     }
 
     private void excludeSpecialFolder(LocalSearch search, String folderName) {

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -605,28 +605,28 @@ public class K9 extends Application {
             }
 
             @Override
-            public void synchronizeMailboxRemovedMessage(Account account, String folder, Message message) {
-                broadcastIntent(K9.Intents.EmailReceived.ACTION_EMAIL_DELETED, account, folder, message);
+            public void synchronizeMailboxRemovedMessage(Account account, String folderServerId, Message message) {
+                broadcastIntent(K9.Intents.EmailReceived.ACTION_EMAIL_DELETED, account, folderServerId, message);
                 updateUnreadWidget();
                 updateMailListWidget();
             }
 
             @Override
-            public void messageDeleted(Account account, String folder, Message message) {
-                broadcastIntent(K9.Intents.EmailReceived.ACTION_EMAIL_DELETED, account, folder, message);
+            public void messageDeleted(Account account, String folderServerId, Message message) {
+                broadcastIntent(K9.Intents.EmailReceived.ACTION_EMAIL_DELETED, account, folderServerId, message);
                 updateUnreadWidget();
                 updateMailListWidget();
             }
 
             @Override
-            public void synchronizeMailboxNewMessage(Account account, String folder, Message message) {
-                broadcastIntent(K9.Intents.EmailReceived.ACTION_EMAIL_RECEIVED, account, folder, message);
+            public void synchronizeMailboxNewMessage(Account account, String folderServerId, Message message) {
+                broadcastIntent(K9.Intents.EmailReceived.ACTION_EMAIL_RECEIVED, account, folderServerId, message);
                 updateUnreadWidget();
                 updateMailListWidget();
             }
 
             @Override
-            public void folderStatusChanged(Account account, String folderName,
+            public void folderStatusChanged(Account account, String folderServerId,
                     int unreadMessageCount) {
 
                 updateUnreadWidget();
@@ -635,7 +635,7 @@ public class K9 extends Application {
                 // let observers know a change occurred
                 Intent intent = new Intent(K9.Intents.EmailReceived.ACTION_REFRESH_OBSERVER, null);
                 intent.putExtra(K9.Intents.EmailReceived.EXTRA_ACCOUNT, account.getDescription());
-                intent.putExtra(K9.Intents.EmailReceived.EXTRA_FOLDER, folderName);
+                intent.putExtra(K9.Intents.EmailReceived.EXTRA_FOLDER, folderServerId);
                 K9.this.sendBroadcast(intent);
 
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -257,7 +257,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         }
 
         @Override
-        public void folderStatusChanged(Account account, String folderName, int unreadMessageCount) {
+        public void folderStatusChanged(Account account, String folderServerId, int unreadMessageCount) {
             try {
                 AccountStats stats = account.getStats(Accounts.this);
                 if (stats == null) {
@@ -304,26 +304,26 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         @Override
         public void synchronizeMailboxFinished(
             Account account,
-            String folder,
+            String folderServerId,
             int totalMessagesInMailbox,
         int numNewMessages) {
             MessagingController.getInstance(getApplication()).getAccountStats(Accounts.this, account, mListener);
-            super.synchronizeMailboxFinished(account, folder, totalMessagesInMailbox, numNewMessages);
+            super.synchronizeMailboxFinished(account, folderServerId, totalMessagesInMailbox, numNewMessages);
 
             handler.progress(false);
 
         }
 
         @Override
-        public void synchronizeMailboxStarted(Account account, String folder) {
-            super.synchronizeMailboxStarted(account, folder);
+        public void synchronizeMailboxStarted(Account account, String folderServerId) {
+            super.synchronizeMailboxStarted(account, folderServerId);
             handler.progress(true);
         }
 
         @Override
-        public void synchronizeMailboxFailed(Account account, String folder,
+        public void synchronizeMailboxFailed(Account account, String folderServerId,
         String message) {
-            super.synchronizeMailboxFailed(account, folder, message);
+            super.synchronizeMailboxFailed(account, folderServerId, message);
             handler.progress(false);
 
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -674,11 +674,11 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 Timber.i("refusing to open account that is not available");
                 return false;
             }
-            if (K9.FOLDER_NONE.equals(realAccount.getAutoExpandFolderName())) {
+            if (K9.FOLDER_NONE.equals(realAccount.getAutoExpandFolder())) {
                 FolderList.actionHandleAccount(this, realAccount);
             } else {
-                LocalSearch search = new LocalSearch(realAccount.getAutoExpandFolderName());
-                search.addAllowedFolder(realAccount.getAutoExpandFolderName());
+                LocalSearch search = new LocalSearch(realAccount.getAutoExpandFolder());
+                search.addAllowedFolder(realAccount.getAutoExpandFolder());
                 search.addAccountUuid(realAccount.getUuid());
                 MessageList.actionDisplaySearch(this, search, false, true);}
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -315,8 +315,8 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         }
 
         @Override
-        public void synchronizeMailboxStarted(Account account, String folderServerId) {
-            super.synchronizeMailboxStarted(account, folderServerId);
+        public void synchronizeMailboxStarted(Account account, String folderServerId, String folderName) {
+            super.synchronizeMailboxStarted(account, folderServerId, folderName);
             handler.progress(true);
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -85,9 +85,9 @@ public class ActivityListener extends SimpleMessagingListener {
             }
 
             if (account != null) {
-                if (displayName.equals(account.getInboxFolderName())) {
+                if (displayName.equals(account.getInboxFolder())) {
                     displayName = context.getString(R.string.special_mailbox_name_inbox);
-                } else if (displayName.equals(account.getOutboxFolderName())) {
+                } else if (displayName.equals(account.getOutboxFolder())) {
                     displayName = context.getString(R.string.special_mailbox_name_outbox);
                 }
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -20,7 +20,9 @@ public class ActivityListener extends SimpleMessagingListener {
     private final Object lock = new Object();
 
     @GuardedBy("lock") private Account account = null;
+    @GuardedBy("lock") private String loadingFolderServerId = null;
     @GuardedBy("lock") private String loadingFolderName = null;
+    @GuardedBy("lock") private String loadingHeaderFolderServerId = null;
     @GuardedBy("lock") private String loadingHeaderFolderName = null;
     @GuardedBy("lock") private String loadingAccountDescription = null;
     @GuardedBy("lock") private String sendingAccountDescription = null;
@@ -41,7 +43,7 @@ public class ActivityListener extends SimpleMessagingListener {
         synchronized (lock) {
             if (loadingAccountDescription != null ||
                     sendingAccountDescription != null ||
-                    loadingHeaderFolderName != null ||
+                    loadingHeaderFolderServerId != null ||
                     processingAccountDescription != null) {
                 return getActionInProgressOperation(context);
             }
@@ -76,23 +78,31 @@ public class ActivityListener extends SimpleMessagingListener {
         String progress = folderTotal > 0 ?
                 context.getString(R.string.folder_progress, folderCompleted, folderTotal) : "";
 
-        if (loadingFolderName != null || loadingHeaderFolderName != null) {
-            String displayName;
-            if (loadingHeaderFolderName != null) {
-                displayName = loadingHeaderFolderName;
+        if (loadingFolderServerId != null || loadingHeaderFolderServerId != null) {
+            String folderServerId;
+            String folderName;
+            if (loadingHeaderFolderServerId != null) {
+                folderServerId = loadingHeaderFolderServerId;
+                folderName = loadingHeaderFolderName;
             } else {
-                displayName = loadingFolderName;
+                folderServerId = loadingFolderServerId;
+                folderName = loadingFolderName;
             }
 
+            String displayName;
             if (account != null) {
-                if (displayName.equals(account.getInboxFolder())) {
+                if (folderServerId.equals(account.getInboxFolder())) {
                     displayName = context.getString(R.string.special_mailbox_name_inbox);
-                } else if (displayName.equals(account.getOutboxFolder())) {
+                } else if (folderServerId.equals(account.getOutboxFolder())) {
                     displayName = context.getString(R.string.special_mailbox_name_outbox);
+                } else {
+                    displayName = folderName;
                 }
+            } else {
+                displayName = folderName;
             }
 
-            if (loadingHeaderFolderName != null) {
+            if (loadingHeaderFolderServerId != null) {
                 return context.getString(R.string.status_loading_account_folder_headers,
                         loadingAccountDescription, displayName, progress);
             } else {
@@ -125,6 +135,7 @@ public class ActivityListener extends SimpleMessagingListener {
             int numNewMessages) {
         synchronized (lock) {
             loadingAccountDescription = null;
+            loadingFolderServerId = null;
             loadingFolderName = null;
             this.account = null;
         }
@@ -133,10 +144,11 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxStarted(Account account, String folderServerId) {
+    public void synchronizeMailboxStarted(Account account, String folderServerId, String folderName) {
         synchronized (lock) {
             loadingAccountDescription = account.getDescription();
-            loadingFolderName = folderServerId;
+            loadingFolderServerId = folderServerId;
+            loadingFolderName = folderName;
             this.account = account;
             folderCompleted = 0;
             folderTotal = 0;
@@ -146,10 +158,11 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxHeadersStarted(Account account, String folderServerId) {
+    public void synchronizeMailboxHeadersStarted(Account account, String folderServerId, String folderName) {
         synchronized (lock) {
             loadingAccountDescription = account.getDescription();
-            loadingHeaderFolderName = folderServerId;
+            loadingHeaderFolderServerId = folderServerId;
+            loadingHeaderFolderName = folderName;
         }
 
         informUserOfStatus();
@@ -168,6 +181,7 @@ public class ActivityListener extends SimpleMessagingListener {
     @Override
     public void synchronizeMailboxHeadersFinished(Account account, String folderServerId, int total, int completed) {
         synchronized (lock) {
+            loadingHeaderFolderServerId = null;
             loadingHeaderFolderName = null;
             folderCompleted = 0;
             folderTotal = 0;
@@ -190,7 +204,9 @@ public class ActivityListener extends SimpleMessagingListener {
     public void synchronizeMailboxFailed(Account account, String folderServerId, String message) {
         synchronized (lock) {
             loadingAccountDescription = null;
+            loadingHeaderFolderServerId = null;
             loadingHeaderFolderName = null;
+            loadingFolderServerId = null;
             loadingFolderName = null;
             this.account = null;
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ActivityListener.java
@@ -121,7 +121,7 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxFinished(Account account, String folder, int totalMessagesInMailbox,
+    public void synchronizeMailboxFinished(Account account, String folderServerId, int totalMessagesInMailbox,
             int numNewMessages) {
         synchronized (lock) {
             loadingAccountDescription = null;
@@ -133,10 +133,10 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxStarted(Account account, String folder) {
+    public void synchronizeMailboxStarted(Account account, String folderServerId) {
         synchronized (lock) {
             loadingAccountDescription = account.getDescription();
-            loadingFolderName = folder;
+            loadingFolderName = folderServerId;
             this.account = account;
             folderCompleted = 0;
             folderTotal = 0;
@@ -146,17 +146,17 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxHeadersStarted(Account account, String folder) {
+    public void synchronizeMailboxHeadersStarted(Account account, String folderServerId) {
         synchronized (lock) {
             loadingAccountDescription = account.getDescription();
-            loadingHeaderFolderName = folder;
+            loadingHeaderFolderName = folderServerId;
         }
 
         informUserOfStatus();
     }
 
     @Override
-    public void synchronizeMailboxHeadersProgress(Account account, String folder, int completed, int total) {
+    public void synchronizeMailboxHeadersProgress(Account account, String folderServerId, int completed, int total) {
         synchronized (lock) {
             folderCompleted = completed;
             folderTotal = total;
@@ -166,7 +166,7 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxHeadersFinished(Account account, String folder, int total, int completed) {
+    public void synchronizeMailboxHeadersFinished(Account account, String folderServerId, int total, int completed) {
         synchronized (lock) {
             loadingHeaderFolderName = null;
             folderCompleted = 0;
@@ -177,7 +177,7 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxProgress(Account account, String folder, int completed, int total) {
+    public void synchronizeMailboxProgress(Account account, String folderServerId, int completed, int total) {
         synchronized (lock) {
             folderCompleted = completed;
             folderTotal = total;
@@ -187,7 +187,7 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxFailed(Account account, String folder, String message) {
+    public void synchronizeMailboxFailed(Account account, String folderServerId, String message) {
         synchronized (lock) {
             loadingAccountDescription = null;
             loadingHeaderFolderName = null;
@@ -273,7 +273,7 @@ public class ActivityListener extends SimpleMessagingListener {
     }
 
     @Override
-    public void folderStatusChanged(Account account, String folder, int unreadMessageCount) {
+    public void folderStatusChanged(Account account, String folderServerId, int unreadMessageCount) {
         informUserOfStatus();
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -299,7 +299,8 @@ public class ChooseFolder extends K9ListActivity {
                 }
 
                 long id = folder.getDatabaseId();
-                String displayName = buildDisplayName(account, serverId);
+                String name = folder.getName();
+                String displayName = buildDisplayName(account, serverId, name);
                 FolderDisplayData folderDisplayData = new FolderDisplayData(id, serverId, displayName);
 
                 if (folder.isInTopGroup()) {
@@ -380,12 +381,12 @@ public class ChooseFolder extends K9ListActivity {
         }
     };
 
-    private String buildDisplayName(Account account, String serverId) {
-        if (!account.getInboxFolder().equals(serverId)) {
-            return serverId;
+    private String buildDisplayName(Account account, String serverId, String name) {
+        if (account.getInboxFolder().equals(serverId)) {
+            return getString(R.string.special_mailbox_name_inbox);
+        } else {
+            return name;
         }
-
-        return getString(R.string.special_mailbox_name_inbox);
     }
 
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -40,6 +40,7 @@ public class ChooseFolder extends K9ListActivity {
     public static final String EXTRA_SHOW_CURRENT = "com.fsck.k9.ChooseFolder_showcurrent";
     public static final String EXTRA_SHOW_FOLDER_NONE = "com.fsck.k9.ChooseFolder_showOptionNone";
     public static final String EXTRA_SHOW_DISPLAYABLE_ONLY = "com.fsck.k9.ChooseFolder_showDisplayableOnly";
+    public static final String RESULT_FOLDER_DISPLAY_NAME = "folderDisplayName";
 
 
     String currentFolder;
@@ -132,6 +133,7 @@ public class ChooseFolder extends K9ListActivity {
                 if (mMessageReference != null) {
                     result.putExtra(EXTRA_MESSAGE, mMessageReference.toIdentityString());
                 }
+                result.putExtra(RESULT_FOLDER_DISPLAY_NAME, folder.displayName);
                 setResult(RESULT_OK, result);
                 finish();
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -42,7 +42,7 @@ public class ChooseFolder extends K9ListActivity {
     public static final String EXTRA_SHOW_DISPLAYABLE_ONLY = "com.fsck.k9.ChooseFolder_showDisplayableOnly";
 
 
-    String mFolder;
+    String currentFolder;
     String mSelectFolder;
     Account mAccount;
     MessageReference mMessageReference;
@@ -85,7 +85,7 @@ public class ChooseFolder extends K9ListActivity {
             String messageReferenceString = intent.getStringExtra(EXTRA_MESSAGE);
             mMessageReference = MessageReference.parse(messageReferenceString);
         }
-        mFolder = intent.getStringExtra(EXTRA_CUR_FOLDER);
+        currentFolder = intent.getStringExtra(EXTRA_CUR_FOLDER);
         mSelectFolder = intent.getStringExtra(EXTRA_SEL_FOLDER);
         if (intent.getStringExtra(EXTRA_SHOW_CURRENT) != null) {
             mHideCurrentFolder = false;
@@ -96,8 +96,8 @@ public class ChooseFolder extends K9ListActivity {
         if (intent.getStringExtra(EXTRA_SHOW_DISPLAYABLE_ONLY) != null) {
             mShowDisplayableOnly = true;
         }
-        if (mFolder == null)
-            mFolder = "";
+        if (currentFolder == null)
+            currentFolder = "";
 
         mAdapter = new ArrayAdapter<FolderDisplayData>(this, android.R.layout.simple_list_item_1) {
             private Filter myFilter = null;
@@ -126,9 +126,9 @@ public class ChooseFolder extends K9ListActivity {
 
                 Intent result = new Intent();
                 result.putExtra(EXTRA_ACCOUNT, mAccount.getUuid());
-                result.putExtra(EXTRA_CUR_FOLDER, mFolder);
-                String destFolderName = folder.name;
-                result.putExtra(EXTRA_NEW_FOLDER, destFolderName);
+                result.putExtra(EXTRA_CUR_FOLDER, currentFolder);
+                String targetFolder = folder.serverId;
+                result.putExtra(EXTRA_NEW_FOLDER, targetFolder);
                 if (mMessageReference != null) {
                     result.putExtra(EXTRA_MESSAGE, mMessageReference.toIdentityString());
                 }
@@ -277,12 +277,12 @@ public class ChooseFolder extends K9ListActivity {
             List<FolderDisplayData> topFolders = new ArrayList<>();
 
             for (LocalFolder folder : folders) {
-                String name = folder.getName();
+                String serverId = folder.getServerId();
 
-                if (mHideCurrentFolder && name.equals(mFolder)) {
+                if (mHideCurrentFolder && serverId.equals(currentFolder)) {
                     continue;
                 }
-                if (account.getOutboxFolder().equals(name)) {
+                if (account.getOutboxFolder().equals(serverId)) {
                     continue;
                 }
 
@@ -299,8 +299,8 @@ public class ChooseFolder extends K9ListActivity {
                 }
 
                 long id = folder.getDatabaseId();
-                String displayName = buildDisplayName(account, name);
-                FolderDisplayData folderDisplayData = new FolderDisplayData(id, name, displayName);
+                String displayName = buildDisplayName(account, serverId);
+                FolderDisplayData folderDisplayData = new FolderDisplayData(id, serverId, displayName);
 
                 if (folder.isInTopGroup()) {
                     topFolders.add(folderDisplayData);
@@ -345,11 +345,11 @@ public class ChooseFolder extends K9ListActivity {
                          * (mSelectedFolder) was provided.
                          */
 
-                        if (folder.name.equals(mSelectFolder)) {
+                        if (folder.serverId.equals(mSelectFolder)) {
                             selectedFolder = position;
                             break;
                         }
-                    } else if (folder.name.equals(mFolder)) {
+                    } else if (folder.serverId.equals(currentFolder)) {
                         selectedFolder = position;
                         break;
                     }
@@ -380,9 +380,9 @@ public class ChooseFolder extends K9ListActivity {
         }
     };
 
-    private String buildDisplayName(Account account, String name) {
-        if (!account.getInboxFolder().equals(name)) {
-            return name;
+    private String buildDisplayName(Account account, String serverId) {
+        if (!account.getInboxFolder().equals(serverId)) {
+            return serverId;
         }
 
         return getString(R.string.special_mailbox_name_inbox);
@@ -391,12 +391,12 @@ public class ChooseFolder extends K9ListActivity {
 
     static class FolderDisplayData {
         final long id;
-        final String name;
+        final String serverId;
         final String displayName;
 
-        FolderDisplayData(long id, String name, String displayName) {
+        FolderDisplayData(long id, String serverId, String displayName) {
             this.id = id;
-            this.name = name;
+            this.serverId = serverId;
             this.displayName = displayName;
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -282,7 +282,7 @@ public class ChooseFolder extends K9ListActivity {
                 if (mHideCurrentFolder && name.equals(mFolder)) {
                     continue;
                 }
-                if (account.getOutboxFolderName().equals(name)) {
+                if (account.getOutboxFolder().equals(name)) {
                     continue;
                 }
 
@@ -381,7 +381,7 @@ public class ChooseFolder extends K9ListActivity {
     };
 
     private String buildDisplayName(Account account, String name) {
-        if (!account.getInboxFolderName().equals(name)) {
+        if (!account.getInboxFolder().equals(name)) {
             return name;
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
@@ -81,7 +81,7 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
 
         this.status = truncateStatus(folder.getStatus());
 
-        this.displayName = getDisplayName(context, account, serverId);
+        this.displayName = getDisplayName(context, account, serverId, folder.getName());
         setMoreMessagesFromFolder(folder);
     }
 
@@ -91,37 +91,22 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
      * <p>
      * This will return localized strings for special folders like the Inbox or the Trash folder.
      * </p>
-     *
-     * @param context
-     *         A {@link Context} instance that is used to get the string resources.
-     * @param account
-     *         The {@link Account} the folder belongs to.
-     * @param name
-     *         The name of the folder for which to return the display name.
-     *
-     * @return The localized name for the provided folder if it's a special folder or the original
-     *         folder name if it's a non-special folder.
      */
-    public static String getDisplayName(Context context, Account account, String name) {
+    public static String getDisplayName(Context context, Account account, String serverId, String name) {
         final String displayName;
-        if (name.equals(account.getSpamFolder())) {
-            displayName = String.format(
-                    context.getString(R.string.special_mailbox_name_spam_fmt), name);
-        } else if (name.equals(account.getArchiveFolder())) {
-            displayName = String.format(
-                    context.getString(R.string.special_mailbox_name_archive_fmt), name);
-        } else if (name.equals(account.getSentFolder())) {
-            displayName = String.format(
-                    context.getString(R.string.special_mailbox_name_sent_fmt), name);
-        } else if (name.equals(account.getTrashFolder())) {
-            displayName = String.format(
-                    context.getString(R.string.special_mailbox_name_trash_fmt), name);
-        } else if (name.equals(account.getDraftsFolder())) {
-            displayName = String.format(
-                    context.getString(R.string.special_mailbox_name_drafts_fmt), name);
-        } else if (name.equals(account.getOutboxFolder())) {
+        if (serverId.equals(account.getSpamFolder())) {
+            displayName = context.getString(R.string.special_mailbox_name_spam_fmt, serverId);
+        } else if (serverId.equals(account.getArchiveFolder())) {
+            displayName = context.getString(R.string.special_mailbox_name_archive_fmt, serverId);
+        } else if (serverId.equals(account.getSentFolder())) {
+            displayName = context.getString(R.string.special_mailbox_name_sent_fmt, serverId);
+        } else if (serverId.equals(account.getTrashFolder())) {
+            displayName = context.getString(R.string.special_mailbox_name_trash_fmt, serverId);
+        } else if (serverId.equals(account.getDraftsFolder())) {
+            displayName = context.getString(R.string.special_mailbox_name_drafts_fmt, serverId);
+        } else if (serverId.equals(account.getOutboxFolder())) {
             displayName = context.getString(R.string.special_mailbox_name_outbox);
-        } else if (name.equals(account.getInboxFolder())) {
+        } else if (serverId.equals(account.getInboxFolder())) {
             displayName = context.getString(R.string.special_mailbox_name_inbox);
         } else {
             displayName = name;

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
@@ -104,24 +104,24 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
      */
     public static String getDisplayName(Context context, Account account, String name) {
         final String displayName;
-        if (name.equals(account.getSpamFolderName())) {
+        if (name.equals(account.getSpamFolder())) {
             displayName = String.format(
                     context.getString(R.string.special_mailbox_name_spam_fmt), name);
-        } else if (name.equals(account.getArchiveFolderName())) {
+        } else if (name.equals(account.getArchiveFolder())) {
             displayName = String.format(
                     context.getString(R.string.special_mailbox_name_archive_fmt), name);
-        } else if (name.equals(account.getSentFolderName())) {
+        } else if (name.equals(account.getSentFolder())) {
             displayName = String.format(
                     context.getString(R.string.special_mailbox_name_sent_fmt), name);
-        } else if (name.equals(account.getTrashFolderName())) {
+        } else if (name.equals(account.getTrashFolder())) {
             displayName = String.format(
                     context.getString(R.string.special_mailbox_name_trash_fmt), name);
-        } else if (name.equals(account.getDraftsFolderName())) {
+        } else if (name.equals(account.getDraftsFolder())) {
             displayName = String.format(
                     context.getString(R.string.special_mailbox_name_drafts_fmt), name);
-        } else if (name.equals(account.getOutboxFolderName())) {
+        } else if (name.equals(account.getOutboxFolder())) {
             displayName = context.getString(R.string.special_mailbox_name_outbox);
-        } else if (name.equals(account.getInboxFolderName())) {
+        } else if (name.equals(account.getInboxFolder())) {
             displayName = context.getString(R.string.special_mailbox_name_inbox);
         } else {
             displayName = name;

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderInfoHolder.java
@@ -9,7 +9,7 @@ import com.fsck.k9.mailstore.LocalFolder;
 
 
 public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
-    public String name;
+    public String serverId;
     public String displayName;
     public long lastChecked;
     public int unreadMessageCount = -1;
@@ -23,17 +23,17 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
 
     @Override
     public boolean equals(Object o) {
-        return o instanceof FolderInfoHolder && name.equals(((FolderInfoHolder) o).name);
+        return o instanceof FolderInfoHolder && serverId.equals(((FolderInfoHolder) o).serverId);
     }
 
     @Override
     public int hashCode() {
-        return name.hashCode();
+        return serverId.hashCode();
     }
 
     public int compareTo(FolderInfoHolder o) {
-        String s1 = this.name;
-        String s2 = o.name;
+        String s1 = this.serverId;
+        String s2 = o.serverId;
 
         int ret = s1.compareToIgnoreCase(s2);
         if (ret != 0) {
@@ -76,12 +76,12 @@ public class FolderInfoHolder implements Comparable<FolderInfoHolder> {
 
     public void populate(Context context, LocalFolder folder, Account account) {
         this.folder = folder;
-        this.name = folder.getName();
+        this.serverId = folder.getServerId();
         this.lastChecked = folder.getLastUpdate();
 
         this.status = truncateStatus(folder.getStatus());
 
-        this.displayName = getDisplayName(context, account, name);
+        this.displayName = getDisplayName(context, account, serverId);
         setMoreMessagesFromFolder(folder);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -771,8 +771,8 @@ public class FolderList extends K9ListActivity {
             }
 
             @Override
-            public void synchronizeMailboxStarted(Account account, String folderServerId) {
-                super.synchronizeMailboxStarted(account, folderServerId);
+            public void synchronizeMailboxStarted(Account account, String folderServerId, String folderName) {
+                super.synchronizeMailboxStarted(account, folderServerId, folderName);
                 if (account.equals(FolderList.this.account)) {
 
                     handler.progress(true);

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -333,8 +333,8 @@ public class FolderList extends K9ListActivity {
         }
 
         if (intent.getBooleanExtra(EXTRA_FROM_SHORTCUT, false) &&
-                   !K9.FOLDER_NONE.equals(account.getAutoExpandFolderName())) {
-            onOpenFolder(account.getAutoExpandFolderName());
+                   !K9.FOLDER_NONE.equals(account.getAutoExpandFolder())) {
+            onOpenFolder(account.getAutoExpandFolder());
             finish();
         } else {
             initializeActivityView();
@@ -870,7 +870,7 @@ public class FolderList extends K9ListActivity {
             @Override
             public void emptyTrashCompleted(Account account) {
                 if (account.equals(FolderList.this.account)) {
-                    refreshFolder(account, FolderList.this.account.getTrashFolderName());
+                    refreshFolder(account, FolderList.this.account.getTrashFolder());
                 }
             }
 
@@ -886,7 +886,7 @@ public class FolderList extends K9ListActivity {
             public void sendPendingMessagesCompleted(Account account) {
                 super.sendPendingMessagesCompleted(account);
                 if (account.equals(FolderList.this.account)) {
-                    refreshFolder(account, FolderList.this.account.getOutboxFolderName());
+                    refreshFolder(account, FolderList.this.account.getOutboxFolder());
                 }
             }
 
@@ -903,7 +903,7 @@ public class FolderList extends K9ListActivity {
             public void sendPendingMessagesFailed(Account account) {
                 super.sendPendingMessagesFailed(account);
                 if (account.equals(FolderList.this.account)) {
-                    refreshFolder(account, FolderList.this.account.getOutboxFolderName());
+                    refreshFolder(account, FolderList.this.account.getOutboxFolder());
                 }
             }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderListFilter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderListFilter.java
@@ -32,10 +32,10 @@ public class FolderListFilter<T> extends Filter {
     /**
      * Create a filter for a list of folders.
      *
-     * @param folderNames
+     * @param folders
      */
-    public FolderListFilter(final ArrayAdapter<T> folderNames) {
-        this.mFolders = folderNames;
+    public FolderListFilter(final ArrayAdapter<T> folders) {
+        this.mFolders = folders;
     }
 
     /**

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1,7 +1,6 @@
 package com.fsck.k9.activity;
 
 
-import java.io.IOException;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -1062,7 +1061,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     }
 
     private void openAutoExpandFolder() {
-        String folder = account.getAutoExpandFolderName();
+        String folder = account.getAutoExpandFolder();
         LocalSearch search = new LocalSearch(folder);
         search.addAccountUuid(account.getUuid());
         search.addAllowedFolder(folder);

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1436,15 +1436,15 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         private void updateReferencedMessage() {
             if (messageReference != null && messageReference.getFlag() != null) {
                 Timber.d("Setting referenced message (%s, %s) flag to %s",
-                        messageReference.getFolderName(),
+                        messageReference.getFolderServerId(),
                         messageReference.getUid(),
                         messageReference.getFlag());
 
                 final Account account = Preferences.getPreferences(context)
                         .getAccount(messageReference.getAccountUuid());
-                final String folderName = messageReference.getFolderName();
+                final String folderServerId = messageReference.getFolderServerId();
                 final String sourceMessageUid = messageReference.getUid();
-                MessagingController.getInstance(context).setFlag(account, folderName,
+                MessagingController.getInstance(context).setFlag(account, folderServerId,
                         sourceMessageUid, messageReference.getFlag(), true);
             }
         }
@@ -1661,18 +1661,18 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     public MessagingListener messagingListener = new SimpleMessagingListener() {
 
         @Override
-        public void messageUidChanged(Account account, String folder, String oldUid, String newUid) {
+        public void messageUidChanged(Account account, String folderServerId, String oldUid, String newUid) {
             if (relatedMessageReference == null) {
                 return;
             }
 
             Account sourceAccount = Preferences.getPreferences(MessageCompose.this)
                     .getAccount(relatedMessageReference.getAccountUuid());
-            String sourceFolder = relatedMessageReference.getFolderName();
+            String sourceFolder = relatedMessageReference.getFolderServerId();
             String sourceMessageUid = relatedMessageReference.getUid();
 
             boolean changedMessageIsCurrent =
-                    account.equals(sourceAccount) && folder.equals(sourceFolder) && oldUid.equals(sourceMessageUid);
+                    account.equals(sourceAccount) && folderServerId.equals(sourceFolder) && oldUid.equals(sourceMessageUid);
             if (changedMessageIsCurrent) {
                 relatedMessageReference = relatedMessageReference.withModifiedUid(newUid);
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -166,7 +166,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     private int firstBackStackId = -1;
 
     private Account account;
-    private String folderName;
+    private String folderServerId;
     private LocalSearch search;
     private boolean singleFolderMode;
     private boolean singleAccountMode;
@@ -257,7 +257,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
         messageReference = null;
         search = null;
-        folderName = null;
+        folderServerId = null;
 
         if (!decodeExtras(intent)) {
             return;
@@ -391,9 +391,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
             Collection<Account> accounts = Preferences.getPreferences(this).getAvailableAccounts();
             for (Account account : accounts) {
                 if (String.valueOf(account.getAccountNumber()).equals(accountId)) {
-                    String folderName = segmentList.get(1);
+                    String folderServerId = segmentList.get(1);
                     String messageUid = segmentList.get(2);
-                    messageReference = new MessageReference(account.getUuid(), folderName, messageUid, null);
+                    messageReference = new MessageReference(account.getUuid(), folderServerId, messageUid, null);
                     break;
                 }
             }
@@ -445,18 +445,18 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         if (messageReference != null) {
             search = new LocalSearch();
             search.addAccountUuid(messageReference.getAccountUuid());
-            search.addAllowedFolder(messageReference.getFolderName());
+            search.addAllowedFolder(messageReference.getFolderServerId());
         }
 
         if (search == null) {
             // We've most likely been started by an old unread widget
             String accountUuid = intent.getStringExtra("account");
-            String folderName = intent.getStringExtra("folder");
+            String folderServerId = intent.getStringExtra("folder");
 
-            search = new LocalSearch(folderName);
+            search = new LocalSearch(folderServerId);
             search.addAccountUuid((accountUuid == null) ? "invalid" : accountUuid);
-            if (folderName != null) {
-                search.addAllowedFolder(folderName);
+            if (folderServerId != null) {
+                search.addAllowedFolder(folderServerId);
             }
         }
 
@@ -475,7 +475,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 account = prefs.getAccount(accountUuids[0]);
             }
         }
-        singleFolderMode = singleAccountMode && (search.getFolderNames().size() == 1);
+        singleFolderMode = singleAccountMode && (search.getFolderServerIds().size() == 1);
 
         if (singleAccountMode && (account == null || !account.isAvailable(this))) {
             Timber.i("not opening MessageList of unavailable account");
@@ -484,7 +484,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         }
 
         if (singleFolderMode) {
-            folderName = search.getFolderNames().get(0);
+            folderServerId = search.getFolderServerIds().get(0);
         }
 
         // now we know if we are in single account mode and need a subtitle
@@ -951,8 +951,8 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 return true;
             }
             case R.id.folder_settings: {
-                if (folderName != null) {
-                    FolderSettings.actionSettings(this, account, folderName);
+                if (folderServerId != null) {
+                    FolderSettings.actionSettings(this, account, folderServerId);
                 }
                 return true;
             }
@@ -1211,9 +1211,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     public void openMessage(MessageReference messageReference) {
         Preferences prefs = Preferences.getPreferences(getApplicationContext());
         Account account = prefs.getAccount(messageReference.getAccountUuid());
-        String folderName = messageReference.getFolderName();
+        String folderServerId = messageReference.getFolderServerId();
 
-        if (folderName.equals(account.getDraftsFolder())) {
+        if (folderServerId.equals(account.getDraftsFolder())) {
             MessageActions.actionEditDraft(this, messageReference);
         } else {
             messageViewContainer.removeView(messageViewPlaceHolder);
@@ -1355,13 +1355,13 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     }
 
     @Override
-    public boolean startSearch(Account account, String folderName) {
+    public boolean startSearch(Account account, String folderServerId) {
         // If this search was started from a MessageList of a single folder, pass along that folder info
         // so that we can enable remote search.
-        if (account != null && folderName != null) {
+        if (account != null && folderServerId != null) {
             final Bundle appData = new Bundle();
             appData.putString(EXTRA_SEARCH_ACCOUNT, account.getUuid());
-            appData.putString(EXTRA_SEARCH_FOLDER, folderName);
+            appData.putString(EXTRA_SEARCH_FOLDER, folderServerId);
             startSearch(null, false, appData, false);
         } else {
             // TODO Handle the case where we're searching from within a search result.
@@ -1372,7 +1372,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     }
 
     @Override
-    public void showThread(Account account, String folderName, long threadRootId) {
+    public void showThread(Account account, String folderServerId, long threadRootId) {
         showMessageViewPlaceHolder();
 
         LocalSearch tmpSearch = new LocalSearch();

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1213,7 +1213,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         Account account = prefs.getAccount(messageReference.getAccountUuid());
         String folderName = messageReference.getFolderName();
 
-        if (folderName.equals(account.getDraftsFolderName())) {
+        if (folderName.equals(account.getDraftsFolder())) {
             MessageActions.actionEditDraft(this, messageReference);
         } else {
             messageViewContainer.removeView(messageViewPlaceHolder);

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -426,10 +426,10 @@ public class MessageLoaderHelper {
     private void startDownloadingMessageBody(boolean downloadComplete) {
         if (downloadComplete) {
             MessagingController.getInstance(context).loadMessageRemote(
-                    account, messageReference.getFolderName(), messageReference.getUid(), downloadMessageListener);
+                    account, messageReference.getFolderServerId(), messageReference.getUid(), downloadMessageListener);
         } else {
             MessagingController.getInstance(context).loadMessageRemotePartial(
-                    account, messageReference.getFolderName(), messageReference.getUid(), downloadMessageListener);
+                    account, messageReference.getFolderServerId(), messageReference.getUid(), downloadMessageListener);
         }
     }
 
@@ -459,15 +459,15 @@ public class MessageLoaderHelper {
 
     MessagingListener downloadMessageListener = new SimpleMessagingListener() {
         @Override
-        public void loadMessageRemoteFinished(Account account, String folder, String uid) {
-            if (!messageReference.equals(account.getUuid(), folder, uid)) {
+        public void loadMessageRemoteFinished(Account account, String folderServerId, String uid) {
+            if (!messageReference.equals(account.getUuid(), folderServerId, uid)) {
                 return;
             }
             onMessageDownloadFinished();
         }
 
         @Override
-        public void loadMessageRemoteFailed(Account account, String folder, String uid, final Throwable t) {
+        public void loadMessageRemoteFailed(Account account, String folderServerId, String uid, final Throwable t) {
             onDownloadMessageFailed(t);
         }
     };

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageReference.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageReference.java
@@ -17,7 +17,7 @@ public class MessageReference {
 
 
     private final String accountUuid;
-    private final String folderName;
+    private final String folderServerId;
     private final String uid;
     private final Flag flag;
 
@@ -34,11 +34,11 @@ public class MessageReference {
         }
 
         String accountUuid = Base64.decode(tokens.nextToken());
-        String folderName = Base64.decode(tokens.nextToken());
+        String folderServerId = Base64.decode(tokens.nextToken());
         String uid = Base64.decode(tokens.nextToken());
 
         if (!tokens.hasMoreTokens()) {
-            return new MessageReference(accountUuid, folderName, uid, null);
+            return new MessageReference(accountUuid, folderServerId, uid, null);
         }
 
         Flag flag;
@@ -48,12 +48,12 @@ public class MessageReference {
             return null;
         }
 
-        return new MessageReference(accountUuid, folderName, uid, flag);
+        return new MessageReference(accountUuid, folderServerId, uid, flag);
     }
 
-    public MessageReference(String accountUuid, String folderName, String uid, Flag flag) {
+    public MessageReference(String accountUuid, String folderServerId, String uid, Flag flag) {
         this.accountUuid = checkNotNull(accountUuid);
-        this.folderName = checkNotNull(folderName);
+        this.folderServerId = checkNotNull(folderServerId);
         this.uid = checkNotNull(uid);
         this.flag = flag;
     }
@@ -65,7 +65,7 @@ public class MessageReference {
         refString.append(IDENTITY_SEPARATOR);
         refString.append(Base64.encode(accountUuid));
         refString.append(IDENTITY_SEPARATOR);
-        refString.append(Base64.encode(folderName));
+        refString.append(Base64.encode(folderServerId));
         refString.append(IDENTITY_SEPARATOR);
         refString.append(Base64.encode(uid));
         if (flag != null) {
@@ -82,11 +82,11 @@ public class MessageReference {
             return false;
         }
         MessageReference other = (MessageReference) o;
-        return equals(other.accountUuid, other.folderName, other.uid);
+        return equals(other.accountUuid, other.folderServerId, other.uid);
     }
 
-    public boolean equals(String accountUuid, String folderName, String uid) {
-        return this.accountUuid.equals(accountUuid) && this.folderName.equals(folderName) && this.uid.equals(uid);
+    public boolean equals(String accountUuid, String folderServerId, String uid) {
+        return this.accountUuid.equals(accountUuid) && this.folderServerId.equals(folderServerId) && this.uid.equals(uid);
     }
 
     @Override
@@ -95,7 +95,7 @@ public class MessageReference {
 
         int result = 1;
         result = MULTIPLIER * result + accountUuid.hashCode();
-        result = MULTIPLIER * result + folderName.hashCode();
+        result = MULTIPLIER * result + folderServerId.hashCode();
         result = MULTIPLIER * result + uid.hashCode();
         return result;
     }
@@ -104,7 +104,7 @@ public class MessageReference {
     public String toString() {
         return "MessageReference{" +
                "accountUuid='" + accountUuid + '\'' +
-               ", folderName='" + folderName + '\'' +
+               ", folderServerId='" + folderServerId + '\'' +
                ", uid='" + uid + '\'' +
                ", flag=" + flag +
                '}';
@@ -114,8 +114,8 @@ public class MessageReference {
         return accountUuid;
     }
 
-    public String getFolderName() {
-        return folderName;
+    public String getFolderServerId() {
+        return folderServerId;
     }
 
     public String getUid() {
@@ -127,10 +127,10 @@ public class MessageReference {
     }
 
     public MessageReference withModifiedUid(String newUid) {
-        return new MessageReference(accountUuid, folderName, newUid, flag);
+        return new MessageReference(accountUuid, folderServerId, newUid, flag);
     }
 
     public MessageReference withModifiedFlag(Flag newFlag) {
-        return new MessageReference(accountUuid, folderName, uid, newFlag);
+        return new MessageReference(accountUuid, folderServerId, uid, newFlag);
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/UnreadWidgetConfiguration.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/UnreadWidgetConfiguration.java
@@ -54,7 +54,7 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
     private Preference unreadFolder;
 
     private String selectedAccountUuid;
-    private String selectedFolderName;
+    private String selectedFolder;
 
     @Override
     public void onCreate(Bundle icicle) {
@@ -91,7 +91,7 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
             @Override
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 unreadFolder.setSummary(getString(R.string.unread_widget_folder_summary));
-                selectedFolderName = null;
+                selectedFolder = null;
                 return true;
             }
         });
@@ -132,7 +132,7 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
         }
 
         selectedAccountUuid = accountUuid;
-        selectedFolderName = null;
+        selectedFolder = null;
         unreadFolder.setSummary(getString(R.string.unread_widget_folder_summary));
         if (SearchAccount.UNIFIED_INBOX.equals(selectedAccountUuid) ||
                 SearchAccount.ALL_MESSAGES.equals(selectedAccountUuid)) {
@@ -151,7 +151,7 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
         unreadFolderEnabled.setEnabled(false);
         unreadFolderEnabled.setChecked(false);
         unreadFolder.setEnabled(false);
-        selectedFolderName = null;
+        selectedFolder = null;
     }
 
     private void handleRegularAccount() {
@@ -165,9 +165,9 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
         unreadFolder.setEnabled(true);
     }
 
-    private void handleChooseFolder(String folderName) {
-        selectedFolderName = folderName;
-        unreadFolder.setSummary(selectedFolderName);
+    private void handleChooseFolder(String folderServerId) {
+        selectedFolder = folderServerId;
+        unreadFolder.setSummary(selectedFolder);
     }
 
     @Override
@@ -194,7 +194,7 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
         if (selectedAccountUuid == null) {
             Toast.makeText(this, R.string.unread_widget_account_not_selected, Toast.LENGTH_LONG).show();
             return false;
-        } else if (unreadFolderEnabled.isChecked() && selectedFolderName == null) {
+        } else if (unreadFolderEnabled.isChecked() && selectedFolder == null) {
             Toast.makeText(this, R.string.unread_widget_folder_not_selected, Toast.LENGTH_LONG).show();
             return false;
         }
@@ -202,7 +202,7 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
     }
 
     private void updateWidgetAndExit() {
-        UnreadWidgetProperties properties = new UnreadWidgetProperties(appWidgetId, selectedAccountUuid,selectedFolderName);
+        UnreadWidgetProperties properties = new UnreadWidgetProperties(appWidgetId, selectedAccountUuid, selectedFolder);
         saveWidgetProperties(this, properties);
 
         // Update widget
@@ -222,15 +222,15 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
         SharedPreferences.Editor editor =
                 context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit();
         editor.putString(PREF_PREFIX_KEY + appWidgetId, properties.getAccountUuid());
-        editor.putString(PREF_PREFIX_KEY + appWidgetId + PREF_FOLDER_NAME_SUFFIX_KEY, properties.getFolderName());
+        editor.putString(PREF_PREFIX_KEY + appWidgetId + PREF_FOLDER_NAME_SUFFIX_KEY, properties.getFolderServerId());
         editor.apply();
     }
 
     public static UnreadWidgetProperties getWidgetProperties(Context context, int appWidgetId) {
         SharedPreferences prefs = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE);
         String accountUuid = prefs.getString(PREF_PREFIX_KEY + appWidgetId, null);
-        String folderName = prefs.getString(PREF_PREFIX_KEY + appWidgetId + PREF_FOLDER_NAME_SUFFIX_KEY, null);
-        return new UnreadWidgetProperties(appWidgetId, accountUuid, folderName);
+        String folderServerId = prefs.getString(PREF_PREFIX_KEY + appWidgetId + PREF_FOLDER_NAME_SUFFIX_KEY, null);
+        return new UnreadWidgetProperties(appWidgetId, accountUuid, folderServerId);
     }
 
     public static void deleteWidgetConfiguration(Context context, int appWidgetId) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/UnreadWidgetConfiguration.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/UnreadWidgetConfiguration.java
@@ -118,7 +118,9 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
                     handleChooseAccount(data.getStringExtra(ChooseAccount.EXTRA_ACCOUNT_UUID));
                     break;
                 case REQUEST_CHOOSE_FOLDER:
-                    handleChooseFolder(data.getStringExtra(ChooseFolder.EXTRA_NEW_FOLDER));
+                    String folderServerId = data.getStringExtra(ChooseFolder.EXTRA_NEW_FOLDER);
+                    String folderDisplayName = data.getStringExtra(ChooseFolder.RESULT_FOLDER_DISPLAY_NAME);
+                    handleChooseFolder(folderServerId, folderDisplayName);
                     break;
             }
         }
@@ -165,9 +167,9 @@ public class UnreadWidgetConfiguration extends K9PreferenceActivity {
         unreadFolder.setEnabled(true);
     }
 
-    private void handleChooseFolder(String folderServerId) {
+    private void handleChooseFolder(String folderServerId, String folderDisplayName) {
         selectedFolder = folderServerId;
-        unreadFolder.setSummary(selectedFolder);
+        unreadFolder.setSummary(folderDisplayName);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -1042,7 +1042,7 @@ public class AccountSettings extends K9PreferenceActivity {
             Iterator <? extends Folder > iter = folders.iterator();
             while (iter.hasNext()) {
                 Folder folder = iter.next();
-                if (account.getOutboxFolder().equals(folder.getName())) {
+                if (account.getOutboxFolder().equals(folder.getServerId())) {
                     iter.remove();
                 }
             }
@@ -1055,8 +1055,8 @@ public class AccountSettings extends K9PreferenceActivity {
 
             int i = 1;
             for (Folder folder : folders) {
-                allFolderLabels[i] = folder.getName();
-                allFolderValues[i] = folder.getName();
+                allFolderLabels[i] = folder.getServerId();
+                allFolderValues[i] = folder.getServerId();
                 i++;
             }
             return null;

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -808,16 +808,16 @@ public class AccountSettings extends K9PreferenceActivity {
         // In webdav account we use the exact folder name also for inbox,
         // since it varies because of internationalization
         if (account.getStoreUri().startsWith("webdav"))
-            account.setAutoExpandFolderName(autoExpandFolder.getValue());
+            account.setAutoExpandFolder(autoExpandFolder.getValue());
         else
-            account.setAutoExpandFolderName(reverseTranslateFolder(autoExpandFolder.getValue()));
+            account.setAutoExpandFolder(reverseTranslateFolder(autoExpandFolder.getValue()));
 
         if (isMoveCapable) {
-            account.setArchiveFolderName(archiveFolder.getValue());
-            account.setDraftsFolderName(draftsFolder.getValue());
-            account.setSentFolderName(sentFolder.getValue());
-            account.setSpamFolderName(spamFolder.getValue());
-            account.setTrashFolderName(trashFolder.getValue());
+            account.setArchiveFolder(archiveFolder.getValue());
+            account.setDraftsFolder(draftsFolder.getValue());
+            account.setSentFolder(sentFolder.getValue());
+            account.setSpamFolder(spamFolder.getValue());
+            account.setTrashFolder(trashFolder.getValue());
         }
 
         //IMAP stuff
@@ -986,7 +986,7 @@ public class AccountSettings extends K9PreferenceActivity {
     }
 
     private String translateFolder(String in) {
-        if (account.getInboxFolderName().equals(in)) {
+        if (account.getInboxFolder().equals(in)) {
             return getString(R.string.special_mailbox_name_inbox);
         } else {
             return in;
@@ -995,7 +995,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
     private String reverseTranslateFolder(String in) {
         if (getString(R.string.special_mailbox_name_inbox).equals(in)) {
-            return account.getInboxFolderName();
+            return account.getInboxFolder();
         } else {
             return in;
         }
@@ -1042,7 +1042,7 @@ public class AccountSettings extends K9PreferenceActivity {
             Iterator <? extends Folder > iter = folders.iterator();
             while (iter.hasNext()) {
                 Folder folder = iter.next();
-                if (account.getOutboxFolderName().equals(folder.getName())) {
+                if (account.getOutboxFolder().equals(folder.getName())) {
                     iter.remove();
                 }
             }
@@ -1090,14 +1090,14 @@ public class AccountSettings extends K9PreferenceActivity {
 
         @Override
         protected void onPostExecute(Void res) {
-            initListPreference(autoExpandFolder, account.getAutoExpandFolderName(), allFolderLabels, allFolderValues);
+            initListPreference(autoExpandFolder, account.getAutoExpandFolder(), allFolderLabels, allFolderValues);
             autoExpandFolder.setEnabled(true);
             if (isMoveCapable) {
-                initListPreference(archiveFolder, account.getArchiveFolderName(), allFolderLabels, allFolderValues);
-                initListPreference(draftsFolder, account.getDraftsFolderName(), allFolderLabels, allFolderValues);
-                initListPreference(sentFolder, account.getSentFolderName(), allFolderLabels, allFolderValues);
-                initListPreference(spamFolder, account.getSpamFolderName(), allFolderLabels, allFolderValues);
-                initListPreference(trashFolder, account.getTrashFolderName(), allFolderLabels, allFolderValues);
+                initListPreference(archiveFolder, account.getArchiveFolder(), allFolderLabels, allFolderValues);
+                initListPreference(draftsFolder, account.getDraftsFolder(), allFolderLabels, allFolderValues);
+                initListPreference(sentFolder, account.getSentFolder(), allFolderLabels, allFolderValues);
+                initListPreference(spamFolder, account.getSpamFolder(), allFolderLabels, allFolderValues);
+                initListPreference(trashFolder, account.getTrashFolder(), allFolderLabels, allFolderValues);
                 archiveFolder.setEnabled(true);
                 spamFolder.setEnabled(true);
                 draftsFolder.setEnabled(true);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -423,16 +423,16 @@ public class AccountSetupBasics extends K9Activity
     }
 
     private void setupFolderNames(String domain) {
-        mAccount.setDraftsFolderName(getString(R.string.special_mailbox_name_drafts));
-        mAccount.setTrashFolderName(getString(R.string.special_mailbox_name_trash));
-        mAccount.setSentFolderName(getString(R.string.special_mailbox_name_sent));
-        mAccount.setArchiveFolderName(getString(R.string.special_mailbox_name_archive));
+        mAccount.setDraftsFolder(getString(R.string.special_mailbox_name_drafts));
+        mAccount.setTrashFolder(getString(R.string.special_mailbox_name_trash));
+        mAccount.setSentFolder(getString(R.string.special_mailbox_name_sent));
+        mAccount.setArchiveFolder(getString(R.string.special_mailbox_name_archive));
 
         // Yahoo! has a special folder for Spam, called "Bulk Mail".
         if (domain.endsWith(".yahoo.com")) {
-            mAccount.setSpamFolderName("Bulk Mail");
+            mAccount.setSpamFolder("Bulk Mail");
         } else {
-            mAccount.setSpamFolderName(getString(R.string.special_mailbox_name_spam));
+            mAccount.setSpamFolder(getString(R.string.special_mailbox_name_spam));
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -506,7 +506,7 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
             }
             MessagingController.getInstance(getApplication()).listFoldersSynchronous(account, true, null);
             MessagingController.getInstance(getApplication())
-                    .synchronizeMailbox(account, account.getInboxFolderName(), null, null);
+                    .synchronizeMailbox(account, account.getInboxFolder(), null, null);
         }
 
         @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
@@ -45,9 +45,9 @@ public class FolderSettings extends K9PreferenceActivity {
     private ListPreference mPushClass;
     private ListPreference mNotifyClass;
 
-    public static void actionSettings(Context context, Account account, String folderName) {
+    public static void actionSettings(Context context, Account account, String folderServerId) {
         Intent i = new Intent(context, FolderSettings.class);
-        i.putExtra(EXTRA_FOLDER_NAME, folderName);
+        i.putExtra(EXTRA_FOLDER_NAME, folderServerId);
         i.putExtra(EXTRA_ACCOUNT, account.getUuid());
         context.startActivity(i);
     }
@@ -56,16 +56,16 @@ public class FolderSettings extends K9PreferenceActivity {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
-        String folderName = (String)getIntent().getSerializableExtra(EXTRA_FOLDER_NAME);
+        String folderServerId = (String)getIntent().getSerializableExtra(EXTRA_FOLDER_NAME);
         String accountUuid = getIntent().getStringExtra(EXTRA_ACCOUNT);
         Account mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
 
         try {
             LocalStore localStore = mAccount.getLocalStore();
-            mFolder = localStore.getFolder(folderName);
+            mFolder = localStore.getFolder(folderServerId);
             mFolder.open(Folder.OPEN_MODE_RW);
         } catch (MessagingException me) {
-            Timber.e(me, "Unable to edit folder %s preferences", folderName);
+            Timber.e(me, "Unable to edit folder %s preferences", folderServerId);
             return;
         }
 
@@ -79,7 +79,7 @@ public class FolderSettings extends K9PreferenceActivity {
 
         addPreferencesFromResource(R.xml.folder_settings_preferences);
 
-        String displayName = FolderInfoHolder.getDisplayName(this, mAccount, mFolder.getName());
+        String displayName = FolderInfoHolder.getDisplayName(this, mAccount, mFolder.getServerId());
         Preference category = findPreference(PREFERENCE_TOP_CATERGORY);
         category.setTitle(displayName);
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
@@ -79,7 +79,8 @@ public class FolderSettings extends K9PreferenceActivity {
 
         addPreferencesFromResource(R.xml.folder_settings_preferences);
 
-        String displayName = FolderInfoHolder.getDisplayName(this, mAccount, mFolder.getServerId());
+        String folderName = mFolder.getName();
+        String displayName = FolderInfoHolder.getDisplayName(this, mAccount, folderServerId, folderName);
         Preference category = findPreference(PREFERENCE_TOP_CATERGORY);
         category.setTitle(displayName);
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
@@ -90,7 +90,8 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
             }
             Memory somethingStarted = null;
             if (syncStarted != null) {
-                other.synchronizeMailboxStarted(syncStarted.account, syncStarted.folderServerId);
+                other.synchronizeMailboxStarted(syncStarted.account, syncStarted.folderServerId,
+                        syncStarted.folderName);
                 somethingStarted = syncStarted;
             }
             if (sendStarted != null) {
@@ -117,8 +118,10 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     }
 
     @Override
-    public synchronized void synchronizeMailboxStarted(Account account, String folderServerId) {
+    public synchronized void synchronizeMailboxStarted(Account account, String folderServerId,
+            String folderName) {
         Memory memory = getMemory(account, folderServerId);
+        memory.folderName = folderName;
         memory.syncingState = MemorizingState.STARTED;
         memory.folderCompleted = 0;
         memory.folderTotal = 0;
@@ -222,6 +225,7 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     private static class Memory {
         Account account;
         String folderServerId;
+        String folderName;
         MemorizingState syncingState = null;
         MemorizingState sendingState = null;
         MemorizingState pushingState = null;

--- a/k9mail/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
@@ -41,11 +41,11 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
                             syncStarted = memory;
                             break;
                         case FINISHED:
-                            other.synchronizeMailboxFinished(memory.account, memory.folderName,
+                            other.synchronizeMailboxFinished(memory.account, memory.folderServerId,
                                     memory.syncingTotalMessagesInMailbox, memory.syncingNumNewMessages);
                             break;
                         case FAILED:
-                            other.synchronizeMailboxFailed(memory.account, memory.folderName,
+                            other.synchronizeMailboxFailed(memory.account, memory.folderServerId,
                                     memory.failureMessage);
                             break;
                     }
@@ -67,10 +67,10 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
                 if (memory.pushingState != null) {
                     switch (memory.pushingState) {
                         case STARTED:
-                            other.setPushActive(memory.account, memory.folderName, true);
+                            other.setPushActive(memory.account, memory.folderServerId, true);
                             break;
                         case FINISHED:
-                            other.setPushActive(memory.account, memory.folderName, false);
+                            other.setPushActive(memory.account, memory.folderServerId, false);
                             break;
                         case FAILED:
                             break;
@@ -90,7 +90,7 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
             }
             Memory somethingStarted = null;
             if (syncStarted != null) {
-                other.synchronizeMailboxStarted(syncStarted.account, syncStarted.folderName);
+                other.synchronizeMailboxStarted(syncStarted.account, syncStarted.folderServerId);
                 somethingStarted = syncStarted;
             }
             if (sendStarted != null) {
@@ -109,7 +109,7 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
                 somethingStarted = processingStarted;
             }
             if (somethingStarted != null && somethingStarted.folderTotal > 0) {
-                other.synchronizeMailboxProgress(somethingStarted.account, somethingStarted.folderName,
+                other.synchronizeMailboxProgress(somethingStarted.account, somethingStarted.folderServerId,
                         somethingStarted.folderCompleted, somethingStarted.folderTotal);
             }
 
@@ -117,34 +117,34 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     }
 
     @Override
-    public synchronized void synchronizeMailboxStarted(Account account, String folder) {
-        Memory memory = getMemory(account, folder);
+    public synchronized void synchronizeMailboxStarted(Account account, String folderServerId) {
+        Memory memory = getMemory(account, folderServerId);
         memory.syncingState = MemorizingState.STARTED;
         memory.folderCompleted = 0;
         memory.folderTotal = 0;
     }
 
     @Override
-    public synchronized void synchronizeMailboxFinished(Account account, String folder,
+    public synchronized void synchronizeMailboxFinished(Account account, String folderServerId,
             int totalMessagesInMailbox, int numNewMessages) {
-        Memory memory = getMemory(account, folder);
+        Memory memory = getMemory(account, folderServerId);
         memory.syncingState = MemorizingState.FINISHED;
         memory.syncingTotalMessagesInMailbox = totalMessagesInMailbox;
         memory.syncingNumNewMessages = numNewMessages;
     }
 
     @Override
-    public synchronized void synchronizeMailboxFailed(Account account, String folder,
+    public synchronized void synchronizeMailboxFailed(Account account, String folderServerId,
             String message) {
 
-        Memory memory = getMemory(account, folder);
+        Memory memory = getMemory(account, folderServerId);
         memory.syncingState = MemorizingState.FAILED;
         memory.failureMessage = message;
     }
 
     @Override
-    public synchronized void setPushActive(Account account, String folderName, boolean active) {
-        Memory memory = getMemory(account, folderName);
+    public synchronized void setPushActive(Account account, String folderServerId, boolean active) {
+        Memory memory = getMemory(account, folderServerId);
         memory.pushingState = (active ? MemorizingState.STARTED : MemorizingState.FINISHED);
     }
 
@@ -170,9 +170,9 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
 
 
     @Override
-    public synchronized void synchronizeMailboxProgress(Account account, String folderName, int completed,
+    public synchronized void synchronizeMailboxProgress(Account account, String folderServerId, int completed,
             int total) {
-        Memory memory = getMemory(account, folderName);
+        Memory memory = getMemory(account, folderServerId);
         memory.folderCompleted = completed;
         memory.folderTotal = total;
     }
@@ -204,24 +204,24 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
         memory.processingCommandTitle = null;
     }
 
-    private Memory getMemory(Account account, String folderName) {
-        Memory memory = memories.get(getMemoryKey(account, folderName));
+    private Memory getMemory(Account account, String folderServerId) {
+        Memory memory = memories.get(getMemoryKey(account, folderServerId));
         if (memory == null) {
-            memory = new Memory(account, folderName);
-            memories.put(getMemoryKey(memory.account, memory.folderName), memory);
+            memory = new Memory(account, folderServerId);
+            memories.put(getMemoryKey(memory.account, memory.folderServerId), memory);
         }
         return memory;
     }
 
-    private static String getMemoryKey(Account taccount, String tfolderName) {
-        return taccount.getDescription() + ":" + tfolderName;
+    private static String getMemoryKey(Account account, String folderServerId) {
+        return account.getDescription() + ":" + folderServerId;
     }
 
     private enum MemorizingState { STARTED, FINISHED, FAILED }
 
     private static class Memory {
         Account account;
-        String folderName;
+        String folderServerId;
         MemorizingState syncingState = null;
         MemorizingState sendingState = null;
         MemorizingState pushingState = null;
@@ -235,9 +235,9 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
         int folderTotal = 0;
         String processingCommandTitle = null;
 
-        Memory(Account nAccount, String nFolderName) {
-            account = nAccount;
-            folderName = nFolderName;
+        Memory(Account account, String folderServerId) {
+            this.account = account;
+            this.folderServerId = folderServerId;
         }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -758,7 +758,7 @@ public class MessagingController {
         /*
          * We don't ever sync the Outbox
          */
-        if (folder.equals(account.getOutboxFolderName())) {
+        if (folder.equals(account.getOutboxFolder())) {
             for (MessagingListener l : getListeners(listener)) {
                 l.synchronizeMailboxFinished(account, folder, 0, 0);
             }
@@ -1028,9 +1028,9 @@ public class MessagingController {
      */
     private boolean verifyOrCreateRemoteSpecialFolder(Account account, String folder, Folder remoteFolder,
             MessagingListener listener) throws MessagingException {
-        if (folder.equals(account.getTrashFolderName()) ||
-                folder.equals(account.getSentFolderName()) ||
-                folder.equals(account.getDraftsFolderName())) {
+        if (folder.equals(account.getTrashFolder()) ||
+                folder.equals(account.getSentFolder()) ||
+                folder.equals(account.getDraftsFolder())) {
             if (!remoteFolder.exists()) {
                 if (!remoteFolder.create(FolderType.HOLDS_MESSAGES)) {
                     for (MessagingListener l : getListeners(listener)) {
@@ -1881,7 +1881,7 @@ public class MessagingController {
 
             Map<String, String> remoteUidMap = null;
 
-            if (!isCopy && destFolder.equals(account.getTrashFolderName())) {
+            if (!isCopy && destFolder.equals(account.getTrashFolder())) {
                 Timber.d("processingPendingMoveOrCopy doing special case for deleting message");
 
                 String destFolderName = destFolder;
@@ -2179,7 +2179,7 @@ public class MessagingController {
 
             // Allows for re-allowing sending of messages that could not be sent
             if (flag == Flag.FLAGGED && !newState &&
-                    account.getOutboxFolderName().equals(folderName)) {
+                    account.getOutboxFolder().equals(folderName)) {
                 for (Message message : messages) {
                     String uid = message.getUid();
                     if (uid != null) {
@@ -2452,7 +2452,7 @@ public class MessagingController {
             MessagingListener listener) {
         try {
             LocalStore localStore = account.getLocalStore();
-            LocalFolder localFolder = localStore.getFolder(account.getOutboxFolderName());
+            LocalFolder localFolder = localStore.getFolder(account.getOutboxFolder());
             localFolder.open(Folder.OPEN_MODE_RW);
             localFolder.appendMessages(Collections.singletonList(message));
             Message localMessage = localFolder.getMessage(message.getUid());
@@ -2521,7 +2521,7 @@ public class MessagingController {
         Folder localFolder = null;
         try {
             localFolder = account.getLocalStore().getFolder(
-                    account.getOutboxFolderName());
+                    account.getOutboxFolder());
             if (!localFolder.exists()) {
                 return false;
             }
@@ -2550,7 +2550,7 @@ public class MessagingController {
         try {
             LocalStore localStore = account.getLocalStore();
             localFolder = localStore.getFolder(
-                    account.getOutboxFolderName());
+                    account.getOutboxFolder());
             if (!localFolder.exists()) {
                 Timber.v("Outbox does not exist");
                 return;
@@ -2564,7 +2564,7 @@ public class MessagingController {
             int progress = 0;
             int todo = localMessages.size();
             for (MessagingListener l : getListeners()) {
-                l.synchronizeMailboxProgress(account, account.getSentFolderName(), progress, todo);
+                l.synchronizeMailboxProgress(account, account.getSentFolder(), progress, todo);
             }
             /*
              * The profile we will use to pull all of the content
@@ -2575,7 +2575,7 @@ public class MessagingController {
             fp.add(FetchProfile.Item.BODY);
 
             Timber.i("Scanning folder '%s' (%d) for messages to send",
-                    account.getOutboxFolderName(), localFolder.getDatabaseId());
+                    account.getOutboxFolder(), localFolder.getDatabaseId());
 
             Transport transport = transportProvider.getTransport(K9.app, account);
 
@@ -2618,7 +2618,7 @@ public class MessagingController {
                         message.setFlag(Flag.SEEN, true);
                         progress++;
                         for (MessagingListener l : getListeners()) {
-                            l.synchronizeMailboxProgress(account, account.getSentFolderName(), progress, todo);
+                            l.synchronizeMailboxProgress(account, account.getSentFolder(), progress, todo);
                         }
                         moveOrDeleteSentMessage(account, localStore, localFolder, message);
                     } catch (AuthenticationFailedException e) {
@@ -2686,12 +2686,12 @@ public class MessagingController {
             Timber.i("Account does not have a sent mail folder; deleting sent message");
             message.setFlag(Flag.DELETED, true);
         } else {
-            LocalFolder localSentFolder = localStore.getFolder(account.getSentFolderName());
-            Timber.i("Moving sent message to folder '%s' (%d)", account.getSentFolderName(), localSentFolder.getDatabaseId());
+            LocalFolder localSentFolder = localStore.getFolder(account.getSentFolder());
+            Timber.i("Moving sent message to folder '%s' (%d)", account.getSentFolder(), localSentFolder.getDatabaseId());
 
             localFolder.moveMessages(Collections.singletonList(message), localSentFolder);
 
-            Timber.i("Moved sent message to folder '%s' (%d)", account.getSentFolderName(), localSentFolder.getDatabaseId());
+            Timber.i("Moved sent message to folder '%s' (%d)", account.getSentFolder(), localSentFolder.getDatabaseId());
 
             PendingCommand command = PendingAppend.create(localSentFolder.getName(), message.getUid());
             queuePendingCommand(account, command);
@@ -2715,7 +2715,7 @@ public class MessagingController {
 
     private void moveMessageToDraftsFolder(Account account, Folder localFolder, LocalStore localStore, Message message)
             throws MessagingException {
-        LocalFolder draftsFolder = localStore.getFolder(account.getDraftsFolderName());
+        LocalFolder draftsFolder = localStore.getFolder(account.getDraftsFolder());
         localFolder.moveMessages(Collections.singletonList(message), draftsFolder);
     }
 
@@ -3066,12 +3066,12 @@ public class MessagingController {
         LocalFolder localFolder = null;
         try {
             LocalStore localStore = account.getLocalStore();
-            localFolder = localStore.getFolder(account.getDraftsFolderName());
+            localFolder = localStore.getFolder(account.getDraftsFolder());
             localFolder.open(Folder.OPEN_MODE_RW);
             String uid = localFolder.getMessageUidById(id);
             if (uid != null) {
                 MessageReference messageReference = new MessageReference(
-                        account.getUuid(), account.getDraftsFolderName(), uid, null);
+                        account.getUuid(), account.getDraftsFolder(), uid, null);
                 deleteMessage(messageReference, null);
             }
         } catch (MessagingException me) {
@@ -3210,7 +3210,7 @@ public class MessagingController {
             LocalStore localStore = account.getLocalStore();
             localFolder = localStore.getFolder(folder);
             Map<String, String> uidMap = null;
-            if (folder.equals(account.getTrashFolderName()) || !account.hasTrashFolder()) {
+            if (folder.equals(account.getTrashFolder()) || !account.hasTrashFolder()) {
                 Timber.d("Deleting messages in trash folder or trash set to -None-, not copying");
 
                 if (!localOnlyMessages.isEmpty()) {
@@ -3220,7 +3220,7 @@ public class MessagingController {
                     localFolder.setFlags(syncedMessages, Collections.singleton(Flag.DELETED), true);
                 }
             } else {
-                localTrashFolder = localStore.getFolder(account.getTrashFolderName());
+                localTrashFolder = localStore.getFolder(account.getTrashFolder());
                 if (!localTrashFolder.exists()) {
                     localTrashFolder.create(Folder.FolderType.HOLDS_MESSAGES);
                 }
@@ -3235,27 +3235,27 @@ public class MessagingController {
             for (MessagingListener l : getListeners()) {
                 l.folderStatusChanged(account, folder, localFolder.getUnreadMessageCount());
                 if (localTrashFolder != null) {
-                    l.folderStatusChanged(account, account.getTrashFolderName(),
+                    l.folderStatusChanged(account, account.getTrashFolder(),
                             localTrashFolder.getUnreadMessageCount());
                 }
             }
 
             Timber.d("Delete policy for account %s is %s", account.getDescription(), account.getDeletePolicy());
 
-            if (folder.equals(account.getOutboxFolderName())) {
+            if (folder.equals(account.getOutboxFolder())) {
                 for (Message message : messages) {
                     // If the message was in the Outbox, then it has been copied to local Trash, and has
                     // to be copied to remote trash
-                    PendingCommand command = PendingAppend.create(account.getTrashFolderName(), message.getUid());
+                    PendingCommand command = PendingAppend.create(account.getTrashFolder(), message.getUid());
                     queuePendingCommand(account, command);
                 }
                 processPendingCommands(account);
             } else if (!syncedMessageUids.isEmpty()) {
                 if (account.getDeletePolicy() == DeletePolicy.ON_DELETE) {
-                    if (folder.equals(account.getTrashFolderName())) {
+                    if (folder.equals(account.getTrashFolder())) {
                         queueSetFlag(account, folder, true, Flag.DELETED, syncedMessageUids);
                     } else {
-                        queueMoveOrCopy(account, folder, account.getTrashFolderName(), false,
+                        queueMoveOrCopy(account, folder, account.getTrashFolder(), false,
                                     syncedMessageUids, uidMap);
                     }
                     processPendingCommands(account);
@@ -3290,7 +3290,7 @@ public class MessagingController {
     void processPendingEmptyTrash(Account account) throws MessagingException {
         RemoteStore remoteStore = account.getRemoteStore();
 
-        Folder remoteFolder = remoteStore.getFolder(account.getTrashFolderName());
+        Folder remoteFolder = remoteStore.getFolder(account.getTrashFolder());
         try {
             if (remoteFolder.exists()) {
                 remoteFolder.open(Folder.OPEN_MODE_RW);
@@ -3318,7 +3318,7 @@ public class MessagingController {
                 LocalFolder localFolder = null;
                 try {
                     LocalStore localStore = account.getLocalStore();
-                    localFolder = (LocalFolder) localStore.getFolder(account.getTrashFolderName());
+                    localFolder = (LocalFolder) localStore.getFolder(account.getTrashFolder());
                     localFolder.open(Folder.OPEN_MODE_RW);
 
                     boolean isTrashLocalOnly = isTrashLocalOnly(account);
@@ -3772,11 +3772,11 @@ public class MessagingController {
         Folder folder = message.getFolder();
         if (folder != null) {
             String folderName = folder.getName();
-            if (!account.getInboxFolderName().equals(folderName) &&
-                    (account.getTrashFolderName().equals(folderName)
-                            || account.getDraftsFolderName().equals(folderName)
-                            || account.getSpamFolderName().equals(folderName)
-                            || account.getSentFolderName().equals(folderName))) {
+            if (!account.getInboxFolder().equals(folderName) &&
+                    (account.getTrashFolder().equals(folderName)
+                            || account.getDraftsFolder().equals(folderName)
+                            || account.getSpamFolder().equals(folderName)
+                            || account.getSentFolder().equals(folderName))) {
                 return false;
             }
         }
@@ -3826,7 +3826,7 @@ public class MessagingController {
         Message localMessage = null;
         try {
             LocalStore localStore = account.getLocalStore();
-            LocalFolder localFolder = localStore.getFolder(account.getDraftsFolderName());
+            LocalFolder localFolder = localStore.getFolder(account.getDraftsFolder());
             localFolder.open(Folder.OPEN_MODE_RW);
 
             if (existingDraftId != INVALID_MESSAGE_ID) {
@@ -3929,7 +3929,7 @@ public class MessagingController {
 
             LocalStore localStore = account.getLocalStore();
             for (final Folder folder : localStore.getPersonalNamespaces(false)) {
-                if (folder.getName().equals(account.getOutboxFolderName())) {
+                if (folder.getName().equals(account.getOutboxFolder())) {
                     continue;
                 }
                 folder.open(Folder.OPEN_MODE_RW);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -756,23 +756,25 @@ public class MessagingController {
 
         Timber.i("Synchronizing folder %s:%s", account.getDescription(), folder);
 
-        for (MessagingListener l : getListeners(listener)) {
-            l.synchronizeMailboxStarted(account, folder);
-        }
-        /*
-         * We don't ever sync the Outbox
-         */
+        // We don't ever sync the Outbox
         if (folder.equals(account.getOutboxFolder())) {
-            for (MessagingListener l : getListeners(listener)) {
-                l.synchronizeMailboxFinished(account, folder, 0, 0);
-            }
-
             return;
         }
 
         Exception commandException = null;
         try {
             Timber.d("SYNC: About to process pending commands for account %s", account.getDescription());
+
+            Timber.v("SYNC: About to get local folder %s", folder);
+            final LocalStore localStore = account.getLocalStore();
+            tLocalFolder = localStore.getFolder(folder);
+            final LocalFolder localFolder = tLocalFolder;
+            localFolder.open(Folder.OPEN_MODE_RW);
+            String folderName = localFolder.getName();
+
+            for (MessagingListener l : getListeners(listener)) {
+                l.synchronizeMailboxStarted(account, folder, folderName);
+            }
 
             try {
                 processPendingCommandsSynchronous(account);
@@ -785,12 +787,7 @@ public class MessagingController {
              * Get the message list from the local store and create an index of
              * the uids within the list.
              */
-            Timber.v("SYNC: About to get local folder %s", folder);
 
-            final LocalStore localStore = account.getLocalStore();
-            tLocalFolder = localStore.getFolder(folder);
-            final LocalFolder localFolder = tLocalFolder;
-            localFolder.open(Folder.OPEN_MODE_RW);
             Map<String, Long> localUidMap = localFolder.getAllMessagesAndEffectiveDates();
 
             RemoteStore remoteStore = account.getRemoteStore();
@@ -864,7 +861,7 @@ public class MessagingController {
 
                 final AtomicInteger headerProgress = new AtomicInteger(0);
                 for (MessagingListener l : getListeners(listener)) {
-                    l.synchronizeMailboxHeadersStarted(account, folder);
+                    l.synchronizeMailboxHeadersStarted(account, folder, folderName);
                 }
 
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -115,8 +115,8 @@ public class MessagingControllerCommands {
         public final String uid;
 
 
-        public static PendingAppend create(String folderName, String uid) {
-            return new PendingAppend(folderName, uid);
+        public static PendingAppend create(String folderServerId, String uid) {
+            return new PendingAppend(folderServerId, uid);
         }
 
         private PendingAppend(String folder, String uid) {
@@ -162,8 +162,8 @@ public class MessagingControllerCommands {
         public final String folder;
 
 
-        public static PendingExpunge create(String folderName) {
-            return new PendingExpunge(folderName);
+        public static PendingExpunge create(String folderServerId) {
+            return new PendingExpunge(folderServerId);
         }
 
         private PendingExpunge(String folder) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
@@ -40,28 +40,28 @@ public class MessagingControllerPushReceiver implements PushReceiver {
     }
 
     public void syncFolder(Folder folder) {
-        Timber.v("syncFolder(%s)", folder.getName());
+        Timber.v("syncFolder(%s)", folder.getServerId());
 
         final CountDownLatch latch = new CountDownLatch(1);
-        controller.synchronizeMailbox(account, folder.getName(), new SimpleMessagingListener() {
+        controller.synchronizeMailbox(account, folder.getServerId(), new SimpleMessagingListener() {
             @Override
-            public void synchronizeMailboxFinished(Account account, String folder,
+            public void synchronizeMailboxFinished(Account account, String folderServerId,
             int totalMessagesInMailbox, int numNewMessages) {
                 latch.countDown();
             }
 
             @Override
-            public void synchronizeMailboxFailed(Account account, String folder,
+            public void synchronizeMailboxFailed(Account account, String folderServerId,
             String message) {
                 latch.countDown();
             }
         }, folder);
 
-        Timber.v("syncFolder(%s) about to await latch release", folder.getName());
+        Timber.v("syncFolder(%s) about to await latch release", folder.getServerId());
 
         try {
             latch.await();
-            Timber.v("syncFolder(%s) got latch release", folder.getName());
+            Timber.v("syncFolder(%s) got latch release", folder.getServerId());
         } catch (Exception e) {
             Timber.e(e, "Interrupted while awaiting latch release");
         }
@@ -87,15 +87,15 @@ public class MessagingControllerPushReceiver implements PushReceiver {
         controller.handleAuthenticationFailure(account, true);
     }
 
-    public String getPushState(String folderName) {
+    public String getPushState(String folderServerId) {
         LocalFolder localFolder = null;
         try {
             LocalStore localStore = account.getLocalStore();
-            localFolder = localStore.getFolder(folderName);
+            localFolder = localStore.getFolder(folderServerId);
             localFolder.open(Folder.OPEN_MODE_RW);
             return localFolder.getPushState();
         } catch (Exception e) {
-            Timber.e(e, "Unable to get push state from account %s, folder %s", account.getDescription(), folderName);
+            Timber.e(e, "Unable to get push state from account %s, folder %s", account.getDescription(), folderServerId);
             return null;
         } finally {
             if (localFolder != null) {
@@ -104,9 +104,9 @@ public class MessagingControllerPushReceiver implements PushReceiver {
         }
     }
 
-    public void setPushActive(String folderName, boolean enabled) {
+    public void setPushActive(String folderServerId, boolean enabled) {
         for (MessagingListener l : controller.getListeners()) {
-            l.setPushActive(account, folderName, enabled);
+            l.setPushActive(account, folderServerId, enabled);
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
@@ -28,8 +28,8 @@ public interface MessagingListener {
 
     void listLocalMessagesAddMessages(Account account, String folderServerId, List<LocalMessage> messages);
 
-    void synchronizeMailboxStarted(Account account, String folderServerId);
-    void synchronizeMailboxHeadersStarted(Account account, String folderServerId);
+    void synchronizeMailboxStarted(Account account, String folderServerId, String folderName);
+    void synchronizeMailboxHeadersStarted(Account account, String folderServerId, String folderName);
     void synchronizeMailboxHeadersProgress(Account account, String folderServerId, int completed, int total);
     void synchronizeMailboxHeadersFinished(Account account, String folderServerId, int totalMessagesInMailbox,
             int numNewMessages);

--- a/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/MessagingListener.java
@@ -26,21 +26,21 @@ public interface MessagingListener {
     void listFoldersFinished(Account account);
     void listFoldersFailed(Account account, String message);
 
-    void listLocalMessagesAddMessages(Account account, String folder, List<LocalMessage> messages);
+    void listLocalMessagesAddMessages(Account account, String folderServerId, List<LocalMessage> messages);
 
-    void synchronizeMailboxStarted(Account account, String folder);
-    void synchronizeMailboxHeadersStarted(Account account, String folder);
-    void synchronizeMailboxHeadersProgress(Account account, String folder, int completed, int total);
-    void synchronizeMailboxHeadersFinished(Account account, String folder, int totalMessagesInMailbox,
+    void synchronizeMailboxStarted(Account account, String folderServerId);
+    void synchronizeMailboxHeadersStarted(Account account, String folderServerId);
+    void synchronizeMailboxHeadersProgress(Account account, String folderServerId, int completed, int total);
+    void synchronizeMailboxHeadersFinished(Account account, String folderServerId, int totalMessagesInMailbox,
             int numNewMessages);
-    void synchronizeMailboxProgress(Account account, String folder, int completed, int total);
-    void synchronizeMailboxNewMessage(Account account, String folder, Message message);
-    void synchronizeMailboxRemovedMessage(Account account, String folder, Message message);
-    void synchronizeMailboxFinished(Account account, String folder, int totalMessagesInMailbox, int numNewMessages);
-    void synchronizeMailboxFailed(Account account, String folder, String message);
+    void synchronizeMailboxProgress(Account account, String folderServerId, int completed, int total);
+    void synchronizeMailboxNewMessage(Account account, String folderServerId, Message message);
+    void synchronizeMailboxRemovedMessage(Account account, String folderServerId, Message message);
+    void synchronizeMailboxFinished(Account account, String folderServerId, int totalMessagesInMailbox, int numNewMessages);
+    void synchronizeMailboxFailed(Account account, String folderServerId, String message);
 
-    void loadMessageRemoteFinished(Account account, String folder, String uid);
-    void loadMessageRemoteFailed(Account account, String folder, String uid, Throwable t);
+    void loadMessageRemoteFinished(Account account, String folderServerId, String uid);
+    void loadMessageRemoteFailed(Account account, String folderServerId, String uid, Throwable t);
 
     void checkMailStarted(Context context, Account account);
     void checkMailFinished(Context context, Account account);
@@ -51,13 +51,13 @@ public interface MessagingListener {
 
     void emptyTrashCompleted(Account account);
 
-    void folderStatusChanged(Account account, String folderName, int unreadMessageCount);
+    void folderStatusChanged(Account account, String folderServerId, int unreadMessageCount);
     void systemStatusChanged();
 
-    void messageDeleted(Account account, String folder, Message message);
-    void messageUidChanged(Account account, String folder, String oldUid, String newUid);
+    void messageDeleted(Account account, String folderServerId, Message message);
+    void messageUidChanged(Account account, String folderServerId, String oldUid, String newUid);
 
-    void setPushActive(Account account, String folderName, boolean enabled);
+    void setPushActive(Account account, String folderServerId, boolean enabled);
 
     void loadAttachmentFinished(Account account, Message message, Part part);
     void loadAttachmentFailed(Account account, Message message, Part part, String reason);
@@ -68,9 +68,9 @@ public interface MessagingListener {
     void pendingCommandsFinished(Account account);
 
     void remoteSearchStarted(String folder);
-    void remoteSearchServerQueryComplete(String folderName, int numResults, int maxResults);
-    void remoteSearchFinished(String folder, int numResults, int maxResults, List<Message> extraResults);
-    void remoteSearchFailed(String folder, String err);
+    void remoteSearchServerQueryComplete(String folderServerId, int numResults, int maxResults);
+    void remoteSearchFinished(String folderServerId, int numResults, int maxResults, List<Message> extraResults);
+    void remoteSearchFailed(String folderServerId, String err);
 
     void enableProgressIndicator(boolean enable);
 

--- a/k9mail/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
@@ -49,11 +49,11 @@ public abstract class SimpleMessagingListener implements MessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxStarted(Account account, String folderServerId) {
+    public void synchronizeMailboxStarted(Account account, String folderServerId, String folderName) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersStarted(Account account, String folderServerId) {
+    public void synchronizeMailboxHeadersStarted(Account account, String folderServerId, String folderName) {
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
@@ -45,53 +45,53 @@ public abstract class SimpleMessagingListener implements MessagingListener {
     }
 
     @Override
-    public void listLocalMessagesAddMessages(Account account, String folder, List<LocalMessage> messages) {
+    public void listLocalMessagesAddMessages(Account account, String folderServerId, List<LocalMessage> messages) {
     }
 
     @Override
-    public void synchronizeMailboxStarted(Account account, String folder) {
+    public void synchronizeMailboxStarted(Account account, String folderServerId) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersStarted(Account account, String folder) {
+    public void synchronizeMailboxHeadersStarted(Account account, String folderServerId) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersProgress(Account account, String folder, int completed, int total) {
+    public void synchronizeMailboxHeadersProgress(Account account, String folderServerId, int completed, int total) {
     }
 
     @Override
-    public void synchronizeMailboxHeadersFinished(Account account, String folder, int totalMessagesInMailbox,
+    public void synchronizeMailboxHeadersFinished(Account account, String folderServerId, int totalMessagesInMailbox,
             int numNewMessages) {
     }
 
     @Override
-    public void synchronizeMailboxProgress(Account account, String folder, int completed, int total) {
+    public void synchronizeMailboxProgress(Account account, String folderServerId, int completed, int total) {
     }
 
     @Override
-    public void synchronizeMailboxNewMessage(Account account, String folder, Message message) {
+    public void synchronizeMailboxNewMessage(Account account, String folderServerId, Message message) {
     }
 
     @Override
-    public void synchronizeMailboxRemovedMessage(Account account, String folder, Message message) {
+    public void synchronizeMailboxRemovedMessage(Account account, String folderServerId, Message message) {
     }
 
     @Override
-    public void synchronizeMailboxFinished(Account account, String folder, int totalMessagesInMailbox,
+    public void synchronizeMailboxFinished(Account account, String folderServerId, int totalMessagesInMailbox,
             int numNewMessages) {
     }
 
     @Override
-    public void synchronizeMailboxFailed(Account account, String folder, String message) {
+    public void synchronizeMailboxFailed(Account account, String folderServerId, String message) {
     }
 
     @Override
-    public void loadMessageRemoteFinished(Account account, String folder, String uid) {
+    public void loadMessageRemoteFinished(Account account, String folderServerId, String uid) {
     }
 
     @Override
-    public void loadMessageRemoteFailed(Account account, String folder, String uid, Throwable t) {
+    public void loadMessageRemoteFailed(Account account, String folderServerId, String uid, Throwable t) {
     }
 
     @Override
@@ -119,7 +119,7 @@ public abstract class SimpleMessagingListener implements MessagingListener {
     }
 
     @Override
-    public void folderStatusChanged(Account account, String folderName, int unreadMessageCount) {
+    public void folderStatusChanged(Account account, String folderServerId, int unreadMessageCount) {
     }
 
     @Override
@@ -127,15 +127,15 @@ public abstract class SimpleMessagingListener implements MessagingListener {
     }
 
     @Override
-    public void messageDeleted(Account account, String folder, Message message) {
+    public void messageDeleted(Account account, String folderServerId, Message message) {
     }
 
     @Override
-    public void messageUidChanged(Account account, String folder, String oldUid, String newUid) {
+    public void messageUidChanged(Account account, String folderServerId, String oldUid, String newUid) {
     }
 
     @Override
-    public void setPushActive(Account account, String folderName, boolean enabled) {
+    public void setPushActive(Account account, String folderServerId, boolean enabled) {
     }
 
     @Override
@@ -167,15 +167,15 @@ public abstract class SimpleMessagingListener implements MessagingListener {
     }
 
     @Override
-    public void remoteSearchServerQueryComplete(String folderName, int numResults, int maxResults) {
+    public void remoteSearchServerQueryComplete(String folderServerId, int numResults, int maxResults) {
     }
 
     @Override
-    public void remoteSearchFinished(String folder, int numResults, int maxResults, List<Message> extraResults) {
+    public void remoteSearchFinished(String folderServerId, int numResults, int maxResults, List<Message> extraResults) {
     }
 
     @Override
-    public void remoteSearchFailed(String folder, String err) {
+    public void remoteSearchFailed(String folderServerId, String err) {
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/controller/imap/ImapSync.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/imap/ImapSync.java
@@ -281,7 +281,7 @@ class ImapSync {
             if (commandException != null) {
                 String rootMessage = getRootCauseMessage(commandException);
                 Timber.e("Root cause failure in %s:%s was '%s'",
-                        account.getDescription(), tLocalFolder.getName(), rootMessage);
+                        account.getDescription(), tLocalFolder.getServerId(), rootMessage);
                 localFolder.setStatus(rootMessage);
                 for (MessagingListener l : getListeners(listener)) {
                     l.synchronizeMailboxFailed(account, folder, rootMessage);
@@ -307,7 +307,7 @@ class ImapSync {
                     tLocalFolder.setLastChecked(System.currentTimeMillis());
                 } catch (MessagingException me) {
                     Timber.e(e, "Could not set last checked on folder %s:%s",
-                            account.getDescription(), tLocalFolder.getName());
+                            account.getDescription(), tLocalFolder.getServerId());
                 }
             }
 
@@ -383,7 +383,7 @@ class ImapSync {
         if (earliestDate != null) {
             Timber.d("Only syncing messages after %s", earliestDate);
         }
-        final String folder = remoteFolder.getName();
+        final String folder = remoteFolder.getServerId();
 
         int unreadBeforeStart = 0;
         try {
@@ -562,7 +562,7 @@ class ImapSync {
             final AtomicInteger progress,
             final int todo,
             FetchProfile fp) throws MessagingException {
-        final String folder = remoteFolder.getName();
+        final String folder = remoteFolder.getServerId();
 
         final Date earliestDate = account.getEarliestPollDate();
         remoteFolder.fetch(unsyncedMessages, fp,
@@ -619,7 +619,7 @@ class ImapSync {
             final AtomicInteger newMessages,
             final int todo,
             FetchProfile fp) throws MessagingException {
-        final String folder = remoteFolder.getName();
+        final String folder = remoteFolder.getServerId();
 
         final Date earliestDate = account.getEarliestPollDate();
 
@@ -693,7 +693,7 @@ class ImapSync {
             final AtomicInteger newMessages,
             final int todo,
             FetchProfile fp) throws MessagingException {
-        final String folder = remoteFolder.getName();
+        final String folder = remoteFolder.getServerId();
         final Date earliestDate = account.getEarliestPollDate();
 
         Timber.d("SYNC: Fetching large messages for folder %s", folder);
@@ -747,7 +747,7 @@ class ImapSync {
             final int todo
     ) throws MessagingException {
 
-        final String folder = remoteFolder.getName();
+        final String folder = remoteFolder.getServerId();
         Timber.d("SYNC: About to sync flags for %d remote messages for folder %s", syncFlagMessages.size(), folder);
 
         FetchProfile fp = new FetchProfile();

--- a/k9mail/src/main/java/com/fsck/k9/controller/imap/ImapSync.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/imap/ImapSync.java
@@ -76,7 +76,7 @@ class ImapSync {
         /*
          * We don't ever sync the Outbox
          */
-        if (folder.equals(account.getOutboxFolderName())) {
+        if (folder.equals(account.getOutboxFolder())) {
             for (MessagingListener l : getListeners(listener)) {
                 l.synchronizeMailboxFinished(account, folder, 0, 0);
             }
@@ -335,9 +335,9 @@ class ImapSync {
      */
     private boolean verifyOrCreateRemoteSpecialFolder(Account account, String folder, Folder remoteFolder,
             MessagingListener listener) throws MessagingException {
-        if (folder.equals(account.getTrashFolderName()) ||
-                folder.equals(account.getSentFolderName()) ||
-                folder.equals(account.getDraftsFolderName())) {
+        if (folder.equals(account.getTrashFolder()) ||
+                folder.equals(account.getSentFolder()) ||
+                folder.equals(account.getDraftsFolder())) {
             if (!remoteFolder.exists()) {
                 if (!remoteFolder.create(FolderType.HOLDS_MESSAGES)) {
                     for (MessagingListener l : getListeners(listener)) {

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MLFProjectionInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MLFProjectionInfo.java
@@ -29,7 +29,7 @@ public final class MLFProjectionInfo {
             MessageColumns.PREVIEW,
             ThreadColumns.ROOT,
             SpecialColumns.ACCOUNT_UUID,
-            SpecialColumns.FOLDER_NAME,
+            SpecialColumns.FOLDER_SERVER_ID,
 
             SpecialColumns.THREAD_COUNT,
     };
@@ -52,7 +52,7 @@ public final class MLFProjectionInfo {
     static final int PREVIEW_COLUMN = 15;
     static final int THREAD_ROOT_COLUMN = 16;
     static final int ACCOUNT_UUID_COLUMN = 17;
-    static final int FOLDER_NAME_COLUMN = 18;
+    static final int FOLDER_SERVER_ID_COLUMN = 18;
     static final int THREAD_COUNT_COLUMN = 19;
 
     static final String[] PROJECTION = Arrays.copyOf(THREADED_PROJECTION,

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
@@ -32,7 +32,7 @@ import static com.fsck.k9.fragment.MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.CC_LIST_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.DATE_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.FLAGGED_COLUMN;
-import static com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_NAME_COLUMN;
+import static com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.FORWARDED_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_TYPE_COLUMN;
@@ -289,10 +289,10 @@ public class MessageListAdapter extends CursorAdapter {
 
     private void changeBackgroundColorIfActiveMessage(Cursor cursor, Account account, View view) {
         String uid = cursor.getString(UID_COLUMN);
-        String folderName = cursor.getString(FOLDER_NAME_COLUMN);
+        String folderServerId = cursor.getString(FOLDER_SERVER_ID_COLUMN);
 
         if (account.getUuid().equals(fragment.activeMessage.getAccountUuid()) &&
-                folderName.equals(fragment.activeMessage.getFolderName()) &&
+                folderServerId.equals(fragment.activeMessage.getFolderServerId()) &&
                 uid.equals(fragment.activeMessage.getUid())) {
             int res = R.attr.messageListActiveItemBackgroundColor;
 

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -943,7 +943,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                     activeMessages = null; // don't need it any more
 
                     if (messages.size() > 0) {
-                        MlfUtils.setLastSelectedFolderName(preferences, messages, destFolderName);
+                        MlfUtils.setLastSelectedFolder(preferences, messages, destFolderName);
                     }
 
                     switch (requestCode) {
@@ -1789,7 +1789,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
         for (Entry<Account, List<MessageReference>> entry : messagesByAccount.entrySet()) {
             Account account = entry.getKey();
-            String archiveFolder = account.getArchiveFolderName();
+            String archiveFolder = account.getArchiveFolder();
 
             if (!K9.FOLDER_NONE.equals(archiveFolder)) {
                 move(entry.getValue(), archiveFolder);
@@ -1838,7 +1838,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
         for (Entry<Account, List<MessageReference>> entry : messagesByAccount.entrySet()) {
             Account account = entry.getKey();
-            String spamFolder = account.getSpamFolderName();
+            String spamFolder = account.getSpamFolder();
 
             if (!K9.FOLDER_NONE.equals(spamFolder)) {
                 move(entry.getValue(), spamFolder);
@@ -2508,7 +2508,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     public boolean isOutbox() {
-        return (folderName != null && folderName.equals(account.getOutboxFolderName()));
+        return (folderName != null && folderName.equals(account.getOutboxFolder()));
     }
 
     public boolean isRemoteFolder() {
@@ -2518,7 +2518,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
         if (!messagingController.isMoveCapable(account)) {
             // For POP3 accounts only the Inbox is a remote folder.
-            return (folderName != null && folderName.equals(account.getInboxFolderName()));
+            return (folderName != null && folderName.equals(account.getInboxFolder()));
         }
 
         return true;

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -180,6 +180,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
      * Stores the server ID of the folder that we want to open as soon as possible after load.
      */
     private String folderServerId;
+    private String folderName;
 
     private boolean remoteSearchPerformed = false;
     private Future<?> remoteSearchFuture = null;
@@ -316,8 +317,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         // regular folder content display
         if (!isManualSearch() && singleFolderMode) {
             Activity activity = getActivity();
-            String displayName = FolderInfoHolder.getDisplayName(activity, account,
-                    folderServerId);
+            String displayName = FolderInfoHolder.getDisplayName(activity, account, folderServerId, folderName);
 
             fragmentListener.setMessageListTitle(displayName);
 
@@ -593,6 +593,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             singleFolderMode = true;
             folderServerId = search.getFolderServerIds().get(0);
             currentFolder = getFolderInfoHolder(folderServerId, account);
+            folderName = currentFolder.displayName;
         }
 
         allAccounts = false;

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -1364,12 +1364,12 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         }
 
         @Override
-        public void synchronizeMailboxStarted(Account account, String folderServerId) {
+        public void synchronizeMailboxStarted(Account account, String folderServerId, String folderName) {
             if (updateForMe(account, folderServerId)) {
                 handler.progress(true);
                 handler.folderLoading(folderServerId, true);
             }
-            super.synchronizeMailboxStarted(account, folderServerId);
+            super.synchronizeMailboxStarted(account, folderServerId, folderName);
         }
 
         @Override

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MlfUtils.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MlfUtils.java
@@ -15,7 +15,6 @@ import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalStore;
-import timber.log.Timber;
 
 import static com.fsck.k9.fragment.MLFProjectionInfo.SENDER_LIST_COLUMN;
 
@@ -31,14 +30,9 @@ public class MlfUtils {
 
     static void setLastSelectedFolderName(Preferences preferences,
             List<MessageReference> messages, String destFolderName) {
-        try {
-            MessageReference firstMsg = messages.get(0);
-            Account account = preferences.getAccount(firstMsg.getAccountUuid());
-            LocalFolder firstMsgFolder = MlfUtils.getOpenFolder(firstMsg.getFolderName(), account);
-            firstMsgFolder.setLastSelectedFolderName(destFolderName);
-        } catch (MessagingException e) {
-            Timber.e(e, "Error getting folder for setLastSelectedFolderName()");
-        }
+        MessageReference firstMsg = messages.get(0);
+        Account account = preferences.getAccount(firstMsg.getAccountUuid());
+        account.setLastSelectedFolder(destFolderName);
     }
 
     static String getSenderAddressFromCursor(Cursor cursor) {

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MlfUtils.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MlfUtils.java
@@ -21,9 +21,9 @@ import static com.fsck.k9.fragment.MLFProjectionInfo.SENDER_LIST_COLUMN;
 
 public class MlfUtils {
 
-    static LocalFolder getOpenFolder(String folderName, Account account) throws MessagingException {
+    static LocalFolder getOpenFolder(String folderServerId, Account account) throws MessagingException {
         LocalStore localStore = account.getLocalStore();
-        LocalFolder localFolder = localStore.getFolder(folderName);
+        LocalFolder localFolder = localStore.getFolder(folderServerId);
         localFolder.open(Folder.OPEN_MODE_RO);
         return localFolder;
     }

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MlfUtils.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MlfUtils.java
@@ -28,7 +28,7 @@ public class MlfUtils {
         return localFolder;
     }
 
-    static void setLastSelectedFolderName(Preferences preferences,
+    static void setLastSelectedFolder(Preferences preferences,
             List<MessageReference> messages, String destFolderName) {
         MessageReference firstMsg = messages.get(0);
         Account account = preferences.getAccount(firstMsg.getAccountUuid());

--- a/k9mail/src/main/java/com/fsck/k9/helper/UnreadWidgetProperties.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/UnreadWidgetProperties.java
@@ -111,11 +111,11 @@ public class UnreadWidgetProperties {
 
     private Intent getClickIntentForAccount(Context context) {
         Account account = Preferences.getPreferences(context).getAccount(accountUuid);
-        if (K9.FOLDER_NONE.equals(account.getAutoExpandFolderName())) {
+        if (K9.FOLDER_NONE.equals(account.getAutoExpandFolder())) {
             return FolderList.actionHandleAccountIntent(context, account, false);
         }
-        LocalSearch search = new LocalSearch(account.getAutoExpandFolderName());
-        search.addAllowedFolder(account.getAutoExpandFolderName());
+        LocalSearch search = new LocalSearch(account.getAutoExpandFolder());
+        search.addAllowedFolder(account.getAutoExpandFolder());
         search.addAccountUuid(account.getUuid());
         return MessageList.intentDisplaySearch(context, search, false, true, true);
     }

--- a/k9mail/src/main/java/com/fsck/k9/helper/UnreadWidgetProperties.java
+++ b/k9mail/src/main/java/com/fsck/k9/helper/UnreadWidgetProperties.java
@@ -20,13 +20,13 @@ public class UnreadWidgetProperties {
 
     private int appWidgetId;
     private String accountUuid;
-    private String folderName;
+    private String folderServerId;
     private Type type;
 
-    public UnreadWidgetProperties(int appWidgetId, String accountUuid, String folderName) {
+    public UnreadWidgetProperties(int appWidgetId, String accountUuid, String folderServerId) {
         this.appWidgetId = appWidgetId;
         this.accountUuid = accountUuid;
-        this.folderName = folderName;
+        this.folderServerId = folderServerId;
         calculateType();
     }
 
@@ -37,7 +37,7 @@ public class UnreadWidgetProperties {
             case ACCOUNT:
                 return accountName;
             case FOLDER:
-                return context.getString(R.string.unread_widget_title, accountName, folderName);
+                return context.getString(R.string.unread_widget_title, accountName, folderServerId);
             default:
                 return null;
         }
@@ -56,7 +56,7 @@ public class UnreadWidgetProperties {
                 stats = account.getStats(context);
                 return stats.unreadMessageCount;
             case FOLDER:
-                return ((Account) baseAccount).getFolderUnreadCount(context, folderName);
+                return ((Account) baseAccount).getFolderUnreadCount(context, folderServerId);
             default:
                 return -1;
         }
@@ -85,15 +85,15 @@ public class UnreadWidgetProperties {
         return accountUuid;
     }
 
-    public String getFolderName() {
-        return folderName;
+    public String getFolderServerId() {
+        return folderServerId;
     }
 
     private void calculateType() {
         if (SearchAccount.UNIFIED_INBOX.equals(accountUuid) ||
                 SearchAccount.ALL_MESSAGES.equals(accountUuid)) {
             type = Type.SEARCH_ACCOUNT;
-        } else if(folderName != null) {
+        } else if (folderServerId != null) {
             type = Type.FOLDER;
         } else {
             type = Type.ACCOUNT;
@@ -122,8 +122,8 @@ public class UnreadWidgetProperties {
 
     private Intent getClickIntentForFolder(Context context) {
         Account account = Preferences.getPreferences(context).getAccount(accountUuid);
-        LocalSearch search = new LocalSearch(folderName);
-        search.addAllowedFolder(folderName);
+        LocalSearch search = new LocalSearch(folderServerId);
+        search.addAllowedFolder(folderServerId);
         search.addAccountUuid(account.getUuid());
         Intent clickIntent = MessageList.intentDisplaySearch(context, search, false, true, true);
         clickIntent.addFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -224,6 +224,11 @@ public class LocalFolder extends Folder<LocalMessage> {
     }
 
     @Override
+    public String getName() {
+        return serverId;
+    }
+
+    @Override
     public boolean exists() throws MessagingException {
         return this.localStore.getDatabase().execute(false, new DbCallback<Boolean>() {
             @Override

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -103,7 +103,7 @@ public class LocalFolder extends Folder<LocalMessage> {
         this.name = name;
         attachmentInfoExtractor = localStore.getAttachmentInfoExtractor();
 
-        if (getAccount().getInboxFolderName().equals(getName())) {
+        if (getAccount().getInboxFolder().equals(getName())) {
             syncClass =  FolderClass.FIRST_CLASS;
             pushClass =  FolderClass.FIRST_CLASS;
             isInTopGroup = true;
@@ -597,25 +597,25 @@ public class LocalFolder extends Folder<LocalMessage> {
         String id = getPrefId();
 
         // there can be a lot of folders.  For the defaults, let's not save prefs, saving space, except for INBOX
-        if (displayClass == FolderClass.NO_CLASS && !getAccount().getInboxFolderName().equals(getName())) {
+        if (displayClass == FolderClass.NO_CLASS && !getAccount().getInboxFolder().equals(getName())) {
             editor.remove(id + ".displayMode");
         } else {
             editor.putString(id + ".displayMode", displayClass.name());
         }
 
-        if (syncClass == FolderClass.INHERITED && !getAccount().getInboxFolderName().equals(getName())) {
+        if (syncClass == FolderClass.INHERITED && !getAccount().getInboxFolder().equals(getName())) {
             editor.remove(id + ".syncMode");
         } else {
             editor.putString(id + ".syncMode", syncClass.name());
         }
 
-        if (notifyClass == FolderClass.INHERITED && !getAccount().getInboxFolderName().equals(getName())) {
+        if (notifyClass == FolderClass.INHERITED && !getAccount().getInboxFolder().equals(getName())) {
             editor.remove(id + ".notifyMode");
         } else {
             editor.putString(id + ".notifyMode", notifyClass.name());
         }
 
-        if (pushClass == FolderClass.SECOND_CLASS && !getAccount().getInboxFolderName().equals(getName())) {
+        if (pushClass == FolderClass.SECOND_CLASS && !getAccount().getInboxFolder().equals(getName())) {
             editor.remove(id + ".pushMode");
         } else {
             editor.putString(id + ".pushMode", pushClass.name());

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -130,10 +130,6 @@ public class LocalFolder extends Folder<LocalMessage> {
         return getAccount().getSignatureUse();
     }
 
-    public void setLastSelectedFolderName(String destFolderName) {
-        getAccount().setLastSelectedFolderName(destFolderName);
-    }
-
     public boolean syncRemoteDeletions() {
         return getAccount().syncRemoteDeletions();
     }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -230,6 +230,21 @@ public class LocalFolder extends Folder<LocalMessage> {
         return name;
     }
 
+    public void setName(String name) throws MessagingException {
+        try {
+            open(OPEN_MODE_RW);
+
+            if (name.equals(this.name)) {
+                return;
+            }
+
+            this.name = name;
+        } catch (MessagingException e) {
+            throw new WrappedException(e);
+        }
+        updateFolderColumn("name", name);
+    }
+
     @Override
     public boolean exists() throws MessagingException {
         return this.localStore.getDatabase().execute(false, new DbCallback<Boolean>() {

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -78,6 +78,7 @@ public class LocalFolder extends Folder<LocalMessage> {
 
 
     private String serverId = null;
+    private String name;
     private long databaseId = -1;
     private int visibleLimit = -1;
     private String prefId = null;
@@ -154,7 +155,7 @@ public class LocalFolder extends Folder<LocalMessage> {
                         String baseQuery = "SELECT " + LocalStore.GET_FOLDER_COLS + " FROM folders ";
 
                         if (serverId != null) {
-                            cursor = db.rawQuery(baseQuery + "where folders.name = ?", new String[] { serverId });
+                            cursor = db.rawQuery(baseQuery + "where folders.server_id = ?", new String[] { serverId });
                         } else {
                             cursor = db.rawQuery(baseQuery + "where folders.id = ?", new String[] { Long.toString(
                                     databaseId) });
@@ -206,6 +207,7 @@ public class LocalFolder extends Folder<LocalMessage> {
         this.syncClass = Folder.FolderClass.valueOf((syncClass == null) ? noClass : syncClass);
         String moreMessagesValue = cursor.getString(LocalStore.MORE_MESSAGES_INDEX);
         moreMessages = MoreMessages.fromDatabaseName(moreMessagesValue);
+        name = cursor.getString(LocalStore.FOLDER_NAME_INDEX);
     }
 
     @Override
@@ -225,7 +227,7 @@ public class LocalFolder extends Folder<LocalMessage> {
 
     @Override
     public String getName() {
-        return serverId;
+        return name;
     }
 
     @Override
@@ -235,7 +237,7 @@ public class LocalFolder extends Folder<LocalMessage> {
             public Boolean doDbWork(final SQLiteDatabase db) throws WrappedException {
                 Cursor cursor = null;
                 try {
-                    cursor = db.rawQuery("SELECT id FROM folders where folders.name = ?",
+                    cursor = db.rawQuery("SELECT id FROM folders where folders.server_id = ?",
                             new String[] { LocalFolder.this.getServerId() });
                     if (cursor.moveToFirst()) {
                         int folderId = cursor.getInt(0);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -407,7 +407,7 @@ public class LocalMessage extends MimeMessage {
 
     public MessageReference makeMessageReference() {
         if (messageReference == null) {
-            messageReference = new MessageReference(getFolder().getAccountUuid(), getFolder().getName(), mUid, null);
+            messageReference = new MessageReference(getFolder().getAccountUuid(), getFolder().getServerId(), mUid, null);
         }
         return messageReference;
     }
@@ -418,7 +418,7 @@ public class LocalMessage extends MimeMessage {
     }
 
     public String getUri() {
-        return "email://messages/" +  getAccount().getAccountNumber() + "/" + getFolder().getName() + "/" + getUid();
+        return "email://messages/" +  getAccount().getAccountNumber() + "/" + getFolder().getServerId() + "/" + getUid();
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -176,7 +176,7 @@ public class LocalStore {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 61;
+    public static final int DB_VERSION = 62;
 
     private final Context context;
     private final ContentResolver contentResolver;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -918,7 +918,7 @@ public class LocalStore {
                     if (account.isSpecialFolder(name)) {
                         prefHolder.inTopGroup = true;
                         prefHolder.displayClass = LocalFolder.FolderClass.FIRST_CLASS;
-                        if (name.equals(account.getInboxFolderName())) {
+                        if (name.equals(account.getInboxFolder())) {
                             prefHolder.integrate = true;
                             prefHolder.notifyClass = LocalFolder.FolderClass.FIRST_CLASS;
                             prefHolder.pushClass = LocalFolder.FolderClass.FIRST_CLASS;
@@ -926,7 +926,7 @@ public class LocalStore {
                             prefHolder.pushClass = LocalFolder.FolderClass.INHERITED;
 
                         }
-                        if (name.equals(account.getInboxFolderName()) || name.equals(account.getDraftsFolderName())) {
+                        if (name.equals(account.getInboxFolder()) || name.equals(account.getDraftsFolder())) {
                             prefHolder.syncClass = LocalFolder.FolderClass.FIRST_CLASS;
                         } else {
                             prefHolder.syncClass = LocalFolder.FolderClass.NO_CLASS;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/StoreSchemaDefinition.java
@@ -90,10 +90,13 @@ class StoreSchemaDefinition implements LockableDatabase.SchemaDefinition {
                 "push_class TEXT, " +
                 "display_class TEXT, " +
                 "notify_class TEXT default '"+ Folder.FolderClass.INHERITED.name() + "', " +
-                "more_messages TEXT default \"unknown\"" +
+                "more_messages TEXT default \"unknown\", " +
+                "server_id TEXT" +
                 ")");
 
-        db.execSQL("CREATE INDEX IF NOT EXISTS folder_name ON folders (name)");
+        db.execSQL("DROP INDEX IF EXISTS folder_server_id");
+        db.execSQL("CREATE INDEX folder_server_id ON folders (server_id)");
+
         db.execSQL("DROP TABLE IF EXISTS messages");
         db.execSQL("CREATE TABLE messages (" +
                 "id INTEGER PRIMARY KEY, " +

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo41.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo41.java
@@ -57,7 +57,7 @@ class MigrationTo41 {
         Folder.FolderClass pushClass = Folder.FolderClass.SECOND_CLASS;
         boolean inTopGroup = false;
         boolean integrate = false;
-        if (account.getInboxFolderName().equals(name)) {
+        if (account.getInboxFolder().equals(name)) {
             displayClass = Folder.FolderClass.FIRST_CLASS;
             syncClass =  Folder.FolderClass.FIRST_CLASS;
             pushClass =  Folder.FolderClass.FIRST_CLASS;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo43.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo43.java
@@ -44,7 +44,7 @@ class MigrationTo43 {
                 if (messages.size() > 0) {
                     // ... and move them to the drafts folder (we don't want to
                     // surprise the user by sending potentially very old messages)
-                    LocalFolder drafts = new LocalFolder(localStore, account.getDraftsFolderName());
+                    LocalFolder drafts = new LocalFolder(localStore, account.getDraftsFolder());
                     obsoleteOutbox.moveMessages(messages, drafts);
                 }
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo50.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo50.java
@@ -24,6 +24,6 @@ class MigrationTo50 {
         cv.put("notify_class", Folder.FolderClass.FIRST_CLASS.name());
 
         Account account = migrationsHelper.getAccount();
-        db.update("folders", cv, "name = ?", new String[] { account.getInboxFolderName() });
+        db.update("folders", cv, "name = ?", new String[] { account.getInboxFolder() });
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo62.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/MigrationTo62.java
@@ -1,0 +1,15 @@
+package com.fsck.k9.mailstore.migrations;
+
+
+import android.database.sqlite.SQLiteDatabase;
+
+
+class MigrationTo62 {
+    public static void addServerIdColumnToFoldersTable(SQLiteDatabase db) {
+        db.execSQL("ALTER TABLE folders ADD server_id TEXT");
+        db.execSQL("UPDATE folders SET server_id = name");
+
+        db.execSQL("DROP INDEX IF EXISTS folder_name");
+        db.execSQL("CREATE INDEX folder_server_id ON folders (server_id)");
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/migrations/Migrations.java
@@ -81,6 +81,8 @@ public class Migrations {
                 MigrationTo60.migratePendingCommands(db);
             case 60:
                 MigrationTo61.removeErrorsFolder(db);
+            case 61:
+                MigrationTo62.addServerIdColumnToFoldersTable(db);
         }
 
         if (shouldBuildFtsTable) {

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionCreator.java
@@ -276,7 +276,7 @@ class NotificationActionCreator {
     }
 
     private boolean skipFolderListInBackStack(Account account, String folderName) {
-        return folderName != null && folderName.equals(account.getAutoExpandFolderName());
+        return folderName != null && folderName.equals(account.getAutoExpandFolder());
     }
 
     private boolean skipAccountsInBackStack() {

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionCreator.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionCreator.java
@@ -44,8 +44,8 @@ class NotificationActionCreator {
         return stack.getPendingIntent(notificationId, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT);
     }
 
-    public PendingIntent createViewFolderPendingIntent(Account account, String folderName, int notificationId) {
-        TaskStackBuilder stack = buildMessageListBackStack(account, folderName);
+    public PendingIntent createViewFolderPendingIntent(Account account, String folderServerId, int notificationId) {
+        TaskStackBuilder stack = buildMessageListBackStack(account, folderServerId);
         return stack.getPendingIntent(notificationId, PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_ONE_SHOT);
     }
 
@@ -56,12 +56,12 @@ class NotificationActionCreator {
         if (account.goToUnreadMessageSearch()) {
             stack = buildUnreadBackStack(account);
         } else {
-            String folderName = getFolderNameOfAllMessages(messageReferences);
+            String folderServerId = getFolderServerIdOfAllMessages(messageReferences);
 
-            if (folderName == null) {
+            if (folderServerId == null) {
                 stack = buildFolderListBackStack(account);
             } else {
-                stack = buildMessageListBackStack(account, folderName);
+                stack = buildMessageListBackStack(account, folderServerId);
             }
         }
 
@@ -236,12 +236,12 @@ class NotificationActionCreator {
         return stack;
     }
 
-    private TaskStackBuilder buildMessageListBackStack(Account account, String folderName) {
-        TaskStackBuilder stack = skipFolderListInBackStack(account, folderName) ?
+    private TaskStackBuilder buildMessageListBackStack(Account account, String folderServerId) {
+        TaskStackBuilder stack = skipFolderListInBackStack(account, folderServerId) ?
                 buildAccountsBackStack() : buildFolderListBackStack(account);
 
-        LocalSearch search = new LocalSearch(folderName);
-        search.addAllowedFolder(folderName);
+        LocalSearch search = new LocalSearch(folderServerId);
+        search.addAllowedFolder(folderServerId);
         search.addAccountUuid(account.getUuid());
         Intent intent = MessageList.intentDisplaySearch(context, search, false, true, true);
 
@@ -252,8 +252,8 @@ class NotificationActionCreator {
 
     private TaskStackBuilder buildMessageViewBackStack(MessageReference message) {
         Account account = Preferences.getPreferences(context).getAccount(message.getAccountUuid());
-        String folderName = message.getFolderName();
-        TaskStackBuilder stack = buildMessageListBackStack(account, folderName);
+        String folderServerId = message.getFolderServerId();
+        TaskStackBuilder stack = buildMessageListBackStack(account, folderServerId);
 
         Intent intent = MessageList.actionDisplayMessageIntent(context, message);
 
@@ -262,21 +262,21 @@ class NotificationActionCreator {
         return stack;
     }
 
-    private String getFolderNameOfAllMessages(List<MessageReference> messageReferences) {
+    private String getFolderServerIdOfAllMessages(List<MessageReference> messageReferences) {
         MessageReference firstMessage = messageReferences.get(0);
-        String folderName = firstMessage.getFolderName();
+        String folderServerId = firstMessage.getFolderServerId();
 
         for (MessageReference messageReference : messageReferences) {
-            if (!TextUtils.equals(folderName, messageReference.getFolderName())) {
+            if (!TextUtils.equals(folderServerId, messageReference.getFolderServerId())) {
                 return null;
             }
         }
 
-        return folderName;
+        return folderServerId;
     }
 
-    private boolean skipFolderListInBackStack(Account account, String folderName) {
-        return folderName != null && folderName.equals(account.getAutoExpandFolder());
+    private boolean skipFolderListInBackStack(Account account, String folderServerId) {
+        return folderServerId != null && folderServerId.equals(account.getAutoExpandFolder());
     }
 
     private boolean skipAccountsInBackStack() {

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionService.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionService.java
@@ -159,9 +159,9 @@ public class NotificationActionService extends CoreService {
         List<String> messageReferenceStrings = intent.getStringArrayListExtra(EXTRA_MESSAGE_REFERENCES);
         List<MessageReference> messageReferences = toMessageReferenceList(messageReferenceStrings);
         for (MessageReference messageReference : messageReferences) {
-            String folderName = messageReference.getFolderName();
+            String folderServerId = messageReference.getFolderServerId();
             String uid = messageReference.getUid();
-            controller.setFlag(account, folderName, uid, Flag.SEEN, true);
+            controller.setFlag(account, folderServerId, uid, Flag.SEEN, true);
         }
     }
 
@@ -188,7 +188,7 @@ public class NotificationActionService extends CoreService {
         List<MessageReference> messageReferences = toMessageReferenceList(messageReferenceStrings);
         for (MessageReference messageReference : messageReferences) {
             if (controller.isMoveCapable(messageReference)) {
-                String sourceFolderName = messageReference.getFolderName();
+                String sourceFolderName = messageReference.getFolderServerId();
                 controller.moveMessage(account, sourceFolderName, messageReference, archiveFolderName);
             }
         }
@@ -206,7 +206,7 @@ public class NotificationActionService extends CoreService {
 
         String spamFolderName = account.getSpamFolder();
         if (spamFolderName != null && !K9.confirmSpam() && isMovePossible(controller, account, spamFolderName)) {
-            String sourceFolderName = messageReference.getFolderName();
+            String sourceFolderName = messageReference.getFolderServerId();
             controller.moveMessage(account, sourceFolderName, messageReference, spamFolderName);
         }
     }

--- a/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionService.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/NotificationActionService.java
@@ -176,9 +176,9 @@ public class NotificationActionService extends CoreService {
     private void archiveMessages(Intent intent, Account account, MessagingController controller) {
         Timber.i("NotificationActionService archiving messages");
 
-        String archiveFolderName = account.getArchiveFolderName();
+        String archiveFolderName = account.getArchiveFolder();
         if (archiveFolderName == null ||
-                (archiveFolderName.equals(account.getSpamFolderName()) && K9.confirmSpam()) ||
+                (archiveFolderName.equals(account.getSpamFolder()) && K9.confirmSpam()) ||
                 !isMovePossible(controller, account, archiveFolderName)) {
             Timber.w("Can not archive messages");
             return;
@@ -204,7 +204,7 @@ public class NotificationActionService extends CoreService {
             return;
         }
 
-        String spamFolderName = account.getSpamFolderName();
+        String spamFolderName = account.getSpamFolder();
         if (spamFolderName != null && !K9.confirmSpam() && isMovePossible(controller, account, spamFolderName)) {
             String sourceFolderName = messageReference.getFolderName();
             controller.moveMessage(account, sourceFolderName, messageReference, spamFolderName);

--- a/k9mail/src/main/java/com/fsck/k9/notification/SyncNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/SyncNotifications.java
@@ -64,12 +64,13 @@ class SyncNotifications {
     public void showFetchingMailNotification(Account account, Folder folder) {
         String accountName = account.getDescription();
         String folderServerId = folder.getServerId();
+        String folderName = folder.getName();
 
         Context context = controller.getContext();
-        String tickerText = context.getString(R.string.notification_bg_sync_ticker, accountName, folderServerId);
+        String tickerText = context.getString(R.string.notification_bg_sync_ticker, accountName, folderName);
         String title = context.getString(R.string.notification_bg_sync_title);
         //TODO: Use format string from resources
-        String text = accountName + context.getString(R.string.notification_bg_title_separator) + folderServerId;
+        String text = accountName + context.getString(R.string.notification_bg_title_separator) + folderName;
 
         int notificationId = NotificationIds.getFetchingMailNotificationId(account);
         PendingIntent showMessageListPendingIntent = actionBuilder.createViewFolderPendingIntent(

--- a/k9mail/src/main/java/com/fsck/k9/notification/SyncNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/SyncNotifications.java
@@ -33,7 +33,7 @@ class SyncNotifications {
         String tickerText = context.getString(R.string.notification_bg_send_ticker, accountName);
 
         int notificationId = NotificationIds.getFetchingMailNotificationId(account);
-        String outboxFolderName = account.getOutboxFolderName();
+        String outboxFolderName = account.getOutboxFolder();
         PendingIntent showMessageListPendingIntent = actionBuilder.createViewFolderPendingIntent(
                 account, outboxFolderName, notificationId);
 

--- a/k9mail/src/main/java/com/fsck/k9/notification/SyncNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/SyncNotifications.java
@@ -33,9 +33,9 @@ class SyncNotifications {
         String tickerText = context.getString(R.string.notification_bg_send_ticker, accountName);
 
         int notificationId = NotificationIds.getFetchingMailNotificationId(account);
-        String outboxFolderName = account.getOutboxFolder();
+        String outboxFolder = account.getOutboxFolder();
         PendingIntent showMessageListPendingIntent = actionBuilder.createViewFolderPendingIntent(
-                account, outboxFolderName, notificationId);
+                account, outboxFolder, notificationId);
 
         NotificationCompat.Builder builder = controller.createNotificationBuilder()
                 .setSmallIcon(R.drawable.ic_notify_check_mail)
@@ -63,17 +63,17 @@ class SyncNotifications {
 
     public void showFetchingMailNotification(Account account, Folder folder) {
         String accountName = account.getDescription();
-        String folderName = folder.getName();
+        String folderServerId = folder.getServerId();
 
         Context context = controller.getContext();
-        String tickerText = context.getString(R.string.notification_bg_sync_ticker, accountName, folderName);
+        String tickerText = context.getString(R.string.notification_bg_sync_ticker, accountName, folderServerId);
         String title = context.getString(R.string.notification_bg_sync_title);
         //TODO: Use format string from resources
-        String text = accountName + context.getString(R.string.notification_bg_title_separator) + folderName;
+        String text = accountName + context.getString(R.string.notification_bg_title_separator) + folderServerId;
 
         int notificationId = NotificationIds.getFetchingMailNotificationId(account);
         PendingIntent showMessageListPendingIntent = actionBuilder.createViewFolderPendingIntent(
-                account, folderName, notificationId);
+                account, folderServerId, notificationId);
 
         NotificationCompat.Builder builder = controller.createNotificationBuilder()
                 .setSmallIcon(R.drawable.ic_notify_check_mail)

--- a/k9mail/src/main/java/com/fsck/k9/notification/WearNotifications.java
+++ b/k9mail/src/main/java/com/fsck/k9/notification/WearNotifications.java
@@ -230,12 +230,12 @@ class WearNotifications extends BaseNotifications {
     }
 
     private boolean isArchiveActionAvailableForWear(Account account) {
-        String archiveFolderName = account.getArchiveFolderName();
+        String archiveFolderName = account.getArchiveFolder();
         return archiveFolderName != null && isMovePossible(account, archiveFolderName);
     }
 
     private boolean isSpamActionAvailableForWear(Account account) {
-        String spamFolderName = account.getSpamFolderName();
+        String spamFolderName = account.getSpamFolder();
         return spamFolderName != null && !K9.confirmSpam() && isMovePossible(account, spamFolderName);
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
@@ -94,7 +94,7 @@ public class EmailProvider extends ContentProvider {
 
     private static final String[] FOLDERS_COLUMNS = {
             FolderColumns.ID,
-            FolderColumns.NAME,
+            FolderColumns.SERVER_ID,
             FolderColumns.LAST_UPDATED,
             FolderColumns.UNREAD_COUNT,
             FolderColumns.VISIBLE_LIMIT,
@@ -126,7 +126,7 @@ public class EmailProvider extends ContentProvider {
 
         String THREAD_COUNT = "thread_count";
 
-        String FOLDER_NAME = "name";
+        String FOLDER_SERVER_ID = "name";
         String INTEGRATE = "integrate";
     }
 
@@ -161,7 +161,7 @@ public class EmailProvider extends ContentProvider {
 
     public interface FolderColumns {
         String ID = "id";
-        String NAME = "name";
+        String SERVER_ID = "name";
         String LAST_UPDATED = "last_updated";
         String UNREAD_COUNT = "unread_count";
         String VISIBLE_LIMIT = "visible_limit";

--- a/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/EmailProvider.java
@@ -94,7 +94,7 @@ public class EmailProvider extends ContentProvider {
 
     private static final String[] FOLDERS_COLUMNS = {
             FolderColumns.ID,
-            FolderColumns.SERVER_ID,
+            FolderColumns.NAME,
             FolderColumns.LAST_UPDATED,
             FolderColumns.UNREAD_COUNT,
             FolderColumns.VISIBLE_LIMIT,
@@ -106,7 +106,8 @@ public class EmailProvider extends ContentProvider {
             FolderColumns.TOP_GROUP,
             FolderColumns.POLL_CLASS,
             FolderColumns.PUSH_CLASS,
-            FolderColumns.DISPLAY_CLASS
+            FolderColumns.DISPLAY_CLASS,
+            FolderColumns.SERVER_ID
     };
 
     private static final String THREADS_TABLE = "threads";
@@ -126,7 +127,7 @@ public class EmailProvider extends ContentProvider {
 
         String THREAD_COUNT = "thread_count";
 
-        String FOLDER_SERVER_ID = "name";
+        String FOLDER_SERVER_ID = "server_id";
         String INTEGRATE = "integrate";
     }
 
@@ -161,7 +162,7 @@ public class EmailProvider extends ContentProvider {
 
     public interface FolderColumns {
         String ID = "id";
-        String SERVER_ID = "name";
+        String NAME = "name";
         String LAST_UPDATED = "last_updated";
         String UNREAD_COUNT = "unread_count";
         String VISIBLE_LIMIT = "visible_limit";
@@ -174,6 +175,7 @@ public class EmailProvider extends ContentProvider {
         String POLL_CLASS = "poll_class";
         String PUSH_CLASS = "push_class";
         String DISPLAY_CLASS = "display_class";
+        String SERVER_ID = "server_id";
     }
 
     public interface ThreadColumns {

--- a/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/MessageProvider.java
@@ -107,7 +107,7 @@ public class MessageProvider extends ContentProvider {
 
                 MessagingController.getInstance(application).addListener(new SimpleMessagingListener() {
                     @Override
-                    public void folderStatusChanged(Account account, String folderName, int unreadMessageCount) {
+                    public void folderStatusChanged(Account account, String folderServerId, int unreadMessageCount) {
                         application.getContentResolver().notifyChange(CONTENT_URI, null);
                     }
                 });
@@ -165,7 +165,7 @@ public class MessageProvider extends ContentProvider {
 
         List<String> segments = uri.getPathSegments();
         int accountId = Integer.parseInt(segments.get(1));
-        String folderName = segments.get(2);
+        String folderServerId = segments.get(2);
         String msgUid = segments.get(3);
 
         // get account
@@ -185,7 +185,7 @@ public class MessageProvider extends ContentProvider {
         }
 
         if (myAccount != null) {
-            MessageReference messageReference = new MessageReference(myAccount.getUuid(), folderName, msgUid, null);
+            MessageReference messageReference = new MessageReference(myAccount.getUuid(), folderServerId, msgUid, null);
             MessagingController controller = MessagingController.getInstance(getContext());
             controller.deleteMessage(messageReference, null);
         }
@@ -417,7 +417,7 @@ public class MessageProvider extends ContentProvider {
             return CONTENT_URI.buildUpon()
                     .appendPath("delete_message")
                     .appendPath(Integer.toString(accountNumber))
-                    .appendPath(message.getFolder().getName())
+                    .appendPath(message.getFolder().getServerId())
                     .appendPath(message.getUid())
                     .build()
                     .toString();
@@ -1089,7 +1089,7 @@ public class MessageProvider extends ContentProvider {
         }
 
         @Override
-        public void listLocalMessagesAddMessages(Account account, String folderName, List<LocalMessage> messages) {
+        public void listLocalMessagesAddMessages(Account account, String folderServerId, List<LocalMessage> messages) {
             Context context = getContext();
 
             for (LocalMessage message : messages) {

--- a/k9mail/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
+++ b/k9mail/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
@@ -169,7 +169,7 @@ public class RawMessageProvider extends ContentProvider {
 
     private LocalMessage loadMessage(MessageReference messageReference) {
         String accountUuid = messageReference.getAccountUuid();
-        String folderName = messageReference.getFolderName();
+        String folderServerId = messageReference.getFolderServerId();
         String uid = messageReference.getUid();
 
         Account account = Preferences.getPreferences(getContext()).getAccount(accountUuid);
@@ -180,12 +180,12 @@ public class RawMessageProvider extends ContentProvider {
 
         try {
             LocalStore localStore = LocalStore.getInstance(account, getContext());
-            LocalFolder localFolder = localStore.getFolder(folderName);
+            LocalFolder localFolder = localStore.getFolder(folderServerId);
             localFolder.open(Folder.OPEN_MODE_RW);
 
             LocalMessage message = localFolder.getMessage(uid);
             if (message == null || message.getDatabaseId() == 0) {
-                Timber.w("Message not found: folder=%s, uid=%s", folderName, uid);
+                Timber.w("Message not found: folder=%s, uid=%s", folderServerId, uid);
                 return null;
             }
 
@@ -196,7 +196,7 @@ public class RawMessageProvider extends ContentProvider {
 
             return message;
         } catch (MessagingException e) {
-            Timber.e(e, "Error loading message: folder=%s, uid=%s", folderName, uid);
+            Timber.e(e, "Error loading message: folder=%s, uid=%s", folderServerId, uid);
             return null;
         }
     }

--- a/k9mail/src/main/java/com/fsck/k9/search/LocalSearch.java
+++ b/k9mail/src/main/java/com/fsck/k9/search/LocalSearch.java
@@ -249,7 +249,7 @@ public class LocalSearch implements SearchSpecification {
      * This is a temporarely solution that does NOT WORK for
      * real searches because of possible extra conditions to a folder requirement.
      */
-    public List<String> getFolderNames() {
+    public List<String> getFolderServerIds() {
         List<String> results = new ArrayList<String>();
         for (ConditionsTreeNode node : mLeafSet) {
             if (node.mCondition.field == SearchField.FOLDER &&

--- a/k9mail/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
@@ -31,8 +31,8 @@ public class SqlQueryBuilder {
             SearchCondition condition = node.mCondition;
             switch (condition.field) {
                 case FOLDER: {
-                    String folderName = condition.value;
-                    long folderId = getFolderId(account, folderName);
+                    String folderServerId = condition.value;
+                    long folderId = getFolderId(account, folderServerId);
                     if (condition.attribute == Attribute.EQUALS) {
                         query.append("folder_id = ?");
                     } else {
@@ -104,11 +104,11 @@ public class SqlQueryBuilder {
         appendExprRight(condition, query, selectionArgs);
     }
 
-    private static long getFolderId(Account account, String folderName) {
+    private static long getFolderId(Account account, String folderServerId) {
         long folderId = 0;
         try {
             LocalStore localStore = account.getLocalStore();
-            LocalFolder folder = localStore.getFolder(folderName);
+            LocalFolder folder = localStore.getFolder(folderServerId);
             folder.open(Folder.OPEN_MODE_RO);
             folderId = folder.getDatabaseId();
         } catch (MessagingException e) {

--- a/k9mail/src/main/java/com/fsck/k9/service/PollService.java
+++ b/k9mail/src/main/java/com/fsck/k9/service/PollService.java
@@ -107,7 +107,7 @@ public class PollService extends CoreService {
         @Override
         public void synchronizeMailboxFinished(
             Account account,
-            String folder,
+            String folderServerId,
             int totalMessagesInMailbox,
             int numNewMessages) {
             if (account.isNotifyNewMail()) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageLoader.java
@@ -60,11 +60,11 @@ public class LocalMessageLoader extends AsyncTaskLoader<LocalMessage> {
     }
 
     private LocalMessage loadMessageMetadataFromDatabase() throws MessagingException {
-        return controller.loadMessageMetadata(account, messageReference.getFolderName(), messageReference.getUid());
+        return controller.loadMessageMetadata(account, messageReference.getFolderServerId(), messageReference.getUid());
     }
 
     private LocalMessage loadMessageFromDatabase() throws MessagingException {
-        return controller.loadMessage(account, messageReference.getFolderName(), messageReference.getUid());
+        return controller.loadMessage(account, messageReference.getFolderServerId(), messageReference.getUid());
     }
 
     public boolean isCreatedFor(MessageReference messageReference) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -314,7 +314,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     private void refileMessage(String dstFolder) {
-        String srcFolder = mMessageReference.getFolderName();
+        String srcFolder = mMessageReference.getFolderServerId();
         MessageReference messageToMove = mMessageReference;
         mFragmentListener.showNextMessageOrReturn();
         mController.moveMessage(mAccount, srcFolder, messageToMove, dstFolder);
@@ -347,7 +347,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     public void onToggleFlagged() {
         if (mMessage != null) {
             boolean newState = !mMessage.isSet(Flag.FLAGGED);
-            mController.setFlag(mAccount, mMessage.getFolder().getName(),
+            mController.setFlag(mAccount, mMessage.getFolder().getServerId(),
                     Collections.singletonList(mMessage), Flag.FLAGGED, newState);
             mMessageView.setHeaders(mMessage, mAccount);
         }
@@ -398,7 +398,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     private void startRefileActivity(int activity) {
         Intent intent = new Intent(getActivity(), ChooseFolder.class);
         intent.putExtra(ChooseFolder.EXTRA_ACCOUNT, mAccount.getUuid());
-        intent.putExtra(ChooseFolder.EXTRA_CUR_FOLDER, mMessageReference.getFolderName());
+        intent.putExtra(ChooseFolder.EXTRA_CUR_FOLDER, mMessageReference.getFolderServerId());
         intent.putExtra(ChooseFolder.EXTRA_SEL_FOLDER, mAccount.getLastSelectedFolder());
         intent.putExtra(ChooseFolder.EXTRA_MESSAGE, mMessageReference.toIdentityString());
         startActivityForResult(intent, activity);
@@ -451,19 +451,19 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                     return;
                 }
 
-                String destFolderName = data.getStringExtra(ChooseFolder.EXTRA_NEW_FOLDER);
+                String destFolder = data.getStringExtra(ChooseFolder.EXTRA_NEW_FOLDER);
                 String messageReferenceString = data.getStringExtra(ChooseFolder.EXTRA_MESSAGE);
                 MessageReference ref = MessageReference.parse(messageReferenceString);
                 if (mMessageReference.equals(ref)) {
-                    mAccount.setLastSelectedFolder(destFolderName);
+                    mAccount.setLastSelectedFolder(destFolder);
                     switch (requestCode) {
                         case ACTIVITY_CHOOSE_FOLDER_MOVE: {
                             mFragmentListener.showNextMessageOrReturn();
-                            moveMessage(ref, destFolderName);
+                            moveMessage(ref, destFolder);
                             break;
                         }
                         case ACTIVITY_CHOOSE_FOLDER_COPY: {
-                            copyMessage(ref, destFolderName);
+                            copyMessage(ref, destFolder);
                             break;
                         }
                     }
@@ -481,7 +481,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
     public void onToggleRead() {
         if (mMessage != null) {
-            mController.setFlag(mAccount, mMessage.getFolder().getName(),
+            mController.setFlag(mAccount, mMessage.getFolder().getServerId(),
                     Collections.singletonList(mMessage), Flag.SEEN, !mMessage.isSet(Flag.SEEN));
             mMessageView.setHeaders(mMessage, mAccount);
             String subject = mMessage.getSubject();
@@ -512,11 +512,11 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     public void moveMessage(MessageReference reference, String destFolderName) {
-        mController.moveMessage(mAccount, mMessageReference.getFolderName(), reference, destFolderName);
+        mController.moveMessage(mAccount, mMessageReference.getFolderServerId(), reference, destFolderName);
     }
 
     public void copyMessage(MessageReference reference, String destFolderName) {
-        mController.copyMessage(mAccount, mMessageReference.getFolderName(), reference, destFolderName);
+        mController.copyMessage(mAccount, mMessageReference.getFolderServerId(), reference, destFolderName);
     }
 
     private void showDialog(int dialogId) {
@@ -629,12 +629,12 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     public boolean canMessageBeArchived() {
-        return (!mMessageReference.getFolderName().equals(mAccount.getArchiveFolder())
+        return (!mMessageReference.getFolderServerId().equals(mAccount.getArchiveFolder())
                 && mAccount.hasArchiveFolder());
     }
 
     public boolean canMessageBeMovedToSpam() {
-        return (!mMessageReference.getFolderName().equals(mAccount.getSpamFolder())
+        return (!mMessageReference.getFolderServerId().equals(mAccount.getSpamFolder())
                 && mAccount.hasSpamFolder());
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -305,7 +305,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
             return;
         }
 
-        if (mAccount.getSpamFolderName().equals(dstFolder) && K9.confirmSpam()) {
+        if (mAccount.getSpamFolder().equals(dstFolder) && K9.confirmSpam()) {
             mDstFolder = dstFolder;
             showDialog(R.id.dialog_confirm_spam);
         } else {
@@ -383,11 +383,11 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     public void onArchive() {
-        onRefile(mAccount.getArchiveFolderName());
+        onRefile(mAccount.getArchiveFolder());
     }
 
     public void onSpam() {
-        onRefile(mAccount.getSpamFolderName());
+        onRefile(mAccount.getSpamFolder());
     }
 
     public void onSelectText() {
@@ -399,7 +399,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         Intent intent = new Intent(getActivity(), ChooseFolder.class);
         intent.putExtra(ChooseFolder.EXTRA_ACCOUNT, mAccount.getUuid());
         intent.putExtra(ChooseFolder.EXTRA_CUR_FOLDER, mMessageReference.getFolderName());
-        intent.putExtra(ChooseFolder.EXTRA_SEL_FOLDER, mAccount.getLastSelectedFolderName());
+        intent.putExtra(ChooseFolder.EXTRA_SEL_FOLDER, mAccount.getLastSelectedFolder());
         intent.putExtra(ChooseFolder.EXTRA_MESSAGE, mMessageReference.toIdentityString());
         startActivityForResult(intent, activity);
     }
@@ -455,7 +455,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                 String messageReferenceString = data.getStringExtra(ChooseFolder.EXTRA_MESSAGE);
                 MessageReference ref = MessageReference.parse(messageReferenceString);
                 if (mMessageReference.equals(ref)) {
-                    mAccount.setLastSelectedFolderName(destFolderName);
+                    mAccount.setLastSelectedFolder(destFolderName);
                     switch (requestCode) {
                         case ACTIVITY_CHOOSE_FOLDER_MOVE: {
                             mFragmentListener.showNextMessageOrReturn();
@@ -629,12 +629,12 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     public boolean canMessageBeArchived() {
-        return (!mMessageReference.getFolderName().equals(mAccount.getArchiveFolderName())
+        return (!mMessageReference.getFolderName().equals(mAccount.getArchiveFolder())
                 && mAccount.hasArchiveFolder());
     }
 
     public boolean canMessageBeMovedToSpam() {
-        return (!mMessageReference.getFolderName().equals(mAccount.getSpamFolderName())
+        return (!mMessageReference.getFolderName().equals(mAccount.getSpamFolder())
                 && mAccount.hasSpamFolder());
     }
 

--- a/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
@@ -19,7 +19,8 @@ import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class ActivityListenerTest {
-    private static final String FOLDER = "folder";
+    private static final String FOLDER_SERVER_ID = ":folder:123";
+    private static final String FOLDER_NAME = "folder";
     private static final String ERROR_MESSAGE = "errorMessage";
     private static final int COUNT = 23;
 
@@ -41,8 +42,8 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenFolderStatusChanged() {
-        activityListener.synchronizeMailboxStarted(account, FOLDER);
-        activityListener.folderStatusChanged(account, FOLDER, COUNT);
+        activityListener.synchronizeMailboxStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
+        activityListener.folderStatusChanged(account, FOLDER_SERVER_ID, COUNT);
 
         String operation = activityListener.getOperation(context);
 
@@ -51,7 +52,7 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenSynchronizeMailboxStarted() {
-        activityListener.synchronizeMailboxStarted(account, FOLDER);
+        activityListener.synchronizeMailboxStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
 
         String operation = activityListener.getOperation(context);
 
@@ -60,8 +61,8 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenSynchronizeMailboxProgress_shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, FOLDER);
-        activityListener.synchronizeMailboxProgress(account, FOLDER, 1, 2);
+        activityListener.synchronizeMailboxStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
+        activityListener.synchronizeMailboxProgress(account, FOLDER_SERVER_ID, 1, 2);
 
         String operation = activityListener.getOperation(context);
 
@@ -70,8 +71,8 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenSynchronizeMailboxFailed_shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, FOLDER);
-        activityListener.synchronizeMailboxFailed(account, FOLDER, ERROR_MESSAGE);
+        activityListener.synchronizeMailboxStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
+        activityListener.synchronizeMailboxFailed(account, FOLDER_SERVER_ID, ERROR_MESSAGE);
 
         String operation = activityListener.getOperation(context);
 
@@ -84,9 +85,9 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenSynchronizeMailboxFailedAfterHeadersStarted_shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxStarted(account, FOLDER);
-        activityListener.synchronizeMailboxHeadersStarted(account, FOLDER);
-        activityListener.synchronizeMailboxFailed(account, FOLDER, ERROR_MESSAGE);
+        activityListener.synchronizeMailboxStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
+        activityListener.synchronizeMailboxHeadersStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
+        activityListener.synchronizeMailboxFailed(account, FOLDER_SERVER_ID, ERROR_MESSAGE);
 
         String operation = activityListener.getOperation(context);
 
@@ -99,8 +100,8 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenSynchronizeMailboxFinished() {
-        activityListener.synchronizeMailboxStarted(account, FOLDER);
-        activityListener.synchronizeMailboxFinished(account, FOLDER, COUNT, COUNT);
+        activityListener.synchronizeMailboxStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
+        activityListener.synchronizeMailboxFinished(account, FOLDER_SERVER_ID, COUNT, COUNT);
 
         String operation = activityListener.getOperation(context);
 
@@ -113,7 +114,7 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenSynchronizeMailboxHeadersStarted_shouldResultInValidStatus() {
-        activityListener.synchronizeMailboxHeadersStarted(account, FOLDER);
+        activityListener.synchronizeMailboxHeadersStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
 
         String operation = activityListener.getOperation(context);
 
@@ -122,8 +123,8 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenSynchronizeMailboxHeadersProgress() {
-        activityListener.synchronizeMailboxHeadersStarted(account, FOLDER);
-        activityListener.synchronizeMailboxHeadersProgress(account, FOLDER, 2, 3);
+        activityListener.synchronizeMailboxHeadersStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
+        activityListener.synchronizeMailboxHeadersProgress(account, FOLDER_SERVER_ID, 2, 3);
 
         String operation = activityListener.getOperation(context);
 
@@ -132,8 +133,8 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenSynchronizeMailboxHeadersFinished() {
-        activityListener.synchronizeMailboxHeadersStarted(account, FOLDER);
-        activityListener.synchronizeMailboxHeadersFinished(account, FOLDER, COUNT, COUNT);
+        activityListener.synchronizeMailboxHeadersStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
+        activityListener.synchronizeMailboxHeadersFinished(account, FOLDER_SERVER_ID, COUNT, COUNT);
 
         String operation = activityListener.getOperation(context);
 
@@ -142,8 +143,8 @@ public class ActivityListenerTest {
 
     @Test
     public void getOperation__whenSynchronizeMailboxNewMessage() {
-        activityListener.synchronizeMailboxStarted(account, FOLDER);
-        activityListener.synchronizeMailboxNewMessage(account, FOLDER, message);
+        activityListener.synchronizeMailboxStarted(account, FOLDER_SERVER_ID, FOLDER_NAME);
+        activityListener.synchronizeMailboxNewMessage(account, FOLDER_SERVER_ID, message);
 
         String operation = activityListener.getOperation(context);
 

--- a/k9mail/src/test/java/com/fsck/k9/activity/MessageReferenceTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/MessageReferenceTest.java
@@ -37,7 +37,7 @@ public class MessageReferenceTest {
 
         assertNotNull(messageReference);
         assertEquals("o hai!", messageReference.getAccountUuid());
-        assertEquals("folder", messageReference.getFolderName());
+        assertEquals("folder", messageReference.getFolderServerId());
         assertEquals("10101010", messageReference.getUid());
         assertNull(messageReference.getFlag());
     }
@@ -48,7 +48,7 @@ public class MessageReferenceTest {
 
         assertNotNull(messageReference);
         assertEquals("o hai!", messageReference.getAccountUuid());
-        assertEquals("folder", messageReference.getFolderName());
+        assertEquals("folder", messageReference.getFolderServerId());
         assertEquals("10101010", messageReference.getUid());
         assertEquals(Flag.ANSWERED, messageReference.getFlag());
     }
@@ -61,7 +61,7 @@ public class MessageReferenceTest {
         MessageReference messageReferenceTwo = messageReferenceOne.withModifiedUid("---");
 
         assertEquals("account", messageReferenceTwo.getAccountUuid());
-        assertEquals("folder", messageReferenceTwo.getFolderName());
+        assertEquals("folder", messageReferenceTwo.getFolderServerId());
         assertEquals("---", messageReferenceTwo.getUid());
         assertEquals(Flag.ANSWERED, messageReferenceTwo.getFlag());
     }
@@ -74,7 +74,7 @@ public class MessageReferenceTest {
         MessageReference messageReferenceTwo = messageReferenceOne.withModifiedFlag(Flag.DELETED);
 
         assertEquals("account", messageReferenceTwo.getAccountUuid());
-        assertEquals("folder", messageReferenceTwo.getFolderName());
+        assertEquals("folder", messageReferenceTwo.getFolderServerId());
         assertEquals("uid", messageReferenceTwo.getUid());
         assertEquals(Flag.DELETED, messageReferenceTwo.getFlag());
     }
@@ -207,13 +207,13 @@ public class MessageReferenceTest {
         createMessageReference("account", "folder", null);
     }
 
-    private MessageReference createMessageReference(String accountUuid, String folderName, String uid) {
-        return new MessageReference(accountUuid, folderName, uid, null);
+    private MessageReference createMessageReference(String accountUuid, String folderServerId, String uid) {
+        return new MessageReference(accountUuid, folderServerId, uid, null);
     }
 
-    private MessageReference createMessageReferenceWithFlag(String accountUuid, String folderName, String uid,
+    private MessageReference createMessageReferenceWithFlag(String accountUuid, String folderServerId, String uid,
             Flag flag) {
-        return new MessageReference(accountUuid, folderName, uid, flag);
+        return new MessageReference(accountUuid, folderServerId, uid, flag);
     }
 
     private void assertEqualsReturnsTrueSymmetrically(MessageReference referenceOne, MessageReference referenceTwo) {

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -508,7 +508,7 @@ public class MessagingControllerTest {
 
     @Test
     public void sendPendingMessagesSynchronous_withNonExistentOutbox_shouldNotStartSync() throws MessagingException {
-        when(account.getOutboxFolderName()).thenReturn(FOLDER_NAME);
+        when(account.getOutboxFolder()).thenReturn(FOLDER_NAME);
         when(localFolder.exists()).thenReturn(false);
         controller.addListener(listener);
 
@@ -826,9 +826,9 @@ public class MessagingControllerTest {
     }
 
     private void setupAccountWithMessageToSend() throws MessagingException {
-        when(account.getOutboxFolderName()).thenReturn(FOLDER_NAME);
+        when(account.getOutboxFolder()).thenReturn(FOLDER_NAME);
         when(account.hasSentFolder()).thenReturn(true);
-        when(account.getSentFolderName()).thenReturn(SENT_FOLDER_NAME);
+        when(account.getSentFolder()).thenReturn(SENT_FOLDER_NAME);
         when(localStore.getFolder(SENT_FOLDER_NAME)).thenReturn(sentFolder);
         when(sentFolder.getDatabaseId()).thenReturn(1L);
         when(localFolder.exists()).thenReturn(true);

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -254,7 +254,7 @@ public class MessagingControllerTest {
 
         List<Folder> folders = Collections.singletonList(remoteFolder);
         when(remoteStore.getPersonalNamespaces(false)).thenAnswer(createAnswer(folders));
-        when(remoteFolder.getName()).thenReturn("NewFolder");
+        when(remoteFolder.getServerId()).thenReturn("NewFolder");
         when(localStore.getFolder("NewFolder")).thenReturn(newLocalFolder);
 
         controller.refreshRemoteSynchronous(account, listener);
@@ -266,7 +266,7 @@ public class MessagingControllerTest {
     public void refreshRemoteSynchronous_shouldDeleteFoldersNotOnRemote() throws MessagingException {
         configureRemoteStoreWithFolder();
         LocalFolder oldLocalFolder = mock(LocalFolder.class);
-        when(oldLocalFolder.getName()).thenReturn("OldLocalFolder");
+        when(oldLocalFolder.getServerId()).thenReturn("OldLocalFolder");
         when(localStore.getPersonalNamespaces(false))
                 .thenReturn(Collections.singletonList(oldLocalFolder));
         List<Folder> folders = Collections.emptyList();
@@ -295,7 +295,7 @@ public class MessagingControllerTest {
         configureRemoteStoreWithFolder();
         LocalFolder missingSpecialFolder = mock(LocalFolder.class);
         when(account.isSpecialFolder("Outbox")).thenReturn(true);
-        when(missingSpecialFolder.getName()).thenReturn("Outbox");
+        when(missingSpecialFolder.getServerId()).thenReturn("Outbox");
         when(localStore.getPersonalNamespaces(false))
                 .thenReturn(Collections.singletonList(missingSpecialFolder));
         List<Folder> folders = Collections.emptyList();
@@ -905,14 +905,14 @@ public class MessagingControllerTest {
 
     private void configureLocalStore() throws MessagingException {
         when(localStore.getFolder(FOLDER_NAME)).thenReturn(localFolder);
-        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(localFolder.getServerId()).thenReturn(FOLDER_NAME);
         when(localStore.getPersonalNamespaces(false)).thenReturn(Collections.singletonList(localFolder));
     }
 
     private void configureRemoteStoreWithFolder() throws MessagingException {
         when(account.getRemoteStore()).thenReturn(remoteStore);
         when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
-        when(remoteFolder.getName()).thenReturn(FOLDER_NAME);
+        when(remoteFolder.getServerId()).thenReturn(FOLDER_NAME);
     }
 
     private void setAccountsInPreferences(Map<String, Account> newAccounts)

--- a/k9mail/src/test/java/com/fsck/k9/controller/imap/ImapSyncTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/imap/ImapSyncTest.java
@@ -374,13 +374,13 @@ public class ImapSyncTest {
 
     private void configureLocalStore() throws MessagingException {
         when(localStore.getFolder(FOLDER_NAME)).thenReturn(localFolder);
-        when(localFolder.getName()).thenReturn(FOLDER_NAME);
+        when(localFolder.getServerId()).thenReturn(FOLDER_NAME);
         when(localStore.getPersonalNamespaces(false)).thenReturn(Collections.singletonList(localFolder));
     }
 
     private void configureRemoteStoreWithFolder() throws MessagingException {
         when(account.getRemoteStore()).thenReturn(remoteStore);
         when(remoteStore.getFolder(FOLDER_NAME)).thenReturn(remoteFolder);
-        when(remoteFolder.getName()).thenReturn(FOLDER_NAME);
+        when(remoteFolder.getServerId()).thenReturn(FOLDER_NAME);
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
@@ -355,7 +355,7 @@ public class StoreSchemaDefinitionTest {
 
     private Account createAccount() {
         Account account = mock(Account.class);
-        when(account.getInboxFolderName()).thenReturn("Inbox");
+        when(account.getInboxFolder()).thenReturn("Inbox");
         when(account.getLocalStorageProviderId()).thenReturn(StorageManager.InternalStorageProvider.ID);
         return account;
     }

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationTo60Test.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationTo60Test.java
@@ -255,34 +255,34 @@ public class MigrationTo60Test {
         return command;
     }
 
-    OldPendingCommand queueSetFlagBulk(String folderName, boolean newState, Flag flag, String[] uids) {
+    OldPendingCommand queueSetFlagBulk(String folderServerId, boolean newState, Flag flag, String[] uids) {
         OldPendingCommand command = new OldPendingCommand();
         command.command = PENDING_COMMAND_SET_FLAG_BULK;
         int length = 3 + uids.length;
         command.arguments = new String[length];
-        command.arguments[0] = folderName;
+        command.arguments[0] = folderServerId;
         command.arguments[1] = Boolean.toString(newState);
         command.arguments[2] = flag.toString();
         System.arraycopy(uids, 0, command.arguments, 3, uids.length);
         return command;
     }
 
-    OldPendingCommand queueSetFlagOld(String folderName, boolean newState, Flag flag, String uid) {
+    OldPendingCommand queueSetFlagOld(String folderServerId, boolean newState, Flag flag, String uid) {
         OldPendingCommand command = new OldPendingCommand();
         command.command = PENDING_COMMAND_SET_FLAG;
         command.arguments = new String[4];
-        command.arguments[0] = folderName;
+        command.arguments[0] = folderServerId;
         command.arguments[1] = uid;
         command.arguments[2] = Boolean.toString(newState);
         command.arguments[3] = flag.toString();
         return command;
     }
 
-    OldPendingCommand queueExpunge(String folderName) {
+    OldPendingCommand queueExpunge(String folderServerId) {
         OldPendingCommand command = new OldPendingCommand();
         command.command = PENDING_COMMAND_EXPUNGE;
         command.arguments = new String[1];
-        command.arguments[0] = folderName;
+        command.arguments[0] = folderServerId;
         return command;
     }
 

--- a/k9mail/src/test/java/com/fsck/k9/notification/SyncNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/SyncNotificationsTest.java
@@ -140,7 +140,7 @@ public class SyncNotificationsTest {
 
     private Folder createFakeFolder() {
         Folder folder = mock(Folder.class);
-        when(folder.getName()).thenReturn(FOLDER_NAME);
+        when(folder.getServerId()).thenReturn(FOLDER_NAME);
         return folder;
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/notification/SyncNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/SyncNotificationsTest.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 public class SyncNotificationsTest {
     private static final int ACCOUNT_NUMBER = 1;
     private static final String ACCOUNT_NAME = "TestAccount";
+    private static final String FOLDER_SERVER_ID = "INBOX";
     private static final String FOLDER_NAME = "Inbox";
 
 
@@ -140,7 +141,8 @@ public class SyncNotificationsTest {
 
     private Folder createFakeFolder() {
         Folder folder = mock(Folder.class);
-        when(folder.getServerId()).thenReturn(FOLDER_NAME);
+        when(folder.getServerId()).thenReturn(FOLDER_SERVER_ID);
+        when(folder.getName()).thenReturn(FOLDER_NAME);
         return folder;
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/notification/WearNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/WearNotificationsTest.java
@@ -197,11 +197,11 @@ public class WearNotificationsTest {
     }
 
     private void disableArchiveAction() {
-        when(account.getArchiveFolderName()).thenReturn(K9.FOLDER_NONE);
+        when(account.getArchiveFolder()).thenReturn(K9.FOLDER_NONE);
     }
 
     private void disableSpamAction() {
-        when(account.getSpamFolderName()).thenReturn(K9.FOLDER_NONE);
+        when(account.getSpamFolder()).thenReturn(K9.FOLDER_NONE);
     }
 
     private void enableDeleteAction() {
@@ -210,11 +210,11 @@ public class WearNotificationsTest {
     }
 
     private void enableArchiveAction() {
-        when(account.getArchiveFolderName()).thenReturn("Archive");
+        when(account.getArchiveFolder()).thenReturn("Archive");
     }
 
     private void enableSpamAction() {
-        when(account.getSpamFolderName()).thenReturn("Spam");
+        when(account.getSpamFolder()).thenReturn("Spam");
     }
 
     private void disableOptionalSummaryActions() {


### PR DESCRIPTION
Change our code to separate server ID and name of a folder. The name is only used for display purposes. The server ID is used to reference a folder (for now both locally and remotely, see #3220).

Currently all `RemoteStore` implementations still return the same value for `getName()` and `getServerId()`. So for now this shouldn't change any existing behavior. But it is a necessary step for e.g. displaying the folder hierarchy (see also #2729).

I was almost done when I realized @philipwhiuk had already implemented most of this in #2738. However, I found it easier to finish my branch than to rebase #2738.