### PR TITLE
Remove Google from author field in About screen

### DIFF
--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -15,7 +15,7 @@
 
 
     <!-- Used in the about dialog -->
-    <string name="app_authors">Google, The K-9 Dog Walkers.</string>
+    <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
     <string name="app_license">Licensed under the Apache License, Version 2.0.</string>
 


### PR DESCRIPTION
K-9 Mail started off as a fork of the AOSP Email app. But this was nearly 10 years ago. Most of the app has been rewritten or significantly changed since then. By now I think it's fair to only list the K-9 project as author in the About screen.
Copyright statements in license headers and the copyright statement in the About screen remain unaffected by this change.