### PR TITLE
Clean up LocalKeyStore and related

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Core.kt
+++ b/app/core/src/main/java/com/fsck/k9/Core.kt
@@ -65,7 +65,6 @@ object Core : KoinComponent {
 
     fun init(context: Context) {
         BinaryTempFileBody.setTempDirectory(context.cacheDir)
-        LocalKeyStore.setKeyStoreLocation(context.getDir("KeyStore", Context.MODE_PRIVATE).toString())
 
         setServicesEnabled(context)
         registerReceivers(context)

--- a/app/core/src/main/java/com/fsck/k9/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/KoinModule.kt
@@ -3,6 +3,10 @@ package com.fsck.k9
 import android.content.Context
 import com.fsck.k9.helper.Contacts
 import com.fsck.k9.mail.power.PowerManager
+import com.fsck.k9.mail.ssl.DefaultTrustedSocketFactory
+import com.fsck.k9.mail.ssl.LocalKeyStore
+import com.fsck.k9.mail.ssl.TrustManagerFactory
+import com.fsck.k9.mail.ssl.TrustedSocketFactory
 import com.fsck.k9.mailstore.LocalStoreProvider
 import com.fsck.k9.mailstore.StorageManager
 import com.fsck.k9.power.TracingPowerManager
@@ -15,4 +19,8 @@ val mainModule = applicationContext {
     bean { LocalStoreProvider() }
     bean { TracingPowerManager.getPowerManager(get()) as PowerManager }
     bean { Contacts.getInstance(get()) }
+    bean { LocalKeyStore.createInstance(get()) }
+    bean { TrustManagerFactory.createInstance(get()) }
+    bean { LocalKeyStoreManager(get()) }
+    bean { DefaultTrustedSocketFactory(get(), get()) as TrustedSocketFactory }
 }

--- a/app/core/src/main/java/com/fsck/k9/LocalKeyStoreManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/LocalKeyStoreManager.kt
@@ -7,18 +7,17 @@ import java.security.cert.CertificateException
 import java.security.cert.X509Certificate
 
 class LocalKeyStoreManager(
-        val localKeyStore: LocalKeyStore
+        private val localKeyStore: LocalKeyStore
 ) {
     /**
      * Add a new certificate for the incoming or outgoing server to the local key store.
      */
     @Throws(CertificateException::class)
     fun addCertificate(account: Account, direction: MailServerDirection, certificate: X509Certificate) {
-        val uri: Uri
-        if (direction === MailServerDirection.INCOMING) {
-            uri = Uri.parse(account.storeUri)
+        val uri = if (direction === MailServerDirection.INCOMING) {
+            Uri.parse(account.storeUri)
         } else {
-            uri = Uri.parse(account.transportUri)
+            Uri.parse(account.transportUri)
         }
         localKeyStore.addCertificate(uri.host, uri.port, certificate)
     }
@@ -29,11 +28,10 @@ class LocalKeyStoreManager(
      * old host/port.
      */
     fun deleteCertificate(account: Account, newHost: String, newPort: Int, direction: MailServerDirection) {
-        val uri: Uri
-        if (direction === MailServerDirection.INCOMING) {
-            uri = Uri.parse(account.storeUri)
+        val uri = if (direction === MailServerDirection.INCOMING) {
+            Uri.parse(account.storeUri)
         } else {
-            uri = Uri.parse(account.transportUri)
+            Uri.parse(account.transportUri)
         }
         val oldHost = uri.host
         val oldPort = uri.port

--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -22,8 +22,6 @@ val coreNotificationModule = applicationContext {
         )
     }
     bean { AccountPreferenceSerializer(get(), get()) }
-    bean { LocalKeyStore.getInstance() }
-    bean { LocalKeyStoreManager(get()) }
     bean { CertificateErrorNotifications(get(), get(), get()) }
     bean { AuthenticationErrorNotifications(get(), get(), get()) }
     bean { SyncNotifications(get(), get(), get()) }

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -12,6 +12,7 @@ import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider
 import com.fsck.k9.mail.power.PowerManager
 import com.fsck.k9.mail.ssl.DefaultTrustedSocketFactory
+import com.fsck.k9.mail.ssl.TrustedSocketFactory
 import com.fsck.k9.mail.store.imap.ImapStore
 import com.fsck.k9.mail.transport.smtp.SmtpTransport
 import com.fsck.k9.mail.transport.smtp.SmtpTransportUriCreator
@@ -21,7 +22,8 @@ import com.fsck.k9.mailstore.K9BackendStorageFactory
 class ImapBackendFactory(
         private val context: Context,
         private val powerManager: PowerManager,
-        private val backendStorageFactory: K9BackendStorageFactory
+        private val backendStorageFactory: K9BackendStorageFactory,
+        private val trustedSocketFactory: TrustedSocketFactory
 ) : BackendFactory {
     override val transportUriPrefix = "smtp"
 
@@ -39,7 +41,7 @@ class ImapBackendFactory(
         return ImapStore(
                 serverSettings,
                 account,
-                DefaultTrustedSocketFactory(context),
+                trustedSocketFactory,
                 context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager,
                 oAuth2TokenProvider
         )
@@ -48,7 +50,7 @@ class ImapBackendFactory(
     private fun createSmtpTransport(account: Account): SmtpTransport {
         val serverSettings = decodeTransportUri(account.transportUri)
         val oauth2TokenProvider: OAuth2TokenProvider? = null
-        return SmtpTransport(serverSettings, account, DefaultTrustedSocketFactory(context), oauth2TokenProvider)
+        return SmtpTransport(serverSettings, account, trustedSocketFactory, oauth2TokenProvider)
     }
 
     override fun decodeStoreUri(storeUri: String): ServerSettings {

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/KoinModule.kt
@@ -12,7 +12,7 @@ val backendsModule = applicationContext {
                         "webdav" to get<WebDavBackendFactory>()
                 ))
     }
-    bean { ImapBackendFactory(get(), get(), get()) }
+    bean { ImapBackendFactory(get(), get(), get(), get()) }
     bean { Pop3BackendFactory(get(), get()) }
-    bean { WebDavBackendFactory(get()) }
+    bean { WebDavBackendFactory(get(), get()) }
 }

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
@@ -1,6 +1,5 @@
 package com.fsck.k9.backends
 
-import android.content.Context
 import com.fsck.k9.Account
 import com.fsck.k9.backend.BackendFactory
 import com.fsck.k9.backend.api.Backend
@@ -9,7 +8,7 @@ import com.fsck.k9.backend.pop3.Pop3StoreUriCreator
 import com.fsck.k9.backend.pop3.Pop3StoreUriDecoder
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider
-import com.fsck.k9.mail.ssl.DefaultTrustedSocketFactory
+import com.fsck.k9.mail.ssl.TrustedSocketFactory
 import com.fsck.k9.mail.store.pop3.Pop3Store
 import com.fsck.k9.mail.transport.smtp.SmtpTransport
 import com.fsck.k9.mail.transport.smtp.SmtpTransportUriCreator
@@ -17,8 +16,8 @@ import com.fsck.k9.mail.transport.smtp.SmtpTransportUriDecoder
 import com.fsck.k9.mailstore.K9BackendStorageFactory
 
 class Pop3BackendFactory(
-        private val context: Context,
-        private val backendStorageFactory: K9BackendStorageFactory
+        private val backendStorageFactory: K9BackendStorageFactory,
+        private val trustedSocketFactory: TrustedSocketFactory
 ) : BackendFactory {
     override val transportUriPrefix = "smtp"
 
@@ -32,13 +31,13 @@ class Pop3BackendFactory(
 
     private fun createPop3Store(account: Account): Pop3Store {
         val serverSettings = decodeStoreUri(account.storeUri)
-        return Pop3Store(serverSettings, account, DefaultTrustedSocketFactory(context))
+        return Pop3Store(serverSettings, account, trustedSocketFactory)
     }
 
     private fun createSmtpTransport(account: Account): SmtpTransport {
         val serverSettings = decodeTransportUri(account.transportUri)
         val oauth2TokenProvider: OAuth2TokenProvider? = null
-        return SmtpTransport(serverSettings, account, DefaultTrustedSocketFactory(context), oauth2TokenProvider)
+        return SmtpTransport(serverSettings, account, trustedSocketFactory, oauth2TokenProvider)
     }
 
     override fun decodeStoreUri(storeUri: String): ServerSettings {

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/WebDavBackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/WebDavBackendFactory.kt
@@ -7,12 +7,16 @@ import com.fsck.k9.backend.webdav.WebDavBackend
 import com.fsck.k9.backend.webdav.WebDavStoreUriCreator
 import com.fsck.k9.backend.webdav.WebDavStoreUriDecoder
 import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.mail.ssl.TrustManagerFactory
 import com.fsck.k9.mail.store.webdav.WebDavStore
 import com.fsck.k9.mail.store.webdav.WebDavStoreSettings
 import com.fsck.k9.mail.transport.WebDavTransport
 import com.fsck.k9.mailstore.K9BackendStorageFactory
 
-class WebDavBackendFactory(private val backendStorageFactory: K9BackendStorageFactory) : BackendFactory {
+class WebDavBackendFactory(
+        private val backendStorageFactory: K9BackendStorageFactory,
+        private val trustManagerFactory: TrustManagerFactory
+) : BackendFactory {
     override val transportUriPrefix = "webdav"
 
     override fun createBackend(account: Account): Backend {
@@ -20,12 +24,12 @@ class WebDavBackendFactory(private val backendStorageFactory: K9BackendStorageFa
         val backendStorage = backendStorageFactory.createBackendStorage(account)
         val serverSettings = WebDavStoreUriDecoder.decode(account.storeUri)
         val webDavStore = createWebDavStore(serverSettings, account)
-        val webDavTransport = WebDavTransport(serverSettings, account)
+        val webDavTransport = WebDavTransport(trustManagerFactory, serverSettings, account)
         return WebDavBackend(accountName, backendStorage, webDavStore, webDavTransport)
     }
 
     private fun createWebDavStore(serverSettings: WebDavStoreSettings, account: Account): WebDavStore {
-        return WebDavStore(serverSettings, account)
+        return WebDavStore(trustManagerFactory, serverSettings, account)
     }
 
     override fun decodeStoreUri(storeUri: String): ServerSettings {

--- a/mail/common/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
@@ -31,10 +31,10 @@ import timber.log.Timber;
  * On more modern versions of Android we keep the system configuration.
  */
 public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
-    protected static final String[] ENABLED_CIPHERS;
-    protected static final String[] ENABLED_PROTOCOLS;
+    private static final String[] ENABLED_CIPHERS;
+    private static final String[] ENABLED_PROTOCOLS;
 
-    protected static final String[] ORDERED_KNOWN_CIPHERS = {
+    private static final String[] ORDERED_KNOWN_CIPHERS = {
             "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
             "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
@@ -61,7 +61,7 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
             "TLS_RSA_WITH_AES_128_CBC_SHA",
     };
 
-    protected static final String[] BLACKLISTED_CIPHERS = {
+    private static final String[] BLACKLISTED_CIPHERS = {
             "SSL_RSA_WITH_DES_CBC_SHA",
             "SSL_DHE_RSA_WITH_DES_CBC_SHA",
             "SSL_DHE_DSS_WITH_DES_CBC_SHA",
@@ -85,11 +85,11 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
             "TLS_RSA_WITH_NULL_SHA256"
     };
 
-    protected static final String[] ORDERED_KNOWN_PROTOCOLS = {
+    private static final String[] ORDERED_KNOWN_PROTOCOLS = {
             "TLSv1.2", "TLSv1.1", "TLSv1"
     };
 
-    protected static final String[] BLACKLISTED_PROTOCOLS = {
+    private static final String[] BLACKLISTED_PROTOCOLS = {
             "SSLv3"
     };
 
@@ -140,7 +140,7 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
         return android.os.Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP;
     }
 
-    protected static String[] reorder(String[] enabled, String[] known, String[] blacklisted) {
+    private static String[] reorder(String[] enabled, String[] known, String[] blacklisted) {
         List<String> unknown = new ArrayList<>();
         Collections.addAll(unknown, enabled);
 
@@ -163,7 +163,7 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
         // start showing up in the future.
         result.addAll(unknown);
 
-        return result.toArray(new String[result.size()]);
+        return result.toArray(new String[0]);
     }
 
     protected static String[] remove(String[] enabled, String[] blacklisted) {
@@ -177,7 +177,7 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
             }
         }
 
-        return items.toArray(new String[items.size()]);
+        return items.toArray(new String[0]);
     }
 
     public Socket createSocket(Socket socket, String host, int port, String clientCertificateAlias)

--- a/mail/common/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/ssl/DefaultTrustedSocketFactory.java
@@ -128,8 +128,12 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
 
     }
 
-    public DefaultTrustedSocketFactory(Context context) {
+    private final Context context;
+    private final TrustManagerFactory trustManagerFactory;
+
+    public DefaultTrustedSocketFactory(Context context, TrustManagerFactory trustManagerFactory) {
         this.context = context;
+        this.trustManagerFactory = trustManagerFactory;
     }
 
     private static boolean hasWeakSslImplementation() {
@@ -176,12 +180,10 @@ public class DefaultTrustedSocketFactory implements TrustedSocketFactory {
         return items.toArray(new String[items.size()]);
     }
 
-    private Context context;
-
     public Socket createSocket(Socket socket, String host, int port, String clientCertificateAlias)
             throws NoSuchAlgorithmException, KeyManagementException, MessagingException, IOException {
 
-        TrustManager[] trustManagers = new TrustManager[] { TrustManagerFactory.get(host, port) };
+        TrustManager[] trustManagers = new TrustManager[] { trustManagerFactory.getTrustManagerForDomain(host, port) };
         KeyManager[] keyManagers = null;
         if (!TextUtils.isEmpty(clientCertificateAlias)) {
             keyManagers = new KeyManager[] { new KeyChainKeyManager(context, clientCertificateAlias) };

--- a/mail/common/src/main/java/com/fsck/k9/mail/ssl/TrustManagerFactory.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/ssl/TrustManagerFactory.java
@@ -83,10 +83,10 @@ public class TrustManagerFactory {
 
         public void checkServerTrusted(X509Certificate[] chain, String authType)
                 throws CertificateException {
-            String message = null;
+            String message;
             X509Certificate certificate = chain[0];
 
-            Throwable cause = null;
+            Throwable cause;
 
             try {
                 defaultTrustManager.checkServerTrusted(chain, authType);

--- a/mail/common/src/main/java/com/fsck/k9/mail/ssl/TrustManagerFactory.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/ssl/TrustManagerFactory.java
@@ -1,14 +1,6 @@
 
 package com.fsck.k9.mail.ssl;
 
-import com.fsck.k9.mail.CertificateChainException;
-
-import javax.net.ssl.SSLException;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509TrustManager;
-
-import org.apache.http.conn.ssl.StrictHostnameVerifier;
-import timber.log.Timber;
 
 import java.security.KeyStore;
 import java.security.KeyStoreException;
@@ -18,34 +10,70 @@ import java.security.cert.X509Certificate;
 import java.util.HashMap;
 import java.util.Map;
 
-public final class TrustManagerFactory {
-    private static X509TrustManager defaultTrustManager;
+import com.fsck.k9.mail.CertificateChainException;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import org.apache.http.conn.ssl.StrictHostnameVerifier;
+import timber.log.Timber;
 
-    private static LocalKeyStore keyStore;
+public class TrustManagerFactory {
+    public static TrustManagerFactory createInstance(LocalKeyStore localKeyStore) {
+        TrustManagerFactory trustManagerFactory = new TrustManagerFactory(localKeyStore);
+        try {
+            trustManagerFactory.initialize();
+        } catch (NoSuchAlgorithmException | KeyStoreException e) {
+            Timber.e(e, "Failed to initialize X509 Trust Manager!");
+            throw new IllegalStateException(e);
+        }
+        return trustManagerFactory;
+    }
 
 
-    private static class SecureX509TrustManager implements X509TrustManager {
-        private static final Map<String, SecureX509TrustManager> mTrustManager = new HashMap<>();
+    private X509TrustManager defaultTrustManager;
+    private LocalKeyStore keyStore;
+    private final Map<String, SecureX509TrustManager> cachedTrustManagers = new HashMap<>();
 
+
+    private TrustManagerFactory(LocalKeyStore localKeyStore) {
+        this.keyStore = localKeyStore;
+    }
+
+    private void initialize() throws KeyStoreException, NoSuchAlgorithmException {
+        javax.net.ssl.TrustManagerFactory tmf = javax.net.ssl.TrustManagerFactory.getInstance("X509");
+        tmf.init((KeyStore) null);
+
+        TrustManager[] tms = tmf.getTrustManagers();
+        if (tms != null) {
+            for (TrustManager tm : tms) {
+                if (tm instanceof X509TrustManager) {
+                    defaultTrustManager = (X509TrustManager) tm;
+                    break;
+                }
+            }
+        }
+    }
+
+    public X509TrustManager getTrustManagerForDomain(String host, int port) {
+        String key = host + ":" + port;
+        SecureX509TrustManager trustManager;
+        if (cachedTrustManagers.containsKey(key)) {
+            trustManager = cachedTrustManagers.get(key);
+        } else {
+            trustManager = new SecureX509TrustManager(host, port);
+            cachedTrustManagers.put(key, trustManager);
+        }
+
+        return trustManager;
+    }
+
+    private class SecureX509TrustManager implements X509TrustManager {
         private final String mHost;
         private final int mPort;
 
         private SecureX509TrustManager(String host, int port) {
             mHost = host;
             mPort = port;
-        }
-
-        public synchronized static X509TrustManager getInstance(String host, int port) {
-            String key = host + ":" + port;
-            SecureX509TrustManager trustManager;
-            if (mTrustManager.containsKey(key)) {
-                trustManager = mTrustManager.get(key);
-            } else {
-                trustManager = new SecureX509TrustManager(host, port);
-                mTrustManager.put(key, trustManager);
-            }
-
-            return trustManager;
         }
 
         public void checkClientTrusted(X509Certificate[] chain, String authType)
@@ -85,35 +113,5 @@ public final class TrustManagerFactory {
             return defaultTrustManager.getAcceptedIssuers();
         }
 
-    }
-
-    static {
-        try {
-            keyStore = LocalKeyStore.getInstance();
-
-            javax.net.ssl.TrustManagerFactory tmf = javax.net.ssl.TrustManagerFactory.getInstance("X509");
-            tmf.init((KeyStore) null);
-
-            TrustManager[] tms = tmf.getTrustManagers();
-            if (tms != null) {
-                for (TrustManager tm : tms) {
-                    if (tm instanceof X509TrustManager) {
-                        defaultTrustManager = (X509TrustManager) tm;
-                        break;
-                    }
-                }
-            }
-        } catch (NoSuchAlgorithmException e) {
-            Timber.e(e, "Unable to get X509 Trust Manager ");
-        } catch (KeyStoreException e) {
-            Timber.e(e, "Key Store exception while initializing TrustManagerFactory");
-        }
-    }
-
-    private TrustManagerFactory() {
-    }
-
-    public static X509TrustManager get(String host, int port) {
-        return SecureX509TrustManager.getInstance(host, port);
     }
 }

--- a/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
+++ b/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/store/webdav/WebDavSocketFactory.java
@@ -25,10 +25,10 @@ public class WebDavSocketFactory implements LayeredSocketFactory {
     private SSLSocketFactory mSocketFactory;
     private org.apache.http.conn.ssl.SSLSocketFactory mSchemeSocketFactory;
 
-    public WebDavSocketFactory(String host, int port) throws NoSuchAlgorithmException, KeyManagementException {
+    public WebDavSocketFactory(TrustManagerFactory trustManagerFactory, String host, int port) throws NoSuchAlgorithmException, KeyManagementException {
         SSLContext sslContext = SSLContext.getInstance("TLS");
         sslContext.init(null, new TrustManager[] {
-                TrustManagerFactory.get(host, port)
+                trustManagerFactory.getTrustManagerForDomain(host, port)
         }, null);
         mSocketFactory = sslContext.getSocketFactory();
         mSchemeSocketFactory = org.apache.http.conn.ssl.SSLSocketFactory.getSocketFactory();

--- a/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/transport/WebDavTransport.java
+++ b/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/transport/WebDavTransport.java
@@ -7,6 +7,7 @@ import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Transport;
+import com.fsck.k9.mail.ssl.TrustManagerFactory;
 import com.fsck.k9.mail.store.StoreConfig;
 import com.fsck.k9.mail.store.webdav.WebDavStore;
 import com.fsck.k9.mail.store.webdav.WebDavStoreSettings;
@@ -15,8 +16,8 @@ import timber.log.Timber;
 public class WebDavTransport extends Transport {
     private WebDavStore store;
 
-    public WebDavTransport(WebDavStoreSettings serverSettings, StoreConfig storeConfig) {
-        store = new WebDavStore(serverSettings, storeConfig);
+    public WebDavTransport(TrustManagerFactory trustManagerFactory, WebDavStoreSettings serverSettings, StoreConfig storeConfig) {
+        store = new WebDavStore(trustManagerFactory, serverSettings, storeConfig);
 
         if (K9MailLib.isDebug())
             Timber.d(">>> New WebDavTransport creation complete");

--- a/mail/protocols/webdav/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
+++ b/mail/protocols/webdav/src/test/java/com/fsck/k9/mail/store/webdav/WebDavStoreTest.java
@@ -16,6 +16,7 @@ import com.fsck.k9.mail.Folder.FolderType;
 import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.filter.Base64;
+import com.fsck.k9.mail.ssl.TrustManagerFactory;
 import com.fsck.k9.mail.store.StoreConfig;
 import javax.net.ssl.SSLException;
 import org.apache.http.HttpEntity;
@@ -68,6 +69,8 @@ public class WebDavStoreTest {
     private ClientConnectionManager mockClientConnectionManager;
     @Mock
     private SchemeRegistry mockSchemeRegistry;
+    @Mock
+    private TrustManagerFactory trustManagerFactory;
 
     private ArgumentCaptor<HttpGeneric> requestCaptor;
 
@@ -358,12 +361,12 @@ public class WebDavStoreTest {
     }
 
     private WebDavStore createWebDavStore() {
-        return new WebDavStore(serverSettings, storeConfig, mockHttpClientFactory);
+        return new WebDavStore(trustManagerFactory, serverSettings, storeConfig, mockHttpClientFactory);
     }
 
     private WebDavStore createWebDavStore(ConnectionSecurity connectionSecurity) {
         WebDavStoreSettings serverSettings = createWebDavStoreSettings(connectionSecurity);
-        return new WebDavStore(serverSettings, storeConfig, mockHttpClientFactory);
+        return new WebDavStore(trustManagerFactory, serverSettings, storeConfig, mockHttpClientFactory);
     }
 
     private void configureHttpResponses(HttpResponse... responses) throws IOException {


### PR DESCRIPTION
I introduced a bug in #3744 by injecting LocalKeyStore via Koin before the storage path is initialized. This PR cleans up LocalKeyStore and related classes, and they are now properly dependency injected.