### PR TITLE
Automatic special folder selection

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -40,6 +40,7 @@ import com.fsck.k9.search.LocalSearch;
 import com.fsck.k9.search.SearchSpecification.Attribute;
 import com.fsck.k9.search.SearchSpecification.SearchCondition;
 import com.fsck.k9.search.SearchSpecification.SearchField;
+import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
 
 import static com.fsck.k9.Preferences.getEnumStringPref;
@@ -1055,22 +1056,27 @@ public class Account implements BaseAccount, StoreConfig {
         return spamFolder != null;
     }
 
+    @NotNull
     public SpecialFolderSelection getDraftsFolderSelection() {
         return draftsFolderSelection;
     }
 
+    @NotNull
     public synchronized SpecialFolderSelection getSentFolderSelection() {
         return sentFolderSelection;
     }
 
+    @NotNull
     public synchronized SpecialFolderSelection getTrashFolderSelection() {
         return trashFolderSelection;
     }
 
+    @NotNull
     public synchronized SpecialFolderSelection getArchiveFolderSelection() {
         return archiveFolderSelection;
     }
 
+    @NotNull
     public synchronized SpecialFolderSelection getSpamFolderSelection() {
         return spamFolderSelection;
     }

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -172,6 +172,11 @@ public class Account implements BaseAccount, StoreConfig {
     private String trashFolder;
     private String archiveFolder;
     private String spamFolder;
+    private SpecialFolderSelection draftsFolderSelection;
+    private SpecialFolderSelection sentFolderSelection;
+    private SpecialFolderSelection trashFolderSelection;
+    private SpecialFolderSelection archiveFolderSelection;
+    private SpecialFolderSelection spamFolderSelection;
     private String autoExpandFolder;
     private FolderMode folderDisplayMode;
     private FolderMode folderSyncMode;
@@ -244,6 +249,11 @@ public class Account implements BaseAccount, StoreConfig {
         NONE, ALL, FIRST_CLASS, FIRST_AND_SECOND_CLASS, NOT_SECOND_CLASS
     }
 
+    public enum SpecialFolderSelection {
+        AUTOMATIC,
+        MANUAL
+    }
+
     public enum ShowPictures {
         NEVER, ALWAYS, ONLY_FROM_CONTACTS
     }
@@ -311,6 +321,11 @@ public class Account implements BaseAccount, StoreConfig {
         sentFolder = null;
         spamFolder = null;
         trashFolder = null;
+        archiveFolderSelection = SpecialFolderSelection.AUTOMATIC;
+        draftsFolderSelection = SpecialFolderSelection.AUTOMATIC;
+        sentFolderSelection = SpecialFolderSelection.AUTOMATIC;
+        spamFolderSelection = SpecialFolderSelection.AUTOMATIC;
+        trashFolderSelection = SpecialFolderSelection.AUTOMATIC;
 
         searchableFolders = Searchable.ALL;
 
@@ -371,6 +386,17 @@ public class Account implements BaseAccount, StoreConfig {
         trashFolder = storage.getString(accountUuid + ".trashFolderName", null);
         archiveFolder = storage.getString(accountUuid + ".archiveFolderName", null);
         spamFolder = storage.getString(accountUuid + ".spamFolderName", null);
+        archiveFolderSelection = getEnumStringPref(storage, accountUuid + ".archiveFolderSelection",
+                SpecialFolderSelection.AUTOMATIC);
+        draftsFolderSelection = getEnumStringPref(storage, accountUuid + ".draftsFolderSelection",
+                SpecialFolderSelection.AUTOMATIC);
+        sentFolderSelection = getEnumStringPref(storage, accountUuid + ".sentFolderSelection",
+                SpecialFolderSelection.AUTOMATIC);
+        spamFolderSelection = getEnumStringPref(storage, accountUuid + ".spamFolderSelection",
+                SpecialFolderSelection.AUTOMATIC);
+        trashFolderSelection = getEnumStringPref(storage, accountUuid + ".trashFolderSelection",
+                SpecialFolderSelection.AUTOMATIC);
+
         expungePolicy = getEnumStringPref(storage, accountUuid + ".expungePolicy", Expunge.EXPUNGE_IMMEDIATELY);
         syncRemoteDeletions = storage.getBoolean(accountUuid + ".syncRemoteDeletions", true);
 
@@ -491,6 +517,11 @@ public class Account implements BaseAccount, StoreConfig {
         editor.remove(accountUuid + ".trashFolderName");
         editor.remove(accountUuid + ".archiveFolderName");
         editor.remove(accountUuid + ".spamFolderName");
+        editor.remove(accountUuid + ".archiveFolderSelection");
+        editor.remove(accountUuid + ".draftsFolderSelection");
+        editor.remove(accountUuid + ".sentFolderSelection");
+        editor.remove(accountUuid + ".spamFolderSelection");
+        editor.remove(accountUuid + ".trashFolderSelection");
         editor.remove(accountUuid + ".autoExpandFolderName");
         editor.remove(accountUuid + ".accountNumber");
         editor.remove(accountUuid + ".vibrate");
@@ -665,6 +696,11 @@ public class Account implements BaseAccount, StoreConfig {
         editor.putString(accountUuid + ".trashFolderName", trashFolder);
         editor.putString(accountUuid + ".archiveFolderName", archiveFolder);
         editor.putString(accountUuid + ".spamFolderName", spamFolder);
+        editor.putString(accountUuid + ".archiveFolderSelection", archiveFolderSelection.name());
+        editor.putString(accountUuid + ".draftsFolderSelection", draftsFolderSelection.name());
+        editor.putString(accountUuid + ".sentFolderSelection", sentFolderSelection.name());
+        editor.putString(accountUuid + ".spamFolderSelection", spamFolderSelection.name());
+        editor.putString(accountUuid + ".trashFolderSelection", trashFolderSelection.name());
         editor.putString(accountUuid + ".autoExpandFolderName", autoExpandFolder);
         editor.putInt(accountUuid + ".accountNumber", accountNumber);
         editor.putString(accountUuid + ".sortTypeEnum", sortType.name());
@@ -937,8 +973,9 @@ public class Account implements BaseAccount, StoreConfig {
         return draftsFolder;
     }
 
-    public synchronized void setDraftsFolder(String name) {
+    public synchronized void setDraftsFolder(String name, SpecialFolderSelection selection) {
         draftsFolder = name;
+        draftsFolderSelection = selection;
     }
 
     /**
@@ -953,8 +990,9 @@ public class Account implements BaseAccount, StoreConfig {
         return sentFolder;
     }
 
-    public synchronized void setSentFolder(String name) {
+    public synchronized void setSentFolder(String name, SpecialFolderSelection selection) {
         sentFolder = name;
+        sentFolderSelection = selection;
     }
 
     /**
@@ -970,8 +1008,9 @@ public class Account implements BaseAccount, StoreConfig {
         return trashFolder;
     }
 
-    public synchronized void setTrashFolder(String name) {
+    public synchronized void setTrashFolder(String name, SpecialFolderSelection selection) {
         trashFolder = name;
+        trashFolderSelection = selection;
     }
 
     /**
@@ -986,8 +1025,9 @@ public class Account implements BaseAccount, StoreConfig {
         return archiveFolder;
     }
 
-    public synchronized void setArchiveFolder(String archiveFolder) {
+    public synchronized void setArchiveFolder(String archiveFolder, SpecialFolderSelection selection) {
         this.archiveFolder = archiveFolder;
+        archiveFolderSelection = selection;
     }
 
     /**
@@ -1002,8 +1042,9 @@ public class Account implements BaseAccount, StoreConfig {
         return spamFolder;
     }
 
-    public synchronized void setSpamFolder(String name) {
+    public synchronized void setSpamFolder(String name, SpecialFolderSelection selection) {
         spamFolder = name;
+        spamFolderSelection = selection;
     }
 
     /**
@@ -1012,6 +1053,26 @@ public class Account implements BaseAccount, StoreConfig {
      */
     public synchronized boolean hasSpamFolder() {
         return spamFolder != null;
+    }
+
+    public SpecialFolderSelection getDraftsFolderSelection() {
+        return draftsFolderSelection;
+    }
+
+    public synchronized SpecialFolderSelection getSentFolderSelection() {
+        return sentFolderSelection;
+    }
+
+    public synchronized SpecialFolderSelection getTrashFolderSelection() {
+        return trashFolderSelection;
+    }
+
+    public synchronized SpecialFolderSelection getArchiveFolderSelection() {
+        return archiveFolderSelection;
+    }
+
+    public synchronized SpecialFolderSelection getSpamFolderSelection() {
+        return spamFolderSelection;
     }
 
     public String getOutboxFolder() {
@@ -1783,5 +1844,30 @@ public class Account implements BaseAccount, StoreConfig {
             Uri uri = Uri.parse(transportUri);
             localKeyStore.deleteCertificate(uri.getHost(), uri.getPort());
         }
+    }
+
+    @Override
+    public void setArchiveFolder(String name) {
+        setArchiveFolder(name, SpecialFolderSelection.AUTOMATIC);
+    }
+
+    @Override
+    public void setDraftsFolder(String name) {
+        setDraftsFolder(name, SpecialFolderSelection.AUTOMATIC);
+    }
+
+    @Override
+    public void setTrashFolder(String name) {
+        setTrashFolder(name, SpecialFolderSelection.AUTOMATIC);
+    }
+
+    @Override
+    public void setSpamFolder(String name) {
+        setSpamFolder(name, SpecialFolderSelection.AUTOMATIC);
+    }
+
+    @Override
+    public void setSentFolder(String name) {
+        setSentFolder(name, SpecialFolderSelection.AUTOMATIC);
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -1851,29 +1851,4 @@ public class Account implements BaseAccount, StoreConfig {
             localKeyStore.deleteCertificate(uri.getHost(), uri.getPort());
         }
     }
-
-    @Override
-    public void setArchiveFolder(String name) {
-        setArchiveFolder(name, SpecialFolderSelection.AUTOMATIC);
-    }
-
-    @Override
-    public void setDraftsFolder(String name) {
-        setDraftsFolder(name, SpecialFolderSelection.AUTOMATIC);
-    }
-
-    @Override
-    public void setTrashFolder(String name) {
-        setTrashFolder(name, SpecialFolderSelection.AUTOMATIC);
-    }
-
-    @Override
-    public void setSpamFolder(String name) {
-        setSpamFolder(name, SpecialFolderSelection.AUTOMATIC);
-    }
-
-    @Override
-    public void setSentFolder(String name) {
-        setSentFolder(name, SpecialFolderSelection.AUTOMATIC);
-    }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
@@ -11,6 +11,7 @@ class FolderRepository(
 ) {
     private val sortForDisplay = compareByDescending<LocalFolder> { it.serverId == account.inboxFolder }
             .thenByDescending { it.serverId == account.outboxFolder }
+            .thenByDescending { account.isSpecialFolder(it.serverId) }
             .thenByDescending { it.isInTopGroup }
             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name }
 

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepositoryManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepositoryManager.kt
@@ -2,6 +2,6 @@ package com.fsck.k9.mailstore
 
 import com.fsck.k9.Account
 
-class FolderRepositoryManager {
-    fun getFolderRepository(account: Account) = FolderRepository(account)
+class FolderRepositoryManager(private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy) {
+    fun getFolderRepository(account: Account) = FolderRepository(specialFolderSelectionStrategy, account)
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderTypeConverter.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderTypeConverter.kt
@@ -1,0 +1,33 @@
+@file:JvmName("FolderTypeConverter")
+package com.fsck.k9.mailstore
+
+import com.fsck.k9.mail.Folder.FolderType
+
+
+@JvmName("fromDatabaseFolderType")
+fun String.toFolderType(): FolderType {
+    return when (this) {
+        "regular" -> FolderType.REGULAR
+        "inbox" -> FolderType.INBOX
+        "outbox" -> FolderType.OUTBOX
+        "drafts" -> FolderType.DRAFTS
+        "sent" -> FolderType.SENT
+        "trash" -> FolderType.TRASH
+        "spam" -> FolderType.SPAM
+        "archive" -> FolderType.ARCHIVE
+        else -> throw AssertionError("Unknown folder type: $this")
+    }
+}
+
+fun FolderType.toDatabaseFolderType(): String {
+    return when (this) {
+        FolderType.REGULAR -> "regular"
+        FolderType.INBOX -> "inbox"
+        FolderType.OUTBOX -> "outbox"
+        FolderType.DRAFTS -> "drafts"
+        FolderType.SENT -> "sent"
+        FolderType.TRASH -> "trash"
+        FolderType.SPAM -> "spam"
+        FolderType.ARCHIVE -> "archive"
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorage.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorage.kt
@@ -8,6 +8,7 @@ import com.fsck.k9.Preferences
 import com.fsck.k9.backend.api.BackendFolder
 import com.fsck.k9.backend.api.BackendStorage
 import com.fsck.k9.backend.api.FolderInfo
+import com.fsck.k9.mail.Folder.FolderType
 
 class K9BackendStorage(
         private val preferences: Preferences,
@@ -35,7 +36,7 @@ class K9BackendStorage(
     override fun createFolders(folders: List<FolderInfo>) {
         if (folders.isEmpty()) return
 
-        val localFolders = folders.map { localStore.getFolder(it.serverId, it.name) }
+        val localFolders = folders.map { localStore.getFolder(it.serverId, it.name, it.type) }
         localStore.createFolders(localFolders, account.displayCount)
     }
 
@@ -46,10 +47,11 @@ class K9BackendStorage(
                 .forEach { it.delete() }
     }
 
-    override fun changeFolder(folderServerId: String, name: String) {
+    override fun changeFolder(folderServerId: String, name: String, type: FolderType) {
         database.execute(false) { db ->
             val values = ContentValues().apply {
                 put("name", name)
+                put("type", type.toDatabaseFolderType())
             }
 
             db.update("folders", values, "server_id = ?", arrayOf(folderServerId))

--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
@@ -1,0 +1,15 @@
+package com.fsck.k9.mailstore
+
+import com.fsck.k9.Account
+import com.fsck.k9.Preferences
+
+class K9BackendStorageFactory(
+        private val preferences: Preferences,
+        private val folderRepositoryManager: FolderRepositoryManager
+) {
+    fun createBackendStorage(account: Account): K9BackendStorage {
+        val folderRepository = folderRepositoryManager.getFolderRepository(account)
+        val specialFolderUpdater = SpecialFolderUpdater(preferences, folderRepository, account)
+        return K9BackendStorage(preferences, account, account.localStore, specialFolderUpdater)
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -8,4 +8,5 @@ val mailStoreModule = applicationContext {
     bean { StorageManager.getInstance(get()) }
     bean { SearchStatusManager() }
     bean { SpecialFolderSelectionStrategy() }
+    bean { K9BackendStorageFactory(get(), get()) }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -3,8 +3,9 @@ package com.fsck.k9.mailstore
 import org.koin.dsl.module.applicationContext
 
 val mailStoreModule = applicationContext {
-    bean { FolderRepositoryManager() }
+    bean { FolderRepositoryManager(get()) }
     bean { MessageViewInfoExtractor(get(), get(), get()) }
     bean { StorageManager.getInstance(get()) }
     bean { SearchStatusManager() }
+    bean { SpecialFolderSelectionStrategy() }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -109,9 +109,14 @@ public class LocalFolder extends Folder<LocalMessage> {
     }
 
     public LocalFolder(LocalStore localStore, String serverId, String name) {
+        this(localStore, serverId, name, FolderType.REGULAR);
+    }
+
+    public LocalFolder(LocalStore localStore, String serverId, String name, FolderType type) {
         this.localStore = localStore;
         this.serverId = serverId;
         this.name = name;
+        super.setType(type);
         attachmentInfoExtractor = localStore.getAttachmentInfoExtractor();
 
         if (getAccount().getInboxFolder().equals(getServerId())) {
@@ -218,6 +223,9 @@ public class LocalFolder extends Folder<LocalMessage> {
         moreMessages = MoreMessages.fromDatabaseName(moreMessagesValue);
         name = cursor.getString(LocalStore.FOLDER_NAME_INDEX);
         localOnly = cursor.getInt(LocalStore.LOCAL_ONLY_INDEX) == 1;
+        String typeString = cursor.getString(LocalStore.TYPE_INDEX);
+        FolderType folderType = FolderTypeConverter.fromDatabaseFolderType(typeString);
+        super.setType(folderType);
     }
 
     @Override
@@ -253,6 +261,16 @@ public class LocalFolder extends Folder<LocalMessage> {
             throw new WrappedException(e);
         }
         updateFolderColumn("name", name);
+    }
+
+    @Override
+    public void setType(FolderType type) {
+        super.setType(type);
+        try {
+            updateFolderColumn("type", FolderTypeConverter.toDatabaseFolderType(type));
+        } catch (MessagingException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Override

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -132,7 +132,7 @@ public class LocalStore {
     static final String GET_FOLDER_COLS =
         "folders.id, name, visible_limit, last_updated, status, push_state, last_pushed, " +
         "integrate, top_group, poll_class, push_class, display_class, notify_class, more_messages, server_id, " +
-        "local_only";
+        "local_only, type";
 
     static final int FOLDER_ID_INDEX = 0;
     static final int FOLDER_NAME_INDEX = 1;
@@ -150,6 +150,7 @@ public class LocalStore {
     static final int MORE_MESSAGES_INDEX = 13;
     static final int FOLDER_SERVER_ID_INDEX = 14;
     static final int LOCAL_ONLY_INDEX = 15;
+    static final int TYPE_INDEX = 16;
 
     static final String[] UID_CHECK_PROJECTION = { "uid" };
 
@@ -911,6 +912,7 @@ public class LocalStore {
                     String serverId = folder.getServerId();
                     String name = folder.getName();
                     boolean localOnly = folder.isLocalOnly();
+                    String databaseFolderType = FolderTypeConverter.toDatabaseFolderType(folder.getType());
 
                     if (K9.DEVELOPER_MODE) {
                         Cursor cursor = db.query("folders", new String[] { "id", "server_id" },
@@ -953,7 +955,7 @@ public class LocalStore {
                     }
                     folder.refresh(serverId, prefHolder);   // Recover settings from Preferences
 
-                    db.execSQL("INSERT INTO folders (name, visible_limit, top_group, display_class, poll_class, notify_class, push_class, integrate, server_id, local_only) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", new Object[] {
+                    db.execSQL("INSERT INTO folders (name, visible_limit, top_group, display_class, poll_class, notify_class, push_class, integrate, server_id, local_only, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", new Object[] {
                                    name,
                                    visibleLimit,
                                    prefHolder.inTopGroup ? 1 : 0,
@@ -963,7 +965,8 @@ public class LocalStore {
                                    prefHolder.pushClass.name(),
                                    prefHolder.integrate ? 1 : 0,
                                    serverId,
-                                   localOnly ? 1 : 0
+                                   localOnly ? 1 : 0,
+                                   databaseFolderType
                                });
 
                 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -43,6 +43,7 @@ import com.fsck.k9.mail.FetchProfile;
 import com.fsck.k9.mail.FetchProfile.Item;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Folder.FolderType;
 import com.fsck.k9.mail.MessageRetrievalListener;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Multipart;
@@ -405,8 +406,8 @@ public class LocalStore {
         return new LocalFolder(this, serverId);
     }
 
-    public LocalFolder getFolder(String serverId, String name) {
-        return new LocalFolder(this, serverId, name);
+    public LocalFolder getFolder(String serverId, String name, FolderType type) {
+        return new LocalFolder(this, serverId, name, type);
     }
 
     // TODO this takes about 260-300ms, seems slow.

--- a/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderSelectionStrategy.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderSelectionStrategy.kt
@@ -1,0 +1,10 @@
+package com.fsck.k9.mailstore
+
+/**
+ * Implements the automatic special folder selection strategy.
+ */
+class SpecialFolderSelectionStrategy {
+    fun selectSpecialFolder(folders: List<Folder>, type: FolderType): Folder? {
+        return folders.firstOrNull { folder -> folder.type == type }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
@@ -1,0 +1,82 @@
+package com.fsck.k9.mailstore
+
+import com.fsck.k9.Account
+import com.fsck.k9.Account.SpecialFolderSelection
+import com.fsck.k9.Preferences
+
+/**
+ * Updates special folders in [Account] if they are marked as [SpecialFolderSelection.AUTOMATIC] or if they are marked
+ * as [SpecialFolderSelection.MANUAL] but have been deleted from the server.
+ */
+class SpecialFolderUpdater(
+        private val preferences: Preferences,
+        private val folderRepository: FolderRepository,
+        private val account: Account
+) {
+    fun updateSpecialFolders() {
+        val (folders, automaticSpecialFolders) = folderRepository.getRemoteFolderInfo()
+
+        updateInbox(folders)
+        updateSpecialFolder(FolderType.ARCHIVE, folders, automaticSpecialFolders)
+        updateSpecialFolder(FolderType.DRAFTS, folders, automaticSpecialFolders)
+        updateSpecialFolder(FolderType.SENT, folders, automaticSpecialFolders)
+        updateSpecialFolder(FolderType.SPAM, folders, automaticSpecialFolders)
+        updateSpecialFolder(FolderType.TRASH, folders, automaticSpecialFolders)
+
+        saveAccount()
+    }
+
+    private fun updateInbox(folders: List<Folder>) {
+        account.inboxFolder = folders.first { it.type == FolderType.INBOX }.serverId
+    }
+
+    private fun updateSpecialFolder(
+            type: FolderType,
+            folders: List<Folder>,
+            automaticSpecialFolders: Map<FolderType, Folder?>
+    ) {
+        when (getSpecialFolderSelection(type)) {
+            SpecialFolderSelection.AUTOMATIC -> {
+                setSpecialFolder(type, automaticSpecialFolders[type]?.serverId, SpecialFolderSelection.AUTOMATIC)
+            }
+            SpecialFolderSelection.MANUAL -> {
+                if (folders.none { it.serverId == getSpecialFolder(type) }) {
+                    setSpecialFolder(type, null, SpecialFolderSelection.MANUAL)
+                }
+            }
+        }
+    }
+
+    private fun getSpecialFolderSelection(type: FolderType) = when (type) {
+        FolderType.ARCHIVE -> account.archiveFolderSelection
+        FolderType.DRAFTS -> account.draftsFolderSelection
+        FolderType.SENT -> account.sentFolderSelection
+        FolderType.SPAM -> account.spamFolderSelection
+        FolderType.TRASH -> account.trashFolderSelection
+        else -> throw AssertionError("Unsupported: $type")
+    }
+
+    private fun getSpecialFolder(type: FolderType): String? = when (type) {
+        FolderType.ARCHIVE -> account.archiveFolder
+        FolderType.DRAFTS -> account.draftsFolder
+        FolderType.SENT -> account.sentFolder
+        FolderType.SPAM -> account.spamFolder
+        FolderType.TRASH -> account.trashFolder
+        else -> throw AssertionError("Unsupported: $type")
+    }
+
+    private fun setSpecialFolder(type: FolderType, folder: String?, selection: SpecialFolderSelection) {
+        when (type) {
+            FolderType.ARCHIVE -> account.setArchiveFolder(folder, selection)
+            FolderType.DRAFTS -> account.setDraftsFolder(folder, selection)
+            FolderType.SENT -> account.setSentFolder(folder, selection)
+            FolderType.SPAM -> account.setSpamFolder(folder, selection)
+            FolderType.TRASH -> account.setTrashFolder(folder, selection)
+            else -> throw AssertionError("Unsupported: $type")
+        }
+    }
+
+    private fun saveAccount() {
+        account.save(preferences)
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -19,6 +19,7 @@ import com.fsck.k9.Account.QuoteStyle;
 import com.fsck.k9.Account.Searchable;
 import com.fsck.k9.Account.ShowPictures;
 import com.fsck.k9.Account.SortType;
+import com.fsck.k9.Account.SpecialFolderSelection;
 import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.core.R;
@@ -244,6 +245,21 @@ public class AccountSettings {
         s.put("uploadSentMessages", Settings.versions(
                 new V(52, new BooleanSetting(true))
         ));
+        s.put("archiveFolderSelection", Settings.versions(
+                new V(54, new EnumSetting<>(SpecialFolderSelection.class, SpecialFolderSelection.AUTOMATIC))
+        ));
+        s.put("draftsFolderSelection", Settings.versions(
+                new V(54, new EnumSetting<>(SpecialFolderSelection.class, SpecialFolderSelection.AUTOMATIC))
+        ));
+        s.put("sentFolderSelection", Settings.versions(
+                new V(54, new EnumSetting<>(SpecialFolderSelection.class, SpecialFolderSelection.AUTOMATIC))
+        ));
+        s.put("spamFolderSelection", Settings.versions(
+                new V(54, new EnumSetting<>(SpecialFolderSelection.class, SpecialFolderSelection.AUTOMATIC))
+        ));
+        s.put("trashFolderSelection", Settings.versions(
+                new V(54, new EnumSetting<>(SpecialFolderSelection.class, SpecialFolderSelection.AUTOMATIC))
+        ));
         // note that there is no setting for openPgpProvider, because this will have to be set up together
         // with the actual provider after import anyways.
 
@@ -251,7 +267,8 @@ public class AccountSettings {
 
         Map<Integer, SettingsUpgrader> u = new HashMap<>();
         u.put(53, new SettingsUpgraderV53());
-        
+        u.put(54, new SettingsUpgraderV54());
+
         UPGRADERS = Collections.unmodifiableMap(u);
     }
 
@@ -429,6 +446,26 @@ public class AccountSettings {
             if (FOLDER_NONE.equals(archiveFolderName)) {
                 settings.put(key, null);
             }
+        }
+    }
+
+    /**
+     * Upgrades settings from version 53 to 54
+     *
+     * Inserts folder selection entries with a value of "MANUAL"
+     */
+    private static class SettingsUpgraderV54 implements SettingsUpgrader {
+        private static final String FOLDER_SELECTION_MANUAL = "MANUAL";
+
+        @Override
+        public Set<String> upgrade(Map<String, Object> settings) {
+            settings.put("archiveFolderSelection", FOLDER_SELECTION_MANUAL);
+            settings.put("draftsFolderSelection", FOLDER_SELECTION_MANUAL);
+            settings.put("sentFolderSelection", FOLDER_SELECTION_MANUAL);
+            settings.put("spamFolderSelection", FOLDER_SELECTION_MANUAL);
+            settings.put("trashFolderSelection", FOLDER_SELECTION_MANUAL);
+
+            return null;
         }
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 53;
+    public static final int VERSION = 54;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo4.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo4.kt
@@ -1,0 +1,31 @@
+package com.fsck.k9.preferences.migrations
+
+import android.database.sqlite.SQLiteDatabase
+
+/**
+ * Add `*FolderSelection` values of "MANUAL" for existing accounts (default for new accounts is "AUTOMATIC").
+ */
+class StorageMigrationTo4(
+        private val db: SQLiteDatabase,
+        private val migrationsHelper: StorageMigrationsHelper
+) {
+    fun insertSpecialFolderSelectionValues() {
+        val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")
+        if (accountUuidsListValue == null || accountUuidsListValue.isEmpty()) {
+            return
+        }
+
+        val accountUuids = accountUuidsListValue.split(",")
+        for (accountUuid in accountUuids) {
+            insertSpecialFolderSelectionValues(accountUuid)
+        }
+    }
+
+    private fun insertSpecialFolderSelectionValues(accountUuid: String) {
+        migrationsHelper.insertValue(db, "$accountUuid.archiveFolderSelection", "MANUAL")
+        migrationsHelper.insertValue(db, "$accountUuid.draftsFolderSelection", "MANUAL")
+        migrationsHelper.insertValue(db, "$accountUuid.sentFolderSelection", "MANUAL")
+        migrationsHelper.insertValue(db, "$accountUuid.spamFolderSelection", "MANUAL")
+        migrationsHelper.insertValue(db, "$accountUuid.trashFolderSelection", "MANUAL")
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
@@ -9,5 +9,6 @@ internal object StorageMigrations {
 
         if (oldVersion <= 1) StorageMigrationTo2.urlEncodeUserNameAndPassword(db, migrationsHelper)
         if (oldVersion <= 2) StorageMigrationTo3(db, migrationsHelper).rewriteFolderNone()
+        if (oldVersion <= 3) StorageMigrationTo4(db, migrationsHelper).insertSpecialFolderSelectionValues()
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationsHelper.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationsHelper.kt
@@ -5,4 +5,5 @@ import android.database.sqlite.SQLiteDatabase
 interface StorageMigrationsHelper {
     fun readValue(db: SQLiteDatabase, key: String): String?
     fun writeValue(db: SQLiteDatabase, key: String, value: String?)
+    fun insertValue(db: SQLiteDatabase, key: String, value: String?)
 }

--- a/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
@@ -10,6 +10,7 @@ import com.fsck.k9.backend.api.BackendFolder
 import com.fsck.k9.backend.api.FolderInfo
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.Flag
+import com.fsck.k9.mail.Folder.FolderType
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.internet.MimeMessage
 import com.fsck.k9.mail.internet.MimeMessageHelper
@@ -84,7 +85,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
     fun createBackendFolder(): BackendFolder {
         val localStore: LocalStore = account.localStore
         val backendStorage = K9BackendStorage(preferences, account, localStore)
-        backendStorage.createFolders(listOf(FolderInfo(FOLDER_SERVER_ID, FOLDER_NAME)))
+        backendStorage.createFolders(listOf(FolderInfo(FOLDER_SERVER_ID, FOLDER_NAME, FOLDER_TYPE)))
 
         val folderServerIds = backendStorage.getFolderServerIds()
         assertTrue(FOLDER_SERVER_ID in folderServerIds)
@@ -127,6 +128,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
     companion object {
         const val FOLDER_SERVER_ID = "testFolder"
         const val FOLDER_NAME = "Test Folder"
+        val FOLDER_TYPE = FolderType.REGULAR
         const val MESSAGE_SERVER_ID = "msg001"
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
@@ -26,6 +26,7 @@ import org.koin.standalone.inject
 
 class K9BackendFolderTest : K9RobolectricTest() {
     val preferences: Preferences by inject()
+    val folderRepositoryManager: FolderRepositoryManager by inject()
 
     val account: Account = createAccount()
     val backendFolder = createBackendFolder()
@@ -84,7 +85,9 @@ class K9BackendFolderTest : K9RobolectricTest() {
 
     fun createBackendFolder(): BackendFolder {
         val localStore: LocalStore = account.localStore
-        val backendStorage = K9BackendStorage(preferences, account, localStore)
+        val folderRepository = folderRepositoryManager.getFolderRepository(account)
+        val specialFolderUpdater = SpecialFolderUpdater(preferences, folderRepository, account)
+        val backendStorage = K9BackendStorage(preferences, account, localStore, specialFolderUpdater)
         backendStorage.createFolders(listOf(FolderInfo(FOLDER_SERVER_ID, FOLDER_NAME, FOLDER_TYPE)))
 
         val folderServerIds = backendStorage.getFolderServerIds()
@@ -128,7 +131,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
     companion object {
         const val FOLDER_SERVER_ID = "testFolder"
         const val FOLDER_NAME = "Test Folder"
-        val FOLDER_TYPE = FolderType.REGULAR
+        val FOLDER_TYPE = FolderType.INBOX
         const val MESSAGE_SERVER_ID = "msg001"
     }
 }

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -3,7 +3,6 @@ package com.fsck.k9.backends
 import android.content.Context
 import android.net.ConnectivityManager
 import com.fsck.k9.Account
-import com.fsck.k9.Preferences
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.backend.imap.ImapBackend
@@ -17,18 +16,18 @@ import com.fsck.k9.mail.store.imap.ImapStore
 import com.fsck.k9.mail.transport.smtp.SmtpTransport
 import com.fsck.k9.mail.transport.smtp.SmtpTransportUriCreator
 import com.fsck.k9.mail.transport.smtp.SmtpTransportUriDecoder
-import com.fsck.k9.mailstore.K9BackendStorage
+import com.fsck.k9.mailstore.K9BackendStorageFactory
 
 class ImapBackendFactory(
         private val context: Context,
-        private val preferences: Preferences,
-        private val powerManager: PowerManager
+        private val powerManager: PowerManager,
+        private val backendStorageFactory: K9BackendStorageFactory
 ) : BackendFactory {
     override val transportUriPrefix = "smtp"
 
     override fun createBackend(account: Account): Backend {
         val accountName = account.displayName
-        val backendStorage = K9BackendStorage(preferences, account, account.localStore)
+        val backendStorage = backendStorageFactory.createBackendStorage(account)
         val imapStore = createImapStore(account)
         val smtpTransport = createSmtpTransport(account)
         return ImapBackend(accountName, backendStorage, imapStore, powerManager, smtpTransport)

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
@@ -2,27 +2,29 @@ package com.fsck.k9.backends
 
 import android.content.Context
 import com.fsck.k9.Account
-import com.fsck.k9.Preferences
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.backend.pop3.Pop3Backend
+import com.fsck.k9.backend.pop3.Pop3StoreUriCreator
+import com.fsck.k9.backend.pop3.Pop3StoreUriDecoder
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider
 import com.fsck.k9.mail.ssl.DefaultTrustedSocketFactory
 import com.fsck.k9.mail.store.pop3.Pop3Store
-import com.fsck.k9.backend.pop3.Pop3StoreUriCreator
-import com.fsck.k9.backend.pop3.Pop3StoreUriDecoder
 import com.fsck.k9.mail.transport.smtp.SmtpTransport
 import com.fsck.k9.mail.transport.smtp.SmtpTransportUriCreator
 import com.fsck.k9.mail.transport.smtp.SmtpTransportUriDecoder
-import com.fsck.k9.mailstore.K9BackendStorage
+import com.fsck.k9.mailstore.K9BackendStorageFactory
 
-class Pop3BackendFactory(private val context: Context, private val preferences: Preferences) : BackendFactory {
+class Pop3BackendFactory(
+        private val context: Context,
+        private val backendStorageFactory: K9BackendStorageFactory
+) : BackendFactory {
     override val transportUriPrefix = "smtp"
 
     override fun createBackend(account: Account): Backend {
         val accountName = account.displayName
-        val backendStorage = K9BackendStorage(preferences, account, account.localStore)
+        val backendStorage = backendStorageFactory.createBackendStorage(account)
         val pop3Store = createPop3Store(account)
         val smtpTransport = createSmtpTransport(account)
         return Pop3Backend(accountName, backendStorage, pop3Store, smtpTransport)

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/WebDavBackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/WebDavBackendFactory.kt
@@ -1,24 +1,23 @@
 package com.fsck.k9.backends
 
 import com.fsck.k9.Account
-import com.fsck.k9.Preferences
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.backend.webdav.WebDavBackend
+import com.fsck.k9.backend.webdav.WebDavStoreUriCreator
+import com.fsck.k9.backend.webdav.WebDavStoreUriDecoder
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.webdav.WebDavStore
 import com.fsck.k9.mail.store.webdav.WebDavStoreSettings
-import com.fsck.k9.backend.webdav.WebDavStoreUriCreator
-import com.fsck.k9.backend.webdav.WebDavStoreUriDecoder
 import com.fsck.k9.mail.transport.WebDavTransport
-import com.fsck.k9.mailstore.K9BackendStorage
+import com.fsck.k9.mailstore.K9BackendStorageFactory
 
-class WebDavBackendFactory(private val preferences: Preferences) : BackendFactory {
+class WebDavBackendFactory(private val backendStorageFactory: K9BackendStorageFactory) : BackendFactory {
     override val transportUriPrefix = "webdav"
 
     override fun createBackend(account: Account): Backend {
         val accountName = account.displayName
-        val backendStorage = K9BackendStorage(preferences, account, account.localStore)
+        val backendStorage = backendStorageFactory.createBackendStorage(account)
         val serverSettings = WebDavStoreUriDecoder.decode(account.storeUri)
         val webDavStore = createWebDavStore(serverSettings, account)
         val webDavTransport = WebDavTransport(serverSettings, account)

--- a/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -12,7 +12,7 @@ import timber.log.Timber;
 
 
 class StoreSchemaDefinition implements SchemaDefinition {
-    static final int DB_VERSION = 66;
+    static final int DB_VERSION = 67;
 
     private final MigrationsHelper migrationsHelper;
 
@@ -92,8 +92,9 @@ class StoreSchemaDefinition implements SchemaDefinition {
                 "display_class TEXT, " +
                 "notify_class TEXT default '"+ Folder.FolderClass.INHERITED.name() + "', " +
                 "more_messages TEXT default \"unknown\", " +
-                "server_id TEXT," +
-                "local_only INTEGER" +
+                "server_id TEXT, " +
+                "local_only INTEGER, " +
+                "type TEXT DEFAULT \"regular\"" +
                 ")");
 
         db.execSQL("DROP INDEX IF EXISTS folder_server_id");

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo67.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo67.kt
@@ -1,0 +1,27 @@
+package com.fsck.k9.storage.migrations
+
+import android.database.sqlite.SQLiteDatabase
+import com.fsck.k9.mailstore.MigrationsHelper
+
+
+internal object MigrationTo67 {
+    @JvmStatic
+    fun addTypeColumnToFoldersTable(db: SQLiteDatabase, migrationsHelper: MigrationsHelper) {
+        db.execSQL("ALTER TABLE folders ADD type TEXT DEFAULT \"regular\"")
+
+        val account = migrationsHelper.account
+        setFolderType(db, account.inboxFolder, "inbox")
+        setFolderType(db, account.outboxFolder, "outbox")
+        setFolderType(db, account.trashFolder, "trash")
+        setFolderType(db, account.draftsFolder, "drafts")
+        setFolderType(db, account.spamFolder, "spam")
+        setFolderType(db, account.sentFolder, "sent")
+        setFolderType(db, account.archiveFolder, "archive")
+    }
+
+    private fun setFolderType(db: SQLiteDatabase, serverId: String?, type: String) {
+        if (serverId != null) {
+            db.execSQL("UPDATE folders SET type = ? WHERE server_id = ?", arrayOf(type, serverId))
+        }
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.java
@@ -90,6 +90,8 @@ public class Migrations {
                 MigrationTo65.addLocalOnlyColumnToFoldersTable(db, migrationsHelper);
             case 65:
                 MigrationTo66.addEncryptionTypeColumnToMessagesTable(db);
+            case 66:
+                MigrationTo67.addTypeColumnToFoldersTable(db, migrationsHelper);
         }
 
         if (shouldBuildFtsTable) {

--- a/app/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.java
+++ b/app/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.java
@@ -14,6 +14,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.text.TextUtils;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.K9;
 import com.fsck.k9.core.BuildConfig;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.MessagingException;
@@ -371,6 +372,12 @@ public class StoreSchemaDefinitionTest extends K9RobolectricTest {
     private Account createAccount() {
         Account account = mock(Account.class);
         when(account.getInboxFolder()).thenReturn("Inbox");
+        when(account.getOutboxFolder()).thenReturn(Account.OUTBOX);
+        when(account.getTrashFolder()).thenReturn("Trash");
+        when(account.getDraftsFolder()).thenReturn("Drafts");
+        when(account.getSpamFolder()).thenReturn("Spam");
+        when(account.getSentFolder()).thenReturn("Sent");
+        when(account.getArchiveFolder()).thenReturn(null);
         when(account.getLocalStorageProviderId()).thenReturn(StorageManager.InternalStorageProvider.ID);
         when(account.getStoreUri()).thenReturn("dummy://");
         return account;

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -27,6 +27,7 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.Account.SpecialFolderSelection;
 import com.fsck.k9.DI;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.K9Activity;
@@ -531,9 +532,9 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
             createLocalFolder(localStore, sentFolderInternalId, getString(R.string.special_mailbox_name_sent));
             createLocalFolder(localStore, trashFolderInternalId, getString(R.string.special_mailbox_name_trash));
 
-            account.setDraftsFolder(draftsFolderInternalId);
-            account.setSentFolder(sentFolderInternalId);
-            account.setTrashFolder(trashFolderInternalId);
+            account.setDraftsFolder(draftsFolderInternalId, SpecialFolderSelection.MANUAL);
+            account.setSentFolder(sentFolderInternalId, SpecialFolderSelection.MANUAL);
+            account.setTrashFolder(trashFolderInternalId, SpecialFolderSelection.MANUAL);
         }
 
         private void createLocalFolder(LocalStore localStore, String internalId, String folderName)

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -5,8 +5,8 @@ import android.arch.lifecycle.MutableLiveData
 import android.arch.lifecycle.ViewModel
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
-import com.fsck.k9.mailstore.Folder
 import com.fsck.k9.mailstore.FolderRepositoryManager
+import com.fsck.k9.mailstore.RemoteFolderInfo
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import org.jetbrains.anko.coroutines.experimental.bg
@@ -16,7 +16,7 @@ class AccountSettingsViewModel(
         private val folderRepositoryManager: FolderRepositoryManager
 ) : ViewModel() {
     private val accountLiveData = MutableLiveData<Account>()
-    private val foldersLiveData = MutableLiveData<List<Folder>>()
+    private val foldersLiveData = MutableLiveData<RemoteFolderInfo>()
 
     fun getAccount(accountUuid: String): LiveData<Account> {
         if (accountLiveData.value == null) {
@@ -44,7 +44,7 @@ class AccountSettingsViewModel(
 
     private fun loadAccount(accountUuid: String) = preferences.getAccount(accountUuid)
 
-    fun getFolders(account: Account): LiveData<List<Folder>> {
+    fun getFolders(account: Account): LiveData<RemoteFolderInfo> {
         if (foldersLiveData.value == null) {
             loadFolders(account)
         }
@@ -55,11 +55,11 @@ class AccountSettingsViewModel(
     private fun loadFolders(account: Account) {
         val folderRepository = folderRepositoryManager.getFolderRepository(account)
         launch(UI) {
-            val folders = bg {
-                folderRepository.getRemoteFolders()
+            val remoteFolderInfo = bg {
+                folderRepository.getRemoteFolderInfo()
             }.await()
 
-            foldersLiveData.value = folders
+            foldersLiveData.value = remoteFolderInfo
         }
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/FolderListPreference.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/FolderListPreference.kt
@@ -28,24 +28,37 @@ constructor(
         defStyleRes: Int = 0
 ) : ListPreference(context, attrs, defStyleAttr, defStyleRes), KoinComponent {
     private val folderNameFormatter: FolderNameFormatter by inject()
-    private val noFolderSelectedName = SpannableString(context.getString(R.string.account_settings_no_folder_selected))
-            .apply { setSpan(StyleSpan(Typeface.ITALIC), 0, this.length, 0) }
-
-
-    var folders: List<Folder>
-        get() = throw UnsupportedOperationException()
-        set(folders) {
-            entries = (listOf(noFolderSelectedName) + folders.map { folderNameFormatter.displayName(it) }).toTypedArray()
-            entryValues = (listOf(NO_FOLDER_SELECTED_VALUE) + folders.map { it.serverId }).toTypedArray()
-
-            isEnabled = true
-        }
-
+    private val noFolderSelectedName = context.getString(R.string.account_settings_no_folder_selected).italicize()
+    private lateinit var automaticFolderOption: CharSequence
 
     init {
         entries = emptyArray()
         entryValues = emptyArray()
         isEnabled = false
+    }
+
+
+    fun setFolders(folders: List<Folder>) {
+        entries = (listOf(noFolderSelectedName) + getFolderDisplayNames(folders)).toTypedArray()
+        entryValues = (listOf(NO_FOLDER_SELECTED_VALUE) + getFolderValues(folders)).toTypedArray()
+        isEnabled = true
+    }
+
+    fun setFolders(folders: List<Folder>, automaticFolder: Folder?) {
+        val automaticFolderName = if (automaticFolder != null) {
+            folderNameFormatter.displayName(automaticFolder)
+        } else {
+            context.getString(R.string.account_settings_no_folder_selected)
+        }
+        val automaticFolderValue = AUTOMATIC_PREFIX + (automaticFolder?.serverId ?: NO_FOLDER_VALUE)
+
+        automaticFolderOption = context.getString(R.string.account_settings_automatic_special_folder,
+                automaticFolderName).italicize()
+
+        entries = (listOf(automaticFolderOption) + noFolderSelectedName + getFolderDisplayNames(folders)).toTypedArray()
+        entryValues = (listOf(automaticFolderValue) + NO_FOLDER_SELECTED_VALUE + getFolderValues(folders)).toTypedArray()
+
+        isEnabled = true
     }
 
     override fun getSummary(): CharSequence {
@@ -55,13 +68,25 @@ constructor(
         return when {
             entries.isEmpty() -> PLACEHOLDER_SUMMARY
             value == NO_FOLDER_SELECTED_VALUE -> noFolderSelectedName
+            value.startsWith(AUTOMATIC_PREFIX) -> automaticFolderOption
             else -> super.getSummary()
         }
     }
 
+    private fun getFolderDisplayNames(folders: List<Folder>) = folders.map { folderNameFormatter.displayName(it) }
+
+    private fun getFolderValues(folders: List<Folder>) = folders.map { MANUAL_PREFIX + it.serverId }
+
+    private fun String.italicize(): CharSequence {
+        return SpannableString(this).apply { setSpan(StyleSpan(Typeface.ITALIC), 0, this.length, 0) }
+    }
 
     companion object {
-        const val NO_FOLDER_SELECTED_VALUE = ""
+        const val FOLDER_VALUE_DELIMITER = "|"
+        const val AUTOMATIC_PREFIX = "AUTOMATIC|"
+        const val MANUAL_PREFIX = "MANUAL|"
+        const val NO_FOLDER_VALUE = ""
+        private const val NO_FOLDER_SELECTED_VALUE = MANUAL_PREFIX + NO_FOLDER_VALUE
         private const val PLACEHOLDER_SUMMARY = " "
     }
 }

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -903,6 +903,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_searchable_none">None</string>
 
     <string name="account_settings_no_folder_selected">None</string>
+    <string name="account_settings_automatic_special_folder">Automatic (%s)</string>
 
     <string name="font_size_settings_title">Font size</string>
     <string name="font_size_settings_description">Configure font size</string>

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/BackendStorage.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/BackendStorage.kt
@@ -1,5 +1,7 @@
 package com.fsck.k9.backend.api
 
+import com.fsck.k9.mail.Folder.FolderType
+
 interface BackendStorage {
     fun getFolder(folderServerId: String): BackendFolder
 
@@ -7,7 +9,7 @@ interface BackendStorage {
 
     fun createFolders(folders: List<FolderInfo>)
     fun deleteFolders(folderServerIds: List<String>)
-    fun changeFolder(folderServerId: String, name: String)
+    fun changeFolder(folderServerId: String, name: String, type: FolderType)
 
     fun getExtraString(name: String): String?
     fun setExtraString(name: String, value: String)

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/FolderInfo.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/FolderInfo.kt
@@ -1,3 +1,5 @@
 package com.fsck.k9.backend.api
 
-data class FolderInfo(val serverId: String, val name: String)
+import com.fsck.k9.mail.Folder
+
+data class FolderInfo(val serverId: String, val name: String, val type: Folder.FolderType)

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandRefreshFolderList.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandRefreshFolderList.kt
@@ -3,7 +3,6 @@ package com.fsck.k9.backend.imap
 
 import com.fsck.k9.backend.api.BackendStorage
 import com.fsck.k9.backend.api.FolderInfo
-import com.fsck.k9.mail.Folder.FolderType
 import com.fsck.k9.mail.store.imap.ImapStore
 
 
@@ -17,11 +16,10 @@ internal class CommandRefreshFolderList(
 
         val foldersToCreate = mutableListOf<FolderInfo>()
         for (folder in foldersOnServer) {
-            //FIXME: Use correct folder type
             if (folder.serverId !in oldFolderServerIds) {
-                foldersToCreate.add(FolderInfo(folder.serverId, folder.name, FolderType.REGULAR))
+                foldersToCreate.add(FolderInfo(folder.serverId, folder.name, folder.type))
             } else {
-                backendStorage.changeFolder(folder.serverId, folder.name, FolderType.REGULAR)
+                backendStorage.changeFolder(folder.serverId, folder.name, folder.type)
             }
         }
         backendStorage.createFolders(foldersToCreate)

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandRefreshFolderList.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandRefreshFolderList.kt
@@ -3,6 +3,7 @@ package com.fsck.k9.backend.imap
 
 import com.fsck.k9.backend.api.BackendStorage
 import com.fsck.k9.backend.api.FolderInfo
+import com.fsck.k9.mail.Folder.FolderType
 import com.fsck.k9.mail.store.imap.ImapStore
 
 
@@ -16,10 +17,11 @@ internal class CommandRefreshFolderList(
 
         val foldersToCreate = mutableListOf<FolderInfo>()
         for (folder in foldersOnServer) {
+            //FIXME: Use correct folder type
             if (folder.serverId !in oldFolderServerIds) {
-                foldersToCreate.add(FolderInfo(folder.serverId, folder.name))
+                foldersToCreate.add(FolderInfo(folder.serverId, folder.name, FolderType.REGULAR))
             } else {
-                backendStorage.changeFolder(folder.serverId, folder.name)
+                backendStorage.changeFolder(folder.serverId, folder.name, FolderType.REGULAR)
             }
         }
         backendStorage.createFolders(foldersToCreate)

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/CommandRefreshFolderList.kt
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/CommandRefreshFolderList.kt
@@ -3,6 +3,7 @@ package com.fsck.k9.backend.pop3
 
 import com.fsck.k9.backend.api.BackendStorage
 import com.fsck.k9.backend.api.FolderInfo
+import com.fsck.k9.mail.Folder.FolderType
 import com.fsck.k9.mail.store.pop3.Pop3Folder
 
 
@@ -10,7 +11,7 @@ internal class CommandRefreshFolderList(private val backendStorage: BackendStora
     fun refreshFolderList() {
         val folderServerIds = backendStorage.getFolderServerIds()
         if (Pop3Folder.INBOX !in folderServerIds) {
-            val inbox = FolderInfo(Pop3Folder.INBOX, Pop3Folder.INBOX)
+            val inbox = FolderInfo(Pop3Folder.INBOX, Pop3Folder.INBOX, FolderType.INBOX)
             backendStorage.createFolders(listOf(inbox))
         }
     }

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/CommandRefreshFolderList.kt
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/CommandRefreshFolderList.kt
@@ -3,7 +3,6 @@ package com.fsck.k9.backend.webdav
 
 import com.fsck.k9.backend.api.BackendStorage
 import com.fsck.k9.backend.api.FolderInfo
-import com.fsck.k9.mail.Folder.FolderType
 import com.fsck.k9.mail.store.webdav.WebDavStore
 
 
@@ -17,11 +16,10 @@ internal class CommandRefreshFolderList(
 
         val foldersToCreate = mutableListOf<FolderInfo>()
         for (folder in foldersOnServer) {
-            //FIXME: Use correct folder type
             if (folder.serverId !in oldFolderServerIds) {
-                foldersToCreate.add(FolderInfo(folder.serverId, folder.name, FolderType.REGULAR))
+                foldersToCreate.add(FolderInfo(folder.serverId, folder.name, folder.type))
             } else {
-                backendStorage.changeFolder(folder.serverId, folder.name, FolderType.REGULAR)
+                backendStorage.changeFolder(folder.serverId, folder.name, folder.type)
             }
         }
         backendStorage.createFolders(foldersToCreate)

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/CommandRefreshFolderList.kt
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/CommandRefreshFolderList.kt
@@ -3,6 +3,7 @@ package com.fsck.k9.backend.webdav
 
 import com.fsck.k9.backend.api.BackendStorage
 import com.fsck.k9.backend.api.FolderInfo
+import com.fsck.k9.mail.Folder.FolderType
 import com.fsck.k9.mail.store.webdav.WebDavStore
 
 
@@ -16,10 +17,11 @@ internal class CommandRefreshFolderList(
 
         val foldersToCreate = mutableListOf<FolderInfo>()
         for (folder in foldersOnServer) {
+            //FIXME: Use correct folder type
             if (folder.serverId !in oldFolderServerIds) {
-                foldersToCreate.add(FolderInfo(folder.serverId, folder.name))
+                foldersToCreate.add(FolderInfo(folder.serverId, folder.name, FolderType.REGULAR))
             } else {
-                backendStorage.changeFolder(folder.serverId, folder.name)
+                backendStorage.changeFolder(folder.serverId, folder.name, FolderType.REGULAR)
             }
         }
         backendStorage.createFolders(foldersToCreate)

--- a/mail/common/src/main/java/com/fsck/k9/mail/Folder.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Folder.java
@@ -13,6 +13,7 @@ public abstract class Folder<T extends Message> {
     private String status = null;
     private long lastChecked = 0;
     private long lastPush = 0;
+    private FolderType type = FolderType.REGULAR;
 
     public static final int OPEN_MODE_RW=0;
     public static final int OPEN_MODE_RO=1;
@@ -20,6 +21,17 @@ public abstract class Folder<T extends Message> {
     // NONE is obsolete, it will be translated to NO_CLASS for display and to INHERITED for sync and push
     public enum FolderClass {
         NONE, NO_CLASS, INHERITED, FIRST_CLASS, SECOND_CLASS
+    }
+
+    public enum FolderType {
+        REGULAR,
+        INBOX,
+        OUTBOX,
+        DRAFTS,
+        SENT,
+        TRASH,
+        SPAM,
+        ARCHIVE
     }
 
     /**
@@ -200,5 +212,13 @@ public abstract class Folder<T extends Message> {
     public List<T> search(String queryString, final Set<Flag> requiredFlags, final Set<Flag> forbiddenFlags)
         throws MessagingException {
         throw new MessagingException("K-9 does not support searches on this folder type");
+    }
+
+    public FolderType getType() {
+        return type;
+    }
+
+    public void setType(FolderType type) {
+        this.type = type;
     }
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
@@ -11,14 +11,6 @@ public interface StoreConfig {
     String getOutboxFolder();
     String getDraftsFolder();
 
-    void setArchiveFolder(String name);
-    void setDraftsFolder(String name);
-    void setTrashFolder(String name);
-    void setSpamFolder(String name);
-    void setSentFolder(String name);
-    void setAutoExpandFolder(String name);
-    void setInboxFolder(String name);
-
     int getMaximumAutoDownloadMessageSize();
 
     boolean allowRemoteSearch();

--- a/mail/protocols/imap/build.gradle
+++ b/mail/protocols/imap/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply plugin: 'org.jetbrains.kotlin.android'
 
 apply from: "${rootProject.projectDir}/gradle/plugins/checkstyle-android.gradle"
 apply from: "${rootProject.projectDir}/gradle/plugins/findbugs-android.gradle"
@@ -8,6 +9,8 @@ if (rootProject.testCoverage) {
 }
 
 dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
+
     api project(":mail:common")
 
     implementation "com.jcraft:jzlib:1.0.7"

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/FolderListItem.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/FolderListItem.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.mail.store.imap
+
+import com.fsck.k9.mail.Folder.FolderType
+
+data class FolderListItem(val name: String, val type: FolderType)

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
@@ -6,8 +6,10 @@ import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Deque;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import android.net.ConnectivityManager;
@@ -15,6 +17,7 @@ import android.net.ConnectivityManager;
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Folder.FolderType;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
@@ -29,12 +32,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 
@@ -98,7 +99,7 @@ public class ImapStoreTest {
     }
 
     @Test
-    public void autoconfigureFolders_withSpecialUseCapability_shouldSetSpecialFolders() throws Exception {
+    public void getPersonalNamespaces_withSpecialUseCapability_shouldReturnSpecialFolderInfo() throws Exception {
         ImapConnection imapConnection = mock(ImapConnection.class);
         when(imapConnection.hasCapability(Capabilities.SPECIAL_USE)).thenReturn(true);
         List<ImapResponse> imapResponses = Arrays.asList(
@@ -114,50 +115,29 @@ public class ImapStoreTest {
                 createImapResponse("5 OK Success")
         );
         when(imapConnection.executeSimpleCommand("LIST (SPECIAL-USE) \"\" \"*\"")).thenReturn(imapResponses);
+        imapStore.enqueueImapConnection(imapConnection);
 
-        imapStore.autoconfigureFolders(imapConnection);
+        List<ImapFolder> folders = imapStore.getPersonalNamespaces();
 
-        verify(storeConfig).setDraftsFolder("[Gmail]/Drafts");
-        verify(storeConfig).setSentFolder("[Gmail]/Sent Mail");
-        verify(storeConfig).setSpamFolder("[Gmail]/Spam");
-        verify(storeConfig).setTrashFolder("[Gmail]/Trash");
-        verify(storeConfig).setArchiveFolder("[Gmail]/All Mail");
+        Map<String, ImapFolder> folderMap = toFolderMap(folders);
+        assertEquals(FolderType.INBOX, folderMap.get("INBOX").getType());
+        assertEquals(FolderType.DRAFTS, folderMap.get("[Gmail]/Drafts").getType());
+        assertEquals(FolderType.SENT, folderMap.get("[Gmail]/Sent Mail").getType());
+        assertEquals(FolderType.SPAM, folderMap.get("[Gmail]/Spam").getType());
+        assertEquals(FolderType.TRASH, folderMap.get("[Gmail]/Trash").getType());
+        assertEquals(FolderType.ARCHIVE, folderMap.get("[Gmail]/All Mail").getType());
     }
 
     @Test
-    public void autoconfigureFolders_withoutSpecialUseCapability_shouldNotIssueImapCommand() throws Exception {
+    public void getPersonalNamespaces_withoutSpecialUseCapability_shouldUseSimpleListCommand() throws Exception {
         ImapConnection imapConnection = mock(ImapConnection.class);
         when(imapConnection.hasCapability(Capabilities.SPECIAL_USE)).thenReturn(false);
+        imapStore.enqueueImapConnection(imapConnection);
 
-        imapStore.autoconfigureFolders(imapConnection);
+        imapStore.getPersonalNamespaces();
 
-        verify(imapConnection, atLeastOnce()).hasCapability(anyString());
-        verifyNoMoreInteractions(imapConnection);
-    }
-
-    @Test
-    public void autoconfigureFolders_removeNamespacePrefix() throws Exception {
-        ImapConnection imapConnection = mock(ImapConnection.class);
-        when(imapConnection.hasCapability(Capabilities.SPECIAL_USE)).thenReturn(true);
-        List<ImapResponse> imapResponses = Arrays.asList(
-                createImapResponse("* LIST (\\Drafts) \".\" \"INBOX.Drafts\""),
-                createImapResponse("* LIST (\\Sent) \".\" \"INBOX.Sent\""),
-                createImapResponse("* LIST (\\Junk) \".\" \"INBOX.Spam\""),
-                createImapResponse("* LIST (\\Trash) \".\" \"INBOX.Trash\""),
-                createImapResponse("* LIST (\\Archive) \".\" \"INBOX.Archive\""),
-                createImapResponse("5 OK Success")
-        );
-        when(imapConnection.executeSimpleCommand("LIST (SPECIAL-USE) \"\" \"INBOX.*\"")).thenReturn(imapResponses);
-
-        imapStore.setTestCombinedPrefix("INBOX.");
-        imapStore.autoconfigureFolders(imapConnection);
-
-        assertEquals("INBOX.", imapStore.getCombinedPrefix());
-        verify(storeConfig).setDraftsFolder("Drafts");
-        verify(storeConfig).setSentFolder("Sent");
-        verify(storeConfig).setSpamFolder("Spam");
-        verify(storeConfig).setTrashFolder("Trash");
-        verify(storeConfig).setArchiveFolder("Archive");
+        verify(imapConnection, never()).executeSimpleCommand("LIST (SPECIAL-USE) \"\" \"*\"");
+        verify(imapConnection).executeSimpleCommand("LIST \"\" \"*\"");
     }
 
     @Test
@@ -370,6 +350,15 @@ public class ImapStoreTest {
         }
 
         return folderNames;
+    }
+
+    private Map<String, ImapFolder> toFolderMap(List<ImapFolder> folders) {
+        Map<String, ImapFolder> folderMap = new HashMap<>();
+        for (ImapFolder folder : folders) {
+            folderMap.put(folder.getServerId(), folder);
+        }
+
+        return folderMap;
     }
 
 

--- a/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
+++ b/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Store.java
@@ -61,8 +61,6 @@ public class Pop3Store extends RemoteStore {
 
     @Override
     public void checkSettings() throws MessagingException {
-        mStoreConfig.setInboxFolder(Pop3Folder.INBOX);
-
         Pop3Folder folder = new Pop3Folder(this, Pop3Folder.INBOX);
         try {
             folder.open(Folder.OPEN_MODE_RW);

--- a/mail/protocols/webdav/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
+++ b/mail/protocols/webdav/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
@@ -4,12 +4,15 @@ package com.fsck.k9.mail.store.webdav;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.Folder;
+import com.fsck.k9.mail.Folder.FolderType;
 import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.filter.Base64;
@@ -223,9 +226,15 @@ public class WebDavStoreTest {
         configureHttpResponses(UNAUTHORIZED_401_RESPONSE, OK_200_RESPONSE, createOkPropfindResponse(),
                 createOkSearchResponse());
 
-        webDavStore.getPersonalNamespaces();
+        List<? extends Folder> folders = webDavStore.getPersonalNamespaces();
 
-        verify(storeConfig).setInboxFolder("Inbox");
+        Map<String, FolderType> folderNameToTypeMap = new HashMap<>();
+        for (Folder folder : folders) {
+            folderNameToTypeMap.put(folder.getName(), folder.getType());
+        }
+        assertEquals(FolderType.INBOX, folderNameToTypeMap.get("Inbox"));
+        assertEquals(FolderType.REGULAR, folderNameToTypeMap.get("Drafts"));
+        assertEquals(FolderType.REGULAR, folderNameToTypeMap.get("Folder2"));
     }
 
     @Test


### PR DESCRIPTION
This adds an option to use special folders configured on the server. If selected, the special folders used by K-9 Mail will be updated when special folders are changed on the server.

<img src="https://user-images.githubusercontent.com/218061/48452344-f2490e80-e7ae-11e8-8371-07fdb962d79c.png" alt="k9mail_account_settings_folders" width=300> <img src="https://user-images.githubusercontent.com/218061/48452345-f2490e80-e7ae-11e8-8f29-3e260366941f.png" alt="k9mail_special_folder_selection" width=300>



