### PR TITLE
Use per account instances of RemoteMessageStore

### DIFF
--- a/k9mail/src/main/java/com/fsck/k9/controller/RemoteMessageStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/RemoteMessageStore.java
@@ -1,15 +1,10 @@
 package com.fsck.k9.controller;
 
 
-import com.fsck.k9.Account;
 import com.fsck.k9.mail.Folder;
 
 
 public interface RemoteMessageStore {
-    // TODO: Nicer interface
-    //       Instead of using Account pass in "remote store config", "sync config", "local mail store" (like LocalStore
-    //       only with an interface/implementation optimized for sync; eventually this can replace LocalStore which does
-    //       many things we don't need and does badly some of the things we do need), "folder id"
     // TODO: Add a way to cancel the sync process
-    void sync(Account account, String folder, SyncListener listener, Folder providedRemoteFolder);
+    void sync(String folder, SyncListener listener, Folder providedRemoteFolder);
 }

--- a/k9mail/src/main/java/com/fsck/k9/controller/imap/ImapMessageStore.java
+++ b/k9mail/src/main/java/com/fsck/k9/controller/imap/ImapMessageStore.java
@@ -5,18 +5,21 @@ import com.fsck.k9.Account;
 import com.fsck.k9.controller.RemoteMessageStore;
 import com.fsck.k9.controller.SyncListener;
 import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.store.imap.ImapStore;
+import com.fsck.k9.mailstore.LocalStore;
 
 
 public class ImapMessageStore implements RemoteMessageStore {
     private final ImapSync imapSync;
 
 
-    public ImapMessageStore() {
-        this.imapSync = new ImapSync();
+    // TODO: Pass in SyncConfig interface instead of Account, LocalMessageStore interface instead of LocalStore
+    public ImapMessageStore(Account account, LocalStore localStore, ImapStore imapStore) {
+        this.imapSync = new ImapSync(account, localStore, imapStore);
     }
 
     @Override
-    public void sync(Account account, String folder, SyncListener listener, Folder providedRemoteFolder) {
-        imapSync.sync(account, folder, listener, providedRemoteFolder);
+    public void sync(String folder, SyncListener listener, Folder providedRemoteFolder) {
+        imapSync.sync(folder, listener, providedRemoteFolder);
     }
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -40,7 +40,7 @@ import timber.log.Timber;
 import static com.fsck.k9.mail.store.imap.ImapUtility.getLastResponse;
 
 
-class ImapFolder extends Folder<ImapMessage> {
+public class ImapFolder extends Folder<ImapMessage> {
     static final String INBOX = "INBOX";
     private static final ThreadLocal<SimpleDateFormat> RFC3501_DATE = new ThreadLocal<SimpleDateFormat>() {
         @Override


### PR DESCRIPTION
More work towards being able to extract protocol-specific code to separate Gradle modules.