### PR TITLE
Stop ImapFolderPusher on CertificateValidationException

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.fsck.k9.mail.AuthenticationFailedException;
+import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.Message;
@@ -194,6 +195,12 @@ class ImapFolderPusher extends ImapFolder {
 
                     pushReceiver.authenticationFailed();
                     stop = true;
+                } catch (CertificateValidationException e) {
+                    reacquireWakeLockAndCleanUp();
+
+                    Timber.e(e, "Certificate check failed. Stopping ImapFolderPusher.");
+                    stop = true;
+                    pushReceiver.pushError("Push error for " + getServerId(), e);
                 } catch (Exception e) {
                     reacquireWakeLockAndCleanUp();
 


### PR DESCRIPTION
Certificate errors are permanent and ask the user for interaction, but currently not treated as such by ImapFolderPusher. I got a certificate error notification every two seconds just now (because LocalKeyStore is broken, see #3772). This PR simply stops the pusher on a certificate error.

On a related note, the backoff mechanism doesn't seem to work, I would expect the notifications to at least show up with increasing delay. Maybe because the idle connections are all opened and then error in parallel.