### PR TITLE
Always send IP instead of hostname in HELO/EHLO

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -755,11 +755,6 @@ public class Account implements BaseAccount, StoreConfig {
         return idleRefreshMinutes;
     }
 
-    @Override
-    public boolean shouldHideHostname() {
-        return K9.hideHostnameWhenConnecting();
-    }
-
     public synchronized void setIdleRefreshMinutes(int idleRefreshMinutes) {
         this.idleRefreshMinutes = idleRefreshMinutes;
     }

--- a/app/core/src/main/java/com/fsck/k9/K9.java
+++ b/app/core/src/main/java/com/fsck/k9/K9.java
@@ -178,7 +178,6 @@ public class K9 {
     private static boolean wrapFolderNames = false;
     private static boolean hideUserAgent = false;
     private static boolean hideTimeZone = false;
-    private static boolean hideHostnameWhenConnecting = false;
 
     private static SortType sortType;
     private static Map<SortType, Boolean> sortAscending = new HashMap<>();
@@ -287,7 +286,6 @@ public class K9 {
         editor.putBoolean("wrapFolderNames", wrapFolderNames);
         editor.putBoolean("hideUserAgent", hideUserAgent);
         editor.putBoolean("hideTimeZone", hideTimeZone);
-        editor.putBoolean("hideHostnameWhenConnecting", hideHostnameWhenConnecting);
 
         editor.putString("language", language);
         editor.putInt("theme", theme.ordinal());
@@ -434,7 +432,6 @@ public class K9 {
         wrapFolderNames = storage.getBoolean("wrapFolderNames", false);
         hideUserAgent = storage.getBoolean("hideUserAgent", false);
         hideTimeZone = storage.getBoolean("hideTimeZone", false);
-        hideHostnameWhenConnecting = storage.getBoolean("hideHostnameWhenConnecting", false);
 
         confirmDelete = storage.getBoolean("confirmDelete", false);
         confirmDiscardMessage = storage.getBoolean("confirmDiscardMessage", true);
@@ -906,14 +903,6 @@ public class K9 {
     }
     public static void setHideTimeZone(final boolean state) {
         hideTimeZone = state;
-    }
-
-    public static boolean hideHostnameWhenConnecting() {
-        return hideHostnameWhenConnecting;
-    }
-
-    public static void setHideHostnameWhenConnecting(final boolean state) {
-        hideHostnameWhenConnecting = state;
     }
 
     public static String getAttachmentDefaultPath() {

--- a/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -295,7 +295,8 @@ public class GlobalSettings {
                 new V(48, new FontSizeSetting(FontSizes.FONT_DEFAULT))
         ));
         s.put("hideHostnameWhenConnecting", Settings.versions(
-                new V(49, new BooleanSetting(false))
+                new V(49, new BooleanSetting(false)),
+                new V(56, null)
         ));
 
         SETTINGS = Collections.unmodifiableMap(s);

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 55;
+    public static final int VERSION = 56;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -11,7 +11,6 @@ import com.fsck.k9.backend.imap.ImapStoreUriDecoder
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider
 import com.fsck.k9.mail.power.PowerManager
-import com.fsck.k9.mail.ssl.DefaultTrustedSocketFactory
 import com.fsck.k9.mail.ssl.TrustedSocketFactory
 import com.fsck.k9.mail.store.imap.ImapStore
 import com.fsck.k9.mail.transport.smtp.SmtpTransport
@@ -50,7 +49,7 @@ class ImapBackendFactory(
     private fun createSmtpTransport(account: Account): SmtpTransport {
         val serverSettings = decodeTransportUri(account.transportUri)
         val oauth2TokenProvider: OAuth2TokenProvider? = null
-        return SmtpTransport(serverSettings, account, trustedSocketFactory, oauth2TokenProvider)
+        return SmtpTransport(serverSettings, trustedSocketFactory, oauth2TokenProvider)
     }
 
     override fun decodeStoreUri(storeUri: String): ServerSettings {

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/Pop3BackendFactory.kt
@@ -37,7 +37,7 @@ class Pop3BackendFactory(
     private fun createSmtpTransport(account: Account): SmtpTransport {
         val serverSettings = decodeTransportUri(account.transportUri)
         val oauth2TokenProvider: OAuth2TokenProvider? = null
-        return SmtpTransport(serverSettings, account, trustedSocketFactory, oauth2TokenProvider)
+        return SmtpTransport(serverSettings, trustedSocketFactory, oauth2TokenProvider)
     }
 
     override fun decodeStoreUri(storeUri: String): ServerSettings {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -44,7 +44,6 @@ class GeneralSettingsDataStore(
             "disable_notifications_during_quiet_time" -> !K9.isNotificationDuringQuietTimeEnabled()
             "privacy_hide_useragent" -> K9.hideUserAgent()
             "privacy_hide_timezone" -> K9.hideTimeZone()
-            "privacy_hide_hostname_when_connecting" -> K9.hideHostnameWhenConnecting()
             "debug_logging" -> K9.isDebug()
             "sensitive_logging" -> K9.DEBUG_SENSITIVE
             else -> defValue
@@ -79,7 +78,6 @@ class GeneralSettingsDataStore(
             "disable_notifications_during_quiet_time" -> K9.setNotificationDuringQuietTimeEnabled(!value)
             "privacy_hide_useragent" -> K9.setHideUserAgent(value)
             "privacy_hide_timezone" -> K9.setHideTimeZone(value)
-            "privacy_hide_hostname_when_connecting" -> K9.hideHostnameWhenConnecting()
             "debug_logging" -> K9.setDebug(value)
             "sensitive_logging" -> K9.DEBUG_SENSITIVE = value
             else -> return

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -351,8 +351,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_privacy_hide_useragent_detail">Remove K-9 User-Agent from mail headers</string>
     <string name="global_settings_privacy_hide_timezone">Hide timezone</string>
     <string name="global_settings_privacy_hide_timezone_detail">Use UTC instead of local timezone in mail headers and reply header</string>
-    <string name="global_settings_privacy_hide_hostname_when_connecting">Hide hostname</string>
-    <string name="global_settings_privacy_hide_hostname_when_connecting_detail">Identify as \'localhost\' when connecting to SMTP servers</string>
     <string name="global_settings_notification_hide_subject_title">Hide subject in notifications</string>
     <string name="global_settings_notification_hide_subject_never">Never</string>
     <string name="global_settings_notification_hide_subject_when_locked">When device is locked</string>

--- a/app/ui/src/main/res/xml/general_settings.xml
+++ b/app/ui/src/main/res/xml/general_settings.xml
@@ -368,11 +368,6 @@
             android:summary="@string/global_settings_privacy_hide_timezone_detail"
             android:title="@string/global_settings_privacy_hide_timezone" />
 
-        <CheckBoxPreference
-            android:key="privacy_hide_hostname_when_connecting"
-            android:summary="@string/global_settings_privacy_hide_hostname_when_connecting_detail"
-            android:title="@string/global_settings_privacy_hide_hostname_when_connecting" />
-
     </PreferenceScreen>
 
     <PreferenceScreen

--- a/mail/common/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/store/StoreConfig.java
@@ -21,6 +21,4 @@ public interface StoreConfig {
     int getDisplayCount();
 
     int getIdleRefreshMinutes();
-
-    boolean shouldHideHostname();
 }

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.java
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.java
@@ -301,15 +301,14 @@ public class SmtpTransport extends Transport {
         }
     }
 
-    @VisibleForTesting
-    protected String buildHostnameToReport() {
+    private String buildHostnameToReport() {
         InetAddress localAddress = socket.getLocalAddress();
-        String ipAddr = localAddress.getHostAddress();
 
+        // we use local ip statically for privacy reasons, see https://github.com/k9mail/k-9/pull/3798
         if (localAddress instanceof Inet6Address) {
-            return "[IPv6:" + ipAddr + "]";
+            return "[IPv6:::1]";
         } else {
-            return "[" + ipAddr + "]";
+            return "[127.0.0.1]";
         }
     }
 

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
@@ -16,7 +16,6 @@ import com.fsck.k9.mail.helpers.TestTrustedSocketFactory;
 import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
-import com.fsck.k9.mail.store.StoreConfig;
 import com.fsck.k9.mail.transport.mockServer.MockSmtpServer;
 import org.junit.Before;
 import org.junit.Test;
@@ -43,7 +42,6 @@ public class SmtpTransportTest {
     
     private TrustedSocketFactory socketFactory;
     private OAuth2TokenProvider oAuth2TokenProvider;
-    private StoreConfig storeConfig = mock(StoreConfig.class);
 
 
     @Before
@@ -62,7 +60,7 @@ public class SmtpTransportTest {
         server.output("250-localhost Hello client.localhost");
         server.output("250 OK");
         SmtpTransport transport = startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE,
-                null, "[127.0.0.1]");
+                null);
 
         transport.open();
 
@@ -861,18 +859,16 @@ public class SmtpTransportTest {
     }
 
     private SmtpTransport startServerAndCreateSmtpTransportWithoutPassword(MockSmtpServer server) throws Exception {
-        return startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE, null,
-                "[127.0.0.1]");
+        return startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE, null);
     }
 
     private SmtpTransport startServerAndCreateSmtpTransport(MockSmtpServer server, AuthType authenticationType,
             ConnectionSecurity connectionSecurity) throws Exception {
-        return startServerAndCreateSmtpTransport(server, authenticationType, connectionSecurity, PASSWORD,
-                "[127.0.0.1]");
+        return startServerAndCreateSmtpTransport(server, authenticationType, connectionSecurity, PASSWORD);
     }
 
     private SmtpTransport startServerAndCreateSmtpTransport(MockSmtpServer server, AuthType authenticationType,
-            ConnectionSecurity connectionSecurity, String password, String injectedHostname)
+            ConnectionSecurity connectionSecurity, String password)
             throws Exception {
         server.start();
 
@@ -888,7 +884,7 @@ public class SmtpTransportTest {
                 password,
                 CLIENT_CERTIFICATE_ALIAS);
 
-        return new TestSmtpTransport(serverSettings, socketFactory, oAuth2TokenProvider, injectedHostname);
+        return new SmtpTransport(serverSettings, socketFactory, oAuth2TokenProvider);
     }
 
     private TestMessageBuilder getDefaultMessageBuilder() {
@@ -924,22 +920,5 @@ public class SmtpTransportTest {
         server.output("235 2.7.0 Authentication successful");
         
         return server;
-    }
-    
-    
-    static class TestSmtpTransport extends SmtpTransport {
-        private final String injectedHostname;
-
-        TestSmtpTransport(ServerSettings serverSettings,
-                TrustedSocketFactory trustedSocketFactory, OAuth2TokenProvider oAuth2TokenProvider,
-                String injectedHostname)  {
-            super(serverSettings, trustedSocketFactory, oAuth2TokenProvider);
-            this.injectedHostname = injectedHostname;
-        }
-
-        @Override
-        protected String buildHostnameToReport() {
-            return injectedHostname;
-        }
     }
 }

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
@@ -1,8 +1,6 @@
 package com.fsck.k9.mail.transport.smtp;
 
 
-import java.net.InetAddress;
-
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.CertificateValidationException;
@@ -57,63 +55,15 @@ public class SmtpTransportTest {
     }
 
     @Test
-    public void open_withShouldHideHostnameTrue_shouldProvideLocalhost() throws Exception {
-        MockSmtpServer server = new MockSmtpServer();
-        server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
-        server.output("250-localhost Hello client.localhost");
-        server.output("250 OK");
-        when(storeConfig.shouldHideHostname()).thenReturn(true);
-        SmtpTransport transport = startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE, null,
-                "private.host.org", "127.0.0.1");
-
-        transport.open();
-
-        server.verifyConnectionStillOpen();
-        server.verifyInteractionCompleted();
-    }
-
-    @Test
-    public void open_withShouldHideHostnameFalse_shouldProvideHostname() throws Exception {
-        MockSmtpServer server = new MockSmtpServer();
-        server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO visible.host.org");
-        server.output("250-localhost Hello client.localhost");
-        server.output("250 OK");
-        SmtpTransport transport = startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE, null,
-                "visible.host.org", "127.0.0.1");
-
-        transport.open();
-
-        server.verifyConnectionStillOpen();
-        server.verifyInteractionCompleted();
-    }
-
-    @Test
-    public void open_withEmptyHostname_shouldProvideIPAddress() throws Exception {
+    public void open__shouldProvideHostname() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
         server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 OK");
-        SmtpTransport transport = startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE, null,
-                "", "127.0.0.1");
-
-        transport.open();
-
-        server.verifyConnectionStillOpen();
-        server.verifyInteractionCompleted();
-    }
-
-    @Test
-    public void open_withEmptyHostnameAndIP_shouldProvideSensibleDefault() throws Exception {
-        MockSmtpServer server = new MockSmtpServer();
-        server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO android");
-        server.output("250-localhost Hello client.localhost");
-        server.output("250 OK");
-        SmtpTransport transport = startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE, null,
-                "", "");
+        when(storeConfig.shouldHideHostname()).thenReturn(true);
+        SmtpTransport transport = startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE,
+                null, "[127.0.0.1]");
 
         transport.open();
 
@@ -125,7 +75,7 @@ public class SmtpTransportTest {
     public void open_withoutAuthLoginExtension_shouldConnectWithoutAuthentication() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 OK");
         SmtpTransport transport = startServerAndCreateSmtpTransportWithoutPassword(server);
@@ -140,7 +90,7 @@ public class SmtpTransportTest {
     public void open_withAuthPlainExtension() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH PLAIN LOGIN");
         server.expect("AUTH PLAIN AHVzZXIAcGFzc3dvcmQ=");
@@ -157,7 +107,7 @@ public class SmtpTransportTest {
     public void open_withAuthLoginExtension() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH LOGIN");
         server.expect("AUTH LOGIN");
@@ -178,7 +128,7 @@ public class SmtpTransportTest {
     public void open_withoutLoginAndPlainAuthExtensions_shouldThrow() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH");
         server.expect("QUIT");
@@ -200,7 +150,7 @@ public class SmtpTransportTest {
     public void open_withCramMd5AuthExtension() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH CRAM-MD5");
         server.expect("AUTH CRAM-MD5");
@@ -219,7 +169,7 @@ public class SmtpTransportTest {
     public void open_withoutCramMd5AuthExtension_shouldThrow() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH PLAIN LOGIN");
         server.expect("QUIT");
@@ -241,7 +191,7 @@ public class SmtpTransportTest {
     public void open_withXoauth2Extension() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH XOAUTH2");
         server.expect("AUTH XOAUTH2 dXNlcj11c2VyAWF1dGg9QmVhcmVyIG9sZFRva2VuAQE=");
@@ -258,7 +208,7 @@ public class SmtpTransportTest {
     public void open_withXoauth2Extension_shouldThrowOn401Response() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH XOAUTH2");
         server.expect("AUTH XOAUTH2 dXNlcj11c2VyAWF1dGg9QmVhcmVyIG9sZFRva2VuAQE=");
@@ -291,7 +241,7 @@ public class SmtpTransportTest {
     public void open_withXoauth2Extension_shouldInvalidateAndRetryOn400Response() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH XOAUTH2");
         server.expect("AUTH XOAUTH2 dXNlcj11c2VyAWF1dGg9QmVhcmVyIG9sZFRva2VuAQE=");
@@ -317,7 +267,7 @@ public class SmtpTransportTest {
     public void open_withXoauth2Extension_shouldInvalidateAndRetryOnInvalidJsonResponse() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH XOAUTH2");
         server.expect("AUTH XOAUTH2 dXNlcj11c2VyAWF1dGg9QmVhcmVyIG9sZFRva2VuAQE=");
@@ -343,7 +293,7 @@ public class SmtpTransportTest {
     public void open_withXoauth2Extension_shouldInvalidateAndRetryOnMissingStatusJsonResponse() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH XOAUTH2");
         server.expect("AUTH XOAUTH2 dXNlcj11c2VyAWF1dGg9QmVhcmVyIG9sZFRva2VuAQE=");
@@ -369,7 +319,7 @@ public class SmtpTransportTest {
     public void open_withXoauth2Extension_shouldThrowOnMultipleFailure() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH XOAUTH2");
         server.expect("AUTH XOAUTH2 dXNlcj11c2VyAWF1dGg9QmVhcmVyIG9sZFRva2VuAQE=");
@@ -405,7 +355,7 @@ public class SmtpTransportTest {
     public void open_withXoauth2Extension_shouldThrowOnFailure_fetchingToken() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH XOAUTH2");
         server.expect("QUIT");
@@ -429,7 +379,7 @@ public class SmtpTransportTest {
     public void open_withoutXoauth2Extension_shouldThrow() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH PLAIN LOGIN");
         server.expect("QUIT");
@@ -451,7 +401,7 @@ public class SmtpTransportTest {
     public void open_withAuthExternalExtension() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH EXTERNAL");
         server.expect("AUTH EXTERNAL dXNlcg==");
@@ -468,7 +418,7 @@ public class SmtpTransportTest {
     public void open_withoutAuthExternalExtension_shouldThrow() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH");
         server.expect("QUIT");
@@ -491,7 +441,7 @@ public class SmtpTransportTest {
             throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH CRAM-MD5");
         server.expect("AUTH CRAM-MD5");
@@ -511,7 +461,7 @@ public class SmtpTransportTest {
     public void open_withAutomaticAuthAndNoTransportSecurityAndAuthPlainExtension_shouldThrow() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 AUTH PLAIN LOGIN");
         server.expect("QUIT");
@@ -535,9 +485,9 @@ public class SmtpTransportTest {
     public void open_withEhloFailing_shouldTryHelo() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("502 5.5.1, Unrecognized command.");
-        server.expect("HELO localhost");
+        server.expect("HELO [127.0.0.1]");
         server.output("250 localhost");
         SmtpTransport transport = startServerAndCreateSmtpTransportWithoutPassword(server);
 
@@ -552,7 +502,7 @@ public class SmtpTransportTest {
             throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250-ENHANCEDSTATUSCODES");
         server.output("250 AUTH XOAUTH2");
@@ -586,7 +536,7 @@ public class SmtpTransportTest {
     public void open_withManyExtensions_shouldParseAll() throws Exception {
         MockSmtpServer server = new MockSmtpServer();
         server.output("220 smtp.gmail.com ESMTP x25sm19117693wrx.27 - gsmtp");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-smtp.gmail.com at your service, [86.147.34.216]");
         server.output("250-SIZE 35882577");
         server.output("250-8BITMIME");
@@ -913,17 +863,17 @@ public class SmtpTransportTest {
 
     private SmtpTransport startServerAndCreateSmtpTransportWithoutPassword(MockSmtpServer server) throws Exception {
         return startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE, null,
-                "localhost", "127.0.0.1");
+                "[127.0.0.1]");
     }
 
     private SmtpTransport startServerAndCreateSmtpTransport(MockSmtpServer server, AuthType authenticationType,
             ConnectionSecurity connectionSecurity) throws Exception {
         return startServerAndCreateSmtpTransport(server, authenticationType, connectionSecurity, PASSWORD,
-                "localhost", "127.0.0.1");
+                "[127.0.0.1]");
     }
 
     private SmtpTransport startServerAndCreateSmtpTransport(MockSmtpServer server, AuthType authenticationType,
-            ConnectionSecurity connectionSecurity, String password, String injectedHostname, String injectedIP)
+            ConnectionSecurity connectionSecurity, String password, String injectedHostname)
             throws Exception {
         server.start();
 
@@ -939,8 +889,7 @@ public class SmtpTransportTest {
                 password,
                 CLIENT_CERTIFICATE_ALIAS);
 
-        return new TestSmtpTransport(serverSettings, storeConfig, socketFactory, oAuth2TokenProvider, injectedHostname,
-                injectedIP);
+        return new TestSmtpTransport(serverSettings, socketFactory, oAuth2TokenProvider, injectedHostname);
     }
 
     private TestMessageBuilder getDefaultMessageBuilder() {
@@ -964,7 +913,7 @@ public class SmtpTransportTest {
         MockSmtpServer server = new MockSmtpServer();
         
         server.output("220 localhost Simple Mail Transfer Service Ready");
-        server.expect("EHLO localhost");
+        server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         
         for (String extension : extensions) {
@@ -981,24 +930,17 @@ public class SmtpTransportTest {
     
     static class TestSmtpTransport extends SmtpTransport {
         private final String injectedHostname;
-        private final String injectedIP;
 
-        TestSmtpTransport(ServerSettings serverSettings, StoreConfig storeConfig,
+        TestSmtpTransport(ServerSettings serverSettings,
                 TrustedSocketFactory trustedSocketFactory, OAuth2TokenProvider oAuth2TokenProvider,
-                String injectedHostname, String injectedIP)  {
-            super(serverSettings, storeConfig, trustedSocketFactory, oAuth2TokenProvider);
+                String injectedHostname)  {
+            super(serverSettings, trustedSocketFactory, oAuth2TokenProvider);
             this.injectedHostname = injectedHostname;
-            this.injectedIP = injectedIP;
         }
 
         @Override
-        protected String getCanonicalHostName(InetAddress localAddress) {
+        protected String buildHostnameToReport() {
             return injectedHostname;
-        }
-
-        @Override
-        protected String getHostAddress(InetAddress localAddress) {
-            return injectedIP;
         }
     }
 }

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
@@ -61,7 +61,6 @@ public class SmtpTransportTest {
         server.expect("EHLO [127.0.0.1]");
         server.output("250-localhost Hello client.localhost");
         server.output("250 OK");
-        when(storeConfig.shouldHideHostname()).thenReturn(true);
         SmtpTransport transport = startServerAndCreateSmtpTransport(server, AuthType.PLAIN, ConnectionSecurity.NONE,
                 null, "[127.0.0.1]");
 


### PR DESCRIPTION
Clients are very often behind NATs, which makes the hostname in HELO/EHLO messages virtually useless these days. Attempting to figure out a hostname we could use also led to issues with some strict Postfix
configurations (see #3387). This PR changes our behavior to simply send the local IP always.