### PR TITLE
Fix periodic mail sync

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2442,7 +2442,7 @@ public class MessagingController {
         }
         final TracingWakeLock wakeLock = twakeLock;
 
-        for (MessagingListener l : getListeners()) {
+        for (MessagingListener l : getListeners(listener)) {
             l.checkMailStarted(context, account);
         }
         putBackground("checkMail", listener, new Runnable() {
@@ -2478,7 +2478,7 @@ public class MessagingController {
                                 if (wakeLock != null) {
                                     wakeLock.release();
                                 }
-                                for (MessagingListener l : getListeners()) {
+                                for (MessagingListener l : getListeners(listener)) {
                                     l.checkMailFinished(context, account);
                                 }
 


### PR DESCRIPTION
The latch in `checkMailBlocking()` was never released because `checkMailFinished()` was never called on the provided `MessagingListener`.