### PR TITLE
Move "About" and "Change Log" from Accounts to Settings screen

### DIFF
--- a/k9mail/src/main/AndroidManifest.xml
+++ b/k9mail/src/main/AndroidManifest.xml
@@ -299,6 +299,10 @@
             android:name=".ui.settings.SettingsActivity"
             android:label="@string/prefs_title" />
 
+        <activity
+            android:name=".ui.settings.AboutActivity"
+            android:label="@string/about_action" />
+
         <receiver
             android:name=".service.BootReceiver"
             android:enabled="true">

--- a/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -6,7 +6,6 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Calendar;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
@@ -25,7 +24,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.DialogInterface.OnMultiChoiceClickListener;
 import android.content.Intent;
-import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.pm.ResolveInfo;
 import android.net.Uri;
@@ -44,7 +42,6 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.ViewGroup;
 import android.view.Window;
-import android.webkit.WebView;
 import android.widget.AdapterView;
 import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.AdapterView.OnItemClickListener;
@@ -1229,9 +1226,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         case R.id.compose:
             onCompose();
             break;
-        case R.id.about:
-            onAbout();
-            break;
         case R.id.search:
             onSearchRequested();
             break;
@@ -1245,97 +1239,6 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
             return super.onOptionsItemSelected(item);
         }
         return true;
-    }
-
-    private static final String[][] USED_LIBRARIES = new String[][] {
-            new String[] {"Android Support Library", "https://developer.android.com/topic/libraries/support-library/index.html"},
-            new String[] {"ckChangeLog", "https://github.com/cketti/ckChangeLog"},
-            new String[] {"Commons IO", "http://commons.apache.org/io/"},
-            new String[] {"Glide", "https://github.com/bumptech/glide"},
-            new String[] {"HoloColorPicker", "https://github.com/LarsWerkman/HoloColorPicker"},
-            new String[] {"jsoup", "https://jsoup.org/"},
-            new String[] {"jutf7", "http://jutf7.sourceforge.net/"},
-            new String[] {"JZlib", "http://www.jcraft.com/jzlib/"},
-            new String[] {"Mime4j", "http://james.apache.org/mime4j/"},
-            new String[] {"Moshi", "https://github.com/square/moshi"},
-            new String[] {"Okio", "https://github.com/square/okio"},
-            new String[] {"SafeContentResolver", "https://github.com/cketti/SafeContentResolver"},
-            new String[] {"ShowcaseView", "https://github.com/amlcurran/ShowcaseView"},
-            new String[] {"Timber", "https://github.com/JakeWharton/timber"},
-            new String[] {"TokenAutoComplete", "https://github.com/splitwise/TokenAutoComplete/"},
-    };
-
-    private void onAbout() {
-        String appName = getString(R.string.app_name);
-        int year = Calendar.getInstance().get(Calendar.YEAR);
-        WebView wv = new WebView(this);
-        StringBuilder html = new StringBuilder()
-        .append("<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />")
-        .append("<img src=\"file:///android_asset/icon.png\" alt=\"").append(appName).append("\"/>")
-        .append("<h1>")
-        .append(String.format(getString(R.string.about_title_fmt),
-                              "<a href=\"" + getString(R.string.app_webpage_url)) + "\">")
-        .append(appName)
-        .append("</a>")
-        .append("</h1><p>")
-        .append(appName)
-        .append(" ")
-        .append(String.format(getString(R.string.debug_version_fmt), getVersionNumber()))
-        .append("</p><p>")
-        .append(String.format(getString(R.string.app_authors_fmt),
-                              getString(R.string.app_authors)))
-        .append("</p><p>")
-        .append(String.format(getString(R.string.app_revision_fmt),
-                              "<a href=\"" + getString(R.string.app_revision_url) + "\">" +
-                              getString(R.string.app_revision_url) +
-                              "</a>"))
-        .append("</p><hr/><p>")
-        .append(String.format(getString(R.string.app_copyright_fmt), Integer.toString(year), Integer.toString(year)))
-        .append("</p><hr/><p>")
-        .append(getString(R.string.app_license))
-        .append("</p><hr/><p>");
-
-        StringBuilder libs = new StringBuilder().append("<ul>");
-        for (String[] library : USED_LIBRARIES) {
-            libs.append("<li><a href=\"").append(library[1]).append("\">").append(library[0]).append("</a></li>");
-        }
-        libs.append("</ul>");
-
-        html.append(String.format(getString(R.string.app_libraries), libs.toString()))
-        .append("</p>");
-
-
-        wv.loadDataWithBaseURL("file:///android_res/drawable/", html.toString(), "text/html", "utf-8", null);
-        new AlertDialog.Builder(this)
-        .setView(wv)
-        .setCancelable(true)
-        .setPositiveButton(R.string.okay_action, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface d, int c) {
-                d.dismiss();
-            }
-        })
-        .setNeutralButton(R.string.changelog_full_title, new DialogInterface.OnClickListener() {
-            public void onClick(DialogInterface d, int c) {
-                new ChangeLog(Accounts.this).getFullLogDialog().show();
-            }
-        })
-        .show();
-    }
-
-    /**
-     * Get current version number.
-     *
-     * @return String version
-     */
-    private String getVersionNumber() {
-        String version = "?";
-        try {
-            PackageInfo pi = getPackageManager().getPackageInfo(getPackageName(), 0);
-            version = pi.versionName;
-        } catch (PackageManager.NameNotFoundException e) {
-            //Log.e(TAG, "Package name not found", e);
-        }
-        return version;
     }
 
     public boolean onItemLongClick(AdapterView<?> parent, View view, int position, long id) {

--- a/k9mail/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/k9mail/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -1,0 +1,127 @@
+package com.fsck.k9.ui.settings
+
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
+import android.webkit.WebView
+import com.fsck.k9.R
+import com.fsck.k9.activity.K9Activity
+import de.cketti.library.changelog.ChangeLog
+import timber.log.Timber
+import java.util.Calendar
+
+class AboutActivity : K9Activity() {
+    private lateinit var webView: WebView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.about)
+
+        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+        webView = findViewById(R.id.about_view)
+
+        val aboutHtml = buildHtml()
+        webView.loadDataWithBaseURL("file:///android_res/drawable/", aboutHtml, "text/html", "utf-8", null)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu): Boolean {
+        super.onCreateOptionsMenu(menu)
+        menuInflater.inflate(R.menu.about_option, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        when (item.itemId) {
+            android.R.id.home -> onBackPressed()
+            R.id.changelog -> displayChangeLog()
+            else -> return super.onOptionsItemSelected(item)
+        }
+
+        return true
+    }
+
+    private fun displayChangeLog() {
+        ChangeLog(this).fullLogDialog.show()
+    }
+
+    private fun buildHtml(): String {
+        val appName = getString(R.string.app_name)
+        val year = Calendar.getInstance().get(Calendar.YEAR)
+
+        val html = StringBuilder()
+                .append("<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />")
+                .append("<img src=\"file:///android_asset/icon.png\" alt=\"").append(appName).append("\"/>")
+                .append("<h1>")
+                .append(getString(R.string.about_title_fmt,
+                        "<a href=\"${ getString(R.string.app_webpage_url) }\">"))
+                .append(appName)
+                .append("</a>")
+                .append("</h1><p>")
+                .append(appName)
+                .append(" ")
+                .append(getString(R.string.debug_version_fmt, getVersionNumber()))
+                .append("</p><p>")
+                .append(getString(R.string.app_authors_fmt, getString(R.string.app_authors)))
+                .append("</p><p>")
+                .append(getString(R.string.app_revision_fmt,
+                        "<a href=\"${ getString(R.string.app_revision_url) }\">" +
+                                getString(R.string.app_revision_url) +
+                                "</a>"))
+                .append("</p><hr/><p>")
+                .append(getString(R.string.app_copyright_fmt, Integer.toString(year), Integer.toString(year)))
+                .append("</p><hr/><p>")
+                .append(getString(R.string.app_license))
+                .append("</p><hr/><p>")
+
+        val libs = StringBuilder().append("<ul>")
+        for ((library, url) in USED_LIBRARIES) {
+            libs.append("<li><a href=\"").append(url).append("\">")
+                    .append(library)
+                    .append("</a></li>")
+        }
+        libs.append("</ul>")
+
+        html.append(getString(R.string.app_libraries, libs.toString()))
+                .append("</p>")
+
+        return html.toString()
+    }
+
+    private fun getVersionNumber(): String {
+        return try {
+            val packageInfo = packageManager.getPackageInfo(packageName, 0)
+            packageInfo.versionName
+        } catch (e: PackageManager.NameNotFoundException) {
+            Timber.e(e, "Error getting PackageInfo")
+            "?"
+        }
+    }
+
+
+    companion object {
+        private val USED_LIBRARIES = mapOf(
+                "Android Support Library" to "https://developer.android.com/topic/libraries/support-library/index.html",
+                "ckChangeLog" to "https://github.com/cketti/ckChangeLog",
+                "Commons IO" to "http://commons.apache.org/io/",
+                "Glide" to "https://github.com/bumptech/glide",
+                "HoloColorPicker" to "https://github.com/LarsWerkman/HoloColorPicker",
+                "jsoup" to "https://jsoup.org/",
+                "jutf7" to "http://jutf7.sourceforge.net/",
+                "JZlib" to "http://www.jcraft.com/jzlib/",
+                "Mime4j" to "http://james.apache.org/mime4j/",
+                "Moshi" to "https://github.com/square/moshi",
+                "Okio" to "https://github.com/square/okio",
+                "SafeContentResolver" to "https://github.com/cketti/SafeContentResolver",
+                "ShowcaseView" to "https://github.com/amlcurran/ShowcaseView",
+                "Timber" to "https://github.com/JakeWharton/timber",
+                "TokenAutoComplete" to "https://github.com/splitwise/TokenAutoComplete/")
+
+        fun start(context: Context) {
+            val intent = Intent(context, AboutActivity::class.java)
+            context.startActivity(intent)
+        }
+    }
+}

--- a/k9mail/src/main/java/com/fsck/k9/ui/settings/SettingsAction.kt
+++ b/k9mail/src/main/java/com/fsck/k9/ui/settings/SettingsAction.kt
@@ -14,6 +14,11 @@ internal enum class SettingsAction {
         override fun execute(activity: Activity) {
             AccountSetupBasics.actionNewAccount(activity)
         }
+    },
+    ABOUT_SCREEN {
+        override fun execute(activity: Activity) {
+            AboutActivity.start(activity)
+        }
     };
 
     abstract fun execute(activity: Activity)

--- a/k9mail/src/main/java/com/fsck/k9/ui/settings/SettingsActivity.kt
+++ b/k9mail/src/main/java/com/fsck/k9/ui/settings/SettingsActivity.kt
@@ -70,6 +70,12 @@ class SettingsActivity : K9Activity() {
             add(SettingsActionItem(getString(R.string.add_account_action), SettingsAction.ADD_ACCOUNT))
         }
         settingsAdapter.add(accountSection)
+
+        //TODO: add header and/or divider
+        val miscSection = Section().apply {
+            add(SettingsActionItem(getString(R.string.about_action), SettingsAction.ABOUT_SCREEN))
+        }
+        settingsAdapter.add(miscSection)
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {

--- a/k9mail/src/main/res/layout/about.xml
+++ b/k9mail/src/main/res/layout/about.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WebView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/about_view"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/k9mail/src/main/res/menu/about_option.xml
+++ b/k9mail/src/main/res/menu/about_option.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/changelog"
+        android:title="@string/changelog_full_title"
+        app:showAsAction="never" />
+
+</menu>

--- a/k9mail/src/main/res/menu/accounts_option.xml
+++ b/k9mail/src/main/res/menu/accounts_option.xml
@@ -20,10 +20,6 @@
         app:showAsAction="always"
         android:title="@string/compose_action"/>
     <item
-        android:id="@+id/about"
-        android:icon="?attr/iconActionAbout"
-        android:title="@string/about_action"/>
-    <item
         android:id="@+id/import_export"
         android:icon="?attr/iconActionImportExport"
         android:title="@string/import_export_action">


### PR DESCRIPTION
I'm starting to move functionality out of the `Accounts` Activity so we can get rid of it. The idea is to switch to a navigation drawer that contains an account switcher.

This PR moves the About dialog. It is now a separate Activity. I'm not sure where the "Change Log" option should end up. For now it's a separate entry in the main settings list.

![k9mail_settings_with_about_and_changelog](https://user-images.githubusercontent.com/218061/38528908-16d39d90-3c62-11e8-842a-4c35df6b667b.png)
![k9mail_about](https://user-images.githubusercontent.com/218061/38528907-16ba45a2-3c62-11e8-8f61-ab16e5ba5b8b.png)
