### PR TITLE
Don't try to operate on an uninitialized drawer

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1698,7 +1698,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
         List<String> folderServerIds = search.getFolderServerIds();
         singleFolderMode = singleAccountMode && folderServerIds.size() == 1;
-        if (singleFolderMode) {
+        if (drawer == null) {
+            return;
+        } else if (singleFolderMode) {
             drawer.selectFolder(folderServerIds.get(0));
         } else if (search.getId().equals(SearchAccount.UNIFIED_INBOX)) {
             drawer.selectUnifiedInbox();


### PR DESCRIPTION
This is necessary whenever the account list is configured as default
starting view.

Fixes #3716

