### PR TITLE
Add ActionBars to activities extending K9PreferenceActivity

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/AppCompatPreferenceActivity.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/AppCompatPreferenceActivity.java
@@ -1,0 +1,126 @@
+package com.fsck.k9.activity;
+/*
+ * Copyright (C) 2014 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import android.content.res.Configuration;
+import android.os.Bundle;
+import android.preference.PreferenceActivity;
+import android.support.annotation.LayoutRes;
+import android.support.annotation.Nullable;
+import android.support.v7.app.ActionBar;
+import android.support.v7.app.AppCompatDelegate;
+import android.support.v7.widget.Toolbar;
+import android.view.MenuInflater;
+import android.view.View;
+import android.view.ViewGroup;
+
+/**
+ * A {@link android.preference.PreferenceActivity} which implements and proxies the necessary calls
+ * to be used with AppCompat.
+ * <p>
+ * This technique can be used with an {@link android.app.Activity} class, not just
+ * {@link android.preference.PreferenceActivity}.
+ */
+public abstract class AppCompatPreferenceActivity extends PreferenceActivity {
+    private AppCompatDelegate mDelegate;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        getDelegate().installViewFactory();
+        getDelegate().onCreate(savedInstanceState);
+        super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    protected void onPostCreate(Bundle savedInstanceState) {
+        super.onPostCreate(savedInstanceState);
+        getDelegate().onPostCreate(savedInstanceState);
+    }
+
+    public ActionBar getSupportActionBar() {
+        return getDelegate().getSupportActionBar();
+    }
+
+    public void setSupportActionBar(@Nullable Toolbar toolbar) {
+        getDelegate().setSupportActionBar(toolbar);
+    }
+
+    @Override
+    public MenuInflater getMenuInflater() {
+        return getDelegate().getMenuInflater();
+    }
+
+    @Override
+    public void setContentView(@LayoutRes int layoutResID) {
+        getDelegate().setContentView(layoutResID);
+    }
+
+    @Override
+    public void setContentView(View view) {
+        getDelegate().setContentView(view);
+    }
+
+    @Override
+    public void setContentView(View view, ViewGroup.LayoutParams params) {
+        getDelegate().setContentView(view, params);
+    }
+
+    @Override
+    public void addContentView(View view, ViewGroup.LayoutParams params) {
+        getDelegate().addContentView(view, params);
+    }
+
+    @Override
+    protected void onPostResume() {
+        super.onPostResume();
+        getDelegate().onPostResume();
+    }
+
+    @Override
+    protected void onTitleChanged(CharSequence title, int color) {
+        super.onTitleChanged(title, color);
+        getDelegate().setTitle(title);
+    }
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        super.onConfigurationChanged(newConfig);
+        getDelegate().onConfigurationChanged(newConfig);
+    }
+
+    @Override
+    protected void onStop() {
+        super.onStop();
+        getDelegate().onStop();
+    }
+
+    @Override
+    protected void onDestroy() {
+        super.onDestroy();
+        getDelegate().onDestroy();
+    }
+
+    public void invalidateOptionsMenu() {
+        getDelegate().invalidateOptionsMenu();
+    }
+
+    private AppCompatDelegate getDelegate() {
+        if (mDelegate == null) {
+            mDelegate = AppCompatDelegate.create(this, null);
+        }
+        return mDelegate;
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/activity/K9PreferenceActivity.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/K9PreferenceActivity.java
@@ -1,6 +1,5 @@
 package com.fsck.k9.activity;
 
-
 import android.arch.lifecycle.Lifecycle;
 import android.arch.lifecycle.Lifecycle.State;
 import android.arch.lifecycle.LifecycleOwner;
@@ -8,13 +7,12 @@ import android.arch.lifecycle.LifecycleRegistry;
 import android.os.Bundle;
 import android.preference.ListPreference;
 import android.preference.Preference;
-import android.preference.PreferenceActivity;
 import android.support.annotation.NonNull;
+import android.view.MenuItem;
 
 import com.fsck.k9.K9;
 
-
-public abstract class K9PreferenceActivity extends PreferenceActivity implements LifecycleOwner {
+public abstract class K9PreferenceActivity extends AppCompatPreferenceActivity implements LifecycleOwner {
     private LifecycleRegistry lifecycleRegistry;
 
     @Override
@@ -24,6 +22,17 @@ public abstract class K9PreferenceActivity extends PreferenceActivity implements
         super.onCreate(icicle);
         lifecycleRegistry = new LifecycleRegistry(this);
         lifecycleRegistry.markState(State.CREATED);
+
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        if (item.getItemId() == android.R.id.home) {
+            onBackPressed();
+            return true;
+        }
+        return super.onOptionsItemSelected(item);
     }
 
     @Override

--- a/app/ui/src/main/res/xml/font_preferences.xml
+++ b/app/ui/src/main/res/xml/font_preferences.xml
@@ -4,14 +4,11 @@
   Make sure to add android:persistent="false" to all preferences to disable saving
   the preference values to SharedPreferences. We use our own storage mechanism for
   the preferences. See com.fsck.k9.preferences.Storage.
-
-  Also note that every sub-PreferenceScreen needs an "android:key" parameter so the correct screen
-  can be displayed after the device has been rotated.
 -->
 
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <PreferenceScreen
+    <PreferenceCategory
         android:title="@string/font_size_account_list"
         android:key="account_list_fonts">
 
@@ -31,9 +28,9 @@
             android:entryValues="@array/font_values"
             android:dialogTitle="@string/font_size_account_description" />
 
-    </PreferenceScreen>
+    </PreferenceCategory>
 
-    <PreferenceScreen
+    <PreferenceCategory
         android:title="@string/font_size_folder_list"
         android:key="folder_list_fonts">
 
@@ -53,9 +50,9 @@
             android:entryValues="@array/font_values"
             android:dialogTitle="@string/font_size_folder_status" />
 
-    </PreferenceScreen>
+    </PreferenceCategory>
 
-    <PreferenceScreen
+    <PreferenceCategory
         android:title="@string/font_size_message_list"
         android:key="message_list_fonts">
 
@@ -91,9 +88,9 @@
             android:entryValues="@array/font_values"
             android:dialogTitle="@string/font_size_message_list_preview" />
 
-    </PreferenceScreen>
+    </PreferenceCategory>
 
-    <PreferenceScreen
+    <PreferenceCategory
         android:title="@string/font_size_message_view"
         android:key="message_view_fonts">
 
@@ -159,9 +156,9 @@
             android:title="@string/font_size_message_view_content"
             android:dialogTitle="@string/font_size_message_view_content" />
 
-    </PreferenceScreen>
+    </PreferenceCategory>
 
-    <PreferenceScreen
+    <PreferenceCategory
         android:title="@string/font_size_message_compose"
         android:key="message_compose_fonts">
 
@@ -173,6 +170,6 @@
             android:entryValues="@array/font_values"
             android:dialogTitle="@string/font_size_message_compose_input" />
 
-    </PreferenceScreen>
+    </PreferenceCategory>
 
 </PreferenceScreen>


### PR DESCRIPTION
I've used [`AppCompatPreferenceActivity`](https://android.googlesource.com/platform/development/+/nougat-release/samples/Support7Demos/src/com/example/android/supportv7/app/AppCompatPreferenceActivity.java) to add ActionBar to preference activities extending K9PreferenceActivity (FontSize settings, UnreadWidget settings, Folder settings).

It works well (see screenshots) although there is one caveat: nested PreferenceScreens do not get the actionbar. From what I can see that's a limitation of `AppCompatPreferenceActivity`. Here, we have only one issue of this kind - in FontSize settings. I've converted them to PreferenceCategories. The question is - is this OK or should I rather look for something that preserves the screen structure? All other solutions I have seen require more boilerplate code, but if someone has a better idea I'd be happy to hear it and rework the PR.

Second issue - it seems I can't get to Folder settings. The folders screen doesn't accept clicks or long clicks. The XML looks flat so it should work by I *didn't test it yet*.

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). :heavy_check_mark: 
* Does not break any unit tests. :heavy_check_mark: 
* Contains a reference to the issue that it fixes. :heavy_check_mark: 
* For cosmetic changes add one or multiple images, if possible. :heavy_check_mark: 

Previously:

![screenshot_1543575489](https://user-images.githubusercontent.com/1718963/49289497-3d983800-f4a4-11e8-8c5b-f3a526979b1b.png)
![screenshot_1543575492](https://user-images.githubusercontent.com/1718963/49289498-3d983800-f4a4-11e8-862f-e1aab80d356a.png)

After this PR:

![screenshot_1543575347](https://user-images.githubusercontent.com/1718963/49289516-4ee14480-f4a4-11e8-8105-e158ad81b785.png)

Resolves #3753.
