### PR TITLE
Properly label button for search of missing keys

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/CryptoInfoDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/CryptoInfoDialog.java
@@ -73,10 +73,21 @@ public class CryptoInfoDialog extends DialogFragment {
                 @Override
                 public void onClick(DialogInterface dialogInterface, int i) {
                     Fragment frag = getTargetFragment();
-                    if (! (frag instanceof OnClickShowCryptoKeyListener)) {
+                    if (!(frag instanceof OnClickShowCryptoKeyListener)) {
                         throw new AssertionError("Displaying activity must implement OnClickShowCryptoKeyListener!");
                     }
                     ((OnClickShowCryptoKeyListener) frag).onClickShowSecurityWarning();
+                }
+            });
+        } else if (displayStatus.isUnknownKey()) {
+            b.setNeutralButton(R.string.crypto_info_search_key, new OnClickListener() {
+                @Override
+                public void onClick(DialogInterface dialogInterface, int i) {
+                    Fragment frag = getTargetFragment();
+                    if (! (frag instanceof OnClickShowCryptoKeyListener)) {
+                        throw new AssertionError("Displaying activity must implement OnClickShowCryptoKeyListener!");
+                    }
+                    ((OnClickShowCryptoKeyListener) frag).onClickSearchKey();
                 }
             });
         } else if (displayStatus.hasAssociatedKey()) {
@@ -124,5 +135,6 @@ public class CryptoInfoDialog extends DialogFragment {
     public interface OnClickShowCryptoKeyListener {
         void onClickShowCryptoKey();
         void onClickShowSecurityWarning();
+        void onClickSearchKey();
     }
 }

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageCryptoPresenter.java
@@ -107,9 +107,6 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
             case LOADING:
                 // no need to do anything, there is a progress bar...
                 break;
-            case UNENCRYPTED_SIGN_UNKNOWN:
-                launchPendingIntent(cryptoResultAnnotation);
-                break;
             default:
                 displayCryptoInfoDialog(displayStatus);
                 break;
@@ -136,9 +133,9 @@ public class MessageCryptoPresenter implements OnCryptoClickListener {
                 displayStatus, cryptoResultAnnotation.hasOpenPgpInsecureWarningPendingIntent());
     }
 
-    private void launchPendingIntent(CryptoResultAnnotation cryptoResultAnnotation) {
+    void onClickSearchKey() {
         try {
-            PendingIntent pendingIntent = cryptoResultAnnotation.getOpenPgpPendingIntent();
+            PendingIntent pendingIntent = cryptoResultAnnotation.getOpenPgpSigningKeyIntentIfAny();
             if (pendingIntent != null) {
                 messageCryptoMvpView.startPendingIntentForCryptoPresenter(
                         pendingIntent.getIntentSender(), REQUEST_CODE_UNKNOWN_KEY, null, 0, 0, 0);

--- a/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/k9mail/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -713,6 +713,11 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     @Override
+    public void onClickSearchKey() {
+        messageCryptoPresenter.onClickSearchKey();
+    }
+
+    @Override
     public void onClickShowCryptoKey() {
         messageCryptoPresenter.onClickShowCryptoKey();
     }

--- a/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
+++ b/k9mail/src/main/java/com/fsck/k9/view/MessageCryptoDisplayStatus.java
@@ -360,7 +360,6 @@ public enum MessageCryptoDisplayStatus {
 
     public boolean hasAssociatedKey() {
         switch (this) {
-            case ENCRYPTED_SIGN_UNKNOWN:
             case ENCRYPTED_SIGN_VERIFIED:
             case ENCRYPTED_SIGN_UNVERIFIED:
             case ENCRYPTED_SIGN_MISMATCH:
@@ -368,7 +367,6 @@ public enum MessageCryptoDisplayStatus {
             case ENCRYPTED_SIGN_REVOKED:
             case ENCRYPTED_SIGN_INSECURE:
 
-            case UNENCRYPTED_SIGN_UNKNOWN:
             case UNENCRYPTED_SIGN_VERIFIED:
             case UNENCRYPTED_SIGN_UNVERIFIED:
             case UNENCRYPTED_SIGN_MISMATCH:
@@ -395,4 +393,12 @@ public enum MessageCryptoDisplayStatus {
         return false;
     }
 
+    public boolean isUnknownKey() {
+        switch (this) {
+            case ENCRYPTED_SIGN_UNKNOWN:
+            case UNENCRYPTED_SIGN_UNKNOWN:
+                return true;
+        }
+        return false;
+    }
 }

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -1241,6 +1241,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="crypto_msg_encrypted_insecure">but encryption not considered secure</string>
 
     <string name="crypto_info_ok">OK</string>
+    <string name="crypto_info_search_key">Search Key</string>
     <string name="crypto_info_view_signer">View Signer</string>
     <string name="crypto_info_view_sender">View Sender</string>
     <string name="crypto_info_view_security_warning">Details</string>


### PR DESCRIPTION
Simple PR that shows the button in the crypto info dialog as "search key" rather than "view key" if that's the expected dialog it triggers.