### PR TITLE
Update address validator to conform to RFC 5322.

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/EmailAddressValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/EmailAddressValidator.kt
@@ -16,15 +16,20 @@ class EmailAddressValidator : Validator {
     companion object {
 
         //https://www.rfc-editor.org/rfc/rfc2396.txt (3.2.2)
+        //https://www.rfc-editor.org/rfc/rfc5322.txt (3.4, 3.2.3, 3.2.4)
+        //ATEXT, DOT_ATOM, and QCONTENT are the terms used in RFC 5322 for the appropriate character classes.
 
         private const val ALPHA = "[a-zA-Z]"
         private const val ALPHANUM = "[a-zA-Z0-9]"
+        private const val ATEXT = "[0-9a-zA-Z!#$%&'*+\\-/=?^_`{|}~]"
+        private const val DOT_ATOM = "($ATEXT|(?<=$ATEXT)\\.(?=$ATEXT))"
+        private const val QCONTENT = "([\\p{Graph}\\p{Blank}&&[^\"\\\\]]|\\\\[\\p{Graph}\\p{Blank}])"
         private const val TOP_LABEL = "(($ALPHA($ALPHANUM|\\-|_)*$ALPHANUM)|$ALPHA)"
         private const val DOMAIN_LABEL = "(($ALPHANUM($ALPHANUM|\\-|_)*$ALPHANUM)|$ALPHANUM)"
         private const val HOST_NAME = "((($DOMAIN_LABEL\\.)+$TOP_LABEL)|$DOMAIN_LABEL)"
 
         private val EMAIL_ADDRESS_PATTERN = Pattern.compile(
-                "[a-zA-Z0-9\\+\\.\\_\\%\\-]{1,256}" +
+                "^($DOT_ATOM{1,64}|\"$QCONTENT{1,62}\")" +
                         "\\@$HOST_NAME"
         )
     }

--- a/app/core/src/main/java/com/fsck/k9/EmailAddressValidator.kt
+++ b/app/core/src/main/java/com/fsck/k9/EmailAddressValidator.kt
@@ -16,20 +16,18 @@ class EmailAddressValidator : Validator {
     companion object {
 
         //https://www.rfc-editor.org/rfc/rfc2396.txt (3.2.2)
-        //https://www.rfc-editor.org/rfc/rfc5322.txt (3.4, 3.2.3, 3.2.4)
-        //ATEXT, DOT_ATOM, and QCONTENT are the terms used in RFC 5322 for the appropriate character classes.
+        //https://www.rfc-editor.org/rfc/rfc5321.txt (4.1.2)
 
         private const val ALPHA = "[a-zA-Z]"
         private const val ALPHANUM = "[a-zA-Z0-9]"
         private const val ATEXT = "[0-9a-zA-Z!#$%&'*+\\-/=?^_`{|}~]"
-        private const val DOT_ATOM = "($ATEXT|(?<=$ATEXT)\\.(?=$ATEXT))"
         private const val QCONTENT = "([\\p{Graph}\\p{Blank}&&[^\"\\\\]]|\\\\[\\p{Graph}\\p{Blank}])"
         private const val TOP_LABEL = "(($ALPHA($ALPHANUM|\\-|_)*$ALPHANUM)|$ALPHA)"
         private const val DOMAIN_LABEL = "(($ALPHANUM($ALPHANUM|\\-|_)*$ALPHANUM)|$ALPHANUM)"
         private const val HOST_NAME = "((($DOMAIN_LABEL\\.)+$TOP_LABEL)|$DOMAIN_LABEL)"
 
         private val EMAIL_ADDRESS_PATTERN = Pattern.compile(
-                "^($DOT_ATOM{1,64}|\"$QCONTENT{1,62}\")" +
+                "^($ATEXT+(\\.$ATEXT+)*|\"$QCONTENT+\")" +
                         "\\@$HOST_NAME"
         )
     }

--- a/app/core/src/test/java/com/fsck/k9/EmailAddressValidatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/EmailAddressValidatorTest.kt
@@ -28,8 +28,9 @@ class EmailAddressValidatorTest {
         Assert.assertFalse(validator.isValidAddressOnly("Abc.example.com"))
         Assert.assertFalse(validator.isValidAddressOnly("\"not\"right@example.com"))
         Assert.assertFalse(validator.isValidAddressOnly("john.doe@example..com"))
+        Assert.assertFalse(validator.isValidAddressOnly("example@c.2"))
         Assert.assertFalse(validator.isValidAddressOnly("this\\ still\\\"not\\\\allowed@example.com"))
         Assert.assertFalse(validator.isValidAddressOnly("john..doe@example.com"))
-        Assert.assertFalse(validator.isValidAddressOnly("1234567890123456789012345678901234567890123456789012345678901234+x@example.com"))
+        Assert.assertFalse(validator.isValidAddressOnly("invalidperiod.@example.com"))
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/EmailAddressValidatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/EmailAddressValidatorTest.kt
@@ -20,10 +20,16 @@ class EmailAddressValidatorTest {
         Assert.assertTrue(validator.isValidAddressOnly("example@1.com"))
         Assert.assertTrue(validator.isValidAddressOnly("admin@mailserver1"))
         Assert.assertTrue(validator.isValidAddressOnly("user@localserver"))
+        Assert.assertTrue(validator.isValidAddressOnly("\"very.(),:;<>[]\\\".VERY.\\\"very@\\\\ \\\"very\\\".unusual\"@strange.example.com"))
+        Assert.assertTrue(validator.isValidAddressOnly("\"()<>[]:,;@\\\\\\\"!#$%&'-/=?^_`{}| ~.a\"@example.org"))
+        Assert.assertTrue(validator.isValidAddressOnly("\" \"@example.org"))
+        Assert.assertTrue(validator.isValidAddressOnly("x@example.com"))
 
         Assert.assertFalse(validator.isValidAddressOnly("Abc.example.com"))
         Assert.assertFalse(validator.isValidAddressOnly("\"not\"right@example.com"))
         Assert.assertFalse(validator.isValidAddressOnly("john.doe@example..com"))
-        Assert.assertFalse(validator.isValidAddressOnly("example@c.2"))
+        Assert.assertFalse(validator.isValidAddressOnly("this\\ still\\\"not\\\\allowed@example.com"))
+        Assert.assertFalse(validator.isValidAddressOnly("john..doe@example.com"))
+        Assert.assertFalse(validator.isValidAddressOnly("1234567890123456789012345678901234567890123456789012345678901234+x@example.com"))
     }
 }


### PR DESCRIPTION
Fix issues #1175, #2781, except for the IPv6 host example in #1175.

- Alter EmailAddressValidator class to conform to local portion address
  specifications in RFC 5322 3.4.1, 3.2.3, 3.2.4

- Limit local portion of address to 64 characters, as specified in SMTP
  specs, RFC 5321 4.5.3.1.1

- Add further test cases to the EmailAddressValidatorTest to ensure
  compliance with RFC 5322