### PR TITLE
Persist send error state

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/KoinModule.kt
@@ -25,4 +25,5 @@ val mainModule = applicationContext {
     bean { TrustManagerFactory.createInstance(get()) }
     bean { LocalKeyStoreManager(get()) }
     bean { DefaultTrustedSocketFactory(get(), get()) as TrustedSocketFactory }
+    bean { Clock.INSTANCE }
 }

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1698,7 +1698,7 @@ public class MessagingController {
             LocalFolder localFolder, LocalMessage message) throws MessagingException {
         if (!account.hasSentFolder() || !account.isUploadSentMessages()) {
             Timber.i("Not uploading sent message; deleting local message");
-            message.setFlag(Flag.DELETED, true);
+            message.destroy();
         } else {
             LocalFolder localSentFolder = localStore.getFolder(account.getSentFolder());
             Timber.i("Moving sent message to folder '%s' (%d)", account.getSentFolder(), localSentFolder.getDatabaseId());

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -29,6 +29,7 @@ import android.text.TextUtils;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.AccountStats;
+import com.fsck.k9.Clock;
 import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.Preferences;
@@ -180,6 +181,7 @@ public class LocalStore {
 
     private final Account account;
     private final LockableDatabase database;
+    private final OutboxStateRepository outboxStateRepository;
 
     static LocalStore createInstance(Account account, Context context) throws MessagingException {
         return new LocalStore(account, context);
@@ -209,6 +211,9 @@ public class LocalStore {
         database = new LockableDatabase(context, account.getUuid(), schemaDefinition);
         database.setStorageProviderId(account.getLocalStorageProviderId());
         database.open();
+
+        Clock clock = DI.get(Clock.class);
+        outboxStateRepository = new OutboxStateRepository(database, clock);
     }
 
     public static int getDbVersion() {
@@ -246,6 +251,10 @@ public class LocalStore {
 
     protected Preferences getPreferences() {
         return Preferences.getPreferences(context);
+    }
+
+    public OutboxStateRepository getOutboxStateRepository() {
+        return outboxStateRepository;
     }
 
     public long getSize() throws MessagingException {

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LockableDatabase.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LockableDatabase.java
@@ -378,6 +378,9 @@ public class LockableDatabase {
                 }
                 doOpenOrCreateDb(databaseFile);
             }
+
+            mDb.execSQL("PRAGMA foreign_keys = ON;");
+
             if (mDb.getVersion() != mSchemaDefinition.getVersion()) {
                 mSchemaDefinition.doDbUpgrade(mDb);
             }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/OutboxState.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/OutboxState.kt
@@ -1,0 +1,8 @@
+package com.fsck.k9.mailstore
+
+data class OutboxState(
+        val sendState: SendState,
+        val numberOfSendAttempts: Int,
+        val sendError: String?,
+        val sendErrorTimestamp: Long
+)

--- a/app/core/src/main/java/com/fsck/k9/mailstore/OutboxStateRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/OutboxStateRepository.kt
@@ -1,0 +1,114 @@
+package com.fsck.k9.mailstore
+
+import android.content.ContentValues
+import com.fsck.k9.Clock
+
+class OutboxStateRepository(private val database: LockableDatabase, private val clock: Clock) {
+
+    fun getOutboxState(messageId: Long): OutboxState {
+        return database.execute(false) { db ->
+            db.query(
+                    TABLE_NAME,
+                    COLUMNS,
+                    "$COLUMN_MESSAGE_ID = ?",
+                    arrayOf(messageId.toString()), null, null, null
+            ).use { cursor ->
+                if (!cursor.moveToFirst()) {
+                    throw IllegalStateException("No outbox_state entry for message with id $messageId")
+                }
+
+                val sendStateString = cursor.getString(cursor.getColumnIndex(COLUMN_SEND_STATE))
+                val numberOfSendAttempts = cursor.getInt(cursor.getColumnIndex(COLUMN_NUMBER_OF_SEND_ATTEMPTS))
+                val sendErrorTimestamp = cursor.getLong(cursor.getColumnIndex(COLUMN_ERROR_TIMESTAMP))
+                val sendErrorColumnIndex = cursor.getColumnIndex(COLUMN_ERROR)
+                val sendError = if (cursor.isNull(sendErrorColumnIndex)) null else cursor.getString(sendErrorColumnIndex)
+
+                val sendState = SendState.fromDatabaseName(sendStateString)
+
+                OutboxState(sendState, numberOfSendAttempts, sendError, sendErrorTimestamp)
+            }
+        }
+    }
+
+    fun initializeOutboxState(messageId: Long) {
+        database.execute(false) { db ->
+            val contentValues = ContentValues().apply {
+                put(COLUMN_MESSAGE_ID, messageId)
+                put(COLUMN_SEND_STATE, SendState.READY.databaseName)
+            }
+
+            db.insert(TABLE_NAME, null, contentValues)
+        }
+    }
+
+    fun removeOutboxState(messageId: Long) {
+        database.execute(false) { db ->
+            db.delete(TABLE_NAME, "$COLUMN_MESSAGE_ID = ?", arrayOf(messageId.toString()))
+        }
+    }
+
+    fun incrementSendAttempts(messageId: Long) {
+        database.execute(false) { db ->
+            db.execSQL("UPDATE $TABLE_NAME " +
+                    "SET $COLUMN_NUMBER_OF_SEND_ATTEMPTS = $COLUMN_NUMBER_OF_SEND_ATTEMPTS + 1 " +
+                    "WHERE $COLUMN_MESSAGE_ID = ?",
+                    arrayOf(messageId.toString())
+            )
+        }
+    }
+
+    fun decrementSendAttempts(messageId: Long) {
+        database.execute(false) { db ->
+            db.execSQL("UPDATE $TABLE_NAME " +
+                    "SET $COLUMN_NUMBER_OF_SEND_ATTEMPTS = $COLUMN_NUMBER_OF_SEND_ATTEMPTS - 1 " +
+                    "WHERE $COLUMN_MESSAGE_ID = ?",
+                    arrayOf(messageId.toString())
+            )
+        }
+    }
+
+    fun setSendAttemptError(messageId: Long, errorMessage: String) {
+        val sendErrorTimestamp = clock.time
+
+        database.execute(false) { db ->
+            val contentValues = ContentValues().apply {
+                put(COLUMN_SEND_STATE, SendState.ERROR.databaseName)
+                put(COLUMN_ERROR_TIMESTAMP, sendErrorTimestamp)
+                put(COLUMN_ERROR, errorMessage)
+            }
+
+            db.update(TABLE_NAME, contentValues, "$COLUMN_MESSAGE_ID = ?", arrayOf(messageId.toString()))
+        }
+    }
+
+    fun setSendAttemptsExceeded(messageId: Long) {
+        val sendErrorTimestamp = clock.time
+
+        database.execute(false) { db ->
+            val contentValues = ContentValues().apply {
+                put(COLUMN_SEND_STATE, SendState.RETRIES_EXCEEDED.databaseName)
+                put(COLUMN_ERROR_TIMESTAMP, sendErrorTimestamp)
+                putNull(COLUMN_ERROR)
+            }
+
+            db.update(TABLE_NAME, contentValues, "$COLUMN_MESSAGE_ID = ?", arrayOf(messageId.toString()))
+        }
+    }
+
+
+    companion object {
+        private const val TABLE_NAME = "outbox_state"
+        private const val COLUMN_MESSAGE_ID = "message_id"
+        private const val COLUMN_SEND_STATE = "send_state"
+        private const val COLUMN_NUMBER_OF_SEND_ATTEMPTS = "number_of_send_attempts"
+        private const val COLUMN_ERROR_TIMESTAMP = "error_timestamp"
+        private const val COLUMN_ERROR = "error"
+
+        private val COLUMNS = arrayOf(
+                COLUMN_SEND_STATE,
+                COLUMN_NUMBER_OF_SEND_ATTEMPTS,
+                COLUMN_ERROR_TIMESTAMP,
+                COLUMN_ERROR
+        )
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/mailstore/SendState.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/SendState.kt
@@ -1,0 +1,15 @@
+package com.fsck.k9.mailstore
+
+enum class SendState(val databaseName: String) {
+    READY("ready"),
+    RETRIES_EXCEEDED("retries_exceeded"),
+    ERROR("error");
+
+    companion object {
+        @JvmStatic
+        fun fromDatabaseName(databaseName: String): SendState {
+            return SendState.values().firstOrNull { it.databaseName == databaseName }
+                    ?: throw IllegalArgumentException("Unknown value: $databaseName")
+        }
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -33,6 +33,9 @@ import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.mailstore.LocalStoreProvider;
+import com.fsck.k9.mailstore.OutboxState;
+import com.fsck.k9.mailstore.OutboxStateRepository;
+import com.fsck.k9.mailstore.SendState;
 import com.fsck.k9.mailstore.UnavailableStorageException;
 import com.fsck.k9.notification.NotificationController;
 import com.fsck.k9.search.LocalSearch;
@@ -533,7 +536,14 @@ public class MessagingControllerTest extends K9RobolectricTest {
         when(localFolder.exists()).thenReturn(true);
         when(localFolder.getMessages(null)).thenReturn(Collections.singletonList(localMessageToSend1));
         when(localMessageToSend1.getUid()).thenReturn("localMessageToSend1");
+        when(localMessageToSend1.getDatabaseId()).thenReturn(42L);
         when(localMessageToSend1.getHeader(K9.IDENTITY_HEADER)).thenReturn(new String[]{});
+
+        OutboxState outboxState = new OutboxState(SendState.READY, 0, null, 0);
+        OutboxStateRepository outboxStateRepository = mock(OutboxStateRepository.class);
+        when(outboxStateRepository.getOutboxState(42L)).thenReturn(outboxState);
+
+        when(localStore.getOutboxStateRepository()).thenReturn(outboxStateRepository);
         controller.addListener(listener);
     }
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -12,7 +12,7 @@ import timber.log.Timber;
 
 
 class StoreSchemaDefinition implements SchemaDefinition {
-    static final int DB_VERSION = 67;
+    static final int DB_VERSION = 68;
 
     private final MigrationsHelper migrationsHelper;
 
@@ -208,6 +208,14 @@ class StoreSchemaDefinition implements SchemaDefinition {
                 "BEGIN " +
                 "UPDATE threads SET root=id WHERE root IS NULL AND ROWID = NEW.ROWID; " +
                 "END");
+
+        db.execSQL("DROP TABLE IF EXISTS outbox_state");
+        db.execSQL("CREATE TABLE outbox_state (" +
+                "message_id INTEGER PRIMARY KEY NOT NULL REFERENCES messages(id) ON DELETE CASCADE," +
+                "send_state TEXT," +
+                "number_of_send_attempts INTEGER DEFAULT 0," +
+                "error_timestamp INTEGER DEFAULT 0," +
+                "error TEXT)");
 
         db.execSQL("DROP TABLE IF EXISTS pending_commands");
         db.execSQL("CREATE TABLE pending_commands " +

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo68.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo68.kt
@@ -1,0 +1,31 @@
+package com.fsck.k9.storage.migrations
+
+import android.database.sqlite.SQLiteDatabase
+
+
+internal object MigrationTo68 {
+    @JvmStatic
+    fun addOutboxStateTable(db: SQLiteDatabase) {
+        createOutboxStateTable(db)
+        createOutboxStateEntries(db)
+    }
+
+    private fun createOutboxStateTable(db: SQLiteDatabase) {
+        db.execSQL("CREATE TABLE outbox_state (" +
+                "message_id INTEGER PRIMARY KEY NOT NULL REFERENCES messages(id) ON DELETE CASCADE," +
+                "send_state TEXT," +
+                "number_of_send_attempts INTEGER DEFAULT 0," +
+                "error_timestamp INTEGER DEFAULT 0," +
+                "error TEXT)")
+    }
+
+    private fun createOutboxStateEntries(db: SQLiteDatabase) {
+        db.execSQL("""
+            INSERT INTO outbox_state (message_id, send_state)
+              SELECT messages.id, 'ready' FROM folders
+                JOIN messages ON (folders.id = messages.folder_id)
+                WHERE folders.server_id = 'K9MAIL_INTERNAL_OUTBOX'
+            """.trimIndent()
+        )
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.java
@@ -92,6 +92,8 @@ public class Migrations {
                 MigrationTo66.addEncryptionTypeColumnToMessagesTable(db);
             case 66:
                 MigrationTo67.addTypeColumnToFoldersTable(db, migrationsHelper);
+            case 67:
+                MigrationTo68.addOutboxStateTable(db);
         }
 
         if (shouldBuildFtsTable) {


### PR DESCRIPTION
This adds the `outbox_state` table to the database to keep track of the number of send attempts and hard send errors (server declined to send the message as opposed to temporary connection or server error).

It's only a first step towards better send error handling. Nicer notifications, better retry logic, displaying error indicators and actions to perform on messages that failed to send are next steps.