### PR TITLE
Add KOIN for dependency injection

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,6 +3,7 @@ androidCompileSdkVersion=27
 androidBuildToolsVersion=27.0.3
 androidSupportLibraryVersion=27.0.2
 timberVersion=4.5.1
+koinVersion=0.9.1
 
 robolectricVersion=3.7.1
 junitVersion=4.12

--- a/k9mail/build.gradle
+++ b/k9mail/build.gradle
@@ -42,6 +42,7 @@ dependencies {
     implementation 'com.xwray:groupie:2.0.3'
     implementation 'com.xwray:groupie-kotlin-android-extensions:2.0.3'
     implementation "org.jetbrains.anko:anko-coroutines:0.10.4"
+    implementation "org.koin:koin-android-architecture:${koinVersion}"
 
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.1'
 
@@ -50,6 +51,7 @@ dependencies {
     testImplementation "com.google.truth:truth:${truthVersion}"
     testImplementation "org.mockito:mockito-core:${mockitoVersion}"
     testImplementation "org.jdom:jdom2:2.0.6"
+    testImplementation "org.koin:koin-test:${koinVersion}"
 }
 
 android {

--- a/k9mail/src/main/java/com/fsck/k9/DI.kt
+++ b/k9mail/src/main/java/com/fsck/k9/DI.kt
@@ -1,0 +1,43 @@
+package com.fsck.k9
+
+import android.app.Application
+import com.fsck.k9.ui.settings.settingsUiModule
+import org.koin.Koin
+import org.koin.KoinContext
+import org.koin.android.ext.koin.with
+import org.koin.android.logger.AndroidLogger
+import org.koin.core.parameter.Parameters
+import org.koin.dsl.module.applicationContext
+import org.koin.log.EmptyLogger
+import org.koin.standalone.StandAloneContext
+
+object DI {
+    private val mainModule = applicationContext {
+        bean { Preferences.getPreferences(get()) }
+    }
+
+    val appModules = listOf(
+        mainModule,
+        settingsUiModule
+    )
+
+    @JvmStatic fun start(application: Application) {
+        @Suppress("ConstantConditionIf")
+        Koin.logger = if (BuildConfig.DEBUG) AndroidLogger() else EmptyLogger()
+
+        StandAloneContext.startKoin(appModules) with application
+    }
+
+    @JvmOverloads
+    @JvmStatic
+    fun <T : Any> get(clazz: Class<T>, name: String = "", parameters: Parameters = { emptyMap() }): T {
+        val koinContext = StandAloneContext.koinContext as KoinContext
+        val kClass = clazz.kotlin
+
+        return if (name.isEmpty()) {
+            koinContext.resolveInstance(kClass, parameters) { koinContext.beanRegistry.searchAll(kClass) }
+        } else {
+            koinContext.resolveInstance(kClass, parameters) { koinContext.beanRegistry.searchByName(name) }
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/K9.java
+++ b/k9mail/src/main/java/com/fsck/k9/K9.java
@@ -530,6 +530,7 @@ public class K9 extends Application {
 
         super.onCreate();
         app = this;
+        DI.start(this);
         Globals.setContext(this);
 
         K9MailLib.setDebugStatus(new K9MailLib.DebugStatus() {

--- a/k9mail/src/main/java/com/fsck/k9/ui/account/AccountsLiveData.kt
+++ b/k9mail/src/main/java/com/fsck/k9/ui/account/AccountsLiveData.kt
@@ -1,29 +1,28 @@
 package com.fsck.k9.ui.account
 
 import android.arch.lifecycle.LiveData
-import android.content.Context
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import org.jetbrains.anko.coroutines.experimental.bg
 
-class AccountsLiveData(context: Context) : LiveData<List<Account>>() {
+class AccountsLiveData(val preferences: Preferences) : LiveData<List<Account>>() {
     init {
-        loadAccountsAsync(context)
+        loadAccountsAsync()
     }
 
-    private fun loadAccountsAsync(context: Context) {
+    private fun loadAccountsAsync() {
         launch(UI) {
             val accounts = bg {
-                loadAccounts(context)
+                loadAccounts()
             }
 
             value = accounts.await()
         }
     }
 
-    private fun loadAccounts(context: Context): List<Account> {
-        return Preferences.getPreferences(context).accounts
+    private fun loadAccounts(): List<Account> {
+        return preferences.accounts
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
+++ b/k9mail/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
@@ -1,0 +1,10 @@
+package com.fsck.k9.ui.settings
+
+import com.fsck.k9.ui.account.AccountsLiveData
+import org.koin.android.architecture.ext.viewModel
+import org.koin.dsl.module.applicationContext
+
+val settingsUiModule = applicationContext {
+    bean { AccountsLiveData(get()) }
+    viewModel { SettingsViewModel(get()) }
+}

--- a/k9mail/src/main/java/com/fsck/k9/ui/settings/SettingsActivity.kt
+++ b/k9mail/src/main/java/com/fsck/k9/ui/settings/SettingsActivity.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.ui.settings
 
 import android.app.Activity
-import android.arch.lifecycle.ViewModelProviders
 import android.content.Intent
 import android.os.Bundle
 import android.support.v7.widget.LinearLayoutManager
@@ -16,8 +15,11 @@ import com.xwray.groupie.Item
 import com.xwray.groupie.Section
 import com.xwray.groupie.kotlinandroidextensions.ViewHolder
 import kotlinx.android.synthetic.main.activity_settings.*
+import org.koin.android.architecture.ext.viewModel
 
 class SettingsActivity : K9Activity() {
+    private val viewModel: SettingsViewModel by viewModel()
+
     private lateinit var settingsAdapter: GroupAdapter<ViewHolder>
 
 
@@ -48,7 +50,6 @@ class SettingsActivity : K9Activity() {
     }
 
     private fun populateSettingsList() {
-        val viewModel = ViewModelProviders.of(this).get(SettingsViewModel::class.java)
         viewModel.accounts.observe(this) { accounts ->
             populateSettingsList(accounts)
         }

--- a/k9mail/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
+++ b/k9mail/src/main/java/com/fsck/k9/ui/settings/SettingsViewModel.kt
@@ -1,9 +1,6 @@
 package com.fsck.k9.ui.settings
 
-import android.app.Application
-import android.arch.lifecycle.AndroidViewModel
+import android.arch.lifecycle.ViewModel
 import com.fsck.k9.ui.account.AccountsLiveData
 
-internal class SettingsViewModel(application: Application) : AndroidViewModel(application) {
-    val accounts = AccountsLiveData(application)
-}
+internal class SettingsViewModel(val accounts: AccountsLiveData) : ViewModel()

--- a/k9mail/src/test/java/com/fsck/k9/DependencyInjectionTest.kt
+++ b/k9mail/src/test/java/com/fsck/k9/DependencyInjectionTest.kt
@@ -1,0 +1,15 @@
+package com.fsck.k9
+
+import org.junit.Test
+import org.koin.Koin
+import org.koin.log.PrintLogger
+import org.koin.test.dryRun
+
+class DependencyInjectionTest : K9RobolectricTest() {
+    @Test
+    fun testDependencyTree() {
+        Koin.logger = PrintLogger()
+
+        dryRun()
+    }
+}

--- a/k9mail/src/test/java/com/fsck/k9/K9RobolectricTest.kt
+++ b/k9mail/src/test/java/com/fsck/k9/K9RobolectricTest.kt
@@ -1,0 +1,14 @@
+package com.fsck.k9
+
+import android.app.Application
+import org.junit.runner.RunWith
+import org.koin.test.AutoCloseKoinTest
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * A Robolectric test that creates an instance of our [Application] class [K9].
+ *
+ * See also [RobolectricTest].
+ */
+@RunWith(RobolectricTestRunner::class)
+abstract class K9RobolectricTest : AutoCloseKoinTest()

--- a/k9mail/src/test/java/com/fsck/k9/RobolectricTest.kt
+++ b/k9mail/src/test/java/com/fsck/k9/RobolectricTest.kt
@@ -1,0 +1,17 @@
+package com.fsck.k9
+
+import android.app.Application
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.annotation.Config
+
+/**
+ * A Robolectric test that does not create an instance of our [Application] class [K9].
+ *
+ * See also [K9RobolectricTest].
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(application = EmptyApplication::class)
+abstract class RobolectricTest
+
+class EmptyApplication : Application()

--- a/k9mail/src/test/java/com/fsck/k9/account/AccountCreatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/account/AccountCreatorTest.java
@@ -2,17 +2,15 @@ package com.fsck.k9.account;
 
 
 import com.fsck.k9.Account.DeletePolicy;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.ServerSettings.Type;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class AccountCreatorTest {
+public class AccountCreatorTest extends RobolectricTest {
 
     @Test
     public void getDefaultDeletePolicy_withImap_shouldReturn_ON_DELETE() {

--- a/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/ActivityListenerTest.java
@@ -5,11 +5,10 @@ import android.content.Context;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.Message;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static junit.framework.Assert.assertEquals;
@@ -17,8 +16,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class ActivityListenerTest {
+public class ActivityListenerTest extends RobolectricTest {
     private static final String FOLDER_SERVER_ID = ":folder:123";
     private static final String FOLDER_NAME = "folder";
     private static final String ERROR_MESSAGE = "errorMessage";

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientLoaderTest.java
@@ -10,13 +10,12 @@ import android.net.Uri;
 import android.provider.ContactsContract;
 import android.provider.ContactsContract.CommonDataKinds.Email;
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
 import com.fsck.k9.view.RecipientSelectView.RecipientCryptoStatus;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static android.provider.ContactsContract.CommonDataKinds.Email.TYPE_HOME;
@@ -30,8 +29,7 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("WeakerAccess")
-@RunWith(RobolectricTestRunner.class)
-public class RecipientLoaderTest {
+public class RecipientLoaderTest extends RobolectricTest {
     static final String CRYPTO_PROVIDER = "cryptoProvider";
     static final String[] PROJECTION = {
             ContactsContract.CommonDataKinds.Email._ID,

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
@@ -11,6 +11,7 @@ import android.os.ParcelFileDescriptor;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
+import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.activity.compose.RecipientMvpView.CryptoSpecialModeDisplayType;
 import com.fsck.k9.activity.compose.RecipientMvpView.CryptoStatusDisplayType;
 import com.fsck.k9.activity.compose.RecipientPresenter.CryptoMode;
@@ -27,13 +28,11 @@ import com.fsck.k9.message.ComposePgpInlineDecider;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.openintents.openpgp.IOpenPgpService2;
 import org.openintents.openpgp.util.OpenPgpApi;
 import org.openintents.openpgp.util.OpenPgpServiceConnection;
 import org.openintents.openpgp.util.ShadowOpenPgpAsyncTask;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowApplication;
 
@@ -49,9 +48,8 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("ConstantConditions")
-@RunWith(RobolectricTestRunner.class)
 @Config(shadows = { ShadowOpenPgpAsyncTask.class })
-public class RecipientPresenterTest {
+public class RecipientPresenterTest extends K9RobolectricTest {
     private static final ReplyToAddresses TO_ADDRESSES = new ReplyToAddresses(Address.parse("to@example.org"));
     private static final List<Address> ALL_TO_ADDRESSES = Arrays.asList(Address.parse("allTo@example.org"));
     private static final List<Address> ALL_CC_ADDRESSES = Arrays.asList(Address.parse("allCc@example.org"));

--- a/k9mail/src/test/java/com/fsck/k9/activity/misc/ContactPictureLoaderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/misc/ContactPictureLoaderTest.java
@@ -1,16 +1,14 @@
 package com.fsck.k9.activity.misc;
 
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.Address;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class ContactPictureLoaderTest {
+public class ContactPictureLoaderTest extends RobolectricTest {
 
     @Test
     public void calcUnknownContactLetter_withNoNameUsesAddress() {

--- a/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderParserTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/autocrypt/AutocryptHeaderParserTest.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.BinaryTempFileBody;
 import com.fsck.k9.mail.internet.MimeMessage;
@@ -19,8 +20,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class AutocryptHeaderParserTest {
+public class AutocryptHeaderParserTest extends RobolectricTest {
     AutocryptHeaderParser autocryptHeaderParser = AutocryptHeaderParser.getInstance();
 
     @Before

--- a/k9mail/src/test/java/com/fsck/k9/cache/EmailProviderCacheTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/cache/EmailProviderCacheTest.java
@@ -4,14 +4,13 @@ package com.fsck.k9.cache;
 import java.util.Collections;
 import java.util.UUID;
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertEquals;
@@ -23,8 +22,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class EmailProviderCacheTest {
+public class EmailProviderCacheTest extends RobolectricTest {
 
     private EmailProviderCache cache;
     @Mock

--- a/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -14,6 +14,7 @@ import android.content.Context;
 import com.fsck.k9.Account;
 import com.fsck.k9.AccountStats;
 import com.fsck.k9.K9;
+import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.mail.AuthenticationFailedException;
@@ -39,7 +40,6 @@ import org.jetbrains.annotations.Nullable;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InOrder;
@@ -48,7 +48,6 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowLog;
 
@@ -73,8 +72,7 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("unchecked")
-@RunWith(RobolectricTestRunner.class)
-public class MessagingControllerTest {
+public class MessagingControllerTest extends K9RobolectricTest {
     private static final String FOLDER_NAME = "Folder";
     private static final String SENT_FOLDER_NAME = "Sent";
     private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;

--- a/k9mail/src/test/java/com/fsck/k9/controller/imap/ImapSyncTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/controller/imap/ImapSyncTest.java
@@ -11,6 +11,7 @@ import android.content.Context;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.AccountStats;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.controller.MessagingListener;
 import com.fsck.k9.controller.SimpleMessagingListener;
@@ -26,14 +27,12 @@ import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.notification.NotificationController;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.shadows.ShadowApplication;
 import org.robolectric.shadows.ShadowLog;
 
@@ -51,8 +50,7 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("unchecked")
-@RunWith(RobolectricTestRunner.class)
-public class ImapSyncTest {
+public class ImapSyncTest extends RobolectricTest {
     private static final String FOLDER_NAME = "Folder";
     private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;
     private static final String MESSAGE_UID1 = "message-uid1";

--- a/k9mail/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
+++ b/k9mail/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
@@ -3,18 +3,16 @@ package com.fsck.k9.helper
 
 import com.fsck.k9.Account
 import com.fsck.k9.Identity
+import com.fsck.k9.RobolectricTest
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.Message.RecipientType
 import com.fsck.k9.mail.internet.MimeMessage
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
 
-@RunWith(RobolectricTestRunner::class)
-class IdentityHelperTest {
+class IdentityHelperTest : RobolectricTest() {
     private val account = createDummyAccount()
 
     @Test

--- a/k9mail/src/test/java/com/fsck/k9/helper/MailToTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/MailToTest.java
@@ -7,13 +7,12 @@ import java.util.List;
 
 import android.net.Uri;
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.helper.MailTo.CaseInsensitiveParamWrapper;
 import com.fsck.k9.mail.Address;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -22,8 +21,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class MailToTest {
+public class MailToTest extends RobolectricTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 

--- a/k9mail/src/test/java/com/fsck/k9/helper/MessageHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/MessageHelperTest.java
@@ -5,19 +5,17 @@ import android.content.Context;
 import android.graphics.Color;
 import android.text.SpannableString;
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.Address;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class MessageHelperTest {
+public class MessageHelperTest extends RobolectricTest {
     private Contacts contacts;
     private Contacts contactsWithFakeContact;
     private Contacts contactsWithFakeSpoofContact;

--- a/k9mail/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.helper.ReplyToParser.ReplyToAddresses;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
@@ -12,8 +13,6 @@ import com.fsck.k9.mail.Message.RecipientType;
 import com.fsck.k9.mail.internet.ListHeaders;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -25,8 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class ReplyToParserTest {
+public class ReplyToParserTest extends RobolectricTest {
     private static final Address[] REPLY_TO_ADDRESSES = Address.parse("replyTo1@example.com, replyTo2@example.com");
     private static final Address[] LIST_POST_ADDRESSES = Address.parse("listPost@example.com");
     private static final Address[] FROM_ADDRESSES = Address.parse("from@example.com");

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/AttachmentResolverTest.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import android.net.Uri;
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.Multipart;
 import com.fsck.k9.mail.Part;
@@ -14,8 +15,6 @@ import com.fsck.k9.mail.internet.MimeMultipart;
 import com.fsck.k9.message.extractors.AttachmentInfoExtractor;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -26,8 +25,7 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("unchecked")
-@RunWith(RobolectricTestRunner.class)
-public class AttachmentResolverTest {
+public class AttachmentResolverTest extends RobolectricTest {
     public static final Uri ATTACHMENT_TEST_URI_1 = Uri.parse("uri://test/1");
     public static final Uri ATTACHMENT_TEST_URI_2 = Uri.parse("uri://test/2");
 

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -11,7 +11,7 @@ import java.util.TimeZone;
 import android.app.Application;
 import android.support.annotation.NonNull;
 
-import com.fsck.k9.GlobalsHelper;
+import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.activity.K9ActivityCommon;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.BodyPart;
@@ -35,10 +35,8 @@ import com.fsck.k9.message.html.HtmlProcessor;
 import com.fsck.k9.ui.crypto.MessageCryptoAnnotations;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static com.fsck.k9.message.TestMessageConstructionUtils.bodypart;
@@ -56,8 +54,7 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("WeakerAccess")
-@RunWith(RobolectricTestRunner.class)
-public class MessageViewInfoExtractorTest {
+public class MessageViewInfoExtractorTest extends K9RobolectricTest {
     public static final String BODY_TEXT = "K-9 Mail rocks :>";
     public static final String BODY_TEXT_HTML = "K-9 Mail rocks :&gt;";
     public static final String BODY_TEXT_FLOWED = "K-9 Mail rocks :> \r\nflowed line\r\nnot flowed line";
@@ -71,8 +68,6 @@ public class MessageViewInfoExtractorTest {
     @Before
     public void setUp() throws Exception {
         context = RuntimeEnvironment.application;
-
-        GlobalsHelper.setContext(context);
 
         HtmlProcessor htmlProcessor = createFakeHtmlProcessor();
         attachmentInfoExtractor = spy(AttachmentInfoExtractor.getInstance());

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/MigrationTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/MigrationTest.java
@@ -14,6 +14,7 @@ import android.database.sqlite.SQLiteDatabase;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
+import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.FetchProfile;
@@ -26,16 +27,13 @@ import org.apache.james.mime4j.util.MimeUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.openintents.openpgp.util.OpenPgpUtils;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowLog;
 import org.robolectric.shadows.ShadowSQLiteConnection;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class MigrationTest {
+public class MigrationTest extends K9RobolectricTest {
 
     Account account;
     File databaseFile;

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/StoreSchemaDefinitionTest.java
@@ -18,11 +18,10 @@ import com.fsck.k9.BuildConfig;
 import com.fsck.k9.GlobalsHelper;
 import com.fsck.k9.K9;
 import com.fsck.k9.R;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.MessagingException;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowLog;
 
@@ -36,8 +35,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class StoreSchemaDefinitionTest {
+public class StoreSchemaDefinitionTest extends RobolectricTest {
     private StoreSchemaDefinition storeSchemaDefinition;
 
 

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationMimeStructureStateTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationMimeStructureStateTest.java
@@ -3,15 +3,13 @@ package com.fsck.k9.mailstore.migrations;
 
 import android.content.ContentValues;
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mailstore.migrations.MigrationTo51.MimeStructureState;
 import org.junit.Assert;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 
-@RunWith(RobolectricTestRunner.class) // required for ContentValues
-public class MigrationMimeStructureStateTest {
+public class MigrationMimeStructureStateTest extends RobolectricTest {
 
     @Test(expected = IllegalStateException.class)
     public void init_popParent_shouldCrash() throws Exception {

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationTo51Test.kt
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationTo51Test.kt
@@ -2,6 +2,7 @@ package com.fsck.k9.mailstore.migrations
 
 import android.database.sqlite.SQLiteDatabase
 import com.fsck.k9.Account
+import com.fsck.k9.RobolectricTest
 import com.fsck.k9.mailstore.StorageManager
 import com.fsck.k9.whenever
 import org.apache.commons.io.IOUtils
@@ -10,17 +11,12 @@ import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
-import org.junit.runner.RunWith
 import org.mockito.Mockito.mock
-import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
-import org.robolectric.annotation.Config
 import java.io.ByteArrayInputStream
 
 
-@RunWith(RobolectricTestRunner::class)
-@Config(manifest = Config.NONE)
-class MigrationTo51Test {
+class MigrationTo51Test : RobolectricTest() {
     private lateinit var mockMigrationsHelper: MigrationsHelper
     private lateinit var database: SQLiteDatabase
 

--- a/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationTo60Test.java
+++ b/k9mail/src/test/java/com/fsck/k9/mailstore/migrations/MigrationTo60Test.java
@@ -12,6 +12,7 @@ import java.util.Set;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingCommand;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingEmptyTrash;
@@ -22,9 +23,6 @@ import com.fsck.k9.controller.MessagingControllerCommands.PendingSetFlag;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mailstore.migrations.MigrationTo60.OldPendingCommand;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
-import org.robolectric.annotation.Config;
 
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
@@ -32,9 +30,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE)
-public class MigrationTo60Test {
+public class MigrationTo60Test extends RobolectricTest {
     private static final String PENDING_COMMAND_MOVE_OR_COPY = "com.fsck.k9.MessagingController.moveOrCopy";
     private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK = "com.fsck.k9.MessagingController.moveOrCopyBulk";
     private static final String PENDING_COMMAND_MOVE_OR_COPY_BULK_NEW = "com.fsck.k9.MessagingController.moveOrCopyBulkNew";

--- a/k9mail/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
@@ -15,6 +15,7 @@ import android.app.Application;
 
 import com.fsck.k9.Account.QuoteStyle;
 import com.fsck.k9.Identity;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.activity.misc.Attachment;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.BodyPart;
@@ -29,10 +30,8 @@ import com.fsck.k9.message.MessageBuilder.Callback;
 import com.fsck.k9.message.quote.InsertableHtmlContent;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.robolectric.Robolectric;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -45,8 +44,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class MessageBuilderTest {
+public class MessageBuilderTest extends RobolectricTest {
     public static final String TEST_MESSAGE_TEXT = "soviet message\r\ntext ☭";
     public static final String TEST_ATTACHMENT_TEXT = "text data in attachment";
     public static final String TEST_SUBJECT = "test_subject";

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -17,6 +17,7 @@ import android.os.Bundle;
 
 import com.fsck.k9.Account.QuoteStyle;
 import com.fsck.k9.Identity;
+import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.ComposeCryptoStatusBuilder;
 import com.fsck.k9.activity.compose.RecipientPresenter.CryptoMode;
@@ -43,12 +44,10 @@ import org.apache.james.mime4j.util.MimeUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.openintents.openpgp.OpenPgpError;
 import org.openintents.openpgp.util.OpenPgpApi;
 import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static com.fsck.k9.autocrypt.AutocryptOperationsHelper.assertMessageHasAutocryptHeader;
@@ -65,8 +64,7 @@ import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class PgpMessageBuilderTest {
+public class PgpMessageBuilderTest extends K9RobolectricTest {
     private static final long TEST_KEY_ID = 123L;
     private static final String TEST_MESSAGE_TEXT = "message text with a ☭ CCCP symbol";
     private static final byte[] AUTOCRYPT_KEY_MATERIAL = { 1, 2, 3 };

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/AttachmentInfoExtractorTest.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MimeBodyPart;
 import com.fsck.k9.mail.internet.MimeHeader;
@@ -15,8 +16,6 @@ import com.fsck.k9.mailstore.LocalBodyPart;
 import com.fsck.k9.provider.AttachmentProvider;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertEquals;
@@ -26,8 +25,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class AttachmentInfoExtractorTest {
+public class AttachmentInfoExtractorTest extends RobolectricTest {
     public static final Uri TEST_URI = Uri.parse("uri://test");
     public static final String TEST_MIME_TYPE = "text/plain";
     public static final long TEST_SIZE = 123L;

--- a/k9mail/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.java
@@ -1,19 +1,17 @@
 package com.fsck.k9.message.extractors;
 
 
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.internet.MimeBodyPart;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static com.fsck.k9.message.MessageCreationHelper.createTextPart;
 import static org.junit.Assert.assertEquals;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class PreviewTextExtractorTest {
+public class PreviewTextExtractorTest extends RobolectricTest {
     private PreviewTextExtractor previewTextExtractor;
 
 

--- a/k9mail/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationsTest.java
@@ -11,10 +11,9 @@ import android.support.v4.app.NotificationManagerCompat;
 import com.fsck.k9.Account;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
+import com.fsck.k9.RobolectricTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.mockito.Matchers.any;
@@ -24,8 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class AuthenticationErrorNotificationsTest {
+public class AuthenticationErrorNotificationsTest extends RobolectricTest {
     private static final boolean INCOMING = true;
     private static final boolean OUTGOING = false;
     private static final int ACCOUNT_NUMBER = 1;

--- a/k9mail/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/CertificateErrorNotificationsTest.java
@@ -11,10 +11,9 @@ import android.support.v4.app.NotificationManagerCompat;
 import com.fsck.k9.Account;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
+import com.fsck.k9.RobolectricTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.mockito.Matchers.any;
@@ -24,8 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class CertificateErrorNotificationsTest {
+public class CertificateErrorNotificationsTest extends RobolectricTest {
     private static final boolean INCOMING = true;
     private static final boolean OUTGOING = false;
     private static final int ACCOUNT_NUMBER = 1;

--- a/k9mail/src/test/java/com/fsck/k9/notification/DeviceNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/DeviceNotificationsTest.java
@@ -17,12 +17,11 @@ import com.fsck.k9.K9.NotificationHideSubject;
 import com.fsck.k9.K9.NotificationQuickDelete;
 import com.fsck.k9.NotificationSetting;
 import com.fsck.k9.R;
+import com.fsck.k9.RobolectricTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static com.fsck.k9.MockHelper.mockBuilder;
@@ -34,8 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class DeviceNotificationsTest {
+public class DeviceNotificationsTest extends RobolectricTest {
     private static final int UNREAD_MESSAGE_COUNT = 42;
     private static final int NEW_MESSAGE_COUNT = 2;
     private static final String ACCOUNT_NAME = "accountName";

--- a/k9mail/src/test/java/com/fsck/k9/notification/LockScreenNotificationTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/LockScreenNotificationTest.java
@@ -13,10 +13,9 @@ import com.fsck.k9.K9;
 import com.fsck.k9.K9.LockScreenNotificationVisibility;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
+import com.fsck.k9.RobolectricTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertEquals;
@@ -27,8 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class LockScreenNotificationTest {
+public class LockScreenNotificationTest extends RobolectricTest {
     private static final String ACCOUNT_NAME = "Hugo";
     private static final int NEW_MESSAGE_COUNT = 3;
     private static final int UNREAD_MESSAGE_COUNT = 4;

--- a/k9mail/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.java
@@ -7,12 +7,11 @@ import android.support.v4.app.NotificationManagerCompat;
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationHideSubject;
+import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.mailstore.LocalMessage;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyBoolean;
@@ -25,8 +24,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class NewMailNotificationsTest {
+public class NewMailNotificationsTest extends K9RobolectricTest {
     private static final int ACCOUNT_NUMBER = 23;
 
     private Account account;

--- a/k9mail/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.java
@@ -4,6 +4,7 @@ package com.fsck.k9.notification;
 import android.content.Context;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Flag;
@@ -12,8 +13,6 @@ import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.message.extractors.PreviewResult.PreviewType;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertEquals;
@@ -22,8 +21,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class NotificationContentCreatorTest {
+public class NotificationContentCreatorTest extends RobolectricTest {
     private static final String ACCOUNT_UUID = "1-2-3";
     private static final String FOLDER_NAME = "INBOX";
     private static final String UID = "42";

--- a/k9mail/src/test/java/com/fsck/k9/notification/NotificationDataTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/NotificationDataTest.java
@@ -4,11 +4,10 @@ package com.fsck.k9.notification;
 import java.util.List;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.activity.MessageReference;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -18,8 +17,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class NotificationDataTest {
+public class NotificationDataTest extends RobolectricTest {
     private static final String ACCOUNT_UUID = "1-2-3";
     private static final int ACCOUNT_NUMBER = 23;
     private static final String FOLDER_NAME = "INBOX";

--- a/k9mail/src/test/java/com/fsck/k9/notification/SendFailedNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/SendFailedNotificationsTest.java
@@ -10,10 +10,9 @@ import android.support.v4.app.NotificationManagerCompat;
 import com.fsck.k9.Account;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
+import com.fsck.k9.RobolectricTest;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.mockito.Matchers.any;
@@ -24,8 +23,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class SendFailedNotificationsTest {
+public class SendFailedNotificationsTest extends RobolectricTest {
     private static final int ACCOUNT_NUMBER = 1;
     private static final String ACCOUNT_NAME = "TestAccount";
 

--- a/k9mail/src/test/java/com/fsck/k9/notification/SyncNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/SyncNotificationsTest.java
@@ -10,11 +10,10 @@ import android.support.v4.app.NotificationManagerCompat;
 import com.fsck.k9.Account;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.mail.Folder;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.mockito.Matchers.any;
@@ -26,8 +25,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class SyncNotificationsTest {
+public class SyncNotificationsTest extends RobolectricTest {
     private static final int ACCOUNT_NUMBER = 1;
     private static final String ACCOUNT_NAME = "TestAccount";
     private static final String FOLDER_SERVER_ID = "INBOX";

--- a/k9mail/src/test/java/com/fsck/k9/notification/WearNotificationsTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/notification/WearNotificationsTest.java
@@ -16,13 +16,12 @@ import com.fsck.k9.K9;
 import com.fsck.k9.K9.NotificationQuickDelete;
 import com.fsck.k9.MockHelper;
 import com.fsck.k9.R;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.activity.MessageReference;
 import com.fsck.k9.controller.MessagingController;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentMatcher;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertEquals;
@@ -34,8 +33,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class WearNotificationsTest {
+public class WearNotificationsTest extends RobolectricTest {
     private static final int ACCOUNT_NUMBER = 42;
     private static final String ACCOUNT_NAME = "accountName";
 

--- a/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.java
@@ -7,11 +7,10 @@ import java.io.InputStream;
 import java.util.Collections;
 import java.util.Set;
 
+import com.fsck.k9.K9RobolectricTest;
 import org.jdom2.Document;
 import org.jdom2.input.SAXBuilder;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertEquals;
@@ -19,8 +18,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 
 
-@RunWith(RobolectricTestRunner.class)
-public class SettingsExporterTest {
+public class SettingsExporterTest extends K9RobolectricTest {
 
     @Test
     public void exportPreferences_producesXML() throws Exception {

--- a/k9mail/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
@@ -7,13 +7,12 @@ import java.util.List;
 import java.util.UUID;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.AuthType;
 import org.apache.tools.ant.filters.StringInputStream;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertEquals;
@@ -21,8 +20,7 @@ import static org.junit.Assert.assertFalse;
 
 
 @SuppressWarnings("unchecked")
-@RunWith(RobolectricTestRunner.class)
-public class SettingsImporterTest {
+public class SettingsImporterTest extends K9RobolectricTest {
 
     @Before
     public void before() {

--- a/k9mail/src/test/java/com/fsck/k9/ui/crypto/MessageCryptoHelperTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/ui/crypto/MessageCryptoHelperTest.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 
 import com.fsck.k9.K9;
+import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.autocrypt.AutocryptOperations;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Body;
@@ -21,7 +22,6 @@ import com.fsck.k9.mailstore.CryptoResultAnnotation;
 import com.fsck.k9.mailstore.CryptoResultAnnotation.CryptoError;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.openintents.openpgp.IOpenPgpService2;
 import org.openintents.openpgp.OpenPgpDecryptionResult;
@@ -31,9 +31,7 @@ import org.openintents.openpgp.util.OpenPgpApi.IOpenPgpCallback;
 import org.openintents.openpgp.util.OpenPgpApi.IOpenPgpSinkResultCallback;
 import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSink;
 import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
-import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
-import org.robolectric.annotation.Config;
 
 import static com.fsck.k9.message.TestMessageConstructionUtils.bodypart;
 import static com.fsck.k9.message.TestMessageConstructionUtils.messageFromBody;
@@ -51,9 +49,7 @@ import static org.mockito.Mockito.when;
 
 
 @SuppressWarnings("unchecked")
-@RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 21)
-public class MessageCryptoHelperTest {
+public class MessageCryptoHelperTest extends RobolectricTest {
     private MessageCryptoHelper messageCryptoHelper;
     private OpenPgpApi openPgpApi;
     private Intent capturedApiIntent;

--- a/k9mail/src/test/java/com/fsck/k9/view/MessageHeaderTest.kt
+++ b/k9mail/src/test/java/com/fsck/k9/view/MessageHeaderTest.kt
@@ -1,14 +1,12 @@
 package com.fsck.k9.view
 
+import com.fsck.k9.RobolectricTest
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.internet.MimeMessage
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import org.junit.runner.RunWith
-import org.robolectric.RobolectricTestRunner
 
-@RunWith(RobolectricTestRunner::class)
-class MessageHeaderTest {
+class MessageHeaderTest : RobolectricTest() {
 
     @Test
     fun shouldShowSender_withSender_shouldReturnTrue() {


### PR DESCRIPTION
I've played around a bit with the dependency injection library KOIN and quite like it. 

* It has a concise DSL for configuration. 
* It has good Android support.
* Replacing dependencies in tests is easy enough (you have to take my word for it; no sample included in this PR). 
* By default it doesn't work too well with Java. But changing that doesn't require much code. See `DI.get()`.

To get a rough idea on what it looks like to use KOIN check out the first commit. The second commit only fixes tests.

More information on the library: https://insert-koin.io/

@philipwhiuk, @Valodim: Please let me know what you think of this. 