### PR TITLE
Add support for Encoded Word encoding with language information

### DIFF
--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/DecoderUtil.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/DecoderUtil.java
@@ -139,7 +139,12 @@ class DecoderUtil {
         if (qm2 == end - 2)
             return null;
 
-        String mimeCharset = body.substring(begin + 2, qm1);
+        // Extract charset, skipping language information if present (example: =?utf-8*en?Q?Text?=)
+        String charsetPart = body.substring(begin + 2, qm1);
+        int languageSuffixStart = charsetPart.indexOf('*');
+        boolean languageSuffixFound = languageSuffixStart != -1;
+        String mimeCharset = languageSuffixFound ? charsetPart.substring(0, languageSuffixStart) : charsetPart;
+
         String encoding = body.substring(qm1 + 1, qm2);
         String encodedText = body.substring(qm2 + 1, end - 2);
 

--- a/k9mail-library/src/main/java/com/fsck/k9/mail/internet/DecoderUtil.java
+++ b/k9mail-library/src/main/java/com/fsck/k9/mail/internet/DecoderUtil.java
@@ -86,13 +86,13 @@ class DecoderUtil {
             if (previousWord == null) {
                 sb.append(sep);
                 if (word == null) {
-                    sb.append(body.substring(begin, end));
+                    sb.append(body, begin, end);
                 }
             } else {
                 if (word == null) {
                     sb.append(charsetDecode(previousWord));
                     sb.append(sep);
-                    sb.append(body.substring(begin, end));
+                    sb.append(body, begin, end);
                 } else {
                     if (!CharsetUtil.isWhitespace(sep)) {
                         sb.append(charsetDecode(previousWord));

--- a/k9mail-library/src/test/java/com/fsck/k9/mail/internet/DecoderUtilTest.java
+++ b/k9mail-library/src/test/java/com/fsck/k9/mail/internet/DecoderUtilTest.java
@@ -211,6 +211,15 @@ public class DecoderUtilTest {
         assertInputDecodesToExpected("(=?ISO-8859-1?Q?a?= =?ISO-8859-2?Q?_b?=)", "(a b)");
     }
 
+    @Test
+    public void decodeEncodedWords_withLanguageInformation() {
+        // Example from RFC 2231, section 5. This is unlikely to ever fail because our charset fallback is US-ASCII.
+        assertInputDecodesToExpected("=?US-ASCII*EN?Q?Keith_Moore?= <moore@cs.utk.edu>",
+                "Keith Moore <moore@cs.utk.edu>");
+
+        assertInputDecodesToExpected("=?utf-8*de?b?R3LDvMOfZQ==?=", "Grüße");
+    }
+
 
     private void assertInputDecodesToExpected(String input, String expected) {
         String decodedText = DecoderUtil.decodeEncodedWords(input, null);


### PR DESCRIPTION
RFC 2231 added language support to the Encoded Word encoding. Right now we don't care about the language. But we need to explicitly ignore it to use the correct character set for decoding.

Example:
```
From: =?US-ASCII*EN?Q?Keith_Moore?= <moore@cs.utk.edu>
```
