### PR TITLE
added RFC2231 parameter decode function into MimeUtility.unfoldAndDecode

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
@@ -909,7 +909,7 @@ public class MimeUtility {
     }
 
     public static String unfoldAndDecode(String s, Message message) {
-        return decode(unfold(s), message);
+        return Rfc2231Parameters.decodeAll(decode(unfold(s), message), message);
     }
 
     // TODO implement proper foldAndEncode

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
@@ -909,7 +909,7 @@ public class MimeUtility {
     }
 
     public static String unfoldAndDecode(String s, Message message) {
-        return Rfc2231Parameters.decodeAll(decode(unfold(s), message), message);
+        return decode(unfold(s), message);
     }
 
     // TODO implement proper foldAndEncode

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Decoder.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Decoder.java
@@ -1,0 +1,128 @@
+package com.fsck.k9.mail.internet;
+
+
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import android.support.annotation.NonNull;
+
+import com.fsck.k9.mail.Message;
+import com.fsck.k9.mail.MessagingException;
+
+
+public class Rfc2231Decoder {
+    private String charset;
+    private String language;
+
+    public String getLanguage() {
+        return language;
+    }
+
+    private List<Byte> bytes;
+    private String text;
+    private Message message;
+
+    Rfc2231Decoder(Message message) {
+        this.message = message;
+    }
+
+    public void addLine(@NonNull Rfc2231Value value) {
+        // first value
+        if (charset == null) {
+            if (value.isEncoded()) {
+                if (analyzeFirstValue(value)) {
+                    return;
+                }
+            }
+            charset = "";
+            text = value.getString();
+            return;
+        }
+
+        // continued value
+        text += value.getString();
+        if (!charset.equals("")) {
+            decode(value.getString());
+        }
+    }
+
+    public String getDecodedText() {
+        if (charset == null) {
+            return null;
+        }
+        if (charset.equals("")) {
+            return text;
+        }
+
+        int len = bytes.size();
+        byte[] byteArray = new byte[len];
+        for (int i = 0; i < len; ++i) {
+            byteArray[i] = bytes.get(i);
+        }
+        try {
+            return new String(byteArray, Charset.forName(charset));
+        } catch (Exception ex) {
+            return text;
+        }
+    }
+
+    private boolean analyzeFirstValue(@NonNull Rfc2231Value value) {
+        final String DELIMITER = "'";
+
+        String str = value.getString();
+        int iDelimiter1 = str.indexOf(DELIMITER);
+        if (iDelimiter1 < 0) {
+            return false;
+        }
+        int iDelimiter2 = str.indexOf(DELIMITER, iDelimiter1 + 1);
+        if (iDelimiter2 < 0) {
+            return false;
+        }
+
+        String charsetRaw = str.substring(0, iDelimiter1);
+        try {
+            charset = CharsetSupport.fixupCharset(charsetRaw, message);
+        } catch (MessagingException e) {
+            charset = "";
+        }
+
+        language = str.substring(iDelimiter1 + 1, iDelimiter2);
+        text = str.substring(iDelimiter2 + 1);
+        bytes = new ArrayList<>();
+        decode(text);
+
+        return true;
+    }
+
+    private void decode(@NonNull String str) {
+        final Pattern pattern = Pattern.compile("%([0-9A-Fa-f]{2})");
+        Matcher m = pattern.matcher(str);
+        int i = 0;
+
+        while (m.find()) {
+            addBytes(str, i, m.start());
+            addByte(m.group(1));
+            i = m.end();
+        }
+
+        int len = str.length();
+        if (i < len) {
+            addBytes(str, i, len);
+        }
+    }
+
+    private void addBytes(@NonNull String str, int beginIndex, int endIndex) {
+        for (byte b : str.substring(beginIndex, endIndex).getBytes(Charset.forName("US-ASCII"))) {
+            bytes.add(b);
+        }
+    }
+
+    private void addByte(@NonNull String hexText) {
+        int i = Integer.parseInt(hexText, 16);
+        byte b = (byte) i;
+        bytes.add(b);
+    }
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Parameters.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Parameters.java
@@ -1,0 +1,142 @@
+package com.fsck.k9.mail.internet;
+
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import android.support.annotation.NonNull;
+
+import com.fsck.k9.mail.Message;
+
+
+public class Rfc2231Parameters {
+    /**
+     * Decodes a string containing encoded words as defined by RFC 2231.
+     *
+     * @param body
+     *         the string to decode.
+     * @param message
+     *         the message which has the string.
+     *
+     * @return the decoded string.
+     */
+    public static String decodeAll(@NonNull String body, Message message) {
+        String body2 = body.replaceAll("[\r\n]", "");
+        String[] lines = body2.split("[\t ]*;[\t ]*");
+        Rfc2231Parameters params = new Rfc2231Parameters(message);
+        for (String line : lines) {
+            params.addLine(line);
+        }
+        return params.getDecodedText();
+    }
+
+    private static final int SINGLE_LINE_INDEX = -1;
+    private Message message;
+
+    private Map<String, SortedMap<Integer, Rfc2231Value>> parameters = new LinkedHashMap<>();
+
+    private void addParameter(String attribute) {
+        parameters.put(attribute, null);
+    }
+
+    private void addParameter(String attribute, Integer index, String value, boolean isEncoded) {
+        if (!parameters.containsKey(attribute)) {
+            parameters.put(attribute, new TreeMap<Integer, Rfc2231Value>());
+        }
+        parameters.get(attribute).put(index, new Rfc2231Value(value, isEncoded));
+    }
+
+    public Rfc2231Parameters(Message message) {
+        this.message = message;
+    }
+
+    public void addLine(String line) {
+        String[] attrAndValue = splitAttributeAndValue(line);
+        mapParameter(attrAndValue);
+    }
+
+    public String getDecodedText() {
+        StringBuilder sb = new StringBuilder();
+        String prefix = "";
+
+        for (Entry<String, SortedMap<Integer, Rfc2231Value>> parameter : parameters.entrySet()) {
+            SortedMap<Integer, Rfc2231Value> lines = parameter.getValue();
+
+            if (lines == null) {
+                sb.append(prefix).append(parameter.getKey());
+                prefix = ";";
+                continue;
+            }
+
+            Rfc2231Decoder decoder = new Rfc2231Decoder(message);
+
+            if (lines.size() == 1) {
+                decoder.addLine(lines.get(lines.firstKey()));
+            } else {
+                for (Entry<Integer, Rfc2231Value> line : lines.entrySet()) {
+                    if (line.getKey() < 0) {
+                        continue;
+                    }
+                    decoder.addLine(line.getValue());
+                }
+            }
+
+            sb.append(prefix).append(parameter.getKey()).append("=").append(decoder.getDecodedText());
+            prefix = ";";
+        }
+
+        return sb.toString();
+    }
+
+    private String[] splitAttributeAndValue(String line) {
+        String[] parts = line.split("[¥t ]*=[¥t ]*", 2);
+        if (parts.length == 2) {
+            parts[1] = deQuote(parts[1]);
+        }
+        return parts;
+    }
+
+    private String deQuote(String source) {
+        int len = source.length();
+        if (len < 2) {
+            return source;
+        }
+
+        if (source.startsWith("\\\"") && source.endsWith("\\\"")) {
+            return source.substring(1, len - 1);
+        } else {
+            return source;
+        }
+    }
+
+    private void mapParameter(String[] parameter) {
+        final Pattern pattern = Pattern.compile("^(.+)\\*([0-9]+)(\\*?)$");
+        // { "name*0", "name*1", ... } and { "name*0*", "name*1*", ... }
+
+        // no "attr=value" text, example: "Content-Disposition: attachment"
+        if (parameter.length < 2) {
+            addParameter(parameter[0]);
+            return;
+        }
+
+        Matcher m = pattern.matcher(parameter[0]);
+        if (m.find()) { // matches only once (whole string), so "while" is needless.
+            addParameter(
+                    m.group(1),
+                    Integer.parseInt(m.group(2)),
+                    parameter[1],
+                    m.group(3).equals("*"));
+        } else {
+            addParameter(
+                    parameter[0],
+                    SINGLE_LINE_INDEX,
+                    parameter[1],
+                    parameter[0].endsWith("*"));
+        }
+    }
+}

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Parameters.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Parameters.java
@@ -109,7 +109,7 @@ public class Rfc2231Parameters {
             return source;
         }
 
-        if (source.startsWith("\\\"") && source.endsWith("\\\"")) {
+        if (source.startsWith("\"") && source.endsWith("\"")) {
             return source.substring(1, len - 1);
         } else {
             return source;

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Parameters.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Parameters.java
@@ -25,7 +25,9 @@ public class Rfc2231Parameters {
      *
      * @return the decoded string.
      */
-    public static String decodeAll(@NonNull String body, Message message) {
+    public static String decodeAll(String body, Message message) {
+        if (body == null) return null;
+        if (body.length() < 1) return "";
         String body2 = body.replaceAll("[\r\n]", "");
         String[] lines = body2.split("[\t ]*;[\t ]*");
         Rfc2231Parameters params = new Rfc2231Parameters(message);

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Value.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/Rfc2231Value.java
@@ -1,0 +1,21 @@
+package com.fsck.k9.mail.internet;
+
+
+public class Rfc2231Value {
+    String string;
+
+    public String getString() {
+        return string;
+    }
+
+    private boolean encoded;
+
+    public boolean isEncoded() {
+        return encoded;
+    }
+
+    Rfc2231Value(String string, boolean encoded) {
+        this.string = string;
+        this.encoded = encoded;
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/Rfc2231DecodeTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/Rfc2231DecodeTest.java
@@ -1,0 +1,31 @@
+package com.fsck.k9.mail.internet;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class Rfc2231DecodeTest {
+    @Test
+    public void decodeAll_thunderbird_Japanese_decode()
+    {
+        String source = "Content-Disposition: attachment;\n" +
+                "filename*0*=utf-8''%61%6C%70%68%61%E5%9B%B3%E9%9D%A2%E5%9F%BA%E6%9C%AC%E6;\n" +
+                "filename*1*=%A1%88%EF%BC%8D%E6%A4%9C%E8%A8%8E%E4%B8%AD%E3%83%BB%E6%A1%88;\n" +
+                "filename*2*=%42%32%2E%74%78%74";
+        String decoded = Rfc2231Parameters.decodeAll(source, null);
+        String name = MimeUtility.getHeaderParameter(decoded, "filename");
+        assertEquals("alpha図面基本案－検討中・案B2.txt",name);
+    }
+
+    @Test
+    public void deodeAll_appleMail_Japanese_decode()
+    {
+        String source = "Content-Disposition: attachment;\n" +
+                "\tfilename*=utf-8''0409%E6%B4%BB%E5%8B%95%E5%A0%B1%E5%91%8A%E6%9B%B8%EF%BC%88%E6%94%B9%E8%A8%822%E7%89%88%EF%BC%89.txt\n";
+        String decoded = Rfc2231Parameters.decodeAll(source, null);
+        String name = MimeUtility.getHeaderParameter(decoded, "filename");
+        assertEquals("0409活動報告書（改訂2版）.txt",name);
+    }
+}

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/Rfc2231DecodeTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/Rfc2231DecodeTest.java
@@ -8,6 +8,43 @@ import static org.junit.Assert.assertEquals;
 
 public class Rfc2231DecodeTest {
     @Test
+    public void decodeAll_rfc2231_example_1()
+    {
+        // From RFC2231 3.
+        // this is Content-Type, not Content-Disposition, but same logic applies.
+        String source = "Content-Type: message/external-body; access-type=URL;\n" +
+                "         URL*0=\"ftp://\";\n" +
+                "         URL*1=\"cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar\"";
+        String decoded = Rfc2231Parameters.decodeAll(source, null);
+        String output = MimeUtility.getHeaderParameter(decoded, "URL");
+        assertEquals("ftp://cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar",output);
+    }
+
+    @Test
+    public void decodeAll_rfc2231_example_2()
+    {
+        // From RFC2231 4.
+        String source = "Content-Type: application/x-stuff;\n" +
+                "         title*=us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A";
+        String decoded = Rfc2231Parameters.decodeAll(source, null);
+        String output = MimeUtility.getHeaderParameter(decoded, "title");
+        assertEquals("This is ***fun***",output);
+    }
+
+    @Test
+    public void decodeAll_rfc2231_example_3()
+    {
+        // From RFC2231 4.1
+        String source = "Content-Type: application/x-stuff;\n" +
+                "    title*0*=us-ascii'en'This%20is%20even%20more%20;\n" +
+                "    title*1*=%2A%2A%2Afun%2A%2A%2A%20;\n" +
+                "    title*2=\"isn't it!\"";
+        String decoded = Rfc2231Parameters.decodeAll(source, null);
+        String output = MimeUtility.getHeaderParameter(decoded, "title");
+        assertEquals("This is even more ***fun*** isn't it!",output);
+    }
+
+    @Test
     public void decodeAll_thunderbird_Japanese_decode()
     {
         String source = "Content-Disposition: attachment;\n" +

--- a/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -11,6 +11,8 @@ import android.content.Context;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+
+import com.fsck.k9.mail.internet.Rfc2231Parameters;
 import timber.log.Timber;
 import android.support.annotation.WorkerThread;
 
@@ -117,7 +119,7 @@ public class AttachmentInfoExtractor {
 
         String mimeType = part.getMimeType();
         String contentTypeHeader = MimeUtility.unfoldAndDecode(part.getContentType());
-        String contentDisposition = MimeUtility.unfoldAndDecode(part.getDisposition());
+        String contentDisposition = Rfc2231Parameters.decodeAll(MimeUtility.unfoldAndDecode(part.getDisposition()),null);
 
         String name = MimeUtility.getHeaderParameter(contentDisposition, "filename");
         if (name == null) {


### PR DESCRIPTION
About issues #1466 .

Major mail applications (Thunderbird, Apple mail) uses RFC2231 for encoding filenames in Content-Disposition, but k9mail doesn't handle them.
This is very troublesome for non-English (like Japanese) users because many attachments are broken in filenames.

This PR resolves that issue.
Unit tests are based on real Content-Disposition.

