### PR TITLE
Set nagivation bar color to dark on dark theme

### DIFF
--- a/k9mail/src/main/res/values-v21/themes.xml
+++ b/k9mail/src/main/res/values-v21/themes.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.K9.Dark.Base" parent="Theme.AppCompat">
+        <item name="android:navigationBarColor">#000000</item>
+    </style>
+</resources>


### PR DESCRIPTION
When using dark theme sets the navigation bar color to dark background.
If the system UI default color is light this fixes the UI mismatch.

Before:

![before](https://user-images.githubusercontent.com/1718963/41682926-83d196cc-74d9-11e8-9240-9f9dd460bd26.png)

After:

![after](https://user-images.githubusercontent.com/1718963/41682936-8a5ab366-74d9-11e8-81c4-6c359b68da75.png)
