### PR TITLE
Introduce lifecycle-based OpenpgpApiManager for service connection

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -99,6 +99,7 @@ import com.fsck.k9.search.LocalSearch;
 import com.fsck.k9.ui.EolConvertingEditText;
 import com.fsck.k9.ui.compose.QuotedMessageMvpView;
 import com.fsck.k9.ui.compose.QuotedMessagePresenter;
+import org.openintents.openpgp.OpenPgpApiManager;
 import org.openintents.openpgp.util.OpenPgpApi;
 import timber.log.Timber;
 
@@ -282,9 +283,11 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         RecipientMvpView recipientMvpView = new RecipientMvpView(this);
         ComposePgpInlineDecider composePgpInlineDecider = new ComposePgpInlineDecider();
         ComposePgpEnableByDefaultDecider composePgpEnableByDefaultDecider = new ComposePgpEnableByDefaultDecider();
-        recipientPresenter = new RecipientPresenter(getApplicationContext(), getLifecycle(), getLoaderManager(),
+        OpenPgpApiManager openPgpApiManager = new OpenPgpApiManager(getApplicationContext(), getLifecycle());
+        recipientPresenter = new RecipientPresenter(getApplicationContext(), getLoaderManager(), openPgpApiManager,
                 recipientMvpView, account, composePgpInlineDecider, composePgpEnableByDefaultDecider,
-                AutocryptStatusInteractor.getInstance(), new ReplyToParser(), this);
+                AutocryptStatusInteractor.getInstance(), new ReplyToParser(), this
+        );
         recipientPresenter.asyncUpdateCryptoStatus();
 
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -282,7 +282,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         RecipientMvpView recipientMvpView = new RecipientMvpView(this);
         ComposePgpInlineDecider composePgpInlineDecider = new ComposePgpInlineDecider();
         ComposePgpEnableByDefaultDecider composePgpEnableByDefaultDecider = new ComposePgpEnableByDefaultDecider();
-        recipientPresenter = new RecipientPresenter(getApplicationContext(), getLoaderManager(),
+        recipientPresenter = new RecipientPresenter(getApplicationContext(), getLifecycle(), getLoaderManager(),
                 recipientMvpView, account, composePgpInlineDecider, composePgpEnableByDefaultDecider,
                 AutocryptStatusInteractor.getInstance(), new ReplyToParser(), this);
         recipientPresenter.asyncUpdateCryptoStatus();
@@ -450,15 +450,6 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         if (currentMessageBuilder != null) {
             setProgressBarIndeterminateVisibility(true);
             currentMessageBuilder.reattachCallback(this);
-        }
-    }
-
-    @Override
-    public void onDestroy() {
-        super.onDestroy();
-
-        if (recipientPresenter != null) {
-            recipientPresenter.onActivityDestroy();
         }
     }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -42,6 +42,7 @@ public class ComposeCryptoStatus {
                 return CryptoStatusDisplayType.UNINITIALIZED;
             case LOST_CONNECTION:
             case ERROR:
+            case UI_REQUIRED:
                 return CryptoStatusDisplayType.ERROR;
             case OK:
                 // provider status is ok -> return value is based on cryptoMode

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -11,7 +11,7 @@ import com.fsck.k9.activity.compose.RecipientMvpView.CryptoStatusDisplayType;
 import com.fsck.k9.activity.compose.RecipientPresenter.CryptoMode;
 import com.fsck.k9.message.AutocryptStatusInteractor.RecipientAutocryptStatus;
 import com.fsck.k9.message.AutocryptStatusInteractor.RecipientAutocryptStatusType;
-import com.fsck.k9.ui.crypto.OpenPgpApiManager.CryptoProviderState;
+import org.openintents.openpgp.OpenPgpApiManager.OpenPgpProviderState;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
 
 /** This is an immutable object which contains all relevant metadata entered
@@ -21,7 +21,7 @@ import com.fsck.k9.view.RecipientSelectView.Recipient;
 public class ComposeCryptoStatus {
 
 
-    private CryptoProviderState cryptoProviderState;
+    private OpenPgpProviderState openPgpProviderState;
     private Long openPgpKeyId;
     private String[] recipientAddresses;
     private boolean enablePgpInline;
@@ -35,7 +35,7 @@ public class ComposeCryptoStatus {
     }
 
     CryptoStatusDisplayType getCryptoStatusDisplayType() {
-        switch (cryptoProviderState) {
+        switch (openPgpProviderState) {
             case UNCONFIGURED:
                 return CryptoStatusDisplayType.UNCONFIGURED;
             case UNINITIALIZED:
@@ -106,7 +106,7 @@ public class ComposeCryptoStatus {
     }
 
     CryptoSpecialModeDisplayType getCryptoSpecialModeDisplayType() {
-        if (cryptoProviderState != CryptoProviderState.OK) {
+        if (openPgpProviderState != OpenPgpProviderState.OK) {
             return CryptoSpecialModeDisplayType.NONE;
         }
 
@@ -127,11 +127,11 @@ public class ComposeCryptoStatus {
 
     public boolean shouldUsePgpMessageBuilder() {
         // CryptoProviderState.ERROR will be handled as an actual error, see SendErrorState
-        return cryptoProviderState != CryptoProviderState.UNCONFIGURED;
+        return openPgpProviderState != OpenPgpProviderState.UNCONFIGURED;
     }
 
     public boolean isEncryptionEnabled() {
-        if (cryptoProviderState == CryptoProviderState.UNCONFIGURED) {
+        if (openPgpProviderState == OpenPgpProviderState.UNCONFIGURED) {
             return false;
         }
 
@@ -153,7 +153,7 @@ public class ComposeCryptoStatus {
     }
 
     public boolean isProviderStateOk() {
-        return cryptoProviderState == CryptoProviderState.OK;
+        return openPgpProviderState == OpenPgpProviderState.OK;
     }
 
     boolean allRecipientsCanEncrypt() {
@@ -190,15 +190,15 @@ public class ComposeCryptoStatus {
 
     public static class ComposeCryptoStatusBuilder {
 
-        private CryptoProviderState cryptoProviderState;
+        private OpenPgpProviderState openPgpProviderState;
         private CryptoMode cryptoMode;
         private Long openPgpKeyId;
         private List<Recipient> recipients;
         private Boolean enablePgpInline;
         private Boolean preferEncryptMutual;
 
-        public ComposeCryptoStatusBuilder setCryptoProviderState(CryptoProviderState cryptoProviderState) {
-            this.cryptoProviderState = cryptoProviderState;
+        public ComposeCryptoStatusBuilder setOpenPgpProviderState(OpenPgpProviderState openPgpProviderState) {
+            this.openPgpProviderState = openPgpProviderState;
             return this;
         }
 
@@ -228,7 +228,7 @@ public class ComposeCryptoStatus {
         }
 
         public ComposeCryptoStatus build() {
-            if (cryptoProviderState == null) {
+            if (openPgpProviderState == null) {
                 throw new AssertionError("cryptoProviderState must be set!");
             }
             if (cryptoMode == null) {
@@ -250,7 +250,7 @@ public class ComposeCryptoStatus {
             }
 
             ComposeCryptoStatus result = new ComposeCryptoStatus();
-            result.cryptoProviderState = cryptoProviderState;
+            result.openPgpProviderState = openPgpProviderState;
             result.cryptoMode = cryptoMode;
             result.recipientAddresses = recipientAddresses.toArray(new String[0]);
             result.openPgpKeyId = openPgpKeyId;
@@ -262,7 +262,7 @@ public class ComposeCryptoStatus {
 
     ComposeCryptoStatus withRecipientAutocryptStatus(RecipientAutocryptStatus recipientAutocryptStatusType) {
         ComposeCryptoStatus result = new ComposeCryptoStatus();
-        result.cryptoProviderState = cryptoProviderState;
+        result.openPgpProviderState = openPgpProviderState;
         result.cryptoMode = cryptoMode;
         result.recipientAddresses = recipientAddresses;
         result.openPgpKeyId = openPgpKeyId;
@@ -278,7 +278,7 @@ public class ComposeCryptoStatus {
     }
 
     public SendErrorState getSendErrorStateOrNull() {
-        if (cryptoProviderState != CryptoProviderState.OK) {
+        if (openPgpProviderState != OpenPgpProviderState.OK) {
             // TODO: be more specific about this error
             return SendErrorState.PROVIDER_ERROR;
         }
@@ -299,7 +299,7 @@ public class ComposeCryptoStatus {
     }
 
     AttachErrorState getAttachErrorStateOrNull() {
-        if (cryptoProviderState == CryptoProviderState.UNCONFIGURED) {
+        if (openPgpProviderState == OpenPgpProviderState.UNCONFIGURED) {
             return null;
         }
 

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -9,9 +9,9 @@ import android.app.PendingIntent;
 import com.fsck.k9.activity.compose.RecipientMvpView.CryptoSpecialModeDisplayType;
 import com.fsck.k9.activity.compose.RecipientMvpView.CryptoStatusDisplayType;
 import com.fsck.k9.activity.compose.RecipientPresenter.CryptoMode;
-import com.fsck.k9.activity.compose.RecipientPresenter.CryptoProviderState;
 import com.fsck.k9.message.AutocryptStatusInteractor.RecipientAutocryptStatus;
 import com.fsck.k9.message.AutocryptStatusInteractor.RecipientAutocryptStatusType;
+import com.fsck.k9.ui.crypto.OpenPgpApiManager.CryptoProviderState;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
 
 /** This is an immutable object which contains all relevant metadata entered

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/ComposeCryptoStatus.java
@@ -40,7 +40,6 @@ public class ComposeCryptoStatus {
                 return CryptoStatusDisplayType.UNCONFIGURED;
             case UNINITIALIZED:
                 return CryptoStatusDisplayType.UNINITIALIZED;
-            case LOST_CONNECTION:
             case ERROR:
             case UI_REQUIRED:
                 return CryptoStatusDisplayType.ERROR;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -9,6 +9,7 @@ import java.util.List;
 import android.app.Activity;
 import android.app.LoaderManager;
 import android.app.PendingIntent;
+import android.arch.lifecycle.Lifecycle;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -17,8 +18,6 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
-import android.support.annotation.VisibleForTesting;
-import android.text.TextUtils;
 import android.view.Menu;
 
 import com.fsck.k9.Account;
@@ -43,17 +42,15 @@ import com.fsck.k9.message.ComposePgpEnableByDefaultDecider;
 import com.fsck.k9.message.ComposePgpInlineDecider;
 import com.fsck.k9.message.MessageBuilder;
 import com.fsck.k9.message.PgpMessageBuilder;
+import com.fsck.k9.ui.crypto.OpenPgpApiManager;
+import com.fsck.k9.ui.crypto.OpenPgpApiManager.CryptoProviderError;
+import com.fsck.k9.ui.crypto.OpenPgpApiManager.OpenPgpApiManagerCallback;
+import com.fsck.k9.ui.crypto.OpenPgpApiManager.CryptoProviderState;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
-import org.openintents.openpgp.IOpenPgpService2;
-import org.openintents.openpgp.OpenPgpError;
-import org.openintents.openpgp.util.OpenPgpApi;
-import org.openintents.openpgp.util.OpenPgpApi.PermissionPingCallback;
-import org.openintents.openpgp.util.OpenPgpServiceConnection;
-import org.openintents.openpgp.util.OpenPgpServiceConnection.OnBound;
 import timber.log.Timber;
 
 
-public class RecipientPresenter implements PermissionPingCallback {
+public class RecipientPresenter {
     private static final String STATE_KEY_CC_SHOWN = "state:ccShown";
     private static final String STATE_KEY_BCC_SHOWN = "state:bccShown";
     private static final String STATE_KEY_LAST_FOCUSED_TYPE = "state:lastFocusedType";
@@ -78,13 +75,10 @@ public class RecipientPresenter implements PermissionPingCallback {
     private final RecipientsChangedListener listener;
     private ReplyToParser replyToParser;
     private Account account;
-    private String openPgpProvider;
     private Boolean hasContactPicker;
-    private PendingIntent pendingUserInteractionIntent;
-    private CryptoProviderState cryptoProviderState = CryptoProviderState.UNCONFIGURED;
-    private OpenPgpServiceConnection openPgpServiceConnection;
     @Nullable
     private ComposeCryptoStatus cachedCryptoStatus;
+    private OpenPgpApiManager openPgpApiManager;
 
 
     // persistent state, saved during onSaveInstanceState
@@ -93,7 +87,7 @@ public class RecipientPresenter implements PermissionPingCallback {
     private boolean cryptoEnablePgpInline = false;
 
 
-    public RecipientPresenter(Context context, LoaderManager loaderManager,
+    public RecipientPresenter(Context context, Lifecycle lifecycle, LoaderManager loaderManager,
             RecipientMvpView recipientMvpView, Account account, ComposePgpInlineDecider composePgpInlineDecider,
             ComposePgpEnableByDefaultDecider composePgpEnableByDefaultDecider,
             AutocryptStatusInteractor autocryptStatusInteractor,
@@ -105,6 +99,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         this.composePgpEnableByDefaultDecider = composePgpEnableByDefaultDecider;
         this.replyToParser = replyToParser;
         this.listener = recipientsChangedListener;
+        this.openPgpApiManager = new OpenPgpApiManager(context, lifecycle, openPgpCallback, account.getOpenPgpProvider());
 
         recipientMvpView.setPresenter(this);
         recipientMvpView.setLoaderManager(loaderManager);
@@ -310,8 +305,9 @@ public class RecipientPresenter implements PermissionPingCallback {
             updateRecipientExpanderVisibility();
         }
 
-        // This does not strictly depend on the account, but this is as good a point to set this as any
-        setupCryptoProvider(account.getOpenPgpProvider());
+        String openPgpProvider = account.getOpenPgpProvider();
+        recipientMvpView.setCryptoProvider(openPgpProvider);
+        // openPgpApiManager.setOpenPgpProvider(openPgpProvider);
     }
 
     @SuppressWarnings("UnusedParameters")
@@ -384,12 +380,7 @@ public class RecipientPresenter implements PermissionPingCallback {
     public void asyncUpdateCryptoStatus() {
         cachedCryptoStatus = null;
 
-        boolean isOkStateButLostConnection = cryptoProviderState == CryptoProviderState.OK &&
-                (openPgpServiceConnection == null || !openPgpServiceConnection.isBound());
-        if (isOkStateButLostConnection) {
-            setCryptoProviderState(CryptoProviderState.LOST_CONNECTION);
-            pendingUserInteractionIntent = null;
-        }
+        final CryptoProviderState cryptoProviderState = openPgpApiManager.getCryptoProviderState();
 
         Long accountCryptoKey = account.getOpenPgpKey();
         if (accountCryptoKey == Account.NO_OPENPGP_KEY) {
@@ -415,7 +406,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                 }
 
                 return autocryptStatusInteractor.retrieveCryptoProviderRecipientStatus(
-                                getOpenPgpApi(), recipientAddresses);
+                        openPgpApiManager.getOpenPgpApi(), recipientAddresses);
             }
 
             @Override
@@ -508,7 +499,7 @@ public class RecipientPresenter implements PermissionPingCallback {
     }
 
     private void addRecipientsFromAddresses(final RecipientType recipientType, final Address... addresses) {
-        new RecipientLoader(context, openPgpProvider, addresses) {
+        new RecipientLoader(context, account.getOpenPgpProvider(), addresses) {
             @Override
             public void deliverResult(List<Recipient> result) {
                 Recipient[] recipientArray = result.toArray(new Recipient[result.size()]);
@@ -521,7 +512,7 @@ public class RecipientPresenter implements PermissionPingCallback {
     }
 
     private void addRecipientFromContactUri(final RecipientType recipientType, final Uri uri) {
-        new RecipientLoader(context, openPgpProvider, uri, false) {
+        new RecipientLoader(context, account.getOpenPgpProvider(), uri, false) {
             @Override
             public void deliverResult(List<Recipient> result) {
                 // TODO handle multiple available mail addresses for a contact?
@@ -568,7 +559,7 @@ public class RecipientPresenter implements PermissionPingCallback {
                 addRecipientFromContactUri(recipientType, data.getData());
                 break;
             case OPENPGP_USER_INTERACTION:
-                cryptoProviderBindOrCheckPermission();
+                openPgpApiManager.onUserInteractionResult();
                 break;
             case REQUEST_CODE_AUTOCRYPT:
                 asyncUpdateCryptoStatus();
@@ -615,7 +606,7 @@ public class RecipientPresenter implements PermissionPingCallback {
     }
 
     void onClickCryptoStatus() {
-        switch (cryptoProviderState) {
+        switch (openPgpApiManager.getCryptoProviderState()) {
             case UNCONFIGURED:
                 Timber.e("click on crypto status while unconfigured - this should not really happen?!");
                 return;
@@ -659,7 +650,7 @@ public class RecipientPresenter implements PermissionPingCallback {
             case LOST_CONNECTION:
             case UNINITIALIZED:
             case ERROR:
-                cryptoProviderBindOrCheckPermission();
+                openPgpApiManager.refreshConnection();
         }
     }
 
@@ -708,149 +699,6 @@ public class RecipientPresenter implements PermissionPingCallback {
         }
     }
 
-    private void setupCryptoProvider(String openPgpProvider) {
-        if (TextUtils.isEmpty(openPgpProvider)) {
-            openPgpProvider = null;
-        }
-
-        boolean providerIsBound = openPgpServiceConnection != null && openPgpServiceConnection.isBound();
-        boolean isSameProvider = openPgpProvider != null && openPgpProvider.equals(this.openPgpProvider);
-        if (isSameProvider && providerIsBound) {
-            cryptoProviderBindOrCheckPermission();
-            return;
-        }
-
-        if (providerIsBound) {
-            openPgpServiceConnection.unbindFromService();
-            openPgpServiceConnection = null;
-        }
-
-        this.openPgpProvider = openPgpProvider;
-
-        if (openPgpProvider == null) {
-            setCryptoProviderState(CryptoProviderState.UNCONFIGURED);
-            return;
-        }
-
-        setCryptoProviderState(CryptoProviderState.UNINITIALIZED);
-        openPgpServiceConnection = new OpenPgpServiceConnection(context, openPgpProvider, new OnBound() {
-            @Override
-            public void onBound(IOpenPgpService2 service) {
-                cryptoProviderBindOrCheckPermission();
-            }
-
-            @Override
-            public void onError(Exception e) {
-                onCryptoProviderError(e);
-            }
-        });
-        cryptoProviderBindOrCheckPermission();
-
-        recipientMvpView.setCryptoProvider(openPgpProvider);
-    }
-
-    private void cryptoProviderBindOrCheckPermission() {
-        if (openPgpServiceConnection == null) {
-            setCryptoProviderState(CryptoProviderState.UNCONFIGURED);
-            return;
-        }
-
-        if (!openPgpServiceConnection.isBound()) {
-            pendingUserInteractionIntent = null;
-            openPgpServiceConnection.bindToService();
-            return;
-        }
-
-        if (pendingUserInteractionIntent != null) {
-            recipientMvpView
-                    .launchUserInteractionPendingIntent(pendingUserInteractionIntent, OPENPGP_USER_INTERACTION);
-            pendingUserInteractionIntent = null;
-            return;
-        }
-
-        getOpenPgpApi().checkPermissionPing(this);
-    }
-
-    private void onCryptoProviderError(Exception e) {
-        // TODO handle error case better
-        recipientMvpView.showErrorOpenPgpConnection();
-        setCryptoProviderState(CryptoProviderState.ERROR);
-        Timber.e(e, "error connecting to crypto provider!");
-        asyncUpdateCryptoStatus();
-    }
-
-    @Override
-    public void onPgpPermissionCheckResult(Intent result) {
-        int resultCode = result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
-        switch (resultCode) {
-            case OpenPgpApi.RESULT_CODE_SUCCESS:
-                setCryptoProviderState(CryptoProviderState.OK);
-                break;
-
-            case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
-                recipientMvpView.showErrorOpenPgpUserInteractionRequired();
-                pendingUserInteractionIntent = result.getParcelableExtra(OpenPgpApi.RESULT_INTENT);
-                setCryptoProviderState(CryptoProviderState.ERROR);
-                break;
-
-            case OpenPgpApi.RESULT_CODE_ERROR:
-            default:
-                if (result.hasExtra(OpenPgpApi.RESULT_ERROR)) {
-                    OpenPgpError error = result.getParcelableExtra(OpenPgpApi.RESULT_ERROR);
-                    if (error != null) {
-                        handleOpenPgpError(error);
-                    } else {
-                        recipientMvpView.showErrorOpenPgpConnection();
-                        setCryptoProviderState(CryptoProviderState.ERROR);
-                    }
-                } else {
-                    recipientMvpView.showErrorOpenPgpConnection();
-                    setCryptoProviderState(CryptoProviderState.ERROR);
-                }
-                break;
-        }
-    }
-
-    private void handleOpenPgpError(OpenPgpError error) {
-        Timber.e("OpenPGP Api error: %s", error);
-
-        if (error.getErrorId() == OpenPgpError.INCOMPATIBLE_API_VERSIONS) {
-            // nothing we can do here, this is irrecoverable!
-            openPgpProvider = null;
-            account.setOpenPgpProvider(null);
-            recipientMvpView.showErrorOpenPgpIncompatible();
-            setCryptoProviderState(CryptoProviderState.UNCONFIGURED);
-        } else {
-            recipientMvpView.showErrorOpenPgpConnection();
-        }
-    }
-
-    private void setCryptoProviderState(CryptoProviderState state) {
-        cryptoProviderState = state;
-
-        if (state == CryptoProviderState.OK) {
-            recipientMvpView.setCryptoProvider(openPgpProvider);
-        } else {
-            recipientMvpView.setCryptoProvider(null);
-        }
-
-        asyncUpdateCryptoStatus();
-    }
-
-    public void onActivityDestroy() {
-        if (openPgpServiceConnection != null && openPgpServiceConnection.isBound()) {
-            openPgpServiceConnection.unbindFromService();
-        }
-        openPgpServiceConnection = null;
-    }
-
-    private OpenPgpApi getOpenPgpApi() {
-        if (openPgpServiceConnection == null || !openPgpServiceConnection.isBound()) {
-            Timber.e("obtained openpgpapi object, but service is not bound! inconsistent state?");
-        }
-        return new OpenPgpApi(context, openPgpServiceConnection.getService());
-    }
-
     public void builderSetProperties(MessageBuilder messageBuilder) {
         if (messageBuilder instanceof PgpMessageBuilder) {
             throw new IllegalArgumentException("PpgMessageBuilder must be called with ComposeCryptoStatus argument!");
@@ -866,7 +714,7 @@ public class RecipientPresenter implements PermissionPingCallback {
         pgpMessageBuilder.setCc(getCcAddresses());
         pgpMessageBuilder.setBcc(getBccAddresses());
 
-        pgpMessageBuilder.setOpenPgpApi(getOpenPgpApi());
+        pgpMessageBuilder.setOpenPgpApi(openPgpApiManager.getOpenPgpApi());
         pgpMessageBuilder.setCryptoStatus(cryptoStatus);
     }
 
@@ -955,33 +803,47 @@ public class RecipientPresenter implements PermissionPingCallback {
         }
     }
 
-    @VisibleForTesting
-    void setOpenPgpServiceConnection(OpenPgpServiceConnection openPgpServiceConnection, String cryptoProvider) {
-        this.openPgpServiceConnection = openPgpServiceConnection;
-        this.openPgpProvider = cryptoProvider;
-    }
-
     public boolean shouldSaveRemotely() {
         // TODO more appropriate logic?
         return cachedCryptoStatus == null || !cachedCryptoStatus.isEncryptionEnabled();
     }
 
-    public enum CryptoProviderState {
-        UNCONFIGURED,
-        UNINITIALIZED,
-        LOST_CONNECTION,
-        ERROR,
-        OK
+    public interface RecipientsChangedListener {
+        void onRecipientsChanged();
     }
+
+    private final OpenPgpApiManagerCallback openPgpCallback = new OpenPgpApiManagerCallback() {
+        @Override
+        public void launchUserInteractionPendingIntent(PendingIntent pendingIntent) {
+            recipientMvpView.launchUserInteractionPendingIntent(pendingIntent, 0);
+        }
+
+        @Override
+        public void onCryptoStatusChanged() {
+            asyncUpdateCryptoStatus();
+        }
+
+        @Override
+        public void onCryptoProviderError(CryptoProviderError error) {
+            switch (error) {
+                case VersionIncompatible:
+                    recipientMvpView.showErrorOpenPgpIncompatible();
+                    break;
+                case UserInteractionRequired:
+                    recipientMvpView.showErrorOpenPgpUserInteractionRequired();
+                    break;
+                case ConnectionFailed:
+                default:
+                    recipientMvpView.showErrorOpenPgpConnection();
+                    break;
+            }
+        }
+    };
 
     public enum CryptoMode {
         SIGN_ONLY,
         NO_CHOICE,
         CHOICE_DISABLED,
         CHOICE_ENABLED,
-    }
-
-    public interface RecipientsChangedListener {
-        void onRecipientsChanged();
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -659,7 +659,6 @@ public class RecipientPresenter {
                 recipientMvpView.launchUserInteractionPendingIntent(pendingIntent, OPENPGP_USER_INTERACTION);
                 break;
 
-            case LOST_CONNECTION:
             case UNINITIALIZED:
             case ERROR:
                 openPgpApiManager.refreshConnection();
@@ -837,6 +836,9 @@ public class RecipientPresenter {
         @Override
         public void onOpenPgpProviderError(OpenPgpProviderError error) {
             switch (error) {
+                case ConnectionLost:
+                    openPgpApiManager.refreshConnection();
+                    break;
                 case VersionIncompatible:
                     recipientMvpView.showErrorOpenPgpIncompatible();
                     break;

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -9,7 +9,6 @@ import java.util.List;
 import android.app.Activity;
 import android.app.LoaderManager;
 import android.app.PendingIntent;
-import android.arch.lifecycle.Lifecycle;
 import android.content.Context;
 import android.content.Intent;
 import android.content.pm.PackageManager;
@@ -88,8 +87,9 @@ public class RecipientPresenter {
     private boolean cryptoEnablePgpInline = false;
 
 
-    public RecipientPresenter(Context context, Lifecycle lifecycle, LoaderManager loaderManager,
-            RecipientMvpView recipientMvpView, Account account, ComposePgpInlineDecider composePgpInlineDecider,
+    public RecipientPresenter(Context context, LoaderManager loaderManager,
+            OpenPgpApiManager openPgpApiManager, RecipientMvpView recipientMvpView, Account account,
+            ComposePgpInlineDecider composePgpInlineDecider,
             ComposePgpEnableByDefaultDecider composePgpEnableByDefaultDecider,
             AutocryptStatusInteractor autocryptStatusInteractor,
             ReplyToParser replyToParser, RecipientsChangedListener recipientsChangedListener) {
@@ -100,7 +100,7 @@ public class RecipientPresenter {
         this.composePgpEnableByDefaultDecider = composePgpEnableByDefaultDecider;
         this.replyToParser = replyToParser;
         this.listener = recipientsChangedListener;
-        this.openPgpApiManager = new OpenPgpApiManager(context, lifecycle, openPgpCallback, account.getOpenPgpProvider());
+        this.openPgpApiManager = openPgpApiManager;
 
         recipientMvpView.setPresenter(this);
         recipientMvpView.setLoaderManager(loaderManager);
@@ -308,7 +308,7 @@ public class RecipientPresenter {
 
         String openPgpProvider = account.getOpenPgpProvider();
         recipientMvpView.setCryptoProvider(openPgpProvider);
-        // openPgpApiManager.setOpenPgpProvider(openPgpProvider);
+        openPgpApiManager.setOpenPgpProvider(openPgpProvider, openPgpCallback);
     }
 
     @SuppressWarnings("UnusedParameters")

--- a/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -42,10 +42,10 @@ import com.fsck.k9.message.ComposePgpEnableByDefaultDecider;
 import com.fsck.k9.message.ComposePgpInlineDecider;
 import com.fsck.k9.message.MessageBuilder;
 import com.fsck.k9.message.PgpMessageBuilder;
-import com.fsck.k9.ui.crypto.OpenPgpApiManager;
-import com.fsck.k9.ui.crypto.OpenPgpApiManager.CryptoProviderError;
-import com.fsck.k9.ui.crypto.OpenPgpApiManager.OpenPgpApiManagerCallback;
-import com.fsck.k9.ui.crypto.OpenPgpApiManager.CryptoProviderState;
+import org.openintents.openpgp.OpenPgpApiManager;
+import org.openintents.openpgp.OpenPgpApiManager.OpenPgpProviderError;
+import org.openintents.openpgp.OpenPgpApiManager.OpenPgpApiManagerCallback;
+import org.openintents.openpgp.OpenPgpApiManager.OpenPgpProviderState;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
 import timber.log.Timber;
 
@@ -380,7 +380,7 @@ public class RecipientPresenter {
     public void asyncUpdateCryptoStatus() {
         cachedCryptoStatus = null;
 
-        final CryptoProviderState cryptoProviderState = openPgpApiManager.getCryptoProviderState();
+        final OpenPgpProviderState openPgpProviderState = openPgpApiManager.getOpenPgpProviderState();
 
         Long accountCryptoKey = account.getOpenPgpKey();
         if (accountCryptoKey == Account.NO_OPENPGP_KEY) {
@@ -388,7 +388,7 @@ public class RecipientPresenter {
         }
 
         final ComposeCryptoStatus composeCryptoStatus = new ComposeCryptoStatusBuilder()
-                .setCryptoProviderState(cryptoProviderState)
+                .setOpenPgpProviderState(openPgpProviderState)
                 .setCryptoMode(currentCryptoMode)
                 .setEnablePgpInline(cryptoEnablePgpInline)
                 .setPreferEncryptMutual(account.getAutocryptPreferEncryptMutual())
@@ -401,7 +401,7 @@ public class RecipientPresenter {
         new AsyncTask<Void,Void,RecipientAutocryptStatus>() {
             @Override
             protected RecipientAutocryptStatus doInBackground(Void... voids) {
-                if (cryptoProviderState != CryptoProviderState.OK) {
+                if (openPgpProviderState != OpenPgpProviderState.OK) {
                     return null;
                 }
 
@@ -606,7 +606,7 @@ public class RecipientPresenter {
     }
 
     void onClickCryptoStatus() {
-        switch (openPgpApiManager.getCryptoProviderState()) {
+        switch (openPgpApiManager.getOpenPgpProviderState()) {
             case UNCONFIGURED:
                 Timber.e("click on crypto status while unconfigured - this should not really happen?!");
                 return;
@@ -819,12 +819,12 @@ public class RecipientPresenter {
         }
 
         @Override
-        public void onCryptoStatusChanged() {
+        public void onOpenPgpProviderStatusChanged() {
             asyncUpdateCryptoStatus();
         }
 
         @Override
-        public void onCryptoProviderError(CryptoProviderError error) {
+        public void onOpenPgpProviderError(OpenPgpProviderError error) {
             switch (error) {
                 case VersionIncompatible:
                     recipientMvpView.showErrorOpenPgpIncompatible();

--- a/k9mail/src/main/java/com/fsck/k9/ui/crypto/OpenPgpApiManager.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/crypto/OpenPgpApiManager.java
@@ -1,0 +1,207 @@
+package com.fsck.k9.ui.crypto;
+
+
+import android.app.PendingIntent;
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.Lifecycle.Event;
+import android.arch.lifecycle.LifecycleObserver;
+import android.arch.lifecycle.OnLifecycleEvent;
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.Nullable;
+
+import org.openintents.openpgp.IOpenPgpService2;
+import org.openintents.openpgp.OpenPgpError;
+import org.openintents.openpgp.util.OpenPgpApi;
+import org.openintents.openpgp.util.OpenPgpApi.IOpenPgpCallback;
+import org.openintents.openpgp.util.OpenPgpServiceConnection;
+import org.openintents.openpgp.util.OpenPgpServiceConnection.OnBound;
+import timber.log.Timber;
+
+
+public class OpenPgpApiManager implements LifecycleObserver {
+    private final Context context;
+    private final String openPgpProvider;
+
+    private OpenPgpServiceConnection openPgpServiceConnection;
+    private OpenPgpApi openPgpApi;
+    private PendingIntent pendingUserInteractionIntent;
+    private OpenPgpApiManagerCallback callback;
+    private CryptoProviderState cryptoProviderState = CryptoProviderState.UNCONFIGURED;
+
+    public OpenPgpApiManager(Context context, Lifecycle lifecycle,
+            OpenPgpApiManagerCallback callback, String openPgpProvider) {
+        this.context = context;
+        this.callback = callback;
+        this.openPgpProvider = openPgpProvider;
+
+        lifecycle.addObserver(this);
+    }
+
+    @OnLifecycleEvent(Event.ON_CREATE)
+    void onLifecycleCreate() {
+        setupCryptoProvider();
+    }
+
+    @OnLifecycleEvent(Event.ON_START)
+    void onLifecycleStart() {
+        refreshConnection();
+    }
+
+    @OnLifecycleEvent(Event.ON_DESTROY)
+    public void onLifecycleDestroy() {
+        disconnect();
+    }
+
+    private void setupCryptoProvider() {
+        boolean providerIsBound = openPgpServiceConnection != null && openPgpServiceConnection.isBound();
+        if (providerIsBound) {
+            refreshConnection();
+            return;
+        }
+
+        if (openPgpProvider == null) {
+            setCryptoProviderState(CryptoProviderState.UNCONFIGURED);
+            return;
+        }
+
+        setCryptoProviderState(CryptoProviderState.UNINITIALIZED);
+        openPgpServiceConnection = new OpenPgpServiceConnection(context, openPgpProvider, new OnBound() {
+            @Override
+            public void onBound(IOpenPgpService2 service) {
+                openPgpApi = new OpenPgpApi(context, service);
+                refreshConnection();
+            }
+
+            @Override
+            public void onError(Exception e) {
+                Timber.e(e, "error connecting to crypto provider!");
+                setCryptoProviderState(CryptoProviderState.ERROR);
+                callback.onCryptoProviderError(CryptoProviderError.ConnectionFailed);
+            }
+        });
+        refreshConnection();
+    }
+
+    public void refreshConnection() {
+        boolean isOkStateButLostConnection = cryptoProviderState == CryptoProviderState.OK &&
+                (openPgpServiceConnection == null || !openPgpServiceConnection.isBound());
+        if (isOkStateButLostConnection) {
+            setCryptoProviderState(CryptoProviderState.LOST_CONNECTION);
+            pendingUserInteractionIntent = null;
+            return;
+        }
+
+        if (openPgpServiceConnection == null) {
+            setCryptoProviderState(CryptoProviderState.UNCONFIGURED);
+            return;
+        }
+
+        if (!openPgpServiceConnection.isBound()) {
+            pendingUserInteractionIntent = null;
+            openPgpServiceConnection.bindToService();
+            return;
+        }
+
+        if (pendingUserInteractionIntent != null) {
+            callback.launchUserInteractionPendingIntent(pendingUserInteractionIntent);
+            pendingUserInteractionIntent = null;
+            return;
+        }
+
+        Intent intent = new Intent(OpenPgpApi.ACTION_CHECK_PERMISSION);
+        getOpenPgpApi().executeApiAsync(intent, null, null, new IOpenPgpCallback() {
+            @Override
+            public void onReturn(Intent result) {
+                onPgpPermissionCheckResult(result);
+            }
+        });
+    }
+
+    public void onUserInteractionResult() {
+        refreshConnection();
+    }
+
+    private void onPgpPermissionCheckResult(Intent result) {
+        int resultCode = result.getIntExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_ERROR);
+        switch (resultCode) {
+            case OpenPgpApi.RESULT_CODE_SUCCESS:
+                setCryptoProviderState(CryptoProviderState.OK);
+                break;
+
+            case OpenPgpApi.RESULT_CODE_USER_INTERACTION_REQUIRED:
+                pendingUserInteractionIntent = result.getParcelableExtra(OpenPgpApi.RESULT_INTENT);
+                setCryptoProviderState(CryptoProviderState.ERROR);
+                callback.onCryptoProviderError(CryptoProviderError.UserInteractionRequired);
+                break;
+
+            case OpenPgpApi.RESULT_CODE_ERROR:
+            default:
+                if (result.hasExtra(OpenPgpApi.RESULT_ERROR)) {
+                    OpenPgpError error = result.getParcelableExtra(OpenPgpApi.RESULT_ERROR);
+                    handleOpenPgpError(error);
+                } else {
+                    setCryptoProviderState(CryptoProviderState.ERROR);
+                    callback.onCryptoProviderError(CryptoProviderError.ConnectionFailed);
+                }
+                break;
+        }
+    }
+
+    private void setCryptoProviderState(CryptoProviderState state) {
+        boolean statusChanged = cryptoProviderState != state;
+        if (statusChanged) {
+            cryptoProviderState = state;
+            callback.onCryptoStatusChanged();
+        }
+    }
+
+    private void handleOpenPgpError(@Nullable OpenPgpError error) {
+        Timber.e("OpenPGP Api error: %s", error);
+
+        if (error != null && error.getErrorId() == OpenPgpError.INCOMPATIBLE_API_VERSIONS) {
+            callback.onCryptoProviderError(CryptoProviderError.VersionIncompatible);
+            setCryptoProviderState(CryptoProviderState.UNCONFIGURED);
+        } else {
+            callback.onCryptoProviderError(CryptoProviderError.ConnectionFailed);
+            setCryptoProviderState(CryptoProviderState.ERROR);
+        }
+    }
+
+    private void disconnect() {
+        openPgpApi = null;
+        if (openPgpServiceConnection != null) {
+            openPgpServiceConnection.unbindFromService();
+        }
+        openPgpServiceConnection = null;
+    }
+
+    public OpenPgpApi getOpenPgpApi() {
+        if (openPgpServiceConnection == null || !openPgpServiceConnection.isBound()) {
+            Timber.e("obtained openpgpapi object, but service is not bound! inconsistent state?");
+        }
+        return openPgpApi;
+    }
+
+    public CryptoProviderState getCryptoProviderState() {
+        return cryptoProviderState;
+    }
+
+    public enum CryptoProviderState {
+        UNCONFIGURED,
+        UNINITIALIZED,
+        LOST_CONNECTION,
+        ERROR,
+        OK
+    }
+
+    public enum CryptoProviderError {
+        ConnectionFailed, VersionIncompatible, UserInteractionRequired
+    }
+
+    public interface OpenPgpApiManagerCallback {
+        void launchUserInteractionPendingIntent(PendingIntent pendingIntent);
+        void onCryptoStatusChanged();
+        void onCryptoProviderError(CryptoProviderError error);
+    }
+}

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1177,7 +1177,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="crypto_mode_private">Encrypt</string>
     <string name="error_crypto_provider_incompatible">Crypto provider uses incompatible version. Please check your settings!</string>
     <string name="error_crypto_provider_connect">Cannot connect to crypto provider, check your settings or click crypto icon to retry!</string>
-    <string name="error_crypto_provider_ui_required">Crypto provider access denied, click crypto icon to retry!</string>
+    <string name="error_crypto_provider_ui_required">Failed to initialize end-to-end encryption, please check your settings</string>
     <string name="error_crypto_inline_attach">PGP/INLINE mode does not support attachments!</string>
     <string name="enable_inline_pgp">Enable PGP/INLINE</string>
     <string name="disable_inline_pgp">Disable PGP/INLINE</string>

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
@@ -6,11 +6,8 @@ import java.util.List;
 
 import android.app.LoaderManager;
 import android.content.Context;
-import android.content.Intent;
-import android.os.ParcelFileDescriptor;
 
 import com.fsck.k9.Account;
-import com.fsck.k9.K9;
 import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.activity.compose.RecipientMvpView.CryptoSpecialModeDisplayType;
 import com.fsck.k9.activity.compose.RecipientMvpView.CryptoStatusDisplayType;
@@ -28,9 +25,11 @@ import com.fsck.k9.message.ComposePgpInlineDecider;
 import com.fsck.k9.view.RecipientSelectView.Recipient;
 import org.junit.Before;
 import org.junit.Test;
-import org.openintents.openpgp.IOpenPgpService2;
+import org.mockito.ArgumentCaptor;
+import org.openintents.openpgp.OpenPgpApiManager;
+import org.openintents.openpgp.OpenPgpApiManager.OpenPgpApiManagerCallback;
+import org.openintents.openpgp.OpenPgpApiManager.OpenPgpProviderState;
 import org.openintents.openpgp.util.OpenPgpApi;
-import org.openintents.openpgp.util.OpenPgpServiceConnection;
 import org.openintents.openpgp.util.ShadowOpenPgpAsyncTask;
 import org.robolectric.Robolectric;
 import org.robolectric.annotation.Config;
@@ -42,6 +41,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -66,6 +66,8 @@ public class RecipientPresenterTest extends K9RobolectricTest {
     private RecipientPresenter.RecipientsChangedListener listener;
     private AutocryptStatusInteractor autocryptStatusInteractor;
     private RecipientAutocryptStatus noRecipientsAutocryptResult;
+    private OpenPgpApiManager openPgpApiManager;
+    private OpenPgpApiManagerCallback openPgpApiManagerCallback;
 
 
     @Before
@@ -74,6 +76,7 @@ public class RecipientPresenterTest extends K9RobolectricTest {
         Robolectric.getBackgroundThreadScheduler().pause();
 
         recipientMvpView = mock(RecipientMvpView.class);
+        openPgpApiManager = mock(OpenPgpApiManager.class);
         account = mock(Account.class);
         composePgpInlineDecider = mock(ComposePgpInlineDecider.class);
         composePgpEnableByDefaultDecider = mock(ComposePgpEnableByDefaultDecider.class);
@@ -82,10 +85,16 @@ public class RecipientPresenterTest extends K9RobolectricTest {
         LoaderManager loaderManager = mock(LoaderManager.class);
         listener = mock(RecipientPresenter.RecipientsChangedListener.class);
 
+        when(openPgpApiManager.getOpenPgpProviderState()).thenReturn(OpenPgpProviderState.UNCONFIGURED);
+
         recipientPresenter = new RecipientPresenter(
-                context, getLifecycle(), loaderManager, recipientMvpView, account, composePgpInlineDecider,
-                composePgpEnableByDefaultDecider, autocryptStatusInteractor, replyToParser, listener);
-        runBackgroundTask();
+                context, loaderManager, openPgpApiManager, recipientMvpView, account, composePgpInlineDecider,
+                composePgpEnableByDefaultDecider, autocryptStatusInteractor, replyToParser, listener
+        );
+
+        ArgumentCaptor<OpenPgpApiManagerCallback> callbackCaptor = ArgumentCaptor.forClass(OpenPgpApiManagerCallback.class);
+        verify(openPgpApiManager).setOpenPgpProvider(isNull(String.class), callbackCaptor.capture());
+        openPgpApiManagerCallback = callbackCaptor.getValue();
 
         noRecipientsAutocryptResult = new RecipientAutocryptStatus(RecipientAutocryptStatusType.NO_RECIPIENTS, null);
     }
@@ -129,6 +138,9 @@ public class RecipientPresenterTest extends K9RobolectricTest {
 
     @Test
     public void getCurrentCryptoStatus_withoutCryptoProvider() throws Exception {
+        when(openPgpApiManager.getOpenPgpProviderState()).thenReturn(OpenPgpProviderState.UNCONFIGURED);
+        recipientPresenter.asyncUpdateCryptoStatus();
+
         ComposeCryptoStatus status = recipientPresenter.getCurrentCachedCryptoStatus();
 
         assertEquals(CryptoStatusDisplayType.UNCONFIGURED, status.getCryptoStatusDisplayType());
@@ -319,28 +331,21 @@ public class RecipientPresenterTest extends K9RobolectricTest {
         assertTrue(taskRun);
     }
 
-    private void setupCryptoProvider(RecipientAutocryptStatus autocryptStatusResult) throws android.os.RemoteException {
+    private void setupCryptoProvider(RecipientAutocryptStatus autocryptStatusResult) throws Exception {
         Account account = mock(Account.class);
-        OpenPgpServiceConnection openPgpServiceConnection = mock(OpenPgpServiceConnection.class);
-        IOpenPgpService2 openPgpService2 = mock(IOpenPgpService2.class);
-        Intent permissionPingIntent = new Intent();
+        OpenPgpApi openPgpApi = mock(OpenPgpApi.class);
 
+        when(account.getOpenPgpProvider()).thenReturn(CRYPTO_PROVIDER);
+        when(account.isOpenPgpProviderConfigured()).thenReturn(true);
+        when(account.getOpenPgpKey()).thenReturn(CRYPTO_KEY_ID);
+        recipientPresenter.onSwitchAccount(account);
+
+        when(openPgpApiManager.getOpenPgpProviderState()).thenReturn(OpenPgpProviderState.OK);
+        when(openPgpApiManager.getOpenPgpApi()).thenReturn(openPgpApi);
         when(autocryptStatusInteractor.retrieveCryptoProviderRecipientStatus(
                 any(OpenPgpApi.class), any(String[].class))).thenReturn(autocryptStatusResult);
 
-        permissionPingIntent.putExtra(OpenPgpApi.RESULT_CODE, OpenPgpApi.RESULT_CODE_SUCCESS);
-        when(account.getOpenPgpKey()).thenReturn(CRYPTO_KEY_ID);
-        when(account.isOpenPgpProviderConfigured()).thenReturn(true);
-        when(account.getOpenPgpProvider()).thenReturn(CRYPTO_PROVIDER);
-        when(openPgpServiceConnection.isBound()).thenReturn(true);
-        when(openPgpServiceConnection.getService()).thenReturn(openPgpService2);
-        when(openPgpService2.execute(any(Intent.class), any(ParcelFileDescriptor.class), any(Integer.class)))
-                .thenReturn(permissionPingIntent);
-
-        recipientPresenter.setOpenPgpServiceConnection(openPgpServiceConnection, CRYPTO_PROVIDER);
-        recipientPresenter.onSwitchAccount(account);
-        // one for the permission ping, one for the async status update
-        runBackgroundTask();
+        openPgpApiManagerCallback.onOpenPgpProviderStatusChanged();
         runBackgroundTask();
     }
 }

--- a/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/activity/compose/RecipientPresenterTest.java
@@ -83,7 +83,7 @@ public class RecipientPresenterTest extends K9RobolectricTest {
         listener = mock(RecipientPresenter.RecipientsChangedListener.class);
 
         recipientPresenter = new RecipientPresenter(
-                context, loaderManager, recipientMvpView, account, composePgpInlineDecider,
+                context, getLifecycle(), loaderManager, recipientMvpView, account, composePgpInlineDecider,
                 composePgpEnableByDefaultDecider, autocryptStatusInteractor, replyToParser, listener);
         runBackgroundTask();
 

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -86,7 +86,7 @@ public class PgpMessageBuilderTest extends K9RobolectricTest {
     public void build__withCryptoProviderUnconfigured__shouldThrow() throws MessagingException {
         cryptoStatusBuilder.setCryptoMode(CryptoMode.NO_CHOICE);
 
-        cryptoStatusBuilder.setCryptoProviderState(CryptoProviderState.UNCONFIGURED);
+        cryptoStatusBuilder.setOpenPgpProviderState(CryptoProviderState.UNCONFIGURED);
         pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
 
         Callback mockCallback = mock(Callback.class);
@@ -100,7 +100,7 @@ public class PgpMessageBuilderTest extends K9RobolectricTest {
     public void build__withCryptoProviderUninitialized__shouldThrow() throws MessagingException {
         cryptoStatusBuilder.setCryptoMode(CryptoMode.NO_CHOICE);
 
-        cryptoStatusBuilder.setCryptoProviderState(CryptoProviderState.UNINITIALIZED);
+        cryptoStatusBuilder.setOpenPgpProviderState(CryptoProviderState.UNINITIALIZED);
         pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
 
         Callback mockCallback = mock(Callback.class);
@@ -114,7 +114,7 @@ public class PgpMessageBuilderTest extends K9RobolectricTest {
     public void build__withCryptoProviderError__shouldThrow() throws MessagingException {
         cryptoStatusBuilder.setCryptoMode(CryptoMode.NO_CHOICE);
 
-        cryptoStatusBuilder.setCryptoProviderState(CryptoProviderState.ERROR);
+        cryptoStatusBuilder.setOpenPgpProviderState(CryptoProviderState.ERROR);
         pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
 
         Callback mockCallback = mock(Callback.class);
@@ -128,7 +128,7 @@ public class PgpMessageBuilderTest extends K9RobolectricTest {
     public void build__withCryptoProviderLostConnection__shouldThrow() throws MessagingException {
         cryptoStatusBuilder.setCryptoMode(CryptoMode.NO_CHOICE);
 
-        cryptoStatusBuilder.setCryptoProviderState(CryptoProviderState.LOST_CONNECTION);
+        cryptoStatusBuilder.setOpenPgpProviderState(CryptoProviderState.LOST_CONNECTION);
         pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
 
         Callback mockCallback = mock(Callback.class);
@@ -607,7 +607,7 @@ public class PgpMessageBuilderTest extends K9RobolectricTest {
                 .setPreferEncryptMutual(false)
                 .setOpenPgpKeyId(TEST_KEY_ID)
                 .setRecipients(new ArrayList<Recipient>())
-                .setCryptoProviderState(CryptoProviderState.OK);
+                .setOpenPgpProviderState(CryptoProviderState.OK);
     }
 
     private static PgpMessageBuilder createDefaultPgpMessageBuilder(OpenPgpApi openPgpApi,

--- a/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/PgpMessageBuilderTest.java
@@ -21,7 +21,6 @@ import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus.ComposeCryptoStatusBuilder;
 import com.fsck.k9.activity.compose.RecipientPresenter.CryptoMode;
-import com.fsck.k9.activity.compose.RecipientPresenter.CryptoProviderState;
 import com.fsck.k9.activity.misc.Attachment;
 import com.fsck.k9.autocrypt.AutocryptOpenPgpApiInteractor;
 import com.fsck.k9.autocrypt.AutocryptOperations;
@@ -45,6 +44,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
+import org.openintents.openpgp.OpenPgpApiManager.OpenPgpProviderState;
 import org.openintents.openpgp.OpenPgpError;
 import org.openintents.openpgp.util.OpenPgpApi;
 import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
@@ -86,7 +86,7 @@ public class PgpMessageBuilderTest extends K9RobolectricTest {
     public void build__withCryptoProviderUnconfigured__shouldThrow() throws MessagingException {
         cryptoStatusBuilder.setCryptoMode(CryptoMode.NO_CHOICE);
 
-        cryptoStatusBuilder.setOpenPgpProviderState(CryptoProviderState.UNCONFIGURED);
+        cryptoStatusBuilder.setOpenPgpProviderState(OpenPgpProviderState.UNCONFIGURED);
         pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
 
         Callback mockCallback = mock(Callback.class);
@@ -100,7 +100,7 @@ public class PgpMessageBuilderTest extends K9RobolectricTest {
     public void build__withCryptoProviderUninitialized__shouldThrow() throws MessagingException {
         cryptoStatusBuilder.setCryptoMode(CryptoMode.NO_CHOICE);
 
-        cryptoStatusBuilder.setOpenPgpProviderState(CryptoProviderState.UNINITIALIZED);
+        cryptoStatusBuilder.setOpenPgpProviderState(OpenPgpProviderState.UNINITIALIZED);
         pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
 
         Callback mockCallback = mock(Callback.class);
@@ -114,21 +114,7 @@ public class PgpMessageBuilderTest extends K9RobolectricTest {
     public void build__withCryptoProviderError__shouldThrow() throws MessagingException {
         cryptoStatusBuilder.setCryptoMode(CryptoMode.NO_CHOICE);
 
-        cryptoStatusBuilder.setOpenPgpProviderState(CryptoProviderState.ERROR);
-        pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
-
-        Callback mockCallback = mock(Callback.class);
-        pgpMessageBuilder.buildAsync(mockCallback);
-
-        verify(mockCallback).onMessageBuildException(any(MessagingException.class));
-        verifyNoMoreInteractions(mockCallback);
-    }
-
-    @Test
-    public void build__withCryptoProviderLostConnection__shouldThrow() throws MessagingException {
-        cryptoStatusBuilder.setCryptoMode(CryptoMode.NO_CHOICE);
-
-        cryptoStatusBuilder.setOpenPgpProviderState(CryptoProviderState.LOST_CONNECTION);
+        cryptoStatusBuilder.setOpenPgpProviderState(OpenPgpProviderState.ERROR);
         pgpMessageBuilder.setCryptoStatus(cryptoStatusBuilder.build());
 
         Callback mockCallback = mock(Callback.class);
@@ -607,7 +593,7 @@ public class PgpMessageBuilderTest extends K9RobolectricTest {
                 .setPreferEncryptMutual(false)
                 .setOpenPgpKeyId(TEST_KEY_ID)
                 .setRecipients(new ArrayList<Recipient>())
-                .setOpenPgpProviderState(CryptoProviderState.OK);
+                .setOpenPgpProviderState(OpenPgpProviderState.OK);
     }
 
     private static PgpMessageBuilder createDefaultPgpMessageBuilder(OpenPgpApi openPgpApi,

--- a/plugins/openpgp-api-lib/openpgp-api/build.gradle
+++ b/plugins/openpgp-api-lib/openpgp-api/build.gradle
@@ -18,6 +18,11 @@ android {
     }
 }
 
+dependencies {
+    implementation "android.arch.lifecycle:extensions:1.1.0"
+    implementation "com.jakewharton.timber:timber:${timberVersion}"
+}
+
 /*
 publish {
     userOrg = 'sufficientlysecure'

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/OpenPgpApiManager.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/OpenPgpApiManager.java
@@ -20,19 +20,19 @@ import timber.log.Timber;
 
 public class OpenPgpApiManager implements LifecycleObserver {
     private final Context context;
-    private final String openPgpProvider;
+
+    @Nullable
+    private String openPgpProvider;
+    @Nullable
+    private OpenPgpApiManagerCallback callback;
 
     private OpenPgpServiceConnection openPgpServiceConnection;
     private OpenPgpApi openPgpApi;
     private PendingIntent userInteractionPendingIntent;
-    private OpenPgpApiManagerCallback callback;
     private OpenPgpProviderState openPgpProviderState = OpenPgpProviderState.UNCONFIGURED;
 
-    public OpenPgpApiManager(Context context, Lifecycle lifecycle,
-            OpenPgpApiManagerCallback callback, String openPgpProvider) {
+    public OpenPgpApiManager(Context context, Lifecycle lifecycle) {
         this.context = context;
-        this.callback = callback;
-        this.openPgpProvider = openPgpProvider;
 
         lifecycle.addObserver(this);
     }
@@ -50,6 +50,17 @@ public class OpenPgpApiManager implements LifecycleObserver {
     @OnLifecycleEvent(Event.ON_DESTROY)
     public void onLifecycleDestroy() {
         disconnect();
+    }
+
+    public void setOpenPgpProvider(@Nullable String openPgpProvider, OpenPgpApiManagerCallback callback) {
+        if (openPgpProvider == null || !openPgpProvider.equals(this.openPgpProvider)) {
+            disconnect();
+        }
+
+        this.openPgpProvider = openPgpProvider;
+        this.callback = callback;
+
+        setupCryptoProvider();
     }
 
     private void setupCryptoProvider() {


### PR DESCRIPTION
This offloads the openpgp service connection code into a specialized class (-200 lines recipientpresenter, yay). This class behaves fairly passively, returning simple callbacks and leaving all handling of error states to the caller.

I plan to use this in other places as well, including the e2e settings dialog. At the moment there are a couple of states that show pending intents for openpgp setup stuff, but I want to change those to go to the e2e settings in a follow-up PR.