### PR TITLE
Enable drawer only for proper accounts

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -250,7 +250,6 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         }
 
         initializeActionBar();
-        initializeDrawer(savedInstanceState);
         initializeFolderIcons();
 
         // Enable gesture detection for MessageLists
@@ -262,6 +261,8 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
         ViewModelProvider viewModelProvider = ViewModelProviders.of(this, new MessageListViewModelFactory());
         MessageListViewModel viewModel = viewModelProvider.get(MessageListViewModel.class);
+
+        initializeDrawer(savedInstanceState);
 
         if (isDrawerEnabled()) {
             viewModel.getFolders(account).observe(this, new Observer<List<Folder>>() {
@@ -717,7 +718,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     }
 
     protected boolean isDrawerEnabled() {
-        return true;
+        return (account != null);
     }
 
     @SuppressLint("InflateParams")


### PR DESCRIPTION
and e.g. not for the Unified Inbox

Fixes #3493

Not ideal because `isDrawerEnabled()` can change from `false` to `true` if `account` is initialized after `isDrawerEnabled()` was already called, so that an uninitialized drawer can in principle be invited to be accessed, but it fixes the issue for now. 

