### PR TITLE
extract persistence logic from Storage into StoragePersister

### DIFF
--- a/app/core/build.gradle
+++ b/app/core/build.gradle
@@ -28,6 +28,7 @@ dependencies {
     testImplementation project(":backend:imap")
     testImplementation project(":mail:protocols:smtp")
     testImplementation project(":app:storage")
+    testImplementation "org.jetbrains.kotlin:kotlin-reflect:${versions.kotlin}"
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -192,7 +192,7 @@ class AccountPreferenceSerializer(
     }
 
     @Synchronized
-    fun save(storage: Storage, editor: StorageEditor, account: Account) {
+    fun save(editor: StorageEditor, storage: Storage, account: Account) {
         val accountUuid = account.uuid
 
         if (!storage.getString("accountUuids", "").contains(account.uuid)) {
@@ -294,13 +294,11 @@ class AccountPreferenceSerializer(
         }
 
         saveIdentities(account, storage, editor)
-
-        editor.commit()
     }
 
 
     @Synchronized
-    fun delete(storage: Storage, account: Account) {
+    fun delete(editor: StorageEditor, storage: Storage, account: Account) {
         val accountUuid = account.uuid
 
         // Get the list of account UUIDs
@@ -313,8 +311,6 @@ class AccountPreferenceSerializer(
                 newUuids.add(uuid)
             }
         }
-
-        val editor = storage.edit()
 
         // Only change the 'accountUuids' value if this account's UUID was listed before
         if (newUuids.size < uuids.size) {
@@ -407,7 +403,6 @@ class AccountPreferenceSerializer(
         }
         deleteIdentities(account, storage, editor)
         // TODO: Remove preference settings that may exist for individual folders in the account.
-        editor.commit()
     }
 
     @Synchronized
@@ -450,9 +445,8 @@ class AccountPreferenceSerializer(
         } while (gotOne)
     }
 
-    fun move(account: Account, storage: Storage, moveUp: Boolean) {
+    fun move(editor: StorageEditor, account: Account, storage: Storage, moveUp: Boolean) {
         val uuids = storage.getString("accountUuids", "").split(",".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
-        val editor = storage.edit()
         val newUuids = arrayOfNulls<String>(uuids.size)
         if (moveUp) {
             for (i in uuids.indices) {
@@ -475,7 +469,6 @@ class AccountPreferenceSerializer(
         }
         val accountUuids = Utility.combine(newUuids, ',')
         editor.putString("accountUuids", accountUuids)
-        editor.commit()
     }
 
     private fun <T : Enum<T>> getEnumStringPref(storage: Storage, key: String, defaultEnum: T): T {

--- a/app/core/src/main/java/com/fsck/k9/K9.java
+++ b/app/core/src/main/java/com/fsck/k9/K9.java
@@ -383,7 +383,7 @@ public class K9 {
             preferences.saveAccount(account);
         }
 
-        storage.edit()
+        preferences.createStorageEditor()
                 .remove("openPgpProvider")
                 .remove("openPgpSupportSignOnly")
                 .commit();
@@ -1075,7 +1075,7 @@ public class K9 {
             @Override
             protected Void doInBackground(Void... voids) {
                 Preferences prefs = DI.get(Preferences.class);
-                StorageEditor editor = prefs.getStorage().edit();
+                StorageEditor editor = prefs.createStorageEditor();
                 save(editor);
                 editor.commit();
 

--- a/app/core/src/main/java/com/fsck/k9/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/KoinModule.kt
@@ -10,12 +10,14 @@ import com.fsck.k9.mail.ssl.TrustedSocketFactory
 import com.fsck.k9.mailstore.LocalStoreProvider
 import com.fsck.k9.mailstore.StorageManager
 import com.fsck.k9.power.TracingPowerManager
+import com.fsck.k9.preferences.StoragePersister
 import org.koin.dsl.module.applicationContext
 
 val mainModule = applicationContext {
     bean { Preferences.getPreferences(get()) }
     bean { get<Context>().resources }
     bean { StorageManager.getInstance(get()) }
+    bean { StoragePersister(get()) }
     bean { LocalStoreProvider() }
     bean { TracingPowerManager.getPowerManager(get()) as PowerManager }
     bean { Contacts.getInstance(get()) }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -29,6 +29,7 @@ import android.support.annotation.NonNull;
 import com.fsck.k9.Account;
 import com.fsck.k9.DI;
 import com.fsck.k9.K9;
+import com.fsck.k9.Preferences;
 import com.fsck.k9.controller.MessageReference;
 import com.fsck.k9.backend.api.MessageRemovalListener;
 import com.fsck.k9.crypto.EncryptionExtractor;
@@ -630,7 +631,7 @@ public class LocalFolder extends Folder<LocalMessage> {
     public void delete() throws MessagingException {
         String id = getPrefId();
 
-        StorageEditor editor = this.localStore.getStorage().edit();
+        StorageEditor editor = localStore.getPreferences().createStorageEditor();
 
         editor.remove(id + ".displayMode");
         editor.remove(id + ".syncMode");
@@ -642,7 +643,7 @@ public class LocalFolder extends Folder<LocalMessage> {
     }
 
     public void save() throws MessagingException {
-        StorageEditor editor = this.localStore.getStorage().edit();
+        StorageEditor editor = localStore.getPreferences().createStorageEditor();
         save(editor);
         editor.commit();
     }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -244,6 +244,10 @@ public class LocalStore {
         return Preferences.getPreferences(context).getStorage();
     }
 
+    protected Preferences getPreferences() {
+        return Preferences.getPreferences(context);
+    }
+
     public long getSize() throws MessagingException {
 
         final StorageManager storageManager = StorageManager.getInstance(context);
@@ -1334,6 +1338,11 @@ public class LocalStore {
         @Override
         public Storage getStorage() {
             return LocalStore.this.getStorage();
+        }
+
+        @Override
+        public Preferences getPreferences() {
+            return LocalStore.this.getPreferences();
         }
 
         @Override

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MigrationsHelper.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MigrationsHelper.java
@@ -6,8 +6,8 @@ import java.util.List;
 import android.content.Context;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.Preferences;
 import com.fsck.k9.mail.Flag;
-import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.preferences.Storage;
 
 
@@ -17,6 +17,7 @@ import com.fsck.k9.preferences.Storage;
 public interface MigrationsHelper {
     LocalStore getLocalStore();
     Storage getStorage();
+    Preferences getPreferences();
     Account getAccount();
     Context getContext();
     String serializeFlags(List<Flag> flags);

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -179,7 +179,7 @@ public class SettingsImporter {
 
             if (globalSettings) {
                 try {
-                    StorageEditor editor = storage.edit();
+                    StorageEditor editor = preferences.createStorageEditor();
                     if (imported.globalSettings != null) {
                         importGlobalSettings(storage, editor, imported.contentVersion, imported.globalSettings);
                     } else {
@@ -202,7 +202,7 @@ public class SettingsImporter {
                         if (imported.accounts.containsKey(accountUuid)) {
                             ImportedAccount account = imported.accounts.get(accountUuid);
                             try {
-                                StorageEditor editor = storage.edit();
+                                StorageEditor editor = preferences.createStorageEditor();
 
                                 AccountDescriptionPair importResult = importAccount(context, editor,
                                         imported.contentVersion, account, overwrite);
@@ -214,7 +214,7 @@ public class SettingsImporter {
                                     // Add UUID of the account we just imported to the list of
                                     // account UUIDs
                                     if (!importResult.overwritten) {
-                                        editor = storage.edit();
+                                        editor = preferences.createStorageEditor();
 
                                         String newUuid = importResult.imported.uuid;
                                         String oldAccountUuids = storage.getString("accountUuids", "");
@@ -253,7 +253,7 @@ public class SettingsImporter {
                         }
                     }
 
-                    StorageEditor editor = storage.edit();
+                    StorageEditor editor = preferences.createStorageEditor();
 
                     String defaultAccountUuid = storage.getString("defaultAccountUuid", null);
                     if (defaultAccountUuid == null) {

--- a/app/core/src/main/java/com/fsck/k9/preferences/Storage.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Storage.java
@@ -1,197 +1,22 @@
 package com.fsck.k9.preferences;
 
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
-import android.content.ContentValues;
-import android.content.Context;
-import android.database.Cursor;
-import android.database.sqlite.SQLiteDatabase;
-import android.database.sqlite.SQLiteStatement;
-import android.os.SystemClock;
-
-import com.fsck.k9.helper.Utility;
-import com.fsck.k9.preferences.migrations.StorageMigrations;
-import com.fsck.k9.preferences.migrations.StorageMigrationsHelper;
-import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import timber.log.Timber;
 
 public class Storage {
-    private static ConcurrentMap<Context, Storage> storages = new ConcurrentHashMap<>();
+    private HashMap<String, String> storage = new HashMap<>();
 
-    private volatile ConcurrentMap<String, String> storage = new ConcurrentHashMap<>();
-
-    private static final int DB_VERSION = 4;
-    private static final String DB_NAME = "preferences_storage";
-
-    private ThreadLocal<ConcurrentMap<String, String>> workingStorage = new ThreadLocal<>();
-    private ThreadLocal<SQLiteDatabase> workingDB = new ThreadLocal<>();
-    private ThreadLocal<List<String>> workingChangedKeys = new ThreadLocal<>();
-
-
-    private Context context = null;
-
-    private SQLiteDatabase openDB() {
-        SQLiteDatabase db = context.openOrCreateDatabase(DB_NAME, Context.MODE_PRIVATE, null);
-
-        db.beginTransaction();
-        try {
-            if (db.getVersion() < 1) {
-                createStorageDatabase(db);
-            } else {
-                StorageMigrations.upgradeDatabase(db, migrationsHelper);
-            }
-
-            db.setVersion(DB_VERSION);
-            db.setTransactionSuccessful();
-        } finally {
-            db.endTransaction();
-        }
-
-        if (db.getVersion() != DB_VERSION) {
-            throw new RuntimeException("Storage database upgrade failed!");
-        }
-
-        return db;
-    }
-
-    private void createStorageDatabase(SQLiteDatabase db) {
-        Timber.i("Creating Storage database");
-
-        db.execSQL("DROP TABLE IF EXISTS preferences_storage");
-        db.execSQL("CREATE TABLE preferences_storage " +
-                    "(primkey TEXT PRIMARY KEY ON CONFLICT REPLACE, value TEXT)");
-        db.setVersion(DB_VERSION);
-    }
-
-    public static Storage getStorage(Context context) {
-        Storage tmpStorage = storages.get(context);
-        if (tmpStorage != null) {
-            Timber.d("Returning already existing Storage");
-            return tmpStorage;
-        } else {
-            Timber.d("Creating provisional storage");
-            tmpStorage = new Storage(context);
-            Storage oldStorage = storages.putIfAbsent(context, tmpStorage);
-            if (oldStorage != null) {
-                Timber.d("Another thread beat us to creating the Storage, returning that one");
-                return oldStorage;
-            } else {
-                Timber.d("Returning the Storage we created");
-                return tmpStorage;
-            }
-        }
-    }
-
-    private void loadValues() {
-        long startTime = SystemClock.elapsedRealtime();
-        Timber.i("Loading preferences from DB into Storage");
-        Cursor cursor = null;
-        SQLiteDatabase mDb = null;
-        try {
-            mDb = openDB();
-
-            cursor = mDb.rawQuery("SELECT primkey, value FROM preferences_storage", null);
-            while (cursor.moveToNext()) {
-                String key = cursor.getString(0);
-                String value = cursor.getString(1);
-                Timber.d("Loading key '%s', value = '%s'", key, value);
-                storage.put(key, value);
-            }
-        } finally {
-            Utility.closeQuietly(cursor);
-            if (mDb != null) {
-                mDb.close();
-            }
-            long endTime = SystemClock.elapsedRealtime();
-            Timber.i("Preferences load took %d ms", endTime - startTime);
-        }
-    }
-
-    private Storage(Context context) {
-        this.context = context;
-        loadValues();
-    }
-
-    private void keyChange(String key) {
-        List<String> changedKeys = workingChangedKeys.get();
-        if (!changedKeys.contains(key)) {
-            changedKeys.add(key);
-        }
-    }
-
-    void put(Map<String, String> insertables) {
-        String sql = "INSERT INTO preferences_storage (primkey, value) VALUES (?, ?)";
-        SQLiteStatement stmt = workingDB.get().compileStatement(sql);
-
-        for (Map.Entry<String, String> entry : insertables.entrySet()) {
-            String key = entry.getKey();
-            String value = entry.getValue();
-            stmt.bindString(1, key);
-            stmt.bindString(2, value);
-            stmt.execute();
-            stmt.clearBindings();
-            liveUpdate(key, value);
-        }
-        stmt.close();
-    }
-
-    private void liveUpdate(String key, String value) {
-        workingStorage.get().put(key, value);
-
-        keyChange(key);
-    }
-
-    void remove(String key) {
-        workingDB.get().delete("preferences_storage", "primkey = ?", new String[] { key });
-        workingStorage.get().remove(key);
-
-        keyChange(key);
-    }
-
-    void doInTransaction(Runnable dbWork) {
-        ConcurrentMap<String, String> newStorage = new ConcurrentHashMap<>(storage);
-        workingStorage.set(newStorage);
-
-        SQLiteDatabase mDb = openDB();
-        workingDB.set(mDb);
-
-        List<String> changedKeys = new ArrayList<>();
-        workingChangedKeys.set(changedKeys);
-
-        mDb.beginTransaction();
-        try {
-            dbWork.run();
-            mDb.setTransactionSuccessful();
-            storage = newStorage;
-        } finally {
-            workingDB.remove();
-            workingStorage.remove();
-            workingChangedKeys.remove();
-            mDb.endTransaction();
-            mDb.close();
-        }
-    }
+    public Storage() { }
 
     public boolean isEmpty() {
         return storage.isEmpty();
     }
 
     public boolean contains(String key) {
-        // TODO this used to be ConcurrentHashMap#contains which is
-        // actually containsValue. But looking at the usage of this method,
-        // it's clear that containsKey is what's intended. Investigate if this
-        // was a bug previously. Looks like it was only used once, when upgrading
         return storage.containsKey(key);
-    }
-
-    public StorageEditor edit() {
-        return new StorageEditor(this);
     }
 
     public Map<String, String> getAll() {
@@ -240,77 +65,8 @@ public class Storage {
         return val;
     }
 
-    private String readValue(SQLiteDatabase mDb, String key) {
-        Cursor cursor = null;
-        String value = null;
-        try {
-            cursor = mDb.query(
-                         "preferences_storage",
-                         new String[] {"value"},
-                         "primkey = ?",
-                         new String[] {key},
-                         null,
-                         null,
-                         null);
-
-            if (cursor.moveToNext()) {
-                value = cursor.getString(0);
-                Timber.d("Loading key '%s', value = '%s'", key, value);
-            }
-        } finally {
-            Utility.closeQuietly(cursor);
-        }
-
-        return value;
+    public void replaceAll(Map<String, String> workingStorage) {
+        storage.clear();
+        storage.putAll(workingStorage);
     }
-
-    private void writeValue(SQLiteDatabase mDb, String key, String value) {
-        if (value == null) {
-            mDb.delete("preferences_storage", "primkey = ?", new String[] { key });
-            return;
-        }
-
-        ContentValues cv = new ContentValues();
-        cv.put("primkey", key);
-        cv.put("value", value);
-
-        long result = mDb.update("preferences_storage", cv, "primkey = ?", new String[] { key });
-
-        if (result == -1) {
-            Timber.e("Error writing key '%s', value = '%s'", key, value);
-        }
-    }
-
-    private void insertValue(SQLiteDatabase mDb, String key, String value) {
-        if (value == null) {
-            return;
-        }
-
-        ContentValues cv = new ContentValues();
-        cv.put("primkey", key);
-        cv.put("value", value);
-
-        long result = mDb.insert("preferences_storage", null, cv);
-
-        if (result == -1) {
-            Timber.e("Error writing key '%s', value = '%s'", key, value);
-        }
-    }
-
-    private StorageMigrationsHelper migrationsHelper = new StorageMigrationsHelper() {
-        @Override
-        public void writeValue(@NotNull SQLiteDatabase db, @NotNull String key, String value) {
-            Storage.this.writeValue(db, key, value);
-        }
-
-        @Override
-        public String readValue(@NotNull SQLiteDatabase db, @NotNull String key) {
-            return Storage.this.readValue(db, key);
-        }
-
-        @Override
-        public void insertValue(@NotNull SQLiteDatabase db, @NotNull String key, @Nullable String value) {
-            Storage.this.insertValue(db, key, value);
-        }
-    };
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/Storage.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Storage.java
@@ -1,13 +1,14 @@
 package com.fsck.k9.preferences;
 
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 import timber.log.Timber;
 
 public class Storage {
-    private HashMap<String, String> storage = new HashMap<>();
+    private volatile Map<String, String> storage = Collections.emptyMap();
 
     public Storage() { }
 
@@ -66,7 +67,6 @@ public class Storage {
     }
 
     public void replaceAll(Map<String, String> workingStorage) {
-        storage.clear();
-        storage.putAll(workingStorage);
+        storage = new HashMap<>(workingStorage);
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/StorageEditor.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/StorageEditor.java
@@ -67,16 +67,14 @@ public class StorageEditor {
                 for (String removeKey : removals) {
                     ops.remove(removeKey);
                 }
-                Map<String, String> insertables = new HashMap<>();
                 for (Entry<String, String> entry : changes.entrySet()) {
                     String key = entry.getKey();
                     String newValue = entry.getValue();
                     String oldValue = snapshot.get(key);
                     if (removals.contains(key) || !newValue.equals(oldValue)) {
-                        insertables.put(key, newValue);
+                        ops.put(key, newValue);
                     }
                 }
-                ops.put(insertables);
             }
 
             @Override

--- a/app/core/src/main/java/com/fsck/k9/preferences/StorageEditor.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/StorageEditor.java
@@ -9,19 +9,23 @@ import java.util.Map.Entry;
 
 import android.os.SystemClock;
 
+import com.fsck.k9.preferences.StoragePersister.StoragePersistOperationCallback;
+import com.fsck.k9.preferences.StoragePersister.StoragePersistOperations;
 import timber.log.Timber;
 
 
 public class StorageEditor {
     private Storage storage;
+    private StoragePersister storagePersister;
+
     private Map<String, String> changes = new HashMap<>();
     private List<String> removals = new ArrayList<>();
+    private Map<String, String> snapshot = new HashMap<>();
 
-    Map<String, String> snapshot = new HashMap<>();
 
-
-    StorageEditor(Storage storage) {
+    public StorageEditor(Storage storage, StoragePersister storagePersister) {
         this.storage = storage;
+        this.storagePersister = storagePersister;
         snapshot.putAll(storage.getAll());
     }
 
@@ -52,10 +56,16 @@ public class StorageEditor {
     private void commitChanges() {
         long startTime = SystemClock.elapsedRealtime();
         Timber.i("Committing preference changes");
-        Runnable committer = new Runnable() {
-            public void run() {
+        StoragePersistOperationCallback committer = new StoragePersistOperationCallback() {
+            @Override
+            public void beforePersistTransaction(Map<String, String> workingStorage) {
+                workingStorage.putAll(storage.getAll());
+            }
+
+            @Override
+            public void persist(StoragePersistOperations ops) {
                 for (String removeKey : removals) {
-                    storage.remove(removeKey);
+                    ops.remove(removeKey);
                 }
                 Map<String, String> insertables = new HashMap<>();
                 for (Entry<String, String> entry : changes.entrySet()) {
@@ -66,13 +76,17 @@ public class StorageEditor {
                         insertables.put(key, newValue);
                     }
                 }
-                storage.put(insertables);
+                ops.put(insertables);
+            }
+
+            @Override
+            public void onPersistTransactionSuccess(Map<String, String> workingStorage) {
+                storage.replaceAll(workingStorage);
             }
         };
-        storage.doInTransaction(committer);
+        storagePersister.doInTransaction(committer);
         long endTime = SystemClock.elapsedRealtime();
         Timber.i("Preferences commit took %d ms", endTime - startTime);
-
     }
 
     public StorageEditor putBoolean(String key,

--- a/app/core/src/main/java/com/fsck/k9/preferences/StoragePersister.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/StoragePersister.java
@@ -1,0 +1,228 @@
+package com.fsck.k9.preferences;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import android.content.ContentValues;
+import android.content.Context;
+import android.database.Cursor;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteStatement;
+import android.os.SystemClock;
+import android.support.annotation.CheckResult;
+
+import com.fsck.k9.helper.Utility;
+import com.fsck.k9.preferences.migrations.StorageMigrations;
+import com.fsck.k9.preferences.migrations.StorageMigrationsHelper;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import timber.log.Timber;
+
+
+public class StoragePersister {
+    private static final int DB_VERSION = 4;
+    private static final String DB_NAME = "preferences_storage";
+
+    private final Context context;
+
+    public StoragePersister(Context context) {
+        this.context = context;
+    }
+
+    private SQLiteDatabase openDB() {
+        SQLiteDatabase db = context.openOrCreateDatabase(DB_NAME, Context.MODE_PRIVATE, null);
+
+        db.beginTransaction();
+        try {
+            if (db.getVersion() < 1) {
+                createStorageDatabase(db);
+            } else {
+                StorageMigrations.upgradeDatabase(db, migrationsHelper);
+            }
+
+            db.setVersion(DB_VERSION);
+            db.setTransactionSuccessful();
+        } finally {
+            db.endTransaction();
+        }
+
+        if (db.getVersion() != DB_VERSION) {
+            throw new RuntimeException("Storage database upgrade failed!");
+        }
+
+        return db;
+    }
+
+    private void createStorageDatabase(SQLiteDatabase db) {
+        Timber.i("Creating Storage database");
+
+        db.execSQL("DROP TABLE IF EXISTS preferences_storage");
+        db.execSQL("CREATE TABLE preferences_storage " +
+                "(primkey TEXT PRIMARY KEY ON CONFLICT REPLACE, value TEXT)");
+        db.setVersion(DB_VERSION);
+    }
+
+    void doInTransaction(StoragePersistOperationCallback operationCallback) {
+        HashMap<String, String> workingStorage = new HashMap<>();
+        SQLiteDatabase workingDb = openDB();
+
+        try {
+            operationCallback.beforePersistTransaction(workingStorage);
+
+            StoragePersistOperations storagePersistOperations = new StoragePersistOperations(workingStorage, workingDb);
+            workingDb.beginTransaction();
+            operationCallback.persist(storagePersistOperations);
+            workingDb.setTransactionSuccessful();
+
+            operationCallback.onPersistTransactionSuccess(workingStorage);
+        } finally {
+            workingDb.endTransaction();
+            workingDb.close();
+        }
+    }
+
+    static class StoragePersistOperations {
+        private SQLiteDatabase workingDB;
+        private Map<String, String> workingStorage;
+
+        private StoragePersistOperations(Map<String, String> workingStorage, SQLiteDatabase workingDb) {
+            this.workingDB = workingDb;
+            this.workingStorage = workingStorage;
+        }
+
+        void put(Map<String, String> insertables) {
+            String sql = "INSERT INTO preferences_storage (primkey, value) VALUES (?, ?)";
+            SQLiteStatement stmt = workingDB.compileStatement(sql);
+
+            for (Map.Entry<String, String> entry : insertables.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+                stmt.bindString(1, key);
+                stmt.bindString(2, value);
+                stmt.execute();
+                stmt.clearBindings();
+                liveUpdate(key, value);
+            }
+            stmt.close();
+        }
+
+        private void liveUpdate(String key, String value) {
+            workingStorage.put(key, value);
+        }
+
+        void remove(String key) {
+            workingDB.delete("preferences_storage", "primkey = ?", new String[] { key });
+            workingStorage.remove(key);
+        }
+    }
+
+    interface StoragePersistOperationCallback {
+        void beforePersistTransaction(Map<String, String> workingStorage);
+        void persist(StoragePersistOperations ops);
+        void onPersistTransactionSuccess(Map<String, String> workingStorage);
+    }
+
+    @CheckResult
+    public Map<String, String> loadValues() {
+        long startTime = SystemClock.elapsedRealtime();
+        Timber.i("Loading preferences from DB into Storage");
+        HashMap<String, String> loadedValues = new HashMap<>();
+        Cursor cursor = null;
+        SQLiteDatabase mDb = null;
+        try {
+            mDb = openDB();
+
+            cursor = mDb.rawQuery("SELECT primkey, value FROM preferences_storage", null);
+            while (cursor.moveToNext()) {
+                String key = cursor.getString(0);
+                String value = cursor.getString(1);
+                Timber.d("Loading key '%s', value = '%s'", key, value);
+                loadedValues.put(key, value);
+            }
+        } finally {
+            Utility.closeQuietly(cursor);
+            if (mDb != null) {
+                mDb.close();
+            }
+            long endTime = SystemClock.elapsedRealtime();
+            Timber.i("Preferences load took %d ms", endTime - startTime);
+        }
+
+        return loadedValues;
+    }
+
+    private String readValue(SQLiteDatabase mDb, String key) {
+        Cursor cursor = null;
+        String value = null;
+        try {
+            cursor = mDb.query(
+                    "preferences_storage",
+                    new String[] {"value"},
+                    "primkey = ?",
+                    new String[] {key},
+                    null,
+                    null,
+                    null);
+
+            if (cursor.moveToNext()) {
+                value = cursor.getString(0);
+                Timber.d("Loading key '%s', value = '%s'", key, value);
+            }
+        } finally {
+            Utility.closeQuietly(cursor);
+        }
+
+        return value;
+    }
+
+    private void writeValue(SQLiteDatabase mDb, String key, String value) {
+        if (value == null) {
+            mDb.delete("preferences_storage", "primkey = ?", new String[] { key });
+            return;
+        }
+
+        ContentValues cv = new ContentValues();
+        cv.put("primkey", key);
+        cv.put("value", value);
+
+        long result = mDb.update("preferences_storage", cv, "primkey = ?", new String[] { key });
+
+        if (result == -1) {
+            Timber.e("Error writing key '%s', value = '%s'", key, value);
+        }
+    }
+
+    private void insertValue(SQLiteDatabase mDb, String key, String value) {
+        if (value == null) {
+            return;
+        }
+
+        ContentValues cv = new ContentValues();
+        cv.put("primkey", key);
+        cv.put("value", value);
+
+        long result = mDb.insert("preferences_storage", null, cv);
+
+        if (result == -1) {
+            Timber.e("Error writing key '%s', value = '%s'", key, value);
+        }
+    }
+
+    private StorageMigrationsHelper migrationsHelper = new StorageMigrationsHelper() {
+        @Override
+        public void writeValue(@NotNull SQLiteDatabase db, @NotNull String key, String value) {
+            StoragePersister.this.writeValue(db, key, value);
+        }
+
+        @Override
+        public String readValue(@NotNull SQLiteDatabase db, @NotNull String key) {
+            return StoragePersister.this.readValue(db, key);
+        }
+
+        @Override
+        public void insertValue(@NotNull SQLiteDatabase db, @NotNull String key, @Nullable String value) {
+            StoragePersister.this.insertValue(db, key, value);
+        }
+    };
+}

--- a/app/core/src/test/java/com/fsck/k9/preferences/StorageEditorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/StorageEditorTest.kt
@@ -1,0 +1,183 @@
+package com.fsck.k9.preferences
+
+
+import com.fsck.k9.K9RobolectricTest
+import com.fsck.k9.whenever
+import com.nhaarman.mockito_kotlin.verifyNoMoreInteractions
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.any
+import org.mockito.ArgumentMatchers.eq
+import org.mockito.Mock
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.MockitoAnnotations
+
+
+class StorageEditorTest : K9RobolectricTest() {
+    @Mock private lateinit var storage: Storage
+    @Mock private lateinit var storagePersister: StoragePersister
+    @Mock private lateinit var storagePersisterOps: StoragePersister.StoragePersistOperations
+    private lateinit var editor: StorageEditor
+
+    private val workingMap = mutableMapOf<String,String>()
+    private val storageMap = mapOf(
+            "storage-key" to "storage-value"
+    )
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        whenever(storage.all).thenReturn(storageMap)
+
+        editor = StorageEditor(storage, storagePersister)
+        verify(storage).all
+    }
+
+    @Test
+    fun commit_exception() {
+        whenever(storagePersister.doInTransaction(any())).thenThrow(RuntimeException())
+
+        val success = editor.commit()
+
+        assertFalse(success)
+    }
+
+    @Test
+    fun commit_trivial() {
+        prepareStoragePersisterMock()
+
+        val success = editor.commit()
+
+        assertTrue(success)
+        verifyNoMoreInteractions(storagePersisterOps)
+    }
+
+    @Test
+    fun putBoolean() {
+        prepareStoragePersisterMock()
+
+        editor.putBoolean("x", true)
+        val success = editor.commit()
+
+        assertTrue(success)
+        verify(storagePersisterOps).put("x", "true")
+        verifyNoMoreInteractions(storagePersisterOps)
+    }
+
+    @Test
+    fun putInt() {
+        prepareStoragePersisterMock()
+
+        editor.putInt("x", 123)
+        val success = editor.commit()
+
+        assertTrue(success)
+        verify(storagePersisterOps).put("x", "123")
+        verifyNoMoreInteractions(storagePersisterOps)
+    }
+
+    @Test
+    fun putLong() {
+        prepareStoragePersisterMock()
+
+        editor.putLong("x", 1234)
+        val success = editor.commit()
+
+        assertTrue(success)
+        verify(storagePersisterOps).put("x", "1234")
+        verifyNoMoreInteractions(storagePersisterOps)
+    }
+
+    @Test
+    fun putString() {
+        prepareStoragePersisterMock()
+
+        editor.putString("x", "y")
+        val success = editor.commit()
+
+        assertTrue(success)
+        verify(storagePersisterOps).put("x", "y")
+        verifyNoMoreInteractions(storagePersisterOps)
+    }
+
+    @Test
+    fun putString_duplicateSame() {
+        prepareStoragePersisterMock()
+
+        editor.putString("storage-key", "storage-value")
+        val success = editor.commit()
+
+        assertTrue(success)
+        verifyNoMoreInteractions(storagePersisterOps)
+    }
+
+    @Test
+    fun putString_duplicateOther() {
+        prepareStoragePersisterMock()
+
+        editor.putString("storage-key", "other-value")
+        val success = editor.commit()
+
+        assertTrue(success)
+        verify(storagePersisterOps).put("storage-key", "other-value")
+        verifyNoMoreInteractions(storagePersisterOps)
+    }
+
+    @Test
+    fun putString_removedDuplicate() {
+        prepareStoragePersisterMock()
+
+        editor.remove("storage-key")
+        editor.putString("storage-key", "storage-value")
+        val success = editor.commit()
+
+        assertTrue(success)
+        verify(storagePersisterOps).remove("storage-key")
+        verify(storagePersisterOps).put("storage-key", "storage-value")
+        verifyNoMoreInteractions(storagePersisterOps)
+    }
+
+    @Test
+    fun remove() {
+        prepareStoragePersisterMock()
+
+        editor.remove("x")
+        val success = editor.commit()
+
+        assertTrue(success)
+        verify(storagePersisterOps).remove("x")
+        verifyNoMoreInteractions(storagePersisterOps)
+    }
+
+    private fun prepareStoragePersisterMock() {
+        whenever(storagePersisterOps.put(any(), any())).then {
+            val key = it.getArgument<String>(0)
+            val value = it.getArgument<String>(0)
+
+            workingMap[key] = value
+            Unit
+        }
+        whenever(storagePersisterOps.remove(any())).then {
+            val key = it.getArgument<String>(0)
+            val value = it.getArgument<String>(0)
+
+            workingMap[key] = value
+            Unit
+        }
+
+        whenever(storagePersister.doInTransaction(any())).then {
+            val operationCallback = it.getArgument<StoragePersister.StoragePersistOperationCallback>(0)
+            operationCallback.beforePersistTransaction(workingMap)
+            verify(storage, times(2)).all
+            assertEquals(workingMap, storageMap)
+
+            operationCallback.persist(storagePersisterOps)
+            verify(storagePersister).doInTransaction(any())
+
+            operationCallback.onPersistTransactionSuccess(workingMap)
+            verify(storage).replaceAll(eq(workingMap))
+        }
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/preferences/StoragePersisterTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/StoragePersisterTest.kt
@@ -1,0 +1,114 @@
+package com.fsck.k9.preferences
+
+
+import android.content.Context
+import com.fsck.k9.K9RobolectricTest
+import com.fsck.k9.preferences.StoragePersister.StoragePersistOperationCallback
+import com.fsck.k9.preferences.StoragePersister.StoragePersistOperations
+import com.nhaarman.mockito_kotlin.*
+import org.junit.Assert.*
+import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+
+
+class StoragePersisterTest : K9RobolectricTest() {
+    private var context: Context = RuntimeEnvironment.application
+    private var storagePersister = StoragePersister(context)
+
+    @Test
+    fun doInTransaction_order() {
+        val operationCallback = prepareCallback()
+        storagePersister.doInTransaction(operationCallback)
+
+        inOrder(operationCallback) {
+            verify(operationCallback).beforePersistTransaction(any())
+            verify(operationCallback).persist(any())
+            verify(operationCallback).onPersistTransactionSuccess(any())
+        }
+        verifyNoMoreInteractions(operationCallback)
+    }
+
+    @Test
+    fun doInTransaction_put() {
+        val operationCallback = prepareCallback(
+                persistOp = { ops -> ops.put("x", "y") },
+                onSuccess = { map ->
+                    assertEquals(1, map.size)
+                    assertEquals("y", map["x"])
+                }
+        )
+
+        storagePersister.doInTransaction(operationCallback)
+
+        val values = storagePersister.loadValues()
+        assertEquals(1, values.size)
+        assertEquals("y", values["x"])
+    }
+
+    @Test
+    fun doInTransaction_putAndThrow() {
+        val exception = Exception("boom")
+        val operationCallback = prepareCallback(
+                persistOp = { ops ->
+                    ops.put("x", "y")
+                    throw exception
+                }
+        )
+
+        try {
+            storagePersister.doInTransaction(operationCallback)
+            fail("expected exception")
+        } catch (e: Exception) {
+            assertSame(exception, e)
+        }
+
+        val values = storagePersister.loadValues()
+        assertTrue(values.isEmpty())
+        verify(operationCallback, never()).onPersistTransactionSuccess(any())
+    }
+
+    @Test
+    fun doInTransaction_remove() {
+        val operationCallback = prepareCallback(
+                before = { map -> map["x"] = "y" },
+                persistOp = { ops -> ops.remove("x") },
+                onSuccess = { map -> assertTrue(map.isEmpty()) }
+        )
+
+        storagePersister.doInTransaction(operationCallback)
+
+        val values = storagePersister.loadValues()
+        assertTrue(values.isEmpty())
+    }
+
+    @Test
+    fun doInTransaction_before_preserveButNotPersist() {
+        val operationCallback = prepareCallback(
+                before = { map -> map["x"] = "y" },
+                onSuccess = { map -> assertEquals("y", map["x"]) }
+        )
+
+        storagePersister.doInTransaction(operationCallback)
+
+        val values = storagePersister.loadValues()
+        assertTrue(values.isEmpty())
+    }
+
+    private fun prepareCallback(
+            persistOp: ((StoragePersistOperations) -> Unit)? = null,
+            before: ((MutableMap<String, String>) -> Unit)? = null,
+            onSuccess: ((Map<String, String>) -> Unit)? = null
+    ): StoragePersistOperationCallback = spy(object : StoragePersistOperationCallback {
+        override fun beforePersistTransaction(workingStorage: MutableMap<String, String>) {
+            before?.invoke(workingStorage)
+        }
+
+        override fun persist(ops: StoragePersistOperations) {
+            persistOp?.invoke(ops)
+        }
+
+        override fun onPersistTransactionSuccess(workingStorage: Map<String, String>) {
+            onSuccess?.invoke(workingStorage)
+        }
+    })
+}

--- a/app/core/src/test/java/com/fsck/k9/preferences/StorageTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/StorageTest.kt
@@ -1,0 +1,79 @@
+package com.fsck.k9.preferences
+
+
+import org.junit.Assert.*
+import org.junit.Test
+
+
+private const val TEST_STRING_KEY = "s"
+private const val TEST_STRING_VALUE = "y"
+private const val TEST_INT_KEY = "i"
+private const val TEST_INT_VALUE = "4"
+private const val TEST_STRING_DEFAULT = "z"
+private const val TEST_INT_DEFAULT = 2
+private val TEST_MAP = mapOf(
+        TEST_STRING_KEY to TEST_STRING_VALUE,
+        TEST_INT_KEY to TEST_INT_VALUE
+)
+
+class StorageTest {
+    internal var storage = Storage()
+
+    @Test
+    fun isEmpty() {
+        assertTrue(storage.isEmpty)
+    }
+
+    @Test
+    fun isNotEmpty() {
+        storage.replaceAll(TEST_MAP)
+        assertFalse(storage.isEmpty)
+    }
+
+    @Test
+    fun contains() {
+        storage.replaceAll(TEST_MAP)
+        assertTrue(storage.contains(TEST_STRING_KEY))
+    }
+
+    @Test
+    fun getString() {
+        storage.replaceAll(TEST_MAP)
+        assertEquals(TEST_STRING_VALUE, storage.getString(TEST_STRING_KEY, TEST_STRING_DEFAULT))
+    }
+
+    @Test
+    fun getString_default() {
+        assertTrue(storage.isEmpty)
+        assertEquals(TEST_STRING_DEFAULT, storage.getString(TEST_STRING_KEY, TEST_STRING_DEFAULT))
+    }
+
+    @Test
+    fun getAll() {
+        storage.replaceAll(TEST_MAP)
+        assertFalse(storage.isEmpty)
+        assertEquals(TEST_MAP, storage.all)
+    }
+
+    @Test
+    fun replaceAll() {
+        storage.replaceAll(TEST_MAP)
+        storage.replaceAll(emptyMap())
+        assertTrue(storage.isEmpty)
+    }
+
+    @Test
+    fun getInteger() {
+        storage.replaceAll(TEST_MAP)
+
+        assertEquals(Integer.parseInt(TEST_INT_VALUE), storage.getInt(TEST_INT_KEY, TEST_INT_DEFAULT))
+    }
+
+    @Test
+    fun getInteger_stringValue() {
+        storage.replaceAll(TEST_MAP)
+
+        // TODO is this good behavior?
+        assertEquals(TEST_INT_DEFAULT, storage.getInt(TEST_STRING_KEY, TEST_INT_DEFAULT))
+    }
+}

--- a/app/k9mail/src/androidTest/java/com/fsck/k9/external/MessageProviderTest.java
+++ b/app/k9mail/src/androidTest/java/com/fsck/k9/external/MessageProviderTest.java
@@ -51,7 +51,7 @@ public class MessageProviderTest extends ProviderTestCase2 {
 
     private void createAccount() {
         Preferences preferences = Preferences.getPreferences(getMockContext());
-        Account account = preferences.newAccount();
+        Account account = preferences.createEmptyAccount();
         account.setDescription("TestAccount");
         account.setChipColor(10);
         account.setStoreUri("imap://user@domain.com/");

--- a/app/k9mail/src/androidTest/java/com/fsck/k9/external/MessageProviderTest.java
+++ b/app/k9mail/src/androidTest/java/com/fsck/k9/external/MessageProviderTest.java
@@ -51,7 +51,7 @@ public class MessageProviderTest extends ProviderTestCase2 {
 
     private void createAccount() {
         Preferences preferences = Preferences.getPreferences(getMockContext());
-        Account account = preferences.createEmptyAccount();
+        Account account = preferences.newAccount();
         account.setDescription("TestAccount");
         account.setChipColor(10);
         account.setStoreUri("imap://user@domain.com/");

--- a/app/k9mail/src/androidTest/java/com/fsck/k9/provider/EmailProviderTest.java
+++ b/app/k9mail/src/androidTest/java/com/fsck/k9/provider/EmailProviderTest.java
@@ -100,7 +100,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test(expected = IllegalArgumentException.class)
     public void query_forMessagesWithAccountAndWithoutRequiredFields_throwsIllegalArgumentException() {
-        Account account = Preferences.getPreferences(getContext()).newAccount();
+        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
         account.getUuid();
 
         Cursor cursor = getProvider().query(
@@ -116,7 +116,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test(expected = SQLException.class) //Handle this better?
     public void query_forMessagesWithAccountAndRequiredFieldsWithNoOrderBy_throwsSQLiteException() {
-        Account account = Preferences.getPreferences(getContext()).newAccount();
+        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
         account.getUuid();
 
         Cursor cursor = getProvider().query(
@@ -136,7 +136,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forMessagesWithEmptyAccountAndRequiredFieldsAndOrderBy_providesEmptyResult() {
-        Account account = Preferences.getPreferences(getContext()).newAccount();
+        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
         account.getUuid();
 
         Cursor cursor = getProvider().query(
@@ -157,7 +157,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forMessagesWithAccountAndRequiredFieldsAndOrderBy_providesResult() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).newAccount();
+        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
 
@@ -179,7 +179,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forMessagesWithAccountAndRequiredFieldsAndOrderBy_sortsCorrectly() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).newAccount();
+        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account)
                 .getFolder("Inbox").appendMessages(Arrays.asList(message, laterMessage));
@@ -205,7 +205,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forThreadedMessages_sortsCorrectly() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).newAccount();
+        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account)
                 .getFolder("Inbox").appendMessages(Arrays.asList(message, laterMessage));
@@ -232,7 +232,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forThreadedMessages_showsThreadOfEmailOnce() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).newAccount();
+        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(reply));
@@ -260,7 +260,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forThreadedMessages_showsThreadOfEmailWithSameSendTimeOnce() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).newAccount();
+        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(replyAtSameTime));
@@ -288,7 +288,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forAThreadOfMessages_returnsMessage() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).newAccount();
+        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
         account.getUuid();
         Message message = new MimeMessage();
         message.setSubject("Test Subject");

--- a/app/k9mail/src/androidTest/java/com/fsck/k9/provider/EmailProviderTest.java
+++ b/app/k9mail/src/androidTest/java/com/fsck/k9/provider/EmailProviderTest.java
@@ -100,7 +100,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test(expected = IllegalArgumentException.class)
     public void query_forMessagesWithAccountAndWithoutRequiredFields_throwsIllegalArgumentException() {
-        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
+        Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
 
         Cursor cursor = getProvider().query(
@@ -116,7 +116,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test(expected = SQLException.class) //Handle this better?
     public void query_forMessagesWithAccountAndRequiredFieldsWithNoOrderBy_throwsSQLiteException() {
-        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
+        Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
 
         Cursor cursor = getProvider().query(
@@ -136,7 +136,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forMessagesWithEmptyAccountAndRequiredFieldsAndOrderBy_providesEmptyResult() {
-        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
+        Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
 
         Cursor cursor = getProvider().query(
@@ -157,7 +157,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forMessagesWithAccountAndRequiredFieldsAndOrderBy_providesResult() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
+        Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
 
@@ -179,7 +179,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forMessagesWithAccountAndRequiredFieldsAndOrderBy_sortsCorrectly() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
+        Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account)
                 .getFolder("Inbox").appendMessages(Arrays.asList(message, laterMessage));
@@ -205,7 +205,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forThreadedMessages_sortsCorrectly() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
+        Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account)
                 .getFolder("Inbox").appendMessages(Arrays.asList(message, laterMessage));
@@ -232,7 +232,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forThreadedMessages_showsThreadOfEmailOnce() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
+        Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(reply));
@@ -260,7 +260,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forThreadedMessages_showsThreadOfEmailWithSameSendTimeOnce() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
+        Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(message));
         DI.get(LocalStoreProvider.class).getInstance(account).getFolder("Inbox").appendMessages(Collections.singletonList(replyAtSameTime));
@@ -288,7 +288,7 @@ public class EmailProviderTest extends ProviderTestCase2<EmailProvider> {
 
     @Test
     public void query_forAThreadOfMessages_returnsMessage() throws MessagingException {
-        Account account = Preferences.getPreferences(getContext()).createEmptyAccount();
+        Account account = Preferences.getPreferences(getContext()).newAccount();
         account.getUuid();
         Message message = new MimeMessage();
         message.setSubject("Test Subject");

--- a/app/k9mail/src/main/java/com/fsck/k9/external/remotecontrol/RemoteControlService.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/external/remotecontrol/RemoteControlService.java
@@ -139,9 +139,7 @@ public class RemoteControlService extends CoreService {
                             K9.setK9Theme(K9RemoteControl.K9_THEME_DARK.equals(theme) ? K9.Theme.DARK : K9.Theme.LIGHT);
                         }
 
-                        Storage storage = preferences.getStorage();
-
-                        StorageEditor editor = storage.edit();
+                        StorageEditor editor = preferences.createStorageEditor();
                         K9.save(editor);
                         editor.commit();
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo42.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo42.java
@@ -18,10 +18,9 @@ class MigrationTo42 {
     public static void from41MoveFolderPreferences(MigrationsHelper migrationsHelper) {
         try {
             LocalStore localStore = migrationsHelper.getLocalStore();
-            Storage storage = migrationsHelper.getStorage();
 
             long startTime = SystemClock.elapsedRealtime();
-            StorageEditor editor = storage.edit();
+            StorageEditor editor = migrationsHelper.getPreferences().createStorageEditor();
 
             List<? extends Folder > folders = localStore.getPersonalNamespaces(true);
             for (Folder folder : folders) {

--- a/app/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.java
+++ b/app/storage/src/test/java/com/fsck/k9/storage/StoreSchemaDefinitionTest.java
@@ -14,7 +14,7 @@ import android.database.sqlite.SQLiteDatabase;
 import android.text.TextUtils;
 
 import com.fsck.k9.Account;
-import com.fsck.k9.K9;
+import com.fsck.k9.Preferences;
 import com.fsck.k9.core.BuildConfig;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.MessagingException;
@@ -337,6 +337,11 @@ public class StoreSchemaDefinitionTest extends K9RobolectricTest {
             @Override
             public LocalStore getLocalStore() {
                 return localStore;
+            }
+
+            @Override
+            public Preferences getPreferences() {
+                return mock(Preferences.class);
             }
 
             @Override

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1611,7 +1611,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         new Thread(new Runnable() {
             @Override
             public void run() {
-                StorageEditor editor = preferences.getStorage().edit();
+                StorageEditor editor = preferences.createStorageEditor();
                 K9.save(editor);
                 editor.commit();
             }

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/FontSizeSettings.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/FontSizeSettings.java
@@ -11,9 +11,8 @@ import com.fsck.k9.FontSizes;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.K9PreferenceActivity;
-import com.fsck.k9.ui.R;
-import com.fsck.k9.preferences.Storage;
 import com.fsck.k9.preferences.StorageEditor;
+import com.fsck.k9.ui.R;
 
 
 /**
@@ -191,8 +190,7 @@ public class FontSizeSettings extends K9PreferenceActivity {
 
         fontSizes.setMessageComposeInput(Integer.parseInt(mMessageComposeInput.getValue()));
 
-        Storage storage = Preferences.getPreferences(this).getStorage();
-        StorageEditor editor = storage.edit();
+        StorageEditor editor = Preferences.getPreferences(this).createStorageEditor();
         fontSizes.save(editor);
         editor.commit();
     }

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -850,7 +850,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             K9.setSortAscending(this.sortType, this.sortAscending);
             sortDateAscending = K9.isSortAscending(SortType.SORT_DATE);
 
-            StorageEditor editor = preferences.getStorage().edit();
+            StorageEditor editor = preferences.createStorageEditor();
             K9.save(editor);
             editor.commit();
         }

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -205,7 +205,7 @@ class GeneralSettingsDataStore(
     }
 
     private fun saveSettings() {
-        val editor = preferences.storage.edit()
+        val editor = preferences.createStorageEditor()
         K9.save(editor)
 
         executorService.execute {


### PR DESCRIPTION
This PR extracts the persistence logic from Storage into a StoragePersister. The Storage class itself is now very simple, changes happen exclusively from a `replaceAll` method. In StoragePersister itself I got rid of the ThreadLocal variables in favor of a slightly smarter callback logic that tracks the relevant variables.

I don't know how the database behaves when there are concurrent edits with multiple open "workingDbs"? But I'm fairly sure this also wasn't synchronized before.

The way `StorageEditor.commit` is sometimes called on background threads and sometimes on the UI thread is pretty fishy still. This PR doesn't fix that, but I didn't want to do too much at once. It should be easier to make those calls more consistent from here.