### PR TITLE
Allow state loss closing dialog - fixes common IllegalStateException

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -562,7 +562,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         DialogFragment fragment = (DialogFragment) fm.findFragmentByTag(getDialogTag(dialogId));
 
         if (fragment != null) {
-            fragment.dismiss();
+            fragment.dismissAllowingStateLoss();
         }
     }
 


### PR DESCRIPTION
Per https://stackoverflow.com/questions/16842088/how-to-safely-dismiss-dialogfragment-in-onstop

this should fix:

java.lang.IllegalStateException: 
  at android.app.FragmentManagerImpl.checkStateLoss (FragmentManager.java:1323)
  at android.app.FragmentManagerImpl.enqueueAction (FragmentManager.java:1341)
  at android.app.BackStackRecord.commitInternal (BackStackRecord.java:609)
  at android.app.BackStackRecord.commit (BackStackRecord.java:587)
  at android.app.DialogFragment.dismissInternal (DialogFragment.java:292)
  at android.app.DialogFragment.dismiss (DialogFragment.java:258)
  at com.fsck.k9.fragment.MessageViewFragment.removeDialog (MessageViewFragment.java:801)
  at com.fsck.k9.fragment.MessageViewFragment.access$1300 (MessageViewFragment.java:51)
  at com.fsck.k9.fragment.MessageViewFragment$Listener$7.run (MessageViewFragment.java:691)

which is causing a whole tonne of crashes.


