### PR TITLE
Replace usage of getLastNonConfigurationInstance()

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -434,7 +434,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         handler.setViewTitle();
 
         // Handle activity restarts because of a configuration change (e.g. rotating the screen)
-        nonConfigurationInstance = (NonConfigurationInstance) getLastNonConfigurationInstance();
+        nonConfigurationInstance = (NonConfigurationInstance) getLastCustomNonConfigurationInstance();
         if (nonConfigurationInstance != null) {
             nonConfigurationInstance.restore(this);
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -351,7 +351,7 @@ public class FolderList extends K9ListActivity {
 
     @SuppressWarnings("unchecked")
     private void restorePreviousData() {
-        final Object previousData = getLastNonConfigurationInstance();
+        final Object previousData = getLastCustomNonConfigurationInstance();
 
         if (previousData != null) {
             adapter.mFolders = (ArrayList<FolderInfoHolder>) previousData;

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -446,7 +446,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
         setTitle();
 
-        currentMessageBuilder = (MessageBuilder) getLastNonConfigurationInstance();
+        currentMessageBuilder = (MessageBuilder) getLastCustomNonConfigurationInstance();
         if (currentMessageBuilder != null) {
             setProgressBarIndeterminateVisibility(true);
             currentMessageBuilder.reattachCallback(this);


### PR DESCRIPTION
After changing to AppCompat we need to use `getLastCustomNonConfigurationInstance()` instead of `getLastNonConfigurationInstance()`.

