### PR TITLE
Added colored chip in Unified Inbox widget items

### DIFF
--- a/app/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListRemoteViewFactory.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListRemoteViewFactory.java
@@ -18,9 +18,7 @@ import android.view.View;
 import android.widget.RemoteViews;
 import android.widget.RemoteViewsService;
 
-import com.fsck.k9.Account;
 import com.fsck.k9.K9;
-import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
 import com.fsck.k9.external.MessageProvider;
 
@@ -33,7 +31,8 @@ public class MessageListRemoteViewFactory implements RemoteViewsService.RemoteVi
             MessageProvider.MessageColumns.PREVIEW,
             MessageProvider.MessageColumns.UNREAD,
             MessageProvider.MessageColumns.HAS_ATTACHMENTS,
-            MessageProvider.MessageColumns.URI
+            MessageProvider.MessageColumns.URI,
+            MessageProvider.MessageColumns.ACCOUNT_COLOR,
     };
 
 
@@ -86,11 +85,7 @@ public class MessageListRemoteViewFactory implements RemoteViewsService.RemoteVi
                 boolean unread = toBoolean(cursor.getString(4));
                 boolean hasAttachment = toBoolean(cursor.getString(5));
                 Uri viewUri = Uri.parse(cursor.getString(6));
-
-                String segment = viewUri.getPathSegments().get(0);
-                int index = Integer.parseInt(segment);
-                Account account = Preferences.getPreferences(context.getApplicationContext()).getAccounts().get(index);
-                int color = account.getChipColor();
+                int color = cursor.getInt(7);
 
                 mailItems.add(new MailItem(sender, date, subject, preview, unread, hasAttachment, viewUri, color));
             }

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListRemoteViewFactory.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListRemoteViewFactory.java
@@ -18,7 +18,9 @@ import android.view.View;
 import android.widget.RemoteViews;
 import android.widget.RemoteViewsService;
 
+import com.fsck.k9.Account;
 import com.fsck.k9.K9;
+import com.fsck.k9.Preferences;
 import com.fsck.k9.R;
 import com.fsck.k9.external.MessageProvider;
 
@@ -85,7 +87,12 @@ public class MessageListRemoteViewFactory implements RemoteViewsService.RemoteVi
                 boolean hasAttachment = toBoolean(cursor.getString(5));
                 Uri viewUri = Uri.parse(cursor.getString(6));
 
-                mailItems.add(new MailItem(sender, date, subject, preview, unread, hasAttachment, viewUri));
+                String segment = viewUri.getPathSegments().get(0);
+                int index = Integer.parseInt(segment);
+                Account account = Preferences.getPreferences(context.getApplicationContext()).getAccounts().get(index);
+                int color = account.getChipColor();
+
+                mailItems.add(new MailItem(sender, date, subject, preview, unread, hasAttachment, viewUri, color));
             }
         } finally {
             cursor.close();
@@ -135,6 +142,9 @@ public class MessageListRemoteViewFactory implements RemoteViewsService.RemoteVi
         Intent intent = new Intent();
         intent.setData(item.uri);
         remoteView.setOnClickFillInIntent(R.id.mail_list_item, intent);
+
+        remoteView.setInt(R.id.chip, "setBackgroundColor", item.color);
+
         return remoteView;
     }
 
@@ -180,10 +190,11 @@ public class MessageListRemoteViewFactory implements RemoteViewsService.RemoteVi
         final boolean unread;
         final boolean hasAttachment;
         final Uri uri;
+        final int color;
 
 
         MailItem(String sender, long date, String subject, String preview, boolean unread, boolean hasAttachment,
-                Uri viewUri) {
+                Uri viewUri, int color) {
             this.sender = sender;
             this.date = date;
             this.preview = preview;
@@ -191,6 +202,7 @@ public class MessageListRemoteViewFactory implements RemoteViewsService.RemoteVi
             this.unread = unread;
             this.uri = viewUri;
             this.hasAttachment = hasAttachment;
+            this.color = color;
         }
 
         int getTextColor() {

--- a/app/k9mail/src/main/res/layout/message_list_widget_list_item.xml
+++ b/app/k9mail/src/main/res/layout/message_list_widget_list_item.xml
@@ -1,72 +1,86 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/mail_list_item"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:padding="@dimen/widget_padding">
+    tools:background="@color/md_white_1000">
 
+    <!-- A regular View breaks things for some reason, but a TextView does the job -->
     <TextView
-        android:id="@+id/mail_date"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
-        android:layout_marginLeft="4dp"
-        android:layout_marginStart="4dp"
-        tools:text="25 May" />
+        android:id="@+id/chip"
+        android:layout_width="8dip"
+        android:layout_height="match_parent"
+        tools:background="@color/orange"
+        android:visibility="visible" />
 
-    <ImageView
-        android:id="@+id/attachment"
-        android:layout_width="wrap_content"
+    <RelativeLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_alignBottom="@+id/mail_date"
-        android:layout_centerInParent="true"
-        android:layout_marginLeft="4dp"
-        android:layout_marginStart="4dp"
-        android:layout_toLeftOf="@+id/mail_date"
-        android:layout_toStartOf="@+id/mail_date"
-        android:src="@drawable/ic_email_attachment_small"
-        android:visibility="gone"
-        tools:visibility="visible" />
+        android:padding="@dimen/widget_padding">
 
-    <TextView
-        android:id="@+id/sender"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentTop="true"
-        android:layout_gravity="start"
-        android:layout_toLeftOf="@id/attachment"
-        android:layout_toStartOf="@id/attachment"
-        android:maxLines="1"
-        android:ellipsize="end"
-        android:textSize="16sp"
-        tools:text="Kinda long subject that should be long enough to exceed the available display space" />
+        <TextView
+            android:id="@+id/mail_date"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentEnd="true"
+            android:layout_alignParentRight="true"
+            android:layout_marginStart="4dp"
+            android:layout_marginLeft="4dp"
+            tools:text="25 May" />
 
-    <TextView
-        android:id="@+id/mail_subject"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/sender"
-        android:maxLines="1"
-        android:ellipsize="end"
-        android:paddingBottom="2dp"
-        android:textSize="15sp"
-        tools:text="Wikipedia" />
+        <ImageView
+            android:id="@+id/attachment"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignBottom="@+id/mail_date"
+            android:layout_centerInParent="true"
+            android:layout_marginStart="4dp"
+            android:layout_marginLeft="4dp"
+            android:layout_toStartOf="@+id/mail_date"
+            android:layout_toLeftOf="@+id/mail_date"
+            android:src="@drawable/ic_email_attachment_small"
+            android:visibility="gone"
+            tools:visibility="visible" />
 
-    <TextView
-        android:id="@+id/mail_preview"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_alignParentLeft="true"
-        android:layout_alignParentStart="true"
-        android:layout_below="@+id/mail_subject"
-        android:maxLines="1"
-        android:textSize="13sp"
-        tools:text="Towel Day is celebrated every year on 25 May as a tribute to the author Douglas Adams by his fans." />
+        <TextView
+            android:id="@+id/sender"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
+            android:layout_alignParentTop="true"
+            android:layout_gravity="start"
+            android:layout_toStartOf="@id/attachment"
+            android:layout_toLeftOf="@id/attachment"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:textSize="16sp"
+            tools:text="Kinda long subject that should be long enough to exceed the available display space" />
 
-</RelativeLayout>
+        <TextView
+            android:id="@+id/mail_subject"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/sender"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
+            android:ellipsize="end"
+            android:maxLines="1"
+            android:paddingBottom="2dp"
+            android:textSize="15sp"
+            tools:text="Wikipedia" />
+
+        <TextView
+            android:id="@+id/mail_preview"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_below="@+id/mail_subject"
+            android:layout_alignParentStart="true"
+            android:layout_alignParentLeft="true"
+            android:maxLines="1"
+            android:textSize="13sp"
+            tools:text="Towel Day is celebrated every year on 25 May as a tribute to the author Douglas Adams by his fans." />
+
+    </RelativeLayout>
+</LinearLayout>


### PR DESCRIPTION
I added the feature mentioned in #3758. The result:

![k-9_1](https://user-images.githubusercontent.com/17316999/49138035-6aa2ea00-f2ee-11e8-8653-e6d15f1be88c.png)

Personally I am not fond of the way I implemented it: I feel I should be using an account UUID instead of getting the index of the account from the URI. However, I haven't figured out yet how to retrieve the correct UUID.

I am also using a `TextView` instead of a regular `View` because otherwise the items won't render for some reason.

Closes #3758 