### PR TITLE
Remove partially constructed accounts on resume

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -373,7 +373,9 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
             createSpecialAccounts();
         }
 
-        List<Account> accounts = Preferences.getPreferences(this).getAccounts();
+        Preferences preferences = Preferences.getPreferences(this);
+        preferences.loadAccounts();
+        List<Account> accounts = preferences.getAccounts();
         Intent intent = getIntent();
         //onNewIntent(intent);
 
@@ -538,8 +540,10 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
 
     private void refresh() {
+        Preferences preferences = Preferences.getPreferences(this);
+        preferences.loadAccounts();
         accounts.clear();
-        accounts.addAll(Preferences.getPreferences(this).getAccounts());
+        accounts.addAll(preferences.getAccounts());
 
         // see if we should show the welcome message
 //        if (accounts.length < 1) {


### PR DESCRIPTION
Resuming account setup activity when the account has been partially constructed (the setup has not been finished) resulted in having unsaved account with ID = -1 in the accounts list. The application would then on resume proceed to messages list but there won't be any folders as the setup has been aborted.

The fix clears the list of accounts on resume and create so that the application properly reacts to the event of no setup accounts.

Fixes #3717.

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). ✅
* Does not break any unit tests. ✅
* Contains a reference to the issue that it fixes. ✅
* For cosmetic changes add one or multiple images, if possible. N/A

I tried several alternative approaches but this seemed to be the simplest that solves the issue.

It's best to be tested with an account that doesn't have auto-configuration from `providers.xml`.

Thanks for your time!
