### PR TITLE
Account e2e improved

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/K9PreferenceActivity.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/K9PreferenceActivity.java
@@ -1,19 +1,72 @@
 package com.fsck.k9.activity;
 
+
+import android.arch.lifecycle.Lifecycle;
+import android.arch.lifecycle.Lifecycle.State;
+import android.arch.lifecycle.LifecycleOwner;
+import android.arch.lifecycle.LifecycleRegistry;
 import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.Preference;
 import android.preference.PreferenceActivity;
+import android.support.annotation.NonNull;
 
 import com.fsck.k9.K9;
 
 
-public abstract class K9PreferenceActivity extends PreferenceActivity {
+public abstract class K9PreferenceActivity extends PreferenceActivity implements LifecycleOwner {
+    private LifecycleRegistry lifecycleRegistry;
+
     @Override
     public void onCreate(Bundle icicle) {
         K9ActivityCommon.setLanguage(this, K9.getK9Language());
         setTheme(K9.getK9ThemeResourceId());
         super.onCreate(icicle);
+        lifecycleRegistry = new LifecycleRegistry(this);
+        lifecycleRegistry.markState(State.CREATED);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        lifecycleRegistry.markState(State.STARTED);
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        lifecycleRegistry.markState(State.RESUMED);
+    }
+
+    @Override
+    protected void onPause() {
+        lifecycleRegistry.markState(State.STARTED);
+        super.onPause();
+    }
+
+    @Override
+    protected void onStop() {
+        lifecycleRegistry.markState(State.CREATED);
+        super.onStop();
+    }
+
+    @Override
+    protected void onDestroy() {
+        lifecycleRegistry.markState(State.DESTROYED);
+        super.onDestroy();
+    }
+
+    @Override
+    protected void onSaveInstanceState(Bundle outState) {
+        // see https://developer.android.com/topic/libraries/architecture/lifecycle.html#onStop-and-savedState
+        lifecycleRegistry.markState(State.CREATED);
+        super.onSaveInstanceState(outState);
+    }
+
+    @NonNull
+    @Override
+    public Lifecycle getLifecycle() {
+        return lifecycleRegistry;
     }
 
     /**

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -23,7 +23,6 @@ import android.preference.Preference.OnPreferenceClickListener;
 import android.preference.PreferenceScreen;
 import android.preference.RingtonePreference;
 import android.preference.SwitchPreference;
-import android.text.TextUtils;
 import android.widget.ListAdapter;
 import android.widget.Toast;
 
@@ -50,6 +49,7 @@ import com.fsck.k9.mailstore.StorageManager;
 import com.fsck.k9.service.MailService;
 import com.fsck.k9.ui.dialog.AutocryptPreferEncryptDialog;
 import com.fsck.k9.ui.dialog.AutocryptPreferEncryptDialog.OnPreferEncryptChangedListener;
+import org.openintents.openpgp.OpenPgpApiManager;
 import org.openintents.openpgp.util.OpenPgpKeyPreference;
 import org.openintents.openpgp.util.OpenPgpProviderUtil;
 import timber.log.Timber;
@@ -206,6 +206,7 @@ public class AccountSettings extends K9PreferenceActivity {
     private ListPreference trashFolder;
     private CheckBoxPreference alwaysShowCcBcc;
     private SwitchPreference pgpEnable;
+    private OpenPgpApiManager openPgpApiManager;
 
 
     public static void actionSettings(Context context, Account account) {
@@ -224,6 +225,8 @@ public class AccountSettings extends K9PreferenceActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+
+        openPgpApiManager = new OpenPgpApiManager(getApplicationContext(), getLifecycle());
 
         String accountUuid = getIntent().getStringExtra(EXTRA_ACCOUNT);
         account = Preferences.getPreferences(this).getAccount(accountUuid);
@@ -776,11 +779,10 @@ public class AccountSettings extends K9PreferenceActivity {
                     return true;
                 }
             });
-
-            pgpCryptoKey.setOpenPgpProvider(pgpProvider);
         }
 
-        pgpCryptoKey.setEnabled(isPgpConfigured);
+        pgpCryptoKey.setOpenPgpApiManager(openPgpApiManager);
+        pgpCryptoKey.setOpenPgpProvider(pgpProvider);
         pgpCryptoKey.setValue(account.getOpenPgpKey());
         pgpCryptoKey.setDefaultUserId(OpenPgpApiHelper.buildUserId(account.getIdentity(0)));
         pgpCryptoKey.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -777,6 +777,7 @@ public class AccountSettings extends K9PreferenceActivity {
                 public boolean onPreferenceClick(Preference preference) {
                     pgpEnable.setOnPreferenceClickListener(null);
                     account.setOpenPgpProvider(null);
+                    account.setOpenPgpKey(Account.NO_OPENPGP_KEY);
                     setupCryptoSettings();
                     return true;
                 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -713,6 +713,8 @@ public class AccountSettings extends K9PreferenceActivity {
             }
         });
 
+        setupCryptoSettings();
+
         if (savedInstanceState == null && startInOpenPgp) {
             PreferenceScreen preference = (PreferenceScreen) findPreference(PREFERENCE_CRYPTO);
             goToPreferenceScreen(preference);

--- a/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/setup/AccountSettings.java
@@ -781,9 +781,8 @@ public class AccountSettings extends K9PreferenceActivity {
             });
         }
 
-        pgpCryptoKey.setOpenPgpApiManager(openPgpApiManager);
-        pgpCryptoKey.setOpenPgpProvider(pgpProvider);
         pgpCryptoKey.setValue(account.getOpenPgpKey());
+        pgpCryptoKey.setOpenPgpProvider(openPgpApiManager, pgpProvider);
         pgpCryptoKey.setDefaultUserId(OpenPgpApiHelper.buildUserId(account.getIdentity(0)));
         pgpCryptoKey.setOnPreferenceChangeListener(new OnPreferenceChangeListener() {
             public boolean onPreferenceChange(Preference preference, Object newValue) {

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpApi.java
@@ -266,6 +266,7 @@ public class OpenPgpApi {
 
     // GET_SIGN_KEY_ID
     public static final String EXTRA_USER_ID = "user_id";
+    public static final String EXTRA_PRESELECT_KEY_ID = "preselect_key_id";
 
     // GET_KEY
     public static final String EXTRA_KEY_ID = "key_id";

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpKeyPreference.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpKeyPreference.java
@@ -263,7 +263,7 @@ public class OpenPgpKeyPreference extends Preference implements OpenPgpApiManage
         public SavedState(Parcel source) {
             super(source);
 
-            keyId = source.readInt();
+            keyId = source.readLong();
             defaultUserId = source.readString();
         }
 

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpKeyPreference.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpKeyPreference.java
@@ -23,8 +23,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.res.TypedArray;
-import android.os.Parcel;
-import android.os.Parcelable;
 import android.preference.Preference;
 import android.util.AttributeSet;
 import android.util.Log;
@@ -211,84 +209,6 @@ public class OpenPgpKeyPreference extends Preference implements OpenPgpApiManage
             long value = (Long) defaultValue;
             setAndPersist(value);
         }
-    }
-
-    @Override
-    protected Parcelable onSaveInstanceState() {
-        /*
-         * Suppose a client uses this preference type without persisting. We
-         * must save the instance state so it is able to, for example, survive
-         * orientation changes.
-         */
-
-        final Parcelable superState = super.onSaveInstanceState();
-        if (isPersistent()) {
-            // No need to save instance state since it's persistent
-            return superState;
-        }
-
-        // Save the instance state
-        final SavedState myState = new SavedState(superState);
-        myState.keyId = keyId;
-        myState.defaultUserId = defaultUserId;
-        return myState;
-    }
-
-    @Override
-    protected void onRestoreInstanceState(Parcelable state) {
-        if (!state.getClass().equals(SavedState.class)) {
-            // Didn't save state for us in onSaveInstanceState
-            super.onRestoreInstanceState(state);
-            return;
-        }
-
-        // Restore the instance state
-        SavedState myState = (SavedState) state;
-        super.onRestoreInstanceState(myState.getSuperState());
-        keyId = myState.keyId;
-        defaultUserId = myState.defaultUserId;
-        notifyChanged();
-    }
-
-    /**
-     * SavedState, a subclass of {@link BaseSavedState}, will store the state
-     * of MyPreference, a subclass of Preference.
-     * <p/>
-     * It is important to always call through to super methods.
-     */
-    private static class SavedState extends BaseSavedState {
-        long keyId;
-        String defaultUserId;
-
-        public SavedState(Parcel source) {
-            super(source);
-
-            keyId = source.readLong();
-            defaultUserId = source.readString();
-        }
-
-        @Override
-        public void writeToParcel(Parcel dest, int flags) {
-            super.writeToParcel(dest, flags);
-
-            dest.writeLong(keyId);
-            dest.writeString(defaultUserId);
-        }
-
-        public SavedState(Parcelable superState) {
-            super(superState);
-        }
-
-        public static final Parcelable.Creator<SavedState> CREATOR =
-                new Parcelable.Creator<SavedState>() {
-                    public SavedState createFromParcel(Parcel in) {
-                        return new SavedState(in);
-                    }
-
-                    public SavedState[] newArray(int size) {
-                        return new SavedState[size];
-                    }
-                };
     }
 
     public boolean handleOnActivityResult(int requestCode, int resultCode, Intent data) {

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpKeyPreference.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpKeyPreference.java
@@ -26,7 +26,6 @@ import android.content.res.TypedArray;
 import android.preference.Preference;
 import android.text.format.DateUtils;
 import android.util.AttributeSet;
-import android.util.Log;
 
 import org.openintents.openpgp.OpenPgpApiManager;
 import org.openintents.openpgp.OpenPgpApiManager.OpenPgpApiManagerCallback;
@@ -36,6 +35,7 @@ import org.openintents.openpgp.OpenPgpError;
 import org.openintents.openpgp.R;
 import org.openintents.openpgp.util.OpenPgpApi.IOpenPgpCallback;
 import org.openintents.openpgp.util.OpenPgpUtils.UserId;
+import timber.log.Timber;
 
 
 public class OpenPgpKeyPreference extends Preference implements OpenPgpApiManagerCallback {
@@ -149,7 +149,7 @@ public class OpenPgpKeyPreference extends Preference implements OpenPgpApiManage
                 }
                 case OpenPgpApi.RESULT_CODE_ERROR: {
                     OpenPgpError error = result.getParcelableExtra(OpenPgpApi.RESULT_ERROR);
-                    Log.e(OpenPgpApi.TAG, "RESULT_CODE_ERROR: " + error.getMessage());
+                    Timber.e("RESULT_CODE_ERROR: %s", error.getMessage());
 
                     break;
                 }
@@ -169,7 +169,7 @@ public class OpenPgpKeyPreference extends Preference implements OpenPgpApiManage
 
     private void apiStartPendingIntent() {
         if (pendingIntentSelectKey == null) {
-            Log.e(OpenPgpApi.TAG, "Tried to launch pending intent but didn't have any?");
+            Timber.e("Tried to launch pending intent but didn't have any?");
             return;
         }
 
@@ -178,7 +178,7 @@ public class OpenPgpKeyPreference extends Preference implements OpenPgpApiManage
             act.startIntentSenderFromChild(act, pendingIntentSelectKey.getIntentSender(),
                     REQUEST_CODE_KEY_PREFERENCE, null, 0, 0, 0);
         } catch (IntentSender.SendIntentException e) {
-            Log.e(OpenPgpApi.TAG, "SendIntentException", e);
+            Timber.e(e,"Error launching pending intent");
         } finally {
             pendingIntentSelectKey = null;
         }

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/res/values/strings.xml
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/res/values/strings.xml
@@ -3,7 +3,11 @@
 
     <string name="openpgp_list_preference_none">None</string>
     <string name="openpgp_install_openkeychain_via">Install OpenKeychain via %s</string>
+
+    <string name="openpgp_key_title">"Configure end-to-end key"</string>
     <string name="openpgp_no_key_selected">No end-to-end key selected</string>
     <string name="openpgp_key_selected">End-to-end key selected</string>
-
+    <string name="openpgp_key_using">"Using key: %s"</string>
+    <string name="openpgp_key_using_no_name">"Using key: <![CDATA[<no name>]]>"</string>
+    <string name="openpgp_key_created">"Created %s"</string>
 </resources>


### PR DESCRIPTION
This PR has some more work on e2e settings. Notably:

* The OpenPgpKeyPreference now uses an OpenPgpApiManager under the hood (PR based on #3290)
* If available, the key preference displays the name and creation date of the selected key
* Fixes some bugs related to android state saving
* The key setting is no longer remembered when e2e is disabled

See also https://github.com/open-keychain/open-keychain/pull/2301. Between that PR and the related ones here, I feel like the e2e setup flow is slowly becoming acceptable. I made sure this is both forward- and backward-compatible, and tested combiations of old and new branches of K-9 and OpenKeychain for this.