### PR TITLE
Show accounts in the unified inbox drawer

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -16,6 +16,8 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
@@ -819,6 +821,15 @@ public class Account implements BaseAccount, StoreConfig {
 
     public String getDisplayName() {
         return description != null ? description : getEmail();
+    }
+
+    public Drawable getIcon() {
+        GradientDrawable shape = new GradientDrawable();
+        shape.setShape(GradientDrawable.RECTANGLE);
+        shape.setCornerRadii(new float[] { 8, 8, 8, 8, 0, 0, 0, 0 });
+        shape.setColor(chipColor);
+        shape.setStroke(3, chipColor);
+        return shape;
     }
 
     public synchronized String getName() {

--- a/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -666,6 +666,17 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
         return true;
     }
 
+    public static void openRealAccount(Account realAccount, Context context) {
+        if (realAccount.getAutoExpandFolder() == null) {
+            FolderList.actionHandleAccount(context, realAccount);
+        } else {
+            LocalSearch search = new LocalSearch(realAccount.getAutoExpandFolder());
+            search.addAllowedFolder(realAccount.getAutoExpandFolder());
+            search.addAccountUuid(realAccount.getUuid());
+            MessageList.actionDisplaySearch(context, search, false, true);
+        }
+    }
+
     private void onActivateAccount(Account account) {
         List<Account> disabledAccounts = new ArrayList<>();
         disabledAccounts.add(account);

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -3,7 +3,6 @@ package com.fsck.k9.activity;
 
 import android.annotation.SuppressLint;
 import android.app.SearchManager;
-import android.arch.lifecycle.Observer;
 import android.arch.lifecycle.ViewModelProvider;
 import android.arch.lifecycle.ViewModelProviders;
 import android.content.Context;
@@ -15,7 +14,6 @@ import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Parcelable;
-import android.support.annotation.Nullable;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentManager.OnBackStackChangedListener;
 import android.support.v4.app.FragmentTransaction;
@@ -47,7 +45,6 @@ import com.fsck.k9.fragment.MessageListFragment;
 import com.fsck.k9.fragment.MessageListFragment.MessageListFragmentListener;
 import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.helper.ParcelableUtil;
-import com.fsck.k9.mailstore.Folder;
 import com.fsck.k9.mailstore.SearchStatusManager;
 import com.fsck.k9.mailstore.StorageManager;
 import com.fsck.k9.notification.NotificationChannelManager;
@@ -249,12 +246,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         MessageListViewModel viewModel = viewModelProvider.get(MessageListViewModel.class);
 
         if (isDrawerEnabled()) {
-            viewModel.getFolders(account).observe(this, new Observer<List<Folder>>() {
-                @Override
-                public void onChanged(@Nullable List<Folder> folders) {
-                    drawer.setUserFolders(folders);
-                }
-            });
+            drawer.showUserAccountsOrFolders(account);
         }
 
         findFragments();
@@ -619,6 +611,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
 
     public void openUnifiedInbox() {
         drawer.selectUnifiedInbox();
+        drawer.setUserAccounts(preferences.getAccounts());
         performSearch(SearchAccount.createUnifiedInboxAccount().getRelatedSearch());
     }
 


### PR DESCRIPTION
Currently, when in unified inbox mode, the drawer has an empty body, in
the best case. Simply list the mail accounts in the body of the unified
inbox drawer to allow for a quick navigation into them.
