### PR TITLE
Fix consistent crashes when using dark theme

### DIFF
--- a/app/ui/src/main/res/values-v21/themes.xml
+++ b/app/ui/src/main/res/values-v21/themes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <style name="Theme.K9.Dark.Base" parent="Theme.AppCompat">
+    <style name="Theme.K9.Dark.Base" parent="Theme.AppCompat.NoActionBar">
         <item name="android:navigationBarColor">#000000</item>
     </style>
 </resources>


### PR DESCRIPTION
Commit 212f36170 moved dark theme's parent to `Theme.AppCompat.NoActionBar` but the theme file for v21 was not updated. This caused `IllegalStateException` to be thrown when constructingK9Activities when dark theme has been selected.

The fix corrects the parent value.

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). :heavy_check_mark: 
* Does not break any unit tests. :heavy_check_mark: 
* Contains a reference to the issue that it fixes. Didn't create issue for that.
* For cosmetic changes add one or multiple images, if possible. N/A


