### PR TITLE
Fix crash of SettingsActivity on resume

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/account/AccountsLiveData.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/account/AccountsLiveData.kt
@@ -9,9 +9,6 @@ import kotlinx.coroutines.experimental.launch
 import org.jetbrains.anko.coroutines.experimental.bg
 
 class AccountsLiveData(val preferences: Preferences) : LiveData<List<Account>>(), AccountsChangeListener {
-    init {
-        loadAccountsAsync()
-    }
 
     private fun loadAccountsAsync() {
         launch(UI) {
@@ -40,6 +37,5 @@ class AccountsLiveData(val preferences: Preferences) : LiveData<List<Account>>()
     override fun onInactive() {
         super.onInactive()
         preferences.removeOnAccountsChangeListener(this)
-        value = null
     }
 }


### PR DESCRIPTION
`SettingsActivity#populateSettingsList` listens for changes in accounts using `observeNotNull` that throws when a `null` value is assigned.

This change uses an empty list as a null object instead of the literal `null` value.

An alternative approach would be checking for `null` in all observers (currently only `SettingsViewModel`) but using an empty list avoids building this checking logic in each observer (cf. null object pattern).

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). :heavy_check_mark: 
* Does not break any unit tests. :heavy_check_mark: 
* Contains a reference to the issue that it fixes. :x: 
* For cosmetic changes add one or multiple images, if possible. N/A


