### PR TITLE
Don't broadcast message details when message was removed

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2145,8 +2145,9 @@ public class MessagingController {
             //We need to make these callbacks before moving the messages to the trash
             //as messages get a new UID after being moved
             for (Message message : messages) {
+                String messageServerId = message.getUid();
                 for (MessagingListener l : getListeners(listener)) {
-                    l.messageDeleted(account, folder, message);
+                    l.messageDeleted(account, folder, messageServerId);
                 }
             }
 
@@ -3129,10 +3130,8 @@ public class MessagingController {
 
         @Override
         public void syncRemovedMessage(@NotNull String folderServerId, @NotNull String messageServerId) {
-            // FIXME: This is kind of expensive. Get rid of the need to call synchronizeMailboxRemovedMessage()
-            LocalMessage message = loadMessage(folderServerId, messageServerId);
             for (MessagingListener messagingListener : getListeners(listener)) {
-                messagingListener.synchronizeMailboxRemovedMessage(account, folderServerId, message);
+                messagingListener.synchronizeMailboxRemovedMessage(account, folderServerId, messageServerId);
             }
         }
 

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingListener.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingListener.java
@@ -35,7 +35,7 @@ public interface MessagingListener {
             int numNewMessages);
     void synchronizeMailboxProgress(Account account, String folderServerId, int completed, int total);
     void synchronizeMailboxNewMessage(Account account, String folderServerId, Message message);
-    void synchronizeMailboxRemovedMessage(Account account, String folderServerId, Message message);
+    void synchronizeMailboxRemovedMessage(Account account, String folderServerId, String messageServerId);
     void synchronizeMailboxFinished(Account account, String folderServerId, int totalMessagesInMailbox, int numNewMessages);
     void synchronizeMailboxFailed(Account account, String folderServerId, String message);
 
@@ -54,7 +54,7 @@ public interface MessagingListener {
     void folderStatusChanged(Account account, String folderServerId, int unreadMessageCount);
     void systemStatusChanged();
 
-    void messageDeleted(Account account, String folderServerId, Message message);
+    void messageDeleted(Account account, String folderServerId, String messageServerId);
     void messageUidChanged(Account account, String folderServerId, String oldUid, String newUid);
 
     void setPushActive(Account account, String folderServerId, boolean enabled);

--- a/app/core/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
@@ -74,7 +74,7 @@ public abstract class SimpleMessagingListener implements MessagingListener {
     }
 
     @Override
-    public void synchronizeMailboxRemovedMessage(Account account, String folderServerId, Message message) {
+    public void synchronizeMailboxRemovedMessage(Account account, String folderServerId, String messageServerId) {
     }
 
     @Override
@@ -127,7 +127,7 @@ public abstract class SimpleMessagingListener implements MessagingListener {
     }
 
     @Override
-    public void messageDeleted(Account account, String folderServerId, Message message) {
+    public void messageDeleted(Account account, String folderServerId, String messageServerId) {
     }
 
     @Override

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListWidgetUpdateListener.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListWidgetUpdateListener.kt
@@ -21,11 +21,11 @@ class MessageListWidgetUpdateListener(private val context: Context) : SimpleMess
         }
     }
 
-    override fun synchronizeMailboxRemovedMessage(account: Account, folderServerId: String, message: Message) {
+    override fun synchronizeMailboxRemovedMessage(account: Account, folderServerId: String, messageServerId: String) {
         updateMailListWidget()
     }
 
-    override fun messageDeleted(account: Account, folderServerId: String, message: Message) {
+    override fun messageDeleted(account: Account, folderServerId: String, messageServerId: String) {
         updateMailListWidget()
     }
 

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetUpdateListener.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetUpdateListener.kt
@@ -15,11 +15,11 @@ class UnreadWidgetUpdateListener(private val unreadWidgetUpdater: UnreadWidgetUp
         }
     }
 
-    override fun synchronizeMailboxRemovedMessage(account: Account, folderServerId: String, message: Message) {
+    override fun synchronizeMailboxRemovedMessage(account: Account, folderServerId: String, messageServerId: String) {
         updateUnreadWidget()
     }
 
-    override fun messageDeleted(account: Account, folderServerId: String, message: Message) {
+    override fun messageDeleted(account: Account, folderServerId: String, messageServerId: String) {
         updateUnreadWidget()
     }
 

--- a/app/ui/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -52,7 +52,6 @@ import com.fsck.k9.controller.MessagingListener;
 import com.fsck.k9.controller.SimpleMessagingListener;
 import com.fsck.k9.ui.helper.SizeFormatter;
 import com.fsck.k9.mail.Folder;
-import com.fsck.k9.mail.Message;
 import com.fsck.k9.power.TracingPowerManager;
 import com.fsck.k9.power.TracingPowerManager.TracingWakeLock;
 import com.fsck.k9.mailstore.LocalFolder;
@@ -804,8 +803,8 @@ public class FolderList extends K9ListActivity {
 
 
             @Override
-            public void messageDeleted(Account account, String folderServerId, Message message) {
-                synchronizeMailboxRemovedMessage(account, folderServerId, message);
+            public void messageDeleted(Account account, String folderServerId, String messageServerId) {
+                synchronizeMailboxRemovedMessage(account, folderServerId, messageServerId);
             }
 
             @Override


### PR DESCRIPTION
Turns out reading the message from the database after it has been deleted doesn't work particularly well 🤦