### PR TITLE
Fix option #1 for Issue #3255

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -24,6 +24,7 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.EditText;
+import android.widget.Toast;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.EmailAddressValidator;
@@ -398,20 +399,31 @@ public class AccountSetupBasics extends K9Activity
             password = mPasswordView.getText().toString();
         }
 
-        if (mAccount == null) {
-            mAccount = Preferences.getPreferences(this).newAccount();
-        }
-        mAccount.setName(getOwnerName());
-        mAccount.setEmail(email);
-
         // set default uris
         // NOTE: they will be changed again in AccountSetupAccountType!
         ServerSettings storeServer = new ServerSettings(ServerSettings.Type.IMAP, "mail." + domain, -1,
                 ConnectionSecurity.SSL_TLS_REQUIRED, authenticationType, email, password, clientCertificateAlias);
         ServerSettings transportServer = new ServerSettings(ServerSettings.Type.SMTP, "mail." + domain, -1,
                 ConnectionSecurity.SSL_TLS_REQUIRED, authenticationType, email, password, clientCertificateAlias);
-        String storeUri = RemoteStore.createStoreUri(storeServer);
+
+        // createStoreUri() tosses for invalid values, such as: "foo@b.2" ... be graceful.
+        String storeUri = "";
+        try {
+            storeUri = RemoteStore.createStoreUri(storeServer);
+        } catch (IllegalArgumentException e) {
+            final String invalidAccount = getString(R.string.account_setup_basics_email_invalid);
+            Toast.makeText(AccountSetupBasics.this, invalidAccount, Toast.LENGTH_SHORT).show();
+            return;
+        }
         String transportUri = TransportUris.createTransportUri(transportServer);
+
+        // Create and set account info.
+        if (mAccount == null) {
+            mAccount = Preferences.getPreferences(this).newAccount();
+        }
+
+        mAccount.setName(getOwnerName());
+        mAccount.setEmail(email);
         mAccount.setStoreUri(storeUri);
         mAccount.setTransportUri(transportUri);
 

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -374,8 +374,10 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="quiet_time_starts">Quiet Time starts</string>
     <string name="quiet_time_ends">Quiet Time ends</string>
 
+    <!-- Account Setup / Basics -->
     <string name="account_setup_basics_title">Set up a new account</string>
     <string name="account_setup_basics_email_hint">Email address</string>
+    <string name="account_setup_basics_email_invalid">Please enter a valid eMail address</string>
     <string name="account_setup_basics_password_hint">Password</string>
     <string name="account_setup_basics_show_password">Show password</string>
     <string name="account_setup_basics_manual_setup_action">Manual setup</string>


### PR DESCRIPTION
This pull is one of two approaches I considered. It's simple, to-the-point, and demonstrative of the issue.

The other method is to dup enough code from onManualSetup() into validateFields() to ensure we can create a valid RemoteStore.createStoreUri(storeServer) result.

This would trigger each time from the TextWatcher during keyboard entry, and felt non-performant, but perhaps in this case it's acceptable to you.

Let me know? I can post the alternative pull.