### PR TITLE
Allow intermediate states where there's no Inbox folder

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2727,7 +2727,7 @@ public class MessagingController {
         Folder folder = message.getFolder();
         if (folder != null) {
             String folderServerId = folder.getServerId();
-            if (!account.getInboxFolder().equals(folderServerId) &&
+            if (!folderServerId.equals(account.getInboxFolder()) &&
                     (folderServerId.equals(account.getTrashFolder())
                             || folderServerId.equals(account.getDraftsFolder())
                             || folderServerId.equals(account.getSpamFolder())

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -119,7 +119,7 @@ public class LocalFolder extends Folder<LocalMessage> {
         super.setType(type);
         attachmentInfoExtractor = localStore.getAttachmentInfoExtractor();
 
-        if (getAccount().getInboxFolder().equals(getServerId())) {
+        if (getServerId().equals(getAccount().getInboxFolder())) {
             syncClass =  FolderClass.FIRST_CLASS;
             pushClass =  FolderClass.FIRST_CLASS;
             isInTopGroup = true;
@@ -651,25 +651,25 @@ public class LocalFolder extends Folder<LocalMessage> {
         String id = getPrefId();
 
         // there can be a lot of folders.  For the defaults, let's not save prefs, saving space, except for INBOX
-        if (displayClass == FolderClass.NO_CLASS && !getAccount().getInboxFolder().equals(getServerId())) {
+        if (displayClass == FolderClass.NO_CLASS && !getServerId().equals(getAccount().getInboxFolder())) {
             editor.remove(id + ".displayMode");
         } else {
             editor.putString(id + ".displayMode", displayClass.name());
         }
 
-        if (syncClass == FolderClass.INHERITED && !getAccount().getInboxFolder().equals(getServerId())) {
+        if (syncClass == FolderClass.INHERITED && !getServerId().equals(getAccount().getInboxFolder())) {
             editor.remove(id + ".syncMode");
         } else {
             editor.putString(id + ".syncMode", syncClass.name());
         }
 
-        if (notifyClass == FolderClass.INHERITED && !getAccount().getInboxFolder().equals(getServerId())) {
+        if (notifyClass == FolderClass.INHERITED && !getServerId().equals(getAccount().getInboxFolder())) {
             editor.remove(id + ".notifyMode");
         } else {
             editor.putString(id + ".notifyMode", notifyClass.name());
         }
 
-        if (pushClass == FolderClass.SECOND_CLASS && !getAccount().getInboxFolder().equals(getServerId())) {
+        if (pushClass == FolderClass.SECOND_CLASS && !getServerId().equals(getAccount().getInboxFolder())) {
             editor.remove(id + ".pushMode");
         } else {
             editor.putString(id + ".pushMode", pushClass.name());

--- a/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
@@ -27,7 +27,7 @@ class SpecialFolderUpdater(
     }
 
     private fun updateInbox(folders: List<Folder>) {
-        account.inboxFolder = folders.first { it.type == FolderType.INBOX }.serverId
+        account.inboxFolder = folders.firstOrNull { it.type == FolderType.INBOX }?.serverId
     }
 
     private fun updateSpecialFolder(


### PR DESCRIPTION
This is a lazy way to allow a Backend to remove all folders then start adding folders again during folder sync.