### PR TITLE
Pick a contrasting foreground for drawer account chips

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/helper/Utility.java
+++ b/app/core/src/main/java/com/fsck/k9/helper/Utility.java
@@ -9,10 +9,12 @@ import java.util.regex.Pattern;
 
 import android.content.Context;
 import android.database.Cursor;
+import android.graphics.Color;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 import android.os.Handler;
 import android.os.Looper;
+import android.support.annotation.ColorInt;
 import android.text.Editable;
 import android.text.TextUtils;
 import android.widget.EditText;
@@ -322,5 +324,16 @@ public class Utility {
             sMainThreadHandler = new Handler(Looper.getMainLooper());
         }
         return sMainThreadHandler;
+    }
+
+    /**
+     * @return contrast ratio between the given colors
+     * @see <a href="https://www.w3.org/TR/WCAG20/#glossary">W3C's definition of contrast ratio</a>
+     */
+    public static float contrastRatio(@ColorInt int a, @ColorInt int b) {
+        float aLuminance = Color.luminance(a) + 0.05f,
+              bLuminance = Color.luminance(b) + 0.05f;
+
+        return Math.max(aLuminance, bLuminance) / Math.min(aLuminance, bLuminance);
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/K9Drawer.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/K9Drawer.java
@@ -9,6 +9,7 @@ import android.graphics.PorterDuff;
 import android.net.Uri;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
+import android.support.v4.content.res.ResourcesCompat;
 import android.support.v4.widget.DrawerLayout;
 import android.util.TypedValue;
 import android.view.View;
@@ -18,6 +19,7 @@ import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.activity.MessageList;
 import com.fsck.k9.helper.Contacts;
+import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mailstore.Folder;
 import com.fsck.k9.ui.folders.FolderNameFormatter;
 import com.fsck.k9.ui.messagelist.MessageListViewModel;
@@ -131,8 +133,19 @@ public class K9Drawer {
                 photoUris.add(photoUri);
                 pdi.withIcon(photoUri);
             } else {
+                int fg = ResourcesCompat.getColor(parent.getResources(), R.color.material_drawer_background, null),
+                    bg = account.getChipColor();
+
+                float[] hsv = new float[3];
+                Color.colorToHSV(bg, hsv);
+                while (Utility.contrastRatio(fg, bg) < 3) {
+                    hsv[2] *= .9f;
+                    bg = Color.HSVToColor(hsv);
+                }
+
                 pdi.withIcon(new IconicsDrawable(parent, FontAwesome.Icon.faw_user_alt)
-                        .colorRes(R.color.material_drawer_background).backgroundColor(account.getChipColor())
+                        .color(fg)
+                        .backgroundColor(bg)
                         .sizeDp(56).paddingDp(14));
             }
             headerBuilder.addProfiles(pdi);

--- a/app/ui/src/main/res/drawable/drawer_header_background.xml
+++ b/app/ui/src/main/res/drawable/drawer_header_background.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle" >
     <gradient
-        android:angle="45"
+        android:angle="270"
+        android:startColor="#777"
         android:centerColor="#777"
-        android:endColor="#444"
-        android:startColor="#555"
+        android:endColor="#333"
         android:type="linear" />
     <corners
         android:radius="0dp"/>


### PR DESCRIPTION
Uses the greatest contrasting color from the Material Drawer's background colors
This makes the chip icon more visible against lighter backgrounds 

Some screenshots:  
![dark background](https://user-images.githubusercontent.com/26379999/49339395-0f903080-f629-11e8-8c67-5bdd851b2e7a.png)
![light background](https://user-images.githubusercontent.com/26379999/49339396-0f903080-f629-11e8-8ec6-02da0e3774bc.png)
