### PR TITLE
Move logic out of Account class (1)

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -467,32 +467,6 @@ public class Account implements BaseAccount, StoreConfig {
         }
     }
 
-    private static int findNewAccountNumber(List<Integer> accountNumbers) {
-        int newAccountNumber = -1;
-        Collections.sort(accountNumbers);
-        for (int accountNumber : accountNumbers) {
-            if (accountNumber > newAccountNumber + 1) {
-                break;
-            }
-            newAccountNumber = accountNumber;
-        }
-        newAccountNumber++;
-        return newAccountNumber;
-    }
-
-    private static List<Integer> getExistingAccountNumbers(Preferences preferences) {
-        List<Account> accounts = preferences.getAccounts();
-        List<Integer> accountNumbers = new ArrayList<>(accounts.size());
-        for (Account a : accounts) {
-            accountNumbers.add(a.getAccountNumber());
-        }
-        return accountNumbers;
-    }
-    public static int generateAccountNumber(Preferences preferences) {
-        List<Integer> accountNumbers = getExistingAccountNumbers(preferences);
-        return findNewAccountNumber(accountNumbers);
-    }
-
     public void move(Preferences preferences, boolean moveUp) {
         String[] uuids = preferences.getStorage().getString("accountUuids", "").split(",");
         StorageEditor editor = preferences.getStorage().edit();
@@ -526,7 +500,7 @@ public class Account implements BaseAccount, StoreConfig {
     }
 
     public synchronized void save() {
-        DI.get(AccountManager.class).save(this);
+        DI.get(Preferences.class).saveAccount(this);
     }
 
     private void resetVisibleLimits() {

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -17,10 +17,8 @@ import android.text.TextUtils;
 
 import com.fsck.k9.backend.api.SyncConfig.ExpungePolicy;
 import com.fsck.k9.mail.Address;
-import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.NetworkType;
 import com.fsck.k9.mail.store.StoreConfig;
-import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.mailstore.StorageManager;
 import com.fsck.k9.mailstore.StorageManager.StorageProvider;
 import org.jetbrains.annotations.NotNull;
@@ -665,11 +663,6 @@ public class Account implements BaseAccount, StoreConfig {
         int oldMaxPushFolders = this.maxPushFolders;
         this.maxPushFolders = maxPushFolders;
         return oldMaxPushFolders != maxPushFolders;
-    }
-
-    public LocalStore getLocalStore() throws MessagingException {
-        Context context = DI.get(Context.class);
-        return LocalStore.getInstance(this, context);
     }
 
     @Override

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -9,7 +9,6 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import android.content.Context;
@@ -83,16 +82,6 @@ public class Account implements BaseAccount, StoreConfig {
             throw new IllegalArgumentException("DeletePolicy " + initialSetting + " unknown");
         }
     }
-
-    public static final MessageFormat DEFAULT_MESSAGE_FORMAT = MessageFormat.HTML;
-    public static final boolean DEFAULT_MESSAGE_FORMAT_AUTO = false;
-    public static final boolean DEFAULT_MESSAGE_READ_RECEIPT = false;
-    public static final QuoteStyle DEFAULT_QUOTE_STYLE = QuoteStyle.PREFIX;
-    public static final String DEFAULT_QUOTE_PREFIX = ">";
-    public static final boolean DEFAULT_QUOTED_TEXT_SHOWN = true;
-    public static final boolean DEFAULT_REPLY_AFTER_QUOTE = false;
-    public static final boolean DEFAULT_STRIP_SIGNATURE = true;
-    public static final int DEFAULT_REMOTE_SEARCH_NUM_RESULTS = 25;
 
     public enum SortType {
         SORT_DATE(false),
@@ -244,81 +233,6 @@ public class Account implements BaseAccount, StoreConfig {
         TEXT, HTML, AUTO
     }
 
-    public Account(Context context, CoreResourceProvider resourceProvider) {
-        accountUuid = UUID.randomUUID().toString();
-        localStorageProviderId = StorageManager.getInstance(context).getDefaultProviderId();
-        automaticCheckIntervalMinutes = -1;
-        idleRefreshMinutes = 24;
-        pushPollOnConnect = true;
-        displayCount = K9.DEFAULT_VISIBLE_LIMIT;
-        accountNumber = -1;
-        notifyNewMail = true;
-        folderNotifyNewMailMode = FolderMode.ALL;
-        notifySync = true;
-        notifySelfNewMail = true;
-        notifyContactsMailOnly = false;
-        folderDisplayMode = FolderMode.NOT_SECOND_CLASS;
-        folderSyncMode = FolderMode.FIRST_CLASS;
-        folderPushMode = FolderMode.FIRST_CLASS;
-        folderTargetMode = FolderMode.NOT_SECOND_CLASS;
-        sortType = DEFAULT_SORT_TYPE;
-        sortAscending.put(DEFAULT_SORT_TYPE, DEFAULT_SORT_ASCENDING);
-        showPictures = ShowPictures.NEVER;
-        isSignatureBeforeQuotedText = false;
-        expungePolicy = Expunge.EXPUNGE_IMMEDIATELY;
-        autoExpandFolder = INBOX;
-        inboxFolder = INBOX;
-        maxPushFolders = 10;
-        goToUnreadMessageSearch = false;
-        subscribedFoldersOnly = false;
-        maximumPolledMessageAge = -1;
-        maximumAutoDownloadMessageSize = 32768;
-        messageFormat = DEFAULT_MESSAGE_FORMAT;
-        messageFormatAuto = DEFAULT_MESSAGE_FORMAT_AUTO;
-        messageReadReceipt = DEFAULT_MESSAGE_READ_RECEIPT;
-        quoteStyle = DEFAULT_QUOTE_STYLE;
-        quotePrefix = DEFAULT_QUOTE_PREFIX;
-        defaultQuotedTextShown = DEFAULT_QUOTED_TEXT_SHOWN;
-        replyAfterQuote = DEFAULT_REPLY_AFTER_QUOTE;
-        stripSignature = DEFAULT_STRIP_SIGNATURE;
-        syncRemoteDeletions = true;
-        openPgpKey = NO_OPENPGP_KEY;
-        allowRemoteSearch = false;
-        remoteSearchFullText = false;
-        remoteSearchNumResults = DEFAULT_REMOTE_SEARCH_NUM_RESULTS;
-        uploadSentMessages = true;
-        isEnabled = true;
-        markMessageAsReadOnView = true;
-        alwaysShowCcBcc = false;
-        archiveFolder = null;
-        draftsFolder = null;
-        sentFolder = null;
-        spamFolder = null;
-        trashFolder = null;
-        archiveFolderSelection = SpecialFolderSelection.AUTOMATIC;
-        draftsFolderSelection = SpecialFolderSelection.AUTOMATIC;
-        sentFolderSelection = SpecialFolderSelection.AUTOMATIC;
-        spamFolderSelection = SpecialFolderSelection.AUTOMATIC;
-        trashFolderSelection = SpecialFolderSelection.AUTOMATIC;
-
-        searchableFolders = Searchable.ALL;
-
-        identities = new ArrayList<>();
-
-        Identity identity = new Identity();
-        identity.setSignatureUse(true);
-        identity.setSignature(resourceProvider.defaultSignature());
-        identity.setDescription(resourceProvider.defaultIdentityDescription());
-        identities.add(identity);
-
-        notificationSetting = new NotificationSetting();
-        notificationSetting.setVibrate(false);
-        notificationSetting.setVibratePattern(0);
-        notificationSetting.setVibrateTimes(5);
-        notificationSetting.setRingEnabled(true);
-        notificationSetting.setRingtone("content://settings/system/notification_sound");
-        notificationSetting.setLedColor(chipColor);
-    }
 
     public Account(String uuid) {
         this.accountUuid = uuid;
@@ -979,6 +893,14 @@ public class Account implements BaseAccount, StoreConfig {
 
     public void setMessageFormat(MessageFormat messageFormat) {
         this.messageFormat = messageFormat;
+    }
+
+    public synchronized boolean isMessageFormatAuto() {
+        return messageFormatAuto;
+    }
+
+    public synchronized void setMessageFormatAuto(boolean messageFormatAuto) {
+        this.messageFormatAuto = messageFormatAuto;
     }
 
     public synchronized boolean isMessageReadReceipt() {

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -467,38 +467,6 @@ public class Account implements BaseAccount, StoreConfig {
         }
     }
 
-    public void move(Preferences preferences, boolean moveUp) {
-        String[] uuids = preferences.getStorage().getString("accountUuids", "").split(",");
-        StorageEditor editor = preferences.getStorage().edit();
-        String[] newUuids = new String[uuids.length];
-        if (moveUp) {
-            for (int i = 0; i < uuids.length; i++) {
-                if (i > 0 && uuids[i].equals(accountUuid)) {
-                    newUuids[i] = newUuids[i-1];
-                    newUuids[i-1] = accountUuid;
-                }
-                else {
-                    newUuids[i] = uuids[i];
-                }
-            }
-        }
-        else {
-            for (int i = uuids.length - 1; i >= 0; i--) {
-                if (i < uuids.length - 1 && uuids[i].equals(accountUuid)) {
-                    newUuids[i] = newUuids[i+1];
-                    newUuids[i+1] = accountUuid;
-                }
-                else {
-                    newUuids[i] = uuids[i];
-                }
-            }
-        }
-        String accountUuids = Utility.combine(newUuids, ',');
-        editor.putString("accountUuids", accountUuids);
-        editor.commit();
-        preferences.loadAccounts();
-    }
-
     public synchronized void save() {
         DI.get(Preferences.class).saveAccount(this);
     }

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -17,7 +17,6 @@ import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.fsck.k9.backend.api.SyncConfig.ExpungePolicy;
-import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.NetworkType;
@@ -27,7 +26,6 @@ import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.mailstore.StorageManager;
 import com.fsck.k9.mailstore.StorageManager.StorageProvider;
 import com.fsck.k9.preferences.Storage;
-import com.fsck.k9.preferences.StorageEditor;
 import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
 
@@ -260,7 +258,7 @@ public class Account implements BaseAccount, StoreConfig {
         TEXT, HTML, AUTO
     }
 
-    protected Account(Context context, CoreResourceProvider resourceProvider) {
+    public Account(Context context, CoreResourceProvider resourceProvider) {
         accountUuid = UUID.randomUUID().toString();
         localStorageProviderId = StorageManager.getInstance(context).getDefaultProviderId();
         automaticCheckIntervalMinutes = -1;
@@ -465,10 +463,6 @@ public class Account implements BaseAccount, StoreConfig {
         if (description == null) {
             description = getEmail();
         }
-    }
-
-    public synchronized void save() {
-        DI.get(Preferences.class).saveAccount(this);
     }
 
     private void resetVisibleLimits() {

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -2,8 +2,6 @@
 package com.fsck.k9;
 
 
-import java.security.cert.CertificateException;
-import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.Collections;
@@ -15,30 +13,21 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
 import android.content.Context;
-import android.net.Uri;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 
 import com.fsck.k9.backend.api.SyncConfig.ExpungePolicy;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.Address;
-import com.fsck.k9.mail.Folder.FolderClass;
-import com.fsck.k9.mail.MailServerDirection;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.NetworkType;
 import com.fsck.k9.mail.filter.Base64;
-import com.fsck.k9.mail.ssl.LocalKeyStore;
 import com.fsck.k9.mail.store.StoreConfig;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.mailstore.StorageManager;
 import com.fsck.k9.mailstore.StorageManager.StorageProvider;
 import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
-import com.fsck.k9.search.ConditionsTreeNode;
-import com.fsck.k9.search.LocalSearch;
-import com.fsck.k9.search.SearchSpecification.Attribute;
-import com.fsck.k9.search.SearchSpecification.SearchCondition;
-import com.fsck.k9.search.SearchSpecification.SearchField;
 import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
 
@@ -1438,151 +1427,4 @@ public class Account implements BaseAccount, StoreConfig {
         remoteSearchFullText = val;
     }
 
-    /**
-     * Modify the supplied {@link LocalSearch} instance to limit the search to displayable folders.
-     *
-     * <p>
-     * This method uses the current folder display mode to decide what folders to include/exclude.
-     * </p>
-     *
-     * @param search
-     *         The {@code LocalSearch} instance to modify.
-     *
-     * @see #getFolderDisplayMode()
-     */
-    public void limitToDisplayableFolders(LocalSearch search) {
-        final Account.FolderMode displayMode = getFolderDisplayMode();
-
-        switch (displayMode) {
-            case FIRST_CLASS: {
-                // Count messages in the INBOX and non-special first class folders
-                search.and(SearchField.DISPLAY_CLASS, FolderClass.FIRST_CLASS.name(),
-                        Attribute.EQUALS);
-                break;
-            }
-            case FIRST_AND_SECOND_CLASS: {
-                // Count messages in the INBOX and non-special first and second class folders
-                search.and(SearchField.DISPLAY_CLASS, FolderClass.FIRST_CLASS.name(),
-                        Attribute.EQUALS);
-
-                // TODO: Create a proper interface for creating arbitrary condition trees
-                SearchCondition searchCondition = new SearchCondition(SearchField.DISPLAY_CLASS,
-                        Attribute.EQUALS, FolderClass.SECOND_CLASS.name());
-                ConditionsTreeNode root = search.getConditions();
-                if (root.mRight != null) {
-                    root.mRight.or(searchCondition);
-                } else {
-                    search.or(searchCondition);
-                }
-                break;
-            }
-            case NOT_SECOND_CLASS: {
-                // Count messages in the INBOX and non-special non-second-class folders
-                search.and(SearchField.DISPLAY_CLASS, FolderClass.SECOND_CLASS.name(),
-                        Attribute.NOT_EQUALS);
-                break;
-            }
-            default:
-            case ALL: {
-                // Count messages in the INBOX and non-special folders
-                break;
-            }
-        }
-    }
-
-    /**
-     * Modify the supplied {@link LocalSearch} instance to exclude special folders.
-     *
-     * <p>
-     * Currently the following folders are excluded:
-     * <ul>
-     *   <li>Trash</li>
-     *   <li>Drafts</li>
-     *   <li>Spam</li>
-     *   <li>Outbox</li>
-     *   <li>Sent</li>
-     * </ul>
-     * The Inbox will always be included even if one of the special folders is configured to point
-     * to the Inbox.
-     * </p>
-     *
-     * @param search
-     *         The {@code LocalSearch} instance to modify.
-     */
-    public void excludeSpecialFolders(LocalSearch search) {
-        excludeSpecialFolder(search, getTrashFolder());
-        excludeSpecialFolder(search, getDraftsFolder());
-        excludeSpecialFolder(search, getSpamFolder());
-        excludeSpecialFolder(search, getOutboxFolder());
-        excludeSpecialFolder(search, getSentFolder());
-        search.or(new SearchCondition(SearchField.FOLDER, Attribute.EQUALS, getInboxFolder()));
-    }
-
-    /**
-     * Modify the supplied {@link LocalSearch} instance to exclude "unwanted" folders.
-     *
-     * <p>
-     * Currently the following folders are excluded:
-     * <ul>
-     *   <li>Trash</li>
-     *   <li>Spam</li>
-     *   <li>Outbox</li>
-     * </ul>
-     * The Inbox will always be included even if one of the special folders is configured to point
-     * to the Inbox.
-     * </p>
-     *
-     * @param search
-     *         The {@code LocalSearch} instance to modify.
-     */
-    public void excludeUnwantedFolders(LocalSearch search) {
-        excludeSpecialFolder(search, getTrashFolder());
-        excludeSpecialFolder(search, getSpamFolder());
-        excludeSpecialFolder(search, getOutboxFolder());
-        search.or(new SearchCondition(SearchField.FOLDER, Attribute.EQUALS, getInboxFolder()));
-    }
-
-    private void excludeSpecialFolder(LocalSearch search, String folderServerId) {
-        if (folderServerId != null) {
-            search.and(SearchField.FOLDER, folderServerId, Attribute.NOT_EQUALS);
-        }
-    }
-
-    /**
-     * Add a new certificate for the incoming or outgoing server to the local key store.
-     */
-    public void addCertificate(MailServerDirection direction, X509Certificate certificate) throws CertificateException {
-        Uri uri;
-        if (direction == MailServerDirection.INCOMING) {
-            uri = Uri.parse(getStoreUri());
-        } else {
-            uri = Uri.parse(getTransportUri());
-        }
-        LocalKeyStore localKeyStore = LocalKeyStore.getInstance();
-        localKeyStore.addCertificate(uri.getHost(), uri.getPort(), certificate);
-    }
-
-    /**
-     * Examine the existing settings for an account.  If the old host/port is different from the
-     * new host/port, then try and delete any (possibly non-existent) certificate stored for the
-     * old host/port.
-     */
-    public void deleteCertificate(String newHost, int newPort, MailServerDirection direction) {
-        Uri uri;
-        if (direction == MailServerDirection.INCOMING) {
-            uri = Uri.parse(getStoreUri());
-        } else {
-            uri = Uri.parse(getTransportUri());
-        }
-        String oldHost = uri.getHost();
-        int oldPort = uri.getPort();
-        if (oldPort == -1) {
-            // This occurs when a new account is created
-            return;
-        }
-        if (!newHost.equals(oldHost) || newPort != oldPort) {
-            LocalKeyStore localKeyStore = LocalKeyStore.getInstance();
-            localKeyStore.deleteCertificate(oldHost, oldPort);
-        }
-    }
 }

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -204,7 +204,7 @@ public class Account implements BaseAccount, StoreConfig {
 
     private List<Identity> identities;
 
-    private NotificationSetting notificationSetting = new NotificationSetting();
+    private final NotificationSetting notificationSetting = new NotificationSetting();
 
     public enum FolderMode {
         NONE, ALL, FIRST_CLASS, FIRST_AND_SECOND_CLASS, NOT_SECOND_CLASS

--- a/app/core/src/main/java/com/fsck/k9/AccountManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountManager.kt
@@ -1,17 +1,15 @@
 package com.fsck.k9
 
-import android.net.Uri
 import com.fsck.k9.helper.Utility
 import com.fsck.k9.mail.NetworkType
 import com.fsck.k9.mail.filter.Base64
-import com.fsck.k9.mail.ssl.LocalKeyStore
 import com.fsck.k9.preferences.Storage
 import com.fsck.k9.preferences.StorageEditor
 import java.util.*
 
 class AccountManager(
         private val preferences: Preferences,
-        private val localKeyStore: LocalKeyStore
+        private val localKeyStoreManager: LocalKeyStoreManager
 ) {
     @Synchronized
     fun save(account: Account) {
@@ -135,7 +133,7 @@ class AccountManager(
             editor.putInt("$accountUuid.ledColor", notificationSetting.ledColor)
 
             for (type in NetworkType.values()) {
-                val useCompression = compressionMap[type]
+                val useCompression = compressionMap.get(type)
                 if (useCompression != null) {
                     editor.putBoolean("$accountUuid.useCompression.$type", useCompression)
                 }
@@ -150,7 +148,7 @@ class AccountManager(
 
     @Synchronized
     fun delete(account: Account) {
-        deleteCertificates(account)
+        localKeyStoreManager.deleteCertificates(account)
 
         val accountUuid = account.uuid
 
@@ -299,23 +297,6 @@ class AccountManager(
             }
             ident++
         } while (gotOne)
-    }
-
-    /**
-     * Examine the settings for the account and attempt to delete (possibly non-existent)
-     * certificates for the incoming and outgoing servers.
-     */
-    private fun deleteCertificates(account: Account) {
-        val storeUri = account.storeUri
-        if (storeUri != null) {
-            val uri = Uri.parse(storeUri)
-            localKeyStore.deleteCertificate(uri.host, uri.port)
-        }
-        val transportUri = account.transportUri
-        if (transportUri != null) {
-            val uri = Uri.parse(transportUri)
-            localKeyStore.deleteCertificate(uri.host, uri.port)
-        }
     }
 
 }

--- a/app/core/src/main/java/com/fsck/k9/AccountManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountManager.kt
@@ -1,0 +1,321 @@
+package com.fsck.k9
+
+import android.net.Uri
+import com.fsck.k9.helper.Utility
+import com.fsck.k9.mail.NetworkType
+import com.fsck.k9.mail.filter.Base64
+import com.fsck.k9.mail.ssl.LocalKeyStore
+import com.fsck.k9.preferences.Storage
+import com.fsck.k9.preferences.StorageEditor
+import java.util.*
+
+class AccountManager(
+        private val preferences: Preferences,
+        private val localKeyStore: LocalKeyStore
+) {
+    @Synchronized
+    fun save(account: Account) {
+        val accountUuid = account.uuid
+
+        val editor = preferences.storage.edit()
+
+        if (!preferences.storage.getString("accountUuids", "").contains(accountUuid)) {
+            /*
+             * When the account is first created we assign it a unique account number. The
+             * account number will be unique to that account for the lifetime of the account.
+             * So, we get all the existing account numbers, sort them ascending, loop through
+             * the list and check if the number is greater than 1 + the previous number. If so
+             * we use the previous number + 1 as the account number. This refills gaps.
+             * accountNumber starts as -1 on a newly created account. It must be -1 for this
+             * algorithm to work.
+             *
+             * I bet there is a much smarter way to do this. Anyone like to suggest it?
+             */
+            val accounts = preferences.accounts
+            val accountNumbers = IntArray(accounts.size)
+            for (i in accounts.indices) {
+                accountNumbers[i] = accounts[i].accountNumber
+            }
+            Arrays.sort(accountNumbers)
+            for (accountNumber in accountNumbers) {
+                if (accountNumber > account.accountNumber + 1) {
+                    break
+                }
+                account.accountNumber = accountNumber
+            }
+            account.accountNumber += 1
+
+            var accountUuids = preferences.storage.getString("accountUuids", "")
+            accountUuids += (if (accountUuids.isNotEmpty()) "," else "") + accountUuid
+            editor.putString("accountUuids", accountUuids)
+        }
+
+        with (account) {
+            editor.putString("$accountUuid.storeUri", Base64.encode(storeUri))
+            editor.putString("$accountUuid.localStorageProvider", localStorageProviderId)
+            editor.putString("$accountUuid.transportUri", Base64.encode(transportUri))
+            editor.putString("$accountUuid.description", description)
+            editor.putString("$accountUuid.alwaysBcc", alwaysBcc)
+            editor.putInt("$accountUuid.automaticCheckIntervalMinutes", automaticCheckIntervalMinutes)
+            editor.putInt("$accountUuid.idleRefreshMinutes", idleRefreshMinutes)
+            editor.putBoolean("$accountUuid.pushPollOnConnect", isPushPollOnConnect)
+            editor.putInt("$accountUuid.displayCount", displayCount)
+            editor.putLong("$accountUuid.latestOldMessageSeenTime", latestOldMessageSeenTime)
+            editor.putBoolean("$accountUuid.notifyNewMail", isNotifyNewMail)
+            editor.putString("$accountUuid.folderNotifyNewMailMode", folderNotifyNewMailMode.name)
+            editor.putBoolean("$accountUuid.notifySelfNewMail", isNotifySelfNewMail)
+            editor.putBoolean("$accountUuid.notifyContactsMailOnly", isNotifyContactsMailOnly)
+            editor.putBoolean("$accountUuid.notifyMailCheck", isShowOngoing)
+            editor.putInt("$accountUuid.deletePolicy", deletePolicy.setting)
+            editor.putString("$accountUuid.inboxFolderName", inboxFolder)
+            editor.putString("$accountUuid.draftsFolderName", draftsFolder)
+            editor.putString("$accountUuid.sentFolderName", sentFolder)
+            editor.putString("$accountUuid.trashFolderName", trashFolder)
+            editor.putString("$accountUuid.archiveFolderName", archiveFolder)
+            editor.putString("$accountUuid.spamFolderName", spamFolder)
+            editor.putString("$accountUuid.archiveFolderSelection", archiveFolderSelection.name)
+            editor.putString("$accountUuid.draftsFolderSelection", draftsFolderSelection.name)
+            editor.putString("$accountUuid.sentFolderSelection", sentFolderSelection.name)
+            editor.putString("$accountUuid.spamFolderSelection", spamFolderSelection.name)
+            editor.putString("$accountUuid.trashFolderSelection", trashFolderSelection.name)
+            editor.putString("$accountUuid.autoExpandFolderName", autoExpandFolder)
+            editor.putInt("$accountUuid.accountNumber", accountNumber)
+            editor.putString("$accountUuid.sortTypeEnum", sortType.name)
+            editor.putBoolean("$accountUuid.sortAscending", isSortAscending(sortType))
+            editor.putString("$accountUuid.showPicturesEnum", showPictures.name)
+            editor.putString("$accountUuid.folderDisplayMode", folderDisplayMode.name)
+            editor.putString("$accountUuid.folderSyncMode", folderSyncMode.name)
+            editor.putString("$accountUuid.folderPushMode", folderPushMode.name)
+            editor.putString("$accountUuid.folderTargetMode", folderTargetMode.name)
+            editor.putBoolean("$accountUuid.signatureBeforeQuotedText", isSignatureBeforeQuotedText)
+            editor.putString("$accountUuid.expungePolicy", expungePolicy.name)
+            editor.putBoolean("$accountUuid.syncRemoteDeletions", isSyncRemoteDeletions)
+            editor.putInt("$accountUuid.maxPushFolders", maxPushFolders)
+            editor.putString("$accountUuid.searchableFolders", searchableFolders.name)
+            editor.putInt("$accountUuid.chipColor", chipColor)
+            editor.putBoolean("$accountUuid.goToUnreadMessageSearch", isGoToUnreadMessageSearch)
+            editor.putBoolean("$accountUuid.subscribedFoldersOnly", isSubscribedFoldersOnly)
+            editor.putInt("$accountUuid.maximumPolledMessageAge", maximumPolledMessageAge)
+            editor.putInt("$accountUuid.maximumAutoDownloadMessageSize", maximumAutoDownloadMessageSize)
+            val messageFormatAuto = if (Account.MessageFormat.AUTO == messageFormat) {
+                // saving MessageFormat.AUTO as is to the database will cause downgrades to crash on
+                // startup, so we save as MessageFormat.TEXT instead with a separate flag for auto.
+                editor.putString("$accountUuid.messageFormat", Account.MessageFormat.TEXT.name)
+                true
+            } else {
+                editor.putString("$accountUuid.messageFormat", messageFormat.name)
+                false
+            }
+            editor.putBoolean("$accountUuid.messageFormatAuto", messageFormatAuto)
+            editor.putBoolean("$accountUuid.messageReadReceipt", isMessageReadReceiptAlways)
+            editor.putString("$accountUuid.quoteStyle", quoteStyle.name)
+            editor.putString("$accountUuid.quotePrefix", quotePrefix)
+            editor.putBoolean("$accountUuid.defaultQuotedTextShown", isDefaultQuotedTextShown)
+            editor.putBoolean("$accountUuid.replyAfterQuote", isReplyAfterQuote)
+            editor.putBoolean("$accountUuid.stripSignature", isStripSignature)
+            editor.putLong("$accountUuid.cryptoKey", openPgpKey)
+            editor.putBoolean("$accountUuid.openPgpHideSignOnly", isOpenPgpHideSignOnly)
+            editor.putBoolean("$accountUuid.openPgpEncryptSubject", isOpenPgpEncryptSubject)
+            editor.putBoolean("$accountUuid.openPgpEncryptAllDrafts", isOpenPgpEncryptAllDrafts)
+            editor.putString("$accountUuid.openPgpProvider", openPgpProvider)
+            editor.putBoolean("$accountUuid.autocryptMutualMode", autocryptPreferEncryptMutual)
+            editor.putBoolean("$accountUuid.allowRemoteSearch", isAllowRemoteSearch)
+            editor.putBoolean("$accountUuid.remoteSearchFullText", isRemoteSearchFullText)
+            editor.putInt("$accountUuid.remoteSearchNumResults", remoteSearchNumResults)
+            editor.putBoolean("$accountUuid.enabled", isEnabled)
+            editor.putBoolean("$accountUuid.markMessageAsReadOnView", isMarkMessageAsReadOnView)
+            editor.putBoolean("$accountUuid.alwaysShowCcBcc", isAlwaysShowCcBcc)
+
+            editor.putBoolean("$accountUuid.vibrate", notificationSetting.isVibrateEnabled)
+            editor.putInt("$accountUuid.vibratePattern", notificationSetting.vibratePattern)
+            editor.putInt("$accountUuid.vibrateTimes", notificationSetting.vibrateTimes)
+            editor.putBoolean("$accountUuid.ring", notificationSetting.isRingEnabled)
+            editor.putString("$accountUuid.ringtone", notificationSetting.ringtone)
+            editor.putBoolean("$accountUuid.led", notificationSetting.isLedEnabled)
+            editor.putInt("$accountUuid.ledColor", notificationSetting.ledColor)
+
+            for (type in NetworkType.values()) {
+                val useCompression = compressionMap[type]
+                if (useCompression != null) {
+                    editor.putBoolean("$accountUuid.useCompression.$type", useCompression)
+                }
+            }
+        }
+
+        saveIdentities(account, preferences.storage, editor)
+
+        editor.commit()
+    }
+
+
+    @Synchronized
+    fun delete(account: Account) {
+        deleteCertificates(account)
+
+        val accountUuid = account.uuid
+
+        // Get the list of account UUIDs
+        val uuids = preferences.storage.getString("accountUuids", "").split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+
+        // Create a list of all account UUIDs excluding this account
+        val newUuids = ArrayList<String>(uuids.size)
+        for (uuid in uuids) {
+            if (uuid != accountUuid) {
+                newUuids.add(uuid)
+            }
+        }
+
+        val editor = preferences.storage.edit()
+
+        // Only change the 'accountUuids' value if this account's UUID was listed before
+        if (newUuids.size < uuids.size) {
+            val accountUuids = Utility.combine(newUuids.toTypedArray(), ',')
+            editor.putString("accountUuids", accountUuids)
+        }
+
+        editor.remove("$accountUuid.storeUri")
+        editor.remove("$accountUuid.transportUri")
+        editor.remove("$accountUuid.description")
+        editor.remove("$accountUuid.name")
+        editor.remove("$accountUuid.email")
+        editor.remove("$accountUuid.alwaysBcc")
+        editor.remove("$accountUuid.automaticCheckIntervalMinutes")
+        editor.remove("$accountUuid.pushPollOnConnect")
+        editor.remove("$accountUuid.idleRefreshMinutes")
+        editor.remove("$accountUuid.lastAutomaticCheckTime")
+        editor.remove("$accountUuid.latestOldMessageSeenTime")
+        editor.remove("$accountUuid.notifyNewMail")
+        editor.remove("$accountUuid.notifySelfNewMail")
+        editor.remove("$accountUuid.deletePolicy")
+        editor.remove("$accountUuid.draftsFolderName")
+        editor.remove("$accountUuid.sentFolderName")
+        editor.remove("$accountUuid.trashFolderName")
+        editor.remove("$accountUuid.archiveFolderName")
+        editor.remove("$accountUuid.spamFolderName")
+        editor.remove("$accountUuid.archiveFolderSelection")
+        editor.remove("$accountUuid.draftsFolderSelection")
+        editor.remove("$accountUuid.sentFolderSelection")
+        editor.remove("$accountUuid.spamFolderSelection")
+        editor.remove("$accountUuid.trashFolderSelection")
+        editor.remove("$accountUuid.autoExpandFolderName")
+        editor.remove("$accountUuid.accountNumber")
+        editor.remove("$accountUuid.vibrate")
+        editor.remove("$accountUuid.vibratePattern")
+        editor.remove("$accountUuid.vibrateTimes")
+        editor.remove("$accountUuid.ring")
+        editor.remove("$accountUuid.ringtone")
+        editor.remove("$accountUuid.folderDisplayMode")
+        editor.remove("$accountUuid.folderSyncMode")
+        editor.remove("$accountUuid.folderPushMode")
+        editor.remove("$accountUuid.folderTargetMode")
+        editor.remove("$accountUuid.signatureBeforeQuotedText")
+        editor.remove("$accountUuid.expungePolicy")
+        editor.remove("$accountUuid.syncRemoteDeletions")
+        editor.remove("$accountUuid.maxPushFolders")
+        editor.remove("$accountUuid.searchableFolders")
+        editor.remove("$accountUuid.chipColor")
+        editor.remove("$accountUuid.led")
+        editor.remove("$accountUuid.ledColor")
+        editor.remove("$accountUuid.goToUnreadMessageSearch")
+        editor.remove("$accountUuid.subscribedFoldersOnly")
+        editor.remove("$accountUuid.maximumPolledMessageAge")
+        editor.remove("$accountUuid.maximumAutoDownloadMessageSize")
+        editor.remove("$accountUuid.messageFormatAuto")
+        editor.remove("$accountUuid.quoteStyle")
+        editor.remove("$accountUuid.quotePrefix")
+        editor.remove("$accountUuid.sortTypeEnum")
+        editor.remove("$accountUuid.sortAscending")
+        editor.remove("$accountUuid.showPicturesEnum")
+        editor.remove("$accountUuid.replyAfterQuote")
+        editor.remove("$accountUuid.stripSignature")
+        editor.remove("$accountUuid.cryptoApp") // this is no longer set, but cleans up legacy values
+        editor.remove("$accountUuid.cryptoAutoSignature")
+        editor.remove("$accountUuid.cryptoAutoEncrypt")
+        editor.remove("$accountUuid.cryptoApp")
+        editor.remove("$accountUuid.cryptoKey")
+        editor.remove("$accountUuid.cryptoSupportSignOnly")
+        editor.remove("$accountUuid.openPgpProvider")
+        editor.remove("$accountUuid.openPgpHideSignOnly")
+        editor.remove("$accountUuid.openPgpEncryptSubject")
+        editor.remove("$accountUuid.openPgpEncryptAllDrafts")
+        editor.remove("$accountUuid.autocryptMutualMode")
+        editor.remove("$accountUuid.enabled")
+        editor.remove("$accountUuid.markMessageAsReadOnView")
+        editor.remove("$accountUuid.alwaysShowCcBcc")
+        editor.remove("$accountUuid.allowRemoteSearch")
+        editor.remove("$accountUuid.remoteSearchFullText")
+        editor.remove("$accountUuid.remoteSearchNumResults")
+        editor.remove("$accountUuid.uploadSentMessages")
+        editor.remove("$accountUuid.defaultQuotedTextShown")
+        editor.remove("$accountUuid.displayCount")
+        editor.remove("$accountUuid.inboxFolderName")
+        editor.remove("$accountUuid.localStorageProvider")
+        editor.remove("$accountUuid.messageFormat")
+        editor.remove("$accountUuid.messageReadReceipt")
+        editor.remove("$accountUuid.notifyMailCheck")
+        for (type in NetworkType.values()) {
+            editor.remove(accountUuid + ".useCompression." + type.name)
+        }
+        deleteIdentities(account, preferences.storage, editor)
+        // TODO: Remove preference settings that may exist for individual folders in the account.
+        editor.commit()
+    }
+
+    @Synchronized
+    private fun saveIdentities(account: Account, storage: Storage, editor: StorageEditor) {
+        deleteIdentities(account, storage, editor)
+        var ident = 0
+
+        with (account) {
+            for (identity in identities) {
+                editor.putString("$uuid.${Account.IDENTITY_NAME_KEY}.$ident", identity.name)
+                editor.putString("$uuid.${Account.IDENTITY_EMAIL_KEY}.$ident", identity.email)
+                editor.putBoolean("$uuid.signatureUse.$ident", identity.signatureUse)
+                editor.putString("$uuid.signature.$ident", identity.signature)
+                editor.putString("$uuid.${Account.IDENTITY_DESCRIPTION_KEY}.$ident", identity.description)
+                editor.putString("$uuid.replyTo.$ident", identity.replyTo)
+                ident++
+            }
+        }
+    }
+
+    @Synchronized
+    private fun deleteIdentities(account: Account, storage: Storage, editor: StorageEditor) {
+        val accountUuid = account.uuid
+
+        var ident = 0
+        var gotOne: Boolean
+        do {
+            gotOne = false
+            val email = storage.getString(accountUuid + "." + Account.IDENTITY_EMAIL_KEY + "." + ident, null)
+            if (email != null) {
+                editor.remove("$accountUuid.${Account.IDENTITY_NAME_KEY}.$ident")
+                editor.remove("$accountUuid.${Account.IDENTITY_EMAIL_KEY}.$ident")
+                editor.remove("$accountUuid.signatureUse.$ident")
+                editor.remove("$accountUuid.signature.$ident")
+                editor.remove("$accountUuid.${Account.IDENTITY_DESCRIPTION_KEY}.$ident")
+                editor.remove("$accountUuid.replyTo.$ident")
+                gotOne = true
+            }
+            ident++
+        } while (gotOne)
+    }
+
+    /**
+     * Examine the settings for the account and attempt to delete (possibly non-existent)
+     * certificates for the incoming and outgoing servers.
+     */
+    private fun deleteCertificates(account: Account) {
+        val storeUri = account.storeUri
+        if (storeUri != null) {
+            val uri = Uri.parse(storeUri)
+            localKeyStore.deleteCertificate(uri.host, uri.port)
+        }
+        val transportUri = account.transportUri
+        if (transportUri != null) {
+            val uri = Uri.parse(transportUri)
+            localKeyStore.deleteCertificate(uri.host, uri.port)
+        }
+    }
+
+}

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -10,7 +10,10 @@ import com.fsck.k9.preferences.StorageEditor
 import timber.log.Timber
 import java.util.*
 
-class AccountPreferenceSerializer(val storageManager: StorageManager) {
+class AccountPreferenceSerializer(
+        private val storageManager: StorageManager,
+        private val resourceProvider: CoreResourceProvider
+) {
 
     @Synchronized
     fun loadAccount(account: Account, storage: Storage) {
@@ -493,6 +496,79 @@ class AccountPreferenceSerializer(val storageManager: StorageManager) {
         }
     }
 
+    fun loadDefaults(account: Account) {
+        with (account) {
+            localStorageProviderId = storageManager.defaultProviderId
+            automaticCheckIntervalMinutes = -1
+            idleRefreshMinutes = 24
+            isPushPollOnConnect = true
+            displayCount = K9.DEFAULT_VISIBLE_LIMIT
+            accountNumber = -1
+            isNotifyNewMail = true
+            folderNotifyNewMailMode = FolderMode.ALL
+            isNotifySync = true
+            isNotifySelfNewMail = true
+            isNotifyContactsMailOnly = false
+            folderDisplayMode = FolderMode.NOT_SECOND_CLASS
+            folderSyncMode = FolderMode.FIRST_CLASS
+            folderPushMode = FolderMode.FIRST_CLASS
+            folderTargetMode = FolderMode.NOT_SECOND_CLASS
+            sortType = DEFAULT_SORT_TYPE
+            setSortAscending(DEFAULT_SORT_TYPE, DEFAULT_SORT_ASCENDING)
+            showPictures = ShowPictures.NEVER
+            isSignatureBeforeQuotedText = false
+            expungePolicy = Expunge.EXPUNGE_IMMEDIATELY
+            autoExpandFolder = INBOX
+            inboxFolder = INBOX
+            maxPushFolders = 10
+            isGoToUnreadMessageSearch = false
+            isSubscribedFoldersOnly = false
+            maximumPolledMessageAge = -1
+            maximumAutoDownloadMessageSize = 32768
+            messageFormat = DEFAULT_MESSAGE_FORMAT
+            isMessageFormatAuto = DEFAULT_MESSAGE_FORMAT_AUTO
+            isMessageReadReceipt = DEFAULT_MESSAGE_READ_RECEIPT
+            quoteStyle = DEFAULT_QUOTE_STYLE
+            quotePrefix = DEFAULT_QUOTE_PREFIX
+            isDefaultQuotedTextShown = DEFAULT_QUOTED_TEXT_SHOWN
+            isReplyAfterQuote = DEFAULT_REPLY_AFTER_QUOTE
+            isStripSignature = DEFAULT_STRIP_SIGNATURE
+            isSyncRemoteDeletions = true
+            openPgpKey = NO_OPENPGP_KEY
+            isAllowRemoteSearch = false
+            isRemoteSearchFullText = false
+            remoteSearchNumResults = DEFAULT_REMOTE_SEARCH_NUM_RESULTS
+            isUploadSentMessages = true
+            isEnabled = true
+            isMarkMessageAsReadOnView = true
+            isAlwaysShowCcBcc = false
+
+            setArchiveFolder(null, SpecialFolderSelection.AUTOMATIC)
+            setDraftsFolder(null, SpecialFolderSelection.AUTOMATIC)
+            setSentFolder(null, SpecialFolderSelection.AUTOMATIC)
+            setSpamFolder(null, SpecialFolderSelection.AUTOMATIC)
+            setTrashFolder(null, SpecialFolderSelection.AUTOMATIC)
+            setArchiveFolder(null, SpecialFolderSelection.AUTOMATIC)
+
+            searchableFolders = Searchable.ALL
+
+            identities = ArrayList<Identity>()
+
+            val identity = Identity()
+            identity.signatureUse = true
+            identity.signature = resourceProvider.defaultSignature()
+            identity.description = resourceProvider.defaultIdentityDescription()
+            identities.add(identity)
+
+            notificationSetting.setVibrate(false)
+            notificationSetting.setVibratePattern(0)
+            notificationSetting.setVibrateTimes(5)
+            notificationSetting.setRingEnabled(true)
+            notificationSetting.setRingtone("content://settings/system/notification_sound")
+            notificationSetting.setLedColor(chipColor)
+        }
+    }
+
     companion object {
         const val ACCOUNT_DESCRIPTION_KEY = "description"
         const val STORE_URI_KEY = "storeUri"
@@ -503,5 +579,17 @@ class AccountPreferenceSerializer(val storageManager: StorageManager) {
         const val IDENTITY_DESCRIPTION_KEY = "description"
 
         const val FALLBACK_ACCOUNT_COLOR = 0x0099CC
+
+        @JvmField
+        val DEFAULT_MESSAGE_FORMAT = MessageFormat.HTML
+        @JvmField
+        val DEFAULT_QUOTE_STYLE = QuoteStyle.PREFIX
+        const val DEFAULT_MESSAGE_FORMAT_AUTO = false
+        const val DEFAULT_MESSAGE_READ_RECEIPT = false
+        const val DEFAULT_QUOTE_PREFIX = ">"
+        const val DEFAULT_QUOTED_TEXT_SHOWN = true
+        const val DEFAULT_REPLY_AFTER_QUOTE = false
+        const val DEFAULT_STRIP_SIGNATURE = true
+        const val DEFAULT_REMOTE_SEARCH_NUM_RESULTS = 25
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -103,7 +103,7 @@ class AccountPreferenceSerializer(
 
             showPictures = getEnumStringPref<ShowPictures>(storage, "$accountUuid.showPicturesEnum", ShowPictures.NEVER)
 
-            notificationSetting.setVibrate(storage.getBoolean("$accountUuid.vibrate", false))
+            notificationSetting.setVibrateEnabled(storage.getBoolean("$accountUuid.vibrate", false))
             notificationSetting.vibratePattern = storage.getInt("$accountUuid.vibratePattern", 0)
             notificationSetting.vibrateTimes = storage.getInt("$accountUuid.vibrateTimes", 5)
             notificationSetting.isRingEnabled = storage.getBoolean("$accountUuid.ring", true)
@@ -554,18 +554,21 @@ class AccountPreferenceSerializer(
 
             identities = ArrayList<Identity>()
 
-            val identity = Identity()
-            identity.signatureUse = true
-            identity.signature = resourceProvider.defaultSignature()
-            identity.description = resourceProvider.defaultIdentityDescription()
+            val identity = Identity().apply {
+                signatureUse = true
+                signature = resourceProvider.defaultSignature()
+                description = resourceProvider.defaultIdentityDescription()
+            }
             identities.add(identity)
 
-            notificationSetting.setVibrate(false)
-            notificationSetting.setVibratePattern(0)
-            notificationSetting.setVibrateTimes(5)
-            notificationSetting.setRingEnabled(true)
-            notificationSetting.setRingtone("content://settings/system/notification_sound")
-            notificationSetting.setLedColor(chipColor)
+            with (notificationSetting) {
+                isVibrateEnabled = false
+                vibratePattern = 0
+                vibrateTimes = 5
+                isRingEnabled = true
+                ringtone = "content://settings/system/notification_sound"
+                ledColor = chipColor
+            }
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -267,4 +267,31 @@ class AccountPreferenceSerializer {
         } while (gotOne)
     }
 
+    fun move(account: Account, storage: Storage, moveUp: Boolean) {
+        val uuids = storage.getString("accountUuids", "").split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+        val editor = storage.edit()
+        val newUuids = arrayOfNulls<String>(uuids.size)
+        if (moveUp) {
+            for (i in uuids.indices) {
+                if (i > 0 && uuids[i] == account.uuid) {
+                    newUuids[i] = newUuids[i - 1]
+                    newUuids[i - 1] = account.uuid
+                } else {
+                    newUuids[i] = uuids[i]
+                }
+            }
+        } else {
+            for (i in uuids.indices.reversed()) {
+                if (i < uuids.size - 1 && uuids[i] == account.uuid) {
+                    newUuids[i] = newUuids[i + 1]
+                    newUuids[i + 1] = account.uuid
+                } else {
+                    newUuids[i] = uuids[i]
+                }
+            }
+        }
+        val accountUuids = Utility.combine(newUuids, ',')
+        editor.putString("accountUuids", accountUuids)
+        editor.commit()
+    }
 }

--- a/app/core/src/main/java/com/fsck/k9/Core.kt
+++ b/app/core/src/main/java/com/fsck/k9/Core.kt
@@ -19,6 +19,7 @@ import com.fsck.k9.message.html.htmlModule
 import com.fsck.k9.message.quote.quoteModule
 import com.fsck.k9.notification.coreNotificationModule
 import com.fsck.k9.power.DeviceIdleManager
+import com.fsck.k9.search.searchModule
 import com.fsck.k9.service.BootReceiver
 import com.fsck.k9.service.MailService
 import com.fsck.k9.service.ShutdownReceiver
@@ -39,6 +40,7 @@ object Core : KoinComponent {
             openPgpModule,
             autocryptModule,
             mailStoreModule,
+            searchModule,
             extractorModule,
             htmlModule,
             quoteModule,

--- a/app/core/src/main/java/com/fsck/k9/K9.java
+++ b/app/core/src/main/java/com/fsck/k9/K9.java
@@ -382,7 +382,7 @@ public class K9 {
         for (Account account : preferences.getAccounts()) {
             account.setOpenPgpProvider(openPgpProvider);
             account.setOpenPgpHideSignOnly(!openPgpSupportSignOnly);
-            account.save(preferences);
+            account.save();
         }
 
         storage.edit()

--- a/app/core/src/main/java/com/fsck/k9/K9.java
+++ b/app/core/src/main/java/com/fsck/k9/K9.java
@@ -382,7 +382,7 @@ public class K9 {
         for (Account account : preferences.getAccounts()) {
             account.setOpenPgpProvider(openPgpProvider);
             account.setOpenPgpHideSignOnly(!openPgpSupportSignOnly);
-            account.save();
+            preferences.saveAccount(account);
         }
 
         storage.edit()

--- a/app/core/src/main/java/com/fsck/k9/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/KoinModule.kt
@@ -3,6 +3,7 @@ package com.fsck.k9
 import android.content.Context
 import com.fsck.k9.helper.Contacts
 import com.fsck.k9.mail.power.PowerManager
+import com.fsck.k9.mailstore.LocalStoreProvider
 import com.fsck.k9.mailstore.StorageManager
 import com.fsck.k9.power.TracingPowerManager
 import org.koin.dsl.module.applicationContext
@@ -11,6 +12,7 @@ val mainModule = applicationContext {
     bean { Preferences.getPreferences(get()) }
     bean { get<Context>().resources }
     bean { StorageManager.getInstance(get()) }
+    bean { LocalStoreProvider() }
     bean { TracingPowerManager.getPowerManager(get()) as PowerManager }
     bean { Contacts.getInstance(get()) }
 }

--- a/app/core/src/main/java/com/fsck/k9/LocalKeyStoreManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/LocalKeyStoreManager.kt
@@ -1,0 +1,65 @@
+package com.fsck.k9
+
+import android.net.Uri
+import com.fsck.k9.mail.MailServerDirection
+import com.fsck.k9.mail.ssl.LocalKeyStore
+import java.security.cert.CertificateException
+import java.security.cert.X509Certificate
+
+class LocalKeyStoreManager(
+        val localKeyStore: LocalKeyStore
+) {
+    /**
+     * Add a new certificate for the incoming or outgoing server to the local key store.
+     */
+    @Throws(CertificateException::class)
+    fun addCertificate(account: Account, direction: MailServerDirection, certificate: X509Certificate) {
+        val uri: Uri
+        if (direction === MailServerDirection.INCOMING) {
+            uri = Uri.parse(account.storeUri)
+        } else {
+            uri = Uri.parse(account.transportUri)
+        }
+        localKeyStore.addCertificate(uri.host, uri.port, certificate)
+    }
+
+    /**
+     * Examine the existing settings for an account.  If the old host/port is different from the
+     * new host/port, then try and delete any (possibly non-existent) certificate stored for the
+     * old host/port.
+     */
+    fun deleteCertificate(account: Account, newHost: String, newPort: Int, direction: MailServerDirection) {
+        val uri: Uri
+        if (direction === MailServerDirection.INCOMING) {
+            uri = Uri.parse(account.storeUri)
+        } else {
+            uri = Uri.parse(account.transportUri)
+        }
+        val oldHost = uri.host
+        val oldPort = uri.port
+        if (oldPort == -1) {
+            // This occurs when a new account is created
+            return
+        }
+        if (newHost != oldHost || newPort != oldPort) {
+            localKeyStore.deleteCertificate(oldHost, oldPort)
+        }
+    }
+
+    /**
+     * Examine the settings for the account and attempt to delete (possibly non-existent)
+     * certificates for the incoming and outgoing servers.
+     */
+    fun deleteCertificates(account: Account) {
+        val storeUri = account.storeUri
+        if (storeUri != null) {
+            val uri = Uri.parse(storeUri)
+            localKeyStore.deleteCertificate(uri.host, uri.port)
+        }
+        val transportUri = account.transportUri
+        if (transportUri != null) {
+            val uri = Uri.parse(transportUri)
+            localKeyStore.deleteCertificate(uri.host, uri.port)
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/NotificationSetting.java
+++ b/app/core/src/main/java/com/fsck/k9/NotificationSetting.java
@@ -63,7 +63,7 @@ public class NotificationSetting {
         return vibrateEnabled;
     }
 
-    public synchronized void setVibrate(boolean vibrate) {
+    public synchronized void setVibrateEnabled(boolean vibrate) {
         vibrateEnabled = vibrate;
     }
 

--- a/app/core/src/main/java/com/fsck/k9/Preferences.java
+++ b/app/core/src/main/java/com/fsck/k9/Preferences.java
@@ -135,7 +135,7 @@ public class Preferences {
         }
         LocalStore.removeAccount(account);
 
-        account.delete(this);
+        DI.get(AccountManager.class).delete(account);
 
         if (newAccount == account) {
             newAccount = null;

--- a/app/core/src/main/java/com/fsck/k9/Preferences.java
+++ b/app/core/src/main/java/com/fsck/k9/Preferences.java
@@ -11,6 +11,8 @@ import java.util.List;
 import java.util.Map;
 
 import android.content.Context;
+import android.support.annotation.RestrictTo;
+import android.support.annotation.RestrictTo.Scope;
 
 import com.fsck.k9.backend.BackendManager;
 import com.fsck.k9.mailstore.LocalStore;
@@ -59,6 +61,12 @@ public class Preferences {
         }
     }
 
+    @RestrictTo(Scope.TESTS)
+    public void clearAccounts() {
+        accounts = new HashMap<>();
+        accountsInOrder = new LinkedList<>();
+    }
+
     public synchronized void loadAccounts() {
         accounts = new HashMap<>();
         accountsInOrder = new LinkedList<>();
@@ -66,7 +74,8 @@ public class Preferences {
         if ((accountUuids != null) && (accountUuids.length() != 0)) {
             String[] uuids = accountUuids.split(",");
             for (String uuid : uuids) {
-                Account newAccount = new Account(this, uuid);
+                Account newAccount = new Account(uuid);
+                accountPreferenceSerializer.loadAccount(newAccount, storage);
                 accounts.put(uuid, newAccount);
                 accountsInOrder.add(newAccount);
             }
@@ -177,23 +186,6 @@ public class Preferences {
 
     public Storage getStorage() {
         return storage;
-    }
-
-    static <T extends Enum<T>> T getEnumStringPref(Storage storage, String key, T defaultEnum) {
-        String stringPref = storage.getString(key, null);
-
-        if (stringPref == null) {
-            return defaultEnum;
-        } else {
-            try {
-                return Enum.valueOf(defaultEnum.getDeclaringClass(), stringPref);
-            } catch (IllegalArgumentException ex) {
-                Timber.w(ex, "Unable to convert preference key [%s] value [%s] to enum of type %s",
-                        key, stringPref, defaultEnum.getDeclaringClass());
-
-                return defaultEnum;
-            }
-        }
     }
 
     private BackendManager getBackendManager() {

--- a/app/core/src/main/java/com/fsck/k9/Preferences.java
+++ b/app/core/src/main/java/com/fsck/k9/Preferences.java
@@ -16,6 +16,7 @@ import android.support.annotation.RestrictTo;
 import android.support.annotation.RestrictTo.Scope;
 
 import com.fsck.k9.backend.BackendManager;
+import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
@@ -203,7 +204,29 @@ public class Preferences {
             account.setAccountNumber(accountNumber);
         }
 
+        processChangedValues(account);
+
         accountPreferenceSerializer.save(storage, editor, account);
+    }
+
+    private void processChangedValues(Account account) {
+        if (account.isChangedVisibleLimits()) {
+            try {
+                account.getLocalStore().resetVisibleLimits(account.getDisplayCount());
+            } catch (MessagingException e) {
+                Timber.e(e, "Failed to load LocalStore!");
+            }
+        }
+
+        if (account.isChangedLocalStorageProviderId()) {
+            try {
+                account.getLocalStore().switchLocalStorage(account.getLocalStorageProviderId());
+            } catch (MessagingException e) {
+                Timber.e(e, "Failed to load LocalStore!");
+            }
+        }
+
+        account.resetChangeMarkers();
     }
 
     public int generateAccountNumber() {

--- a/app/core/src/main/java/com/fsck/k9/Preferences.java
+++ b/app/core/src/main/java/com/fsck/k9/Preferences.java
@@ -9,6 +9,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 import android.content.Context;
 import android.support.annotation.RestrictTo;
@@ -130,7 +131,9 @@ public class Preferences {
     }
 
     public synchronized Account newAccount() {
-        newAccount = new Account(context, resourceProvider);
+        String accountUuid = UUID.randomUUID().toString();
+        newAccount = new Account(accountUuid);
+        accountPreferenceSerializer.loadDefaults(newAccount);
         accounts.put(newAccount.getUuid(), newAccount);
         accountsInOrder.add(newAccount);
 

--- a/app/core/src/main/java/com/fsck/k9/controller/AccountStatsCollector.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/AccountStatsCollector.kt
@@ -6,6 +6,7 @@ import com.fsck.k9.AccountStats
 import com.fsck.k9.K9
 import com.fsck.k9.Preferences
 import com.fsck.k9.mail.MessagingException
+import com.fsck.k9.search.AccountSearchConditions
 import com.fsck.k9.search.LocalSearch
 import com.fsck.k9.search.SearchAccount
 
@@ -16,7 +17,10 @@ interface AccountStatsCollector {
     fun getSearchAccountStats(searchAccount: SearchAccount): AccountStats
 }
 
-internal class DefaultAccountStatsCollector(private val context: Context) : AccountStatsCollector {
+internal class DefaultAccountStatsCollector(
+        private val context: Context,
+        private val accountSearchConditions: AccountSearchConditions
+) : AccountStatsCollector {
     private val preferences = Preferences.getPreferences(context)
 
 
@@ -28,8 +32,8 @@ internal class DefaultAccountStatsCollector(private val context: Context) : Acco
         val localStore = account.localStore
 
         val search = LocalSearch()
-        account.excludeSpecialFolders(search)
-        account.limitToDisplayableFolders(search)
+        accountSearchConditions.excludeSpecialFolders(account, search)
+        accountSearchConditions.limitToDisplayableFolders(account, search)
 
         val accountStats = localStore.getAccountStats(search)
         if (K9.measureAccounts()) {

--- a/app/core/src/main/java/com/fsck/k9/controller/AccountStatsCollector.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/AccountStatsCollector.kt
@@ -6,6 +6,7 @@ import com.fsck.k9.AccountStats
 import com.fsck.k9.K9
 import com.fsck.k9.Preferences
 import com.fsck.k9.mail.MessagingException
+import com.fsck.k9.mailstore.LocalStoreProvider
 import com.fsck.k9.search.AccountSearchConditions
 import com.fsck.k9.search.LocalSearch
 import com.fsck.k9.search.SearchAccount
@@ -19,7 +20,8 @@ interface AccountStatsCollector {
 
 internal class DefaultAccountStatsCollector(
         private val context: Context,
-        private val accountSearchConditions: AccountSearchConditions
+        private val accountSearchConditions: AccountSearchConditions,
+        private val localStoreProvider: LocalStoreProvider
 ) : AccountStatsCollector {
     private val preferences = Preferences.getPreferences(context)
 
@@ -29,7 +31,7 @@ internal class DefaultAccountStatsCollector(
             return null
         }
 
-        val localStore = account.localStore
+        val localStore = localStoreProvider.getInstance(account)
 
         val search = LocalSearch()
         accountSearchConditions.excludeSpecialFolders(account, search)
@@ -49,7 +51,7 @@ internal class DefaultAccountStatsCollector(
 
         val aggregatedAccountStats = AccountStats()
         for (account in accounts) {
-            val accountStats = account.localStore.getAccountStats(search)
+            val accountStats = localStoreProvider.getInstance(account).getAccountStats(search)
             aggregatedAccountStats.unreadMessageCount += accountStats.unreadMessageCount
             aggregatedAccountStats.flaggedMessageCount += accountStats.flaggedMessageCount
         }

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -4,5 +4,5 @@ import org.koin.dsl.module.applicationContext
 
 val controllerModule = applicationContext {
     bean { MessagingController(get(), get(), get(), get(), get(), get(), get("controllerExtensions")) }
-    bean { DefaultAccountStatsCollector(get()) as AccountStatsCollector }
+    bean { DefaultAccountStatsCollector(get(), get()) as AccountStatsCollector }
 }

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -3,6 +3,6 @@ package com.fsck.k9.controller
 import org.koin.dsl.module.applicationContext
 
 val controllerModule = applicationContext {
-    bean { MessagingController(get(), get(), get(), get(), get(), get(), get("controllerExtensions")) }
-    bean { DefaultAccountStatsCollector(get(), get()) as AccountStatsCollector }
+    bean { MessagingController(get(), get(), get(), get(), get(), get(), get(), get("controllerExtensions")) }
+    bean { DefaultAccountStatsCollector(get(), get(), get()) as AccountStatsCollector }
 }

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -726,7 +726,7 @@ public class MessagingController {
         return new SyncConfig(
                     account.getExpungePolicy().toBackendExpungePolicy(),
                     account.getEarliestPollDate(),
-                    account.syncRemoteDeletions(),
+                    account.isSyncRemoteDeletions(),
                     account.getMaximumAutoDownloadMessageSize(),
                     K9.DEFAULT_VISIBLE_LIMIT,
                     SYNC_FLAGS);

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1506,13 +1506,13 @@ public class MessagingController {
     }
 
     private void showSendingNotificationIfNecessary(Account account) {
-        if (account.isShowOngoing()) {
+        if (account.isNotifySync()) {
             notificationController.showSendingNotification(account);
         }
     }
 
     private void clearSendingNotificationIfNecessary(Account account) {
-        if (account.isShowOngoing()) {
+        if (account.isNotifySync()) {
             notificationController.clearSendingNotification(account);
         }
     }
@@ -2600,13 +2600,13 @@ public class MessagingController {
     }
 
     private void showFetchingMailNotificationIfNecessary(Account account, Folder folder) {
-        if (account.isShowOngoing()) {
+        if (account.isNotifySync()) {
             notificationController.showFetchingMailNotification(account, folder);
         }
     }
 
     private void clearFetchingMailNotificationIfNecessary(Account account) {
-        if (account.isShowOngoing()) {
+        if (account.isNotifySync()) {
             notificationController.clearFetchingMailNotification(account);
         }
     }

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -76,6 +76,7 @@ import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.mailstore.UnavailableStorageException;
 import com.fsck.k9.notification.NotificationController;
 import com.fsck.k9.power.TracingPowerManager;
@@ -114,6 +115,7 @@ public class MessagingController {
     private final Context context;
     private final Contacts contacts;
     private final NotificationController notificationController;
+    private final LocalStoreProvider localStoreProvider;
     private final BackendManager backendManager;
 
     private final Thread controllerThread;
@@ -137,11 +139,13 @@ public class MessagingController {
     }
 
 
-    MessagingController(Context context, NotificationController notificationController, Contacts contacts,
+    MessagingController(Context context, NotificationController notificationController,
+            LocalStoreProvider localStoreProvider, Contacts contacts,
             AccountStatsCollector accountStatsCollector, CoreResourceProvider resourceProvider,
             BackendManager backendManager, List<ControllerExtension> controllerExtensions) {
         this.context = context;
         this.notificationController = notificationController;
+        this.localStoreProvider = localStoreProvider;
         this.contacts = contacts;
         this.accountStatsCollector = accountStatsCollector;
         this.resourceProvider = resourceProvider;
@@ -267,7 +271,7 @@ public class MessagingController {
 
     private LocalStore getLocalStoreOrThrow(Account account) {
         try {
-            return account.getLocalStore();
+            return localStoreProvider.getInstance(account);
         } catch (MessagingException e) {
             throw new IllegalStateException("Couldn't get LocalStore for account " + account.getDescription());
         }
@@ -393,7 +397,7 @@ public class MessagingController {
             Timber.i("not listing folders of unavailable account");
         } else {
             try {
-                LocalStore localStore = account.getLocalStore();
+                LocalStore localStore = localStoreProvider.getInstance(account);
                 localFolders = localStore.getPersonalNamespaces(false);
 
                 if (refreshRemote || localFolders.isEmpty()) {
@@ -441,7 +445,7 @@ public class MessagingController {
             Backend backend = getBackend(account);
             backend.refreshFolderList();
 
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolders = localStore.getPersonalNamespaces(false);
 
             for (MessagingListener l : getListeners(listener)) {
@@ -517,7 +521,7 @@ public class MessagingController {
 
             // build and do the query in the localstore
             try {
-                LocalStore localStore = account.getLocalStore();
+                LocalStore localStore = localStoreProvider.getInstance(account);
                 localStore.searchForMessages(retrievalListener, search);
             } catch (Exception e) {
                 Timber.e(e);
@@ -554,7 +558,7 @@ public class MessagingController {
 
         List<String> extraResults = new ArrayList<>();
         try {
-            LocalStore localStore = acct.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(acct);
 
             LocalFolder localFolder = localStore.getFolder(folderServerId);
             if (localFolder == null) {
@@ -609,7 +613,7 @@ public class MessagingController {
                     listener.enableProgressIndicator(true);
                 }
                 try {
-                    LocalStore localStore = account.getLocalStore();
+                    LocalStore localStore = localStoreProvider.getInstance(account);
 
                     if (localStore == null) {
                         throw new MessagingException("Could not get store");
@@ -656,7 +660,7 @@ public class MessagingController {
 
     public void loadMoreMessages(Account account, String folder, MessagingListener listener) {
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             LocalFolder localFolder = localStore.getFolder(folder);
             if (localFolder.getVisibleLimit() > 0) {
                 localFolder.setVisibleLimit(localFolder.getVisibleLimit() + account.getDisplayCount());
@@ -734,7 +738,7 @@ public class MessagingController {
 
     private void updateFolderStatus(Account account, String folderServerId, String status) {
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             LocalFolder localFolder = localStore.getFolder(folderServerId);
             localFolder.setStatus(status);
         } catch (MessagingException e) {
@@ -754,7 +758,7 @@ public class MessagingController {
 
     private void queuePendingCommand(Account account, PendingCommand command) {
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localStore.addPendingCommand(command);
         } catch (Exception e) {
             throw new RuntimeException("Unable to enqueue pending command", e);
@@ -784,7 +788,7 @@ public class MessagingController {
     }
 
     public void processPendingCommandsSynchronous(Account account) throws MessagingException {
-        LocalStore localStore = account.getLocalStore();
+        LocalStore localStore = localStoreProvider.getInstance(account);
         List<PendingCommand> commands = localStore.getPendingCommands();
 
         int progress = 0;
@@ -859,7 +863,7 @@ public class MessagingController {
             String folder = command.folder;
             String uid = command.uid;
 
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(folder);
             LocalMessage localMessage = localFolder.getMessage(uid);
 
@@ -959,7 +963,7 @@ public class MessagingController {
             boolean isCopy, Map<String, String> newUidMap) throws MessagingException {
         LocalFolder localDestFolder;
 
-        LocalStore localStore = account.getLocalStore();
+        LocalStore localStore = localStoreProvider.getInstance(account);
         localDestFolder = localStore.getFolder(destFolder);
 
         Backend backend = getBackend(account);
@@ -1042,7 +1046,7 @@ public class MessagingController {
         String folder = command.folder;
         LocalFolder localFolder = null;
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(folder);
             localFolder.open(Folder.OPEN_MODE_RW);
             List<? extends Message> messages = localFolder.getMessages(null, false);
@@ -1104,7 +1108,7 @@ public class MessagingController {
 
         LocalStore localStore;
         try {
-            localStore = account.getLocalStore();
+            localStore = localStoreProvider.getInstance(account);
         } catch (MessagingException e) {
             Timber.e(e, "Couldn't get LocalStore instance");
             return;
@@ -1180,7 +1184,7 @@ public class MessagingController {
         //       objects being modified right after this method returns.
         Folder localFolder = null;
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(folderServerId);
             localFolder.open(Folder.OPEN_MODE_RW);
 
@@ -1238,7 +1242,7 @@ public class MessagingController {
             boolean newState) {
         Folder localFolder = null;
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(folderServerId);
             localFolder.open(Folder.OPEN_MODE_RW);
 
@@ -1256,7 +1260,7 @@ public class MessagingController {
     public void clearAllPending(final Account account) {
         try {
             Timber.w("Clearing pending commands!");
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localStore.removePendingCommands();
         } catch (MessagingException me) {
             Timber.e(me, "Unable to clear pending command");
@@ -1288,7 +1292,7 @@ public class MessagingController {
             final String uid, final MessagingListener listener, final boolean loadPartialFromSearch) {
         LocalFolder localFolder = null;
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(folder);
             localFolder.open(Folder.OPEN_MODE_RW);
 
@@ -1344,7 +1348,7 @@ public class MessagingController {
     }
 
     public LocalMessage loadMessage(Account account, String folderServerId, String uid) throws MessagingException {
-        LocalStore localStore = account.getLocalStore();
+        LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderServerId);
         localFolder.open(Folder.OPEN_MODE_RW);
 
@@ -1365,7 +1369,7 @@ public class MessagingController {
     }
 
     public LocalMessage loadMessageMetadata(Account account, String folderServerId, String uid) throws MessagingException {
-        LocalStore localStore = account.getLocalStore();
+        LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderServerId);
         localFolder.open(Folder.OPEN_MODE_RW);
 
@@ -1403,7 +1407,7 @@ public class MessagingController {
                 try {
                     String folderServerId = message.getFolder().getServerId();
 
-                    LocalStore localStore = account.getLocalStore();
+                    LocalStore localStore = localStoreProvider.getInstance(account);
                     localFolder = localStore.getFolder(folderServerId);
 
                     ProgressBodyFactory bodyFactory = new ProgressBodyFactory(new ProgressListener() {
@@ -1446,7 +1450,7 @@ public class MessagingController {
             String plaintextSubject,
             MessagingListener listener) {
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             LocalFolder localFolder = localStore.getFolder(account.getOutboxFolder());
             localFolder.open(Folder.OPEN_MODE_RW);
             localFolder.appendMessages(Collections.singletonList(message));
@@ -1520,7 +1524,7 @@ public class MessagingController {
     private boolean messagesPendingSend(final Account account) {
         Folder localFolder = null;
         try {
-            localFolder = account.getLocalStore().getFolder(
+            localFolder = localStoreProvider.getInstance(account).getFolder(
                     account.getOutboxFolder());
             if (!localFolder.exists()) {
                 return false;
@@ -1548,7 +1552,7 @@ public class MessagingController {
         Exception lastFailure = null;
         boolean wasPermanentFailure = false;
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(
                     account.getOutboxFolder());
             if (!localFolder.exists()) {
@@ -1793,7 +1797,7 @@ public class MessagingController {
     }
 
     public int getFolderUnreadMessageCount(Account account, String folderServerId) throws MessagingException {
-        LocalStore localStore = account.getLocalStore();
+        LocalStore localStore = localStoreProvider.getInstance(account);
         Folder localFolder = localStore.getFolder(folderServerId);
         return localFolder.getUnreadMessageCount();
     }
@@ -1932,7 +1936,7 @@ public class MessagingController {
             final List<? extends Message> inMessages, final String destFolder, final boolean isCopy) {
 
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             if (!isCopy && !isMoveCapable(account)) {
                 return;
             }
@@ -2032,7 +2036,7 @@ public class MessagingController {
     public void deleteDraft(final Account account, long id) {
         LocalFolder localFolder = null;
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(account.getDraftsFolder());
             localFolder.open(Folder.OPEN_MODE_RW);
             String uid = localFolder.getMessageUidById(id);
@@ -2076,10 +2080,10 @@ public class MessagingController {
         }
     }
 
-    private static List<Message> collectMessagesInThreads(Account account, List<? extends Message> messages)
+    private List<Message> collectMessagesInThreads(Account account, List<? extends Message> messages)
             throws MessagingException {
 
-        LocalStore localStore = account.getLocalStore();
+        LocalStore localStore = localStoreProvider.getInstance(account);
 
         List<Message> messagesInThreads = new ArrayList<>();
         for (Message message : messages) {
@@ -2175,7 +2179,7 @@ public class MessagingController {
                 }
             }
 
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(folder);
             Map<String, String> uidMap = null;
             if (folder.equals(account.getTrashFolder()) || !account.hasTrashFolder()) {
@@ -2264,7 +2268,7 @@ public class MessagingController {
 
         // When we empty trash, we need to actually synchronize the folder
         // or local deletes will never get cleaned up
-        LocalStore localStore = account.getLocalStore();
+        LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder folder = localStore.getFolder(trashFolderServerId);
         folder.open(Folder.OPEN_MODE_RW);
         synchronizeFolder(account, folder, true, 0, null);
@@ -2278,7 +2282,7 @@ public class MessagingController {
             public void run() {
                 LocalFolder localFolder = null;
                 try {
-                    LocalStore localStore = account.getLocalStore();
+                    LocalStore localStore = localStoreProvider.getInstance(account);
                     localFolder = localStore.getFolder(account.getTrashFolder());
                     localFolder.open(Folder.OPEN_MODE_RW);
 
@@ -2323,7 +2327,7 @@ public class MessagingController {
     protected void clearFolderSynchronous(Account account, String folderServerId, MessagingListener listener) {
         LocalFolder localFolder = null;
         try {
-            localFolder = account.getLocalStore().getFolder(folderServerId);
+            localFolder = localStoreProvider.getInstance(account).getFolder(folderServerId);
             localFolder.open(Folder.OPEN_MODE_RW);
             localFolder.clearAllMessages();
         } catch (UnavailableStorageException e) {
@@ -2489,7 +2493,7 @@ public class MessagingController {
             Account.FolderMode aDisplayMode = account.getFolderDisplayMode();
             Account.FolderMode aSyncMode = account.getFolderSyncMode();
 
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             for (final Folder folder : localStore.getPersonalNamespaces(false)) {
                 folder.open(Folder.OPEN_MODE_RW);
 
@@ -2569,7 +2573,7 @@ public class MessagingController {
                         try {
                             // In case multiple Commands get enqueued, don't run more than
                             // once
-                            final LocalStore localStore = account.getLocalStore();
+                            final LocalStore localStore = localStoreProvider.getInstance(account);
                             tLocalFolder = localStore.getFolder(folder.getServerId());
                             tLocalFolder.open(Folder.OPEN_MODE_RW);
 
@@ -2617,7 +2621,7 @@ public class MessagingController {
             @Override
             public void run() {
                 try {
-                    LocalStore localStore = account.getLocalStore();
+                    LocalStore localStore = localStoreProvider.getInstance(account);
                     long oldSize = localStore.getSize();
                     localStore.compact();
                     long newSize = localStore.getSize();
@@ -2639,7 +2643,7 @@ public class MessagingController {
             @Override
             public void run() {
                 try {
-                    LocalStore localStore = account.getLocalStore();
+                    LocalStore localStore = localStoreProvider.getInstance(account);
                     long oldSize = localStore.getSize();
                     localStore.clear();
                     localStore.resetVisibleLimits(account.getDisplayCount());
@@ -2667,7 +2671,7 @@ public class MessagingController {
             @Override
             public void run() {
                 try {
-                    LocalStore localStore = account.getLocalStore();
+                    LocalStore localStore = localStoreProvider.getInstance(account);
                     long oldSize = localStore.getSize();
                     localStore.recreate();
                     localStore.resetVisibleLimits(account.getDisplayCount());
@@ -2765,7 +2769,7 @@ public class MessagingController {
     public Message saveDraft(final Account account, final Message message, long existingDraftId, String plaintextSubject, boolean saveRemotely) {
         LocalMessage localMessage = null;
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             LocalFolder localFolder = localStore.getFolder(account.getDraftsFolder());
             localFolder.open(Folder.OPEN_MODE_RW);
 
@@ -2870,7 +2874,7 @@ public class MessagingController {
 
             List<String> names = new ArrayList<>();
 
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             for (final Folder folder : localStore.getPersonalNamespaces(false)) {
                 if (folder.getServerId().equals(account.getOutboxFolder())) {
                     continue;
@@ -2910,7 +2914,7 @@ public class MessagingController {
             }
 
             if (!names.isEmpty()) {
-                PushReceiver receiver = new MessagingControllerPushReceiver(context, account, this);
+                PushReceiver receiver = new MessagingControllerPushReceiver(context, localStoreProvider, account, this);
                 int maxPushFolders = account.getMaxPushFolders();
 
                 if (names.size() > maxPushFolders) {
@@ -3038,7 +3042,7 @@ public class MessagingController {
     private void actOnMessageGroup(
             Account account, String folderServerId, List<MessageReference> messageReferences, MessageActor actor) {
         try {
-            LocalFolder messageFolder = account.getLocalStore().getFolder(folderServerId);
+            LocalFolder messageFolder = localStoreProvider.getInstance(account).getFolder(folderServerId);
             List<LocalMessage> localMessages = messageFolder.getMessagesByReference(messageReferences);
             actor.act(account, messageFolder, localMessages);
         } catch (MessagingException e) {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
@@ -1,31 +1,34 @@
 package com.fsck.k9.controller;
 
-import android.content.Context;
 
-import com.fsck.k9.mail.power.WakeLock;
-import timber.log.Timber;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+import android.content.Context;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.mail.Folder;
-
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.PushReceiver;
+import com.fsck.k9.mail.power.WakeLock;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.service.SleepService;
-
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
+import timber.log.Timber;
 
 public class MessagingControllerPushReceiver implements PushReceiver {
     final Account account;
     final MessagingController controller;
     final Context context;
+    final LocalStoreProvider localStoreProvider;
 
-    public MessagingControllerPushReceiver(Context context, Account nAccount, MessagingController nController) {
+    public MessagingControllerPushReceiver(Context context, LocalStoreProvider localStoreProvider,
+            Account nAccount, MessagingController nController) {
         account = nAccount;
         controller = nController;
+        this.localStoreProvider = localStoreProvider;
         this.context = context;
     }
 
@@ -90,7 +93,7 @@ public class MessagingControllerPushReceiver implements PushReceiver {
     public String getPushState(String folderServerId) {
         LocalFolder localFolder = null;
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(folderServerId);
             localFolder.open(Folder.OPEN_MODE_RW);
             return localFolder.getPushState();

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
@@ -6,6 +6,7 @@ import com.fsck.k9.mail.Folder.FolderClass
 import com.fsck.k9.mail.Folder.FolderType as RemoteFolderType
 
 class FolderRepository(
+        private val localStoreProvider: LocalStoreProvider,
         private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
         private val account: Account
 ) {
@@ -30,7 +31,7 @@ class FolderRepository(
     }
 
     private fun getRemoteFolders(): List<Folder> {
-        val folders = account.localStore.getPersonalNamespaces(false)
+        val folders = localStoreProvider.getInstance(account).getPersonalNamespaces(false)
 
         return folders
                 .filterNot { it.isLocalOnly }
@@ -38,7 +39,7 @@ class FolderRepository(
     }
 
     fun getDisplayFolders(): List<Folder> {
-        val folders = account.localStore.getPersonalNamespaces(false)
+        val folders = localStoreProvider.getInstance(account).getPersonalNamespaces(false)
         return folders
                 .filter(::shouldDisplayFolder)
                 .sortedWith(sortForDisplay)

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepositoryManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepositoryManager.kt
@@ -2,6 +2,9 @@ package com.fsck.k9.mailstore
 
 import com.fsck.k9.Account
 
-class FolderRepositoryManager(private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy) {
-    fun getFolderRepository(account: Account) = FolderRepository(specialFolderSelectionStrategy, account)
+class FolderRepositoryManager(
+        private val localStoreProvider: LocalStoreProvider,
+        private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy
+) {
+    fun getFolderRepository(account: Account) = FolderRepository(localStoreProvider, specialFolderSelectionStrategy, account)
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
@@ -230,7 +230,7 @@ class K9BackendFolder(
 
     override fun setLatestOldMessageSeenTime(date: Date) {
         account.latestOldMessageSeenTime = date.time
-        account.save(preferences)
+        account.save()
     }
 
     override fun getOldestMessageDate(): Date? {

--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
@@ -230,7 +230,7 @@ class K9BackendFolder(
 
     override fun setLatestOldMessageSeenTime(date: Date) {
         account.latestOldMessageSeenTime = date.time
-        account.save()
+        preferences.saveAccount(account)
     }
 
     override fun getOldestMessageDate(): Date? {

--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
@@ -5,11 +5,13 @@ import com.fsck.k9.Preferences
 
 class K9BackendStorageFactory(
         private val preferences: Preferences,
-        private val folderRepositoryManager: FolderRepositoryManager
+        private val folderRepositoryManager: FolderRepositoryManager,
+        private val localStoreProvider: LocalStoreProvider
 ) {
     fun createBackendStorage(account: Account): K9BackendStorage {
         val folderRepository = folderRepositoryManager.getFolderRepository(account)
+        val localStore = localStoreProvider.getInstance(account)
         val specialFolderUpdater = SpecialFolderUpdater(preferences, folderRepository, account)
-        return K9BackendStorage(preferences, account, account.localStore, specialFolderUpdater)
+        return K9BackendStorage(preferences, account, localStore, specialFolderUpdater)
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -3,10 +3,10 @@ package com.fsck.k9.mailstore
 import org.koin.dsl.module.applicationContext
 
 val mailStoreModule = applicationContext {
-    bean { FolderRepositoryManager(get()) }
+    bean { FolderRepositoryManager(get(), get()) }
     bean { MessageViewInfoExtractor(get(), get(), get()) }
     bean { StorageManager.getInstance(get()) }
     bean { SearchStatusManager() }
     bean { SpecialFolderSelectionStrategy() }
-    bean { K9BackendStorageFactory(get(), get()) }
+    bean { K9BackendStorageFactory(get(), get(), get()) }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -147,7 +147,7 @@ public class LocalFolder extends Folder<LocalMessage> {
     }
 
     public boolean syncRemoteDeletions() {
-        return getAccount().syncRemoteDeletions();
+        return getAccount().isSyncRemoteDeletions();
     }
 
     @Override

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStoreProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStoreProvider.kt
@@ -1,0 +1,30 @@
+package com.fsck.k9.mailstore
+
+import android.content.Context
+import com.fsck.k9.Account
+import com.fsck.k9.DI
+import com.fsck.k9.mail.MessagingException
+import java.util.concurrent.ConcurrentHashMap
+
+class LocalStoreProvider {
+    private val localStores = ConcurrentHashMap<String, LocalStore>()
+    private val accountLocks = ConcurrentHashMap<String, Any>()
+
+    @Throws(MessagingException::class)
+    fun getInstance(account: Account): LocalStore {
+        val context = DI.get(Context::class.java)
+        val accountUuid = account.uuid
+
+        // Use per-account locks so DatabaseUpgradeService always knows which account database is currently upgraded.
+        synchronized(accountLocks.getOrPut(accountUuid) { Any() }) {
+            // Creating a LocalStore instance will create or upgrade the database if
+            // necessary. This could take some time.
+            return localStores.getOrPut(accountUuid) { LocalStore.createInstance(account, context) }
+        }
+    }
+
+    fun removeInstance(account: Account) {
+        val accountUuid = account.uuid
+        localStores.remove(accountUuid)
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
@@ -77,6 +77,6 @@ class SpecialFolderUpdater(
     }
 
     private fun saveAccount() {
-        account.save(preferences)
+        account.save()
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/SpecialFolderUpdater.kt
@@ -77,6 +77,6 @@ class SpecialFolderUpdater(
     }
 
     private fun saveAccount() {
-        account.save()
+        preferences.saveAccount(account)
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -3,6 +3,8 @@ package com.fsck.k9.notification
 import android.app.NotificationManager
 import android.content.Context
 import android.support.v4.app.NotificationManagerCompat
+import com.fsck.k9.AccountManager
+import com.fsck.k9.mail.ssl.LocalKeyStore
 import org.koin.dsl.module.applicationContext
 import java.util.concurrent.Executors
 
@@ -18,6 +20,8 @@ val coreNotificationModule = applicationContext {
                 get()
         )
     }
+    bean { LocalKeyStore.getInstance() }
+    bean { AccountManager(get(), get()) }
     bean { CertificateErrorNotifications(get(), get(), get()) }
     bean { AuthenticationErrorNotifications(get(), get(), get()) }
     bean { SyncNotifications(get(), get(), get()) }

--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import android.app.NotificationManager
 import android.content.Context
 import android.support.v4.app.NotificationManagerCompat
-import com.fsck.k9.AccountManager
+import com.fsck.k9.AccountPreferenceSerializer
 import com.fsck.k9.LocalKeyStoreManager
 import com.fsck.k9.mail.ssl.LocalKeyStore
 import org.koin.dsl.module.applicationContext
@@ -21,7 +21,7 @@ val coreNotificationModule = applicationContext {
                 get()
         )
     }
-    bean { AccountManager(get(), get()) }
+    bean { AccountPreferenceSerializer() }
     bean { LocalKeyStore.getInstance() }
     bean { LocalKeyStoreManager(get()) }
     bean { CertificateErrorNotifications(get(), get(), get()) }

--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -21,7 +21,7 @@ val coreNotificationModule = applicationContext {
                 get()
         )
     }
-    bean { AccountPreferenceSerializer() }
+    bean { AccountPreferenceSerializer(get()) }
     bean { LocalKeyStore.getInstance() }
     bean { LocalKeyStoreManager(get()) }
     bean { CertificateErrorNotifications(get(), get(), get()) }

--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -4,6 +4,7 @@ import android.app.NotificationManager
 import android.content.Context
 import android.support.v4.app.NotificationManagerCompat
 import com.fsck.k9.AccountManager
+import com.fsck.k9.LocalKeyStoreManager
 import com.fsck.k9.mail.ssl.LocalKeyStore
 import org.koin.dsl.module.applicationContext
 import java.util.concurrent.Executors
@@ -20,8 +21,9 @@ val coreNotificationModule = applicationContext {
                 get()
         )
     }
-    bean { LocalKeyStore.getInstance() }
     bean { AccountManager(get(), get()) }
+    bean { LocalKeyStore.getInstance() }
+    bean { LocalKeyStoreManager(get()) }
     bean { CertificateErrorNotifications(get(), get(), get()) }
     bean { AuthenticationErrorNotifications(get(), get(), get()) }
     bean { SyncNotifications(get(), get(), get()) }

--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -21,7 +21,7 @@ val coreNotificationModule = applicationContext {
                 get()
         )
     }
-    bean { AccountPreferenceSerializer(get()) }
+    bean { AccountPreferenceSerializer(get(), get()) }
     bean { LocalKeyStore.getInstance() }
     bean { LocalKeyStoreManager(get()) }
     bean { CertificateErrorNotifications(get(), get(), get()) }

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -20,6 +20,7 @@ import com.fsck.k9.Account.Searchable;
 import com.fsck.k9.Account.ShowPictures;
 import com.fsck.k9.Account.SortType;
 import com.fsck.k9.Account.SpecialFolderSelection;
+import com.fsck.k9.AccountPreferenceSerializer;
 import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.core.R;
@@ -68,7 +69,7 @@ public class AccountSettings {
                 new V(1, new ColorSetting(0xFF0000FF))
         ));
         s.put("defaultQuotedTextShown", Settings.versions(
-                new V(1, new BooleanSetting(Account.DEFAULT_QUOTED_TEXT_SHOWN))
+                new V(1, new BooleanSetting(AccountPreferenceSerializer.DEFAULT_QUOTED_TEXT_SHOWN))
         ));
         s.put("deletePolicy", Settings.versions(
                 new V(1, new DeletePolicySetting(DeletePolicy.NEVER))
@@ -128,13 +129,13 @@ public class AccountSettings {
                 new V(1, new IntegerResourceSetting(-1, R.array.message_age_values))
         ));
         s.put("messageFormat", Settings.versions(
-                new V(1, new EnumSetting<>(MessageFormat.class, Account.DEFAULT_MESSAGE_FORMAT))
+                new V(1, new EnumSetting<>(MessageFormat.class, AccountPreferenceSerializer.DEFAULT_MESSAGE_FORMAT))
         ));
         s.put("messageFormatAuto", Settings.versions(
-                new V(2, new BooleanSetting(Account.DEFAULT_MESSAGE_FORMAT_AUTO))
+                new V(2, new BooleanSetting(AccountPreferenceSerializer.DEFAULT_MESSAGE_FORMAT_AUTO))
         ));
         s.put("messageReadReceipt", Settings.versions(
-                new V(1, new BooleanSetting(Account.DEFAULT_MESSAGE_READ_RECEIPT))
+                new V(1, new BooleanSetting(AccountPreferenceSerializer.DEFAULT_MESSAGE_READ_RECEIPT))
         ));
         s.put("notifyMailCheck", Settings.versions(
                 new V(1, new BooleanSetting(false))
@@ -152,13 +153,13 @@ public class AccountSettings {
                 new V(1, new BooleanSetting(true))
         ));
         s.put("quotePrefix", Settings.versions(
-                new V(1, new StringSetting(Account.DEFAULT_QUOTE_PREFIX))
+                new V(1, new StringSetting(AccountPreferenceSerializer.DEFAULT_QUOTE_PREFIX))
         ));
         s.put("quoteStyle", Settings.versions(
-                new V(1, new EnumSetting<>(QuoteStyle.class, Account.DEFAULT_QUOTE_STYLE))
+                new V(1, new EnumSetting<>(QuoteStyle.class, AccountPreferenceSerializer.DEFAULT_QUOTE_STYLE))
         ));
         s.put("replyAfterQuote", Settings.versions(
-                new V(1, new BooleanSetting(Account.DEFAULT_REPLY_AFTER_QUOTE))
+                new V(1, new BooleanSetting(AccountPreferenceSerializer.DEFAULT_REPLY_AFTER_QUOTE))
         ));
         s.put("ring", Settings.versions(
                 new V(1, new BooleanSetting(true))
@@ -190,7 +191,7 @@ public class AccountSettings {
                 new V(53, new StringSetting(null))
         ));
         s.put("stripSignature", Settings.versions(
-                new V(2, new BooleanSetting(Account.DEFAULT_STRIP_SIGNATURE))
+                new V(2, new BooleanSetting(AccountPreferenceSerializer.DEFAULT_STRIP_SIGNATURE))
         ));
         s.put("subscribedFoldersOnly", Settings.versions(
                 new V(1, new BooleanSetting(false))
@@ -224,7 +225,7 @@ public class AccountSettings {
                 new V(18, new BooleanSetting(true))
         ));
         s.put("remoteSearchNumResults", Settings.versions(
-                new V(18, new IntegerResourceSetting(Account.DEFAULT_REMOTE_SEARCH_NUM_RESULTS,
+                new V(18, new IntegerResourceSetting(AccountPreferenceSerializer.DEFAULT_REMOTE_SEARCH_NUM_RESULTS,
                         R.array.remote_search_num_results_values))
         ));
         s.put("remoteSearchFullText", Settings.versions(

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.java
@@ -23,6 +23,7 @@ import android.os.Environment;
 import android.util.Xml;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.AccountPreferenceSerializer;
 import com.fsck.k9.DI;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.backend.BackendManager;
@@ -226,7 +227,7 @@ public class SettingsExporter {
         serializer.startTag(null, ACCOUNT_ELEMENT);
         serializer.attribute(null, UUID_ATTRIBUTE, accountUuid);
 
-        String name = (String) prefs.get(accountUuid + "." + Account.ACCOUNT_DESCRIPTION_KEY);
+        String name = (String) prefs.get(accountUuid + "." + AccountPreferenceSerializer.ACCOUNT_DESCRIPTION_KEY);
         if (name != null) {
             serializer.startTag(null, NAME_ELEMENT);
             serializer.text(name);
@@ -324,7 +325,7 @@ public class SettingsExporter {
                 String secondPart = keyPart.substring(0, indexOfLastDot);
                 String thirdPart = keyPart.substring(indexOfLastDot + 1);
 
-                if (Account.IDENTITY_DESCRIPTION_KEY.equals(secondPart)) {
+                if (AccountPreferenceSerializer.IDENTITY_DESCRIPTION_KEY.equals(secondPart)) {
                     // This is an identity key. Save identity index for later...
                     try {
                         identities.add(Integer.parseInt(thirdPart));
@@ -393,19 +394,19 @@ public class SettingsExporter {
         String suffix = "." + identity;
 
         // Write name belonging to the identity
-        String name = (String) prefs.get(prefix + Account.IDENTITY_NAME_KEY + suffix);
+        String name = (String) prefs.get(prefix + AccountPreferenceSerializer.IDENTITY_NAME_KEY + suffix);
         serializer.startTag(null, NAME_ELEMENT);
         serializer.text(name);
         serializer.endTag(null, NAME_ELEMENT);
 
         // Write email address belonging to the identity
-        String email = (String) prefs.get(prefix + Account.IDENTITY_EMAIL_KEY + suffix);
+        String email = (String) prefs.get(prefix + AccountPreferenceSerializer.IDENTITY_EMAIL_KEY + suffix);
         serializer.startTag(null, EMAIL_ELEMENT);
         serializer.text(email);
         serializer.endTag(null, EMAIL_ELEMENT);
 
         // Write identity description
-        String description = (String) prefs.get(prefix + Account.IDENTITY_DESCRIPTION_KEY + suffix);
+        String description = (String) prefs.get(prefix + AccountPreferenceSerializer.IDENTITY_DESCRIPTION_KEY + suffix);
         if (description != null) {
             serializer.startTag(null, DESCRIPTION_ELEMENT);
             serializer.text(description);

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -18,6 +18,7 @@ import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.AccountPreferenceSerializer;
 import com.fsck.k9.Core;
 import com.fsck.k9.DI;
 import com.fsck.k9.Identity;
@@ -338,7 +339,7 @@ public class SettingsImporter {
 
         // Write account name
         String accountKeyPrefix = uuid + ".";
-        putString(editor, accountKeyPrefix + Account.ACCOUNT_DESCRIPTION_KEY, accountName);
+        putString(editor, accountKeyPrefix + AccountPreferenceSerializer.ACCOUNT_DESCRIPTION_KEY, accountName);
 
         if (account.incoming == null) {
             // We don't import accounts without incoming server settings
@@ -349,7 +350,7 @@ public class SettingsImporter {
         ServerSettings incoming = new ImportedServerSettings(account.incoming);
         BackendManager backendManager = DI.get(BackendManager.class);
         String storeUri = backendManager.createStoreUri(incoming);
-        putString(editor, accountKeyPrefix + Account.STORE_URI_KEY, Base64.encode(storeUri));
+        putString(editor, accountKeyPrefix + AccountPreferenceSerializer.STORE_URI_KEY, Base64.encode(storeUri));
 
         // Mark account as disabled if the AuthType isn't EXTERNAL and the
         // settings file didn't contain a password
@@ -366,7 +367,7 @@ public class SettingsImporter {
             // Write outgoing server settings (transportUri)
             ServerSettings outgoing = new ImportedServerSettings(account.outgoing);
             String transportUri = backendManager.createTransportUri(outgoing);
-            putString(editor, accountKeyPrefix + Account.TRANSPORT_URI_KEY, Base64.encode(transportUri));
+            putString(editor, accountKeyPrefix + AccountPreferenceSerializer.TRANSPORT_URI_KEY, Base64.encode(transportUri));
 
             /*
              * Mark account as disabled if the settings file contained a username but no password. However, no password
@@ -522,7 +523,7 @@ public class SettingsImporter {
 
             // Write name used in identity
             String identityName = (identity.name == null) ? "" : identity.name;
-            putString(editor, accountKeyPrefix + Account.IDENTITY_NAME_KEY + identitySuffix, identityName);
+            putString(editor, accountKeyPrefix + AccountPreferenceSerializer.IDENTITY_NAME_KEY + identitySuffix, identityName);
 
             // Validate email address
             if (!IdentitySettings.isEmailAddressValid(identity.email)) {
@@ -530,10 +531,10 @@ public class SettingsImporter {
             }
 
             // Write email address
-            putString(editor, accountKeyPrefix + Account.IDENTITY_EMAIL_KEY + identitySuffix, identity.email);
+            putString(editor, accountKeyPrefix + AccountPreferenceSerializer.IDENTITY_EMAIL_KEY + identitySuffix, identity.email);
 
             // Write identity description
-            putString(editor, accountKeyPrefix + Account.IDENTITY_DESCRIPTION_KEY + identitySuffix,
+            putString(editor, accountKeyPrefix + AccountPreferenceSerializer.IDENTITY_DESCRIPTION_KEY + identitySuffix,
                     identityDescription);
 
             if (identity.settings != null) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -417,7 +417,7 @@ public class SettingsImporter {
 
         // If it's a new account generate and write a new "accountNumber"
         if (!mergeImportedAccount) {
-            int newAccountNumber = Account.generateAccountNumber(prefs);
+            int newAccountNumber = prefs.generateAccountNumber();
             putString(editor, accountKeyPrefix + "accountNumber", Integer.toString(newAccountNumber));
         }
 

--- a/app/core/src/main/java/com/fsck/k9/provider/AttachmentProvider.java
+++ b/app/core/src/main/java/com/fsck/k9/provider/AttachmentProvider.java
@@ -13,6 +13,9 @@ import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+
+import com.fsck.k9.DI;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import timber.log.Timber;
 
 import com.fsck.k9.Account;
@@ -94,7 +97,7 @@ public class AttachmentProvider extends ContentProvider {
         final AttachmentInfo attachmentInfo;
         try {
             final Account account = Preferences.getPreferences(getContext()).getAccount(accountUuid);
-            attachmentInfo = LocalStore.getInstance(account, getContext()).getAttachmentInfo(id);
+            attachmentInfo = DI.get(LocalStoreProvider.class).getInstance(account).getAttachmentInfo(id);
         } catch (MessagingException e) {
             Timber.e(e, "Unable to retrieve attachment info from local store for ID: %s", id);
             return null;
@@ -143,7 +146,7 @@ public class AttachmentProvider extends ContentProvider {
         final Account account = Preferences.getPreferences(getContext()).getAccount(accountUuid);
 
         try {
-            final LocalStore localStore = LocalStore.getInstance(account, getContext());
+            final LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
 
             AttachmentInfo attachmentInfo = localStore.getAttachmentInfo(id);
             if (mimeType != null) {
@@ -180,7 +183,7 @@ public class AttachmentProvider extends ContentProvider {
     @Nullable
     private OpenPgpDataSource getAttachmentDataSource(String accountUuid, String attachmentId) throws MessagingException {
         final Account account = Preferences.getPreferences(getContext()).getAccount(accountUuid);
-        LocalStore localStore = LocalStore.getInstance(account, getContext());
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
         return localStore.getAttachmentDataSource(attachmentId);
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/provider/EmailProvider.java
+++ b/app/core/src/main/java/com/fsck/k9/provider/EmailProvider.java
@@ -18,11 +18,13 @@ import android.net.Uri;
 import android.text.TextUtils;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.DI;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.cache.EmailProviderCacheCursor;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.mailstore.LockableDatabase;
 import com.fsck.k9.mailstore.LockableDatabase.DbCallback;
 import com.fsck.k9.mailstore.LockableDatabase.WrappedException;
@@ -527,7 +529,7 @@ public class EmailProvider extends ContentProvider {
     private LockableDatabase getDatabase(Account account) {
         LocalStore localStore;
         try {
-            localStore = account.getLocalStore();
+            localStore = DI.get(LocalStoreProvider.class).getInstance(account);
         } catch (MessagingException e) {
             throw new RuntimeException("Couldn't get LocalStore", e);
         }

--- a/app/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
+++ b/app/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
@@ -18,6 +18,7 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.DI;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessageReference;
 import com.fsck.k9.mail.FetchProfile;
@@ -27,6 +28,7 @@ import com.fsck.k9.mail.filter.CountingOutputStream;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import org.openintents.openpgp.util.OpenPgpApi.OpenPgpDataSource;
 import timber.log.Timber;
 
@@ -181,7 +183,7 @@ public class RawMessageProvider extends ContentProvider {
         }
 
         try {
-            LocalStore localStore = LocalStore.getInstance(account, getContext());
+            LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
             LocalFolder localFolder = localStore.getFolder(folderServerId);
             localFolder.open(Folder.OPEN_MODE_RW);
 

--- a/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
+++ b/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
@@ -1,0 +1,135 @@
+package com.fsck.k9.search
+
+import com.fsck.k9.Account
+import com.fsck.k9.BaseAccount
+import com.fsck.k9.mail.Folder
+
+class AccountSearchConditions {
+    /**
+     * Modify the supplied [LocalSearch] instance to limit the search to displayable folders.
+     *
+     *
+     *
+     * This method uses the current folder display mode to decide what folders to include/exclude.
+     *
+     *
+     * @param search
+     * The `LocalSearch` instance to modify.
+     *
+     * @see .getFolderDisplayMode
+     */
+    fun limitToDisplayableFolders(account: Account, search: LocalSearch) {
+        val displayMode = account.folderDisplayMode
+
+        when (displayMode) {
+            Account.FolderMode.FIRST_CLASS -> {
+                // Count messages in the INBOX and non-special first class folders
+                search.and(SearchSpecification.SearchField.DISPLAY_CLASS, Folder.FolderClass.FIRST_CLASS.name,
+                        SearchSpecification.Attribute.EQUALS)
+            }
+            Account.FolderMode.FIRST_AND_SECOND_CLASS -> {
+                // Count messages in the INBOX and non-special first and second class folders
+                search.and(SearchSpecification.SearchField.DISPLAY_CLASS, Folder.FolderClass.FIRST_CLASS.name,
+                        SearchSpecification.Attribute.EQUALS)
+
+                // TODO: Create a proper interface for creating arbitrary condition trees
+                val searchCondition = SearchSpecification.SearchCondition(SearchSpecification.SearchField.DISPLAY_CLASS,
+                        SearchSpecification.Attribute.EQUALS, Folder.FolderClass.SECOND_CLASS.name)
+                val root = search.conditions
+                if (root.mRight != null) {
+                    root.mRight.or(searchCondition)
+                } else {
+                    search.or(searchCondition)
+                }
+            }
+            Account.FolderMode.NOT_SECOND_CLASS -> {
+                // Count messages in the INBOX and non-special non-second-class folders
+                search.and(SearchSpecification.SearchField.DISPLAY_CLASS, Folder.FolderClass.SECOND_CLASS.name,
+                        SearchSpecification.Attribute.NOT_EQUALS)
+            }
+            Account.FolderMode.ALL -> {
+            }// Count messages in the INBOX and non-special folders
+            else -> {
+            }
+        }
+    }
+
+    /**
+     * Modify the supplied [LocalSearch] instance to exclude special folders.
+     *
+     *
+     *
+     * Currently the following folders are excluded:
+     *
+     *  * Trash
+     *  * Drafts
+     *  * Spam
+     *  * Outbox
+     *  * Sent
+     *
+     * The Inbox will always be included even if one of the special folders is configured to point
+     * to the Inbox.
+     *
+     *
+     * @param search
+     * The `LocalSearch` instance to modify.
+     */
+    fun excludeSpecialFolders(account: Account, search: LocalSearch) {
+        excludeSpecialFolder(search, account.trashFolder)
+        excludeSpecialFolder(search, account.draftsFolder)
+        excludeSpecialFolder(search, account.spamFolder)
+        excludeSpecialFolder(search, account.outboxFolder)
+        excludeSpecialFolder(search, account.sentFolder)
+        search.or(SearchSpecification.SearchCondition(SearchSpecification.SearchField.FOLDER, SearchSpecification.Attribute.EQUALS, account.getInboxFolder()))
+    }
+
+    /**
+     * Modify the supplied [LocalSearch] instance to exclude "unwanted" folders.
+     *
+     *
+     *
+     * Currently the following folders are excluded:
+     *
+     *  * Trash
+     *  * Spam
+     *  * Outbox
+     *
+     * The Inbox will always be included even if one of the special folders is configured to point
+     * to the Inbox.
+     *
+     *
+     * @param search
+     * The `LocalSearch` instance to modify.
+     */
+    fun excludeUnwantedFolders(account: Account, search: LocalSearch) {
+        excludeSpecialFolder(search, account.trashFolder)
+        excludeSpecialFolder(search, account.spamFolder)
+        excludeSpecialFolder(search, account.outboxFolder)
+        search.or(SearchSpecification.SearchCondition(SearchSpecification.SearchField.FOLDER, SearchSpecification.Attribute.EQUALS, account.inboxFolder))
+    }
+
+    private fun excludeSpecialFolder(search: LocalSearch, folderServerId: String?) {
+        if (folderServerId != null) {
+            search.and(SearchSpecification.SearchField.FOLDER, folderServerId, SearchSpecification.Attribute.NOT_EQUALS)
+        }
+    }
+
+    fun createUnreadSearch(account: BaseAccount, searchTitle: String): LocalSearch {
+        val search: LocalSearch
+        if (account is SearchAccount) {
+            search = account.relatedSearch.clone()
+            search.name = searchTitle
+        } else {
+            search = LocalSearch(searchTitle)
+            search.addAccountUuid(account.uuid)
+
+            val realAccount = account as Account
+            excludeSpecialFolders(realAccount, search)
+            limitToDisplayableFolders(realAccount, search)
+        }
+
+        search.and(SearchSpecification.SearchField.READ, "1", SearchSpecification.Attribute.NOT_EQUALS)
+
+        return search
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
+++ b/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
@@ -1,17 +1,16 @@
 package com.fsck.k9.search
 
 import com.fsck.k9.Account
+import com.fsck.k9.Account.FolderMode
 import com.fsck.k9.BaseAccount
-import com.fsck.k9.mail.Folder
+import com.fsck.k9.mail.Folder.FolderClass
+import com.fsck.k9.search.SearchSpecification.*
 
 class AccountSearchConditions {
     /**
      * Modify the supplied [LocalSearch] instance to limit the search to displayable folders.
      *
-     *
-     *
      * This method uses the current folder display mode to decide what folders to include/exclude.
-     *
      *
      * @param search
      * The `LocalSearch` instance to modify.
@@ -22,19 +21,17 @@ class AccountSearchConditions {
         val displayMode = account.folderDisplayMode
 
         when (displayMode) {
-            Account.FolderMode.FIRST_CLASS -> {
+            FolderMode.FIRST_CLASS -> {
                 // Count messages in the INBOX and non-special first class folders
-                search.and(SearchSpecification.SearchField.DISPLAY_CLASS, Folder.FolderClass.FIRST_CLASS.name,
-                        SearchSpecification.Attribute.EQUALS)
+                search.and(SearchField.DISPLAY_CLASS, FolderClass.FIRST_CLASS.name, Attribute.EQUALS)
             }
-            Account.FolderMode.FIRST_AND_SECOND_CLASS -> {
+            FolderMode.FIRST_AND_SECOND_CLASS -> {
                 // Count messages in the INBOX and non-special first and second class folders
-                search.and(SearchSpecification.SearchField.DISPLAY_CLASS, Folder.FolderClass.FIRST_CLASS.name,
-                        SearchSpecification.Attribute.EQUALS)
+                search.and(SearchField.DISPLAY_CLASS, FolderClass.FIRST_CLASS.name, Attribute.EQUALS)
 
                 // TODO: Create a proper interface for creating arbitrary condition trees
-                val searchCondition = SearchSpecification.SearchCondition(SearchSpecification.SearchField.DISPLAY_CLASS,
-                        SearchSpecification.Attribute.EQUALS, Folder.FolderClass.SECOND_CLASS.name)
+                val searchCondition = SearchCondition(
+                        SearchField.DISPLAY_CLASS, Attribute.EQUALS, FolderClass.SECOND_CLASS.name)
                 val root = search.conditions
                 if (root.mRight != null) {
                     root.mRight.or(searchCondition)
@@ -42,22 +39,18 @@ class AccountSearchConditions {
                     search.or(searchCondition)
                 }
             }
-            Account.FolderMode.NOT_SECOND_CLASS -> {
+            FolderMode.NOT_SECOND_CLASS -> {
                 // Count messages in the INBOX and non-special non-second-class folders
-                search.and(SearchSpecification.SearchField.DISPLAY_CLASS, Folder.FolderClass.SECOND_CLASS.name,
-                        SearchSpecification.Attribute.NOT_EQUALS)
+                search.and(SearchField.DISPLAY_CLASS, FolderClass.SECOND_CLASS.name, Attribute.NOT_EQUALS)
             }
-            Account.FolderMode.ALL -> {
-            }// Count messages in the INBOX and non-special folders
-            else -> {
+            FolderMode.ALL, FolderMode.NONE -> {
+                // Count messages in the INBOX and non-special folders
             }
         }
     }
 
     /**
      * Modify the supplied [LocalSearch] instance to exclude special folders.
-     *
-     *
      *
      * Currently the following folders are excluded:
      *
@@ -70,7 +63,6 @@ class AccountSearchConditions {
      * The Inbox will always be included even if one of the special folders is configured to point
      * to the Inbox.
      *
-     *
      * @param search
      * The `LocalSearch` instance to modify.
      */
@@ -80,13 +72,11 @@ class AccountSearchConditions {
         excludeSpecialFolder(search, account.spamFolder)
         excludeSpecialFolder(search, account.outboxFolder)
         excludeSpecialFolder(search, account.sentFolder)
-        search.or(SearchSpecification.SearchCondition(SearchSpecification.SearchField.FOLDER, SearchSpecification.Attribute.EQUALS, account.getInboxFolder()))
+        search.or(SearchCondition(SearchField.FOLDER, Attribute.EQUALS, account.getInboxFolder()))
     }
 
     /**
      * Modify the supplied [LocalSearch] instance to exclude "unwanted" folders.
-     *
-     *
      *
      * Currently the following folders are excluded:
      *
@@ -97,7 +87,6 @@ class AccountSearchConditions {
      * The Inbox will always be included even if one of the special folders is configured to point
      * to the Inbox.
      *
-     *
      * @param search
      * The `LocalSearch` instance to modify.
      */
@@ -105,12 +94,12 @@ class AccountSearchConditions {
         excludeSpecialFolder(search, account.trashFolder)
         excludeSpecialFolder(search, account.spamFolder)
         excludeSpecialFolder(search, account.outboxFolder)
-        search.or(SearchSpecification.SearchCondition(SearchSpecification.SearchField.FOLDER, SearchSpecification.Attribute.EQUALS, account.inboxFolder))
+        search.or(SearchCondition(SearchField.FOLDER, Attribute.EQUALS, account.inboxFolder))
     }
 
     private fun excludeSpecialFolder(search: LocalSearch, folderServerId: String?) {
         if (folderServerId != null) {
-            search.and(SearchSpecification.SearchField.FOLDER, folderServerId, SearchSpecification.Attribute.NOT_EQUALS)
+            search.and(SearchField.FOLDER, folderServerId, Attribute.NOT_EQUALS)
         }
     }
 
@@ -128,7 +117,7 @@ class AccountSearchConditions {
             limitToDisplayableFolders(realAccount, search)
         }
 
-        search.and(SearchSpecification.SearchField.READ, "1", SearchSpecification.Attribute.NOT_EQUALS)
+        search.and(SearchField.READ, "1", Attribute.NOT_EQUALS)
 
         return search
     }

--- a/app/core/src/main/java/com/fsck/k9/search/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/search/KoinModule.kt
@@ -1,0 +1,8 @@
+package com.fsck.k9.search
+
+import com.fsck.k9.mailstore.*
+import org.koin.dsl.module.applicationContext
+
+val searchModule = applicationContext {
+    bean { AccountSearchConditions() }
+}

--- a/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
@@ -2,6 +2,7 @@ package com.fsck.k9.search;
 
 import java.util.List;
 
+import com.fsck.k9.DI;
 import timber.log.Timber;
 
 import com.fsck.k9.Account;
@@ -28,6 +29,7 @@ public class SqlQueryBuilder {
         }
 
         if (node.mLeft == null && node.mRight == null) {
+            AccountSearchConditions accountSearchConditions = DI.get(AccountSearchConditions.class);
             SearchCondition condition = node.mCondition;
             switch (condition.field) {
                 case FOLDER: {
@@ -48,7 +50,7 @@ public class SqlQueryBuilder {
                             LocalSearch tempSearch = new LocalSearch();
                             // ...the helper methods in Account to create the necessary conditions
                             // to exclude "unwanted" folders.
-                            account.excludeUnwantedFolders(tempSearch);
+                            accountSearchConditions.excludeUnwantedFolders(account, tempSearch);
 
                             buildWhereClauseInternal(account, tempSearch.getConditions(), query,
                                     selectionArgs);
@@ -59,8 +61,8 @@ public class SqlQueryBuilder {
                             LocalSearch tempSearch = new LocalSearch();
                             // ...the helper methods in Account to create the necessary conditions
                             // to limit the selection to displayable, non-special folders.
-                            account.excludeSpecialFolders(tempSearch);
-                            account.limitToDisplayableFolders(tempSearch);
+                            accountSearchConditions.excludeSpecialFolders(account, tempSearch);
+                            accountSearchConditions.limitToDisplayableFolders(account, tempSearch);
 
                             buildWhereClauseInternal(account, tempSearch.getConditions(), query,
                                     selectionArgs);

--- a/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
@@ -3,6 +3,7 @@ package com.fsck.k9.search;
 import java.util.List;
 
 import com.fsck.k9.DI;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import timber.log.Timber;
 
 import com.fsck.k9.Account;
@@ -109,7 +110,7 @@ public class SqlQueryBuilder {
     private static long getFolderId(Account account, String folderServerId) {
         long folderId = 0;
         try {
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
             LocalFolder folder = localStore.getFolder(folderServerId);
             folder.open(Folder.OPEN_MODE_RO);
             folderId = folder.getDatabaseId();

--- a/app/core/src/main/java/com/fsck/k9/service/DatabaseUpgradeService.java
+++ b/app/core/src/main/java/com/fsck/k9/service/DatabaseUpgradeService.java
@@ -12,8 +12,10 @@ import android.os.PowerManager;
 import android.support.v4.content.LocalBroadcastManager;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.mailstore.UnavailableStorageException;
 import com.fsck.k9.power.TracingPowerManager;
 import com.fsck.k9.power.TracingPowerManager.TracingWakeLock;
@@ -192,7 +194,7 @@ public class DatabaseUpgradeService extends Service {
 
             try {
                 // Account.getLocalStore() is blocking and will upgrade the database if necessary
-                account.getLocalStore();
+                DI.get(LocalStoreProvider.class).getInstance(account);
             } catch (UnavailableStorageException e) {
                 Timber.e("Database unavailable");
             } catch (Exception e) {

--- a/app/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
+++ b/app/core/src/test/java/com/fsck/k9/TestCoreResourceProvider.kt
@@ -1,13 +1,9 @@
 package com.fsck.k9
 
 class TestCoreResourceProvider : CoreResourceProvider {
-    override fun defaultSignature(): String {
-        throw UnsupportedOperationException("not implemented")
-    }
+    override fun defaultSignature() = "\n--\nbrevity!"
 
-    override fun defaultIdentityDescription(): String {
-        throw UnsupportedOperationException("not implemented")
-    }
+    override fun defaultIdentityDescription() = "initial identity"
 
     override fun sendAlternateChooserTitle(): String {
         throw UnsupportedOperationException("not implemented")

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -32,6 +32,7 @@ import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.mailstore.UnavailableStorageException;
 import com.fsck.k9.notification.NotificationController;
 import com.fsck.k9.search.LocalSearch;
@@ -84,6 +85,8 @@ public class MessagingControllerTest extends K9RobolectricTest {
     private BackendManager backendManager;
     @Mock
     private Backend backend;
+    @Mock
+    private LocalStoreProvider localStoreProvider;
     @Mock
     private Contacts contacts;
     @Mock
@@ -141,7 +144,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
         MockitoAnnotations.initMocks(this);
         appContext = RuntimeEnvironment.application;
 
-        controller = new MessagingController(appContext, notificationController, contacts,
+        controller = new MessagingController(appContext, notificationController, localStoreProvider, contacts,
                 accountStatsCollector, mock(CoreResourceProvider.class), backendManager,
                 Collections.<ControllerExtension>emptyList());
 
@@ -545,13 +548,13 @@ public class MessagingControllerTest extends K9RobolectricTest {
         account.setMaximumAutoDownloadMessageSize(MAXIMUM_SMALL_MESSAGE_SIZE);
         account.setEmail("user@host.com");
         Mockito.doReturn(true).when(account).isAvailable(appContext);
-        Mockito.doReturn(localStore).when(account).getLocalStore();
     }
 
     private void configureLocalStore() throws MessagingException {
         when(localStore.getFolder(FOLDER_NAME)).thenReturn(localFolder);
         when(localFolder.getServerId()).thenReturn(FOLDER_NAME);
         when(localStore.getPersonalNamespaces(false)).thenReturn(Collections.singletonList(localFolder));
+        when(localStoreProvider.getInstance(account)).thenReturn(localStore);
     }
 
     private void setAccountsInPreferences(Map<String, Account> newAccounts)

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -566,13 +566,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
         accountsInOrder.set(Preferences.getPreferences(appContext), newAccountsInOrder);
     }
 
-    private void removeAccountsFromPreferences() throws Exception {
-        Field accounts = Preferences.class.getDeclaredField("accounts");
-        accounts.setAccessible(true);
-        accounts.set(Preferences.getPreferences(appContext), null);
-
-        Field accountsInOrder = Preferences.class.getDeclaredField("accountsInOrder");
-        accountsInOrder.setAccessible(true);
-        accountsInOrder.set(Preferences.getPreferences(appContext), null);
+    private void removeAccountsFromPreferences() {
+        Preferences.getPreferences(appContext).clearAccounts();
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -12,12 +12,13 @@ import android.content.Context;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.SpecialFolderSelection;
+import com.fsck.k9.AccountPreferenceSerializer;
 import com.fsck.k9.AccountStats;
 import com.fsck.k9.CoreResourceProvider;
+import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.Preferences;
-import com.fsck.k9.TestCoreResourceProvider;
 import com.fsck.k9.backend.BackendManager;
 import com.fsck.k9.backend.api.Backend;
 import com.fsck.k9.helper.Contacts;
@@ -46,6 +47,7 @@ import org.mockito.ArgumentMatchers;
 import org.mockito.Captor;
 import org.mockito.InOrder;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -75,7 +77,6 @@ public class MessagingControllerTest extends K9RobolectricTest {
     private static final String SENT_FOLDER_NAME = "Sent";
     private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;
     private static final String ACCOUNT_UUID = "1";
-
 
     private MessagingController controller;
     private Account account;
@@ -539,12 +540,12 @@ public class MessagingControllerTest extends K9RobolectricTest {
 
     private void configureAccount() throws MessagingException {
         // TODO use simple account object without mocks
-        account = spy(new Account(appContext, new TestCoreResourceProvider()));
+        account = spy(new Account(ACCOUNT_UUID));
+        DI.get(AccountPreferenceSerializer.class).loadDefaults(account);
         account.setMaximumAutoDownloadMessageSize(MAXIMUM_SMALL_MESSAGE_SIZE);
         account.setEmail("user@host.com");
-        when(account.getUuid()).thenReturn(ACCOUNT_UUID);
-        when(account.isAvailable(appContext)).thenReturn(true);
-        when(account.getLocalStore()).thenReturn(localStore);
+        Mockito.doReturn(true).when(account).isAvailable(appContext);
+        Mockito.doReturn(localStore).when(account).getLocalStore();
     }
 
     private void configureLocalStore() throws MessagingException {

--- a/app/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
@@ -144,5 +144,5 @@ class IdentityHelperTest : RobolectricTest() {
     }
 
 
-    class DummyAccount : Account(RuntimeEnvironment.application, mock())
+    class DummyAccount : Account("dummy-uuid")
 }

--- a/app/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/helper/IdentityHelperTest.kt
@@ -9,9 +9,8 @@ import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.Message.RecipientType
 import com.fsck.k9.mail.internet.MimeMessage
 import com.google.common.truth.Truth.assertThat
-import com.nhaarman.mockito_kotlin.mock
 import org.junit.Test
-import org.robolectric.RuntimeEnvironment
+import java.util.*
 
 class IdentityHelperTest : RobolectricTest() {
     private val account = createDummyAccount()
@@ -110,7 +109,7 @@ class IdentityHelperTest : RobolectricTest() {
     }
 
 
-    private fun createDummyAccount() = DummyAccount().apply {
+    private fun createDummyAccount() = Account(UUID.randomUUID().toString()).apply {
         identities = listOf(
                 newIdentity("Default", DEFAULT_ADDRESS),
                 newIdentity("Identity 1", IDENTITY_1_ADDRESS),
@@ -142,7 +141,4 @@ class IdentityHelperTest : RobolectricTest() {
         const val IDENTITY_4_ADDRESS = "identity4@example.org"
         const val IDENTITY_5_ADDRESS = "identity5@example.org"
     }
-
-
-    class DummyAccount : Account("dummy-uuid")
 }

--- a/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
@@ -78,7 +78,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
 
     fun createAccount(): Account {
         //FIXME: This is a hack to get Preferences into a state where it's safe to call newAccount()
-        preferences.loadAccounts()
+        preferences.clearAccounts()
 
         return preferences.newAccount()
     }

--- a/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
@@ -27,10 +27,11 @@ import org.koin.standalone.inject
 class K9BackendFolderTest : K9RobolectricTest() {
     val preferences: Preferences by inject()
     val folderRepositoryManager: FolderRepositoryManager by inject()
+    val localStoreProvider: LocalStoreProvider by inject()
 
     val account: Account = createAccount()
     val backendFolder = createBackendFolder()
-    val database: LockableDatabase = account.localStore.database
+    val database: LockableDatabase = localStoreProvider.getInstance(account).database
 
 
     @Before
@@ -84,7 +85,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
     }
 
     fun createBackendFolder(): BackendFolder {
-        val localStore: LocalStore = account.localStore
+        val localStore: LocalStore = localStoreProvider.getInstance(account)
         val folderRepository = folderRepositoryManager.getFolderRepository(account)
         val specialFolderUpdater = SpecialFolderUpdater(preferences, folderRepository, account)
         val backendStorage = K9BackendStorage(preferences, account, localStore, specialFolderUpdater)

--- a/app/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
+++ b/app/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import com.fsck.k9.Account;
 import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.AuthType;
@@ -32,9 +31,7 @@ public class SettingsImporterTest extends K9RobolectricTest {
 
     private void deletePreExistingAccounts() {
         Preferences preferences = Preferences.getPreferences(RuntimeEnvironment.application);
-        for (Account account : preferences.getAccounts()) {
-            preferences.deleteAccount(account);
-        }
+        preferences.clearAccounts();
     }
 
     @Test(expected = SettingsImportExportException.class)

--- a/app/k9mail/src/androidTest/java/com/fsck/k9/external/MessageProviderTest.java
+++ b/app/k9mail/src/androidTest/java/com/fsck/k9/external/MessageProviderTest.java
@@ -55,7 +55,7 @@ public class MessageProviderTest extends ProviderTestCase2 {
         account.setDescription("TestAccount");
         account.setChipColor(10);
         account.setStoreUri("imap://user@domain.com/");
-        account.save(preferences);
+        account.save();
     }
 
     @Test

--- a/app/k9mail/src/androidTest/java/com/fsck/k9/external/MessageProviderTest.java
+++ b/app/k9mail/src/androidTest/java/com/fsck/k9/external/MessageProviderTest.java
@@ -55,7 +55,7 @@ public class MessageProviderTest extends ProviderTestCase2 {
         account.setDescription("TestAccount");
         account.setChipColor(10);
         account.setStoreUri("imap://user@domain.com/");
-        account.save();
+        preferences.saveAccount(account);
     }
 
     @Test

--- a/app/k9mail/src/androidTest/java/com/fsck/k9/mailstore/ReconstructMessageFromDatabaseTest.java
+++ b/app/k9mail/src/androidTest/java/com/fsck/k9/mailstore/ReconstructMessageFromDatabaseTest.java
@@ -12,6 +12,7 @@ import android.test.ApplicationTestCase;
 import android.test.RenamingDelegatingContext;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.FetchProfile;
@@ -134,7 +135,7 @@ public class ReconstructMessageFromDatabaseTest extends ApplicationTestCase<K9> 
     }
 
     protected LocalFolder createFolderInDatabase() throws MessagingException {
-        LocalStore localStore = LocalStore.getInstance(account, getApplication());
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
         LocalFolder inbox = localStore.getFolder("INBOX");
         localStore.createFolders(Collections.singletonList(inbox), 10);
         return inbox;

--- a/app/k9mail/src/androidTest/java/com/fsck/k9/provider/EmailProviderTest.java
+++ b/app/k9mail/src/androidTest/java/com/fsck/k9/provider/EmailProviderTest.java
@@ -13,10 +13,12 @@ import android.support.test.runner.AndroidJUnit4;
 import android.test.ProviderTestCase2;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.DI;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.MimeMessage;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -157,7 +159,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
     public void query_forMessagesWithAccountAndRequiredFieldsAndOrderBy_providesResult() throws MessagingException {
         Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
-        account.getLocalStore().getFolder("Inbox").appendMessages(Collections.singletonList(message));
+        DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
 
         Cursor cursor = getProvider().query(
                 Uri.parse("content://" + EmailProvider.AUTHORITY + "/account/" + account.getUuid() + "/messages"),
@@ -179,7 +181,8 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
     public void query_forMessagesWithAccountAndRequiredFieldsAndOrderBy_sortsCorrectly() throws MessagingException {
         Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
-        account.getLocalStore().getFolder("Inbox").appendMessages(Arrays.asList(message, laterMessage));
+        DI.get(LocalStoreProvider.class).getInstance(account)
+                .getFolder("Inbox").appendMessages(Arrays.asList(message, laterMessage));
 
         Cursor cursor = getProvider().query(
                 Uri.parse("content://" + EmailProvider.AUTHORITY + "/account/" + account.getUuid() + "/messages"),
@@ -204,7 +207,8 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
     public void query_forThreadedMessages_sortsCorrectly() throws MessagingException {
         Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
-        account.getLocalStore().getFolder("Inbox").appendMessages(Arrays.asList(message, laterMessage));
+        DI.get(LocalStoreProvider.class).getInstance(account)
+                .getFolder("Inbox").appendMessages(Arrays.asList(message, laterMessage));
 
         Cursor cursor = getProvider().query(
                 Uri.parse("content://" + EmailProvider.AUTHORITY + "/account/" + account.getUuid() +
@@ -230,8 +234,8 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
     public void query_forThreadedMessages_showsThreadOfEmailOnce() throws MessagingException {
         Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
-        account.getLocalStore().getFolder("Inbox").appendMessages(Collections.singletonList(message));
-        account.getLocalStore().getFolder("Inbox").appendMessages(Collections.singletonList(reply));
+        DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
+        DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(reply));
 
         Cursor cursor = getProvider().query(
                 Uri.parse("content://" + EmailProvider.AUTHORITY + "/account/" + account.getUuid() +
@@ -258,8 +262,8 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
     public void query_forThreadedMessages_showsThreadOfEmailWithSameSendTimeOnce() throws MessagingException {
         Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
-        account.getLocalStore().getFolder("Inbox").appendMessages(Collections.singletonList(message));
-        account.getLocalStore().getFolder("Inbox").appendMessages(Collections.singletonList(replyAtSameTime));
+        DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
+        DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(replyAtSameTime));
 
         Cursor cursor = getProvider().query(
                 Uri.parse("content://" + EmailProvider.AUTHORITY + "/account/" + account.getUuid() +
@@ -289,7 +293,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
         Message message = new MimeMessage();
         message.setSubject("Test Subject");
         message.setSentDate(new GregorianCalendar(2016, 1, 2).getTime(), false);
-        account.getLocalStore().getFolder("Inbox").appendMessages(Collections.singletonList(message));
+        DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
 
         //Now get the thread id we just put in.
         Cursor cursor = getProvider().query(

--- a/app/k9mail/src/main/java/com/fsck/k9/external/remotecontrol/RemoteControlService.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/external/remotecontrol/RemoteControlService.java
@@ -114,7 +114,7 @@ public class RemoteControlService extends CoreService {
                                         }
                                     }
                                 }
-                                account.save(Preferences.getPreferences(RemoteControlService.this));
+                                account.save();
                             }
                         }
 

--- a/app/k9mail/src/main/java/com/fsck/k9/external/remotecontrol/RemoteControlService.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/external/remotecontrol/RemoteControlService.java
@@ -114,7 +114,7 @@ public class RemoteControlService extends CoreService {
                                         }
                                     }
                                 }
-                                account.save();
+                                Preferences.getPreferences(getApplicationContext()).saveAccount(account);
                             }
                         }
 

--- a/app/k9mail/src/main/java/com/fsck/k9/external/remotecontrol/RemoteControlService.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/external/remotecontrol/RemoteControlService.java
@@ -97,7 +97,7 @@ public class RemoteControlService extends CoreService {
                                     account.getNotificationSetting().setRingEnabled(Boolean.parseBoolean(ringEnabled));
                                 }
                                 if (vibrateEnabled != null) {
-                                    account.getNotificationSetting().setVibrate(Boolean.parseBoolean(vibrateEnabled));
+                                    account.getNotificationSetting().setVibrateEnabled(Boolean.parseBoolean(vibrateEnabled));
                                 }
                                 if (pushClasses != null) {
                                     needsPushRestart |= account.setFolderPushMode(FolderMode.valueOf(pushClasses));

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
@@ -58,7 +58,7 @@ class K9NotificationActionCreator implements NotificationActionCreator {
             int notificationId) {
 
         TaskStackBuilder stack;
-        if (account.goToUnreadMessageSearch()) {
+        if (account.isGoToUnreadMessageSearch()) {
             stack = buildUnreadBackStack(account);
         } else {
             String folderServerId = getFolderServerIdOfAllMessages(messageReferences);

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
@@ -10,8 +10,10 @@ import android.support.v4.app.TaskStackBuilder;
 import android.text.TextUtils;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
+import com.fsck.k9.R;
 import com.fsck.k9.activity.Accounts;
 import com.fsck.k9.activity.FolderList;
 import com.fsck.k9.activity.MessageList;
@@ -20,6 +22,7 @@ import com.fsck.k9.activity.NotificationDeleteConfirmation;
 import com.fsck.k9.activity.compose.MessageActions;
 import com.fsck.k9.activity.setup.AccountSetupIncoming;
 import com.fsck.k9.activity.setup.AccountSetupOutgoing;
+import com.fsck.k9.search.AccountSearchConditions;
 import com.fsck.k9.search.LocalSearch;
 
 
@@ -35,6 +38,7 @@ import com.fsck.k9.search.LocalSearch;
  */
 class K9NotificationActionCreator implements NotificationActionCreator {
     private final Context context;
+    private final AccountSearchConditions accountSearchConditions = DI.get(AccountSearchConditions.class);
 
 
     public K9NotificationActionCreator(Context context) {
@@ -227,7 +231,8 @@ class K9NotificationActionCreator implements NotificationActionCreator {
     private TaskStackBuilder buildUnreadBackStack(final Account account) {
         TaskStackBuilder stack = buildAccountsBackStack();
 
-        LocalSearch search = Accounts.createUnreadSearch(context, account);
+        String searchTitle = context.getString(R.string.search_title, account.getDescription(), context.getString(R.string.unread_modifier));
+        LocalSearch search = accountSearchConditions.createUnreadSearch(account, searchTitle);
         Intent intent = MessageList.intentDisplaySearch(context, search, true, false, false);
 
         stack.addNextIntent(intent);

--- a/app/storage/src/test/java/com/fsck/k9/storage/MigrationTest.java
+++ b/app/storage/src/test/java/com/fsck/k9/storage/MigrationTest.java
@@ -724,7 +724,7 @@ public class MigrationTest extends K9RobolectricTest {
         Preferences preferences = Preferences.getPreferences(RuntimeEnvironment.application);
 
         //FIXME: This is a hack to get Preferences into a state where it's safe to call newAccount()
-        preferences.loadAccounts();
+        preferences.clearAccounts();
 
         Account account = preferences.newAccount();
         account.setStoreUri("imap+tls+://user:password@imap.example.org");

--- a/app/storage/src/test/java/com/fsck/k9/storage/MigrationTest.java
+++ b/app/storage/src/test/java/com/fsck/k9/storage/MigrationTest.java
@@ -28,6 +28,7 @@ import com.fsck.k9.mailstore.FileBackedBody;
 import com.fsck.k9.mailstore.LocalBodyPart;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.mailstore.StorageManager;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.util.MimeUtil;
@@ -161,7 +162,7 @@ public class MigrationTest extends K9RobolectricTest {
         insertSimplePlaintextMessage(db);
         db.close();
 
-        LocalStore localStore = LocalStore.getInstance(account, RuntimeEnvironment.application);
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
 
         LocalMessage msg = localStore.getFolder("dev").getMessage("3");
         FetchProfile fp = new FetchProfile();
@@ -228,7 +229,7 @@ public class MigrationTest extends K9RobolectricTest {
         insertMixedWithAttachments(db);
         db.close();
 
-        LocalStore localStore = LocalStore.getInstance(account, RuntimeEnvironment.application);
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
 
         LocalMessage msg = localStore.getFolder("dev").getMessage("4");
         FetchProfile fp = new FetchProfile();
@@ -300,7 +301,7 @@ public class MigrationTest extends K9RobolectricTest {
         insertPgpMimeSignedMessage(db);
         db.close();
 
-        LocalStore localStore = LocalStore.getInstance(account, RuntimeEnvironment.application);
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
 
         LocalMessage msg = localStore.getFolder("dev").getMessage("5");
         FetchProfile fp = new FetchProfile();
@@ -359,7 +360,7 @@ public class MigrationTest extends K9RobolectricTest {
         insertPgpMimeEncryptedMessage(db);
         db.close();
 
-        LocalStore localStore = LocalStore.getInstance(account, RuntimeEnvironment.application);
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
 
         LocalMessage msg = localStore.getFolder("dev").getMessage("6");
         FetchProfile fp = new FetchProfile();
@@ -477,7 +478,7 @@ public class MigrationTest extends K9RobolectricTest {
         insertPgpInlineEncryptedMessage(db);
         db.close();
 
-        LocalStore localStore = LocalStore.getInstance(account, RuntimeEnvironment.application);
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
 
         LocalMessage msg = localStore.getFolder("dev").getMessage("7");
         FetchProfile fp = new FetchProfile();
@@ -564,7 +565,7 @@ public class MigrationTest extends K9RobolectricTest {
         insertPgpInlineClearsignedMessage(db);
         db.close();
 
-        LocalStore localStore = LocalStore.getInstance(account, RuntimeEnvironment.application);
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
 
         LocalMessage msg = localStore.getFolder("dev").getMessage("8");
         FetchProfile fp = new FetchProfile();
@@ -622,7 +623,7 @@ public class MigrationTest extends K9RobolectricTest {
         insertMultipartAlternativeMessage(db);
         db.close();
 
-        LocalStore localStore = LocalStore.getInstance(account, RuntimeEnvironment.application);
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
 
         LocalMessage msg = localStore.getFolder("dev").getMessage("9");
         FetchProfile fp = new FetchProfile();
@@ -687,7 +688,7 @@ public class MigrationTest extends K9RobolectricTest {
         insertHtmlWithRelatedMessage(db);
         db.close();
 
-        LocalStore localStore = LocalStore.getInstance(account, RuntimeEnvironment.application);
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
 
         LocalMessage msg = localStore.getFolder("dev").getMessage("10");
         FetchProfile fp = new FetchProfile();

--- a/app/storage/src/test/java/com/fsck/k9/storage/MigrationTest.java
+++ b/app/storage/src/test/java/com/fsck/k9/storage/MigrationTest.java
@@ -8,13 +8,15 @@ import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Collections;
+import java.util.UUID;
 
 import android.content.Context;
 import android.database.sqlite.SQLiteDatabase;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.AccountPreferenceSerializer;
+import com.fsck.k9.DI;
 import com.fsck.k9.K9;
-import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.FetchProfile;
 import com.fsck.k9.mail.Multipart;
@@ -721,14 +723,9 @@ public class MigrationTest extends K9RobolectricTest {
     }
 
     private Account getNewAccount() {
-        Preferences preferences = Preferences.getPreferences(RuntimeEnvironment.application);
-
-        //FIXME: This is a hack to get Preferences into a state where it's safe to call newAccount()
-        preferences.clearAccounts();
-
-        Account account = preferences.newAccount();
+        Account account = new Account(UUID.randomUUID().toString());
+        DI.get(AccountPreferenceSerializer.class).loadDefaults(account);
         account.setStoreUri("imap+tls+://user:password@imap.example.org");
-
         return account;
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -988,7 +988,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 mAccount.setEnabled(true);
 
                 // Save the account settings
-                mAccount.save(Preferences.getPreferences(mContext));
+                mAccount.save();
 
                 // Start services if necessary
                 Core.setServicesEnabled(mContext);

--- a/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -75,6 +75,7 @@ import com.fsck.k9.backend.BackendManager;
 import com.fsck.k9.controller.MessagingController;
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.ServerSettings;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.mailstore.StorageManager;
 import com.fsck.k9.preferences.Protocols;
 import com.fsck.k9.preferences.SettingsExporter;
@@ -1028,7 +1029,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                     if (selectedContextAccount instanceof Account) {
                         Account realAccount = (Account) selectedContextAccount;
                         try {
-                            realAccount.getLocalStore().delete();
+                            DI.get(LocalStoreProvider.class).getInstance(realAccount).delete();
                         } catch (Exception e) {
                             // Ignore, this may lead to localStores on sd-cards that
                             // are currently not inserted to be left

--- a/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -2030,7 +2030,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
 
         @Override
         protected Void doInBackground(Void... args) {
-            mAccount.move(Preferences.getPreferences(mContext), mUp);
+            Preferences.getPreferences(mContext).move(mAccount, mUp);
             return null;
         }
 

--- a/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/Accounts.java
@@ -968,7 +968,7 @@ public class Accounts extends K9ListActivity implements OnItemClickListener {
                 mAccount.setEnabled(true);
 
                 // Save the account settings
-                mAccount.save();
+                Preferences.getPreferences(mContext).saveAccount(mAccount);
 
                 // Start services if necessary
                 Core.setServicesEnabled(mContext);

--- a/app/ui/src/main/java/com/fsck/k9/activity/EditIdentity.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/EditIdentity.java
@@ -113,7 +113,7 @@ public class EditIdentity extends K9Activity {
             identities.add(mIdentityIndex, mIdentity);
         }
 
-        mAccount.save(Preferences.getPreferences(getApplication().getApplicationContext()));
+        mAccount.save();
 
         finish();
     }

--- a/app/ui/src/main/java/com/fsck/k9/activity/EditIdentity.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/EditIdentity.java
@@ -113,7 +113,7 @@ public class EditIdentity extends K9Activity {
             identities.add(mIdentityIndex, mIdentity);
         }
 
-        mAccount.save();
+        Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
 
         finish();
     }

--- a/app/ui/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -420,7 +420,7 @@ public class FolderList extends K9ListActivity {
 
     private void setDisplayMode(FolderMode newMode) {
         account.setFolderDisplayMode(newMode);
-        account.save(Preferences.getPreferences(this));
+        account.save();
         if (account.getFolderPushMode() != FolderMode.NONE) {
             MailService.actionRestartPushers(this, null);
         }

--- a/app/ui/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -420,7 +420,7 @@ public class FolderList extends K9ListActivity {
 
     private void setDisplayMode(FolderMode newMode) {
         account.setFolderDisplayMode(newMode);
-        account.save();
+        Preferences.getPreferences(getApplicationContext()).saveAccount(account);
         if (account.getFolderPushMode() != FolderMode.NONE) {
             MailService.actionRestartPushers(this, null);
         }

--- a/app/ui/src/main/java/com/fsck/k9/activity/FolderList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/FolderList.java
@@ -44,6 +44,7 @@ import com.fsck.k9.DI;
 import com.fsck.k9.FontSizes;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.activity.compose.MessageActions;
 import com.fsck.k9.activity.setup.FolderSettings;
@@ -742,7 +743,7 @@ public class FolderList extends K9ListActivity {
                             Timber.i("not refreshing folder of unavailable account");
                             return;
                         }
-                        localFolder = account.getLocalStore().getFolder(folderServerId);
+                        localFolder = DI.get(LocalStoreProvider.class).getInstance(account).getFolder(folderServerId);
                         FolderInfoHolder folderHolder = getFolder(folderServerId);
                         if (folderHolder != null) {
                             folderHolder.populate(context, localFolder, FolderList.this.account, -1);

--- a/app/ui/src/main/java/com/fsck/k9/activity/ManageIdentities.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/ManageIdentities.java
@@ -13,7 +13,6 @@ import android.widget.ListView;
 import android.widget.Toast;
 
 import com.fsck.k9.Identity;
-import com.fsck.k9.Preferences;
 import com.fsck.k9.ui.R;
 
 public class ManageIdentities extends ChooseIdentity {
@@ -129,7 +128,7 @@ public class ManageIdentities extends ChooseIdentity {
     private void saveIdentities() {
         if (mIdentitiesChanged) {
             mAccount.setIdentities(identities);
-            mAccount.save(Preferences.getPreferences(getApplication().getApplicationContext()));
+            mAccount.save();
         }
         finish();
     }

--- a/app/ui/src/main/java/com/fsck/k9/activity/ManageIdentities.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/ManageIdentities.java
@@ -13,6 +13,7 @@ import android.widget.ListView;
 import android.widget.Toast;
 
 import com.fsck.k9.Identity;
+import com.fsck.k9.Preferences;
 import com.fsck.k9.ui.R;
 
 public class ManageIdentities extends ChooseIdentity {
@@ -128,7 +129,7 @@ public class ManageIdentities extends ChooseIdentity {
     private void saveIdentities() {
         if (mIdentitiesChanged) {
             mAccount.setIdentities(identities);
-            mAccount.save();
+            Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
         }
         finish();
     }

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -393,7 +393,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             signatureView.setVisibility(View.GONE);
         }
 
-        requestReadReceipt = account.isMessageReadReceiptAlways();
+        requestReadReceipt = account.isMessageReadReceipt();
 
         updateFrom();
 

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageLoaderHelper.java
@@ -300,7 +300,7 @@ public class MessageLoaderHelper {
             retainCryptoHelperFragment.setData(messageCryptoHelper);
         }
         messageCryptoHelper.asyncStartOrResumeProcessingMessage(
-                localMessage, messageCryptoCallback, cachedDecryptionResult, !account.getOpenPgpHideSignOnly());
+                localMessage, messageCryptoCallback, cachedDecryptionResult, !account.isOpenPgpHideSignOnly());
     }
 
     private void cancelAndClearCryptoOperation() {

--- a/app/ui/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
@@ -51,9 +51,9 @@ import com.fsck.k9.service.DatabaseUpgradeService;
  * Currently we make no attempts to stop the background code (e.g. {@link MessagingController}) from
  * opening the accounts' databases. If this happens the upgrade is performed in one of the
  * background threads and not by {@link DatabaseUpgradeService}. But this is not a problem. Due to
- * the locking in {@link LocalStore#getInstance(Account, Context)} the upgrade
- * service will block in the {@link Account#getLocalStore()} call and from the outside (especially
- * for this activity) it will appear as if {@link DatabaseUpgradeService} is performing the upgrade.
+ * the locking in {@link com.fsck.k9.mailstore.LocalStoreProvider#getInstance(Account)} the upgrade service will block
+ * and from the outside (especially for this activity) it will appear as if
+ * {@link DatabaseUpgradeService} is performing the upgrade.
  * </p>
  */
 public class UpgradeDatabases extends K9Activity {

--- a/app/ui/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -35,7 +35,6 @@ import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Message.RecipientType;
-import com.fsck.k9.mail.Part;
 import com.fsck.k9.message.AutocryptStatusInteractor;
 import com.fsck.k9.message.AutocryptStatusInteractor.RecipientAutocryptStatus;
 import com.fsck.k9.message.ComposePgpEnableByDefaultDecider;
@@ -307,7 +306,7 @@ public class RecipientPresenter {
             menu.findItem(R.id.openpgp_encrypt_enable).setVisible(!isEncrypting);
             menu.findItem(R.id.openpgp_encrypt_disable).setVisible(isEncrypting);
 
-            boolean showSignOnly = !account.getOpenPgpHideSignOnly();
+            boolean showSignOnly = !account.isOpenPgpHideSignOnly();
             boolean isSignOnly = currentCryptoStatus.isSignOnly();
             menu.findItem(R.id.openpgp_sign_only).setVisible(showSignOnly && !isSignOnly);
             menu.findItem(R.id.openpgp_sign_only_disable).setVisible(showSignOnly && isSignOnly);
@@ -429,8 +428,8 @@ public class RecipientPresenter {
                 cryptoEnablePgpInline,
                 account.getAutocryptPreferEncryptMutual(),
                 isReplyToEncryptedMessage,
-                account.getOpenPgpEncryptAllDrafts(),
-                account.getOpenPgpEncryptSubject(),
+                account.isOpenPgpEncryptAllDrafts(),
+                account.isOpenPgpEncryptSubject(),
                 currentCryptoMode);
 
         if (openPgpProviderState != OpenPgpProviderState.OK) {

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -376,7 +376,7 @@ public class AccountSetupBasics extends K9Activity
             } else {
                 //We've successfully checked outgoing as well.
                 mAccount.setDescription(mAccount.getEmail());
-                mAccount.save(Preferences.getPreferences(this));
+                mAccount.save();
                 Core.setServicesEnabled(this);
                 AccountSetupNames.actionSetNames(this, mAccount);
                 finish();

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -376,7 +376,7 @@ public class AccountSetupBasics extends K9Activity
             } else {
                 //We've successfully checked outgoing as well.
                 mAccount.setDescription(mAccount.getEmail());
-                mAccount.save();
+                Preferences.getPreferences(this).saveAccount(mAccount);
                 Core.setServicesEnabled(this);
                 AccountSetupNames.actionSetNames(this, mAccount);
                 finish();

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -29,6 +29,7 @@ import android.widget.TextView;
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.SpecialFolderSelection;
 import com.fsck.k9.DI;
+import com.fsck.k9.LocalKeyStoreManager;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.K9Activity;
 import com.fsck.k9.controller.MessagingController;
@@ -301,7 +302,7 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
      */
     private void acceptCertificate(X509Certificate certificate) {
         try {
-            mAccount.addCertificate(mDirection.toMailServerDirection(), certificate);
+            DI.get(LocalKeyStoreManager.class).addCertificate(mAccount, mDirection.toMailServerDirection(), certificate);
         } catch (CertificateException e) {
             showErrorDialog(
                     R.string.account_setup_failed_dlg_certificate_message_fmt,

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -43,6 +43,7 @@ import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.filter.Hex;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.ui.R;
 import timber.log.Timber;
 
@@ -518,7 +519,7 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
                 return;
             }
 
-            LocalStore localStore = account.getLocalStore();
+            LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
             createLocalFolder(localStore, Account.OUTBOX, getString(R.string.special_mailbox_name_outbox));
 
             if  (!account.getStoreUri().startsWith("pop3")) {

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
@@ -117,7 +117,7 @@ public class AccountSetupComposition extends K9Activity {
             mAccount.setSignatureBeforeQuotedText(isSignatureBeforeQuotedText);
         }
 
-        mAccount.save(Preferences.getPreferences(this));
+        mAccount.save();
     }
 
     @Override
@@ -134,7 +134,7 @@ public class AccountSetupComposition extends K9Activity {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        mAccount.save(Preferences.getPreferences(this));
+        mAccount.save();
         finish();
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
@@ -117,7 +117,7 @@ public class AccountSetupComposition extends K9Activity {
             mAccount.setSignatureBeforeQuotedText(isSignatureBeforeQuotedText);
         }
 
-        mAccount.save();
+        Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
     }
 
     @Override
@@ -134,7 +134,7 @@ public class AccountSetupComposition extends K9Activity {
 
     @Override
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
-        mAccount.save();
+        Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
         finish();
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -304,7 +304,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
             }
             mCurrentPortViewSetting = mPortView.getText().toString();
 
-            mSubscribedFoldersOnly.setChecked(mAccount.subscribedFoldersOnly());
+            mSubscribedFoldersOnly.setChecked(mAccount.isSubscribedFoldersOnly());
         } catch (Exception e) {
             failure(e);
         }
@@ -515,7 +515,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 if (isPushCapable && mAccount.getFolderPushMode() != FolderMode.NONE) {
                     MailService.actionRestartPushers(this, null);
                 }
-                mAccount.save(Preferences.getPreferences(this));
+                mAccount.save();
                 finish();
             } else {
                 /*

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -30,6 +30,7 @@ import android.widget.Toast;
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.FolderMode;
 import com.fsck.k9.DI;
+import com.fsck.k9.LocalKeyStoreManager;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.backend.BackendManager;
 import com.fsck.k9.preferences.Protocols;
@@ -588,7 +589,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                         mWebdavMailboxPathView.getText().toString());
             }
 
-            mAccount.deleteCertificate(host, port, MailServerDirection.INCOMING);
+            DI.get(LocalKeyStoreManager.class).deleteCertificate(mAccount, host, port, MailServerDirection.INCOMING);
             ServerSettings settings = new ServerSettings(mStoreType, host, port,
                     connectionSecurity, authType, username, password, clientCertificateAlias, extra);
 

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -516,7 +516,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 if (isPushCapable && mAccount.getFolderPushMode() != FolderMode.NONE) {
                     MailService.actionRestartPushers(this, null);
                 }
-                mAccount.save();
+                Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
                 finish();
             } else {
                 /*

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
@@ -89,7 +89,7 @@ public class AccountSetupNames extends K9Activity implements OnClickListener {
             mAccount.setDescription(mDescription.getText().toString());
         }
         mAccount.setName(mName.getText().toString());
-        mAccount.save(Preferences.getPreferences(this));
+        mAccount.save();
         Accounts.listAccounts(this);
         finish();
     }

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
@@ -89,7 +89,7 @@ public class AccountSetupNames extends K9Activity implements OnClickListener {
             mAccount.setDescription(mDescription.getText().toString());
         }
         mAccount.setName(mName.getText().toString());
-        mAccount.save();
+        Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
         Accounts.listAccounts(this);
         finish();
     }

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
@@ -143,7 +143,7 @@ public class AccountSetupOptions extends K9Activity implements OnClickListener {
             mAccount.setFolderPushMode(Account.FolderMode.NONE);
         }
 
-        mAccount.save(Preferences.getPreferences(this));
+        mAccount.save();
         if (mAccount.equals(Preferences.getPreferences(this).getDefaultAccount()) ||
                 getIntent().getBooleanExtra(EXTRA_MAKE_DEFAULT, false)) {
             Preferences.getPreferences(this).setDefaultAccount(mAccount);

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
@@ -111,7 +111,7 @@ public class AccountSetupOptions extends K9Activity implements OnClickListener {
         mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
 
         mNotifyView.setChecked(mAccount.isNotifyNewMail());
-        mNotifySyncView.setChecked(mAccount.isShowOngoing());
+        mNotifySyncView.setChecked(mAccount.isNotifySync());
         SpinnerOption.setSpinnerOptionValue(mCheckFrequencyView, mAccount
                                             .getAutomaticCheckIntervalMinutes());
         SpinnerOption.setSpinnerOptionValue(mDisplayCountView, mAccount
@@ -131,7 +131,7 @@ public class AccountSetupOptions extends K9Activity implements OnClickListener {
     private void onDone() {
         mAccount.setDescription(mAccount.getEmail());
         mAccount.setNotifyNewMail(mNotifyView.isChecked());
-        mAccount.setShowOngoing(mNotifySyncView.isChecked());
+        mAccount.setNotifySync(mNotifySyncView.isChecked());
         mAccount.setAutomaticCheckIntervalMinutes((Integer)((SpinnerOption)mCheckFrequencyView
                 .getSelectedItem()).value);
         mAccount.setDisplayCount((Integer)((SpinnerOption)mDisplayCountView

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
@@ -143,7 +143,7 @@ public class AccountSetupOptions extends K9Activity implements OnClickListener {
             mAccount.setFolderPushMode(Account.FolderMode.NONE);
         }
 
-        mAccount.save();
+        Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
         if (mAccount.equals(Preferences.getPreferences(this).getDefaultAccount()) ||
                 getIntent().getBooleanExtra(EXTRA_MAKE_DEFAULT, false)) {
             Preferences.getPreferences(this).setDefaultAccount(mAccount);

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -459,7 +459,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (resultCode == RESULT_OK) {
             if (Intent.ACTION_EDIT.equals(getIntent().getAction())) {
-                mAccount.save(Preferences.getPreferences(this));
+                mAccount.save();
                 finish();
             } else {
                 AccountSetupOptions.actionOptions(this, mAccount, mMakeDefault);

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -460,7 +460,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     public void onActivityResult(int requestCode, int resultCode, Intent data) {
         if (resultCode == RESULT_OK) {
             if (Intent.ACTION_EDIT.equals(getIntent().getAction())) {
-                mAccount.save();
+                Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
                 finish();
             } else {
                 AccountSetupOptions.actionOptions(this, mAccount, mMakeDefault);

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -27,6 +27,7 @@ import android.widget.Toast;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.DI;
+import com.fsck.k9.LocalKeyStoreManager;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.backend.BackendManager;
 import com.fsck.k9.preferences.Protocols;
@@ -490,7 +491,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         int newPort = Integer.parseInt(mPortView.getText().toString());
         ServerSettings server = new ServerSettings(Protocols.SMTP, newHost, newPort, securityType, authType, username, password, clientCertificateAlias);
         uri = backendManager.createTransportUri(server);
-        mAccount.deleteCertificate(newHost, newPort, MailServerDirection.OUTGOING);
+        DI.get(LocalKeyStoreManager.class).deleteCertificate(mAccount, newHost, newPort, MailServerDirection.OUTGOING);
         mAccount.setTransportUri(uri);
         AccountSetupCheckSettings.actionCheckSettings(this, mAccount, CheckDirection.OUTGOING);
     }

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/FolderSettings.java
@@ -12,6 +12,7 @@ import android.preference.Preference;
 import com.fsck.k9.Account;
 import com.fsck.k9.DI;
 import com.fsck.k9.Preferences;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.activity.FolderInfoHolder;
 import com.fsck.k9.activity.K9PreferenceActivity;
@@ -64,7 +65,7 @@ public class FolderSettings extends K9PreferenceActivity {
         Account mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
 
         try {
-            LocalStore localStore = mAccount.getLocalStore();
+            LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(mAccount);
             mFolder = localStore.getFolder(folderServerId);
             mFolder.open(Folder.OPEN_MODE_RW);
         } catch (MessagingException me) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -838,7 +838,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             account.setSortAscending(this.sortType, this.sortAscending);
             sortDateAscending = account.isSortAscending(SortType.SORT_DATE);
 
-            account.save(preferences);
+            account.save();
         } else {
             K9.setSortType(this.sortType);
 
@@ -2442,7 +2442,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         boolean allowRemoteSearch = false;
         final Account searchAccount = account;
         if (searchAccount != null) {
-            allowRemoteSearch = searchAccount.allowRemoteSearch();
+            allowRemoteSearch = searchAccount.isAllowRemoteSearch();
         }
 
         return allowRemoteSearch;

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -838,7 +838,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             account.setSortAscending(this.sortType, this.sortAscending);
             sortDateAscending = account.isSortAscending(SortType.SORT_DATE);
 
-            account.save();
+            Preferences.getPreferences(getContext()).saveAccount(account);
         } else {
             K9.setSortType(this.sortType);
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MlfUtils.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MlfUtils.java
@@ -7,6 +7,7 @@ import android.database.Cursor;
 import android.text.TextUtils;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.DI;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessageReference;
 import com.fsck.k9.helper.Utility;
@@ -15,6 +16,7 @@ import com.fsck.k9.mail.Folder;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalStore;
+import com.fsck.k9.mailstore.LocalStoreProvider;
 
 import static com.fsck.k9.fragment.MLFProjectionInfo.SENDER_LIST_COLUMN;
 
@@ -22,7 +24,7 @@ import static com.fsck.k9.fragment.MLFProjectionInfo.SENDER_LIST_COLUMN;
 public class MlfUtils {
 
     static LocalFolder getOpenFolder(String folderServerId, Account account) throws MessagingException {
-        LocalStore localStore = account.getLocalStore();
+        LocalStore localStore = DI.get(LocalStoreProvider.class).getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderServerId);
         localFolder.open(Folder.OPEN_MODE_RO);
         return localFolder;

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -118,7 +118,7 @@ public class MessageTopView extends LinearLayout {
                 containerView, false);
         containerView.addView(view);
 
-        boolean hideUnsignedTextDivider = account.getOpenPgpHideSignOnly();
+        boolean hideUnsignedTextDivider = account.isOpenPgpHideSignOnly();
         view.displayMessageViewContainer(messageViewInfo, new OnRenderingFinishedListener() {
             @Override
             public void onLoadFinished() {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -19,7 +19,7 @@ class AccountSettingsDataStore(
         return when (key) {
             "account_default" -> account == preferences.defaultAccount
             "mark_message_as_read_on_view" -> account.isMarkMessageAsReadOnView
-            "account_sync_remote_deletetions" -> account.isSyncRemoteDeletions()
+            "account_sync_remote_deletetions" -> account.isSyncRemoteDeletions
             "push_poll_on_connect" -> account.isPushPollOnConnect
             "always_show_cc_bcc" -> account.isAlwaysShowCcBcc
             "message_read_receipt" -> account.isMessageReadReceipt
@@ -32,11 +32,11 @@ class AccountSettingsDataStore(
             "account_vibrate" -> account.notificationSetting.isVibrateEnabled
             "account_led" -> account.notificationSetting.isLedEnabled
             "account_notify_sync" -> account.isNotifySync
-            "notification_opens_unread" -> account.isGoToUnreadMessageSearch()
-            "remote_search_enabled" -> account.isAllowRemoteSearch()
+            "notification_opens_unread" -> account.isGoToUnreadMessageSearch
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject
             "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts
+            "remote_search_enabled" -> account.isAllowRemoteSearch
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual
             "upload_sent_messages" -> account.isUploadSentMessages
             else -> defValue
@@ -52,21 +52,21 @@ class AccountSettingsDataStore(
                 return
             }
             "mark_message_as_read_on_view" -> account.isMarkMessageAsReadOnView = value
-            "account_sync_remote_deletetions" -> account.setSyncRemoteDeletions(value)
+            "account_sync_remote_deletetions" -> account.isSyncRemoteDeletions = value
             "push_poll_on_connect" -> account.isPushPollOnConnect = value
             "always_show_cc_bcc" -> account.isAlwaysShowCcBcc = value
-            "message_read_receipt" -> account.setMessageReadReceipt(value)
+            "message_read_receipt" -> account.isMessageReadReceipt = value
             "default_quoted_text_shown" -> account.isDefaultQuotedTextShown = value
             "reply_after_quote" -> account.isReplyAfterQuote = value
             "strip_signature" -> account.isStripSignature = value
             "account_notify" -> account.isNotifyNewMail = value
             "account_notify_self" -> account.isNotifySelfNewMail = value
             "account_notify_contacts_mail_only" -> account.isNotifyContactsMailOnly = value
-            "account_vibrate" -> account.notificationSetting.setVibrate(value)
+            "account_vibrate" -> account.notificationSetting.isVibrateEnabled = value
             "account_led" -> account.notificationSetting.setLed(value)
             "account_notify_sync" -> account.isNotifySync = value
-            "notification_opens_unread" -> account.setGoToUnreadMessageSearch(value)
-            "remote_search_enabled" -> account.setAllowRemoteSearch(value)
+            "notification_opens_unread" -> account.isGoToUnreadMessageSearch = value
+            "remote_search_enabled" -> account.isAllowRemoteSearch = value
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly = value
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject = value
             "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts = value

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -19,7 +19,7 @@ class AccountSettingsDataStore(
         return when (key) {
             "account_default" -> account == preferences.defaultAccount
             "mark_message_as_read_on_view" -> account.isMarkMessageAsReadOnView
-            "account_sync_remote_deletetions" -> account.syncRemoteDeletions()
+            "account_sync_remote_deletetions" -> account.isSyncRemoteDeletions()
             "push_poll_on_connect" -> account.isPushPollOnConnect
             "always_show_cc_bcc" -> account.isAlwaysShowCcBcc
             "message_read_receipt" -> account.isMessageReadReceiptAlways
@@ -32,11 +32,11 @@ class AccountSettingsDataStore(
             "account_vibrate" -> account.notificationSetting.isVibrateEnabled
             "account_led" -> account.notificationSetting.isLedEnabled
             "account_notify_sync" -> account.isShowOngoing
-            "notification_opens_unread" -> account.goToUnreadMessageSearch()
-            "remote_search_enabled" -> account.allowRemoteSearch()
-            "openpgp_hide_sign_only" -> account.openPgpHideSignOnly
-            "openpgp_encrypt_subject" -> account.openPgpEncryptSubject
-            "openpgp_encrypt_all_drafts" -> account.openPgpEncryptAllDrafts
+            "notification_opens_unread" -> account.isGoToUnreadMessageSearch()
+            "remote_search_enabled" -> account.isAllowRemoteSearch()
+            "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly
+            "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject
+            "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual
             "upload_sent_messages" -> account.isUploadSentMessages
             else -> defValue
@@ -67,9 +67,9 @@ class AccountSettingsDataStore(
             "account_notify_sync" -> account.isShowOngoing = value
             "notification_opens_unread" -> account.setGoToUnreadMessageSearch(value)
             "remote_search_enabled" -> account.setAllowRemoteSearch(value)
-            "openpgp_hide_sign_only" -> account.openPgpHideSignOnly = value
-            "openpgp_encrypt_subject" -> account.openPgpEncryptSubject = value
-            "openpgp_encrypt_all_drafts" -> account.openPgpEncryptAllDrafts = value
+            "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly = value
+            "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject = value
+            "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts = value
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual = value
             "upload_sent_messages" -> account.isUploadSentMessages = value
             else -> return
@@ -218,7 +218,7 @@ class AccountSettingsDataStore(
     }
 
     private fun saveSettings() {
-        account.save(preferences)
+        account.save()
     }
 
     private fun reschedulePoll() {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -218,7 +218,7 @@ class AccountSettingsDataStore(
     }
 
     private fun saveSettings() {
-        account.save()
+        preferences.saveAccount(account)
     }
 
     private fun reschedulePoll() {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -22,7 +22,7 @@ class AccountSettingsDataStore(
             "account_sync_remote_deletetions" -> account.isSyncRemoteDeletions()
             "push_poll_on_connect" -> account.isPushPollOnConnect
             "always_show_cc_bcc" -> account.isAlwaysShowCcBcc
-            "message_read_receipt" -> account.isMessageReadReceiptAlways
+            "message_read_receipt" -> account.isMessageReadReceipt
             "default_quoted_text_shown" -> account.isDefaultQuotedTextShown
             "reply_after_quote" -> account.isReplyAfterQuote
             "strip_signature" -> account.isStripSignature
@@ -31,7 +31,7 @@ class AccountSettingsDataStore(
             "account_notify_contacts_mail_only" -> account.isNotifyContactsMailOnly
             "account_vibrate" -> account.notificationSetting.isVibrateEnabled
             "account_led" -> account.notificationSetting.isLedEnabled
-            "account_notify_sync" -> account.isShowOngoing
+            "account_notify_sync" -> account.isNotifySync
             "notification_opens_unread" -> account.isGoToUnreadMessageSearch()
             "remote_search_enabled" -> account.isAllowRemoteSearch()
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly
@@ -64,7 +64,7 @@ class AccountSettingsDataStore(
             "account_notify_contacts_mail_only" -> account.isNotifyContactsMailOnly = value
             "account_vibrate" -> account.notificationSetting.setVibrate(value)
             "account_led" -> account.notificationSetting.setLed(value)
-            "account_notify_sync" -> account.isShowOngoing = value
+            "account_notify_sync" -> account.isNotifySync = value
             "notification_opens_unread" -> account.setGoToUnreadMessageSearch(value)
             "remote_search_enabled" -> account.setAllowRemoteSearch(value)
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly = value

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -194,13 +194,7 @@ class AccountSettingsDataStore(
             "account_vibrate_pattern" -> account.notificationSetting.vibratePattern = value.toInt()
             "account_vibrate_times" -> account.notificationSetting.vibrateTimes = value.toInt()
             "account_remote_search_num_results" -> account.remoteSearchNumResults = value.toInt()
-            "local_storage_provider" -> {
-                executorService.execute {
-                    account.localStorageProviderId = value
-                    saveSettings()
-                }
-                return
-            }
+            "local_storage_provider" -> account.localStorageProviderId = value
             "account_ringtone" -> with(account.notificationSetting) {
                 isRingEnabled = true
                 ringtone = value

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
@@ -332,7 +332,7 @@ public class OpenPgpAppSelectDialog extends FragmentActivity {
 
     private void persistOpenPgpProviderSetting(String selectedPackage) {
         account.setOpenPgpProvider(selectedPackage);
-        account.save(Preferences.getPreferences(this));
+        account.save();
     }
 
     public void onDismissApgDialog() {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
@@ -332,7 +332,7 @@ public class OpenPgpAppSelectDialog extends FragmentActivity {
 
     private void persistOpenPgpProviderSetting(String selectedPackage) {
         account.setOpenPgpProvider(selectedPackage);
-        account.save();
+        Preferences.getPreferences(getApplicationContext()).saveAccount(account);
     }
 
     public void onDismissApgDialog() {

--- a/mail/common/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
@@ -4,7 +4,7 @@ package com.fsck.k9.mail.store;
 import com.fsck.k9.mail.NetworkType;
 
 public interface StoreConfig {
-    boolean subscribedFoldersOnly();
+    boolean isSubscribedFoldersOnly();
     boolean useCompression(NetworkType type);
 
     String getInboxFolder();
@@ -13,7 +13,7 @@ public interface StoreConfig {
 
     int getMaximumAutoDownloadMessageSize();
 
-    boolean allowRemoteSearch();
+    boolean isAllowRemoteSearch();
     boolean isRemoteSearchFullText();
 
     boolean isPushPollOnConnect();

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.java
@@ -1399,7 +1399,7 @@ public class ImapFolder extends Folder<ImapMessage> {
     public List<ImapMessage> search(final String queryString, final Set<Flag> requiredFlags,
             final Set<Flag> forbiddenFlags) throws MessagingException {
 
-        if (!store.getStoreConfig().allowRemoteSearch()) {
+        if (!store.getStoreConfig().isAllowRemoteSearch()) {
             throw new MessagingException("Your settings do not allow remote searching of this account");
         }
 

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -126,7 +126,7 @@ public class ImapStore extends RemoteStore {
         try {
             List<FolderListItem> folders = listFolders(connection, false);
 
-            if (!mStoreConfig.subscribedFoldersOnly()) {
+            if (!mStoreConfig.isSubscribedFoldersOnly()) {
                 return getFolders(folders);
             }
 

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapFolderTest.java
@@ -1067,7 +1067,7 @@ public class ImapFolderTest {
     public void search_withFullTextSearchEnabled_shouldIssueRespectiveCommand() throws Exception {
         ImapFolder folder = createFolder("Folder");
         prepareImapFolderForOpen(OPEN_MODE_RO);
-        when(storeConfig.allowRemoteSearch()).thenReturn(true);
+        when(storeConfig.isAllowRemoteSearch()).thenReturn(true);
         when(storeConfig.isRemoteSearchFullText()).thenReturn(true);
         setupUidSearchResponses("1 OK SEARCH completed");
 
@@ -1080,7 +1080,7 @@ public class ImapFolderTest {
     public void search_withFullTextSearchDisabled_shouldIssueRespectiveCommand() throws Exception {
         ImapFolder folder = createFolder("Folder");
         prepareImapFolderForOpen(OPEN_MODE_RO);
-        when(storeConfig.allowRemoteSearch()).thenReturn(true);
+        when(storeConfig.isAllowRemoteSearch()).thenReturn(true);
         when(storeConfig.isRemoteSearchFullText()).thenReturn(false);
         setupUidSearchResponses("1 OK SEARCH completed");
 
@@ -1092,7 +1092,7 @@ public class ImapFolderTest {
     @Test
     public void search_withRemoteSearchDisabled_shouldThrow() throws Exception {
         ImapFolder folder = createFolder("Folder");
-        when(storeConfig.allowRemoteSearch()).thenReturn(false);
+        when(storeConfig.isAllowRemoteSearch()).thenReturn(false);
 
         try {
             folder.search("query", Collections.<Flag>emptySet(), Collections.<Flag>emptySet());

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
@@ -142,7 +142,7 @@ public class ImapStoreTest {
 
     @Test
     public void getPersonalNamespaces_withoutSubscribedFoldersOnly() throws Exception {
-        when(storeConfig.subscribedFoldersOnly()).thenReturn(false);
+        when(storeConfig.isSubscribedFoldersOnly()).thenReturn(false);
         ImapConnection imapConnection = mock(ImapConnection.class);
         List<ImapResponse> imapResponses = Arrays.asList(
                 createImapResponse("* LIST (\\HasNoChildren) \".\" \"INBOX\""),
@@ -162,7 +162,7 @@ public class ImapStoreTest {
     @Test
     public void getPersonalNamespaces_withSubscribedFoldersOnly_shouldOnlyReturnExistingSubscribedFolders()
             throws Exception {
-        when(storeConfig.subscribedFoldersOnly()).thenReturn(true);
+        when(storeConfig.isSubscribedFoldersOnly()).thenReturn(true);
         ImapConnection imapConnection = mock(ImapConnection.class);
         List<ImapResponse> lsubResponses = Arrays.asList(
                 createImapResponse("* LSUB (\\HasNoChildren) \".\" \"INBOX\""),


### PR DESCRIPTION
These are the first two commits of #3737, before converting to Kotlin. This already gets rid of 500 lines in Account, and should be reasonable to review as a first step.