### PR TITLE
more clearly use getExternalFilesDir in ExternalStorageProvider

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/StorageManager.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/StorageManager.java
@@ -331,11 +331,6 @@ public class StorageManager {
         private final CoreResourceProvider resourceProvider;
 
         /**
-         * Root of the denoted storage.
-         */
-        private File mRoot;
-
-        /**
          * Chosen base directory.
          */
         private File mApplicationDirectory;
@@ -352,9 +347,7 @@ public class StorageManager {
 
         @Override
         public void init(Context context) {
-            mRoot = Environment.getExternalStorageDirectory();
-            mApplicationDirectory = new File(new File(new File(new File(mRoot, "Android"), "data"),
-                                             context.getPackageName()), "files");
+            mApplicationDirectory = context.getExternalFilesDir(null);
         }
 
         @Override
@@ -384,7 +377,7 @@ public class StorageManager {
 
         @Override
         public File getRoot(Context context) {
-            return mRoot;
+            return Environment.getExternalStorageDirectory();
         }
     }
 


### PR DESCRIPTION
We've been using the directory pointed to by [getExternalFilesDir(null)](https://developer.android.com/reference/android/content/Context.html#getExternalFilesDir(java.lang.String)) all along, and access to that directory [doesn't actually require permission](https://developer.android.com/training/data-storage/files#ExternalStoragePermissions).

This PR introduces no semantic changes, it just makes this more explicit. I tested the external storage provider and it works fine without storage permission.