### PR TITLE
Revamp e2e settings

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -1517,6 +1517,9 @@ public class Account implements BaseAccount, StoreConfig {
 
     @Nullable
     public String getOpenPgpProvider() {
+        if (TextUtils.isEmpty(openPgpProvider)) {
+            return null;
+        }
         return openPgpProvider;
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import android.content.Context;
 import android.net.Uri;
+import android.support.annotation.Nullable;
 
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
 import com.fsck.k9.helper.Utility;
@@ -201,9 +202,10 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean replyAfterQuote;
     private boolean stripSignature;
     private boolean syncRemoteDeletions;
-    private long pgpCryptoKey;
+    private String openPgpProvider;
+    private long openPgpKey;
     private boolean autocryptPreferEncryptMutual;
-    private boolean pgpHideSignOnly;
+    private boolean openPgpHideSignOnly;
     private boolean markMessageAsReadOnView;
     private boolean alwaysShowCcBcc;
     private boolean allowRemoteSearch;
@@ -297,7 +299,7 @@ public class Account implements BaseAccount, StoreConfig {
         replyAfterQuote = DEFAULT_REPLY_AFTER_QUOTE;
         stripSignature = DEFAULT_STRIP_SIGNATURE;
         syncRemoteDeletions = true;
-        pgpCryptoKey = NO_OPENPGP_KEY;
+        openPgpKey = NO_OPENPGP_KEY;
         allowRemoteSearch = false;
         remoteSearchFullText = false;
         remoteSearchNumResults = DEFAULT_REMOTE_SEARCH_NUM_RESULTS;
@@ -429,8 +431,8 @@ public class Account implements BaseAccount, StoreConfig {
         isSignatureBeforeQuotedText = storage.getBoolean(accountUuid + ".signatureBeforeQuotedText", false);
         identities = loadIdentities(storage);
 
-        pgpCryptoKey = storage.getLong(accountUuid + ".cryptoKey", NO_OPENPGP_KEY);
-        pgpHideSignOnly = storage.getBoolean(accountUuid + ".pgpHideSignOnly", true);
+        openPgpKey = storage.getLong(accountUuid + ".cryptoKey", NO_OPENPGP_KEY);
+        openPgpHideSignOnly = storage.getBoolean(accountUuid + ".openPgpHideSignOnly", true);
         allowRemoteSearch = storage.getBoolean(accountUuid + ".allowRemoteSearch", false);
         remoteSearchFullText = storage.getBoolean(accountUuid + ".remoteSearchFullText", false);
         remoteSearchNumResults = storage.getInt(accountUuid + ".remoteSearchNumResults", DEFAULT_REMOTE_SEARCH_NUM_RESULTS);
@@ -696,8 +698,8 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(accountUuid + ".defaultQuotedTextShown", defaultQuotedTextShown);
         editor.putBoolean(accountUuid + ".replyAfterQuote", replyAfterQuote);
         editor.putBoolean(accountUuid + ".stripSignature", stripSignature);
-        editor.putLong(accountUuid + ".cryptoKey", pgpCryptoKey);
-        editor.putBoolean(accountUuid + ".pgpHideSignOnly", pgpHideSignOnly);
+        editor.putLong(accountUuid + ".cryptoKey", openPgpKey);
+        editor.putBoolean(accountUuid + ".openPgpHideSignOnly", openPgpHideSignOnly);
         editor.putBoolean(accountUuid + ".allowRemoteSearch", allowRemoteSearch);
         editor.putBoolean(accountUuid + ".remoteSearchFullText", remoteSearchFullText);
         editor.putInt(accountUuid + ".remoteSearchNumResults", remoteSearchNumResults);
@@ -1504,16 +1506,29 @@ public class Account implements BaseAccount, StoreConfig {
         this.stripSignature = stripSignature;
     }
 
-    public long getCryptoKey() {
-        return pgpCryptoKey;
+    public boolean isOpenPgpProviderConfigured() {
+        return openPgpProvider != null;
     }
 
-    public void setCryptoKey(long keyId) {
-        pgpCryptoKey = keyId;
+    @Nullable
+    public String getOpenPgpProvider() {
+        return openPgpProvider;
     }
 
-    public boolean hasCryptoKey() {
-        return pgpCryptoKey != NO_OPENPGP_KEY;
+    public void setOpenPgpProvider(String openPgpProvider) {
+        this.openPgpProvider = openPgpProvider;
+    }
+
+    public long getOpenPgpKey() {
+        return openPgpKey;
+    }
+
+    public void setOpenPgpKey(long keyId) {
+        openPgpKey = keyId;
+    }
+
+    public boolean hasOpenPgpKey() {
+        return openPgpKey != NO_OPENPGP_KEY;
     }
 
     public boolean getAutocryptPreferEncryptMutual() {
@@ -1524,12 +1539,12 @@ public class Account implements BaseAccount, StoreConfig {
         this.autocryptPreferEncryptMutual = autocryptPreferEncryptMutual;
     }
 
-    public boolean getPgpHideSignOnly() {
-        return pgpHideSignOnly;
+    public boolean getOpenPgpHideSignOnly() {
+        return openPgpHideSignOnly;
     }
 
-    public void setPgpHideSignOnly(boolean pgpHideSignOnly) {
-        this.pgpHideSignOnly = pgpHideSignOnly;
+    public void setOpenPgpHideSignOnly(boolean openPgpHideSignOnly) {
+        this.openPgpHideSignOnly = openPgpHideSignOnly;
     }
 
     public boolean allowRemoteSearch() {

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -203,6 +203,7 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean syncRemoteDeletions;
     private long pgpCryptoKey;
     private boolean autocryptPreferEncryptMutual;
+    private boolean pgpHideSignOnly;
     private boolean markMessageAsReadOnView;
     private boolean alwaysShowCcBcc;
     private boolean allowRemoteSearch;
@@ -429,6 +430,7 @@ public class Account implements BaseAccount, StoreConfig {
         identities = loadIdentities(storage);
 
         pgpCryptoKey = storage.getLong(accountUuid + ".cryptoKey", NO_OPENPGP_KEY);
+        pgpHideSignOnly = storage.getBoolean(accountUuid + ".pgpHideSignOnly", true);
         allowRemoteSearch = storage.getBoolean(accountUuid + ".allowRemoteSearch", false);
         remoteSearchFullText = storage.getBoolean(accountUuid + ".remoteSearchFullText", false);
         remoteSearchNumResults = storage.getInt(accountUuid + ".remoteSearchNumResults", DEFAULT_REMOTE_SEARCH_NUM_RESULTS);
@@ -695,6 +697,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(accountUuid + ".replyAfterQuote", replyAfterQuote);
         editor.putBoolean(accountUuid + ".stripSignature", stripSignature);
         editor.putLong(accountUuid + ".cryptoKey", pgpCryptoKey);
+        editor.putBoolean(accountUuid + ".pgpHideSignOnly", pgpHideSignOnly);
         editor.putBoolean(accountUuid + ".allowRemoteSearch", allowRemoteSearch);
         editor.putBoolean(accountUuid + ".remoteSearchFullText", remoteSearchFullText);
         editor.putInt(accountUuid + ".remoteSearchNumResults", remoteSearchNumResults);
@@ -1515,6 +1518,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public void setAutocryptPreferEncryptMutual(boolean autocryptPreferEncryptMutual) {
         this.autocryptPreferEncryptMutual = autocryptPreferEncryptMutual;
+    }
+
+    public boolean getPgpHideSignOnly() {
+        return pgpHideSignOnly;
+    }
+
+    public void setPgpHideSignOnly(boolean pgpHideSignOnly) {
+        this.pgpHideSignOnly = pgpHideSignOnly;
     }
 
     public boolean allowRemoteSearch() {

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -18,6 +18,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
 import com.fsck.k9.helper.Utility;
@@ -431,8 +432,10 @@ public class Account implements BaseAccount, StoreConfig {
         isSignatureBeforeQuotedText = storage.getBoolean(accountUuid + ".signatureBeforeQuotedText", false);
         identities = loadIdentities(storage);
 
+        openPgpProvider = storage.getString(accountUuid + ".openPgpProvider", "");
         openPgpKey = storage.getLong(accountUuid + ".cryptoKey", NO_OPENPGP_KEY);
         openPgpHideSignOnly = storage.getBoolean(accountUuid + ".openPgpHideSignOnly", true);
+        autocryptPreferEncryptMutual = storage.getBoolean(accountUuid + ".autocryptMutualMode", false);
         allowRemoteSearch = storage.getBoolean(accountUuid + ".allowRemoteSearch", false);
         remoteSearchFullText = storage.getBoolean(accountUuid + ".remoteSearchFullText", false);
         remoteSearchNumResults = storage.getInt(accountUuid + ".remoteSearchNumResults", DEFAULT_REMOTE_SEARCH_NUM_RESULTS);
@@ -700,6 +703,8 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putBoolean(accountUuid + ".stripSignature", stripSignature);
         editor.putLong(accountUuid + ".cryptoKey", openPgpKey);
         editor.putBoolean(accountUuid + ".openPgpHideSignOnly", openPgpHideSignOnly);
+        editor.putString(accountUuid + ".openPgpProvider", openPgpProvider);
+        editor.putBoolean(accountUuid + ".autocryptMutualMode", autocryptPreferEncryptMutual);
         editor.putBoolean(accountUuid + ".allowRemoteSearch", allowRemoteSearch);
         editor.putBoolean(accountUuid + ".remoteSearchFullText", remoteSearchFullText);
         editor.putInt(accountUuid + ".remoteSearchNumResults", remoteSearchNumResults);
@@ -1507,7 +1512,7 @@ public class Account implements BaseAccount, StoreConfig {
     }
 
     public boolean isOpenPgpProviderConfigured() {
-        return openPgpProvider != null;
+        return !TextUtils.isEmpty(openPgpProvider);
     }
 
     @Nullable

--- a/k9mail/src/main/java/com/fsck/k9/Account.java
+++ b/k9mail/src/main/java/com/fsck/k9/Account.java
@@ -1512,6 +1512,10 @@ public class Account implements BaseAccount, StoreConfig {
         pgpCryptoKey = keyId;
     }
 
+    public boolean hasCryptoKey() {
+        return pgpCryptoKey != NO_OPENPGP_KEY;
+    }
+
     public boolean getAutocryptPreferEncryptMutual() {
         return autocryptPreferEncryptMutual;
     }

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -1257,14 +1257,6 @@ public class K9 extends Application {
         K9.openPgpProvider = openPgpProvider;
     }
 
-    public static boolean getOpenPgpSupportSignOnly() {
-        return openPgpSupportSignOnly;
-    }
-
-    public static void setOpenPgpSupportSignOnly(boolean supportSignOnly) {
-        openPgpSupportSignOnly = supportSignOnly;
-    }
-
     public static String getAttachmentDefaultPath() {
         return attachmentDefaultPath;
     }

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -50,6 +50,9 @@ import timber.log.Timber.DebugTree;
 
 
 public class K9 extends Application {
+
+    public static final int VERSION_MIGRATE_OPENPGP_TO_ACCOUNTS = 63;
+
     /**
      * Components that are interested in knowing when the K9 instance is
      * available and ready (Android invokes Application.onCreate() after other
@@ -239,9 +242,6 @@ public class K9 extends Application {
     private static boolean hideTimeZone = false;
     private static boolean hideHostnameWhenConnecting = false;
 
-    private static String openPgpProvider = "";
-    private static boolean openPgpSupportSignOnly = false;
-
     private static SortType sortType;
     private static Map<SortType, Boolean> sortAscending = new HashMap<SortType, Boolean>();
 
@@ -310,8 +310,6 @@ public class K9 extends Application {
     public static final int MAIL_SERVICE_WAKE_LOCK_TIMEOUT = 60000;
 
     public static final int BOOT_RECEIVER_WAKE_LOCK_TIMEOUT = 60000;
-
-    public static final String NO_OPENPGP_PROVIDER = "";
 
     public static class Intents {
 
@@ -478,9 +476,6 @@ public class K9 extends Application {
         editor.putBoolean("hideUserAgent", hideUserAgent);
         editor.putBoolean("hideTimeZone", hideTimeZone);
         editor.putBoolean("hideHostnameWhenConnecting", hideHostnameWhenConnecting);
-
-        editor.putString("openPgpProvider", openPgpProvider);
-        editor.putBoolean("openPgpSupportSignOnly", openPgpSupportSignOnly);
 
         editor.putString("language", language);
         editor.putInt("theme", theme.ordinal());
@@ -669,6 +664,27 @@ public class K9 extends Application {
         if (cachedVersion >= LocalStore.DB_VERSION) {
             K9.setDatabasesUpToDate(false);
         }
+        if (cachedVersion < VERSION_MIGRATE_OPENPGP_TO_ACCOUNTS) {
+            migrateOpenPgpGlobalToAccountSettings();
+        }
+    }
+
+    private void migrateOpenPgpGlobalToAccountSettings() {
+        Preferences preferences = Preferences.getPreferences(this);
+        Storage storage = preferences.getStorage();
+
+        String openPgpProvider = storage.getString("openPgpProvider", null);
+        boolean openPgpSupportSignOnly = storage.getBoolean("openPgpSupportSignOnly", false);
+
+        for (Account account : preferences.getAccounts()) {
+            account.setOpenPgpProvider(openPgpProvider);
+            account.setOpenPgpHideSignOnly(!openPgpSupportSignOnly);
+        }
+
+        storage.edit()
+                .remove("openPgpProvider")
+                .remove("openPgpSupportSignOnly")
+                .commit();
     }
 
     /**
@@ -715,9 +731,6 @@ public class K9 extends Application {
         hideUserAgent = storage.getBoolean("hideUserAgent", false);
         hideTimeZone = storage.getBoolean("hideTimeZone", false);
         hideHostnameWhenConnecting = storage.getBoolean("hideHostnameWhenConnecting", false);
-
-        openPgpProvider = storage.getString("openPgpProvider", NO_OPENPGP_PROVIDER);
-        openPgpSupportSignOnly = storage.getBoolean("openPgpSupportSignOnly", false);
 
         confirmDelete = storage.getBoolean("confirmDelete", false);
         confirmDiscardMessage = storage.getBoolean("confirmDiscardMessage", true);
@@ -1243,18 +1256,6 @@ public class K9 extends Application {
 
     public static void setHideHostnameWhenConnecting(final boolean state) {
         hideHostnameWhenConnecting = state;
-    }
-
-    public static boolean isOpenPgpProviderConfigured() {
-        return !NO_OPENPGP_PROVIDER.equals(openPgpProvider);
-    }
-
-    public static String getOpenPgpProvider() {
-        return openPgpProvider;
-    }
-
-    public static void setOpenPgpProvider(String openPgpProvider) {
-        K9.openPgpProvider = openPgpProvider;
     }
 
     public static String getAttachmentDefaultPath() {

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -679,6 +679,7 @@ public class K9 extends Application {
         for (Account account : preferences.getAccounts()) {
             account.setOpenPgpProvider(openPgpProvider);
             account.setOpenPgpHideSignOnly(!openPgpSupportSignOnly);
+            account.save(preferences);
         }
 
         storage.edit()

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -140,8 +140,8 @@ public class MessageLoaderHelper {
         cancelAndClearCryptoOperation();
         cancelAndClearDecodeLoader();
 
-        String openPgpProvider = account.getOpenPgpProvider();
-        if (openPgpProvider != null) {
+        if (account.isOpenPgpProviderConfigured()) {
+            String openPgpProvider = account.getOpenPgpProvider();
             startOrResumeCryptoOperation(openPgpProvider);
         } else {
             startOrResumeDecodeMessage();
@@ -228,8 +228,8 @@ public class MessageLoaderHelper {
             return;
         }
 
-        String openPgpProvider = account.getOpenPgpProvider();
-        if (openPgpProvider != null) {
+        if (account.isOpenPgpProviderConfigured()) {
+            String openPgpProvider = account.getOpenPgpProvider();
             startOrResumeCryptoOperation(openPgpProvider);
             return;
         }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -81,7 +81,6 @@ public class MessageLoaderHelper {
     private LoaderManager loaderManager;
     @Nullable // make this explicitly nullable, make sure to cancel/ignore any operation if this is null
     private MessageLoaderCallbacks callback;
-    private final boolean processSignedOnly;
 
 
     // transient state
@@ -102,8 +101,6 @@ public class MessageLoaderHelper {
         this.loaderManager = loaderManager;
         this.fragmentManager = fragmentManager;
         this.callback = callback;
-
-        processSignedOnly = K9.getOpenPgpSupportSignOnly();
     }
 
 
@@ -298,7 +295,7 @@ public class MessageLoaderHelper {
             retainCryptoHelperFragment.setData(messageCryptoHelper);
         }
         messageCryptoHelper.asyncStartOrResumeProcessingMessage(
-                localMessage, messageCryptoCallback, cachedDecryptionResult, processSignedOnly);
+                localMessage, messageCryptoCallback, cachedDecryptionResult, !account.getPgpHideSignOnly());
     }
 
     private void cancelAndClearCryptoOperation() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -277,10 +277,10 @@ public class RecipientPresenter implements PermissionPingCallback {
             menu.findItem(R.id.openpgp_encrypt_enable).setVisible(!isEncrypting);
             menu.findItem(R.id.openpgp_encrypt_disable).setVisible(isEncrypting);
 
-            boolean hideSignOnly = account.getOpenPgpHideSignOnly();
+            boolean showSignOnly = !account.getOpenPgpHideSignOnly();
             boolean isSignOnly = currentCryptoStatus.isSignOnly();
-            menu.findItem(R.id.openpgp_sign_only).setVisible(!hideSignOnly && !isSignOnly);
-            menu.findItem(R.id.openpgp_sign_only_disable).setVisible(!hideSignOnly && isSignOnly);
+            menu.findItem(R.id.openpgp_sign_only).setVisible(showSignOnly && !isSignOnly);
+            menu.findItem(R.id.openpgp_sign_only_disable).setVisible(showSignOnly && isSignOnly);
 
             boolean pgpInlineModeEnabled = currentCryptoStatus.isPgpInlineModeEnabled();
             boolean showPgpInlineEnable = (isEncrypting || isSignOnly) && !pgpInlineModeEnabled;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -277,10 +277,10 @@ public class RecipientPresenter implements PermissionPingCallback {
             menu.findItem(R.id.openpgp_encrypt_enable).setVisible(!isEncrypting);
             menu.findItem(R.id.openpgp_encrypt_disable).setVisible(isEncrypting);
 
-            boolean showSignOnly = K9.getOpenPgpSupportSignOnly();
+            boolean hideSignOnly = account.getPgpHideSignOnly();
             boolean isSignOnly = currentCryptoStatus.isSignOnly();
-            menu.findItem(R.id.openpgp_sign_only).setVisible(showSignOnly && !isSignOnly);
-            menu.findItem(R.id.openpgp_sign_only_disable).setVisible(showSignOnly && isSignOnly);
+            menu.findItem(R.id.openpgp_sign_only).setVisible(!hideSignOnly && !isSignOnly);
+            menu.findItem(R.id.openpgp_sign_only_disable).setVisible(!hideSignOnly && isSignOnly);
 
             boolean pgpInlineModeEnabled = currentCryptoStatus.isPgpInlineModeEnabled();
             boolean showPgpInlineEnable = (isEncrypting || isSignOnly) && !pgpInlineModeEnabled;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -277,7 +277,7 @@ public class RecipientPresenter implements PermissionPingCallback {
             menu.findItem(R.id.openpgp_encrypt_enable).setVisible(!isEncrypting);
             menu.findItem(R.id.openpgp_encrypt_disable).setVisible(isEncrypting);
 
-            boolean hideSignOnly = account.getPgpHideSignOnly();
+            boolean hideSignOnly = account.getOpenPgpHideSignOnly();
             boolean isSignOnly = currentCryptoStatus.isSignOnly();
             menu.findItem(R.id.openpgp_sign_only).setVisible(!hideSignOnly && !isSignOnly);
             menu.findItem(R.id.openpgp_sign_only_disable).setVisible(!hideSignOnly && isSignOnly);
@@ -311,7 +311,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         }
 
         // This does not strictly depend on the account, but this is as good a point to set this as any
-        setupCryptoProvider();
+        setupCryptoProvider(account.getOpenPgpProvider());
     }
 
     @SuppressWarnings("UnusedParameters")
@@ -391,7 +391,7 @@ public class RecipientPresenter implements PermissionPingCallback {
             pendingUserInteractionIntent = null;
         }
 
-        Long accountCryptoKey = account.getCryptoKey();
+        Long accountCryptoKey = account.getOpenPgpKey();
         if (accountCryptoKey == Account.NO_OPENPGP_KEY) {
             accountCryptoKey = null;
         }
@@ -708,8 +708,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         }
     }
 
-    private void setupCryptoProvider() {
-        String openPgpProvider = K9.getOpenPgpProvider();
+    private void setupCryptoProvider(String openPgpProvider) {
         if (TextUtils.isEmpty(openPgpProvider)) {
             openPgpProvider = null;
         }
@@ -818,7 +817,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         if (error.getErrorId() == OpenPgpError.INCOMPATIBLE_API_VERSIONS) {
             // nothing we can do here, this is irrecoverable!
             openPgpProvider = null;
-            K9.setOpenPgpProvider(null);
+            account.setOpenPgpProvider(null);
             recipientMvpView.showErrorOpenPgpIncompatible();
             setCryptoProviderState(CryptoProviderState.UNCONFIGURED);
         } else {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -714,6 +714,7 @@ public class AccountSettings extends K9PreferenceActivity {
         pgpHideSignOnly = (SwitchPreference) findPreference(PREFERENCE_CRYPTO_HIDE_SIGN_ONLY);
 
         boolean isPgpConfigured = K9.isOpenPgpProviderConfigured();
+        boolean isKeyConfigured = account.hasCryptoKey();
 
         if (!isPgpConfigured) {
             pgpEnable.setChecked(false);
@@ -728,16 +729,11 @@ public class AccountSettings extends K9PreferenceActivity {
                         K9.setOpenPgpProvider(openPgpProviderPackages.get(0));
                         setupCryptoStuff();
                     } else {
-                        Intent i = new Intent(getApplicationContext(), OpenPgpAppSelectDialog.class);
-                        startActivity(i);
+                        OpenPgpAppSelectDialog.startOpenPgpChooserActivity(getApplicationContext());
                     }
                     return false;
                 }
             });
-
-            pgpCryptoKey.setEnabled(false);
-            autocryptPreferEncryptMutual.setEnabled(false);
-            pgpHideSignOnly.setEnabled(false);
         } else {
             String pgpProvider = K9.getOpenPgpProvider();
             String pgpProviderName = OpenPgpProviderUtil.getOpenPgpProviderName(getPackageManager(), pgpProvider);
@@ -755,12 +751,9 @@ public class AccountSettings extends K9PreferenceActivity {
             });
 
             pgpCryptoKey.setOpenPgpProvider(pgpProvider);
-
-            pgpCryptoKey.setEnabled(true);
-            autocryptPreferEncryptMutual.setEnabled(true);
-            pgpHideSignOnly.setEnabled(true);
         }
 
+        pgpCryptoKey.setEnabled(isPgpConfigured);
         pgpCryptoKey.setValue(account.getCryptoKey());
         pgpCryptoKey.setDefaultUserId(OpenPgpApiHelper.buildUserId(account.getIdentity(0)));
         pgpCryptoKey.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
@@ -771,6 +764,7 @@ public class AccountSettings extends K9PreferenceActivity {
             }
         });
 
+        autocryptPreferEncryptMutual.setEnabled(isPgpConfigured && isKeyConfigured);
         autocryptPreferEncryptMutual.setOnPreferenceClickListener(new OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {
@@ -779,6 +773,7 @@ public class AccountSettings extends K9PreferenceActivity {
             }
         });
 
+        pgpHideSignOnly.setEnabled(isPgpConfigured && isKeyConfigured);
         pgpHideSignOnly = (SwitchPreference) findPreference(PREFERENCE_CRYPTO_HIDE_SIGN_ONLY);
         pgpHideSignOnly.setChecked(account.getPgpHideSignOnly());
     }

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -23,6 +23,7 @@ import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceScreen;
 import android.preference.RingtonePreference;
 import android.preference.SwitchPreference;
+import android.text.TextUtils;
 import android.widget.ListAdapter;
 import android.widget.Toast;
 
@@ -731,7 +732,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
         String pgpProvider = account.getOpenPgpProvider();
         String pgpProviderName = null;
-        boolean isPgpConfigured = pgpProvider != null;
+        boolean isPgpConfigured = account.isOpenPgpProviderConfigured();
         boolean isKeyConfigured = account.hasOpenPgpKey();
 
         if (isPgpConfigured) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -713,8 +713,8 @@ public class AccountSettings extends K9PreferenceActivity {
         autocryptPreferEncryptMutual = findPreference(PREFERENCE_AUTOCRYPT_PREFER_ENCRYPT);
         pgpHideSignOnly = (SwitchPreference) findPreference(PREFERENCE_CRYPTO_HIDE_SIGN_ONLY);
 
-        boolean isPgpConfigured = K9.isOpenPgpProviderConfigured();
-        boolean isKeyConfigured = account.hasCryptoKey();
+        boolean isPgpConfigured = account.isOpenPgpProviderConfigured();
+        boolean isKeyConfigured = account.hasOpenPgpKey();
 
         if (!isPgpConfigured) {
             pgpEnable.setChecked(false);
@@ -726,16 +726,16 @@ public class AccountSettings extends K9PreferenceActivity {
                     List<String> openPgpProviderPackages =
                             OpenPgpProviderUtil.getOpenPgpProviderPackages(getApplicationContext());
                     if (openPgpProviderPackages.size() == 1) {
-                        K9.setOpenPgpProvider(openPgpProviderPackages.get(0));
+                        account.setOpenPgpProvider(openPgpProviderPackages.get(0));
                         setupCryptoStuff();
                     } else {
-                        OpenPgpAppSelectDialog.startOpenPgpChooserActivity(getApplicationContext());
+                        OpenPgpAppSelectDialog.startOpenPgpChooserActivity(getApplicationContext(), account);
                     }
                     return false;
                 }
             });
         } else {
-            String pgpProvider = K9.getOpenPgpProvider();
+            String pgpProvider = account.getOpenPgpProvider();
             String pgpProviderName = OpenPgpProviderUtil.getOpenPgpProviderName(getPackageManager(), pgpProvider);
 
             pgpEnable.setChecked(true);
@@ -744,7 +744,7 @@ public class AccountSettings extends K9PreferenceActivity {
                 @Override
                 public boolean onPreferenceClick(Preference preference) {
                     pgpEnable.setOnPreferenceClickListener(null);
-                    K9.setOpenPgpProvider("");
+                    account.setOpenPgpProvider(null);
                     setupCryptoStuff();
                     return true;
                 }
@@ -754,7 +754,7 @@ public class AccountSettings extends K9PreferenceActivity {
         }
 
         pgpCryptoKey.setEnabled(isPgpConfigured);
-        pgpCryptoKey.setValue(account.getCryptoKey());
+        pgpCryptoKey.setValue(account.getOpenPgpKey());
         pgpCryptoKey.setDefaultUserId(OpenPgpApiHelper.buildUserId(account.getIdentity(0)));
         pgpCryptoKey.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             public boolean onPreferenceChange(Preference preference, Object newValue) {
@@ -775,7 +775,7 @@ public class AccountSettings extends K9PreferenceActivity {
 
         pgpHideSignOnly.setEnabled(isPgpConfigured && isKeyConfigured);
         pgpHideSignOnly = (SwitchPreference) findPreference(PREFERENCE_CRYPTO_HIDE_SIGN_ONLY);
-        pgpHideSignOnly.setChecked(account.getPgpHideSignOnly());
+        pgpHideSignOnly.setChecked(account.getOpenPgpHideSignOnly());
     }
 
     private void removeListEntry(ListPreference listPreference, String remove) {
@@ -837,9 +837,9 @@ public class AccountSettings extends K9PreferenceActivity {
         account.setStripSignature(stripSignature.isChecked());
         account.setLocalStorageProviderId(localStorageProvider.getValue());
         if (pgpCryptoKey != null) {
-            account.setCryptoKey(pgpCryptoKey.getValue());
+            account.setOpenPgpKey(pgpCryptoKey.getValue());
         }
-        account.setPgpHideSignOnly(pgpHideSignOnly.isChecked());
+        account.setOpenPgpHideSignOnly(pgpHideSignOnly.isChecked());
 
         account.setAutoExpandFolder(autoExpandFolder.getValue());
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -24,6 +24,7 @@ import android.preference.PreferenceScreen;
 import android.preference.RingtonePreference;
 import android.preference.SwitchPreference;
 import android.widget.ListAdapter;
+import android.widget.Toast;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.DeletePolicy;
@@ -728,8 +729,21 @@ public class AccountSettings extends K9PreferenceActivity {
         autocryptPreferEncryptMutual = findPreference(PREFERENCE_AUTOCRYPT_PREFER_ENCRYPT);
         pgpHideSignOnly = (SwitchPreference) findPreference(PREFERENCE_CRYPTO_HIDE_SIGN_ONLY);
 
-        boolean isPgpConfigured = account.isOpenPgpProviderConfigured();
+        String pgpProvider = account.getOpenPgpProvider();
+        String pgpProviderName = null;
+        boolean isPgpConfigured = pgpProvider != null;
         boolean isKeyConfigured = account.hasOpenPgpKey();
+
+        if (isPgpConfigured) {
+            pgpProviderName = OpenPgpProviderUtil.getOpenPgpProviderName(getPackageManager(), pgpProvider);
+
+            if (pgpProviderName == null) {
+                Toast.makeText(this, R.string.account_settings_openpgp_missing, Toast.LENGTH_LONG).show();
+                account.setOpenPgpProvider(null);
+                pgpProvider = null;
+                isPgpConfigured = false;
+            }
+        }
 
         if (!isPgpConfigured) {
             pgpEnable.setChecked(false);
@@ -750,9 +764,6 @@ public class AccountSettings extends K9PreferenceActivity {
                 }
             });
         } else {
-            String pgpProvider = account.getOpenPgpProvider();
-            String pgpProviderName = OpenPgpProviderUtil.getOpenPgpProviderName(getPackageManager(), pgpProvider);
-
             pgpEnable.setChecked(true);
             pgpEnable.setSummary(getString(R.string.account_settings_crypto_summary_on, pgpProviderName));
             pgpEnable.setOnPreferenceClickListener(new OnPreferenceClickListener() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -720,10 +720,10 @@ public class AccountSettings extends K9PreferenceActivity {
         super.onResume();
 
         // we might return here from the play store, so it's important we refresh on resume
-        setupCryptoStuff();
+        setupCryptoSettings();
     }
 
-    private void setupCryptoStuff() {
+    private void setupCryptoSettings() {
         pgpEnable = (SwitchPreference) findPreference(PREFERENCE_CRYPTO_PROVIDER);
         pgpCryptoKey = (OpenPgpKeyPreference) findPreference(PREFERENCE_CRYPTO_KEY);
         autocryptPreferEncryptMutual = findPreference(PREFERENCE_AUTOCRYPT_PREFER_ENCRYPT);
@@ -756,7 +756,7 @@ public class AccountSettings extends K9PreferenceActivity {
                             OpenPgpProviderUtil.getOpenPgpProviderPackages(getApplicationContext());
                     if (openPgpProviderPackages.size() == 1) {
                         account.setOpenPgpProvider(openPgpProviderPackages.get(0));
-                        setupCryptoStuff();
+                        setupCryptoSettings();
                     } else {
                         OpenPgpAppSelectDialog.startOpenPgpChooserActivity(getApplicationContext(), account);
                     }
@@ -771,7 +771,7 @@ public class AccountSettings extends K9PreferenceActivity {
                 public boolean onPreferenceClick(Preference preference) {
                     pgpEnable.setOnPreferenceClickListener(null);
                     account.setOpenPgpProvider(null);
-                    setupCryptoStuff();
+                    setupCryptoSettings();
                     return true;
                 }
             });
@@ -786,7 +786,7 @@ public class AccountSettings extends K9PreferenceActivity {
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 long value = (Long) newValue;
                 pgpCryptoKey.setValue(value);
-                setupCryptoStuff();
+                setupCryptoSettings();
                 return false;
             }
         });

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -23,6 +23,7 @@ import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceScreen;
 import android.preference.RingtonePreference;
 import android.preference.SwitchPreference;
+import android.widget.ListAdapter;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.DeletePolicy;
@@ -54,6 +55,7 @@ import timber.log.Timber;
 
 public class AccountSettings extends K9PreferenceActivity {
     private static final String EXTRA_ACCOUNT = "account";
+    private static final String EXTRA_SHOW_OPENPGP = "show_openpgp";
 
     private static final int DIALOG_COLOR_PICKER_ACCOUNT = 1;
     private static final int DIALOG_COLOR_PICKER_LED = 2;
@@ -210,12 +212,20 @@ public class AccountSettings extends K9PreferenceActivity {
         context.startActivity(i);
     }
 
+    public static void actionSettingsOpenPgp(Context context, Account account) {
+        Intent i = new Intent(context, AccountSettings.class);
+        i.putExtra(EXTRA_ACCOUNT, account.getUuid());
+        i.putExtra(EXTRA_SHOW_OPENPGP, true);
+        context.startActivity(i);
+    }
+
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
 
         String accountUuid = getIntent().getStringExtra(EXTRA_ACCOUNT);
         account = Preferences.getPreferences(this).getAccount(accountUuid);
+        boolean startInOpenPgp = getIntent().getBooleanExtra(EXTRA_SHOW_OPENPGP, false);
 
         try {
             RemoteStore store = account.getRemoteStore();
@@ -697,6 +707,11 @@ public class AccountSettings extends K9PreferenceActivity {
                 return true;
             }
         });
+
+        if (startInOpenPgp) {
+            PreferenceScreen preference = (PreferenceScreen) findPreference(PREFERENCE_CRYPTO);
+            goToPreferenceScreen(preference);
+        }
     }
 
     @Override
@@ -1026,6 +1041,17 @@ public class AccountSettings extends K9PreferenceActivity {
 
             remoteSearchNumResults
                     .setSummary(String.format(getString(R.string.account_settings_remote_search_num_summary), maxResults));
+        }
+    }
+
+    private void goToPreferenceScreen(PreferenceScreen preference) {
+        PreferenceScreen preferenceScreen = getPreferenceScreen();
+        ListAdapter listAdapter = preferenceScreen.getRootAdapter();
+        for (int itemNumber = 0; itemNumber < listAdapter.getCount(); itemNumber++) {
+            if (listAdapter.getItem(itemNumber).equals(preference)) {
+                preferenceScreen.onItemClick(null, null, itemNumber, 0);
+                break;
+            }
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -709,7 +709,7 @@ public class AccountSettings extends K9PreferenceActivity {
             }
         });
 
-        if (startInOpenPgp) {
+        if (savedInstanceState == null && startInOpenPgp) {
             PreferenceScreen preference = (PreferenceScreen) findPreference(PREFERENCE_CRYPTO);
             goToPreferenceScreen(preference);
         }
@@ -758,7 +758,7 @@ public class AccountSettings extends K9PreferenceActivity {
                         account.setOpenPgpProvider(openPgpProviderPackages.get(0));
                         setupCryptoSettings();
                     } else {
-                        OpenPgpAppSelectDialog.startOpenPgpChooserActivity(getApplicationContext(), account);
+                        OpenPgpAppSelectDialog.startOpenPgpChooserActivity(AccountSettings.this, account);
                     }
                     return false;
                 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -786,6 +786,7 @@ public class AccountSettings extends K9PreferenceActivity {
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 long value = (Long) newValue;
                 pgpCryptoKey.setValue(value);
+                setupCryptoStuff();
                 return false;
             }
         });

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -786,7 +786,7 @@ public class AccountSettings extends K9PreferenceActivity {
         pgpCryptoKey.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             public boolean onPreferenceChange(Preference preference, Object newValue) {
                 long value = (Long) newValue;
-                pgpCryptoKey.setValue(value);
+                account.setOpenPgpKey(value);
                 setupCryptoSettings();
                 return false;
             }

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/OpenPgpAppSelectDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/OpenPgpAppSelectDialog.java
@@ -304,6 +304,13 @@ public class OpenPgpAppSelectDialog extends Activity {
 
             dismiss();
         }
+
+        @Override
+        public void onDismiss(DialogInterface dialog) {
+            super.onDismiss(dialog);
+
+            getActivity().finish();
+        }
     }
 
     public void onSelectProvider(String selectedPackage) {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/OpenPgpAppSelectDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/OpenPgpAppSelectDialog.java
@@ -8,6 +8,7 @@ import android.app.Activity;
 import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
@@ -271,6 +272,16 @@ public class OpenPgpAppSelectDialog extends Activity {
         @Override
         public String toString() {
             return simpleName;
+        }
+    }
+
+    private void startInstallPackageActivity(String providerPackage) {
+        try {
+            startActivity(new Intent(Intent.ACTION_VIEW,
+                    Uri.parse("market://details?id=" + providerPackage)));
+        } catch (ActivityNotFoundException anfe) {
+            startActivity(new Intent(Intent.ACTION_VIEW,
+                    Uri.parse("https://play.google.com/store/apps/details?id=" + providerPackage)));
         }
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/Prefs.java
@@ -8,10 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
-import android.content.DialogInterface.OnCancelListener;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
@@ -39,8 +36,6 @@ import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
 import com.fsck.k9.preferences.TimePickerPreference;
 import com.fsck.k9.service.MailService;
-import com.fsck.k9.ui.dialog.ApgDeprecationWarningDialog;
-import org.openintents.openpgp.util.OpenPgpAppPreference;
 
 
 public class Prefs extends K9PreferenceActivity {
@@ -94,9 +89,6 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_HIDE_TIMEZONE = "privacy_hide_timezone";
     private static final String PREFERENCE_HIDE_HOSTNAME_WHEN_CONNECTING = "privacy_hide_hostname_when_connecting";
 
-    private static final String PREFERENCE_OPENPGP_PROVIDER = "openpgp_provider";
-    private static final String PREFERENCE_OPENPGP_SUPPORT_SIGN_ONLY = "openpgp_support_sign_only";
-
     private static final String PREFERENCE_AUTOFIT_WIDTH = "messageview_autofit_width";
     private static final String PREFERENCE_BACKGROUND_OPS = "background_ops";
     private static final String PREFERENCE_DEBUG_LOGGING = "debug_logging";
@@ -108,11 +100,7 @@ public class Prefs extends K9PreferenceActivity {
     private static final String PREFERENCE_FOLDERLIST_WRAP_NAME = "folderlist_wrap_folder_name";
     private static final String PREFERENCE_SPLITVIEW_MODE = "splitview_mode";
 
-    private static final String APG_PROVIDER_PLACEHOLDER = "apg-placeholder";
-
     private static final int ACTIVITY_CHOOSE_FOLDER = 1;
-
-    private static final int DIALOG_APG_DEPRECATION_WARNING = 1;
 
     // Named indices for the mVisibleRefileActions field
     private static final int VISIBLE_REFILE_ACTIONS_DELETE = 0;
@@ -156,9 +144,6 @@ public class Prefs extends K9PreferenceActivity {
     private CheckBoxPreference mHideHostnameWhenConnecting;
     private CheckBoxPreference mWrapFolderNames;
     private CheckBoxListPreference mVisibleRefileActions;
-
-    private OpenPgpAppPreference mOpenPgpProvider;
-    private CheckBoxPreference mOpenPgpSupportSignOnly;
 
     private CheckBoxPreference mQuietTimeEnabled;
     private CheckBoxPreference mDisableNotificationDuringQuietTime;
@@ -388,28 +373,6 @@ public class Prefs extends K9PreferenceActivity {
         mHideTimeZone.setChecked(K9.hideTimeZone());
         mHideHostnameWhenConnecting.setChecked(K9.hideHostnameWhenConnecting());
 
-        mOpenPgpProvider = (OpenPgpAppPreference) findPreference(PREFERENCE_OPENPGP_PROVIDER);
-        mOpenPgpProvider.setValue(K9.getOpenPgpProvider());
-        if (OpenPgpAppPreference.isApgInstalled(getApplicationContext())) {
-            mOpenPgpProvider.addLegacyProvider(
-                    APG_PROVIDER_PLACEHOLDER, getString(R.string.apg), R.drawable.ic_apg_small);
-        }
-        mOpenPgpProvider.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-            public boolean onPreferenceChange(Preference preference, Object newValue) {
-                String value = newValue.toString();
-                if (APG_PROVIDER_PLACEHOLDER.equals(value)) {
-                    mOpenPgpProvider.setValue("");
-                    showDialog(DIALOG_APG_DEPRECATION_WARNING);
-                } else {
-                    mOpenPgpProvider.setValue(value);
-                }
-                return false;
-            }
-        });
-
-        mOpenPgpSupportSignOnly = (CheckBoxPreference) findPreference(PREFERENCE_OPENPGP_SUPPORT_SIGN_ONLY);
-        mOpenPgpSupportSignOnly.setChecked(K9.getOpenPgpSupportSignOnly());
-
         mAttachmentPathPreference = findPreference(PREFERENCE_ATTACHMENT_DEF_PATH);
         mAttachmentPathPreference.setSummary(K9.getAttachmentDefaultPath());
         mAttachmentPathPreference
@@ -566,9 +529,6 @@ public class Prefs extends K9PreferenceActivity {
         K9.setHideTimeZone(mHideTimeZone.isChecked());
         K9.setHideHostnameWhenConnecting(mHideHostnameWhenConnecting.isChecked());
 
-        K9.setOpenPgpProvider(mOpenPgpProvider.getValue());
-        K9.setOpenPgpSupportSignOnly(mOpenPgpSupportSignOnly.isChecked());
-
         StorageEditor editor = storage.edit();
         K9.save(editor);
         editor.commit();
@@ -595,25 +555,6 @@ public class Prefs extends K9PreferenceActivity {
             }
         },
         K9.getContactNameColor()).show();
-    }
-
-    @Override
-    protected Dialog onCreateDialog(int id) {
-        Dialog dialog = null;
-        switch (id) {
-            case DIALOG_APG_DEPRECATION_WARNING: {
-                dialog = new ApgDeprecationWarningDialog(this);
-                dialog.setOnCancelListener(new OnCancelListener() {
-                    @Override
-                    public void onCancel(DialogInterface dialog) {
-                        mOpenPgpProvider.show();
-                    }
-                });
-                break;
-            }
-
-        }
-        return dialog;
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -178,7 +178,7 @@ public class LocalStore {
      */
     private static final int THREAD_FLAG_UPDATE_BATCH_SIZE = 500;
 
-    public static final int DB_VERSION = 62;
+    public static final int DB_VERSION = 63;
 
     private final Context context;
     private final ContentResolver contentResolver;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -12,7 +12,6 @@ import android.support.annotation.VisibleForTesting;
 import android.support.annotation.WorkerThread;
 
 import com.fsck.k9.Globals;
-import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.crypto.MessageCryptoStructureDetector;
 import com.fsck.k9.mail.Address;
@@ -70,8 +69,8 @@ public class MessageViewInfoExtractor {
     }
 
     @WorkerThread
-    public MessageViewInfo extractMessageForView(Message message, @Nullable MessageCryptoAnnotations cryptoAnnotations)
-            throws MessagingException {
+    public MessageViewInfo extractMessageForView(Message message, @Nullable MessageCryptoAnnotations cryptoAnnotations,
+            boolean openPgpProviderConfigured) throws MessagingException {
         ArrayList<Part> extraParts = new ArrayList<>();
         Part cryptoContentPart = MessageCryptoStructureDetector.findPrimaryEncryptedOrSignedPart(message, extraParts);
 
@@ -85,7 +84,7 @@ public class MessageViewInfoExtractor {
         boolean isOpenPgpEncrypted = (MessageCryptoStructureDetector.isPartMultipartEncrypted(cryptoContentPart) &&
                         MessageCryptoStructureDetector.isMultipartEncryptedOpenPgpProtocol(cryptoContentPart)) ||
                         MessageCryptoStructureDetector.isPartPgpInlineEncrypted(cryptoContentPart);
-        if (!K9.isOpenPgpProviderConfigured() && isOpenPgpEncrypted) {
+        if (!openPgpProviderConfigured && isOpenPgpEncrypted) {
             CryptoResultAnnotation noProviderAnnotation = CryptoResultAnnotation.createErrorAnnotation(
                     CryptoError.OPENPGP_ENCRYPTED_NO_PROVIDER, null);
             return MessageViewInfo.createWithErrorState(message, false)

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -230,6 +230,8 @@ public class AccountSettings {
         s.put("autocryptMutualMode", Settings.versions(
                 new V(50, new BooleanSetting(false))
         ));
+        // note that there is no setting for openPgpProvider, because this will have to be set up together
+        // with the actual provider after import anyways.
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -224,6 +224,12 @@ public class AccountSettings {
         s.put("notifyContactsMailOnly", Settings.versions(
                 new V(42, new BooleanSetting(false))
         ));
+        s.put("openPgpHideSignOnly", Settings.versions(
+                new V(50, new BooleanSetting(true))
+        ));
+        s.put("autocryptMutualMode", Settings.versions(
+                new V(50, new BooleanSetting(false))
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -290,12 +290,6 @@ public class GlobalSettings {
         s.put("pgpSignOnlyDialogCounter", Settings.versions(
                 new V(45, new IntegerRangeSetting(0, Integer.MAX_VALUE, 0))
         ));
-        s.put("openPgpProvider", Settings.versions(
-                new V(46, new StringSetting(K9.NO_OPENPGP_PROVIDER))
-        ));
-        s.put("openPgpSupportSignOnly", Settings.versions(
-                new V(47, new BooleanSetting(false))
-        ));
         s.put("fontSizeMessageViewBCC", Settings.versions(
                 new V(48, new FontSizeSetting(FontSizes.FONT_DEFAULT))
         ));

--- a/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/k9mail/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 49;
+    public static final int VERSION = 50;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/MessageCryptoHelper.java
@@ -62,7 +62,7 @@ public class MessageCryptoHelper {
 
 
     private final Context context;
-    private final String openPgpProviderPackage;
+    private final String openPgpProvider;
     private final AutocryptOperations autocryptOperations;
     private final Object callbackLock = new Object();
     private final Deque<CryptoPart> partsToProcess = new ArrayDeque<>();
@@ -91,20 +91,16 @@ public class MessageCryptoHelper {
 
 
     public MessageCryptoHelper(Context context, OpenPgpApiFactory openPgpApiFactory,
-            AutocryptOperations autocryptOperations) {
+            AutocryptOperations autocryptOperations, @NonNull String openPgpProvider) {
         this.context = context.getApplicationContext();
-
-        if (!K9.isOpenPgpProviderConfigured()) {
-            throw new IllegalStateException("MessageCryptoHelper must only be called with a OpenPGP provider!");
-        }
 
         this.autocryptOperations = autocryptOperations;
         this.openPgpApiFactory = openPgpApiFactory;
-        openPgpProviderPackage = K9.getOpenPgpProvider();
+        this.openPgpProvider = openPgpProvider;
     }
 
-    public boolean isConfiguredForOutdatedCryptoProvider() {
-        return !openPgpProviderPackage.equals(K9.getOpenPgpProvider());
+    public boolean isConfiguredForOpenPgpProvider(String openPgpProvider) {
+        return this.openPgpProvider.equals(openPgpProvider);
     }
 
     public void asyncStartOrResumeProcessingMessage(Message message, MessageCryptoCallback callback,
@@ -236,7 +232,7 @@ public class MessageCryptoHelper {
     }
 
     private void connectToCryptoProviderService() {
-        openPgpServiceConnection = new OpenPgpServiceConnection(context, openPgpProviderPackage,
+        openPgpServiceConnection = new OpenPgpServiceConnection(context, openPgpProvider,
                 new OnBound() {
 
                     @Override

--- a/k9mail/src/main/java/com/fsck/k9/ui/dialog/ApgDeprecationWarningDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/dialog/ApgDeprecationWarningDialog.java
@@ -29,7 +29,7 @@ public class ApgDeprecationWarningDialog extends AlertDialog {
         setIcon(R.drawable.ic_apg_small);
         setTitle(R.string.apg_deprecated_title);
         setView(contentView);
-        setButton(Dialog.BUTTON_NEUTRAL, context.getString(R.string.apg_deprecated_ok), new OnClickListener() {
+        setButton(Dialog.BUTTON_POSITIVE, context.getString(R.string.apg_deprecated_ok), new OnClickListener() {
             @Override
             public void onClick(DialogInterface dialogInterface, int i) {
                 cancel();

--- a/k9mail/src/main/java/com/fsck/k9/ui/dialog/AutocryptPreferEncryptDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/dialog/AutocryptPreferEncryptDialog.java
@@ -46,7 +46,7 @@ public class AutocryptPreferEncryptDialog extends AlertDialog implements OnClick
         // TODO add autocrypt logo?
         // setIcon(R.drawable.autocrypt);
         setView(contentView);
-        setButton(Dialog.BUTTON_NEUTRAL, context.getString(R.string.done_action), new OnClickListener() {
+        setButton(Dialog.BUTTON_POSITIVE, context.getString(R.string.done_action), new OnClickListener() {
             @Override
             public void onClick(DialogInterface dialogInterface, int i) {
                 cancel();

--- a/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageExtractorLoader.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/message/LocalMessageExtractorLoader.java
@@ -18,13 +18,13 @@ public class LocalMessageExtractorLoader extends AsyncTaskLoader<MessageViewInfo
     private static final MessageViewInfoExtractor messageViewInfoExtractor = MessageViewInfoExtractor.getInstance();
 
 
-    private final Message message;
+    private final LocalMessage message;
     private MessageViewInfo messageViewInfo;
     @Nullable
     private MessageCryptoAnnotations annotations;
 
     public LocalMessageExtractorLoader(
-            Context context, Message message, @Nullable MessageCryptoAnnotations annotations) {
+            Context context, LocalMessage message, @Nullable MessageCryptoAnnotations annotations) {
         super(context);
         this.message = message;
         this.annotations = annotations;
@@ -51,7 +51,7 @@ public class LocalMessageExtractorLoader extends AsyncTaskLoader<MessageViewInfo
     @WorkerThread
     public MessageViewInfo loadInBackground() {
         try {
-            return messageViewInfoExtractor.extractMessageForView(message, annotations);
+            return messageViewInfoExtractor.extractMessageForView(message, annotations, message.getAccount().isOpenPgpProviderConfigured());
         } catch (Exception e) {
             Timber.e(e, "Error while decoding message");
             return null;

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -67,11 +67,6 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
             return false;
         }
 
-        boolean suppressSignOnlyMessages = !K9.getOpenPgpSupportSignOnly();
-        if (suppressSignOnlyMessages && displayStatus.isUnencryptedSigned()) {
-            return false;
-        }
-
         if (cryptoResultAnnotation.isOverrideSecurityWarning()) {
             overrideCryptoWarning = true;
         }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -11,9 +11,9 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
+import android.text.TextUtils;
 
 import com.fsck.k9.Account;
-import com.fsck.k9.K9;
 import com.fsck.k9.mailstore.CryptoResultAnnotation;
 import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.view.MessageCryptoDisplayStatus;
@@ -75,20 +75,20 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
 
         switch (displayStatus) {
             case CANCELLED: {
-                Drawable providerIcon = getOpenPgpApiProviderIcon(messageView.getContext());
+                Drawable providerIcon = getOpenPgpApiProviderIcon(messageView.getContext(), account.getOpenPgpProvider());
                 messageView.showMessageCryptoCancelledView(messageViewInfo, providerIcon);
                 break;
             }
 
             case INCOMPLETE_ENCRYPTED: {
-                Drawable providerIcon = getOpenPgpApiProviderIcon(messageView.getContext());
+                Drawable providerIcon = getOpenPgpApiProviderIcon(messageView.getContext(), account.getOpenPgpProvider());
                 messageView.showMessageEncryptedButIncomplete(messageViewInfo, providerIcon);
                 break;
             }
 
             case ENCRYPTED_ERROR:
             case UNSUPPORTED_ENCRYPTED: {
-                Drawable providerIcon = getOpenPgpApiProviderIcon(messageView.getContext());
+                Drawable providerIcon = getOpenPgpApiProviderIcon(messageView.getContext(), account.getOpenPgpProvider());
                 messageView.showMessageCryptoErrorView(messageViewInfo, providerIcon);
                 break;
             }
@@ -201,10 +201,9 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
     }
 
     @Nullable
-    private static Drawable getOpenPgpApiProviderIcon(Context context) {
+    private static Drawable getOpenPgpApiProviderIcon(Context context, String openPgpProvider) {
         try {
-            String openPgpProvider = K9.getOpenPgpProvider();
-            if (K9.NO_OPENPGP_PROVIDER.equals(openPgpProvider)) {
+            if (TextUtils.isEmpty(openPgpProvider)) {
                 return null;
             }
             return context.getPackageManager().getApplicationIcon(openPgpProvider);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -117,7 +117,7 @@ public class MessageTopView extends LinearLayout {
                 containerView, false);
         containerView.addView(view);
 
-        boolean hideUnsignedTextDivider = account.getPgpHideSignOnly();
+        boolean hideUnsignedTextDivider = account.getOpenPgpHideSignOnly();
         view.displayMessageViewContainer(messageViewInfo, new OnRenderingFinishedListener() {
             @Override
             public void onLoadFinished() {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -20,7 +20,6 @@ import android.widget.TextView;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.ShowPictures;
-import com.fsck.k9.K9;
 import com.fsck.k9.R;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.Address;
@@ -118,7 +117,7 @@ public class MessageTopView extends LinearLayout {
                 containerView, false);
         containerView.addView(view);
 
-        boolean hideUnsignedTextDivider = !K9.getOpenPgpSupportSignOnly();
+        boolean hideUnsignedTextDivider = account.getPgpHideSignOnly();
         view.displayMessageViewContainer(messageViewInfo, new OnRenderingFinishedListener() {
             @Override
             public void onLoadFinished() {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -36,7 +36,7 @@ import com.fsck.k9.activity.ChooseFolder;
 import com.fsck.k9.activity.MessageLoaderHelper;
 import com.fsck.k9.activity.MessageLoaderHelper.MessageLoaderCallbacks;
 import com.fsck.k9.activity.MessageReference;
-import com.fsck.k9.activity.setup.OpenPgpAppSelectDialog;
+import com.fsck.k9.activity.setup.AccountSettings;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.fragment.AttachmentDownloadDialogFragment;
 import com.fsck.k9.fragment.ConfirmationDialogFragment;
@@ -708,7 +708,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
         @Override
         public void showCryptoConfigDialog() {
-            OpenPgpAppSelectDialog.startOpenPgpChooserActivity(getActivity(), mAccount);
+            AccountSettings.actionSettingsOpenPgp(getActivity(), mAccount);
         }
     };
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -404,11 +404,6 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         startActivityForResult(intent, activity);
     }
 
-    private void startOpenPgpChooserActivity() {
-        Intent i = new Intent(getActivity(), OpenPgpAppSelectDialog.class);
-        startActivity(i);
-    }
-
     public void onPendingIntentResult(int requestCode, int resultCode, Intent data) {
         if ((requestCode & REQUEST_MASK_LOADER_HELPER) == REQUEST_MASK_LOADER_HELPER) {
             requestCode ^= REQUEST_MASK_LOADER_HELPER;
@@ -713,7 +708,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
         @Override
         public void showCryptoConfigDialog() {
-            startOpenPgpChooserActivity();
+            OpenPgpAppSelectDialog.startOpenPgpChooserActivity(getActivity());
         }
     };
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -244,7 +244,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                 mMessageView, mAccount, messageViewInfo);
         if (!handledByCryptoPresenter) {
             mMessageView.showMessage(mAccount, messageViewInfo);
-            if (K9.isOpenPgpProviderConfigured()) {
+            if (mAccount.isOpenPgpProviderConfigured()) {
                 mMessageView.getMessageHeaderView().setCryptoStatusDisabled();
             } else {
                 mMessageView.getMessageHeaderView().hideCryptoStatus();
@@ -254,7 +254,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
     private void displayHeaderForLoadingMessage(LocalMessage message) {
         mMessageView.setHeaders(message, mAccount);
-        if (K9.isOpenPgpProviderConfigured()) {
+        if (mAccount.isOpenPgpProviderConfigured()) {
             mMessageView.getMessageHeaderView().setCryptoStatusLoading();
         }
         displayMessageSubject(getSubjectForMessage(message));
@@ -708,7 +708,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
         @Override
         public void showCryptoConfigDialog() {
-            OpenPgpAppSelectDialog.startOpenPgpChooserActivity(getActivity());
+            OpenPgpAppSelectDialog.startOpenPgpChooserActivity(getActivity(), mAccount);
         }
     };
 

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -134,8 +134,8 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         mController = MessagingController.getInstance(context);
         downloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
         messageCryptoPresenter = new MessageCryptoPresenter(savedInstanceState, messageCryptoMvpView);
-        messageLoaderHelper =
-                new MessageLoaderHelper(context, getLoaderManager(), getFragmentManager(), messageLoaderCallbacks);
+        messageLoaderHelper = new MessageLoaderHelper(
+                context, getLoaderManager(), getFragmentManager(), messageLoaderCallbacks);
         mInitialized = true;
     }
 

--- a/k9mail/src/main/res/layout/dialog_openkeychain_info.xml
+++ b/k9mail/src/main/res/layout/dialog_openkeychain_info.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="K-9 Mail requires OpenKeychain for end-to-end encryption."
+        style="?android:textAppearanceMedium"
+        android:id="@+id/textView" />
+
+</LinearLayout>

--- a/k9mail/src/main/res/layout/dialog_openkeychain_info.xml
+++ b/k9mail/src/main/res/layout/dialog_openkeychain_info.xml
@@ -8,7 +8,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="K-9 Mail requires OpenKeychain for end-to-end encryption."
+        android:text="@string/dialog_openkeychain_info_text"
         style="?android:textAppearanceMedium"
         android:id="@+id/textView" />
 

--- a/k9mail/src/main/res/layout/select_openpgp_app_item.xml
+++ b/k9mail/src/main/res/layout/select_openpgp_app_item.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_height="wrap_content"
+    android:layout_width="match_parent"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="horizontal"
+    android:paddingLeft="12dp"
+    android:paddingRight="7dp"
+    android:paddingStart="12dip"
+    android:paddingEnd="7dip"
+    >
+
+    <ImageView
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_gravity="center_vertical"
+        android:layout_marginRight="8dp"
+        android:layout_marginEnd="8dp"
+        android:id="@android:id/icon1"
+        tools:src="@drawable/ic_action_cancel_launchersize_light"
+        />
+
+    <CheckedTextView
+        android:id="@android:id/text1"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="?android:attr/listPreferredItemHeight"
+        android:textAppearance="?android:attr/textAppearanceLarge"
+        android:textColor="?android:attr/textColorAlertDialogListItem"
+        android:gravity="center_vertical"
+        android:checkMark="?android:attr/listChoiceIndicatorSingle"
+        android:ellipsize="marquee"
+        tools:text="None"
+        />
+
+</LinearLayout>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -591,6 +591,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_quote_prefix_label">Quoted text prefix</string>
     <string name="account_settings_crypto">End-to-end encryption</string>
     <string name="account_settings_crypto_app">Enable OpenPGP support</string>
+    <string name="account_settings_crypto_app_select_title">Select OpenPGP app</string>
     <string name="account_settings_crypto_key">Configure end-to-end key</string>
     <string name="account_settings_crypto_summary_off">No OpenPGP app configured</string>
     <string name="account_settings_crypto_summary_on">Connected to %s</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -670,6 +670,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_sync_remote_deletetions_label">Sync server deletions</string>
     <string name="account_settings_sync_remote_deletetions_summary">Remove messages when deleted on server</string>
 
+    <string name="account_settings_openpgp_missing">Missing OpenPGP app - was it uninstalled?</string>
+
     <string name="folder_settings_title">Folder settings</string>
 
     <string name="folder_settings_in_top_group_label">Show in top group</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1298,4 +1298,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="dialog_autocrypt_mutual_learn_more">You can <a href="https://k9mail.github.io/2018/02/26/OpenPGP-Considerations-Part-III-Autocrypt.html">click here</a> to learn more.</string>
 
     <string name="general_settings_title">General settings</string>
+
+    <string name="dialog_openkeychain_info_title">No OpenPGP app installed</string>
+    <string name="dialog_openkeychain_info_install">Install</string>
+    <string name="dialog_openkeychain_info_text">K-9 Mail requires OpenKeychain for end-to-end encryption.</string>
 </resources>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1269,7 +1269,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="no_crypto_provider_see_global">No OpenPGP app configured, see global settings!</string>
     <string name="crypto_no_provider_title">This email is encrypted</string>
     <string name="crypto_no_provider_message">This email has been encrypted with OpenPGP.\nTo read it, you need to install and configure a compatible OpenPGP App.</string>
-    <string name="crypto_no_provider_button">Choose OpenPGP App</string>
+    <string name="crypto_no_provider_button">Go to Settings</string>
 
     <string name="mail_list_widget_text">K-9 Message List</string>
     <string name="mail_list_widget_loading">Loading messages…</string>

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -589,10 +589,13 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_sync">Fetching mail</string>
     <string name="account_settings_folders">Folders</string>
     <string name="account_settings_quote_prefix_label">Quoted text prefix</string>
-    <string name="account_settings_crypto">Cryptography</string>
-    <string name="account_settings_crypto_app">OpenPGP app</string>
-    <string name="account_settings_crypto_key">My Key</string>
+    <string name="account_settings_crypto">End-to-end encryption</string>
+    <string name="account_settings_crypto_app">Enable OpenPGP support</string>
+    <string name="account_settings_crypto_key">Configure end-to-end key</string>
+    <string name="account_settings_crypto_summary_off">No OpenPGP app configured</string>
+    <string name="account_settings_crypto_summary_on">Connected to %s</string>
     <string name="account_settings_no_openpgp_provider_configured">No OpenPGP app configured</string>
+    <string name="account_settings_no_openpgp_provider_installed">No OpenPGP app found - click to install</string>
 
     <string name="account_settings_mail_check_frequency_label">Folder poll frequency</string>
 
@@ -1249,9 +1252,9 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="recipient_error_non_ascii">Special characters are currently not supported!</string>
     <string name="recipient_error_parse_failed">Error parsing address!</string>
-    <string name="account_settings_crypto_support_sign_only">Show unencrypted signatures</string>
-    <string name="account_settings_crypto_support_sign_only_on">Unencrypted signatures will be displayed</string>
-    <string name="account_settings_crypto_support_sign_only_off">Unencrypted signatures will be ignored</string>
+    <string name="account_settings_crypto_hide_sign_only">Hide unencrypted signatures</string>
+    <string name="account_settings_crypto_hide_sign_only_on">Only encrypted signatures will be displayed</string>
+    <string name="account_settings_crypto_hide_sign_only_off">All signatures will be displayed</string>
     <string name="error_sign_only_no_encryption">Encryption unavailable in sign-only mode!</string>
     <string name="unsigned_text_divider_label">Unsigned Text</string>
     <string name="apg_deprecated_title">APG Deprecation Warning</string>

--- a/k9mail/src/main/res/xml/account_settings_preferences.xml
+++ b/k9mail/src/main/res/xml/account_settings_preferences.xml
@@ -472,16 +472,29 @@
 
     <PreferenceScreen
         android:title="@string/account_settings_crypto"
-        android:key="crypto">
+        android:key="openpgp">
+
+        <SwitchPreference
+            android:persistent="false"
+            android:key="openpgp_provider"
+            android:title="@string/account_settings_crypto_app" />
 
         <org.openintents.openpgp.util.OpenPgpKeyPreference
             android:persistent="false"
-            android:key="crypto_key"
+            android:key="openpgp_key"
             android:title="@string/account_settings_crypto_key" />
 
         <Preference
             android:key="autocrypt_prefer_encrypt"
             android:title="@string/account_settings_crypto_prefer_encrypt"
+            />
+
+        <SwitchPreference
+            android:persistent="false"
+            android:key="openpgp_hide_sign_only"
+            android:title="@string/account_settings_crypto_hide_sign_only"
+            android:summaryOn="@string/account_settings_crypto_hide_sign_only_on"
+            android:summaryOff="@string/account_settings_crypto_hide_sign_only_off"
             />
 
     </PreferenceScreen>

--- a/k9mail/src/main/res/xml/global_preferences.xml
+++ b/k9mail/src/main/res/xml/global_preferences.xml
@@ -417,23 +417,4 @@
 
     </PreferenceScreen>
 
-    <PreferenceScreen
-        android:title="@string/account_settings_crypto"
-        android:key="crypto">
-
-        <org.openintents.openpgp.util.OpenPgpAppPreference
-            android:persistent="false"
-            android:key="openpgp_provider"
-            android:title="@string/account_settings_crypto_app" />
-
-        <CheckBoxPreference
-            android:persistent="false"
-            android:key="openpgp_support_sign_only"
-            android:title="@string/account_settings_crypto_support_sign_only"
-            android:summaryOn="@string/account_settings_crypto_support_sign_only_on"
-            android:summaryOff="@string/account_settings_crypto_support_sign_only_off"
-            />
-
-    </PreferenceScreen>
-
 </PreferenceScreen>

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
@@ -328,9 +328,10 @@ public class RecipientPresenterTest extends K9RobolectricTest {
         when(autocryptStatusInteractor.retrieveCryptoProviderRecipientStatus(
                 any(OpenPgpApi.class), any(String[].class))).thenReturn(autocryptStatusResult);
 
-        K9.setOpenPgpProvider(CRYPTO_PROVIDER);
         permissionPingIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
-        when(account.getCryptoKey()).thenReturn(CRYPTO_KEY_ID);
+        when(account.getOpenPgpKey()).thenReturn(CRYPTO_KEY_ID);
+        when(account.isOpenPgpProviderConfigured()).thenReturn(true);
+        when(account.getOpenPgpProvider()).thenReturn(CRYPTO_PROVIDER);
         when(openPgpServiceConnection.isBound()).thenReturn(true);
         when(openPgpServiceConnection.getService()).thenReturn(openPgpService2);
         when(openPgpService2.execute(any(Intent.class), any(ParcelFileDescriptor.class), any(Integer.class)))

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -255,7 +255,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         MimeMessageHelper.setBody(message, multipart);
 
         // Extract text
-        List<Part> outputNonViewableParts = new ArrayList<Part>();
+        List<Part> outputNonViewableParts = new ArrayList<>();
         ArrayList<Viewable> outputViewableParts = new ArrayList<>();
         MessageExtractor.findViewablesAndAttachments(message, outputViewableParts, outputNonViewableParts);
         ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
@@ -376,7 +376,8 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         setupAttachmentInfoForPart(attachmentPart, attachmentViewInfo);
 
 
-        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null);
+        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null,
+                false);
 
 
         assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
@@ -396,7 +397,8 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         MessageCryptoAnnotations messageCryptoAnnotations = createAnnotations(message, annotation);
 
 
-        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, messageCryptoAnnotations);
+        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, messageCryptoAnnotations,
+                false);
 
 
         assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
@@ -419,7 +421,8 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         MessageCryptoAnnotations messageCryptoAnnotations = createAnnotations(message, annotation);
 
 
-        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, messageCryptoAnnotations);
+        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, messageCryptoAnnotations,
+                false);
 
 
         assertEquals("<pre class=\"k9mail\">replacement text</pre>", messageViewInfo.text);
@@ -446,7 +449,8 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         MessageCryptoAnnotations messageCryptoAnnotations = createAnnotations(signedPart, annotation);
 
 
-        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, messageCryptoAnnotations);
+        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, messageCryptoAnnotations,
+                false);
 
 
         assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
@@ -475,7 +479,8 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         setupAttachmentInfoForPart(extraAttachment, attachmentViewInfo);
 
 
-        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, messageCryptoAnnotations);
+        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, messageCryptoAnnotations,
+                false);
 
 
         assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
@@ -493,7 +498,8 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 )
         );
 
-        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null);
+        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null,
+                false);
 
         assertEquals(CryptoError.OPENPGP_ENCRYPTED_NO_PROVIDER, messageViewInfo.cryptoResultAnnotation.getErrorType());
         assertNull(messageViewInfo.text);
@@ -510,7 +516,8 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 )
         );
 
-        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null);
+        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null,
+                false);
 
         assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
         assertNull(messageViewInfo.cryptoResultAnnotation);
@@ -533,7 +540,8 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         AttachmentViewInfo mock = mock(AttachmentViewInfo.class);
         setupAttachmentInfoForPart(extraAttachment, mock);
 
-        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null);
+        MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null,
+                false);
 
         assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
         assertNull(messageViewInfo.cryptoResultAnnotation);

--- a/k9mail/src/test/java/com/fsck/k9/ui/crypto/MessageCryptoHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/ui/crypto/MessageCryptoHelperTest.java
@@ -8,7 +8,6 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 
-import com.fsck.k9.K9;
 import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.autocrypt.AutocryptOperations;
 import com.fsck.k9.mail.Address;
@@ -63,13 +62,11 @@ public class MessageCryptoHelperTest extends RobolectricTest {
         openPgpApi = mock(OpenPgpApi.class);
         autocryptOperations = mock(AutocryptOperations.class);
 
-        K9.setOpenPgpProvider("org.example.dummy");
-
         OpenPgpApiFactory openPgpApiFactory = mock(OpenPgpApiFactory.class);
         when(openPgpApiFactory.createOpenPgpApi(any(Context.class), any(IOpenPgpService2.class))).thenReturn(openPgpApi);
 
         messageCryptoHelper = new MessageCryptoHelper(RuntimeEnvironment.application, openPgpApiFactory,
-                autocryptOperations);
+                autocryptOperations, "org.example.dummy");
         messageCryptoCallback = mock(MessageCryptoCallback.class);
     }
 

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpProviderUtil.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpProviderUtil.java
@@ -1,0 +1,52 @@
+package org.openintents.openpgp.util;
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+
+
+public class OpenPgpProviderUtil {
+    public static List<String> getOpenPgpProviderPackages(Context context) {
+        ArrayList<String> result = new ArrayList<>();
+
+        Intent intent = new Intent(OpenPgpApi.SERVICE_INTENT_2);
+        List<ResolveInfo> resInfo = context.getPackageManager().queryIntentServices(intent, 0);
+        if (resInfo == null) {
+            return result;
+        }
+
+        for (ResolveInfo resolveInfo : resInfo) {
+            if (resolveInfo.serviceInfo == null) {
+                continue;
+            }
+
+            result.add(resolveInfo.serviceInfo.packageName);
+        }
+
+        return result;
+    }
+
+    public static String getOpenPgpProviderName(PackageManager packageManager, String openPgpProvider) {
+        Intent intent = new Intent(OpenPgpApi.SERVICE_INTENT_2);
+        intent.setPackage(openPgpProvider);
+        List<ResolveInfo> resInfo = packageManager.queryIntentServices(intent, 0);
+        if (resInfo == null) {
+            return "";
+        }
+
+        for (ResolveInfo resolveInfo : resInfo) {
+            if (resolveInfo.serviceInfo == null) {
+                continue;
+            }
+
+            return String.valueOf(resolveInfo.serviceInfo.loadLabel(packageManager));
+        }
+
+        return "";
+    }
+}

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpProviderUtil.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpProviderUtil.java
@@ -36,7 +36,7 @@ public class OpenPgpProviderUtil {
         intent.setPackage(openPgpProvider);
         List<ResolveInfo> resInfo = packageManager.queryIntentServices(intent, 0);
         if (resInfo == null) {
-            return "";
+            return null;
         }
 
         for (ResolveInfo resolveInfo : resInfo) {
@@ -47,6 +47,6 @@ public class OpenPgpProviderUtil {
             return String.valueOf(resolveInfo.serviceInfo.loadLabel(packageManager));
         }
 
-        return "";
+        return null;
     }
 }

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpProviderUtil.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpProviderUtil.java
@@ -11,6 +11,12 @@ import android.content.pm.ResolveInfo;
 
 
 public class OpenPgpProviderUtil {
+    private static final String PACKAGE_NAME_APG = "org.thialfihar.android.apg";
+    private static final ArrayList<String> PROVIDER_BLACKLIST = new ArrayList<>();
+    static {
+        PROVIDER_BLACKLIST.add(PACKAGE_NAME_APG);
+    }
+
     public static List<String> getOpenPgpProviderPackages(Context context) {
         ArrayList<String> result = new ArrayList<>();
 
@@ -48,5 +54,9 @@ public class OpenPgpProviderUtil {
         }
 
         return null;
+    }
+
+    public static boolean isBlacklisted(String packageName) {
+        return PROVIDER_BLACKLIST.contains(packageName);
     }
 }

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/res/values/strings.xml
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/res/values/strings.xml
@@ -3,7 +3,7 @@
 
     <string name="openpgp_list_preference_none">None</string>
     <string name="openpgp_install_openkeychain_via">Install OpenKeychain via %s</string>
-    <string name="openpgp_no_key_selected">No key selected</string>
-    <string name="openpgp_key_selected">Key has been selected</string>
+    <string name="openpgp_no_key_selected">No end-to-end key selected</string>
+    <string name="openpgp_key_selected">End-to-end key selected</string>
 
 </resources>


### PR DESCRIPTION
This PRchanges e2e settings around quite a bit. I'm not sure if it's perfect, but at least it's no longer a disaster.

Notably, the crypto provider preference moved from global settings to account settings, so there are no longer two places for "Cryptography" settings. I added a migration for that, not sure if the SettingsUpdater would be a better place for this migration since so far only migrated settings within the same area were handled there?

The provider setting is now a switch ("Enable OpenPGP support"), which will simply pick the one installed provider if installed or instruct the user to install one, and only show a selection dialog if more than one choice is available.

It's missing some improvements to OpenKeychain for a more seamless setup, but it's getting there. This is also now a good place to put the Autocrypt Setup Message.