### PR TITLE
Encrypted subjects using protected-headers=v1

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MessageExtractor.java
@@ -208,6 +208,8 @@ public class MessageExtractor {
             outputViewableParts.add(viewable);
         } else if (isSameMimeType(part.getMimeType(), "application/pgp-signature")) {
             // ignore this type explicitly
+        } else if (isSameMimeType(part.getMimeType(), "text/rfc822-headers")) {
+            // ignore this type explicitly
         } else {
             if (skipSavingNonViewableParts) {
                 return;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeHeader.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeHeader.java
@@ -12,6 +12,7 @@ import android.support.annotation.NonNull;
 
 
 public class MimeHeader implements Cloneable {
+    public static final String SUBJECT = "Subject";
     public static final String HEADER_CONTENT_TYPE = "Content-Type";
     public static final String HEADER_CONTENT_TRANSFER_ENCODING = "Content-Transfer-Encoding";
     public static final String HEADER_CONTENT_DISPOSITION = "Content-Disposition";

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1229,8 +1229,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private void processMessageToReplyTo(MessageViewInfo messageViewInfo) throws MessagingException {
         Message message = messageViewInfo.message;
 
-        if (message.getSubject() != null) {
-            final String subject = PREFIX.matcher(message.getSubject()).replaceFirst("");
+        if (messageViewInfo.subject != null) {
+            final String subject = PREFIX.matcher(messageViewInfo.subject).replaceFirst("");
 
             if (!subject.toLowerCase(Locale.US).startsWith("re:")) {
                 subjectView.setText("Re: " + subject);
@@ -1278,7 +1278,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private void processMessageToForward(MessageViewInfo messageViewInfo, boolean asAttachment) throws MessagingException {
         Message message = messageViewInfo.message;
 
-        String subject = message.getSubject();
+        String subject = messageViewInfo.subject;
         if (subject != null && !subject.toLowerCase(Locale.US).startsWith("fwd:")) {
             subjectView.setText("Fwd: " + subject);
         } else {
@@ -1308,7 +1308,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private void processDraftMessage(MessageViewInfo messageViewInfo) {
         Message message = messageViewInfo.message;
         draftId = MessagingController.getInstance(getApplication()).getId(message);
-        subjectView.setText(message.getSubject());
+        subjectView.setText(messageViewInfo.subject);
 
         recipientPresenter.initFromDraftMessage(message);
 

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/CryptoResultAnnotation.java
@@ -109,6 +109,10 @@ public final class CryptoResultAnnotation {
         return openPgpDecryptionResult;
     }
 
+    public boolean isEncrypted() {
+        return openPgpDecryptionResult != null && openPgpDecryptionResult.result == OpenPgpDecryptionResult.RESULT_ENCRYPTED;
+    }
+
     @Nullable
     public OpenPgpSignatureResult getOpenPgpSignatureResult() {
         return openPgpSignatureResult;

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
@@ -12,6 +12,7 @@ public class MessageViewInfo {
     public final Message message;
     public final boolean isMessageIncomplete;
     public final Part rootPart;
+    public final String subject;
     public final AttachmentResolver attachmentResolver;
     public final String text;
     public final CryptoResultAnnotation cryptoResultAnnotation;
@@ -22,6 +23,7 @@ public class MessageViewInfo {
 
     public MessageViewInfo(
             Message message, boolean isMessageIncomplete, Part rootPart,
+            String subject,
             String text, List<AttachmentViewInfo> attachments,
             CryptoResultAnnotation cryptoResultAnnotation,
             AttachmentResolver attachmentResolver,
@@ -29,6 +31,7 @@ public class MessageViewInfo {
         this.message = message;
         this.isMessageIncomplete = isMessageIncomplete;
         this.rootPart = rootPart;
+        this.subject = subject;
         this.text = text;
         this.cryptoResultAnnotation = cryptoResultAnnotation;
         this.attachmentResolver = attachmentResolver;
@@ -40,25 +43,32 @@ public class MessageViewInfo {
     static MessageViewInfo createWithExtractedContent(Message message, Part rootPart, boolean isMessageIncomplete,
             String text, List<AttachmentViewInfo> attachments, AttachmentResolver attachmentResolver) {
         return new MessageViewInfo(
-                message, isMessageIncomplete, rootPart, text, attachments, null, attachmentResolver, null,
+                message, isMessageIncomplete, rootPart, null, text, attachments, null, attachmentResolver, null,
                 Collections.<AttachmentViewInfo>emptyList());
     }
 
     public static MessageViewInfo createWithErrorState(Message message, boolean isMessageIncomplete) {
-        return new MessageViewInfo(message, isMessageIncomplete, null, null, null, null, null, null, null);
+        return new MessageViewInfo(message, isMessageIncomplete, null, null, null, null, null, null, null, null);
     }
 
     public static MessageViewInfo createForMetadataOnly(Message message, boolean isMessageIncomplete) {
-        return new MessageViewInfo(message, isMessageIncomplete, null, null, null, null, null, null, null);
+        return new MessageViewInfo(message, isMessageIncomplete, null, null, null, null, null, null, null, null);
     }
 
     MessageViewInfo withCryptoData(CryptoResultAnnotation rootPartAnnotation, String extraViewableText,
             List<AttachmentViewInfo> extraAttachmentInfos) {
         return new MessageViewInfo(
-                message, isMessageIncomplete, rootPart, text, attachments,
+                message, isMessageIncomplete, rootPart, subject, text, attachments,
                 rootPartAnnotation,
                 attachmentResolver,
                 extraViewableText, extraAttachmentInfos
+        );
+    }
+
+    MessageViewInfo withSubject(String subject) {
+        return new MessageViewInfo(
+                message, isMessageIncomplete, rootPart, subject, text, attachments,
+                cryptoResultAnnotation, attachmentResolver, extraText, extraAttachments
         );
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/MessageBuilder.java
@@ -39,7 +39,7 @@ import org.apache.james.mime4j.util.MimeUtil;
 
 
 public abstract class MessageBuilder {
-    private final Context context;
+    protected final Context context;
     private final MessageIdGenerator messageIdGenerator;
     private final BoundaryGenerator boundaryGenerator;
 

--- a/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -15,6 +15,7 @@ import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 
 import com.fsck.k9.Globals;
+import com.fsck.k9.R;
 import com.fsck.k9.activity.compose.ComposeCryptoStatus;
 import com.fsck.k9.autocrypt.AutocryptOpenPgpApiInteractor;
 import com.fsck.k9.autocrypt.AutocryptOperations;
@@ -175,6 +176,13 @@ public class PgpMessageBuilder extends MessageBuilder {
         String[] contentType = currentProcessedMimeMessage.getHeader(MimeHeader.HEADER_CONTENT_TYPE);
         if (contentType.length > 0) {
             bodyPart.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType[0]);
+        }
+
+        String[] subjects = currentProcessedMimeMessage.getHeader(MimeHeader.SUBJECT);
+        if (subjects.length > 0) {
+            bodyPart.setHeader(MimeHeader.HEADER_CONTENT_TYPE, bodyPart.getContentType() + "; protected-headers=\"v1\"");
+            bodyPart.setHeader(MimeHeader.SUBJECT, subjects[0]);
+            currentProcessedMimeMessage.setHeader(MimeHeader.SUBJECT, context.getString(R.string.encrypted_subject));
         }
 
         addGossipHeadersToBodyPart(shouldEncrypt, bodyPart);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -8,7 +8,6 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.pm.PackageManager.NameNotFoundException;
 import android.graphics.drawable.Drawable;
-import android.os.Bundle;
 import android.os.Parcelable;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -30,25 +29,13 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
     private final MessageCryptoMvpView messageCryptoMvpView;
 
 
-    // persistent state
-    private boolean overrideCryptoWarning;
-
-
     // transient state
     private CryptoResultAnnotation cryptoResultAnnotation;
     private boolean reloadOnResumeWithoutRecreateFlag;
 
 
-    public MessageCryptoPresenter(Bundle savedInstanceState, MessageCryptoMvpView messageCryptoMvpView) {
+    public MessageCryptoPresenter(MessageCryptoMvpView messageCryptoMvpView) {
         this.messageCryptoMvpView = messageCryptoMvpView;
-
-        if (savedInstanceState != null) {
-            overrideCryptoWarning = savedInstanceState.getBoolean("overrideCryptoWarning");
-        }
-    }
-
-    public void onSaveInstanceState(Bundle outState) {
-        outState.putBoolean("overrideCryptoWarning", overrideCryptoWarning);
     }
 
     public void onResume() {
@@ -65,10 +52,6 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
                 MessageCryptoDisplayStatus.fromResultAnnotation(messageViewInfo.cryptoResultAnnotation);
         if (displayStatus == MessageCryptoDisplayStatus.DISABLED) {
             return false;
-        }
-
-        if (cryptoResultAnnotation.isOverrideSecurityWarning()) {
-            overrideCryptoWarning = true;
         }
 
         messageView.getMessageHeaderView().setCryptoStatus(displayStatus);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -8,6 +8,7 @@ import android.content.Context;
 import android.graphics.drawable.Drawable;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -205,9 +206,13 @@ public class MessageTopView extends LinearLayout {
         return mHeaderContainer;
     }
 
-    public void setHeaders(final Message message, Account account) {
+    public void setHeaders(Message message, Account account) {
         mHeaderContainer.populate(message, account);
         mHeaderContainer.setVisibility(View.VISIBLE);
+    }
+
+    public void setSubject(@NonNull String subject) {
+        mHeaderContainer.setSubject(subject);
     }
 
     public void setOnToggleFlagClickListener(OnClickListener listener) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -133,7 +133,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         Context context = getActivity().getApplicationContext();
         mController = MessagingController.getInstance(context);
         downloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
-        messageCryptoPresenter = new MessageCryptoPresenter(savedInstanceState, messageCryptoMvpView);
+        messageCryptoPresenter = new MessageCryptoPresenter(messageCryptoMvpView);
         messageLoaderHelper = new MessageLoaderHelper(
                 context, getLoaderManager(), getFragmentManager(), messageLoaderCallbacks);
         mInitialized = true;
@@ -144,13 +144,6 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         super.onResume();
 
         messageCryptoPresenter.onResume();
-    }
-
-    @Override
-    public void onSaveInstanceState(Bundle outState) {
-        super.onSaveInstanceState(outState);
-
-        messageCryptoPresenter.onSaveInstanceState(outState);
     }
 
     @Override

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -243,6 +243,10 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                 mMessageView.getMessageHeaderView().hideCryptoStatus();
             }
         }
+
+        if (messageViewInfo.subject != null) {
+            displaySubject(messageViewInfo.subject);
+        }
     }
 
     private void displayHeaderForLoadingMessage(LocalMessage message) {
@@ -250,8 +254,17 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         if (mAccount.isOpenPgpProviderConfigured()) {
             mMessageView.getMessageHeaderView().setCryptoStatusLoading();
         }
-        displayMessageSubject(getSubjectForMessage(message));
+        displaySubject(message.getSubject());
         mFragmentListener.updateMenu();
+    }
+
+    private void displaySubject(String subject) {
+        if (TextUtils.isEmpty(subject)) {
+            subject = mContext.getString(R.string.general_no_subject);
+        }
+
+        mMessageView.setSubject(subject);
+        displayMessageSubject(subject);
     }
 
     /**
@@ -472,8 +485,6 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
             mController.setFlag(mAccount, mMessage.getFolder().getServerId(),
                     Collections.singletonList(mMessage), Flag.SEEN, !mMessage.isSet(Flag.SEEN));
             mMessageView.setHeaders(mMessage, mAccount);
-            String subject = mMessage.getSubject();
-            displayMessageSubject(subject);
             mFragmentListener.updateMenu();
         }
     }
@@ -488,15 +499,6 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         if (mFragmentListener != null) {
             mFragmentListener.displayMessageSubject(subject);
         }
-    }
-
-    private String getSubjectForMessage(LocalMessage message) {
-        String subject = message.getSubject();
-        if (TextUtils.isEmpty(subject)) {
-            return mContext.getString(R.string.general_no_subject);
-        }
-
-        return subject;
     }
 
     public void moveMessage(MessageReference reference, String destFolderName) {

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -11,6 +11,7 @@ import android.content.Context;
 import android.graphics.Typeface;
 import android.os.Parcel;
 import android.os.Parcelable;
+import android.support.annotation.NonNull;
 import android.text.SpannableString;
 import android.text.SpannableStringBuilder;
 import android.text.TextUtils;
@@ -317,14 +318,6 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
             mSenderView.setVisibility(View.GONE);
         }
 
-        final String subject = message.getSubject();
-        if (TextUtils.isEmpty(subject)) {
-            mSubjectView.setText(mContext.getText(R.string.general_no_subject));
-        } else {
-            mSubjectView.setText(subject);
-        }
-        mSubjectView.setTextColor(0xff000000 | defaultSubjectColor);
-
         String dateTime = DateUtils.formatDateTime(mContext,
                 message.getSentDate().getTime(),
                 DateUtils.FORMAT_SHOW_DATE
@@ -363,6 +356,11 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         } else {
             hideAdditionalHeaders();
         }
+    }
+
+    public void setSubject(@NonNull String subject) {
+        mSubjectView.setText(subject);
+        mSubjectView.setTextColor(0xff000000 | defaultSubjectColor);
     }
 
     public static boolean shouldShowSender(Message message) {

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1302,4 +1302,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="dialog_openkeychain_info_title">No OpenPGP app installed</string>
     <string name="dialog_openkeychain_info_install">Install</string>
     <string name="dialog_openkeychain_info_text">K-9 Mail requires OpenKeychain for end-to-end encryption.</string>
+
+    <string name="encrypted_subject">"Encrypted Message"</string>
 </resources>

--- a/k9mail/src/test/java/com/fsck/k9/message/TestMessageConstructionUtils.java
+++ b/k9mail/src/test/java/com/fsck/k9/message/TestMessageConstructionUtils.java
@@ -13,6 +13,12 @@ import com.fsck.k9.mail.internet.TextBody;
 
 
 public class TestMessageConstructionUtils {
+    public static MimeMessage messageFromBody(String subject, BodyPart bodyPart) throws MessagingException {
+        MimeMessage message = messageFromBody(bodyPart);
+        message.setSubject(subject);
+        return message;
+    }
+
     public static MimeMessage messageFromBody(BodyPart bodyPart) throws MessagingException {
         MimeMessage message = new MimeMessage();
         MimeMessageHelper.setBody(message, bodyPart.getBody());


### PR DESCRIPTION
This PR adds support for the protected-headers=v1 parameter in pgp/mime encrypted messages. The subject is extracted in MessageViewInfoExtractor, displayed in message view, on replies/forwards/etc. It is also generated in outgoing messages, replacing the original subject with "Encrypted Message".

For some reason, the encrypted subject as sent right now don't work in Enigmail. I sent a message to Patrick Brunschwig, he said he'll take a look next week. I believe what I do should work, my guess is that Enigmail's behavior is just slightly brittle.