### PR TITLE
Return empty string for empty addresses

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/helper/MessageHelper.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/MessageHelper.java
@@ -133,8 +133,10 @@ public class MessageHelper {
 
         if (!TextUtils.isEmpty(address.getPersonal()) && !isSpoofAddress(address.getPersonal())) {
             return address.getPersonal();
-        } else {
+        } else if (address.getAddress() != null) {
             return address.getAddress();
+        } else {
+            return "";
         }
     }
 

--- a/app/core/src/test/java/com/fsck/k9/helper/MessageHelperTest.java
+++ b/app/core/src/test/java/com/fsck/k9/helper/MessageHelperTest.java
@@ -88,6 +88,13 @@ public class MessageHelperTest extends RobolectricTest {
     }
 
     @Test
+    public void testToFriendlyWithoutAddressOrPersonal() throws Exception {
+        Address address = new Address("<>");
+        CharSequence friendly = MessageHelper.toFriendly(new Address[] { address }, contactsWithFakeContact);
+        assertEquals("", friendly.toString());
+    }
+
+    @Test
     public void toFriendly_spoofPreventionOverridesPersonal() {
         Address address = new Address("test@testor.com", "potus@whitehouse.gov");
         CharSequence friendly = MessageHelper.toFriendly(address, contacts);


### PR DESCRIPTION
Previously `MessageHelper#toFriendly` returned `null` for certain kind of addresses such as `<>`.

This fix returns an empty string in this case thus making `toFriendly` return a non-null response for all input data.

Fixes #3652.

To be honest it's not 100% clear if this is the same case as #3652 as there is no input data attached there but the stack trace produced on failing test is very similar to what was attached there.

Stack trace on failed test (without code fix):
```
java.lang.NullPointerException
	at android.text.SpannableStringBuilder.append(SpannableStringBuilder.java:251)
	at com.fsck.k9.helper.MessageHelper.toFriendly(MessageHelper.java:103)
        ...
```

An address like this `<>` will be converted to empty string `""`. If you have better idea (for example using entire un-parsed address instead of empty string) please say so and I'll adjust.

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). ✅ 
* Does not break any unit tests. ✅ 
* Contains a reference to the issue that it fixes. ✅ 
* For cosmetic changes add one or multiple images, if possible. N/A


