### PR TITLE
Add proper header parameter parser/decoder

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
+++ b/app/core/src/main/java/com/fsck/k9/message/extractors/AttachmentInfoExtractor.java
@@ -105,13 +105,12 @@ public class AttachmentInfoExtractor {
     }
 
     @WorkerThread
-    private AttachmentViewInfo extractAttachmentInfo(Part part, Uri uri, long size, boolean isContentAvailable)
-            throws MessagingException {
+    private AttachmentViewInfo extractAttachmentInfo(Part part, Uri uri, long size, boolean isContentAvailable) {
         boolean inlineAttachment = false;
 
         String mimeType = part.getMimeType();
-        String contentTypeHeader = MimeUtility.unfoldAndDecode(part.getContentType());
-        String contentDisposition = MimeUtility.unfoldAndDecode(part.getDisposition());
+        String contentTypeHeader = part.getContentType();
+        String contentDisposition = part.getDisposition();
 
         String name = MimeUtility.getHeaderParameter(contentDisposition, "filename");
         if (name == null) {

--- a/app/core/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
+++ b/app/core/src/test/java/com/fsck/k9/message/MessageBuilderTest.java
@@ -84,7 +84,8 @@ public class MessageBuilderTest extends RobolectricTest {
             "text =E2=98=AD";
 
     private static final String MESSAGE_CONTENT_WITH_ATTACH = "" +
-            "Content-Type: multipart/mixed; boundary=\"" + BOUNDARY_1 + "\"\r\n" +
+            "Content-Type: multipart/mixed;\r\n" +
+            " boundary=" + BOUNDARY_1 + "\r\n" +
             "Content-Transfer-Encoding: 7bit\r\n" +
             "\r\n" +
             "--" + BOUNDARY_1 + "\r\n" +
@@ -107,7 +108,8 @@ public class MessageBuilderTest extends RobolectricTest {
             "--" + BOUNDARY_1 + "--\r\n";
 
     private static final String MESSAGE_CONTENT_WITH_LONG_FILE_NAME =
-            "Content-Type: multipart/mixed; boundary=\"" + BOUNDARY_1 + "\"\r\n" +
+            "Content-Type: multipart/mixed;\r\n" +
+            " boundary=" + BOUNDARY_1 + "\r\n" +
             "Content-Transfer-Encoding: 7bit\r\n" +
             "\r\n" +
             "--" + BOUNDARY_1 + "\r\n" +
@@ -133,7 +135,8 @@ public class MessageBuilderTest extends RobolectricTest {
 
     private static final String ATTACHMENT_FILENAME_NON_ASCII = "テスト文書.txt";
     private static final String MESSAGE_CONTENT_WITH_ATTACH_NON_ASCII_FILENAME = "" +
-            "Content-Type: multipart/mixed; boundary=\"" + BOUNDARY_1 + "\"\r\n" +
+            "Content-Type: multipart/mixed;\r\n" +
+            " boundary=" + BOUNDARY_1 + "\r\n" +
             "Content-Transfer-Encoding: 7bit\r\n" +
             "\r\n" +
             "--" + BOUNDARY_1 + "\r\n" +
@@ -156,7 +159,8 @@ public class MessageBuilderTest extends RobolectricTest {
             "--" + BOUNDARY_1 + "--\r\n";
 
     private static final String MESSAGE_CONTENT_WITH_MESSAGE_ATTACH = "" +
-            "Content-Type: multipart/mixed; boundary=\"" + BOUNDARY_1 + "\"\r\n" +
+            "Content-Type: multipart/mixed;\r\n" +
+            " boundary=" + BOUNDARY_1 + "\r\n" +
             "Content-Transfer-Encoding: 7bit\r\n" +
             "\r\n" +
             "--" + BOUNDARY_1 + "\r\n" +

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/Headers.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/Headers.kt
@@ -7,6 +7,22 @@ object Headers {
     }
 
     @JvmStatic
+    fun contentType(mimeType: String, charset: String, name: String?): String {
+        val parameters = if (name == null) {
+            mapOf("charset" to charset)
+        } else {
+            mapOf("charset" to charset, "name" to name)
+        }
+
+        return MimeParameterEncoder.encode(mimeType, parameters)
+    }
+
+    @JvmStatic
+    fun contentTypeForMultipart(mimeType: String, boundary: String): String {
+        return MimeParameterEncoder.encode(mimeType, mapOf("boundary" to boundary))
+    }
+
+    @JvmStatic
     @JvmOverloads
     fun contentDisposition(disposition: String, fileName: String, size: Long? = null): String {
         val parameters = if (size == null) {

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeBodyPart.java
@@ -13,6 +13,8 @@ import java.io.OutputStreamWriter;
 
 import android.support.annotation.NonNull;
 
+import static com.fsck.k9.mail.internet.MimeUtility.isSameMimeType;
+
 
 /**
  * TODO this is a close approximation of Message, need to update along with
@@ -95,12 +97,14 @@ public class MimeBodyPart extends BodyPart {
     public String getContentType() {
         String contentType = getFirstHeader(MimeHeader.HEADER_CONTENT_TYPE);
         if (contentType != null) {
-            return MimeUtility.unfoldAndDecode(contentType);
+            return contentType;
         }
+
         Multipart parent = getParent();
-        if (parent != null && "multipart/digest".equals(parent.getMimeType())) {
+        if (parent != null && isSameMimeType(parent.getMimeType(), "multipart/digest")) {
             return "message/rfc822";
         }
+
         return "text/plain";
     }
 

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeExtensions.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeExtensions.kt
@@ -10,6 +10,10 @@ internal const val HTAB = '\t'
 // RFC 5234: SP = %x20
 internal const val SPACE = ' '
 
+
+// RFC 5234: CRLF = %d13.10
+internal const val CRLF = "\r\n"
+
 internal const val CR = '\r'
 internal const val LF = '\n'
 internal const val DQUOTE = '"'

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeExtensions.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeExtensions.kt
@@ -1,0 +1,35 @@
+package com.fsck.k9.mail.internet
+
+
+// RFC 2045: tspecials :=  "(" / ")" / "<" / ">" / "@" / "," / ";" / ":" / "\" / <"> / "/" / "[" / "]" / "?" / "="
+private val TSPECIALS = charArrayOf('(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=')
+
+// RFC 5234: HTAB = %x09
+internal const val HTAB = '\t'
+
+// RFC 5234: SP = %x20
+internal const val SPACE = ' '
+
+internal const val CR = '\r'
+internal const val LF = '\n'
+internal const val DQUOTE = '"'
+internal const val SEMICOLON = ';'
+internal const val EQUALS_SIGN = '='
+internal const val ASTERISK = '*'
+internal const val SINGLE_QUOTE = '\''
+
+
+internal fun Char.isTSpecial() = this in TSPECIALS
+
+// RFC 2045: token := 1*<any (US-ASCII) CHAR except SPACE, CTLs, or tspecials>
+// RFC 5234: CTL = %x00-1F / %x7F
+internal fun Char.isTokenChar() = isVChar() && !isTSpecial()
+
+// RFC 5234: VCHAR = %x21-7E
+internal fun Char.isVChar() = toInt() in 33..126
+
+// RFC 5234: WSP =  SP / HTAB
+internal fun Char.isWsp() = this == SPACE || this == HTAB
+
+// RFC 2231: attribute-char := <any (US-ASCII) CHAR except SPACE, CTLs, "*", "'", "%", or tspecials>
+internal fun Char.isAttributeChar() = isVChar() && this != '*' && this != '\'' && this != '%' && !isTSpecial()

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeHeaderParser.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeHeaderParser.kt
@@ -1,0 +1,186 @@
+package com.fsck.k9.mail.internet
+
+import okio.Buffer
+
+class MimeHeaderParser(private val input: String) {
+    private val endIndex = input.length
+    private var currentIndex = 0
+
+    fun readHeaderValue(): String {
+        return buildString {
+            var whitespace = false
+            loop@while (!endReached()) {
+                val character = peek()
+                when {
+                    character == ';' -> break@loop
+                    character.isWsp() || character == CR || character == LF -> {
+                        skipWhitespace()
+                        whitespace = true
+                    }
+                    character == '(' -> skipComment()
+                    else -> {
+                        if (isNotEmpty() && whitespace) {
+                            append(' ')
+                        }
+                        append(character)
+                        currentIndex++
+                        whitespace = false
+                    }
+                }
+            }
+        }
+    }
+
+    fun readUntil(character: Char) = readWhile { peek() != character }
+
+    fun readExtendedParameterValueInto(output: Buffer) {
+        while (!endReached() && peek() != ';') {
+            val c = read()
+            when {
+                c == '%' -> output.writeByte(readPercentEncoded())
+                c.isAttributeChar() -> output.writeByte(c.toInt())
+                else -> return
+            }
+        }
+    }
+
+    private fun readPercentEncoded(): Int {
+        val value1 = readHexDigit()
+        val value2 = readHexDigit()
+
+        return (value1 shl 4) + value2
+    }
+
+    private fun readHexDigit(): Int {
+        val character = read()
+        return when (character) {
+            in '0'..'9' -> character - '0'
+            in 'a'..'f' -> character - 'a' + 10
+            in 'A'..'F' -> character - 'A' + 10
+            else -> throw MimeHeaderParserException("Expected hex character", currentIndex - 1)
+        }
+    }
+
+    fun readQuotedString(): String {
+        expect('"')
+
+        val text = buildString {
+            while (!endReached() && peek() != '\"') {
+                val c = read()
+                when (c) {
+                    CR -> Unit
+                    LF -> Unit
+                    '\\' -> append(read())
+                    else -> append(c)
+                }
+            }
+        }
+
+        expect('"')
+
+        return text
+    }
+
+    fun readToken(): String {
+        skipCFWS()
+        val startIndex = currentIndex
+        while (!endReached() && peek().isTokenChar()) {
+            currentIndex++
+        }
+
+        if (startIndex == currentIndex) {
+            throw MimeHeaderParserException("At least one character expected in token", currentIndex)
+        }
+
+        return input.substring(startIndex, currentIndex)
+    }
+
+    fun optional(character: Char): Boolean {
+        if (peek() == character) {
+            currentIndex++
+            return true
+        }
+
+        return false
+    }
+
+    fun endReached() = currentIndex >= endIndex
+
+    fun position() = currentIndex
+
+    fun expect(character: Char) {
+        if (!endReached() && peek() == character) {
+            currentIndex++
+        } else {
+            throw MimeHeaderParserException("Expected '$character' (${character.toInt()})", currentIndex)
+        }
+    }
+
+    private fun skipWhitespace() {
+        while (!endReached() && peek().let { it.isWsp() || it == CR || it == LF }) {
+            currentIndex++
+        }
+    }
+
+    fun skipCFWS() {
+        while (!endReached()) {
+            val character = peek()
+            when {
+                character.isWsp() || character == CR || character == LF -> currentIndex++
+                character == '(' -> skipComment()
+                else -> return
+            }
+        }
+    }
+
+    private fun skipComment() {
+        expect('(')
+        var depth = 1
+        while (!endReached() && depth > 0) {
+            val character = read()
+            when {
+                character == '(' -> depth++
+                character == ')' -> depth--
+                character == '\\' -> currentIndex++
+                character == CR -> Unit
+                character == LF -> Unit
+                character.isWsp() -> Unit
+                character.isVChar() -> Unit
+                else -> {
+                    currentIndex--
+                    throw MimeHeaderParserException("Unexpected '$character' (${character.toInt()}) in comment",
+                            errorIndex = currentIndex)
+                }
+            }
+        }
+    }
+
+    fun peek(): Char {
+        if (currentIndex >= input.length) {
+            throw MimeHeaderParserException("End of input reached unexpectedly", currentIndex)
+        }
+
+        return input[currentIndex]
+    }
+
+    fun read(): Char {
+        if (currentIndex >= input.length) {
+            throw MimeHeaderParserException("End of input reached unexpectedly", currentIndex)
+        }
+
+        val value = input[currentIndex]
+        currentIndex++
+        return value
+    }
+
+    private inline fun readWhile(crossinline predicate: () -> Boolean): String {
+        val startIndex = currentIndex
+        while (!endReached() && predicate()) {
+            currentIndex++
+        }
+
+        return input.substring(startIndex, currentIndex)
+    }
+}
+
+class MimeHeaderParserException(message: String, val errorIndex: Int) : RuntimeException(message)

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -36,6 +36,7 @@ import org.apache.james.mime4j.parser.MimeStreamParser;
 import org.apache.james.mime4j.stream.BodyDescriptor;
 import org.apache.james.mime4j.stream.Field;
 import org.apache.james.mime4j.stream.MimeConfig;
+import timber.log.Timber;
 
 
 /**
@@ -126,12 +127,16 @@ public class MimeMessage extends Message {
     @Override
     public Date getSentDate() {
         if (mSentDate == null) {
+            String dateHeaderBody = getFirstHeader("Date");
+            if (dateHeaderBody == null) {
+                return null;
+            }
+
             try {
-                DateTimeField field = (DateTimeField)DefaultFieldParser.parse("Date: "
-                                      + MimeUtility.unfoldAndDecode(getFirstHeader("Date")));
+                DateTimeField field = (DateTimeField) DefaultFieldParser.parse("Date: " + dateHeaderBody);
                 mSentDate = field.getDate();
             } catch (Exception e) {
-
+                Timber.d(e, "Couldn't parse Date header field");
             }
         }
         return mSentDate;
@@ -171,12 +176,12 @@ public class MimeMessage extends Message {
     @Override
     public String getContentType() {
         String contentType = getFirstHeader(MimeHeader.HEADER_CONTENT_TYPE);
-        return (contentType == null) ? "text/plain" : MimeUtility.unfoldAndDecode(contentType);
+        return (contentType == null) ? "text/plain" : contentType;
     }
 
     @Override
     public String getDisposition() {
-        return MimeUtility.unfoldAndDecode(getFirstHeader(MimeHeader.HEADER_CONTENT_DISPOSITION));
+        return getFirstHeader(MimeHeader.HEADER_CONTENT_DISPOSITION);
     }
 
     @Override

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeMessageHelper.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeMessageHelper.java
@@ -23,23 +23,21 @@ public class MimeMessageHelper {
         if (body instanceof Multipart) {
             Multipart multipart = ((Multipart) body);
             multipart.setParent(part);
-            String mimeType = multipart.getMimeType();
-            String contentType = String.format("%s; boundary=\"%s\"", mimeType, multipart.getBoundary());
+            String contentType = Headers.contentTypeForMultipart(multipart.getMimeType(), multipart.getBoundary());
             part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType);
             // note: if this is ever changed to 8bit, multipart/signed parts must always be 7bit!
             setEncoding(part, MimeUtil.ENC_7BIT);
         } else if (body instanceof TextBody) {
-            String contentType;
-            if (MimeUtility.mimeTypeMatches(part.getMimeType(), "text/*")) {
-                contentType = String.format("%s;\r\n charset=utf-8", part.getMimeType());
-                String name = MimeUtility.getHeaderParameter(part.getContentType(), "name");
-                if (name != null) {
-                    contentType += String.format(";\r\n name=\"%s\"", name);
-                }
+            MimeValue contentTypeHeader = MimeParameterDecoder.decode(part.getContentType());
+            String mimeType = contentTypeHeader.getValue();
+            if (MimeUtility.mimeTypeMatches(mimeType, "text/*")) {
+                String name = contentTypeHeader.getParameters().get("name");
+
+                String contentType = Headers.contentType(mimeType, "utf-8", name);
+                part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType);
             } else {
-                contentType = part.getMimeType();
+                part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, mimeType);
             }
-            part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, contentType);
 
             setEncoding(part, MimeUtil.ENC_QUOTED_PRINTABLE);
         } else if (body instanceof RawDataBody) {

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeParameterDecoder.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeParameterDecoder.kt
@@ -1,0 +1,278 @@
+package com.fsck.k9.mail.internet
+
+import okio.Buffer
+import java.nio.charset.Charset
+import java.nio.charset.IllegalCharsetNameException
+import java.util.Locale
+
+private typealias Parameters = Map<String, String>
+private typealias BasicParameters = Map<String, ParameterValue>
+private typealias SimpleParameter = Pair<String, String>
+private typealias IgnoredParameters = List<SimpleParameter>
+
+/**
+ * Decode MIME parameter values as specified in RFC 2045 and RFC 2231.
+ *
+ * Parsing MIME header parameters is quite challenging because a lot of things have to be considered:
+ * - RFC 822 allows comments and (folding) whitespace between all tokens in structured header fields
+ * - parameter names are case insensitive
+ * - the ordering of parameters is not significant
+ * - parameters could be present in RFC 2045 style and RFC 2231 style
+ * - it's not specified what happens when an extended parameter value (RFC 2231) doesn't specify a charset value
+ * - some clients don't use the method described in RFC 2231 to encode parameter values with non-ASCII characters; but
+ *   encoded words as described in RFC 2047
+ *
+ * This class takes a very lenient approach in order to be able to decode as many real world messages as possible.
+ * First it does a pass to extract RFC 2045 style parameter names and values while remembering how the values were
+ * encoded (token vs. quoted string). When a parsing error is encountered parsing is stopped, but anything successfully
+ * parsed before that is kept. A second pass then checks if successfully parsed parameters are RFC 2231 encoded and
+ * combines/decodes them.
+ * If a parameter is present encoded according to RFC 2045 and also also as described in RFC 2231 the latter version
+ * is preferred. In case only a RFC 2045 style parameter is present this class attempts to RFC 2047 (encoded word)
+ * decode it. This is not a valid encoding for the structured header fields `Content-Type` and `Content-Disposition`,
+ * but it is seen in the wild.
+ */
+object MimeParameterDecoder {
+
+    @JvmStatic
+    fun decode(headerBody: String): MimeValue {
+        val parser = MimeHeaderParser(headerBody)
+
+        val value = parser.readHeaderValue()
+        parser.skipCFWS()
+        if (parser.endReached()) {
+            return MimeValue(value)
+        }
+
+        val (basicParameters, duplicateParameters, parserErrorIndex) = readBasicParameters(parser)
+        val (parameters, ignoredParameters) = reconstructParameters(basicParameters)
+
+        return MimeValue(
+                value = value,
+                parameters = parameters,
+                ignoredParameters = duplicateParameters + ignoredParameters,
+                parserErrorIndex = parserErrorIndex
+        )
+    }
+
+    private fun readBasicParameters(parser: MimeHeaderParser): BasicParameterResults {
+        val parameters = mutableMapOf<String, ParameterValue>()
+        val duplicateParameterNames = mutableSetOf<String>()
+        val ignoredParameters = mutableListOf<SimpleParameter>()
+        val parserErrorIndex = try {
+            do {
+                parser.expect(SEMICOLON)
+
+                val parameterName = parser.readToken().toLowerCase(Locale.ROOT)
+
+                parser.skipCFWS()
+                parser.expect(EQUALS_SIGN)
+                parser.skipCFWS()
+
+                val parameterValue = if (parser.peek() == DQUOTE) {
+                    ParameterValue(parser.readQuotedString(), wasToken = false)
+                } else {
+                    ParameterValue(parser.readToken(), wasToken = true)
+                }
+
+                val existingParameterValue = parameters.remove(parameterName)
+                when {
+                    existingParameterValue != null -> {
+                        duplicateParameterNames.add(parameterName)
+                        ignoredParameters.add(parameterName to existingParameterValue.value)
+                        ignoredParameters.add(parameterName to parameterValue.value)
+                    }
+                    parameterName !in duplicateParameterNames -> parameters[parameterName] = parameterValue
+                    else -> ignoredParameters.add(parameterName to parameterValue.value)
+                }
+
+                parser.skipCFWS()
+            } while (!parser.endReached())
+
+            null
+        } catch (e: MimeHeaderParserException) {
+            e.errorIndex
+        }
+
+        return BasicParameterResults(parameters, ignoredParameters, parserErrorIndex)
+    }
+
+    private fun reconstructParameters(basicParameters: BasicParameters): Pair<Parameters, IgnoredParameters> {
+        val parameterSectionMap = mutableMapOf<String, MutableList<ParameterSection>>()
+        val singleParameters = mutableMapOf<String, String>()
+
+        for ((parameterName, parameterValue) in basicParameters) {
+            val parameterSection = convertToParameterSection(parameterName, parameterValue)
+
+            if (parameterSection == null) {
+                singleParameters[parameterName] = parameterValue.value
+            } else {
+                parameterSectionMap.getOrPut(parameterSection.name) { mutableListOf() }
+                        .add(parameterSection)
+            }
+        }
+
+        val parameters = mutableMapOf<String, String>()
+        for ((parameterName, parameterSections) in parameterSectionMap) {
+            parameterSections.sortBy { it.section }
+
+            if (areParameterSectionsValid(parameterSections)) {
+                parameters[parameterName] = combineParameterSections(parameterSections)
+            } else {
+                for (parameterSection in parameterSections) {
+                    val originalParameterName = parameterSection.originalName
+                    parameters[originalParameterName] = basicParameters[originalParameterName]!!.value
+                }
+            }
+        }
+
+        val ignoredParameters = mutableListOf<Pair<String, String>>()
+        for ((parameterName, parameterValue) in singleParameters) {
+            if (parameterName !in parameters) {
+                parameters[parameterName] = DecoderUtil.decodeEncodedWords(parameterValue, null)
+            } else {
+                ignoredParameters.add(parameterName to parameterValue)
+            }
+        }
+
+        return Pair(parameters, ignoredParameters)
+    }
+
+    private fun convertToParameterSection(parameterName: String, parameterValue: ParameterValue): ParameterSection? {
+        val extendedValue = parameterName.endsWith(ASTERISK)
+        if (extendedValue && !parameterValue.wasToken) {
+            return null
+        }
+
+        val parts = parameterName.split(ASTERISK)
+        if (parts.size !in 2..3 || parts.size == 3 && parts[2].isNotEmpty()) {
+            return null
+        }
+
+        val newParameterName = parts[0]
+        val sectionText = parts[1]
+        val section = when {
+            parts.size == 2 && extendedValue -> null
+            sectionText == "0" -> 0
+            sectionText.startsWith('0') -> return null
+            sectionText.isNotAsciiNumber() -> return null
+            else -> parts[1].toIntOrNull() ?: return null
+        }
+
+        val parameterText = parameterValue.value
+        return if (extendedValue) {
+            val parser = MimeHeaderParser(parameterText)
+            if (section == null || section == 0) {
+                readExtendedParameterValue(parser, parameterName, newParameterName, section, parameterText)
+            } else {
+                val data = Buffer()
+                parser.readExtendedParameterValueInto(data)
+
+                ExtendedValueParameterSection(newParameterName, parameterName, section, data)
+            }
+        } else {
+            RegularValueParameterSection(newParameterName, parameterName, section, parameterText)
+        }
+    }
+
+    private fun readExtendedParameterValue(
+            parser: MimeHeaderParser,
+            parameterName: String,
+            newParameterName: String,
+            section: Int?,
+            parameterText: String
+    ): ParameterSection? {
+        return try {
+            val charsetName = parser.readUntil(SINGLE_QUOTE)
+            parser.expect(SINGLE_QUOTE)
+            val language = parser.readUntil(SINGLE_QUOTE)
+            parser.expect(SINGLE_QUOTE)
+
+            if (charsetName.isSupportedCharset()) {
+                val data = Buffer()
+                parser.readExtendedParameterValueInto(data)
+
+                InitialExtendedValueParameterSection(
+                        newParameterName, parameterName, section, charsetName, language, data)
+            } else {
+                val encodedParameterText = parameterText.substring(parser.position())
+                RegularValueParameterSection(newParameterName, parameterName, section, encodedParameterText)
+            }
+        } catch (e: MimeHeaderParserException) {
+            null
+        }
+    }
+
+    private fun areParameterSectionsValid(parameterSections: MutableList<ParameterSection>): Boolean {
+        if (parameterSections.size == 1) {
+            val section = parameterSections.first().section
+            return section == null || section == 0
+        }
+
+        val isExtendedValue = parameterSections.first() is InitialExtendedValueParameterSection
+
+        parameterSections.forEachIndexed { index, parameterSection ->
+            if (parameterSection.section != index ||
+                    !isExtendedValue && parameterSection is ExtendedValueParameterSection) {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private fun combineParameterSections(parameterSections: MutableList<ParameterSection>): String {
+        val initialParameterSection = parameterSections.first()
+        return if (initialParameterSection is InitialExtendedValueParameterSection) {
+            val charset = Charset.forName(initialParameterSection.charsetName)
+            combineExtendedParameterSections(parameterSections, charset)
+        } else {
+            combineRegularParameterSections(parameterSections)
+        }
+    }
+
+    private fun combineExtendedParameterSections(parameterSections: List<ParameterSection>, charset: Charset): String {
+        val buffer = Buffer()
+        return buildString {
+            for (parameterSection in parameterSections) {
+                when (parameterSection) {
+                    is ExtendedValueParameterSection -> buffer.writeAll(parameterSection.data)
+                    is RegularValueParameterSection -> {
+                        append(buffer.readString(charset))
+                        append(parameterSection.text)
+                    }
+                }
+            }
+            append(buffer.readString(charset))
+        }
+    }
+
+    private fun combineRegularParameterSections(parameterSections: MutableList<ParameterSection>): String {
+        return buildString {
+            for (parameterSection in parameterSections) {
+                if (parameterSection !is RegularValueParameterSection) throw AssertionError()
+                append(parameterSection.text)
+            }
+        }
+    }
+
+    private fun String.isSupportedCharset(): Boolean {
+        if (isEmpty()) return false
+
+        return try {
+            Charset.isSupported(this)
+        } catch (e: IllegalCharsetNameException) {
+            false
+        }
+    }
+
+    private fun String.isNotAsciiNumber(): Boolean = any { character -> character !in '0'..'9' }
+}
+
+private data class ParameterValue(val value: String, val wasToken: Boolean)
+
+private data class BasicParameterResults(
+        val parameters: BasicParameters,
+        val ignoredParameters: IgnoredParameters,
+        val parserErrorIndex: Int?
+)

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeParameterDecoder.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeParameterDecoder.kt
@@ -55,6 +55,12 @@ object MimeParameterDecoder {
         )
     }
 
+    @JvmStatic
+    fun extractHeaderValue(headerBody: String): String {
+        val parser = MimeHeaderParser(headerBody)
+        return parser.readHeaderValue()
+    }
+
     private fun readBasicParameters(parser: MimeHeaderParser): BasicParameterResults {
         val parameters = mutableMapOf<String, ParameterValue>()
         val duplicateParameterNames = mutableSetOf<String>()

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeParameterEncoder.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeParameterEncoder.kt
@@ -11,21 +11,6 @@ object MimeParameterEncoder {
     // RFC 5322, section 2.1.1
     private const val MAX_LINE_LENGTH = 78
 
-    // RFC 5234: CRLF = %d13.10
-    private const val CRLF = "\r\n"
-
-    // RFC 5234: HTAB = %x09
-    private const val HTAB = '\t'
-
-    // RFC 5234: SP = %x20
-    private const val SPACE = ' '
-
-    // RFC 5234: DQUOTE = %x22
-    private const val DQUOTE = '"'
-
-    // RFC 2045: tspecials :=  "(" / ")" / "<" / ">" / "@" / "," / ";" / ":" / "\" / <"> / "/" / "[" / "]" / "?" / "="
-    private val TSPECIALS = charArrayOf('(', ')', '<', '>', '@', ',', ';', ':', '\\', '"', '/', '[', ']', '?', '=')
-
     private const val ENCODED_VALUE_PREFIX = "UTF-8''"
 
 
@@ -200,12 +185,6 @@ object MimeParameterEncoder {
         else -> false
     }
 
-    private fun Char.isTSpecial() = this in TSPECIALS
-
-    // RFC 2045: token := 1*<any (US-ASCII) CHAR except SPACE, CTLs, or tspecials>
-    // RFC 5234: CTL = %x00-1F / %x7F
-    private fun Char.isTokenChar() = isVChar() && !isTSpecial()
-
     // RFC 5322: qtext = %d33 / %d35-91 / %d93-126 / obs-qtext
     private fun Char.isQText() = when (toInt()) {
         33 -> true
@@ -213,13 +192,4 @@ object MimeParameterEncoder {
         in 93..126 -> true
         else -> false
     }
-
-    // RFC 5234: VCHAR = %x21-7E
-    private fun Char.isVChar() = toInt() in 33..126
-
-    // RFC 5234: WSP =  SP / HTAB
-    private fun Char.isWsp() = this == SPACE || this == HTAB
-
-    // RFC 2231: attribute-char := <any (US-ASCII) CHAR except SPACE, CTLs, "*", "'", "%", or tspecials>
-    private fun Char.isAttributeChar() = isVChar() && this != '*' && this != '\'' && this != '%' && !isTSpecial()
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
@@ -918,40 +918,33 @@ public class MimeUtility {
     }
 
     /**
-     * Returns the named parameter of a header field. If name is null the first
-     * parameter is returned, or if there are no additional parameters in the
-     * field the entire field is returned. Otherwise the named parameter is
-     * searched for in a case insensitive fashion and returned.
+     * Returns the named parameter of a header field.
      *
-     * @param headerValue the header value
-     * @param parameterName the parameter name
-     * @return the value. if the parameter cannot be found the method returns null.
+     * <p>
+     * If name is {@code null} the "value" of the header is returned, i.e. "text/html" in the following example:
+     * <br>
+     *{@code Content-Type: text/html; charset="utf-8"}
+     * </p>
+     * <p>
+     * Note: Parsing header parameters is not a very cheap operation. Prefer using {@code MimeParameterDecoder}
+     * directly over calling this method multiple times for extracting different parameters from the the same header.
+     * </p>
+     *
+     * @param headerBody The header body.
+     * @param parameterName The parameter name. Might be {@code null}.
+     * @return the (parameter) value. if the parameter cannot be found the method returns null.
      */
-    public static String getHeaderParameter(String headerValue, String parameterName) {
-        if (headerValue == null) {
+    public static String getHeaderParameter(String headerBody, String parameterName) {
+        if (headerBody == null) {
             return null;
         }
-        headerValue = headerValue.replaceAll("\r|\n", "");
-        String[] parts = headerValue.split(";");
-        if (parameterName == null && parts.length > 0) {
-            return parts[0].trim();
+
+        if (parameterName == null) {
+            return MimeParameterDecoder.extractHeaderValue(headerBody);
+        } else {
+            MimeValue mimeValue = MimeParameterDecoder.decode(headerBody);
+            return mimeValue.getParameters().get(parameterName.toLowerCase(Locale.ROOT));
         }
-        for (String part : parts) {
-            if (parameterName != null &&
-                    part.trim().toLowerCase(Locale.US).startsWith(parameterName.toLowerCase(Locale.US))) {
-                String[] partParts = part.split("=", 2);
-                if (partParts.length == 2) {
-                    String parameter = partParts[1].trim();
-                    int len = parameter.length();
-                    if (len >= 2 && parameter.startsWith("\"") && parameter.endsWith("\"")) {
-                        return parameter.substring(1, len - 1);
-                    } else {
-                        return parameter;
-                    }
-                }
-            }
-        }
-        return null;
     }
 
     public static Map<String,String> getAllHeaderParameters(String headerValue) {

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeValue.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeValue.kt
@@ -1,0 +1,8 @@
+package com.fsck.k9.mail.internet
+
+data class MimeValue(
+        val value: String,
+        val parameters: Map<String, String> = emptyMap(),
+        val ignoredParameters: List<Pair<String, String>> = emptyList(),
+        val parserErrorIndex: Int? = null
+)

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/ParameterSection.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/ParameterSection.kt
@@ -1,0 +1,32 @@
+package com.fsck.k9.mail.internet
+
+import okio.Buffer
+
+internal sealed class ParameterSection(
+        val name: String,
+        val originalName: String,
+        val section: Int?
+)
+
+internal open class ExtendedValueParameterSection(
+        name: String,
+        originalName: String,
+        section: Int?,
+        val data: Buffer
+) : ParameterSection(name, originalName, section)
+
+internal class InitialExtendedValueParameterSection(
+        name: String,
+        originalName: String,
+        section: Int?,
+        val charsetName: String,
+        val language: String?,
+        data: Buffer
+) : ExtendedValueParameterSection(name, originalName, section, data)
+
+internal class RegularValueParameterSection(
+        name: String,
+        originalName: String = name,
+        section: Int? = null,
+        val text: String
+) : ParameterSection(name, originalName, section)

--- a/mail/common/src/test/java/com/fsck/k9/mail/MessageTest.kt
+++ b/mail/common/src/test/java/com/fsck/k9/mail/MessageTest.kt
@@ -67,7 +67,8 @@ class MessageTest {
             Subject: Test Message
             Date: Wed, 28 Aug 2013 08:51:09 -0400
             MIME-Version: 1.0
-            Content-Type: multipart/mixed; boundary="----Boundary103"
+            Content-Type: multipart/mixed;
+             boundary=----Boundary103
             Content-Transfer-Encoding: 7bit
 
             ------Boundary103
@@ -96,7 +97,8 @@ class MessageTest {
             Subject: Test Message
             Date: Wed, 28 Aug 2013 08:51:09 -0400
             MIME-Version: 1.0
-            Content-Type: multipart/mixed; boundary="----Boundary102"
+            Content-Type: multipart/mixed;
+             boundary=----Boundary102
             Content-Transfer-Encoding: 7bit
 
             ------Boundary102
@@ -125,7 +127,8 @@ class MessageTest {
             Subject: Test Message
             Date: Wed, 28 Aug 2013 08:51:09 -0400
             MIME-Version: 1.0
-            Content-Type: multipart/mixed; boundary="----Boundary101"
+            Content-Type: multipart/mixed;
+             boundary=----Boundary101
             Content-Transfer-Encoding: 7bit
 
             ------Boundary101
@@ -163,7 +166,8 @@ class MessageTest {
         bodyPart.writeTo(out)
 
         assertThat(out.toString()).isEqualTo("""
-            Content-Type: multipart/mixed; boundary="----Boundary103"
+            Content-Type: multipart/mixed;
+             boundary=----Boundary103
             Content-Transfer-Encoding: 7bit
 
             ------Boundary103
@@ -192,7 +196,8 @@ class MessageTest {
             Subject: Test Message
             Date: Wed, 28 Aug 2013 08:51:09 -0400
             MIME-Version: 1.0
-            Content-Type: multipart/mixed; boundary="----Boundary102"
+            Content-Type: multipart/mixed;
+             boundary=----Boundary102
             Content-Transfer-Encoding: 7bit
 
             ------Boundary102
@@ -221,7 +226,8 @@ class MessageTest {
             Subject: Test Message
             Date: Wed, 28 Aug 2013 08:51:09 -0400
             MIME-Version: 1.0
-            Content-Type: multipart/mixed; boundary="----Boundary101"
+            Content-Type: multipart/mixed;
+             boundary=----Boundary101
             Content-Transfer-Encoding: 7bit
 
             ------Boundary101

--- a/mail/common/src/test/java/com/fsck/k9/mail/internet/MimeParameterDecoderTest.kt
+++ b/mail/common/src/test/java/com/fsck/k9/mail/internet/MimeParameterDecoderTest.kt
@@ -1,0 +1,359 @@
+package com.fsck.k9.mail.internet
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+
+class MimeParameterDecoderTest {
+    @Test
+    fun rfc2045_example1() {
+        val mimeValue = MimeParameterDecoder.decode("text/plain; charset=us-ascii (Plain text)")
+
+        assertEquals("text/plain", mimeValue.value)
+        assertParametersEquals(mimeValue, "charset" to "us-ascii")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun rfc2045_example2() {
+        val mimeValue = MimeParameterDecoder.decode("text/plain; charset=\"us-ascii\"")
+
+        assertEquals("text/plain", mimeValue.value)
+        assertParametersEquals(mimeValue, "charset" to "us-ascii")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun rfc2231_example1() {
+        val mimeValue = MimeParameterDecoder.decode("message/external-body; access-type=URL;\r\n" +
+                " URL*0=\"ftp://\";\r\n" +
+                " URL*1=\"cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar\"")
+
+        assertEquals("message/external-body", mimeValue.value)
+        assertParametersEquals(mimeValue,
+                "access-type" to "URL",
+                "url" to "ftp://cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun rfc2231_example2() {
+        val mimeValue = MimeParameterDecoder.decode("message/external-body; access-type=URL;\r\n" +
+                " URL=\"ftp://cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar\"")
+
+        assertEquals("message/external-body", mimeValue.value)
+        assertParametersEquals(mimeValue,
+                "access-type" to "URL",
+                "url" to "ftp://cs.utk.edu/pub/moore/bulk-mailer/bulk-mailer.tar")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun rfc2231_example3() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name*=us-ascii'en-us'This%20is%20%2A%2A%2Afun%2A%2A%2A")
+
+        assertEquals("application/x-stuff", mimeValue.value)
+        assertParametersEquals(mimeValue, "name" to "This is ***fun***")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun rfc2231_example4() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name*0*=us-ascii'en'This%20is%20even%20more%20;\r\n" +
+                " name*1*=%2A%2A%2Afun%2A%2A%2A%20;\r\n" +
+                " name*2=\"isn't it!\"")
+
+        assertEquals("application/x-stuff", mimeValue.value)
+        assertParametersEquals(mimeValue, "name" to "This is even more ***fun*** isn't it!")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun multiple_sections_out_of_order() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name*2=\"[three]\";\r\n" +
+                " name*1=\"[two]\";\r\n" +
+                " name*0=\"[one]\"")
+
+        assertParametersEquals(mimeValue, "name" to "[one][two][three]")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun multiple_sections_differently_cased() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name*0=\"[one]\";\r\n" +
+                " name*1=\"[two]\";\r\n" +
+                " name*2=\"[three]\"")
+
+        assertParametersEquals(mimeValue, "name" to "[one][two][three]")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun multiple_sections_switching_between_extended_and_regular_value() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name*0*=utf-8'en'%5Bone%5D;\r\n" +
+                " name*1*=%5btwo%5d;\r\n" +
+                " name*2=\"[three]\";\r\n" +
+                " name*3*=%5Bfour%5D;\r\n" +
+                " name*4=\"[five]\";\r\n" +
+                " name*5=six")
+
+        assertParametersEquals(mimeValue, "name" to "[one][two][three][four][five]six")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun rfc2045_and_rfc2231_style_parameters_should_use_rfc2231() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name=\"filename.ext\";\r\n" +
+                " name*=utf-8''filen%C3%A4me.ext")
+
+        assertParametersEquals(mimeValue, "name" to "filenäme.ext")
+        assertIgnoredParametersEquals(mimeValue, "name" to "filename.ext")
+    }
+
+    @Test
+    fun duplicate_parameter_names() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name=one;\r\n" +
+                " extra=something;\r\n" +
+                " name=two")
+
+        assertParametersEquals(mimeValue, "extra" to "something")
+        assertIgnoredParametersEquals(mimeValue, "name" to "one", "name" to "two")
+    }
+
+    @Test
+    fun duplicate_parameter_names_differing_in_case() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name=one;\r\n" +
+                " extra=something;\r\n" +
+                " NAME=two")
+
+        assertParametersEquals(mimeValue, "extra" to "something")
+        assertIgnoredParametersEquals(mimeValue, "name" to "one", "name" to "two")
+    }
+
+    @Test
+    fun name_only_parameter() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; parameter")
+
+        assertEquals(30, mimeValue.parserErrorIndex)
+        assertTrue(mimeValue.parameters.isEmpty())
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun missing_parameter_value() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; parameter=")
+
+        assertEquals(31, mimeValue.parserErrorIndex)
+        assertTrue(mimeValue.parameters.isEmpty())
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun comments_everywhere() {
+        val mimeValue = MimeParameterDecoder.decode("(comment)application(comment)/(comment)x-stuff" +
+                "(comment);(comment)\r\n" +
+                " (comment)name(comment)=(comment)one(comment);(comment)\r\n" +
+                "  (comment) extra (comment) = (comment) something (comment)")
+
+        assertParametersEquals(mimeValue, "name" to "one", "extra" to "something")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun iso8859_1_charset() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*=iso-8859-1''filen%E4me.ext")
+
+        assertParametersEquals(mimeValue, "name" to "filenäme.ext")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun missing_charset() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*=''filen%AAme.ext")
+
+        assertParametersEquals(mimeValue, "name" to "filen%AAme.ext")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun unknown_charset() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*=foobar''filen%AAme.ext")
+
+        assertParametersEquals(mimeValue, "name" to "filen%AAme.ext")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun section_index_missing() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name**=utf-8''filename")
+
+        assertParametersEquals(mimeValue, "name**" to "utf-8''filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun section_index_not_a_number() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*x*=filename")
+
+        assertParametersEquals(mimeValue, "name*x*" to "filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun section_index_prefixed_with_plus() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*+0=filename")
+
+        assertParametersEquals(mimeValue, "name*+0" to "filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun section_index_prefixed_with_minus() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*-0=filename")
+
+        assertParametersEquals(mimeValue, "name*-0" to "filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun section_index_with_two_zeros() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*00=filename")
+
+        assertParametersEquals(mimeValue, "name*00" to "filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun section_index_with_leading_zero() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name*0=one;\r\n" +
+                " name*01=two")
+
+        assertParametersEquals(mimeValue, "name" to "one", "name*01" to "two")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun section_index_with_huge_number() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name*10000000000000000000=filename")
+
+        assertParametersEquals(mimeValue, "name*10000000000000000000" to "filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun extended_parameter_name_with_additional_asterisk() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*0**=utf-8''filename")
+
+        assertParametersEquals(mimeValue, "name*0**" to "utf-8''filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun extended_parameter_name_with_additional_text() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*0*x=utf-8''filename")
+
+        assertParametersEquals(mimeValue, "name*0*x" to "utf-8''filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun extended_parameter_value_with_quoted_string() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*0*=\"utf-8''filename\"")
+
+        assertParametersEquals(mimeValue, "name*0*" to "utf-8''filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun extended_initial_parameter_value_missing_single_quotes() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*0*=filename")
+
+        assertParametersEquals(mimeValue, "name*0*" to "filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun extended_initial_parameter_value_missing_second_single_quote() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*0*='")
+
+        assertParametersEquals(mimeValue, "name*0*" to "'")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun extended_parameter_value_with_trailing_percent_sign() {
+        val mimeValue = MimeParameterDecoder.decode("attachment; filename*=utf-8''file%")
+
+        assertParametersEquals(mimeValue, "filename*" to "utf-8''file%")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun extended_parameter_value_with_invalid_percent_encoding() {
+        val mimeValue = MimeParameterDecoder.decode("attachment; filename*=UTF-8''f%oo.html")
+
+        assertParametersEquals(mimeValue, "filename*" to "UTF-8''f%oo.html")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun section_0_missing() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff; name*1=filename")
+
+        assertParametersEquals(mimeValue, "name*1" to "filename")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun semicolon_in_parameter_value() {
+        val mimeValue = MimeParameterDecoder.decode("attachment; filename=\"Here's a semicolon;.txt\"")
+
+        assertParametersEquals(mimeValue, "filename" to "Here's a semicolon;.txt")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun rfc2047_encoded() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name=\"=?UTF-8?Q?filn=C3=A4me=2Eext?=\"")
+
+        assertParametersEquals(mimeValue, "name" to "filnäme.ext")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+    @Test
+    fun rfc2047_encoded_multiple_lines() {
+        val mimeValue = MimeParameterDecoder.decode("application/x-stuff;\r\n" +
+                " name=\"=?UTF-8?Q?File_name_that_is_so_long_it_likes_to_be_wrapped_i?=\r\n" +
+                " =?UTF-8?Q?nto_multiple_lines=2E_Also_?=\r\n" +
+                " =?UTF-8?Q?non-ASCII_characters=3A_=C3=A4=E2=82=AC=F0=9F=8C=9E?=\"")
+
+        assertParametersEquals(mimeValue, "name" to "File name that is so long it likes to be wrapped " +
+                "into multiple lines. Also non-ASCII characters: ä€\uD83C\uDF1E")
+        assertTrue(mimeValue.ignoredParameters.isEmpty())
+    }
+
+
+    private fun assertParametersEquals(mimeValue: MimeValue, vararg expected: Pair<String, String>) {
+        assertEquals(expected.toSet(), mimeValue.parameters.toPairSet())
+    }
+
+    private fun assertIgnoredParametersEquals(mimeValue: MimeValue, vararg expected: Pair<String, String>) {
+        assertEquals(expected.toSet(), mimeValue.ignoredParameters.toSet())
+    }
+
+    private fun Map<String, String>.toPairSet(): Set<Pair<String, String>> {
+        return this.map { (key, value) -> key to value }.toSet()
+    }
+}

--- a/mail/common/src/test/java/com/fsck/k9/mail/internet/MimeUtilityTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/internet/MimeUtilityTest.java
@@ -3,52 +3,11 @@ package com.fsck.k9.mail.internet;
 
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
 public class MimeUtilityTest {
-    @Test
-    public void testGetHeaderParameter() {
-        String result;
-
-        /* Test edge cases */
-        result = MimeUtility.getHeaderParameter(";", null);
-        assertEquals(null, result);
-
-        result = MimeUtility.getHeaderParameter("name", "name");
-        assertEquals(null, result);
-
-        result = MimeUtility.getHeaderParameter("name=", "name");
-        assertEquals("", result);
-
-        result = MimeUtility.getHeaderParameter("name=\"", "name");
-        assertEquals("\"", result);
-
-        /* Test expected cases */
-        result = MimeUtility.getHeaderParameter("name=value", "name");
-        assertEquals("value", result);
-
-        result = MimeUtility.getHeaderParameter("name = value", "name");
-        assertEquals("value", result);
-
-        result = MimeUtility.getHeaderParameter("name=\"value\"", "name");
-        assertEquals("value", result);
-
-        result = MimeUtility.getHeaderParameter("name = \"value\"", "name");
-        assertEquals("value", result);
-
-        result = MimeUtility.getHeaderParameter("name=\"\"", "name");
-        assertEquals("", result);
-
-        result = MimeUtility.getHeaderParameter("text/html ; charset=\"windows-1251\"", null);
-        assertEquals("text/html", result);
-
-        result = MimeUtility.getHeaderParameter("text/HTML ; charset=\"windows-1251\"", null);
-        assertEquals("text/HTML", result);
-    }
-
     @Test
     public void isMultipart_withLowerCaseMultipart_shouldReturnTrue() throws Exception {
         assertTrue(MimeUtility.isMultipart("multipart/mixed"));


### PR DESCRIPTION
This replaces our rather naive approach involving string splitting and regular expressions with a parser that properly extracts header parameters as specified in RFC 2045. It also has support for parameter continuations and extended parameter values as specified in RFC 2231.
And because some clients use the encoded word encoding specified in RFC 2047 to (wrongly) encode attachment names, we now support decoding that as well :cry: 

Fixes #1466
Fixes #1619
