### PR TITLE
Caching contact names and picture uris

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/helper/Contacts.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/Contacts.java
@@ -107,6 +107,7 @@ public class Contacts {
         }
 
         mContext.startActivity(contactIntent);
+        clearCache();
     }
 
     /**
@@ -121,6 +122,7 @@ public class Contacts {
         addIntent.putExtra(ContactsContract.Intents.Insert.PHONE, Uri.decode(phoneNumber));
         addIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         mContext.startActivity(addIntent);
+        clearCache();
     }
 
     /**

--- a/app/core/src/main/java/com/fsck/k9/helper/Contacts.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/Contacts.java
@@ -12,6 +12,8 @@ import android.provider.ContactsContract.CommonDataKinds.Photo;
 
 import com.fsck.k9.mail.Address;
 
+import java.util.HashMap;
+
 /**
  * Helper class to access the contacts stored on the device.
  */
@@ -64,6 +66,8 @@ public class Contacts {
 
     protected Context mContext;
     protected ContentResolver mContentResolver;
+    private static HashMap<String, String> nameCache = new HashMap<>();
+    private static HashMap<String, Uri> photoUriCache = new HashMap<>();
 
 
     /**
@@ -171,6 +175,8 @@ public class Contacts {
     public String getNameForAddress(String address) {
         if (address == null) {
             return null;
+        } else if (nameCache.containsKey(address)) {
+            return nameCache.get(address);
         }
 
         final Cursor c = getContactByAddress(address);
@@ -184,6 +190,7 @@ public class Contacts {
             c.close();
         }
 
+        nameCache.put(address, name);
         return name;
     }
 
@@ -229,6 +236,16 @@ public class Contacts {
      *         no such contact could be found or the contact doesn't have a picture.
      */
     public Uri getPhotoUri(String address) {
+        if (photoUriCache.containsKey(address)) {
+            return photoUriCache.get(address);
+        }
+
+        Uri result = getPhotoUriWithoutCache(address);
+        photoUriCache.put(address, result);
+        return result;
+    }
+
+    private Uri getPhotoUriWithoutCache(String address) {
         try {
             final Cursor c = getContactByAddress(address);
             if (c == null) {
@@ -271,6 +288,14 @@ public class Contacts {
                 null,
                 null,
                 SORT_ORDER);
+    }
+
+    /**
+     * Clears the cache for names and photo uris
+     */
+    public static void clearCache() {
+        nameCache.clear();
+        photoUriCache.clear();
     }
 
 }

--- a/app/core/src/main/java/com/fsck/k9/helper/MessageHelper.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/MessageHelper.java
@@ -116,7 +116,6 @@ public class MessageHelper {
             return address.getAddress();
         } else if (contacts != null) {
             final String name = contacts.getNameForAddress(address.getAddress());
-            // TODO: The results should probably be cached for performance reasons.
             if (name != null) {
                 if (changeContactNameColor) {
                     final SpannableString coloredName = new SpannableString(name);

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -47,6 +47,7 @@ import com.fsck.k9.K9;
 import com.fsck.k9.K9.SplitViewMode;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessageReference;
+import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.activity.compose.MessageActions;
 import com.fsck.k9.activity.misc.SwipeGestureDetector.OnSwipeGestureListener;
@@ -530,6 +531,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     public void onResume() {
         super.onResume();
 
+        Contacts.clearCache();
         if (!(this instanceof Search)) {
             //necessary b/c no guarantee Search.onStop will be called before MessageList.onResume
             //when returning from search results

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -531,7 +531,6 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     public void onResume() {
         super.onResume();
 
-        Contacts.clearCache();
         if (!(this instanceof Search)) {
             //necessary b/c no guarantee Search.onStop will be called before MessageList.onResume
             //when returning from search results
@@ -543,6 +542,12 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
             return;
         }
         StorageManager.getInstance(getApplication()).addListener(mStorageListener);
+    }
+
+    @Override
+    protected void onStart() {
+        super.onStart();
+        Contacts.clearCache();
     }
 
     @Override


### PR DESCRIPTION
This caches the contact related information that is displayed in the message list. Currently, the cache is cleared on resume, but this can of course be changed. The effect is noticeable a lot, especially when selecting multiple messages.

Have a look at the attached video. I am selecting the next message as soon as the app becomes responsive again.

![ezgif-1-95e2c13b89](https://user-images.githubusercontent.com/5811634/42473274-7563d150-83c4-11e8-963f-97bf80a15f9e.gif)
