### PR TITLE
Change ReplyToParser to prefer From over List-Post header

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/helper/ReplyToParser.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/ReplyToParser.java
@@ -26,10 +26,10 @@ public class ReplyToParser {
 
         if (replyToAddresses.length > 0) {
             candidateAddress = replyToAddresses;
-        } else if (listPostAddresses.length > 0) {
-            candidateAddress = listPostAddresses;
-        } else {
+        } else if (fromAddresses.length > 0) {
             candidateAddress = fromAddresses;
+        } else {
+            candidateAddress = listPostAddresses;
         }
 
         boolean replyToAddressIsUserIdentity = account.isAnIdentity(candidateAddress);

--- a/app/core/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
+++ b/app/core/src/test/java/com/fsck/k9/helper/ReplyToParserTest.java
@@ -75,27 +75,27 @@ public class ReplyToParserTest extends RobolectricTest {
     }
 
     @Test
-    public void getRecipientsToReplyTo_should_prefer_listPost_over_from_field() throws Exception {
+    public void getRecipientsToReplyTo_should_prefer_from_over_listPost_field() throws Exception {
         when(message.getReplyTo()).thenReturn(EMPTY_ADDRESSES);
         when(message.getHeader(ListHeaders.LIST_POST_HEADER)).thenReturn(LIST_POST_HEADER_VALUES);
         when(message.getFrom()).thenReturn(FROM_ADDRESSES);
 
         ReplyToAddresses result = replyToParser.getRecipientsToReplyTo(message, account);
 
-        assertArrayEquals(LIST_POST_ADDRESSES, result.to);
+        assertArrayEquals(FROM_ADDRESSES, result.to);
         assertArrayEquals(EMPTY_ADDRESSES, result.cc);
         verify(account).isAnIdentity(result.to);
     }
 
     @Test
-    public void getRecipientsToReplyTo_should_return_from_otherwise() throws Exception {
+    public void getRecipientsToReplyTo_should_return_listPost_otherwise() throws Exception {
         when(message.getReplyTo()).thenReturn(EMPTY_ADDRESSES);
-        when(message.getHeader(ListHeaders.LIST_POST_HEADER)).thenReturn(new String[0]);
-        when(message.getFrom()).thenReturn(FROM_ADDRESSES);
+        when(message.getHeader(ListHeaders.LIST_POST_HEADER)).thenReturn(LIST_POST_HEADER_VALUES);
+        when(message.getFrom()).thenReturn(EMPTY_ADDRESSES);
 
         ReplyToAddresses result = replyToParser.getRecipientsToReplyTo(message, account);
 
-        assertArrayEquals(FROM_ADDRESSES, result.to);
+        assertArrayEquals(LIST_POST_ADDRESSES, result.to);
         assertArrayEquals(EMPTY_ADDRESSES, result.cc);
         verify(account).isAnIdentity(result.to);
     }


### PR DESCRIPTION
Behavior before: ReplyToParser preferred List-Post header over the From header which made the list to the default reply-to address.

Behavior after: ReplyToParser prefers the From header over the List-Post header since mailing list tools like mailman also set the Reply-To header to the mailing list in case the admin would like to have the mailing list as default return. This follows also the behavior that most desktop mail clients are using (like Thunderbird, Apple Mail and Outlook).

This PR doesn't contain a reference to an issue ID since I didn't create a bug report or feature request.