### PR TITLE
Fix NPE when accessing settings screens

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -165,10 +165,12 @@ class AccountSettingsFragment : PreferenceFragmentCompat() {
     }
 
     private fun initializeNotifications() {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            PRE_SDK26_NOTIFICATION_PREFERENCES.forEach { findPreference(it).remove() }
-        } else {
-            findPreference(PREFERENCE_OPEN_NOTIFICATION_SETTINGS).remove()
+        findPreference(PREFERENCE_OPEN_NOTIFICATION_SETTINGS)?.let {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                PRE_SDK26_NOTIFICATION_PREFERENCES.forEach { findPreference(it).remove() }
+            } else {
+                it.remove()
+            }
         }
     }
 


### PR DESCRIPTION
Previous PR did not check if preferences to be removed exist on the current screen and failed when the current screen was not the notification settings.

Fixes #3782.

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). :heavy_check_mark: 
* Does not break any unit tests. :heavy_check_mark: 
* Contains a reference to the issue that it fixes. :heavy_check_mark: 
* For cosmetic changes add one or multiple images, if possible. N/A


