### PR TITLE
allow installation to external media (micro SD) #3539

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
+    android:installLocation="auto"
     package="com.fsck.k9">
 
     <uses-feature


### PR DESCRIPTION
This change will enable installation of the app to external as well as internal flash memory which is important for devices where internal memory is limited but external memory is cheap and abundant in form of micro SD cards (Closes: #3539). Thank you for your consideration.