### PR TITLE
(WIP) Change minSdkVersion to 19, use Storage Access Framework for attachments/images 

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.java
+++ b/app/core/src/main/java/com/fsck/k9/K9.java
@@ -916,6 +916,9 @@ public class K9 {
         hideHostnameWhenConnecting = state;
     }
 
+    /**
+     * @return Either a document uri on devices > Lollipop or a path on older devices
+     */
     public static String getAttachmentDefaultPath() {
         return attachmentDefaultPath;
     }

--- a/app/core/src/main/java/com/fsck/k9/helper/FileHelper.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/FileHelper.java
@@ -11,6 +11,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Locale;
 
 import timber.log.Timber;
@@ -79,8 +81,14 @@ public class FileHelper {
      * and a number to the given filename.
      */
     public static DocumentFile createUniqueFile(DocumentFile directory, String filename, String mimeType) {
+        DocumentFile[] folderFiles = directory.listFiles();
+        ArrayList<String> nameList = new ArrayList<String>();
+        for (DocumentFile file: folderFiles) {
+            nameList.add(file.getName());
+        }
+
         DocumentFile file = directory.createFile(mimeType, filename);
-        if (file != null && file.exists()) {
+        if (file != null && !nameList.contains(filename)) {
             return file;
         }
         // Get the extension of the file, if any.
@@ -95,8 +103,9 @@ public class FileHelper {
             extension = "";
         }
         for (int i = 2; i < Integer.MAX_VALUE; i++) {
-            file = directory.createFile(mimeType, String.format(Locale.US, "%s-%d%s", name, i, extension));
-            if (file != null && file.exists()) {
+            String newFilename = String.format(Locale.US, "%s-%d%s", name, i, extension);
+            file = directory.createFile(mimeType, newFilename);
+            if (file != null && !nameList.contains(newFilename)) {
                 return file;
             }
         }

--- a/app/core/src/main/java/com/fsck/k9/helper/FileHelper.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/FileHelper.java
@@ -1,6 +1,8 @@
 package com.fsck.k9.helper;
 
 
+import android.support.v4.provider.DocumentFile;
+
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -61,6 +63,35 @@ public class FileHelper {
         }
         for (int i = 2; i < Integer.MAX_VALUE; i++) {
             file = new File(directory, String.format(Locale.US, "%s-%d%s", name, i, extension));
+            if (!file.exists()) {
+                return file;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Creates a unique file in the given directory by appending a hyphen
+     * and a number to the given filename.
+     */
+    public static DocumentFile createUniqueFile(DocumentFile directory, String filename, String mimeType) {
+        DocumentFile file = directory.createFile(mimeType, filename);
+        if (!file.exists()) {
+            return file;
+        }
+        // Get the extension of the file, if any.
+        int index = filename.lastIndexOf('.');
+        String name;
+        String extension;
+        if (index != -1) {
+            name = filename.substring(0, index);
+            extension = filename.substring(index);
+        } else {
+            name = filename;
+            extension = "";
+        }
+        for (int i = 2; i < Integer.MAX_VALUE; i++) {
+            file = directory.createFile(mimeType, String.format(Locale.US, "%s-%d%s", name, i, extension));
             if (!file.exists()) {
                 return file;
             }

--- a/app/core/src/main/java/com/fsck/k9/helper/FileHelper.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/FileHelper.java
@@ -1,6 +1,10 @@
 package com.fsck.k9.helper;
 
 
+import android.content.Context;
+import android.content.UriPermission;
+import android.net.Uri;
+import android.os.Build;
 import android.support.v4.provider.DocumentFile;
 
 import java.io.File;
@@ -76,7 +80,7 @@ public class FileHelper {
      */
     public static DocumentFile createUniqueFile(DocumentFile directory, String filename, String mimeType) {
         DocumentFile file = directory.createFile(mimeType, filename);
-        if (!file.exists()) {
+        if (file != null && file.exists()) {
             return file;
         }
         // Get the extension of the file, if any.
@@ -92,7 +96,7 @@ public class FileHelper {
         }
         for (int i = 2; i < Integer.MAX_VALUE; i++) {
             file = directory.createFile(mimeType, String.format(Locale.US, "%s-%d%s", name, i, extension));
-            if (!file.exists()) {
+            if (file != null && file.exists()) {
                 return file;
             }
         }
@@ -243,4 +247,25 @@ public class FileHelper {
     public static String sanitizeFilename(String filename) {
         return filename.replaceAll(INVALID_CHARACTERS, REPLACEMENT_CHARACTER);
     }
+
+
+    /**
+     * Checks if the given uri is present in getContentResolver().getPersistedUriPermissions()
+     *
+     * @param context A context
+     * @param dirUri The uri to check
+     * @return True if the uri is present
+     */
+    public static boolean isDocumentTreePermissionGranted(Context context, Uri dirUri) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.KITKAT)
+            return false;
+
+
+        for (UriPermission permission : context.getContentResolver().getPersistedUriPermissions()) {
+            if (permission.isWritePermission() && permission.getUri().equals(dirUri))
+                return true;
+        }
+        return false;
+    }
+
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
@@ -5,6 +5,8 @@ import android.net.Uri;
 
 import com.fsck.k9.mail.Part;
 
+import java.net.URI;
+
 
 public class AttachmentViewInfo {
     public static final long UNKNOWN_SIZE = -1;
@@ -19,6 +21,8 @@ public class AttachmentViewInfo {
      * Note: All content providers must support an alternative MIME type appended as last URI segment.
      */
     public final Uri internalUri;
+    public final Uri outputUri;
+
     public final boolean inlineAttachment;
     public final Part part;
     private boolean contentAvailable;

--- a/app/core/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
@@ -21,7 +21,6 @@ public class AttachmentViewInfo {
      * Note: All content providers must support an alternative MIME type appended as last URI segment.
      */
     public final Uri internalUri;
-    public final Uri outputUri;
 
     public final boolean inlineAttachment;
     public final Part part;

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
@@ -145,6 +145,8 @@ public class AttachmentController {
         String filename = FileHelper.sanitizeFilename(attachment.displayName);
         File file = FileHelper.createUniqueFile(directory, filename);
 
+        //TODO: LOL
+
         writeAttachmentToStorage(file);
 
         addSavedAttachmentToDownloadsDatabase(file);
@@ -156,6 +158,22 @@ public class AttachmentController {
         InputStream in = context.getContentResolver().openInputStream(attachment.internalUri);
         try {
             OutputStream out = new FileOutputStream(file);
+            try {
+                IOUtils.copy(in, out);
+                out.flush();
+            } finally {
+                out.close();
+            }
+        } finally {
+            in.close();
+        }
+    }
+
+    private void writeAttachmentToStorage(Uri file_uri) throws IOException {
+        InputStream in = context.getContentResolver().openInputStream(attachment.internalUri);
+        context.getContentResolver().open
+        try {
+            OutputStream out = context.getContentResolver().openOutputStream(file_uri);
             try {
                 IOUtils.copy(in, out);
                 out.flush();

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/AttachmentController.java
@@ -66,12 +66,27 @@ public class AttachmentController {
         }
     }
 
-    public void saveAttachment() {
-        saveAttachmentTo(K9.getAttachmentDefaultPath());
+    public void saveAttachmentToFolderLegacy() {
+        //Save to default directory
+        saveAttachmentToFolder(K9.getAttachmentDefaultPath());
     }
 
-    public void saveAttachmentTo(String directory) {
+    public void saveAttachmentToFolder(String directory) {
         saveAttachmentTo(new File(directory));
+    }
+
+
+    public void saveAttachmentToFile(DocumentFile fileUri) {
+        saveAttachmentTo(fileUri);
+    }
+
+    public void saveAttachmentToFolder() {
+        //create file
+        String filename = FileHelper.sanitizeFilename(attachment.displayName);
+        DocumentFile pickedDir = DocumentFile.fromTreeUri(context, Uri.parse(K9.getAttachmentDefaultPath()));
+        DocumentFile newFile = FileHelper.createUniqueFile(pickedDir, filename, attachment.mimeType);
+
+        saveAttachmentTo(newFile);
     }
 
 
@@ -148,7 +163,7 @@ public class AttachmentController {
         }
     }
 
-    public void saveAttachmentTo(DocumentFile fileUri) {
+    private void saveAttachmentTo(DocumentFile fileUri) {
         if (!attachment.isContentAvailable()) {
             downloadAndSaveAttachmentTo((LocalPart) attachment.part,fileUri);
         } else {
@@ -164,7 +179,10 @@ public class AttachmentController {
 
     private DocumentFile saveAttachmentWithUniqueFileName(DocumentFile fileUri) throws IOException {
         writeAttachmentToStorage(fileUri);
-        addSavedAttachmentToDownloadsDatabase(fileUri);
+        if (fileUri.isFile()) {
+            addSavedAttachmentToDownloadsDatabase(fileUri);
+        }
+
 
         return fileUri;
     }

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -502,8 +502,11 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                     getApplicationContext().getContentResolver().takePersistableUriPermission(uriTree, takeFlags);
                 }
 
-                Timber.i("ACTIVITY_SAVE_ATTACHMENT_TREE uri " + uriTree.getPath());
+                K9.setAttachmentDefaultPath(documentFile.getUri().toString());
+                K9.saveSettingsAsync();
 
+                Timber.i("ACTIVITY_SAVE_ATTACHMENT_TREE uri " + uriTree.getPath());
+                getAttachmentController(currentAttachmentViewInfo).saveAttachmentToFolder();
         }
     }
 
@@ -857,7 +860,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             //Save to SAF Dir
-            if (FileHelper.isDocumentTreePermissionGranted(getApplicationContext(), Uri.parse(K9.getAttachmentDefaultPath()))){
+            if (FileHelper.isDocumentTreePermissionGranted(getApplicationContext(), Uri.parse(K9.getAttachmentDefaultPath()))) {
                 getAttachmentController(attachment).saveAttachmentToFolder();
             } else {
                 //Request a new (peristent) folder
@@ -866,7 +869,6 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                 intent.addFlags(Intent.FLAG_GRANT_PERSISTABLE_URI_PERMISSION);
                 startActivityForResult(intent, ACTIVITY_SAVE_ATTACHMENT_TREE);
             }
-
 
 
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -19,6 +19,7 @@ import android.os.SystemClock;
 import android.support.v4.app.DialogFragment;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.provider.DocumentFile;
 import android.text.TextUtils;
 import android.view.ContextThemeWrapper;
 import android.view.KeyEvent;
@@ -66,7 +67,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     private static final int ACTIVITY_CHOOSE_FOLDER_COPY = 2;
     private static final int ACTIVITY_CHOOSE_DIRECTORY = 3;
 
-    private static final int ACTIVITY_SAVE_ATTACHMENT = 3;
+    private static final int ACTIVITY_SAVE_ATTACHMENT = 4;
 
     public static final int REQUEST_MASK_LOADER_HELPER = (1 << 8);
     public static final int REQUEST_MASK_CRYPTO_PRESENTER = (1 << 9);
@@ -478,6 +479,15 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                 }
                 break;
             }
+
+            case ACTIVITY_SAVE_ATTACHMENT:
+                Uri documentsUri = data.getData();
+                DocumentFile file = DocumentFile.fromSingleUri(getApplicationContext(), documentsUri);
+
+                Timber.i("ACTIVITY_SAVE_ATTACHMENT uri " + documentsUri.getPath());
+                getAttachmentController(currentAttachmentViewInfo).saveAttachmentTo(file);
+
+                break;
         }
     }
 
@@ -823,8 +833,8 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
             Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
             intent.addCategory(Intent.CATEGORY_OPENABLE);
-            intent.setType(mimeType);
-            intent.putExtra(Intent.EXTRA_TITLE, fileName);
+            intent.setType(currentAttachmentViewInfo.mimeType);
+            intent.putExtra(Intent.EXTRA_TITLE, currentAttachmentViewInfo.displayName);
 
             startActivityForResult(intent, ACTIVITY_SAVE_ATTACHMENT);
         } else {

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -11,6 +11,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
 import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
@@ -32,6 +33,7 @@ import com.fsck.k9.Account;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.K9ActivityCommon;
+import com.fsck.k9.preferences.SettingsExporter;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.activity.ChooseFolder;
 import com.fsck.k9.activity.MessageLoaderHelper;
@@ -64,8 +66,13 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     private static final int ACTIVITY_CHOOSE_FOLDER_COPY = 2;
     private static final int ACTIVITY_CHOOSE_DIRECTORY = 3;
 
+    private static final int ACTIVITY_SAVE_ATTACHMENT = 3;
+
     public static final int REQUEST_MASK_LOADER_HELPER = (1 << 8);
     public static final int REQUEST_MASK_CRYPTO_PRESENTER = (1 << 9);
+
+
+
 
     public static final int PROGRESS_THRESHOLD_MILLIS = 500 * 1000;
 
@@ -808,10 +815,21 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         getAttachmentController(attachment).viewAttachment();
     }
 
+
     @Override
     public void onSaveAttachment(AttachmentViewInfo attachment) {
         currentAttachmentViewInfo = attachment;
-        getAttachmentController(attachment).saveAttachment();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
+            Intent intent = new Intent(Intent.ACTION_CREATE_DOCUMENT);
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType(mimeType);
+            intent.putExtra(Intent.EXTRA_TITLE, fileName);
+
+            startActivityForResult(intent, ACTIVITY_SAVE_ATTACHMENT);
+        } else {
+            getAttachmentController(attachment).saveAttachment();
+        }
     }
 
     @Override

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
@@ -120,12 +120,6 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
             REQUEST_PICK_DIRECTORY_URI_TREE -> {
                 val uriTree = result.getData()
                 val documentFile = DocumentFile.fromTreeUri(getContext(), uriTree)
-                val takeFlags = result.getFlags() and (Intent.FLAG_GRANT_READ_URI_PERMISSION or Intent.FLAG_GRANT_WRITE_URI_PERMISSION)
-
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {
-                    getContext()!!.getContentResolver().takePersistableUriPermission(uriTree, takeFlags)
-
-                }
 
                 Timber.i("ACTIVITY_SAVE_ATTACHMENT_TREE uri " + uriTree.toString())
                 setAttachmentDefaultPath(uriTree.toString())


### PR DESCRIPTION
Introduces saving of attachments with the Storage access framework. It also bumps the MinSdkVersion to 19 (Kitkat) to remove the legacy file saving code (Mainly FileBrowser) for attachments and setting export. With this change the only usage of the storage permission should be the use of external mail database. 

Current behaviour of this PR for saving attachments:
On Kitkat: Saving with simple/long press is handled via `ACTION_CREATE_DOCUMENT`
On >Lollipop: Saving with simple press via `ACTION_OPEN_DOCUMENT_TREE`, On long press with `ACTION_CREATE_DOCUMENT`

ACTION_OPEN_DOCUMENT_TREE will mimic the old behaviour, the user sets a initial directory (or over settings) and the file is saved there. If a file with the name already exists a unique name with -x is created. 

Current behaviour of this PR for saving images:
- On Kitkat: Legacy save
- On Lollipop: Saving via `ACTION_OPEN_DOCUMENT_TREE` on the default attachment location

What is left to do?
- Use`ACTION_CREATE_DOCUMENT`  for saving a image (that would provide a single way to save a file)
- Find a good replacment for the usage of the DownloadManager service. The api does only support paths and no content URIs. 
 I added a toast for now, but I don't feel like this a good way to this. Maybe a own Notification that displays the filename and support the opening of the file? 
- Code and commit log clean-up


Relevant issues: #3752 #2110 
