### PR TITLE
Fix crash with pendingintents in messageview

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -92,7 +92,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     private static final int PREVIOUS = 1;
     private static final int NEXT = 2;
 
-    public static final int REQUEST_MASK_PENDING_INTENT = 1 << 16;
+    public static final int REQUEST_MASK_PENDING_INTENT = 1 << 15;
 
     public static void actionDisplaySearch(Context context, SearchSpecification search,
             boolean noThreading, boolean newTask) {


### PR DESCRIPTION
Only the lower 16 bits can be used for the request code from fragments. This changes our own mask to use the 15th bit instead of the 16th.