### PR TITLE
Disallow Addresses with `null` address part

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/Address.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Address.java
@@ -1,6 +1,7 @@
 
 package com.fsck.k9.mail;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
 import java.io.Serializable;
@@ -28,6 +29,7 @@ public class Address implements Serializable {
      */
     private static final Address[] EMPTY_ADDRESS_ARRAY = new Address[0];
 
+    @NonNull
     private String mAddress;
 
     private String mPersonal;
@@ -46,10 +48,16 @@ public class Address implements Serializable {
     }
 
     private Address(String address, String personal, boolean parse) {
+        if (address == null) {
+            throw new IllegalArgumentException("address");
+        }
         if (parse) {
             Rfc822Token[] tokens =  Rfc822Tokenizer.tokenize(address);
             if (tokens.length > 0) {
                 Rfc822Token token = tokens[0];
+                if (token.getAddress() == null) {
+                    throw new IllegalArgumentException("token.getAddress()");
+                }
                 mAddress = token.getAddress();
                 String name = token.getName();
                 if (!TextUtils.isEmpty(name)) {
@@ -91,6 +99,9 @@ public class Address implements Serializable {
     }
 
     public void setAddress(String address) {
+        if (address == null) {
+            throw new IllegalArgumentException("address");
+        }
         this.mAddress = address;
     }
 
@@ -151,8 +162,7 @@ public class Address implements Serializable {
             }
         } catch (MimeException pe) {
             Timber.e(pe, "MimeException in Address.parse()");
-            //but we do an silent failover : we just use the given string as name with empty address
-            addresses.add(new Address(null, addressList, false));
+            // broken addresses are never added to the resulting array
         }
         return addresses.toArray(EMPTY_ADDRESS_ARRAY);
     }

--- a/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/AddressTest.java
@@ -21,9 +21,7 @@ public class AddressTest {
     public void parse_withMissingEmail__shouldSetPersonal() {
         Address[] addresses = Address.parse("NAME ONLY");
 
-        assertEquals(1, addresses.length);
-        assertEquals(null, addresses[0].getAddress());
-        assertEquals("NAME ONLY", addresses[0].getPersonal());
+        assertEquals(0, addresses.length);
     }
 
     /**
@@ -116,10 +114,9 @@ public class AddressTest {
 
     @Test
     public void hashCode_withoutAddress() throws Exception {
-        Address address = Address.parse("name only")[0];
-        assertNull(address.getAddress());
-        
-        address.hashCode();
+        Address[] addresses = Address.parse("name only");
+
+        assertEquals(0, addresses.length);
     }
 
     @Test
@@ -128,27 +125,6 @@ public class AddressTest {
         assertNull(address.getPersonal());
         
         address.hashCode();
-    }
-
-    @Test
-    public void equals_withoutAddress_matchesSame() throws Exception {
-        Address address = Address.parse("name only")[0];
-        Address address2 = Address.parse("name only")[0];
-        assertNull(address.getAddress());
-
-        boolean result = address.equals(address2);
-
-        assertTrue(result);
-    }
-
-    @Test
-    public void equals_withoutAddress_doesNotMatchWithAddress() throws Exception {
-        Address address = Address.parse("name only")[0];
-        Address address2 = Address.parse("name <alice.example.com>")[0];
-
-        boolean result = address.equals(address2);
-
-        assertFalse(result);
     }
 
     @Test
@@ -170,15 +146,6 @@ public class AddressTest {
         boolean result = address.equals(address2);
 
         assertFalse(result);
-    }
-
-    @Test
-    public void getHostname_withoutAddress_isNull() throws Exception {
-        Address address = Address.parse("Alice")[0];
-
-        String result = address.getHostname();
-
-        assertNull(result);
     }
 
     @Test


### PR DESCRIPTION
This change ensures that Address objects are always created with a valid
`address` part. If an Address contains only `personal` part then it is
silently skipped from parsed list.

Unit tests have been adjusted to this new requirement.

Removed inserting Address with `null` address component introduced in
commit 68cecb168e21364b5015dea3f55b1d315f8202ae.

Fixes #3652.

This PR replaces https://github.com/k9mail/k-9/pull/3739.

See: https://github.com/k9mail/k-9/pull/3739#issuecomment-441242481

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). :white_check_mark:
* Does not break any unit tests. :white_check_mark:
* Contains a reference to the issue that it fixes. :white_check_mark:
* For cosmetic changes add one or multiple images, if possible. N/A


