### PR TITLE
Cache decrypted subjects in message table

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/Flag.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/Flag.java
@@ -62,4 +62,9 @@ public enum Flag {
      * This flag is used for drafts where the message should be sent as PGP/INLINE.
      */
     X_DRAFT_OPENPGP_INLINE,
+
+    /**
+     * This flag is added to messages when their subject is overridden with a decrypted one in the database.
+     */
+    X_SUBJECT_DECRYPTED,
 }

--- a/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -22,6 +22,7 @@ import com.fsck.k9.controller.MessagingListener;
 import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.helper.RetainFragment;
 import com.fsck.k9.mail.Flag;
+import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.ui.crypto.MessageCryptoAnnotations;
@@ -377,6 +378,14 @@ public class MessageLoaderHelper {
             messageViewInfo = createErrorStateMessageViewInfo();
             callback.onMessageViewInfoLoadFailed(messageViewInfo);
             return;
+        }
+
+        if (messageViewInfo.isSubjectEncrypted && !localMessage.hasCachedDecryptedSubject()) {
+            try {
+                localMessage.setCachedDecryptedSubject(messageViewInfo.subject);
+            } catch (MessagingException e) {
+                throw new AssertionError(e);
+            }
         }
 
         callback.onMessageViewInfoLoadFinished(messageViewInfo);

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfo.java
@@ -13,6 +13,7 @@ public class MessageViewInfo {
     public final boolean isMessageIncomplete;
     public final Part rootPart;
     public final String subject;
+    public final boolean isSubjectEncrypted;
     public final AttachmentResolver attachmentResolver;
     public final String text;
     public final CryptoResultAnnotation cryptoResultAnnotation;
@@ -23,7 +24,7 @@ public class MessageViewInfo {
 
     public MessageViewInfo(
             Message message, boolean isMessageIncomplete, Part rootPart,
-            String subject,
+            String subject, boolean isSubjectEncrypted,
             String text, List<AttachmentViewInfo> attachments,
             CryptoResultAnnotation cryptoResultAnnotation,
             AttachmentResolver attachmentResolver,
@@ -32,6 +33,7 @@ public class MessageViewInfo {
         this.isMessageIncomplete = isMessageIncomplete;
         this.rootPart = rootPart;
         this.subject = subject;
+        this.isSubjectEncrypted = isSubjectEncrypted;
         this.text = text;
         this.cryptoResultAnnotation = cryptoResultAnnotation;
         this.attachmentResolver = attachmentResolver;
@@ -43,31 +45,31 @@ public class MessageViewInfo {
     static MessageViewInfo createWithExtractedContent(Message message, Part rootPart, boolean isMessageIncomplete,
             String text, List<AttachmentViewInfo> attachments, AttachmentResolver attachmentResolver) {
         return new MessageViewInfo(
-                message, isMessageIncomplete, rootPart, null, text, attachments, null, attachmentResolver, null,
+                message, isMessageIncomplete, rootPart, null, false, text, attachments, null, attachmentResolver, null,
                 Collections.<AttachmentViewInfo>emptyList());
     }
 
     public static MessageViewInfo createWithErrorState(Message message, boolean isMessageIncomplete) {
-        return new MessageViewInfo(message, isMessageIncomplete, null, null, null, null, null, null, null, null);
+        return new MessageViewInfo(message, isMessageIncomplete, null, null, false, null, null, null, null, null, null);
     }
 
     public static MessageViewInfo createForMetadataOnly(Message message, boolean isMessageIncomplete) {
-        return new MessageViewInfo(message, isMessageIncomplete, null, null, null, null, null, null, null, null);
+        return new MessageViewInfo(message, isMessageIncomplete, null, null, false, null, null, null, null, null, null);
     }
 
     MessageViewInfo withCryptoData(CryptoResultAnnotation rootPartAnnotation, String extraViewableText,
             List<AttachmentViewInfo> extraAttachmentInfos) {
         return new MessageViewInfo(
-                message, isMessageIncomplete, rootPart, subject, text, attachments,
+                message, isMessageIncomplete, rootPart, subject, isSubjectEncrypted, text, attachments,
                 rootPartAnnotation,
                 attachmentResolver,
                 extraViewableText, extraAttachmentInfos
         );
     }
 
-    MessageViewInfo withSubject(String subject) {
+    MessageViewInfo withSubject(String subject, boolean isSubjectEncrypted) {
         return new MessageViewInfo(
-                message, isMessageIncomplete, rootPart, subject, text, attachments,
+                message, isMessageIncomplete, rootPart, subject, isSubjectEncrypted, text, attachments,
                 cryptoResultAnnotation, attachmentResolver, extraText, extraAttachments
         );
     }

--- a/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
+++ b/k9mail/src/main/java/com/fsck/k9/mailstore/MessageViewInfoExtractor.java
@@ -93,21 +93,20 @@ public class MessageViewInfoExtractor {
         }
 
         MessageViewInfo messageViewInfo = getMessageContent(message, cryptoAnnotations, extraParts, cryptoContentPart);
-        String subject = extractSubject(messageViewInfo);
-        messageViewInfo = messageViewInfo.withSubject(subject);
+        messageViewInfo = extractSubject(messageViewInfo);
 
         return messageViewInfo;
     }
 
-    private String extractSubject(MessageViewInfo messageViewInfo) {
+    private MessageViewInfo extractSubject(MessageViewInfo messageViewInfo) {
         if (messageViewInfo.cryptoResultAnnotation != null && messageViewInfo.cryptoResultAnnotation.isEncrypted()) {
             String protectedSubject = extractProtectedSubject(messageViewInfo);
             if (protectedSubject != null) {
-                return protectedSubject;
+                return messageViewInfo.withSubject(protectedSubject, true);
             }
         }
 
-        return messageViewInfo.message.getSubject();
+        return messageViewInfo.withSubject(messageViewInfo.message.getSubject(), false);
     }
 
     @Nullable


### PR DESCRIPTION
With this PR, encrypted subjects are replaced with their plaintext in the `messages` table once the message has been decrypted.

I went for a dedicated `decrypted_subject` column first, but that was three times as much code and made things like message ordering unnecessarily complex. This approach simply replaces the text in the `subject` column, and adds a X_SUBJECT_DECRYPTED flag to avoid replacing it redundantly in the future.