### PR TITLE
Enable vendor multi-window implementations

### DIFF
--- a/k9mail/src/main/AndroidManifest.xml
+++ b/k9mail/src/main/AndroidManifest.xml
@@ -64,10 +64,10 @@
             android:name="android.app.default_searchable"
             android:value="com.fsck.k9.activity.Search"/>
 
+        <!-- TODO: Remove once minSdkVersion has been changed to 24+ -->
         <meta-data
             android:name="com.lge.support.SPLIT_WINDOW"
             android:value="true"/>
-
         <uses-library
             android:name="com.sec.android.app.multiwindow"
             android:required="false"/>
@@ -89,6 +89,8 @@
 
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+
+                <!-- TODO: Remove once minSdkVersion has been changed to 24+ -->
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER"/>
                 <category android:name="android.intent.category.PENWINDOW_LAUNCHER"/>
             </intent-filter>

--- a/k9mail/src/main/AndroidManifest.xml
+++ b/k9mail/src/main/AndroidManifest.xml
@@ -64,6 +64,20 @@
             android:name="android.app.default_searchable"
             android:value="com.fsck.k9.activity.Search"/>
 
+        <meta-data
+            android:name="com.lge.support.SPLIT_WINDOW"
+            android:value="true"/>
+
+        <uses-library
+            android:name="com.sec.android.app.multiwindow"
+            android:required="false"/>
+        <meta-data
+            android:name="com.sec.android.support.multiwindow"
+            android:value="true"/>
+        <meta-data
+            android:name="com.samsung.android.sdk.multiwindow.penwindow.enable"
+            android:value="true"/>
+
         <activity
             android:name=".activity.Accounts"
             android:configChanges="locale"
@@ -75,6 +89,8 @@
 
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER"/>
+                <category android:name="android.intent.category.PENWINDOW_LAUNCHER"/>
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
Before official support in Android N, LG and Samsung both implemented their own multi-window support, but it requires an explicit opt-in.