### PR TITLE
Upload sent messages setting

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -215,6 +215,7 @@ public class Account implements BaseAccount, StoreConfig {
     private boolean allowRemoteSearch;
     private boolean remoteSearchFullText;
     private int remoteSearchNumResults;
+    private boolean uploadSentMessages;
 
 
     /**
@@ -301,6 +302,7 @@ public class Account implements BaseAccount, StoreConfig {
         allowRemoteSearch = false;
         remoteSearchFullText = false;
         remoteSearchNumResults = DEFAULT_REMOTE_SEARCH_NUM_RESULTS;
+        uploadSentMessages = true;
         isEnabled = true;
         markMessageAsReadOnView = true;
         alwaysShowCcBcc = false;
@@ -436,6 +438,7 @@ public class Account implements BaseAccount, StoreConfig {
         allowRemoteSearch = storage.getBoolean(accountUuid + ".allowRemoteSearch", false);
         remoteSearchFullText = storage.getBoolean(accountUuid + ".remoteSearchFullText", false);
         remoteSearchNumResults = storage.getInt(accountUuid + ".remoteSearchNumResults", DEFAULT_REMOTE_SEARCH_NUM_RESULTS);
+        uploadSentMessages = storage.getBoolean(accountUuid + ".uploadSentMessages", true);
 
         isEnabled = storage.getBoolean(accountUuid + ".enabled", true);
         markMessageAsReadOnView = storage.getBoolean(accountUuid + ".markMessageAsReadOnView", true);
@@ -531,6 +534,7 @@ public class Account implements BaseAccount, StoreConfig {
         editor.remove(accountUuid + ".allowRemoteSearch");
         editor.remove(accountUuid + ".remoteSearchFullText");
         editor.remove(accountUuid + ".remoteSearchNumResults");
+        editor.remove(accountUuid + ".uploadSentMessages");
         editor.remove(accountUuid + ".defaultQuotedTextShown");
         editor.remove(accountUuid + ".displayCount");
         editor.remove(accountUuid + ".inboxFolderName");
@@ -1534,6 +1538,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public void setRemoteSearchNumResults(int val) {
         remoteSearchNumResults = (val >= 0 ? val : 0);
+    }
+
+    public boolean isUploadSentMessages() {
+        return uploadSentMessages;
+    }
+
+    public void setUploadSentMessages(boolean uploadSentMessages) {
+        this.uploadSentMessages = uploadSentMessages;
     }
 
     public String getInboxFolder() {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1680,8 +1680,8 @@ public class MessagingController {
 
     private void moveOrDeleteSentMessage(Account account, LocalStore localStore,
             LocalFolder localFolder, LocalMessage message) throws MessagingException {
-        if (!account.hasSentFolder()) {
-            Timber.i("Account does not have a sent mail folder; deleting sent message");
+        if (!account.hasSentFolder() || !account.isUploadSentMessages()) {
+            Timber.i("Not uploading sent message; deleting local message");
             message.setFlag(Flag.DELETED, true);
         } else {
             LocalFolder localSentFolder = localStore.getFolder(account.getSentFolder());

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1823,6 +1823,10 @@ public class MessagingController {
         return getBackend(account).getSupportsSearchByDate();
     }
 
+    public boolean supportsUpload(Account account) {
+        return getBackend(account).getSupportsUpload();
+    }
+
     public void checkIncomingServerSettings(Account account) throws MessagingException {
         getBackend(account).checkIncomingServerSettings();
     }

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -236,6 +236,9 @@ public class AccountSettings {
         s.put("autocryptMutualMode", Settings.versions(
                 new V(50, new BooleanSetting(false))
         ));
+        s.put("uploadSentMessages", Settings.versions(
+                new V(52, new BooleanSetting(true))
+        ));
         // note that there is no setting for openPgpProvider, because this will have to be set up together
         // with the actual provider after import anyways.
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 51;
+    public static final int VERSION = 52;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -36,6 +36,7 @@ class AccountSettingsDataStore(
             "openpgp_hide_sign_only" -> account.openPgpHideSignOnly
             "openpgp_encrypt_subject" -> account.openPgpEncryptSubject
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual
+            "upload_sent_messages" -> account.isUploadSentMessages
             else -> defValue
         }
     }
@@ -67,6 +68,7 @@ class AccountSettingsDataStore(
             "openpgp_hide_sign_only" -> account.openPgpHideSignOnly = value
             "openpgp_encrypt_subject" -> account.openPgpEncryptSubject = value
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual = value
+            "upload_sent_messages" -> account.isUploadSentMessages = value
             else -> return
         }
 

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -52,6 +52,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         initializeIncomingServer()
         initializeComposition()
         initializeManageIdentities()
+        initializeUploadSentMessages(account)
         initializeOutgoingServer()
         initializeQuoteStyle()
         initializeDeletePolicy(account)
@@ -83,6 +84,14 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
     private fun initializeManageIdentities() {
         findPreference(PREFERENCE_MANAGE_IDENTITIES)?.onClick {
             ManageIdentities.start(requireActivity(), accountUuid)
+        }
+    }
+
+    private fun initializeUploadSentMessages(account: Account) {
+        findPreference(PREFERENCE_UPLOAD_SENT_MESSAGES)?.apply {
+            if (!messagingController.supportsUpload(account)) {
+                remove()
+            }
         }
     }
 
@@ -261,6 +270,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
         private const val PREFERENCE_COMPOSITION = "composition"
         private const val PREFERENCE_MANAGE_IDENTITIES = "manage_identities"
         private const val PREFERENCE_OUTGOING_SERVER = "outgoing"
+        private const val PREFERENCE_UPLOAD_SENT_MESSAGES = "upload_sent_messages"
         private const val PREFERENCE_QUOTE_STYLE = "quote_style"
         private const val PREFERENCE_DELETE_POLICY = "delete_policy"
         private const val PREFERENCE_EXPUNGE_POLICY = "expunge_policy"

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -584,6 +584,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_quote_style_prefix">Prefix (like Gmail)</string>
     <string name="account_settings_quote_style_header">Header (like Outlook)</string>
 
+    <string name="account_settings_upload_sent_messages_label">Upload sent messages</string>
+    <string name="account_settings_upload_sent_messages_summary">Upload messages to Sent folder after sending</string>
+
     <string name="account_settings_general_title">General settings</string>
     <string name="account_settings_reading_mail">Reading mail</string>
     <string name="account_settings_sync">Fetching mail</string>

--- a/app/ui/src/main/res/xml/account_settings.xml
+++ b/app/ui/src/main/res/xml/account_settings.xml
@@ -213,6 +213,12 @@
             android:key="account_quote_prefix"
             android:title="@string/account_settings_quote_prefix_label" />
 
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="upload_sent_messages"
+            android:summary="@string/account_settings_upload_sent_messages_summary"
+            android:title="@string/account_settings_upload_sent_messages_label" />
+
         <PreferenceScreen
             android:key="outgoing"
             android:summary="@string/account_settings_outgoing_summary"

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
@@ -17,6 +17,7 @@ interface Backend {
     val supportsExpunge: Boolean
     val supportsMove: Boolean
     val supportsCopy: Boolean
+    val supportsUpload: Boolean
     val supportsTrashFolder: Boolean
     val supportsSearchByDate: Boolean
     val isPushCapable: Boolean

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.java
@@ -83,6 +83,11 @@ public class ImapBackend implements Backend {
     }
 
     @Override
+    public boolean getSupportsUpload() {
+        return true;
+    }
+
+    @Override
     public boolean getSupportsTrashFolder() {
         return true;
     }

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
@@ -31,6 +31,7 @@ class Pop3Backend(
     override val supportsExpunge = false
     override val supportsMove = false
     override val supportsCopy = false
+    override val supportsUpload = false
     override val supportsTrashFolder = false
     override val supportsSearchByDate = false
     override val isPushCapable = false

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavBackend.kt
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavBackend.kt
@@ -35,6 +35,7 @@ class WebDavBackend(
     override val supportsExpunge = true
     override val supportsMove = true
     override val supportsCopy = true
+    override val supportsUpload = true
     override val supportsTrashFolder = true
     override val supportsSearchByDate = false
     override val isPushCapable = false


### PR DESCRIPTION
Some providers automatically add messages sent via their outgoing server to the Sent folder. In that case users probably want to disable uploading of sent messages. Our current recommendation is to set the Sent folder to "-NONE-", which is not particularly user friendly.

In the future we may want to set an appropriate value for this setting when creating an account. Right now the default is `true`, which means there's no change in behavior.

