### PR TITLE
add AccountsChangeListener to Preferences

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/AccountsChangeListener.java
+++ b/app/core/src/main/java/com/fsck/k9/AccountsChangeListener.java
@@ -1,0 +1,6 @@
+package com.fsck.k9;
+
+
+public interface AccountsChangeListener {
+    void onAccountsChanged();
+}

--- a/app/core/src/main/java/com/fsck/k9/Preferences.java
+++ b/app/core/src/main/java/com/fsck/k9/Preferences.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import java.util.UUID;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
 import android.support.annotation.RestrictTo;
 import android.support.annotation.RestrictTo.Scope;
 
@@ -48,7 +49,8 @@ public class Preferences {
     private Map<String, Account> accounts = null;
     private List<Account> accountsInOrder = null;
     private Account newAccount;
-    private Context context;
+    private final ArrayList<AccountsChangeListener> accountsChangeListeners = new ArrayList<>();
+    private final Context context;
     private final LocalStoreProvider localStoreProvider;
     private final CoreResourceProvider resourceProvider;
     private final LocalKeyStoreManager localKeyStoreManager;
@@ -182,6 +184,8 @@ public class Preferences {
         if (newAccount == account) {
             newAccount = null;
         }
+
+        notifyListeners();
     }
 
     /**
@@ -223,6 +227,8 @@ public class Preferences {
         StorageEditor editor = createStorageEditor();
         accountPreferenceSerializer.save(editor, storage, account);
         editor.commit();
+
+        notifyListeners();
     }
 
     private void ensureAssignedAccountNumber(Account account) {
@@ -286,5 +292,21 @@ public class Preferences {
         accountPreferenceSerializer.move(storageEditor, account, storage, mUp);
         storageEditor.commit();
         loadAccounts();
+
+        notifyListeners();
+    }
+
+    private void notifyListeners() {
+        for (AccountsChangeListener listener : accountsChangeListeners) {
+            listener.onAccountsChanged();
+        }
+    }
+
+    public void addOnAccountsChangeListener(@NonNull AccountsChangeListener accountsChangeListener) {
+        accountsChangeListeners.add(accountsChangeListener);
+    }
+
+    public void removeOnAccountsChangeListener(@NonNull AccountsChangeListener accountsChangeListener) {
+        accountsChangeListeners.remove(accountsChangeListener);
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
@@ -21,6 +21,10 @@ class NotificationChannelManager(
         MESSAGES, MISCELLANEOUS
     }
 
+    init {
+        preferences.addOnAccountsChangeListener(this::updateChannels)
+    }
+
     fun updateChannels() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
             return

--- a/app/ui/src/main/java/com/fsck/k9/ui/account/AccountsLiveData.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/account/AccountsLiveData.kt
@@ -2,12 +2,13 @@ package com.fsck.k9.ui.account
 
 import android.arch.lifecycle.LiveData
 import com.fsck.k9.Account
+import com.fsck.k9.AccountsChangeListener
 import com.fsck.k9.Preferences
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import org.jetbrains.anko.coroutines.experimental.bg
 
-class AccountsLiveData(val preferences: Preferences) : LiveData<List<Account>>() {
+class AccountsLiveData(val preferences: Preferences) : LiveData<List<Account>>(), AccountsChangeListener {
     init {
         loadAccountsAsync()
     }
@@ -22,7 +23,21 @@ class AccountsLiveData(val preferences: Preferences) : LiveData<List<Account>>()
         }
     }
 
+    override fun onAccountsChanged() {
+        loadAccountsAsync()
+    }
+
     private fun loadAccounts(): List<Account> {
         return preferences.accounts
+    }
+
+    override fun onActive() {
+        super.onActive()
+        preferences.addOnAccountsChangeListener(this)
+    }
+
+    override fun onInactive() {
+        super.onInactive()
+        preferences.removeOnAccountsChangeListener(this)
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/account/AccountsLiveData.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/account/AccountsLiveData.kt
@@ -34,10 +34,12 @@ class AccountsLiveData(val preferences: Preferences) : LiveData<List<Account>>()
     override fun onActive() {
         super.onActive()
         preferences.addOnAccountsChangeListener(this)
+        loadAccountsAsync()
     }
 
     override fun onInactive() {
         super.onInactive()
         preferences.removeOnAccountsChangeListener(this)
+        value = null
     }
 }


### PR DESCRIPTION
This PR adds a simple way to listen for changes in accounts. At the moment there is no distinction between add/delete/save, since it doesn't seem necessary for the use cases we have.

I'm not entirely sure that this is what @cketti had in mind? Seems slightly weird to me to register as a listener in the init method of a bean.