### PR TITLE
Fix subject being overwritten with `null`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1457,7 +1457,9 @@ public class MessagingController {
             localFolder.appendMessages(Collections.singletonList(message));
             LocalMessage localMessage = localFolder.getMessage(message.getUid());
             localMessage.setFlag(Flag.X_DOWNLOADED_FULL, true);
-            localMessage.setCachedDecryptedSubject(plaintextSubject);
+            if (plaintextSubject != null) {
+                localMessage.setCachedDecryptedSubject(plaintextSubject);
+            }
             localFolder.close();
             sendPendingMessages(account, listener);
         } catch (Exception e) {


### PR DESCRIPTION
Not using crypto-provider passes `null` as `plaintextSubject`. `saveDraft` already has protection against overwriting subject with `null`. This change adds the same check to `sendMessage`.

Fixes #3811.

There was an alternative solution of [returning subject for all messages](https://github.com/k9mail/k-9/issues/3811#issuecomment-445824005), but that would also add the `X_SUBJECT_DECRYPTED` flag (making it useless it if was set for all messages).

The fix is consistent with checks in other methods.

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). :heavy_check_mark: 
* Does not break any unit tests. :heavy_check_mark: 
* Contains a reference to the issue that it fixes. :heavy_check_mark: 
* For cosmetic changes add one or multiple images, if possible. N/A

@morckx, would you be so kind to test this fix? Thank you in advance!
