### PR TITLE
Allow to hide account color

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/activity/ColorPickerDialog.java
+++ b/k9mail/src/main/java/com/fsck/k9/activity/ColorPickerDialog.java
@@ -40,10 +40,11 @@ public class ColorPickerDialog extends AlertDialog {
         @SuppressLint("InflateParams")
         View view = LayoutInflater.from(context).inflate(R.layout.holo_color_picker_dialog, null);
 
-        mColorPicker = (ColorPicker) view.findViewById(R.id.color_picker);
+        mColorPicker = view.findViewById(R.id.color_picker);
         mColorPicker.setColor(color);
 
         setView(view);
+        setTitle(R.string.color_picker_default_title);
 
         setButton(BUTTON_POSITIVE, context.getString(R.string.okay_action),
                 new DialogInterface.OnClickListener() {
@@ -51,6 +52,16 @@ public class ColorPickerDialog extends AlertDialog {
             public void onClick(DialogInterface dialog, int which) {
                 if (mColorChangedListener != null) {
                     mColorChangedListener.colorChanged(mColorPicker.getColor());
+                }
+            }
+        });
+
+        setButton(BUTTON_NEUTRAL, context.getString(R.string.account_settings_color_none),
+                new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                if (mColorChangedListener != null) {
+                    mColorChangedListener.colorChanged(0x0); // Transparent
                 }
             }
         });

--- a/k9mail/src/main/res/values/strings.xml
+++ b/k9mail/src/main/res/values/strings.xml
@@ -604,6 +604,7 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="account_settings_color_label">Account color</string>
     <string name="account_settings_color_summary">The accent color of this account used in folder and account list</string>
+    <string name="account_settings_color_none">No color</string>
 
     <string name="account_settings_led_color_label">Notification LED color</string>
     <string name="account_settings_led_color_summary">The color your device LED should blink for this account</string>


### PR DESCRIPTION
Setting a transparent color basically hides those bars everywhere. That way of implementing does not need another setting (in contrast to #514). In that issue, you wrote that the UI overhaul is on the way. Not sure how long it will take, but in the meantime, we can use this ;)

Before / After
<img width="250" src="https://user-images.githubusercontent.com/5811634/40228059-812916ba-5a90-11e8-9950-3a9579aaa4ac.png" /> <img width="250" src="https://user-images.githubusercontent.com/5811634/40228058-810ee8a8-5a90-11e8-9999-0b475658d981.png" />


