### PR TITLE
Make sure account display name is never null

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -776,6 +776,10 @@ public class Account implements BaseAccount, StoreConfig {
         this.description = description;
     }
 
+    public String getDisplayName() {
+        return description != null ? description : getEmail();
+    }
+
     public synchronized String getName() {
         return identities.get(0).getName();
     }

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -27,7 +27,7 @@ class ImapBackendFactory(
     override val transportUriPrefix = "smtp"
 
     override fun createBackend(account: Account): Backend {
-        val accountName = account.description
+        val accountName = account.displayName
         val backendStorage = K9BackendStorage(preferences, account, account.localStore)
         val imapStore = createImapStore(account)
         val smtpTransport = createSmtpTransport(account)

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
@@ -21,7 +21,7 @@ class Pop3BackendFactory(private val context: Context, private val preferences: 
     override val transportUriPrefix = "smtp"
 
     override fun createBackend(account: Account): Backend {
-        val accountName = account.description
+        val accountName = account.displayName
         val backendStorage = K9BackendStorage(preferences, account, account.localStore)
         val pop3Store = createPop3Store(account)
         val smtpTransport = createSmtpTransport(account)

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/WebDavBackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/WebDavBackendFactory.kt
@@ -17,7 +17,7 @@ class WebDavBackendFactory(private val preferences: Preferences) : BackendFactor
     override val transportUriPrefix = "webdav"
 
     override fun createBackend(account: Account): Backend {
-        val accountName = account.description
+        val accountName = account.displayName
         val backendStorage = K9BackendStorage(preferences, account, account.localStore)
         val serverSettings = WebDavStoreUriDecoder.decode(account.storeUri)
         val webDavStore = createWebDavStore(serverSettings, account)


### PR DESCRIPTION
During account setup the account description is `null`. This lead to an exception when trying to set up a POP3 or WebDAV account because the `accountName` parameter is declared as non-nullable `String`.