### PR TITLE
Don't create special folders on server

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/FolderNotFoundException.kt
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/store/imap/FolderNotFoundException.kt
@@ -1,0 +1,6 @@
+package com.fsck.k9.mail.store.imap
+
+import com.fsck.k9.mail.MessagingException
+
+class FolderNotFoundException(val folderServerId: String)
+    : MessagingException("Folder not found: $folderServerId")

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -418,7 +418,7 @@ public class ImapFolderTest {
     }
 
     @Test
-    public void delete_withoutTrashFolderExisting_shouldCreateTrashFolder() throws Exception {
+    public void delete_withoutTrashFolderExisting_shouldThrow() throws Exception {
         ImapFolder folder = createFolder("Folder");
         prepareImapFolderForOpen(OPEN_MODE_RW);
         ImapFolder trashFolder = createFolder("Trash");
@@ -432,9 +432,12 @@ public class ImapFolderTest {
         doThrow(NegativeImapResponseException.class).doReturn(Collections.emptyList())
                 .when(imapConnection).executeSimpleCommand("STATUS \"Trash\" (RECENT)");
 
-        folder.delete(messages, "Trash");
-
-        verify(imapConnection).executeSimpleCommand("CREATE \"Trash\"");
+        try {
+            folder.delete(messages, "Trash");
+            fail("Expected exception");
+        } catch (FolderNotFoundException e) {
+            assertEquals("Trash", e.getFolderServerId());
+        }
     }
 
     @Test

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -321,6 +321,11 @@ public class Account implements BaseAccount, StoreConfig {
         isEnabled = true;
         markMessageAsReadOnView = true;
         alwaysShowCcBcc = false;
+        archiveFolder = K9.FOLDER_NONE;
+        draftsFolder = K9.FOLDER_NONE;
+        sentFolder = K9.FOLDER_NONE;
+        spamFolder = K9.FOLDER_NONE;
+        trashFolder = K9.FOLDER_NONE;
 
         searchableFolders = Searchable.ALL;
 
@@ -399,11 +404,11 @@ public class Account implements BaseAccount, StoreConfig {
         notifySync = storage.getBoolean(accountUuid + ".notifyMailCheck", false);
         deletePolicy =  DeletePolicy.fromInt(storage.getInt(accountUuid + ".deletePolicy", DeletePolicy.NEVER.setting));
         inboxFolder = storage.getString(accountUuid + ".inboxFolderName", INBOX);
-        draftsFolder = storage.getString(accountUuid + ".draftsFolderName", "Drafts");
-        sentFolder = storage.getString(accountUuid + ".sentFolderName", "Sent");
-        trashFolder = storage.getString(accountUuid + ".trashFolderName", "Trash");
-        archiveFolder = storage.getString(accountUuid + ".archiveFolderName", "Archive");
-        spamFolder = storage.getString(accountUuid + ".spamFolderName", "Spam");
+        draftsFolder = storage.getString(accountUuid + ".draftsFolderName", K9.FOLDER_NONE);
+        sentFolder = storage.getString(accountUuid + ".sentFolderName", K9.FOLDER_NONE);
+        trashFolder = storage.getString(accountUuid + ".trashFolderName", K9.FOLDER_NONE);
+        archiveFolder = storage.getString(accountUuid + ".archiveFolderName", K9.FOLDER_NONE);
+        spamFolder = storage.getString(accountUuid + ".spamFolderName", K9.FOLDER_NONE);
         expungePolicy = getEnumStringPref(storage, accountUuid + ".expungePolicy", Expunge.EXPUNGE_IMMEDIATELY);
         syncRemoteDeletions = storage.getBoolean(accountUuid + ".syncRemoteDeletions", true);
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -5,7 +5,6 @@ package com.fsck.k9.activity.setup;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Locale;
 
 import android.app.AlertDialog;
 import android.app.Dialog;
@@ -320,8 +319,6 @@ public class AccountSetupBasics extends K9Activity
             mAccount.setStoreUri(incomingUri.toString());
             mAccount.setTransportUri(outgoingUri.toString());
 
-            setupFolderNames(incomingUriTemplate.getHost().toLowerCase(Locale.US));
-
             ServerSettings incomingSettings = RemoteStore.decodeStoreUri(incomingUri.toString());
             mAccount.setDeletePolicy(AccountCreator.getDefaultDeletePolicy(incomingSettings.type));
 
@@ -415,27 +412,10 @@ public class AccountSetupBasics extends K9Activity
         mAccount.setStoreUri(storeUri);
         mAccount.setTransportUri(transportUri);
 
-        setupFolderNames(domain);
-
         AccountSetupAccountType.actionSelectAccountType(this, mAccount, false);
 
         finish();
     }
-
-    private void setupFolderNames(String domain) {
-        mAccount.setDraftsFolder(getString(R.string.special_mailbox_name_drafts));
-        mAccount.setTrashFolder(getString(R.string.special_mailbox_name_trash));
-        mAccount.setSentFolder(getString(R.string.special_mailbox_name_sent));
-        mAccount.setArchiveFolder(getString(R.string.special_mailbox_name_archive));
-
-        // Yahoo! has a special folder for Spam, called "Bulk Mail".
-        if (domain.endsWith(".yahoo.com")) {
-            mAccount.setSpamFolder("Bulk Mail");
-        } else {
-            mAccount.setSpamFolder(getString(R.string.special_mailbox_name_spam));
-        }
-    }
-
 
     public void onClick(View v) {
         switch (v.getId()) {

--- a/k9mail/src/main/java/com/fsck/k9/controller/imap/ImapSync.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/imap/ImapSync.java
@@ -114,11 +114,6 @@ class ImapSync {
                 Timber.v("SYNC: About to get remote folder %s", folder);
                 remoteFolder = remoteStore.getFolder(folder);
 
-                if (!verifyOrCreateRemoteSpecialFolder(account, folder, remoteFolder, listener)) {
-                    return;
-                }
-
-
                 /*
                  * Synchronization process:
                  *
@@ -323,30 +318,6 @@ class ImapSync {
             closeFolder(tLocalFolder);
         }
 
-    }
-
-    /*
-     * If the folder is a "special" folder we need to see if it exists
-     * on the remote server. It if does not exist we'll try to create it. If we
-     * can't create we'll abort.
-     */
-    private boolean verifyOrCreateRemoteSpecialFolder(Account account, String folder, Folder remoteFolder,
-            MessagingListener listener) throws MessagingException {
-        if (folder.equals(account.getTrashFolder()) ||
-                folder.equals(account.getSentFolder()) ||
-                folder.equals(account.getDraftsFolder())) {
-            if (!remoteFolder.exists()) {
-                if (!remoteFolder.create(FolderType.HOLDS_MESSAGES)) {
-                    for (MessagingListener l : getListeners(listener)) {
-                        l.synchronizeMailboxFinished(account, folder, 0, 0);
-                    }
-
-                    Timber.i("Done synchronizing folder %s", folder);
-                    return false;
-                }
-            }
-        }
-        return true;
     }
 
     /**

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -167,9 +167,8 @@ public class LocalFolder extends Folder<LocalMessage> {
                                 open(cursor);
                             }
                         } else {
-                            Timber.w("Creating folder %s with existing id %d", getServerId(), getDatabaseId());
-                            create(FolderType.HOLDS_MESSAGES);
-                            open(mode);
+                            throw new MessagingException("LocalFolder.open(): Folder not found: " +
+                                    serverId + " (" + databaseId + ")");
                         }
                     } catch (MessagingException e) {
                         throw new WrappedException(e);

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -51,7 +51,7 @@ public class AccountSettings {
                 new V(13, new BooleanSetting(false))
         ));
         s.put("archiveFolderName", Settings.versions(
-                new V(1, new StringSetting("Archive"))
+                new V(1, new StringSetting(K9.FOLDER_NONE))
         ));
         s.put("autoExpandFolderName", Settings.versions(
                 new V(1, new StringSetting("INBOX"))
@@ -73,7 +73,7 @@ public class AccountSettings {
                         R.array.account_settings_display_count_values))
         ));
         s.put("draftsFolderName", Settings.versions(
-                new V(1, new StringSetting("Drafts"))
+                new V(1, new StringSetting(K9.FOLDER_NONE))
         ));
         s.put("expungePolicy", Settings.versions(
                 new V(1, new StringResourceSetting(Expunge.EXPUNGE_IMMEDIATELY.name(),
@@ -164,7 +164,7 @@ public class AccountSettings {
                 new V(1, new EnumSetting<>(Searchable.class, Searchable.ALL))
         ));
         s.put("sentFolderName", Settings.versions(
-                new V(1, new StringSetting("Sent"))
+                new V(1, new StringSetting(K9.FOLDER_NONE))
         ));
         s.put("sortTypeEnum", Settings.versions(
                 new V(9, new EnumSetting<>(SortType.class, Account.DEFAULT_SORT_TYPE))
@@ -179,7 +179,7 @@ public class AccountSettings {
                 new V(1, new BooleanSetting(false))
         ));
         s.put("spamFolderName", Settings.versions(
-                new V(1, new StringSetting("Spam"))
+                new V(1, new StringSetting(K9.FOLDER_NONE))
         ));
         s.put("stripSignature", Settings.versions(
                 new V(2, new BooleanSetting(Account.DEFAULT_STRIP_SIGNATURE))
@@ -191,7 +191,7 @@ public class AccountSettings {
                 new V(1, new BooleanSetting(true))
         ));
         s.put("trashFolderName", Settings.versions(
-                new V(1, new StringSetting("Trash"))
+                new V(1, new StringSetting(K9.FOLDER_NONE))
         ));
         s.put("useCompression.MOBILE", Settings.versions(
                 new V(1, new BooleanSetting(true))


### PR DESCRIPTION
This changes the code to never create remote folders. Local folders are only created during account setup or folder list sync.
By default special folders are unassigned. So if an IMAP server doesn't support the SPECIAL-USE extension to configure special folders, some functionality will be disabled, e.g. the "Spam" and "Archive" shortcuts. Without a Trash folder configured, deleted messages will be removed from the server which is somewhat dangerous.

Fixes #633