### PR TITLE
Remove unread count from action bar

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -123,7 +123,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
     private ConcurrentMap<BaseAccount, String> pendingWork = new ConcurrentHashMap<BaseAccount, String>();
 
     private BaseAccount selectedContextAccount;
-    private int unreadMessageCount = 0;
 
     private AccountsHandler handler = new AccountsHandler();
     private AccountsAdapter adapter;
@@ -133,10 +132,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
     private MenuItem refreshMenuItem;
     private ActionBar actionBar;
-
-    private TextView actionBarTitle;
-    private TextView actionBarSubTitle;
-    private TextView actionBarUnread;
 
     private boolean exportGlobalSettings;
     private ArrayList<String> exportAccountUuids;
@@ -154,22 +149,14 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
     class AccountsHandler extends Handler {
         private void setViewTitle() {
-            actionBarTitle.setText(getString(R.string.accounts_title));
-
-            if (unreadMessageCount == 0) {
-                actionBarUnread.setVisibility(View.GONE);
-            } else {
-                actionBarUnread.setText(String.format("%d", unreadMessageCount));
-                actionBarUnread.setVisibility(View.VISIBLE);
-            }
+            actionBar.setTitle(R.string.accounts_title);
 
             String operation = mListener.getOperation(Accounts.this);
             operation = operation.trim();
             if (operation.length() < 1) {
-                actionBarSubTitle.setVisibility(View.GONE);
+                actionBar.setSubtitle(null);
             } else {
-                actionBarSubTitle.setVisibility(View.VISIBLE);
-                actionBarSubTitle.setText(operation);
+                actionBar.setSubtitle(operation);
             }
         }
         public void refreshTitle() {
@@ -281,9 +268,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 stats.available = false;
             }
             accountStats.put(account.getUuid(), stats);
-            if (account instanceof Account) {
-                unreadMessageCount += stats.unreadMessageCount - oldUnreadMessageCount;
-            }
             handler.dataChanged();
             pendingWork.remove(account);
 
@@ -331,7 +315,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
     };
 
     private static final String ACCOUNT_STATS = "accountStats";
-    private static final String STATE_UNREAD_COUNT = "unreadCount";
     private static final String SELECTED_CONTEXT_ACCOUNT = "selectedContextAccount";
     private static final String STATE_EXPORT_GLOBAL_SETTINGS = "exportGlobalSettings";
     private static final String STATE_EXPORT_ACCOUNTS = "exportAccountUuids";
@@ -446,14 +429,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
     }
 
     private void initializeActionBar() {
-        actionBar.setDisplayShowCustomEnabled(true);
-        actionBar.setCustomView(R.layout.actionbar_custom);
-
-        View customView = actionBar.getCustomView();
-        actionBarTitle = (TextView) customView.findViewById(R.id.actionbar_title_first);
-        actionBarSubTitle = (TextView) customView.findViewById(R.id.actionbar_title_sub);
-        actionBarUnread = (TextView) customView.findViewById(R.id.actionbar_unread_count);
-
         actionBar.setDisplayHomeAsUpEnabled(false);
     }
 
@@ -472,7 +447,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
             if (oldStats != null) {
                 accountStats.putAll(oldStats);
             }
-            unreadMessageCount = icicle.getInt(STATE_UNREAD_COUNT);
         }
     }
 
@@ -482,7 +456,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         if (selectedContextAccount != null) {
             outState.putString(SELECTED_CONTEXT_ACCOUNT, selectedContextAccount.getUuid());
         }
-        outState.putSerializable(STATE_UNREAD_COUNT, unreadMessageCount);
         outState.putSerializable(ACCOUNT_STATS, accountStats);
 
         outState.putBoolean(STATE_EXPORT_GLOBAL_SETTINGS, exportGlobalSettings);

--- a/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -40,8 +40,6 @@ import android.widget.Toast;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.FolderMode;
-import com.fsck.k9.AccountStats;
-import com.fsck.k9.BaseAccount;
 import com.fsck.k9.FontSizes;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
@@ -88,8 +86,6 @@ public class FolderList extends K9ListActivity {
 
     private FolderListHandler handler = new FolderListHandler();
 
-    private int unreadMessageCount;
-
     private FontSizes fontSizes = K9.getFontSizes();
     private Context context;
 
@@ -97,29 +93,18 @@ public class FolderList extends K9ListActivity {
     private View actionBarProgressView;
     private ActionBar actionBar;
 
-    private TextView actionBarTitle;
-    private TextView actionBarSubTitle;
-    private TextView actionBarUnread;
-
     class FolderListHandler extends Handler {
 
         public void refreshTitle() {
             runOnUiThread(new Runnable() {
                 public void run() {
-                    actionBarTitle.setText(getString(R.string.folders_title));
-
-                    if (unreadMessageCount == 0) {
-                        actionBarUnread.setVisibility(View.GONE);
-                    } else {
-                        actionBarUnread.setText(String.format("%d", unreadMessageCount));
-                        actionBarUnread.setVisibility(View.VISIBLE);
-                    }
+                    actionBar.setTitle(R.string.folders_title);
 
                     String operation = adapter.mListener.getOperation(FolderList.this);
                     if (operation.length() < 1) {
-                        actionBarSubTitle.setText(account.getEmail());
+                        actionBar.setSubtitle(account.getEmail());
                     } else {
-                        actionBarSubTitle.setText(operation);
+                        actionBar.setSubtitle(operation);
                     }
                 }
             });
@@ -303,14 +288,6 @@ public class FolderList extends K9ListActivity {
     }
 
     private void initializeActionBar() {
-        actionBar.setDisplayShowCustomEnabled(true);
-        actionBar.setCustomView(R.layout.actionbar_custom);
-
-        View customView = actionBar.getCustomView();
-        actionBarTitle = (TextView) customView.findViewById(R.id.actionbar_title_first);
-        actionBarSubTitle = (TextView) customView.findViewById(R.id.actionbar_title_sub);
-        actionBarUnread = (TextView) customView.findViewById(R.id.actionbar_unread_count);
-
         actionBar.setDisplayHomeAsUpEnabled(true);
     }
 
@@ -318,7 +295,6 @@ public class FolderList extends K9ListActivity {
     public void onNewIntent(Intent intent) {
         setIntent(intent); // onNewIntent doesn't autoset our "internal" intent
 
-        unreadMessageCount = 0;
         String accountUuid = intent.getStringExtra(EXTRA_ACCOUNT);
         account = Preferences.getPreferences(this).getAccount(accountUuid);
 
@@ -594,7 +570,7 @@ public class FolderList extends K9ListActivity {
             @Override
             public boolean onQueryTextSubmit(String query) {
                 folderMenuItem.collapseActionView();
-                actionBarTitle.setText(getString(R.string.filter_folders_action));
+                actionBar.setTitle(R.string.filter_folders_action);
                 return true;
             }
 
@@ -609,7 +585,7 @@ public class FolderList extends K9ListActivity {
 
             @Override
             public boolean onClose() {
-                actionBarTitle.setText(getString(R.string.folders_title));
+                actionBar.setTitle(R.string.folders_title);
                 return false;
             }
         });
@@ -681,17 +657,6 @@ public class FolderList extends K9ListActivity {
             public void informUserOfStatus() {
                 handler.refreshTitle();
                 handler.dataChanged();
-            }
-            @Override
-            public void accountStatusChanged(BaseAccount account, AccountStats stats) {
-                if (!account.equals(FolderList.this.account)) {
-                    return;
-                }
-                if (stats == null) {
-                    return;
-                }
-                unreadMessageCount = stats.unreadMessageCount;
-                handler.refreshTitle();
             }
 
             @Override

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -155,7 +155,6 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     private MessageTitleView actionBarSubject;
     private TextView actionBarTitle;
     private TextView actionBarSubTitle;
-    private TextView actionBarUnread;
     private Menu menu;
 
     private ViewGroup messageViewContainer;
@@ -546,7 +545,6 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         actionBarSubject = (MessageTitleView) customView.findViewById(R.id.message_title_view);
         actionBarTitle = (TextView) customView.findViewById(R.id.actionbar_title_first);
         actionBarSubTitle = (TextView) customView.findViewById(R.id.actionbar_title_sub);
-        actionBarUnread = (TextView) customView.findViewById(R.id.actionbar_unread_count);
         actionBarProgress = (ProgressBar) customView.findViewById(R.id.actionbar_progress);
         actionButtonIndeterminateProgress = getActionButtonIndeterminateProgress();
 
@@ -1178,15 +1176,6 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         actionBarSubTitle.setText(subTitle);
     }
 
-    public void setActionBarUnread(int unread) {
-        if (unread == 0) {
-            actionBarUnread.setVisibility(View.GONE);
-        } else {
-            actionBarUnread.setVisibility(View.VISIBLE);
-            actionBarUnread.setText(String.format("%d", unread));
-        }
-    }
-
     @Override
     public void setMessageListTitle(String title) {
         setActionBarTitle(title);
@@ -1195,11 +1184,6 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     @Override
     public void setMessageListSubTitle(String subTitle) {
         setActionBarSubTitle(subTitle);
-    }
-
-    @Override
-    public void setUnreadCount(int unread) {
-        setActionBarUnread(unread);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -170,7 +170,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
     private Account account;
     private String[] accountUuids;
-    private int unreadMessageCount = 0;
 
     private Cursor[] cursors;
     private boolean[] cursorValid;
@@ -338,19 +337,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             }
 
             fragmentListener.setMessageListSubTitle(null);
-        }
-
-        // set unread count
-        if (unreadMessageCount <= 0) {
-            fragmentListener.setUnreadCount(0);
-        } else {
-            if (!singleFolderMode && title == null) {
-                // The unread message count is easily confused
-                // with total number of messages in the search result, so let's hide it.
-                fragmentListener.setUnreadCount(0);
-            } else {
-                fragmentListener.setUnreadCount(unreadMessageCount);
-            }
         }
     }
 
@@ -1393,15 +1379,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             super.synchronizeMailboxFailed(account, folderServerId, message);
         }
 
-        @Override
-        public void folderStatusChanged(Account account, String folderServerId, int unreadMessageCount) {
-            if (isSingleAccountMode() && isSingleFolderMode() && MessageListFragment.this.account.equals(account) &&
-                    MessageListFragment.this.folderServerId.equals(folderServerId)) {
-                MessageListFragment.this.unreadMessageCount = unreadMessageCount;
-            }
-            super.folderStatusChanged(account, folderServerId, unreadMessageCount);
-        }
-
         private boolean updateForMe(Account account, String folderServerId) {
             if (account == null || folderServerId == null) {
                 return false;
@@ -2391,7 +2368,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         void openMessage(MessageReference messageReference);
         void setMessageListTitle(String title);
         void setMessageListSubTitle(String subTitle);
-        void setUnreadCount(int unread);
         void onCompose(Account account);
         boolean startSearch(Account account, String folderServerId);
         void remoteSearchStarted();

--- a/k9mail/src/main/res/layout/actionbar_custom.xml
+++ b/k9mail/src/main/res/layout/actionbar_custom.xml
@@ -46,15 +46,6 @@
             android:layout_gravity="center"
             android:visibility="gone" />
 
-        <TextView
-            android:id="@+id/actionbar_unread_count"
-            tools:text="1"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingLeft="12dip"
-            android:paddingRight="12dip"
-            android:textColor="?android:attr/textColorTertiary"
-            android:textSize="36sp" />
     </LinearLayout>
 
     <LinearLayout


### PR DESCRIPTION
I'm currently working on making small improvements to the UI. Most of these will be intermediate steps and not how I envision the final UI should look like.

Before:
![k9mail__unread_count__overview](https://user-images.githubusercontent.com/218061/37246317-8538e8da-24a7-11e8-89d1-2363c8c5749e.png)

After:
![k9mail__no_unread_count__overview](https://user-images.githubusercontent.com/218061/37246319-8a7acba6-24a7-11e8-9ae2-65c2bbd9f5bc.png)

This gets rid of the custom view for the action bar title in `Accounts` and `Folders`. The message list still uses the custom view which is why action bar title and subtitle look different from the other screens.
