### PR TITLE
"Fix" remote search

### DIFF
--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandFetchMessage.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandFetchMessage.kt
@@ -16,6 +16,8 @@ internal class CommandFetchMessage(private val imapStore: ImapStore) {
     fun fetchMessage(folderServerId: String, messageServerId: String, fetchProfile: FetchProfile): Message {
         val folder = imapStore.getFolder(folderServerId)
         try {
+            folder.open(Folder.OPEN_MODE_RO)
+
             val message = folder.getMessage(messageServerId)
 
             //fun fact: ImapFolder.fetch can't handle getting STRUCTURE at same time as headers


### PR DESCRIPTION
Slightly modified version of the changes from @morckx in PR #3501.

This is only a temporary fix. With it we issue an `EXAMINE` command for each found message before retrieving the message details. 
A proper fix should probably move all the work into the `Backend` implementation. Right now remote search is split into multiple operations going back and forth between `MessagingController` and `Backend`.