### PR TITLE
Redesign About activity

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -36,6 +36,10 @@ class AboutActivity : K9Activity() {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_license_url))))
         }
 
+        findViewById<View>(R.id.source).setOnClickListener {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_source_url))))
+        }
+
         webView = findViewById(R.id.about_view)
 
         val aboutHtml = buildHtml()

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -1,17 +1,22 @@
 package com.fsck.k9.ui.settings
 
+import java.util.Calendar
+
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
 import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.webkit.WebView
+import android.widget.TextView
 import com.fsck.k9.activity.K9Activity
 import com.fsck.k9.ui.R
 import de.cketti.library.changelog.ChangeLog
+
 import timber.log.Timber
-import java.util.Calendar
 
 class AboutActivity : K9Activity() {
     private lateinit var webView: WebView
@@ -21,6 +26,16 @@ class AboutActivity : K9Activity() {
         setLayout(R.layout.about)
 
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
+
+        findViewById<TextView>(R.id.version).text = getVersionNumber()
+
+        val year = Integer.toString(Calendar.getInstance().get(Calendar.YEAR))
+        findViewById<TextView>(R.id.copyright).text = getString(R.string.app_copyright_fmt, year, year)
+
+        findViewById<View>(R.id.licenseLayout).setOnClickListener {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_license_url))))
+        }
+
         webView = findViewById(R.id.about_view)
 
         val aboutHtml = buildHtml()
@@ -48,32 +63,13 @@ class AboutActivity : K9Activity() {
     }
 
     private fun buildHtml(): String {
-        val appName = getString(R.string.app_name)
-        val year = Calendar.getInstance().get(Calendar.YEAR)
-
         val html = StringBuilder()
                 .append("<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />")
-                .append("<img src=\"file:///android_asset/icon.png\" alt=\"").append(appName).append("\"/>")
-                .append("<h1>")
-                .append(getString(R.string.about_title_fmt,
-                        "<a href=\"${ getString(R.string.app_webpage_url) }\">"))
-                .append(appName)
-                .append("</a>")
-                .append("</h1><p>")
-                .append(appName)
-                .append(" ")
-                .append(getString(R.string.debug_version_fmt, getVersionNumber()))
-                .append("</p><p>")
-                .append(getString(R.string.app_authors_fmt, getString(R.string.app_authors)))
-                .append("</p><p>")
+                .append("<p>")
                 .append(getString(R.string.app_revision_fmt,
                         "<a href=\"${ getString(R.string.app_revision_url) }\">" +
                                 getString(R.string.app_revision_url) +
                                 "</a>"))
-                .append("</p><hr/><p>")
-                .append(getString(R.string.app_copyright_fmt, Integer.toString(year), Integer.toString(year)))
-                .append("</p><hr/><p>")
-                .append(getString(R.string.app_license))
                 .append("</p><hr/><p>")
 
         val libs = StringBuilder().append("<ul>")

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -40,6 +40,10 @@ class AboutActivity : K9Activity() {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_source_url))))
         }
 
+        findViewById<View>(R.id.changelog).setOnClickListener {
+            displayChangeLog()
+        }
+
         webView = findViewById(R.id.about_view)
 
         val aboutHtml = buildHtml()

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -7,9 +7,14 @@ import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
+import android.support.v4.app.Fragment
+import android.support.v7.widget.RecyclerView
+import android.support.v7.widget.LinearLayoutManager
+import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.view.ViewGroup
 import android.webkit.WebView
 import android.widget.TextView
 import com.fsck.k9.activity.K9Activity
@@ -18,9 +23,9 @@ import de.cketti.library.changelog.ChangeLog
 
 import timber.log.Timber
 
-class AboutActivity : K9Activity() {
-    private lateinit var webView: WebView
+private data class Library(val name: String, val URL: String, val license: String = "")
 
+class AboutActivity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setLayout(R.layout.about)
@@ -52,10 +57,14 @@ class AboutActivity : K9Activity() {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_revision_url))))
         }
 
-        webView = findViewById(R.id.about_view)
-
-        val aboutHtml = buildHtml()
-        webView.loadDataWithBaseURL("file:///android_res/drawable/", aboutHtml, "text/html", "utf-8", null)
+        val manager = LinearLayoutManager(this)
+        val libraries = findViewById<RecyclerView>(R.id.libraries)
+        libraries.apply {
+            layoutManager = manager
+            adapter = LibrariesAdapter(USED_LIBRARIES)
+            setNestedScrollingEnabled(false)
+            setFocusable(false)
+        }
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -78,24 +87,6 @@ class AboutActivity : K9Activity() {
         ChangeLog(this).fullLogDialog.show()
     }
 
-    private fun buildHtml(): String {
-        val html = StringBuilder()
-                .append("<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />")
-
-        val libs = StringBuilder().append("<ul>")
-        for ((library, url) in USED_LIBRARIES) {
-            libs.append("<li><a href=\"").append(url).append("\">")
-                    .append(library)
-                    .append("</a></li>")
-        }
-        libs.append("</ul>")
-
-        html.append(getString(R.string.app_libraries, libs.toString()))
-                .append("</p>")
-
-        return html.toString()
-    }
-
     private fun getVersionNumber(): String {
         return try {
             val packageInfo = packageManager.getPackageInfo(packageName, 0)
@@ -106,29 +97,51 @@ class AboutActivity : K9Activity() {
         }
     }
 
-
     companion object {
-        private val USED_LIBRARIES = mapOf(
-                "Android Support Library" to "https://developer.android.com/topic/libraries/support-library/index.html",
-                "Android-Support-Preference-V7-Fix" to "https://github.com/Gericop/Android-Support-Preference-V7-Fix",
-                "ckChangeLog" to "https://github.com/cketti/ckChangeLog",
-                "Commons IO" to "http://commons.apache.org/io/",
-                "Glide" to "https://github.com/bumptech/glide",
-                "HoloColorPicker" to "https://github.com/LarsWerkman/HoloColorPicker",
-                "jsoup" to "https://jsoup.org/",
-                "jutf7" to "http://jutf7.sourceforge.net/",
-                "JZlib" to "http://www.jcraft.com/jzlib/",
-                "Mime4j" to "http://james.apache.org/mime4j/",
-                "Moshi" to "https://github.com/square/moshi",
-                "Okio" to "https://github.com/square/okio",
-                "SafeContentResolver" to "https://github.com/cketti/SafeContentResolver",
-                "ShowcaseView" to "https://github.com/amlcurran/ShowcaseView",
-                "Timber" to "https://github.com/JakeWharton/timber",
-                "TokenAutoComplete" to "https://github.com/splitwise/TokenAutoComplete/")
+        private val USED_LIBRARIES = arrayOf(
+                Library("Android Support Library", "https://developer.android.com/topic/libraries/support-library/index.html", "Apache License, Version 2.0"),
+                Library("Android-Support-Preference-V7-Fix", "https://github.com/Gericop/Android-Support-Preference-V7-Fix", "Unlicense/Apache License, Version 2.0"),
+                Library("ckChangeLog", "https://github.com/cketti/ckChangeLog", "Apache License, Version 2.0"),
+                Library("Commons IO", "https://commons.apache.org/io/", "Apache License, Version 2.0"),
+                Library("Glide", "https://github.com/bumptech/glide", "Mixed License"),
+                Library("HoloColorPicker", "https://github.com/LarsWerkman/HoloColorPicker", "Apache License, Version 2.0"),
+                Library("jsoup", "https://jsoup.org/", "MIT License"),
+                Library("jutf7", "http://jutf7.sourceforge.net/", "MIT License"),
+                Library("JZlib", "http://www.jcraft.com/jzlib/", "BSD-style License"),
+                Library("Mime4j", "http://james.apache.org/mime4j/", "Apache License, Version 2.0"),
+                Library("Moshi", "https://github.com/square/moshi", "Apache License, Version 2.0"),
+                Library("Okio", "https://github.com/square/okio", "Apache License, Version 2.0"),
+                Library("SafeContentResolver", "https://github.com/cketti/SafeContentResolver", "Apache License, Version 2.0"),
+                Library("ShowcaseView", "https://github.com/amlcurran/ShowcaseView", "Apache License, Version 2.0"),
+                Library("Timber", "https://github.com/JakeWharton/timber", "Apache License, Version 2.0"),
+                Library("TokenAutoComplete", "https://github.com/splitwise/TokenAutoComplete/", "Apache License, Version 2.0"))
 
         fun start(context: Context) {
             val intent = Intent(context, AboutActivity::class.java)
             context.startActivity(intent)
         }
     }
+}
+
+private class LibrariesAdapter(private val dataset: Array<Library>)
+        : RecyclerView.Adapter<LibrariesAdapter.ViewHolder>() {
+
+    class ViewHolder(val view: View) : RecyclerView.ViewHolder(view)
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int) : ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.about_library, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun onBindViewHolder(holder: ViewHolder, index: Int) {
+        val library = dataset[index]
+        holder.view.findViewById<TextView>(R.id.name).text = library.name
+        holder.view.findViewById<TextView>(R.id.license).text = library.license
+        holder.view.setOnClickListener {
+            holder.view.getContext()
+                .startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(library.URL)))
+        }
+    }
+
+    override fun getItemCount() = dataset.size
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -8,8 +8,8 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.support.v4.app.Fragment
-import android.support.v7.widget.RecyclerView
 import android.support.v7.widget.LinearLayoutManager
+import android.support.v7.widget.RecyclerView
 import android.view.LayoutInflater
 import android.view.Menu
 import android.view.MenuItem
@@ -20,6 +20,8 @@ import android.widget.TextView
 import com.fsck.k9.activity.K9Activity
 import com.fsck.k9.ui.R
 import de.cketti.library.changelog.ChangeLog
+import kotlinx.android.synthetic.main.about.*
+import kotlinx.android.synthetic.main.about_library.view.*
 
 import timber.log.Timber
 
@@ -32,33 +34,30 @@ class AboutActivity : K9Activity() {
 
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
 
-        findViewById<TextView>(R.id.version).text = getVersionNumber()
+        version.text = getVersionNumber()
 
         val year = Integer.toString(Calendar.getInstance().get(Calendar.YEAR))
-        findViewById<TextView>(R.id.copyright).text = getString(R.string.app_copyright_fmt, year, year)
+        copyright.text = getString(R.string.app_copyright_fmt, year, year)
 
-        findViewById<View>(R.id.authorsLayout).setOnClickListener {
+        authorsLayout.setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_authors_url))))
         }
 
-        findViewById<View>(R.id.licenseLayout).setOnClickListener {
+        licenseLayout.setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_license_url))))
         }
 
-        findViewById<View>(R.id.source).setOnClickListener {
+        source.setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_source_url))))
         }
 
-        findViewById<View>(R.id.changelog).setOnClickListener {
-            displayChangeLog()
-        }
+        changelog.setOnClickListener { displayChangeLog() }
 
-        findViewById<View>(R.id.revisions).setOnClickListener {
+        revisions.setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_revision_url))))
         }
 
         val manager = LinearLayoutManager(this)
-        val libraries = findViewById<RecyclerView>(R.id.libraries)
         libraries.apply {
             layoutManager = manager
             adapter = LibrariesAdapter(USED_LIBRARIES)
@@ -135,8 +134,8 @@ private class LibrariesAdapter(private val dataset: Array<Library>)
 
     override fun onBindViewHolder(holder: ViewHolder, index: Int) {
         val library = dataset[index]
-        holder.view.findViewById<TextView>(R.id.name).text = library.name
-        holder.view.findViewById<TextView>(R.id.license).text = library.license
+        holder.view.name.text = library.name
+        holder.view.license.text = library.license
         holder.view.setOnClickListener {
             holder.view.getContext()
                 .startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(library.URL)))

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -32,6 +32,10 @@ class AboutActivity : K9Activity() {
         val year = Integer.toString(Calendar.getInstance().get(Calendar.YEAR))
         findViewById<TextView>(R.id.copyright).text = getString(R.string.app_copyright_fmt, year, year)
 
+        findViewById<View>(R.id.authorsLayout).setOnClickListener {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_authors_url))))
+        }
+
         findViewById<View>(R.id.licenseLayout).setOnClickListener {
             startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_license_url))))
         }

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -25,7 +25,7 @@ import kotlinx.android.synthetic.main.about_library.view.*
 
 import timber.log.Timber
 
-private data class Library(val name: String, val URL: String, val license: String = "")
+private data class Library(val name: String, val URL: String, val license: String)
 
 class AboutActivity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -35,6 +35,7 @@ class AboutActivity : K9Activity() {
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
 
         version.text = getVersionNumber()
+        versionLayout.setOnClickListener { displayChangeLog() }
 
         val year = Integer.toString(Calendar.getInstance().get(Calendar.YEAR))
         copyright.text = getString(R.string.app_copyright_fmt, year, year)
@@ -66,16 +67,9 @@ class AboutActivity : K9Activity() {
         }
     }
 
-    override fun onCreateOptionsMenu(menu: Menu): Boolean {
-        super.onCreateOptionsMenu(menu)
-        menuInflater.inflate(R.menu.about_option, menu)
-        return true
-    }
-
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
         when (item.itemId) {
             android.R.id.home -> onBackPressed()
-            R.id.changelog -> displayChangeLog()
             else -> return super.onOptionsItemSelected(item)
         }
 

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AboutActivity.kt
@@ -44,6 +44,10 @@ class AboutActivity : K9Activity() {
             displayChangeLog()
         }
 
+        findViewById<View>(R.id.revisions).setOnClickListener {
+            startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(getString(R.string.app_revision_url))))
+        }
+
         webView = findViewById(R.id.about_view)
 
         val aboutHtml = buildHtml()
@@ -73,12 +77,6 @@ class AboutActivity : K9Activity() {
     private fun buildHtml(): String {
         val html = StringBuilder()
                 .append("<meta http-equiv=\"content-type\" content=\"text/html; charset=utf-8\" />")
-                .append("<p>")
-                .append(getString(R.string.app_revision_fmt,
-                        "<a href=\"${ getString(R.string.app_revision_url) }\">" +
-                                getString(R.string.app_revision_url) +
-                                "</a>"))
-                .append("</p><hr/><p>")
 
         val libs = StringBuilder().append("<ul>")
         for ((library, url) in USED_LIBRARIES) {

--- a/app/ui/src/main/res/drawable-anydpi/ic_code_dark.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_code_dark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+	android:fillColor="#FFFFFFFF"
+	android:pathData="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z" />
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_code_light.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_code_light.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:alpha="0.54"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M9.4 16.6L4.8 12l4.6-4.6L8 6l-6 6 6 6 1.4-1.4zm5.2 0l4.6-4.6-4.6-4.6L16 6l6 6-6 6-1.4-1.4z" />
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_description_dark.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_description_dark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+	android:fillColor="#FFFFFFFF"
+	android:pathData="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z" />
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_description_light.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_description_light.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:alpha="0.54"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M14 2H6c-1.1 0-1.99.9-1.99 2L4 20c0 1.1.89 2 1.99 2H18c1.1 0 2-.9 2-2V8l-6-6zm2 16H8v-2h8v2zm0-4H8v-2h8v2zm-3-5V3.5L18.5 9H13z" />
+</vector>

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -138,8 +138,17 @@
                     android:id="@+id/source"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginRight="10dp"
                     android:background="?android:attr/selectableItemBackground"
                     android:text="@string/source_code"
+                    android:textAllCaps="true" />
+
+            <Button
+                    android:id="@+id/changelog"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:text="@string/changelog_full_title"
                     android:textAllCaps="true" />
         </LinearLayout>
 

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -137,6 +137,7 @@
     <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
+            android:paddingTop="16dp"
             android:layout_gravity="center">
         <Button
                 android:id="@+id/source"

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -130,6 +130,19 @@
             </LinearLayout>
         </LinearLayout>
 
+        <LinearLayout
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center">
+            <Button
+                    android:id="@+id/source"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:text="@string/source_code"
+                    android:textAllCaps="true" />
+        </LinearLayout>
+
         <TextView
                 android:id="@+id/copyright"
                 android:layout_width="match_parent"

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -6,6 +6,140 @@
 
     <include layout="@layout/toolbar" />
 
+    <ImageView
+            android:src="@mipmap/icon"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:layout_gravity="center"
+            android:layout_margin="16dp" />
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:orientation="vertical">
+        <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:gravity="center_vertical"
+                android:text="@string/about_title_fmt"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textSize="34sp"/>
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:gravity="center_vertical">
+            <ImageView
+                    android:src="?attr/iconSettingsAbout"
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:layout_gravity="center" />
+
+            <LinearLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="30dp"
+                    android:orientation="vertical">
+
+                <TextView
+                        android:text="@string/debug_version_fmt"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textColor="?android:attr/textColorPrimary"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                        android:id="@+id/version"
+                        android:text="Version"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:gravity="center_vertical">
+            <ImageView
+                    android:src="?attr/iconAboutAuthors"
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:layout_gravity="center" />
+
+            <LinearLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="30dp"
+                    android:orientation="vertical">
+
+                <TextView
+                        android:text="Authors"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textColor="?android:attr/textColorPrimary"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                        android:text="@string/app_authors"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <LinearLayout
+                android:id="@+id/licenseLayout"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:gravity="center_vertical">
+            <ImageView
+                    android:src="?attr/iconAboutLicense"
+                    android:layout_width="28dp"
+                    android:layout_height="28dp"
+                    android:layout_gravity="center" />
+
+            <LinearLayout
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingLeft="30dp"
+                    android:orientation="vertical">
+
+                <TextView
+                        android:text="License"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textColor="?android:attr/textColorPrimary"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                <TextView
+                        android:text="@string/app_license"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:textAppearance="?android:attr/textAppearanceMedium" />
+            </LinearLayout>
+        </LinearLayout>
+
+        <TextView
+                android:id="@+id/copyright"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:paddingTop="16dp"
+                android:paddingBottom="16dp"
+                android:gravity="center_vertical"
+                android:textAppearance="?android:attr/textAppearanceSmall" />
+    </LinearLayout>
+
     <WebView
             android:id="@+id/about_view"
             android:layout_width="match_parent"

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -48,7 +48,7 @@
                     android:orientation="vertical">
 
                 <TextView
-                        android:text="@string/debug_version_fmt"
+                        android:text="@string/version"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:textColor="?android:attr/textColorPrimary"

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -175,7 +175,7 @@
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         android:background="?android:attr/selectableItemBackground"
-                        android:text="@string/app_revision_fmt"
+                        android:text="@string/app_revision"
                         android:textAllCaps="true" />
             </LinearLayout>
 

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -147,8 +147,17 @@
                     android:id="@+id/changelog"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
+                    android:layout_marginRight="10dp"
                     android:background="?android:attr/selectableItemBackground"
                     android:text="@string/changelog_full_title"
+                    android:textAllCaps="true" />
+
+            <Button
+                    android:id="@+id/revisions"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?android:attr/selectableItemBackground"
+                    android:text="@string/app_revision_fmt"
                     android:textAllCaps="true" />
         </LinearLayout>
 

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -6,180 +6,207 @@
 
     <include layout="@layout/toolbar" />
 
-    <ImageView
-            android:src="@mipmap/icon"
-            android:layout_width="100dp"
-            android:layout_height="100dp"
-            android:layout_gravity="center"
-            android:layout_margin="16dp" />
-
-    <TextView
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:paddingBottom="16dp"
-            android:paddingLeft="16dp"
-            android:gravity="center_vertical"
-            android:text="@string/about_title"
-            android:textColor="?android:attr/textColorPrimary"
-            android:textSize="34sp"/>
-
-    <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:paddingBottom="16dp"
-            android:paddingLeft="16dp"
-            android:gravity="center_vertical">
-        <ImageView
-                android:src="?attr/iconSettingsAbout"
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:layout_gravity="center" />
+    <android.support.v4.widget.NestedScrollView
+              android:layout_height="fill_parent"
+              android:layout_width="fill_parent">
 
         <LinearLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:paddingLeft="30dp"
-                android:orientation="vertical">
+                  android:orientation="vertical"
+                  android:layout_height="fill_parent"
+                  android:layout_width="fill_parent">
+
+            <ImageView
+                    android:src="@mipmap/icon"
+                    android:layout_width="100dp"
+                    android:layout_height="100dp"
+                    android:layout_gravity="center"
+                    android:layout_margin="16dp" />
 
             <TextView
-                    android:text="@string/version"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingTop="16dp"
+                    android:paddingBottom="16dp"
+                    android:paddingLeft="16dp"
+                    android:gravity="center_vertical"
+                    android:text="@string/about_title"
                     android:textColor="?android:attr/textColorPrimary"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    android:textSize="34sp"/>
 
-            <TextView
-                    android:id="@+id/version"
-                    android:text="Version"
+            <LinearLayout
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
-        </LinearLayout>
-    </LinearLayout>
+                    android:paddingTop="16dp"
+                    android:paddingBottom="16dp"
+                    android:paddingLeft="16dp"
+                    android:gravity="center_vertical">
+                <ImageView
+                        android:src="?attr/iconSettingsAbout"
+                        android:layout_width="28dp"
+                        android:layout_height="28dp"
+                        android:layout_gravity="center" />
 
-    <LinearLayout
-            android:id="@+id/authorsLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:paddingBottom="16dp"
-            android:paddingLeft="16dp"
-            android:gravity="center_vertical"
-            android:clickable="true"
-            android:focusable="true"
-            android:background="?attr/selectableItemBackground">
-        <ImageView
-                android:src="?attr/iconAboutAuthors"
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:layout_gravity="center" />
+                <LinearLayout
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingLeft="30dp"
+                        android:orientation="vertical">
 
-        <LinearLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:paddingLeft="30dp"
-                android:orientation="vertical">
+                    <TextView
+                            android:text="@string/version"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="?android:attr/textColorPrimary"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
 
-            <TextView
-                    android:text="Authors"
+                    <TextView
+                            android:id="@+id/version"
+                            android:text="Version"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                    android:id="@+id/authorsLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:paddingTop="16dp"
+                    android:paddingBottom="16dp"
+                    android:paddingLeft="16dp"
+                    android:gravity="center_vertical"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:background="?attr/selectableItemBackground">
+                <ImageView
+                        android:src="?attr/iconAboutAuthors"
+                        android:layout_width="28dp"
+                        android:layout_height="28dp"
+                        android:layout_gravity="center" />
+
+                <LinearLayout
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingLeft="30dp"
+                        android:orientation="vertical">
+
+                    <TextView
+                            android:text="Authors"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="?android:attr/textColorPrimary"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                            android:text="@string/app_authors"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                    android:id="@+id/licenseLayout"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="16dp"
+                    android:paddingBottom="16dp"
+                    android:paddingLeft="16dp"
+                    android:gravity="center_vertical"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:background="?attr/selectableItemBackground">
+                <ImageView
+                        android:src="?attr/iconAboutLicense"
+                        android:layout_width="28dp"
+                        android:layout_height="28dp"
+                        android:layout_gravity="center" />
+
+                <LinearLayout
+                        android:layout_width="fill_parent"
+                        android:layout_height="wrap_content"
+                        android:paddingLeft="30dp"
+                        android:orientation="vertical">
+                    <TextView
+                            android:text="License"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textColor="?android:attr/textColorPrimary"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+
+                    <TextView
+                            android:text="@string/app_license"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                </LinearLayout>
+            </LinearLayout>
+
+            <LinearLayout
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="16dp"
+                    android:layout_gravity="center">
+                <Button
+                        android:id="@+id/source"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginRight="10dp"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:text="@string/source_code"
+                        android:textAllCaps="true" />
+
+                <Button
+                        android:id="@+id/changelog"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:layout_marginRight="10dp"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:text="@string/changelog_full_title"
+                        android:textAllCaps="true" />
+
+                <Button
+                        android:id="@+id/revisions"
+                        android:layout_width="wrap_content"
+                        android:layout_height="wrap_content"
+                        android:background="?android:attr/selectableItemBackground"
+                        android:text="@string/app_revision_fmt"
+                        android:textAllCaps="true" />
+            </LinearLayout>
+
+            <TextView
+                    android:id="@+id/copyright"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="16dp"
+                    android:paddingBottom="16dp"
+                    android:paddingLeft="16dp"
+                    android:paddingRight="16dp"
+                    android:gravity="center_vertical"
+                    android:textAppearance="?android:attr/textAppearanceSmall" />
+
+            <View
+                    android:layout_height="2dp"
+                    android:layout_width="match_parent"
+                    android:background="?android:attr/listDivider" />
+
+            <TextView
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingTop="16dp"
+                    android:paddingBottom="16dp"
+                    android:paddingLeft="16dp"
+                    android:gravity="center_vertical"
+                    android:text="@string/about_libraries"
                     android:textColor="?android:attr/textColorPrimary"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    android:textSize="34sp"/>
 
-            <TextView
-                    android:text="@string/app_authors"
+            <android.support.v7.widget.RecyclerView
+                    android:id="@+id/libraries"
                     android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
+                    android:layout_height="wrap_content" />
+
         </LinearLayout>
-    </LinearLayout>
-
-    <LinearLayout
-            android:id="@+id/licenseLayout"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:paddingBottom="16dp"
-            android:paddingLeft="16dp"
-            android:gravity="center_vertical"
-            android:clickable="true"
-            android:focusable="true"
-            android:background="?attr/selectableItemBackground">
-        <ImageView
-                android:src="?attr/iconAboutLicense"
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:layout_gravity="center" />
-
-        <LinearLayout
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:paddingLeft="30dp"
-                android:orientation="vertical">
-            <TextView
-                    android:text="License"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
-
-            <TextView
-                    android:text="@string/app_license"
-                    android:layout_width="match_parent"
-                    android:layout_height="wrap_content"
-                    android:textAppearance="?android:attr/textAppearanceMedium" />
-        </LinearLayout>
-    </LinearLayout>
-
-    <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:layout_gravity="center">
-        <Button
-                android:id="@+id/source"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginRight="10dp"
-                android:background="?android:attr/selectableItemBackground"
-                android:text="@string/source_code"
-                android:textAllCaps="true" />
-
-        <Button
-                android:id="@+id/changelog"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginRight="10dp"
-                android:background="?android:attr/selectableItemBackground"
-                android:text="@string/changelog_full_title"
-                android:textAllCaps="true" />
-
-        <Button
-                android:id="@+id/revisions"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:background="?android:attr/selectableItemBackground"
-                android:text="@string/app_revision_fmt"
-                android:textAllCaps="true" />
-    </LinearLayout>
-
-    <TextView
-            android:id="@+id/copyright"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:paddingTop="16dp"
-            android:paddingBottom="16dp"
-            android:paddingLeft="16dp"
-            android:paddingRight="16dp"
-            android:gravity="center_vertical"
-            android:textAppearance="?android:attr/textAppearanceSmall" />
-
-    <WebView
-            android:id="@+id/about_view"
-            android:layout_width="match_parent"
-            android:layout_height="0dp"
-            android:layout_weight="1"/>
+    </android.support.v4.widget.NestedScrollView>
 </LinearLayout>

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -34,12 +34,16 @@
                     android:textSize="34sp"/>
 
             <LinearLayout
+                    android:id="@+id/versionLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingTop="16dp"
                     android:paddingBottom="16dp"
                     android:paddingLeft="16dp"
-                    android:gravity="center_vertical">
+                    android:gravity="center_vertical"
+                    android:clickable="true"
+                    android:focusable="true"
+                    android:background="?attr/selectableItemBackground">
                 <ImageView
                         android:src="?attr/iconSettingsAbout"
                         android:layout_width="28dp"

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -13,163 +13,164 @@
             android:layout_gravity="center"
             android:layout_margin="16dp" />
 
+    <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:paddingLeft="16dp"
+            android:gravity="center_vertical"
+            android:text="@string/about_title"
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="34sp"/>
+
     <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
             android:paddingLeft="16dp"
-            android:paddingRight="16dp"
-            android:orientation="vertical">
-        <TextView
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingTop="16dp"
-                android:paddingBottom="16dp"
-                android:gravity="center_vertical"
-                android:text="@string/about_title"
-                android:textColor="?android:attr/textColorPrimary"
-                android:textSize="34sp"/>
+            android:gravity="center_vertical">
+        <ImageView
+                android:src="?attr/iconSettingsAbout"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_gravity="center" />
 
         <LinearLayout
-                android:layout_width="match_parent"
+                android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:paddingTop="16dp"
-                android:paddingBottom="16dp"
-                android:gravity="center_vertical">
-            <ImageView
-                    android:src="?attr/iconSettingsAbout"
-                    android:layout_width="28dp"
-                    android:layout_height="28dp"
-                    android:layout_gravity="center" />
+                android:paddingLeft="30dp"
+                android:orientation="vertical">
 
-            <LinearLayout
-                    android:layout_width="fill_parent"
+            <TextView
+                    android:text="@string/version"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingLeft="30dp"
-                    android:orientation="vertical">
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <TextView
-                        android:text="@string/version"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textColor="?android:attr/textColorPrimary"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                <TextView
-                        android:id="@+id/version"
-                        android:text="Version"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-            </LinearLayout>
-        </LinearLayout>
-
-        <LinearLayout
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:paddingTop="16dp"
-                android:paddingBottom="16dp"
-                android:gravity="center_vertical">
-            <ImageView
-                    android:src="?attr/iconAboutAuthors"
-                    android:layout_width="28dp"
-                    android:layout_height="28dp"
-                    android:layout_gravity="center" />
-
-            <LinearLayout
-                    android:layout_width="fill_parent"
+            <TextView
+                    android:id="@+id/version"
+                    android:text="Version"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingLeft="30dp"
-                    android:orientation="vertical">
-
-                <TextView
-                        android:text="Authors"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textColor="?android:attr/textColorPrimary"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                <TextView
-                        android:text="@string/app_authors"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-            </LinearLayout>
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
         </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:paddingLeft="16dp"
+            android:gravity="center_vertical">
+        <ImageView
+                android:src="?attr/iconAboutAuthors"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_gravity="center" />
 
         <LinearLayout
-                android:id="@+id/licenseLayout"
-                android:layout_width="match_parent"
+                android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
-                android:paddingTop="16dp"
-                android:paddingBottom="16dp"
-                android:gravity="center_vertical">
-            <ImageView
-                    android:src="?attr/iconAboutLicense"
-                    android:layout_width="28dp"
-                    android:layout_height="28dp"
-                    android:layout_gravity="center" />
+                android:paddingLeft="30dp"
+                android:orientation="vertical">
 
-            <LinearLayout
-                    android:layout_width="fill_parent"
+            <TextView
+                    android:text="Authors"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingLeft="30dp"
-                    android:orientation="vertical">
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
 
-                <TextView
-                        android:text="License"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textColor="?android:attr/textColorPrimary"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-
-                <TextView
-                        android:text="@string/app_license"
-                        android:layout_width="match_parent"
-                        android:layout_height="wrap_content"
-                        android:textAppearance="?android:attr/textAppearanceMedium" />
-            </LinearLayout>
+            <TextView
+                    android:text="@string/app_authors"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
         </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+            android:id="@+id/licenseLayout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:paddingLeft="16dp"
+            android:gravity="center_vertical"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground">
+        <ImageView
+                android:src="?attr/iconAboutLicense"
+                android:layout_width="28dp"
+                android:layout_height="28dp"
+                android:layout_gravity="center" />
 
         <LinearLayout
+                android:layout_width="fill_parent"
+                android:layout_height="wrap_content"
+                android:paddingLeft="30dp"
+                android:orientation="vertical">
+            <TextView
+                    android:text="License"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textColor="?android:attr/textColorPrimary"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <TextView
+                    android:text="@string/app_license"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:textAppearance="?android:attr/textAppearanceMedium" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center">
+        <Button
+                android:id="@+id/source"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_gravity="center">
-            <Button
-                    android:id="@+id/source"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="10dp"
-                    android:background="?android:attr/selectableItemBackground"
-                    android:text="@string/source_code"
-                    android:textAllCaps="true" />
+                android:layout_marginRight="10dp"
+                android:background="?android:attr/selectableItemBackground"
+                android:text="@string/source_code"
+                android:textAllCaps="true" />
 
-            <Button
-                    android:id="@+id/changelog"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_marginRight="10dp"
-                    android:background="?android:attr/selectableItemBackground"
-                    android:text="@string/changelog_full_title"
-                    android:textAllCaps="true" />
-
-            <Button
-                    android:id="@+id/revisions"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:background="?android:attr/selectableItemBackground"
-                    android:text="@string/app_revision_fmt"
-                    android:textAllCaps="true" />
-        </LinearLayout>
-
-        <TextView
-                android:id="@+id/copyright"
-                android:layout_width="match_parent"
+        <Button
+                android:id="@+id/changelog"
+                android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:paddingTop="16dp"
-                android:paddingBottom="16dp"
-                android:gravity="center_vertical"
-                android:textAppearance="?android:attr/textAppearanceSmall" />
+                android:layout_marginRight="10dp"
+                android:background="?android:attr/selectableItemBackground"
+                android:text="@string/changelog_full_title"
+                android:textAllCaps="true" />
+
+        <Button
+                android:id="@+id/revisions"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:background="?android:attr/selectableItemBackground"
+                android:text="@string/app_revision_fmt"
+                android:textAllCaps="true" />
     </LinearLayout>
+
+    <TextView
+            android:id="@+id/copyright"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:paddingTop="16dp"
+            android:paddingBottom="16dp"
+            android:paddingLeft="16dp"
+            android:paddingRight="16dp"
+            android:gravity="center_vertical"
+            android:textAppearance="?android:attr/textAppearanceSmall" />
 
     <WebView
             android:id="@+id/about_view"

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -25,7 +25,7 @@
                 android:paddingTop="16dp"
                 android:paddingBottom="16dp"
                 android:gravity="center_vertical"
-                android:text="@string/about_title_fmt"
+                android:text="@string/about_title"
                 android:textColor="?android:attr/textColorPrimary"
                 android:textSize="34sp"/>
 

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -60,12 +60,16 @@
     </LinearLayout>
 
     <LinearLayout
+            android:id="@+id/authorsLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:paddingTop="16dp"
             android:paddingBottom="16dp"
             android:paddingLeft="16dp"
-            android:gravity="center_vertical">
+            android:gravity="center_vertical"
+            android:clickable="true"
+            android:focusable="true"
+            android:background="?attr/selectableItemBackground">
         <ImageView
                 android:src="?attr/iconAboutAuthors"
                 android:layout_width="28dp"

--- a/app/ui/src/main/res/layout/about_library.xml
+++ b/app/ui/src/main/res/layout/about_library.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingTop="16dp"
+        android:paddingBottom="16dp"
+        android:paddingLeft="16dp"
+        android:paddingRight="16dp"
+        android:clickable="true"
+        android:focusable="true"
+        android:background="?attr/selectableItemBackground">
+
+        <TextView
+                android:id="@+id/name"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:gravity="center_vertical"
+                android:text="Test"
+                android:textColor="?android:attr/textColorPrimary"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <TextView
+                android:id="@+id/license"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="16dp"
+                android:gravity="center_vertical"
+                android:ellipsize="end"
+                android:maxLines="1"
+                android:text="Test"
+                android:textColor="?android:attr/textColorSecondary"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+</LinearLayout>

--- a/app/ui/src/main/res/values-bg/strings.xml
+++ b/app/ui/src/main/res/values-bg/strings.xml
@@ -54,7 +54,7 @@ K-9 Mail е мощен, безплатен имейл клиент за Андр
   <string name="open_market">Отвори Play магазина</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Автори: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Информация за версиите: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Информация за версиите</string>
   <string name="app_libraries">Използваме следните библиотеки от трети страни: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Прочитане на имейли</string>
   <string name="read_messages_desc">Позволява на тази праграма да чете вашите Писма.</string>

--- a/app/ui/src/main/res/values-bg/strings.xml
+++ b/app/ui/src/main/res/values-bg/strings.xml
@@ -202,7 +202,7 @@ K-9 Mail е мощен, безплатен имейл клиент за Андр
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Архив)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Спам)</string>
   <string name="send_failure_subject">Грешка при изпращане на някой съобщения</string>
-  <string name="debug_version_fmt">Версия: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Версия</string>
   <string name="debug_enable_debug_logging_title">Включете доклада за дебъгване</string>
   <string name="debug_enable_debug_logging_summary">Записвайте допълнителна диагностична информация</string>
   <string name="debug_enable_sensitive_logging_title">Записвайте поверителна информация</string>

--- a/app/ui/src/main/res/values-bg/strings.xml
+++ b/app/ui/src/main/res/values-bg/strings.xml
@@ -60,7 +60,7 @@ K-9 Mail е мощен, безплатен имейл клиент за Андр
   <string name="read_messages_desc">Позволява на тази праграма да чете вашите Писма.</string>
   <string name="delete_messages_label">Изтрий Писмата</string>
   <string name="delete_messages_desc">Позволи на тази програма да изтрие Писма</string>
-  <string name="about_title_fmt">Относно <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Относно K-9 Mail</string>
   <string name="accounts_title">Профили</string>
   <string name="folders_title">Папки</string>
   <string name="advanced">Допълнителни</string>

--- a/app/ui/src/main/res/values-br/strings.xml
+++ b/app/ui/src/main/res/values-br/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, Baleer Ar C’hi K-9</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> Ar valeerien K-9 Dog. Lodennoù Copyright 2006-<xliff:g>%s</xliff:g> and Android Open Source Project.</string>
-  <string name="app_license">Dindan al lañvaz Apache, Handelv 2.0.</string>
+  <string name="app_license">Lañvaz Apache, Handelv 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Donemat war K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-br/strings.xml
+++ b/app/ui/src/main/res/values-br/strings.xml
@@ -54,7 +54,7 @@ Danevellit beugoù, kenlabourit war keweriusterioù nevez ha savit goulennoù wa
   <string name="open_market">Digeriñ ar Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Aozerien: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">TItouroù an handelv: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">TItouroù an handelv</string>
   <string name="app_libraries">Arverañ a reomp al levraouegoù da-heul: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lenn ar posteloù</string>
   <string name="read_messages_desc">Aotren an arload-mañ da lenn ho posteloù.</string>

--- a/app/ui/src/main/res/values-br/strings.xml
+++ b/app/ui/src/main/res/values-br/strings.xml
@@ -203,7 +203,7 @@ Danevellit beugoù, kenlabourit war keweriusterioù nevez ha savit goulennoù wa
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Dielloù)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Lastez)</string>
   <string name="send_failure_subject">C’hwitadenn en ur gas kemennadennoù ’zo</string>
-  <string name="debug_version_fmt">Handelv: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Handelv</string>
   <string name="debug_enable_debug_logging_title">Kerzhlevr diveugañ</string>
   <string name="debug_enable_debug_logging_summary">Enrollañ titouroù deznaouioù ouzhpenn</string>
   <string name="debug_enable_sensitive_logging_title">Enrollañ titouroù kizidik</string>

--- a/app/ui/src/main/res/values-br/strings.xml
+++ b/app/ui/src/main/res/values-br/strings.xml
@@ -60,7 +60,7 @@ Danevellit beugoù, kenlabourit war keweriusterioù nevez ha savit goulennoù wa
   <string name="read_messages_desc">Aotren an arload-mañ da lenn ho posteloù.</string>
   <string name="delete_messages_label">Dilemel posteloù</string>
   <string name="delete_messages_desc">Aotren an arload-mañ da lenn ho posteloù.</string>
-  <string name="about_title_fmt">A-zivout <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">A-zivout K-9 Mail</string>
   <string name="accounts_title">Kontoù</string>
   <string name="folders_title">Teuliadoù</string>
   <string name="advanced">Kemplezhoc’h</string>

--- a/app/ui/src/main/res/values-ca/strings.xml
+++ b/app/ui/src/main/res/values-ca/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Porcions de Copyright 2006-<xliff:g>%s</xliff:g> Projecte de codi obert d\'Android.</string>
-  <string name="app_license">Llicenciat sota Llicència Apache, Versió 2.0.</string>
+  <string name="app_license">Llicència Apache, Versió 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Us donem la benvinguda al K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-ca/strings.xml
+++ b/app/ui/src/main/res/values-ca/strings.xml
@@ -203,7 +203,7 @@ Si us plau, envieu informes d\'errors, contribuïu-hi amb noves millores i feu p
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arxiu)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Brossa)</string>
   <string name="send_failure_subject">La tramesa d\'alguns missatges ha fallat.</string>
-  <string name="debug_version_fmt">Versió: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versió</string>
   <string name="debug_enable_debug_logging_title">Habilita la depuració del registre</string>
   <string name="debug_enable_debug_logging_summary">Registra informació extra de diagnòstic</string>
   <string name="debug_enable_sensitive_logging_title">Registra informació sensible</string>

--- a/app/ui/src/main/res/values-ca/strings.xml
+++ b/app/ui/src/main/res/values-ca/strings.xml
@@ -54,7 +54,7 @@ Si us plau, envieu informes d\'errors, contribuïu-hi amb noves millores i feu p
   <string name="open_market">Obre la Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autors: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informació de la revisió: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informació de la revisió</string>
   <string name="app_libraries">Fem servir les següents biblioteques de tercers: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Llegeix els correus</string>
   <string name="read_messages_desc">Permet a aquesta aplicació llegir els correus.</string>

--- a/app/ui/src/main/res/values-ca/strings.xml
+++ b/app/ui/src/main/res/values-ca/strings.xml
@@ -60,7 +60,7 @@ Si us plau, envieu informes d\'errors, contribuïu-hi amb noves millores i feu p
   <string name="read_messages_desc">Permet a aquesta aplicació llegir els correus.</string>
   <string name="delete_messages_label">Elimina correus</string>
   <string name="delete_messages_desc">Permet que aquesta aplicació elimini correus.</string>
-  <string name="about_title_fmt">Quant a <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Quant a K-9 Mail</string>
   <string name="accounts_title">Comptes</string>
   <string name="folders_title">Carpetes</string>
   <string name="advanced">Avançat</string>

--- a/app/ui/src/main/res/values-cs/strings.xml
+++ b/app/ui/src/main/res/values-cs/strings.xml
@@ -60,7 +60,7 @@ Chybová hlášení prosím posílejte, přispívejte novými funkcemi a ptejte 
   <string name="read_messages_desc">Povolit této aplikaci číst vaši poštu.</string>
   <string name="delete_messages_label">Mazat zprávy</string>
   <string name="delete_messages_desc">Povolit této aplikaci mazat e-maily.</string>
-  <string name="about_title_fmt">O aplikaci <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">O aplikaci K-9 Mail</string>
   <string name="accounts_title">Účty</string>
   <string name="folders_title">Složky</string>
   <string name="advanced">Pokročilé</string>

--- a/app/ui/src/main/res/values-cs/strings.xml
+++ b/app/ui/src/main/res/values-cs/strings.xml
@@ -54,7 +54,7 @@ Chybová hlášení prosím posílejte, přispívejte novými funkcemi a ptejte 
   <string name="open_market">Otevřít obchod Google Play</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autoři: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informace o revizi: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informace o revizi</string>
   <string name="app_libraries">Používáme tyto knihovny třetích stran: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Číst zprávy</string>
   <string name="read_messages_desc">Povolit této aplikaci číst vaši poštu.</string>

--- a/app/ui/src/main/res/values-cs/strings.xml
+++ b/app/ui/src/main/res/values-cs/strings.xml
@@ -204,7 +204,7 @@ Chybová hlášení prosím posílejte, přispívejte novými funkcemi a ptejte 
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archív)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Nevyžádaná)</string>
   <string name="send_failure_subject">Selhalo odeslání některých zpráv</string>
-  <string name="debug_version_fmt">Verze: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Verze</string>
   <string name="debug_enable_debug_logging_title">Povolit ladící záznam</string>
   <string name="debug_enable_debug_logging_summary">Zaznamenávat rozšířené diagnostické informace</string>
   <string name="debug_enable_sensitive_logging_title">Záznamenávat citlivé informace</string>

--- a/app/ui/src/main/res/values-cs/strings.xml
+++ b/app/ui/src/main/res/values-cs/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licencované pod Apache Licencí, Version 2.0.</string>
+  <string name="app_license">Apache Licencí, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Vítejte v K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-cy/strings.xml
+++ b/app/ui/src/main/res/values-cy/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Hawlfraint 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Hawlfraint Cyfrannau 2006-<xliff:g>%s</xliff:g> Android Open Source Project.</string>
-  <string name="app_license">Trwyddedir dan yr Apache License, Fersiwn 2.0.</string>
+  <string name="app_license">Apache License, Fersiwn 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Croeso i K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-cy/strings.xml
+++ b/app/ui/src/main/res/values-cy/strings.xml
@@ -208,7 +208,7 @@ Plîs rhowch wybod am unrhyw wallau, syniadau am nodweddion newydd, neu ofyn cwe
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archif)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Sbam)</string>
   <string name="send_failure_subject">Methwyd ag anfon rhai negeseuon</string>
-  <string name="debug_version_fmt">Fersiwn: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Fersiwn</string>
   <string name="debug_enable_debug_logging_title">Galluogi logio dadfygio</string>
   <string name="debug_enable_debug_logging_summary">Logio gwybodaeth ddiagnostig ychwanegol</string>
   <string name="debug_enable_sensitive_logging_title">Logio gwybodaeth sensitif</string>

--- a/app/ui/src/main/res/values-cy/strings.xml
+++ b/app/ui/src/main/res/values-cy/strings.xml
@@ -61,7 +61,7 @@ Plîs rhowch wybod am unrhyw wallau, syniadau am nodweddion newydd, neu ofyn cwe
   <string name="read_messages_desc">Galluogi\'r ap hwn i ddarllen dy e-bost.</string>
   <string name="delete_messages_label">Dileu E-bost</string>
   <string name="delete_messages_desc">Galluogi\'r ap hwn i ddileu dy negeseuon e-bost.</string>
-  <string name="about_title_fmt">Ynghylch <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Ynghylch K-9 Mail</string>
   <string name="accounts_title">Cyfrifon</string>
   <string name="folders_title">Ffolderi</string>
   <string name="advanced">Uwch</string>

--- a/app/ui/src/main/res/values-cy/strings.xml
+++ b/app/ui/src/main/res/values-cy/strings.xml
@@ -55,7 +55,7 @@ Plîs rhowch wybod am unrhyw wallau, syniadau am nodweddion newydd, neu ofyn cwe
   <string name="open_market">Agor Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Awduron: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Gwybodaeth Adolygu: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Gwybodaeth Adolygu</string>
   <string name="app_libraries">Rydym yn defnyddio\'r llyfrgelloedd trydydd parti canlynol: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Darllen E-bost</string>
   <string name="read_messages_desc">Galluogi\'r ap hwn i ddarllen dy e-bost.</string>

--- a/app/ui/src/main/res/values-da/strings.xml
+++ b/app/ui/src/main/res/values-da/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Visse dele Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licenseret under the Apache License, Version 2.0.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Velkommen til K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-da/strings.xml
+++ b/app/ui/src/main/res/values-da/strings.xml
@@ -60,7 +60,7 @@ Rapporter venligst fejl, forslag til nye funktioner eller stil spørgsmål på:
   <string name="read_messages_desc">Tillad dette program at læse dine mails.</string>
   <string name="delete_messages_label">Slet mails</string>
   <string name="delete_messages_desc">Tillad dette program at slette dine mails.</string>
-  <string name="about_title_fmt">Om <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Om K-9 Mail</string>
   <string name="accounts_title">Konti</string>
   <string name="folders_title">Mapper</string>
   <string name="advanced">Avanceret</string>

--- a/app/ui/src/main/res/values-da/strings.xml
+++ b/app/ui/src/main/res/values-da/strings.xml
@@ -54,7 +54,7 @@ Rapporter venligst fejl, forslag til nye funktioner eller stil spørgsmål på:
   <string name="open_market">Åben Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Ophavsmænd: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Revisions information: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Revisions information</string>
   <string name="app_libraries">Vi anvender følgende 3je parts biblioteker: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Læs mails</string>
   <string name="read_messages_desc">Tillad dette program at læse dine mails.</string>

--- a/app/ui/src/main/res/values-da/strings.xml
+++ b/app/ui/src/main/res/values-da/strings.xml
@@ -196,7 +196,7 @@ Rapporter venligst fejl, forslag til nye funktioner eller stil spørgsmål på:
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arkiv)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Mislykkedes med at sende nogle mails</string>
-  <string name="debug_version_fmt">Version: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Version</string>
   <string name="debug_enable_debug_logging_title">Aktiver fejllogning</string>
   <string name="debug_enable_debug_logging_summary">Log ekstra diagnostik information</string>
   <string name="debug_enable_sensitive_logging_title">Log sensitiv information</string>

--- a/app/ui/src/main/res/values-de/strings.xml
+++ b/app/ui/src/main/res/values-de/strings.xml
@@ -61,7 +61,7 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="read_messages_desc">Der Anwendung erlauben, Ihre E-Mails zu lesen.</string>
   <string name="delete_messages_label">E-Mails löschen</string>
   <string name="delete_messages_desc">Der Anwendung erlauben, Ihre E-Mails zu löschen.</string>
-  <string name="about_title_fmt">Über <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Über K-9 Mail</string>
   <string name="accounts_title">Konten</string>
   <string name="folders_title">Ordner</string>
   <string name="advanced">Erweitert</string>

--- a/app/ui/src/main/res/values-de/strings.xml
+++ b/app/ui/src/main/res/values-de/strings.xml
@@ -55,7 +55,7 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="open_market">Play Store öffnen</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autoren: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Versionsinformationen: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Versionsinformationen</string>
   <string name="app_libraries">Wir verwenden die folgenden externen Bibliotheken: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">E-Mails lesen</string>
   <string name="read_messages_desc">Der Anwendung erlauben, Ihre E-Mails zu lesen.</string>

--- a/app/ui/src/main/res/values-de/strings.xml
+++ b/app/ui/src/main/res/values-de/strings.xml
@@ -12,7 +12,7 @@
   <string name="app_authors">Google, das K-9-Team und viele Weitere.</string>
   <string name="app_copyright_fmt">\u00a9 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers.
 Teile \u00a9 2006-<xliff:g>%s</xliff:g> Android Open Source Project.</string>
-  <string name="app_license">Lizenziert unter der Apache-Lizenz, Version 2.0.</string>
+  <string name="app_license">Apache-Lizenz, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Willkommen bei K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-de/strings.xml
+++ b/app/ui/src/main/res/values-de/strings.xml
@@ -203,7 +203,7 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archiv)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Nachrichten konnten nicht gesendet werden</string>
-  <string name="debug_version_fmt">Version: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Version</string>
   <string name="debug_enable_debug_logging_title">Fehlersuchprotokollierung aktivieren</string>
   <string name="debug_enable_debug_logging_summary">Zusätzliche Diagnose-Informationen protokollieren</string>
   <string name="debug_enable_sensitive_logging_title">Vertrauliche Informationen protokollieren</string>

--- a/app/ui/src/main/res/values-el/strings.xml
+++ b/app/ui/src/main/res/values-el/strings.xml
@@ -203,7 +203,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Αρχειοθήκη)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Σκουπίδια)</string>
   <string name="send_failure_subject">Αποτυχία αποστολής μερικών μηνυμάτων</string>
-  <string name="debug_version_fmt">Έκδοση: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Έκδοση</string>
   <string name="debug_enable_debug_logging_title">Ενεργοποίηση καταγραφών αποσφαλμάτωσης</string>
   <string name="debug_enable_debug_logging_summary">Καταγραφή πρόσθετων διαγνωστικών πληροφοριών</string>
   <string name="debug_enable_sensitive_logging_title">Καταγραφή ευαίσθητων πληροφοριών</string>

--- a/app/ui/src/main/res/values-el/strings.xml
+++ b/app/ui/src/main/res/values-el/strings.xml
@@ -61,7 +61,7 @@
   <string name="read_messages_desc">Επιτρέπει στην εφαρμογή να διαβάζει τα email.</string>
   <string name="delete_messages_label">Διαγραφή μηνυμάτων</string>
   <string name="delete_messages_desc">Επιτρέπει στην εφαρμογή να σβήνει τα email.</string>
-  <string name="about_title_fmt">Περί του <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Περί του K-9 Mail</string>
   <string name="accounts_title">Λογαριασμοί</string>
   <string name="folders_title">Φάκελοι</string>
   <string name="advanced">Προχωρημένα</string>

--- a/app/ui/src/main/res/values-el/strings.xml
+++ b/app/ui/src/main/res/values-el/strings.xml
@@ -55,7 +55,7 @@
   <string name="open_market">Open Market</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Συγγραφείς: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Πληροφορίες αναθεωρήσεων: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Πληροφορίες αναθεωρήσεων</string>
   <string name="app_libraries">Χρησιμοποιούνται οι ακόλουθες βιβλιοθήκες τρίτων: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ανάγνωση μηνυμάτων</string>
   <string name="read_messages_desc">Επιτρέπει στην εφαρμογή να διαβάζει τα email.</string>

--- a/app/ui/src/main/res/values-eo/strings.xml
+++ b/app/ui/src/main/res/values-eo/strings.xml
@@ -201,7 +201,7 @@ Bonvolu raporti erarojn, kontribui novajn eblojn kaj peti pri novaj funkcioj per
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arĥivo)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Trudmesaĝujo)</string>
   <string name="send_failure_subject">Malsukcesis sendi iujn mesaĝojn</string>
-  <string name="debug_version_fmt">Versio: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versio</string>
   <string name="debug_enable_debug_logging_title">Aktivigi senerarigan protokoladon</string>
   <string name="debug_enable_debug_logging_summary">Protokolas aldonajn informojn pri senerarigo.</string>
   <string name="debug_enable_sensitive_logging_title">Protokoli konfidajn informojn</string>

--- a/app/ui/src/main/res/values-eo/strings.xml
+++ b/app/ui/src/main/res/values-eo/strings.xml
@@ -59,7 +59,7 @@ Bonvolu raporti erarojn, kontribui novajn eblojn kaj peti pri novaj funkcioj per
   <string name="read_messages_desc">Permesas al tiu ĉi aplikaĵo legi viajn retleterojn.</string>
   <string name="delete_messages_label">Forigi retleterojn</string>
   <string name="delete_messages_desc">Permesas al tiu ĉi aplikaĵo forigi viajn retleterojn.</string>
-  <string name="about_title_fmt">Pri <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Pri K-9 Mail</string>
   <string name="accounts_title">Kontoj</string>
   <string name="folders_title">Mesaĝujoj</string>
   <string name="advanced">Spertaj</string>

--- a/app/ui/src/main/res/values-eo/strings.xml
+++ b/app/ui/src/main/res/values-eo/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Kopirajto 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Parta kopirajto 2006-<xliff:g>%s</xliff:g> la Malfermkoda Projekto Android (AOSP).</string>
-  <string name="app_license">Eldonita laŭ la permesilo Apache, versio 2.0.</string>
+  <string name="app_license">Permesilo Apache, versio 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Bonvenon al K-9 Retpoŝtilo</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-eo/strings.xml
+++ b/app/ui/src/main/res/values-eo/strings.xml
@@ -53,7 +53,7 @@ Bonvolu raporti erarojn, kontribui novajn eblojn kaj peti pri novaj funkcioj per
   <string name="open_market">Malfermi vendejon Play</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Aŭtoroj: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informoj pri eldono: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informoj pri eldono</string>
   <string name="app_libraries">La jenaj bibliotekoj de eksteraj liverantoj estas uzataj: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Legi retleterojn</string>
   <string name="read_messages_desc">Permesas al tiu ĉi aplikaĵo legi viajn retleterojn.</string>

--- a/app/ui/src/main/res/values-es/strings.xml
+++ b/app/ui/src/main/res/values-es/strings.xml
@@ -60,7 +60,7 @@ Por favor informe de fallos, aporte nueva funcionalidad o envíe sus preguntas a
   <string name="read_messages_desc">Permitir a esta aplicación leer los correos.</string>
   <string name="delete_messages_label">Borrar correos</string>
   <string name="delete_messages_desc">Permitir a esta aplicación borrar los correos.</string>
-  <string name="about_title_fmt">Acerca de <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Acerca de K-9 Mail</string>
   <string name="accounts_title">Cuentas</string>
   <string name="folders_title">Carpetas</string>
   <string name="advanced">Avanzado</string>

--- a/app/ui/src/main/res/values-es/strings.xml
+++ b/app/ui/src/main/res/values-es/strings.xml
@@ -199,7 +199,7 @@ Por favor informe de fallos, aporte nueva funcionalidad o envíe sus preguntas a
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archivo)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Error al enviar algunos mensajes</string>
-  <string name="debug_version_fmt">Versión: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versión</string>
   <string name="debug_enable_debug_logging_title">Habilitar log de depuración</string>
   <string name="debug_enable_debug_logging_summary">Log con información ampliada</string>
   <string name="debug_enable_sensitive_logging_title">Incluir información sensible</string>

--- a/app/ui/src/main/res/values-es/strings.xml
+++ b/app/ui/src/main/res/values-es/strings.xml
@@ -54,7 +54,7 @@ Por favor informe de fallos, aporte nueva funcionalidad o envíe sus preguntas a
   <string name="open_market">Abrir Google Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Información de la revisión: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Información de la revisión</string>
   <string name="app_libraries">Estamos usando las siguientes librerías de terceros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Leer correos</string>
   <string name="read_messages_desc">Permitir a esta aplicación leer los correos.</string>

--- a/app/ui/src/main/res/values-es/strings.xml
+++ b/app/ui/src/main/res/values-es/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Partes del Copyright 2006-<xliff:g>%s</xliff:g> Android Open Source Project.</string>
-  <string name="app_license">Licenciado con Licencia Apache, Versión 2.0.</string>
+  <string name="app_license">Licencia Apache, Versión 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Bienvenido a K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-et/strings.xml
+++ b/app/ui/src/main/res/values-et/strings.xml
@@ -172,7 +172,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arhiiv)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Rämpspost)</string>
   <string name="send_failure_subject">Mõne kirja saatmine ebaõnnestus</string>
-  <string name="debug_version_fmt">Versioon: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versioon</string>
   <string name="debug_enable_debug_logging_title">Luba silumiste logimine</string>
   <string name="debug_enable_debug_logging_summary">Logi täiendavat informatsiooni diagnostikaks</string>
   <string name="debug_enable_sensitive_logging_title">Logi sensitiivset informatsiooni</string>

--- a/app/ui/src/main/res/values-et/strings.xml
+++ b/app/ui/src/main/res/values-et/strings.xml
@@ -31,7 +31,7 @@
   <string name="read_messages_desc">Luba sellel appil lugeda meilisõnumeid.</string>
   <string name="delete_messages_label">Kustuta meilisõnumid</string>
   <string name="delete_messages_desc">Luba sellel appil kustutada oma meilisõnumeid</string>
-  <string name="about_title_fmt">Teave <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Teave K-9 Mail</string>
   <string name="accounts_title">Kontod</string>
   <string name="folders_title">Kaustad</string>
   <string name="advanced">Täpsemalt</string>

--- a/app/ui/src/main/res/values-et/strings.xml
+++ b/app/ui/src/main/res/values-et/strings.xml
@@ -25,7 +25,7 @@
   <string name="open_market">Ava Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autorid: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Parandusteave: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Parandusteave</string>
   <string name="app_libraries">me kasutame järgnevaid kolmanda osapoole teeke: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Loe meilisõnumeid</string>
   <string name="read_messages_desc">Luba sellel appil lugeda meilisõnumeid.</string>

--- a/app/ui/src/main/res/values-et/strings.xml
+++ b/app/ui/src/main/res/values-et/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google,  K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licensed under the Apache License, Version 2.0.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Tere kasutama K-9 Maili</string>
   <!--Default signature-->

--- a/app/ui/src/main/res/values-eu/strings.xml
+++ b/app/ui/src/main/res/values-eu/strings.xml
@@ -54,7 +54,7 @@ Mesedez akatsen berri emateko, ezaugarri berriak gehitzeko eta galderak egiteko
   <string name="open_market">Ireki Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Egileak: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Berrikuspenaren Informazioa: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Berrikuspenaren Informazioa</string>
   <string name="app_libraries">Hirugarrenen liburutegi hauek erabiltzen ari gara: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Irakurri posta</string>
   <string name="read_messages_desc">Aplikazio honi zure posta irakurtzea onartzen dio.</string>

--- a/app/ui/src/main/res/values-eu/strings.xml
+++ b/app/ui/src/main/res/values-eu/strings.xml
@@ -202,7 +202,7 @@ Mesedez akatsen berri emateko, ezaugarri berriak gehitzeko eta galderak egiteko
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Artxiboa)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Mezu batzuen bidaltzeak huts egin du</string>
-  <string name="debug_version_fmt">Bertsioa: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Bertsioa</string>
   <string name="debug_enable_debug_logging_title">Arazketa erregistroa gaitu</string>
   <string name="debug_enable_debug_logging_summary">Diagnostikorako informazio gehigarria erregistratu</string>
   <string name="debug_enable_sensitive_logging_title">Bereziki babestutako informazioa erregistratu</string>

--- a/app/ui/src/main/res/values-eu/strings.xml
+++ b/app/ui/src/main/res/values-eu/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project-en zatiak.</string>
-  <string name="app_license">Lizentziaduna Apache Lizentziarekin, 2.0 Bertsioa</string>
+  <string name="app_license">Apache Lizentzia, 2.0 Bertsioa</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Ongi etorri K-9 Mail-era</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-fa/strings.xml
+++ b/app/ui/src/main/res/values-fa/strings.xml
@@ -127,7 +127,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (آرشیو)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (هرزنامه)</string>
   <string name="send_failure_subject">ناموفق در ارسال برخی پیام ها</string>
-  <string name="debug_version_fmt">نسخه: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">نسخه</string>
   <string name="debug_enable_debug_logging_title">فعال سازی اشکال زدایی ثبت وقایع</string>
   <string name="debug_enable_debug_logging_summary">ثبت اطلاعات با تشخیص فوق العاده</string>
   <string name="debug_enable_sensitive_logging_title">ثبت اطلاعات حساس</string>

--- a/app/ui/src/main/res/values-fi/strings.xml
+++ b/app/ui/src/main/res/values-fi/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Tekijänoikeudet 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Osittaiset tekijänoikeudet -<xliff:g>%s</xliff:g> Androidin avoimen lähdekoodin hanke.</string>
-  <string name="app_license">Lisensoitu Apache-lisenssin 2.0-versiolla.</string>
+  <string name="app_license">Apache-lisenssin 2.0-versiolla</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Tervetuloa K-9 Mailiin</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-fi/strings.xml
+++ b/app/ui/src/main/res/values-fi/strings.xml
@@ -202,7 +202,7 @@ Ilmoita virheistä, ota osaa sovelluskehitykseen ja esitä kysymyksiä osoittees
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arkisto)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Roskaposti)</string>
   <string name="send_failure_subject">Joidenkin viestien lähettäminen epäonnistui</string>
-  <string name="debug_version_fmt">Versio: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versio</string>
   <string name="debug_enable_debug_logging_title">Käytä virheenkorjaustietojen  lokiinkirjausta</string>
   <string name="debug_enable_debug_logging_summary">Kirjoita lokiin laajempi kuvaus ongelmista</string>
   <string name="debug_enable_sensitive_logging_title">Kirjaa lokiin arkaluontoisia tietoja</string>

--- a/app/ui/src/main/res/values-fi/strings.xml
+++ b/app/ui/src/main/res/values-fi/strings.xml
@@ -54,7 +54,7 @@ Ilmoita virheistä, ota osaa sovelluskehitykseen ja esitä kysymyksiä osoittees
   <string name="open_market">Avaa Play-kauppa</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Tekijät: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Versiotiedot: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Versiotiedot</string>
   <string name="app_libraries">Käytämme seuraavia kolmannen osapuolen kirjastoja: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lue sähköpostit</string>
   <string name="read_messages_desc">Antaa sovellukselle luvan lukea sähköpostisi.</string>

--- a/app/ui/src/main/res/values-fi/strings.xml
+++ b/app/ui/src/main/res/values-fi/strings.xml
@@ -60,7 +60,7 @@ Ilmoita virheistä, ota osaa sovelluskehitykseen ja esitä kysymyksiä osoittees
   <string name="read_messages_desc">Antaa sovellukselle luvan lukea sähköpostisi.</string>
   <string name="delete_messages_label">Poista sähköpostit</string>
   <string name="delete_messages_desc">Antaa sovellukselle luvan poistaa sähköposteja.</string>
-  <string name="about_title_fmt">Tietoja <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Tietoja K-9 Mail</string>
   <string name="accounts_title">Tilit</string>
   <string name="folders_title">Kansiot</string>
   <string name="advanced">Lisäasetukset</string>

--- a/app/ui/src/main/res/values-fr/strings.xml
+++ b/app/ui/src/main/res/values-fr/strings.xml
@@ -203,7 +203,7 @@ jusqu’à <xliff:g id="messages_to_load">%d</xliff:g> de plus</string>
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archive)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Pourriel)</string>
   <string name="send_failure_subject">Échec lors de l’envoi de certains courriels</string>
-  <string name="debug_version_fmt">Version\u00A0: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Version\u00A0</string>
   <string name="debug_enable_debug_logging_title">Activer le journal de débogage</string>
   <string name="debug_enable_debug_logging_summary">Journaliser les informations de diagnostic supplémentaires</string>
   <string name="debug_enable_sensitive_logging_title">Journaliser les informations délicates</string>

--- a/app/ui/src/main/res/values-fr/strings.xml
+++ b/app/ui/src/main/res/values-fr/strings.xml
@@ -60,7 +60,7 @@ Veuillez rapporter les bogues, recommander de nouvelles fonctions et poser vos q
   <string name="read_messages_desc">Permet à cette application de lire vos courriels.</string>
   <string name="delete_messages_label">Supprimer les courriels</string>
   <string name="delete_messages_desc">Permet à cette application de supprimer vos courriels</string>
-  <string name="about_title_fmt">À propos de <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">À propos de K-9 Mail</string>
   <string name="accounts_title">Comptes</string>
   <string name="folders_title">Dossiers</string>
   <string name="advanced">Avancé</string>

--- a/app/ui/src/main/res/values-fr/strings.xml
+++ b/app/ui/src/main/res/values-fr/strings.xml
@@ -54,7 +54,7 @@ Veuillez rapporter les bogues, recommander de nouvelles fonctions et poser vos q
   <string name="open_market">Ouvrir le Google Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Auteurs\u00A0: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informations de révision\u00A0: %s</string>
+  <string name="app_revision">Informations de révision</string>
   <string name="app_libraries">Nous utilisons les bibliothèques tierces suivantes\u00A0: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lire les courriels</string>
   <string name="read_messages_desc">Permet à cette application de lire vos courriels.</string>

--- a/app/ui/src/main/res/values-fr/strings.xml
+++ b/app/ui/src/main/res/values-fr/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Tous droits réservés 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Parties protégées par droits d’auteur 2006-<xliff:g>%s</xliff:g> le projet libre Android.</string>
-  <string name="app_license">Sous licence Apache, version 2.0.</string>
+  <string name="app_license">Licence Apache, version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Bienvenue sur Courriel K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-gd/strings.xml
+++ b/app/ui/src/main/res/values-gd/strings.xml
@@ -61,7 +61,7 @@ Fàilte air bugaichean, com-pàirteachas, iarrtasan airson gleusan ùra is ceist
   <string name="read_messages_desc">Leig leis an aplacaid seo na puist-d agad a leughadh.</string>
   <string name="delete_messages_label">Puist-d a sguabadh às</string>
   <string name="delete_messages_desc">Leig leis an aplacaid seo na puist-d agad a sguabadh às.</string>
-  <string name="about_title_fmt">Mu dhèidhinn <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Mu dhèidhinn K-9 Mail</string>
   <string name="accounts_title">Cunntasan</string>
   <string name="folders_title">Pasganan</string>
   <string name="advanced">Adhartach</string>

--- a/app/ui/src/main/res/values-gd/strings.xml
+++ b/app/ui/src/main/res/values-gd/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, luchd-coiseachd nan con K-9</string>
   <string name="app_copyright_fmt">Còir-lethbhreac 2008-<xliff:g>%s</xliff:g> Luchd-coiseachd nan con K-9. Cuid dhen chòir-lethbhreac 2006-<xliff:g>%s</xliff:g> Android Open Source Project.</string>
-  <string name="app_license">Fo cheadachas Apache, tionndadh 2.0.</string>
+  <string name="app_license">Cheadachas Apache, tionndadh 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Fàilte gu post K-9</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-gd/strings.xml
+++ b/app/ui/src/main/res/values-gd/strings.xml
@@ -205,7 +205,7 @@ Fàilte air bugaichean, com-pàirteachas, iarrtasan airson gleusan ùra is ceist
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Tasg-lann)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spama)</string>
   <string name="send_failure_subject">Cha deach cuid dhe na teachdaireachdan a chur</string>
-  <string name="debug_version_fmt">Tionndadh: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Tionndadh</string>
   <string name="debug_enable_debug_logging_title">Cuir an comas logadh airson dì-bhugachadh</string>
   <string name="debug_enable_debug_logging_summary">Logaich fiosrachadh diagnosachd a bharrachd</string>
   <string name="debug_enable_sensitive_logging_title">Logaich fiosrachadh dìomhair</string>

--- a/app/ui/src/main/res/values-gd/strings.xml
+++ b/app/ui/src/main/res/values-gd/strings.xml
@@ -55,7 +55,7 @@ Fàilte air bugaichean, com-pàirteachas, iarrtasan airson gleusan ùra is ceist
   <string name="open_market">Fosgail Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Na h-ùghdaran: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Fiosrachadh mun lèireamhas: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Fiosrachadh mun lèireamhas</string>
   <string name="app_libraries">Tha sinn a’ cleachdadh na leabhar-lannan a leanas a tha le treas-phàrtaidhean: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Puist-d a leughadh</string>
   <string name="read_messages_desc">Leig leis an aplacaid seo na puist-d agad a leughadh.</string>

--- a/app/ui/src/main/res/values-gl-rES/strings.xml
+++ b/app/ui/src/main/res/values-gl-rES/strings.xml
@@ -154,7 +154,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arquivo)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Correo lixo)</string>
   <string name="send_failure_subject">Erro ao enviar algunhas mensaxes</string>
-  <string name="debug_version_fmt">Versión: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versión</string>
   <string name="debug_enable_debug_logging_title">Activar acceso a depurar</string>
   <string name="debug_enable_debug_logging_summary">Diagnóstico con información adicional</string>
   <string name="debug_enable_sensitive_logging_title">Información sensible</string>

--- a/app/ui/src/main/res/values-gl-rES/strings.xml
+++ b/app/ui/src/main/res/values-gl-rES/strings.xml
@@ -31,7 +31,7 @@
   <string name="read_messages_desc">Permitir a este aplicativo ler os teus correos.</string>
   <string name="delete_messages_label">Eliminar correos</string>
   <string name="delete_messages_desc">Permitir a este aplicativo eliminar os teus correos.</string>
-  <string name="about_title_fmt">Acerca de <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Acerca de K-9 Mail</string>
   <string name="accounts_title">Contas</string>
   <string name="folders_title">Cartafoles</string>
   <string name="advanced">Avanzado</string>

--- a/app/ui/src/main/res/values-gl-rES/strings.xml
+++ b/app/ui/src/main/res/values-gl-rES/strings.xml
@@ -25,7 +25,7 @@
   <string name="open_market">Abrir Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Revisión da información: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Revisión da información</string>
   <string name="app_libraries">Estamos a usar as seguintes librarías de terceiros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ler correos</string>
   <string name="read_messages_desc">Permitir a este aplicativo ler os teus correos.</string>

--- a/app/ui/src/main/res/values-gl-rES/strings.xml
+++ b/app/ui/src/main/res/values-gl-rES/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Baixo licenza Apache, versión 2.0.</string>
+  <string name="app_license">Apache, versión 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Benvido/a a K-9 Mail</string>
   <!--Default signature-->

--- a/app/ui/src/main/res/values-gl/strings.xml
+++ b/app/ui/src/main/res/values-gl/strings.xml
@@ -61,7 +61,7 @@ Por favor envíen informes de fallos, contribúa con novas características e co
   <string name="read_messages_desc">Permitir a esta aplicación ler tus correos</string>
   <string name="delete_messages_label">Borrar correos</string>
   <string name="delete_messages_desc">Permitir a esta aplicación borrar os teus correos.</string>
-  <string name="about_title_fmt">Acerca de <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Acerca de K-9 Mail</string>
   <string name="accounts_title">Contas</string>
   <string name="folders_title">Cartafoles</string>
   <string name="advanced">Avanzado</string>

--- a/app/ui/src/main/res/values-gl/strings.xml
+++ b/app/ui/src/main/res/values-gl/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Porcións Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licienciado baixo a Licencia Apache, Version 2.0.</string>
+  <string name="app_license">Licencia Apache, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Benvido/a a K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-gl/strings.xml
+++ b/app/ui/src/main/res/values-gl/strings.xml
@@ -203,7 +203,7 @@ Por favor envíen informes de fallos, contribúa con novas características e co
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arquivo)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Erro ao enviar algunhas mensaxes</string>
-  <string name="debug_version_fmt">Versión: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versión</string>
   <string name="debug_enable_debug_logging_title">Activar acceso a debug</string>
   <string name="debug_enable_debug_logging_summary">Diagnóstico con información adicional</string>
   <string name="debug_enable_sensitive_logging_title">Información sensible</string>

--- a/app/ui/src/main/res/values-gl/strings.xml
+++ b/app/ui/src/main/res/values-gl/strings.xml
@@ -55,7 +55,7 @@ Por favor envíen informes de fallos, contribúa con novas características e co
   <string name="open_market">Abrir Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Información da revisión: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Información da revisión</string>
   <string name="app_libraries">Usamos as seguintes librerías de terceiros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ler correos</string>
   <string name="read_messages_desc">Permitir a esta aplicación ler tus correos</string>

--- a/app/ui/src/main/res/values-hr/strings.xml
+++ b/app/ui/src/main/res/values-hr/strings.xml
@@ -157,7 +157,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arhiva)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Neželjena pošta)</string>
   <string name="send_failure_subject">Slanje nekih poruka nije uspjelo</string>
-  <string name="debug_version_fmt">Inačica: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Inačica</string>
   <string name="debug_enable_debug_logging_title">Omogući zapisnik ispravljanja</string>
   <string name="debug_enable_debug_logging_summary">Zapisuj posebne informacije dijagnoze</string>
   <string name="debug_enable_sensitive_logging_title">Zapisnik osjetljivih informacija</string>

--- a/app/ui/src/main/res/values-hr/strings.xml
+++ b/app/ui/src/main/res/values-hr/strings.xml
@@ -31,7 +31,7 @@
   <string name="read_messages_desc">Dopušta ovoj aplikaciji čitanje vaše E-Pošte</string>
   <string name="delete_messages_label">Brisanje E-Pošte</string>
   <string name="delete_messages_desc">Dopušta ovoj aplikaciji brisanje vaše E-Pošte.</string>
-  <string name="about_title_fmt">O <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">O K-9 Mail</string>
   <string name="accounts_title">Računi</string>
   <string name="folders_title">Mape</string>
   <string name="advanced">Napredno</string>

--- a/app/ui/src/main/res/values-hr/strings.xml
+++ b/app/ui/src/main/res/values-hr/strings.xml
@@ -25,7 +25,7 @@
   <string name="open_market">Otvorite Trgovinu Play</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informacije Revizije: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informacije Revizije</string>
   <string name="app_libraries">Mi koristimo slijedeće biblioteke treće strane: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Čitanje E-Pošte</string>
   <string name="read_messages_desc">Dopušta ovoj aplikaciji čitanje vaše E-Pošte</string>

--- a/app/ui/src/main/res/values-hr/strings.xml
+++ b/app/ui/src/main/res/values-hr/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licencirano pod Apache License, Version 2.0.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Dobrodošli u K-9 Mail</string>
   <!--Default signature-->

--- a/app/ui/src/main/res/values-hu/strings.xml
+++ b/app/ui/src/main/res/values-hu/strings.xml
@@ -55,7 +55,7 @@ Kérünk küldj hibajelentést, hozzájárulva az új verziókhoz, és tegyél f
   <string name="open_market">Play áruház megnyitása</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Készítők: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Verzió információk: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Verzió információk</string>
   <string name="app_libraries">A következő könyvtárakat használjuk: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Email-ek olvasása</string>
   <string name="read_messages_desc">Engedélyezi ennek az alkalmazásnak, hogy elolvassa az email-jeit.</string>

--- a/app/ui/src/main/res/values-hu/strings.xml
+++ b/app/ui/src/main/res/values-hu/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Apache License, Version 2.0 alatt licencelve.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Üdvözli a K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-hu/strings.xml
+++ b/app/ui/src/main/res/values-hu/strings.xml
@@ -203,7 +203,7 @@ Kérünk küldj hibajelentést, hozzájárulva az új verziókhoz, és tegyél f
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archivált)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Levélszemét)</string>
   <string name="send_failure_subject">Néhány üzenetet nem sikerült elküldeni</string>
-  <string name="debug_version_fmt">Verzió: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Verzió</string>
   <string name="debug_enable_debug_logging_title">Hibakeresés</string>
   <string name="debug_enable_debug_logging_summary">Extra diagnosztikai naplózás</string>
   <string name="debug_enable_sensitive_logging_title">Személyes adatok naplózása</string>

--- a/app/ui/src/main/res/values-in/strings.xml
+++ b/app/ui/src/main/res/values-in/strings.xml
@@ -55,7 +55,7 @@ https://github.com/k9mail/k-9/<a href="https://github.com/k9mail/k-9/">.
   <string name="open_market">Buka Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Pengembang: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informasi Revisi: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informasi Revisi</string>
   <string name="app_libraries">Kami menggunakan pustaka pihak ketiga berikut: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Baca Email</string>
   <string name="read_messages_desc">Izinkan aplikasi ini membaca Email Anda.</string>

--- a/app/ui/src/main/res/values-in/strings.xml
+++ b/app/ui/src/main/res/values-in/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Hak Cipta 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Hak Cipta Sebagian 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Dilisensikan dibawah Apache License, Versi 2.0.</string>
+  <string name="app_license">Apache License, Versi 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Selamat datang di K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-in/strings.xml
+++ b/app/ui/src/main/res/values-in/strings.xml
@@ -61,7 +61,7 @@ https://github.com/k9mail/k-9/<a href="https://github.com/k9mail/k-9/">.
   <string name="read_messages_desc">Izinkan aplikasi ini membaca Email Anda.</string>
   <string name="delete_messages_label">Hapus Email</string>
   <string name="delete_messages_desc">Izinkan aplikasi ini menghapus Email Anda.</string>
-  <string name="about_title_fmt">Tentang <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Tentang K-9 Mail</string>
   <string name="accounts_title">Akun</string>
   <string name="folders_title">Folder</string>
   <string name="advanced">Lanjutan</string>

--- a/app/ui/src/main/res/values-in/strings.xml
+++ b/app/ui/src/main/res/values-in/strings.xml
@@ -200,7 +200,7 @@ https://github.com/k9mail/k-9/<a href="https://github.com/k9mail/k-9/">.
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arsip)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Gagal mengirim beberapa pesan</string>
-  <string name="debug_version_fmt">Versi: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versi</string>
   <string name="debug_enable_debug_logging_title">Fungsikan pencatatan awakutu</string>
   <string name="debug_enable_debug_logging_summary">Catat informasi diagnostik tambahan</string>
   <string name="debug_enable_sensitive_logging_title">Catat informasi sensitif</string>

--- a/app/ui/src/main/res/values-is/strings.xml
+++ b/app/ui/src/main/res/values-is/strings.xml
@@ -60,7 +60,7 @@ Sendu inn villuskýrslur, leggðu fram nýja eiginleika og spurðu spurninga á
   <string name="read_messages_desc">Leyfa þessu forriti að lesa tölvupóstana mína.</string>
   <string name="delete_messages_label">Eyða tölvupóstum</string>
   <string name="delete_messages_desc">Leyfa þessu forriti að eyða tölvupóstum.</string>
-  <string name="about_title_fmt">Um <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Um K-9 Mail</string>
   <string name="accounts_title">Aðgangar</string>
   <string name="folders_title">Möppur</string>
   <string name="advanced">Ítarlegt</string>

--- a/app/ui/src/main/res/values-is/strings.xml
+++ b/app/ui/src/main/res/values-is/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, K-9 hundatemjararnir.</string>
   <string name="app_copyright_fmt">Höfundarréttur 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Höfundarréttur að hluta 2006-<xliff:g>%s</xliff:g> til Android Open Source verkefnisins.</string>
-  <string name="app_license">Gefið út með Apache notkunarleyfinu, útgáfu 2.0.</string>
+  <string name="app_license">Apache notkunarleyfinu, útgáfu 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Velkomin í K-9 póstinn</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-is/strings.xml
+++ b/app/ui/src/main/res/values-is/strings.xml
@@ -203,7 +203,7 @@ Sendu inn villuskýrslur, leggðu fram nýja eiginleika og spurðu spurninga á
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Geymsla)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Ruslpóstur)</string>
   <string name="send_failure_subject">Náði ekki að senda einhver skilaboð</string>
-  <string name="debug_version_fmt">Útgáfa: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Útgáfa</string>
   <string name="debug_enable_debug_logging_title">Skrá upplýsingar fyrir villuleit</string>
   <string name="debug_enable_debug_logging_summary">Skrá viðbótarupplýsingar fyrir villuleit</string>
   <string name="debug_enable_sensitive_logging_title">Skrá viðkvæmar upplýsingar</string>

--- a/app/ui/src/main/res/values-is/strings.xml
+++ b/app/ui/src/main/res/values-is/strings.xml
@@ -54,7 +54,7 @@ Sendu inn villuskýrslur, leggðu fram nýja eiginleika og spurðu spurninga á
   <string name="open_market">Opna Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Höfundar: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Upplýsingar útgáfu: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Upplýsingar útgáfu</string>
   <string name="app_libraries">Við erum að nota eftirfarandi aðgerðasöfn frá öðrum aðilum: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lesa tölvupósta</string>
   <string name="read_messages_desc">Leyfa þessu forriti að lesa tölvupóstana mína.</string>

--- a/app/ui/src/main/res/values-it/strings.xml
+++ b/app/ui/src/main/res/values-it/strings.xml
@@ -61,7 +61,7 @@ Per favore invia segnalazioni di errori, contribuisci con nuove funzionalità e 
   <string name="read_messages_desc">Consenti all\'applicazione di leggere i messaggi.</string>
   <string name="delete_messages_label">Elimina messaggi</string>
   <string name="delete_messages_desc">Permetti all\'applicazione di eliminare i messaggi.</string>
-  <string name="about_title_fmt">Informazioni su <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Informazioni su K-9 Mail</string>
   <string name="accounts_title">Account</string>
   <string name="folders_title">Cartelle</string>
   <string name="advanced">Avanzate</string>

--- a/app/ui/src/main/res/values-it/strings.xml
+++ b/app/ui/src/main/res/values-it/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Rilasciato sotto licenza Apache, versione 2.0.</string>
+  <string name="app_license">Licenza Apache, versione 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Benvenuto in K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-it/strings.xml
+++ b/app/ui/src/main/res/values-it/strings.xml
@@ -204,7 +204,7 @@ Per favore invia segnalazioni di errori, contribuisci con nuove funzionalità e 
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archivio)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Impossibile inviare alcuni messaggi</string>
-  <string name="debug_version_fmt">Versione: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versione</string>
   <string name="debug_enable_debug_logging_title">Attiva la registrazione di debug</string>
   <string name="debug_enable_debug_logging_summary">Registra informazioni diagnostiche aggiuntive</string>
   <string name="debug_enable_sensitive_logging_title">Registra informazioni sensibili</string>

--- a/app/ui/src/main/res/values-it/strings.xml
+++ b/app/ui/src/main/res/values-it/strings.xml
@@ -55,7 +55,7 @@ Per favore invia segnalazioni di errori, contribuisci con nuove funzionalità e 
   <string name="open_market">Apri il Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informazioni di versione: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informazioni di versione</string>
   <string name="app_libraries">Ci avvaliamo delle seguenti librerie di terze parti: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Leggi i messaggi</string>
   <string name="read_messages_desc">Consenti all\'applicazione di leggere i messaggi.</string>

--- a/app/ui/src/main/res/values-iw/strings.xml
+++ b/app/ui/src/main/res/values-iw/strings.xml
@@ -31,7 +31,7 @@
   <string name="read_messages_desc">אפשר ליישום זה לקרוא את האימיילים שלכם.</string>
   <string name="delete_messages_label">מחק אימיילים</string>
   <string name="delete_messages_desc">אפשר ליישום זה למחוק את האימיילים שלכם.</string>
-  <string name="about_title_fmt">אודות <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">אודות K-9 Mail</string>
   <string name="accounts_title">חשבונות</string>
   <string name="folders_title">תיקיות</string>
   <string name="advanced">מתקדם</string>

--- a/app/ui/src/main/res/values-iw/strings.xml
+++ b/app/ui/src/main/res/values-iw/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licensed under the Apache License, Version 2.0.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">ברוך הבא אל דואר K-9</string>
   <!--Default signature-->

--- a/app/ui/src/main/res/values-iw/strings.xml
+++ b/app/ui/src/main/res/values-iw/strings.xml
@@ -25,7 +25,7 @@
   <string name="open_market">פתח את חנות האפליקציות</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">מפתחים: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">מידע על גירסאות: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">מידע על גירסאות</string>
   <string name="app_libraries">אנחנו משתמשים בספריות הבאות של ספקים חיצוניים: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">קרא אימיילים</string>
   <string name="read_messages_desc">אפשר ליישום זה לקרוא את האימיילים שלכם.</string>

--- a/app/ui/src/main/res/values-iw/strings.xml
+++ b/app/ui/src/main/res/values-iw/strings.xml
@@ -168,7 +168,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (ארכיון)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (דואר זבל)</string>
   <string name="send_failure_subject">נכשל בשליחת כמה הודעות</string>
-  <string name="debug_version_fmt">גרסא: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">גרסא</string>
   <string name="debug_enable_debug_logging_title">אפשר רישום איתור באגים</string>
   <string name="debug_enable_debug_logging_summary">יומן ניתוח מידע נוסף</string>
   <string name="debug_enable_sensitive_logging_title">יומן מידע רגיש</string>

--- a/app/ui/src/main/res/values-ja/strings.xml
+++ b/app/ui/src/main/res/values-ja/strings.xml
@@ -61,7 +61,7 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
   <string name="read_messages_desc">このアプリケーションがメールを読むことを許可する</string>
   <string name="delete_messages_label">メールを削除</string>
   <string name="delete_messages_desc">このアプリケーションがメールを削除することを許可する</string>
-  <string name="about_title_fmt">About <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">About K-9 Mail</string>
   <string name="accounts_title">アカウント一覧</string>
   <string name="folders_title">フォルダ一覧</string>
   <string name="advanced">拡張機能</string>

--- a/app/ui/src/main/res/values-ja/strings.xml
+++ b/app/ui/src/main/res/values-ja/strings.xml
@@ -55,7 +55,7 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
   <string name="open_market">マーケット</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Authors: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Revision Information: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Revision Information</string>
   <string name="app_libraries">以下のライブラリを利用しています: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">メールを読む</string>
   <string name="read_messages_desc">このアプリケーションがメールを読むことを許可する</string>

--- a/app/ui/src/main/res/values-ja/strings.xml
+++ b/app/ui/src/main/res/values-ja/strings.xml
@@ -201,7 +201,7 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (アーカイブ)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (迷惑メール)</string>
   <string name="send_failure_subject">メール送信に失敗しました</string>
-  <string name="debug_version_fmt">Version: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Version</string>
   <string name="debug_enable_debug_logging_title">拡張デバッグログ</string>
   <string name="debug_enable_debug_logging_summary">追加診断情報ログ</string>
   <string name="debug_enable_sensitive_logging_title">詳細情報ログ</string>

--- a/app/ui/src/main/res/values-ja/strings.xml
+++ b/app/ui/src/main/res/values-ja/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licensed under the Apache License, Version 2.0.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">K-9 Mailへようこそ</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-ko/strings.xml
+++ b/app/ui/src/main/res/values-ko/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licensed under the Apache License, Version 2.0.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">K-9 메일을 사용하시게 된 것을 환영합니다</string>
   <!--Default signature-->

--- a/app/ui/src/main/res/values-ko/strings.xml
+++ b/app/ui/src/main/res/values-ko/strings.xml
@@ -25,7 +25,7 @@
   <string name="open_market">플레이 스토어 열기</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">작성자들: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">배포 정보: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">배포 정보</string>
   <string name="app_libraries">K-9 메일은 다음 제3자 라이브러리들을 이용합니다. <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">이메일 읽기</string>
   <string name="read_messages_desc">K-9이 이메일을 읽도록 합니다.</string>

--- a/app/ui/src/main/res/values-ko/strings.xml
+++ b/app/ui/src/main/res/values-ko/strings.xml
@@ -164,7 +164,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (보관함)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (스팸함)</string>
   <string name="send_failure_subject">일부 메시지를 보내는 데 실패하였습니다</string>
-  <string name="debug_version_fmt">Version: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Version</string>
   <string name="debug_enable_debug_logging_title">버그 정보 기록</string>
   <string name="debug_enable_debug_logging_summary">부차적인 진단 정보를 기록합니다</string>
   <string name="debug_enable_sensitive_logging_title">중요 정보 기록</string>

--- a/app/ui/src/main/res/values-lt/strings.xml
+++ b/app/ui/src/main/res/values-lt/strings.xml
@@ -24,7 +24,7 @@
   <string name="open_market">Atverti „Play Store“</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autoriai: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Laidos informacija: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Laidos informacija</string>
   <string name="app_libraries">Mes naudojame šias trečiųjų šalių bibliotekas: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Skaityti laiškus</string>
   <string name="read_messages_desc">Leidžia programai skaityti jūsų laiškus.</string>

--- a/app/ui/src/main/res/values-lt/strings.xml
+++ b/app/ui/src/main/res/values-lt/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Autorinės teisės 2008-<xliff:g>%s</xliff:g> K-9 Dog Walkers. Dalis autorinių teisių priklauso 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Išleista pagal Apache License sąlygas, versija 2.</string>
+  <string name="app_license">Apache License, versija 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Sveiki atvykę į „K-9 Mail“</string>
   <!--Default signature-->

--- a/app/ui/src/main/res/values-lt/strings.xml
+++ b/app/ui/src/main/res/values-lt/strings.xml
@@ -30,7 +30,7 @@
   <string name="read_messages_desc">Leidžia programai skaityti jūsų laiškus.</string>
   <string name="delete_messages_label">Šalinti laiškus</string>
   <string name="delete_messages_desc">Leidžia programai šalinti jūsų laiškus.</string>
-  <string name="about_title_fmt">Apie <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Apie K-9 Mail</string>
   <string name="accounts_title">Paskyros</string>
   <string name="folders_title">Aplankai</string>
   <string name="advanced">Išplėstinis</string>

--- a/app/ui/src/main/res/values-lt/strings.xml
+++ b/app/ui/src/main/res/values-lt/strings.xml
@@ -149,7 +149,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archyvas)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Brukalas)</string>
   <string name="send_failure_subject">Kai kurių laiškų išsiųsti nepavyko</string>
-  <string name="debug_version_fmt">Versija: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versija</string>
   <string name="debug_enable_debug_logging_title">Įjungti derinimo žurnalą</string>
   <string name="debug_enable_debug_logging_summary">Įrašyti papildomą diagnostinę informaciją</string>
   <string name="debug_enable_sensitive_logging_title">Įrašyti jautrią informaciją</string>

--- a/app/ui/src/main/res/values-lv/strings.xml
+++ b/app/ui/src/main/res/values-lv/strings.xml
@@ -54,7 +54,7 @@ Lūdzu, iesniedziet kļūdu ziņojumus, ierosiniet jaunas iespējas un uzdodiet 
   <string name="open_market">Atvērt Play veikalu</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Revīzijas informācija: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Revīzijas informācija</string>
   <string name="app_libraries">Mēs izmantojam sekojošas trešo pušu bibliotēkas: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Izlasīt e-pastus</string>
   <string name="read_messages_desc">Atļauj šai aplikācijai lasīt Jūsu e-pastus</string>

--- a/app/ui/src/main/res/values-lv/strings.xml
+++ b/app/ui/src/main/res/values-lv/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Autortiesības 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Daļējas autortiesības 2006-<xliff:g>%s</xliff:g> Android atvērtā koda projekts.</string>
-  <string name="app_license">Licencēts ar Apache License, versija 2.0.</string>
+  <string name="app_license">Apache License, versija 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Laipni lūdzam K-9 Pastā</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-lv/strings.xml
+++ b/app/ui/src/main/res/values-lv/strings.xml
@@ -60,7 +60,7 @@ Lūdzu, iesniedziet kļūdu ziņojumus, ierosiniet jaunas iespējas un uzdodiet 
   <string name="read_messages_desc">Atļauj šai aplikācijai lasīt Jūsu e-pastus</string>
   <string name="delete_messages_label">Izdzēst e-pastus</string>
   <string name="delete_messages_desc">Atļauj šai aplikācijai izdzēst Jūsu e-pastus</string>
-  <string name="about_title_fmt">Par <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Par K-9 Mail</string>
   <string name="accounts_title">Konti</string>
   <string name="folders_title">Mapes</string>
   <string name="advanced">Detalizētāk</string>

--- a/app/ui/src/main/res/values-lv/strings.xml
+++ b/app/ui/src/main/res/values-lv/strings.xml
@@ -202,7 +202,7 @@ pat <xliff:g id="messages_to_load">%d</xliff:g> vairāk</string>
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arhīvs)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Surogātpasts)</string>
   <string name="send_failure_subject">Neizdevās nosūtīt dažas vēstules</string>
-  <string name="debug_version_fmt">Versija: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versija</string>
   <string name="debug_enable_debug_logging_title">Iestatīt programmas kļūdu reģistrēšanu</string>
   <string name="debug_enable_debug_logging_summary">Reģistrēt papildus diagnostisko informāciju</string>
   <string name="debug_enable_sensitive_logging_title">Reģistrēt slepeno informāciju</string>

--- a/app/ui/src/main/res/values-nb/strings.xml
+++ b/app/ui/src/main/res/values-nb/strings.xml
@@ -55,7 +55,7 @@ Send feilmeldinger, bidra med nye funksjoner og still spørsmål her:
   <string name="open_market">Åpne Play-butikken</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Utviklere: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Revisjonsinformasjon: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Revisjonsinformasjon</string>
   <string name="app_libraries">Vi bruker følgende tredjepartsbiblioteker: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Les e-poster</string>
   <string name="read_messages_desc">Tillater denne applikasjonen å lese dine e-poster.</string>

--- a/app/ui/src/main/res/values-nb/strings.xml
+++ b/app/ui/src/main/res/values-nb/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Opphavsrett 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Kopirett for noen deler 2006-<xliff:g>%s</xliff:g> Android Open Source Project.</string>
-  <string name="app_license">Utgitt med Apache-lisens, versjon 2.0.</string>
+  <string name="app_license">Apache-lisens, versjon 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Velkommen til K-9 e-post</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-nb/strings.xml
+++ b/app/ui/src/main/res/values-nb/strings.xml
@@ -61,7 +61,7 @@ Send feilmeldinger, bidra med nye funksjoner og still spørsmål her:
   <string name="read_messages_desc">Tillater denne applikasjonen å lese dine e-poster.</string>
   <string name="delete_messages_label">Slett e-poster</string>
   <string name="delete_messages_desc">Tillater dette programmet å slette dine e-poster.</string>
-  <string name="about_title_fmt">Om <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Om K-9 Mail</string>
   <string name="accounts_title">Kontoer</string>
   <string name="folders_title">Mapper</string>
   <string name="advanced">Avansert</string>

--- a/app/ui/src/main/res/values-nb/strings.xml
+++ b/app/ui/src/main/res/values-nb/strings.xml
@@ -204,7 +204,7 @@ til <xliff:g id="messages_to_load">%d</xliff:g> flere</string>
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arkiv)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Søppel)</string>
   <string name="send_failure_subject">Mislyktes i å sende noen meldinger</string>
-  <string name="debug_version_fmt">Versjon: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versjon</string>
   <string name="debug_enable_debug_logging_title">Aktiver feilsøkingslogg</string>
   <string name="debug_enable_debug_logging_summary">Logg ekstra diagnostisk informasjon</string>
   <string name="debug_enable_sensitive_logging_title">Logg sensitiv informasjon</string>

--- a/app/ui/src/main/res/values-nl/strings.xml
+++ b/app/ui/src/main/res/values-nl/strings.xml
@@ -56,7 +56,7 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   <string name="read_messages_desc">Sta deze appicatie toe om je e-mails te lezen.</string>
   <string name="delete_messages_label">Verwijder e-mails</string>
   <string name="delete_messages_desc">Sta deze applicatie toe om je e-mails te verwijderen.</string>
-  <string name="about_title_fmt">Over <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Over K-9 Mail</string>
   <string name="accounts_title">Accounts</string>
   <string name="folders_title">Mappen</string>
   <string name="advanced">Geavanceerd</string>

--- a/app/ui/src/main/res/values-nl/strings.xml
+++ b/app/ui/src/main/res/values-nl/strings.xml
@@ -50,7 +50,7 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   <string name="open_market">Open Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Auteurs: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Revisie Informatie: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Revisie Informatie</string>
   <string name="app_libraries">De volgende externe bibliotheken worden gebruikt: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">E-mails lezen</string>
   <string name="read_messages_desc">Sta deze appicatie toe om je e-mails te lezen.</string>

--- a/app/ui/src/main/res/values-nl/strings.xml
+++ b/app/ui/src/main/res/values-nl/strings.xml
@@ -198,7 +198,7 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archief)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Fout bij verzenden van berichten</string>
-  <string name="debug_version_fmt">Versie: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versie</string>
   <string name="debug_enable_debug_logging_title">Debug log toestaan</string>
   <string name="debug_enable_debug_logging_summary">Log extra diagnostische informatie</string>
   <string name="debug_enable_sensitive_logging_title">Log gevoelige informatie</string>

--- a/app/ui/src/main/res/values-nl/strings.xml
+++ b/app/ui/src/main/res/values-nl/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licensed under the Apache License, Version 2.0.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Welkom bij K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[ <p> K-9 Mail is een krachtige e-mail cliënt voor Android. </p><p> De verbeterde mogelijkheden bestaan uit ondermeer:

--- a/app/ui/src/main/res/values-pl/strings.xml
+++ b/app/ui/src/main/res/values-pl/strings.xml
@@ -205,7 +205,7 @@ Wysłane za pomocą K-9 Mail.</string>
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archiwum)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Niektóre wiadomości nie zostały wysłane</string>
-  <string name="version">Wersja <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Wersja</string>
   <string name="debug_enable_debug_logging_title">Włącz logowanie</string>
   <string name="debug_enable_debug_logging_summary">Loguj dodatkowe informacje diagnostyczne</string>
   <string name="debug_enable_sensitive_logging_title">Loguj poufne informacje</string>

--- a/app/ui/src/main/res/values-pl/strings.xml
+++ b/app/ui/src/main/res/values-pl/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Wszelkie prawa zastrzeżone</string>
+  <string name="app_license">Licencja Apache, wersja 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Witaj w K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-pl/strings.xml
+++ b/app/ui/src/main/res/values-pl/strings.xml
@@ -55,7 +55,7 @@ Wysłane za pomocą K-9 Mail.</string>
   <string name="open_market">Otwórz Google Play</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autorzy: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Historia zmian: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Historia zmian</string>
   <string name="app_libraries">K-9 mail zawiera kod źródłowy: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Czytaj pocztę</string>
   <string name="read_messages_desc">Zezwalaj tej aplikacji na czytanie Twoich wiadomości</string>

--- a/app/ui/src/main/res/values-pl/strings.xml
+++ b/app/ui/src/main/res/values-pl/strings.xml
@@ -205,7 +205,7 @@ Wysłane za pomocą K-9 Mail.</string>
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archiwum)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Niektóre wiadomości nie zostały wysłane</string>
-  <string name="debug_version_fmt">Wersja <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Wersja <xliff:g id="version">%s</xliff:g></string>
   <string name="debug_enable_debug_logging_title">Włącz logowanie</string>
   <string name="debug_enable_debug_logging_summary">Loguj dodatkowe informacje diagnostyczne</string>
   <string name="debug_enable_sensitive_logging_title">Loguj poufne informacje</string>

--- a/app/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/src/main/res/values-pt-rBR/strings.xml
@@ -200,7 +200,7 @@ Por favor encaminhe relatórios de bugs, contribua com novos recursos e tire dú
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arquivadas)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Algumas mensagens não foram enviadas</string>
-  <string name="debug_version_fmt">Versão: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versão</string>
   <string name="debug_enable_debug_logging_title">Habilitar relatório de depuração</string>
   <string name="debug_enable_debug_logging_summary">Relatar informações de diagnósticos extras</string>
   <string name="debug_enable_sensitive_logging_title">Relatar informações confidencias</string>

--- a/app/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/src/main/res/values-pt-rBR/strings.xml
@@ -60,7 +60,7 @@ Por favor encaminhe relatórios de bugs, contribua com novos recursos e tire dú
   <string name="read_messages_desc">Permite que esta aplicação leia seus e-mails.</string>
   <string name="delete_messages_label">Excluir e-mails</string>
   <string name="delete_messages_desc">Permite que o K-9 exclua seus e-mails.</string>
-  <string name="about_title_fmt">Sobre <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Sobre K-9 Mail</string>
   <string name="accounts_title">Contas</string>
   <string name="folders_title">Pastas</string>
   <string name="advanced">Avançado</string>

--- a/app/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/src/main/res/values-pt-rBR/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Partes do Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licenciado sob a Apache License, Versão 2.0.</string>
+  <string name="app_license">Apache License, Versão 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Bem-vindo ao K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/src/main/res/values-pt-rBR/strings.xml
@@ -54,7 +54,7 @@ Por favor encaminhe relatórios de bugs, contribua com novos recursos e tire dú
   <string name="open_market">Abrir a Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informações da revisão: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informações da revisão</string>
   <string name="app_libraries">Estamos usando as seguintes bibliotecas de terceiros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ler e-mails</string>
   <string name="read_messages_desc">Permite que esta aplicação leia seus e-mails.</string>

--- a/app/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/src/main/res/values-pt-rPT/strings.xml
@@ -55,7 +55,7 @@ Por favor envie relatórios de falhas, contribua com novas funcionalidades e col
   <string name="open_market">Abrir Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informação da revisão: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informação da revisão</string>
   <string name="app_libraries">Estamos a usar as seguintes bibliotecas de terceiros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ler Emails</string>
   <string name="read_messages_desc">Permite que esta aplicação leia os seus emails.</string>

--- a/app/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/src/main/res/values-pt-rPT/strings.xml
@@ -61,7 +61,7 @@ Por favor envie relatórios de falhas, contribua com novas funcionalidades e col
   <string name="read_messages_desc">Permite que esta aplicação leia os seus emails.</string>
   <string name="delete_messages_label">Eliminar emails</string>
   <string name="delete_messages_desc">Permite que esta aplicação elimine os seus emails.</string>
-  <string name="about_title_fmt">Sobre <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Sobre K-9 Mail</string>
   <string name="accounts_title">Contas</string>
   <string name="folders_title">Pastas</string>
   <string name="advanced">Avançado</string>

--- a/app/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/src/main/res/values-pt-rPT/strings.xml
@@ -200,7 +200,7 @@ Por favor envie relatórios de falhas, contribua com novas funcionalidades e col
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arquivo)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Falha ao enviar algumas mensagens</string>
-  <string name="debug_version_fmt">Versão: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versão</string>
   <string name="debug_enable_debug_logging_title">Ativar registo de depuração</string>
   <string name="debug_enable_debug_logging_summary">Registar informação de diagnóstico extra</string>
   <string name="debug_enable_sensitive_logging_title">Registar informação sensível</string>

--- a/app/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/src/main/res/values-pt-rPT/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Partes protegidas por Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licenciado sob a Licença Apache, Versão 2.0.</string>
+  <string name="app_license">Licença Apache, Versão 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Bem-vindo ao K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-ro/strings.xml
+++ b/app/ui/src/main/res/values-ro/strings.xml
@@ -205,7 +205,7 @@ cel mult încă <xliff:g id="messages_to_load">%d</xliff:g></string>
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arhivă)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Nu a reușit să trimită niște mesaje</string>
-  <string name="debug_version_fmt">Versiune: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Versiune</string>
   <string name="debug_enable_debug_logging_title">Activați jurnalul depanării</string>
   <string name="debug_enable_debug_logging_summary">Jurnal informații suplimentare diagnostic</string>
   <string name="debug_enable_sensitive_logging_title">Jurnal informații sensibile</string>

--- a/app/ui/src/main/res/values-ro/strings.xml
+++ b/app/ui/src/main/res/values-ro/strings.xml
@@ -54,7 +54,7 @@ Vă rugăm să ne raportați defecte, să contribuiți cu funcționalități noi
   <string name="open_market">Deschide magazinul Play</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informații despre versiune: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informații despre versiune</string>
   <string name="app_libraries">Folosim următoarele biblioteci externe: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Citire emailuri</string>
   <string name="read_messages_desc">Permiteți acestei aplicații să vă citească emailurile.</string>

--- a/app/ui/src/main/res/values-ro/strings.xml
+++ b/app/ui/src/main/res/values-ro/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Anumite porțiuni Copyright 2006-<xliff:g>%s</xliff:g> Proiectul Open Source Android.</string>
-  <string name="app_license">Licențiat sub licența Apache, versiunea 2.0.</string>
+  <string name="app_license">Licența Apache, versiunea 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Bun venit la K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-ro/strings.xml
+++ b/app/ui/src/main/res/values-ro/strings.xml
@@ -60,7 +60,7 @@ Vă rugăm să ne raportați defecte, să contribuiți cu funcționalități noi
   <string name="read_messages_desc">Permiteți acestei aplicații să vă citească emailurile.</string>
   <string name="delete_messages_label">Ștergere emailuri</string>
   <string name="delete_messages_desc">Permiteți acestei aplicații să vă șteargă emailurile.</string>
-  <string name="about_title_fmt">Despre <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Despre K-9 Mail</string>
   <string name="accounts_title">Conturi</string>
   <string name="folders_title">Dosare</string>
   <string name="advanced">Avansat</string>

--- a/app/ui/src/main/res/values-ru/strings.xml
+++ b/app/ui/src/main/res/values-ru/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project</string>
-  <string name="app_license">Под лицензией Apache 2.0</string>
+  <string name="app_license">Лицензией Apache 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Добро пожаловать!</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-ru/strings.xml
+++ b/app/ui/src/main/res/values-ru/strings.xml
@@ -60,7 +60,7 @@ K-9 Mail — почтовый клиент для Android.
   <string name="read_messages_desc">Разрешить программе чтение почты</string>
   <string name="delete_messages_label">Удаление почты</string>
   <string name="delete_messages_desc">Разрешить программе удаление почты</string>
-  <string name="about_title_fmt">K-9 Mail Team <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">K-9 Mail Team K-9 Mail</string>
   <string name="accounts_title">Ящики</string>
   <string name="folders_title">Папки</string>
   <string name="advanced">Дополнительно</string>

--- a/app/ui/src/main/res/values-ru/strings.xml
+++ b/app/ui/src/main/res/values-ru/strings.xml
@@ -206,7 +206,7 @@ K-9 Mail — почтовый клиент для Android.
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g></string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g></string>
   <string name="send_failure_subject">Сбой отправки почты</string>
-  <string name="debug_version_fmt">Версия: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Версия</string>
   <string name="debug_enable_debug_logging_title">Журнал отладки</string>
   <string name="debug_enable_debug_logging_summary">Запись диагностических сообщений</string>
   <string name="debug_enable_sensitive_logging_title">Личные данные</string>

--- a/app/ui/src/main/res/values-ru/strings.xml
+++ b/app/ui/src/main/res/values-ru/strings.xml
@@ -54,7 +54,7 @@ K-9 Mail — почтовый клиент для Android.
   <string name="open_market">Google Play</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Авторы: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Изменения: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Изменения</string>
   <string name="app_libraries">Сторонние компоненты: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Чтение почты</string>
   <string name="read_messages_desc">Разрешить программе чтение почты</string>

--- a/app/ui/src/main/res/values-sk/strings.xml
+++ b/app/ui/src/main/res/values-sk/strings.xml
@@ -61,7 +61,7 @@ Prosím, nahlasujte prípadné chyby, prispievajte novými funkciami a pýtajte 
   <string name="read_messages_desc">Umožňuje tejto aplikácii čítať vaše e-maily.</string>
   <string name="delete_messages_label">Mazať správy</string>
   <string name="delete_messages_desc">Umožňuje tejto aplikácii mazať vaše e-maily.</string>
-  <string name="about_title_fmt">O aplikácii <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">O aplikácii K-9 Mail</string>
   <string name="accounts_title">Účty</string>
   <string name="folders_title">Priečinky</string>
   <string name="advanced">Pokročilé</string>

--- a/app/ui/src/main/res/values-sk/strings.xml
+++ b/app/ui/src/main/res/values-sk/strings.xml
@@ -55,7 +55,7 @@ Prosím, nahlasujte prípadné chyby, prispievajte novými funkciami a pýtajte 
   <string name="open_market">Otvoriť Obchod Play</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Informácie o revízii: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Informácie o revízii</string>
   <string name="app_libraries">Používame tieto knižnice tretích strán: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Čítať správy</string>
   <string name="read_messages_desc">Umožňuje tejto aplikácii čítať vaše e-maily.</string>

--- a/app/ui/src/main/res/values-sk/strings.xml
+++ b/app/ui/src/main/res/values-sk/strings.xml
@@ -202,7 +202,7 @@ Prosím, nahlasujte prípadné chyby, prispievajte novými funkciami a pýtajte 
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archív)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Nevyžiadaná)</string>
   <string name="send_failure_subject">Nepodarilo sa odoslať niektoré správy</string>
-  <string name="debug_version_fmt">Verzia: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Verzia</string>
   <string name="debug_enable_debug_logging_title">Povoliť vytváranie záznamov pre ladenie</string>
   <string name="debug_enable_debug_logging_summary">Zaznamenávať rozšírené diagnostické informácie</string>
   <string name="debug_enable_sensitive_logging_title">Zaznamenávať citlivé informácie</string>

--- a/app/ui/src/main/res/values-sl/strings.xml
+++ b/app/ui/src/main/res/values-sl/strings.xml
@@ -54,7 +54,7 @@ Poročila o napakah, predloge za nove funkcije in vprašanja lahko pošljete na
   <string name="open_market">Odpri Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Avtorstvo: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Podrobnosti različice: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Podrobnosti različice</string>
   <string name="app_libraries">Vključene so naslednje zunanje knjižnice: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Preberi pošto</string>
   <string name="read_messages_desc">Možnost omogoča programu branje elektronske pošte.</string>

--- a/app/ui/src/main/res/values-sl/strings.xml
+++ b/app/ui/src/main/res/values-sl/strings.xml
@@ -60,7 +60,7 @@ Poročila o napakah, predloge za nove funkcije in vprašanja lahko pošljete na
   <string name="read_messages_desc">Možnost omogoča programu branje elektronske pošte.</string>
   <string name="delete_messages_label">brisanje sporočil elektronske pošte</string>
   <string name="delete_messages_desc">Možnost omogoča programu brisanje sporočil elektronske pošte.</string>
-  <string name="about_title_fmt">O programu <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">O programu K-9 Mail</string>
   <string name="accounts_title">Računi</string>
   <string name="folders_title">Mape</string>
   <string name="advanced">Napredno</string>

--- a/app/ui/src/main/res/values-sl/strings.xml
+++ b/app/ui/src/main/res/values-sl/strings.xml
@@ -207,7 +207,7 @@ dodatnih <xliff:g id="messages_to_load">%d</xliff:g> sporočil</string>
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arhivirano)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Neželena pošta)</string>
   <string name="send_failure_subject">Nekaterih sporočil ni bilo mogoče poslati!</string>
-  <string name="debug_version_fmt">Različica: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Različica</string>
   <string name="debug_enable_debug_logging_title">Omogoči beleženje razhroščevanja</string>
   <string name="debug_enable_debug_logging_summary">Beleženje dodatnih podrobnosti diagnostike</string>
   <string name="debug_enable_sensitive_logging_title">Beleženje občutljivih podrobnosti</string>

--- a/app/ui/src/main/res/values-sq/strings.xml
+++ b/app/ui/src/main/res/values-sq/strings.xml
@@ -204,7 +204,7 @@ Ju lutemi, parashtrim njoftimesh për të meta, kontribute për veçori të reaj
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arkiv)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Të padëshiruar)</string>
   <string name="send_failure_subject">Dështoi dërgimi i disa mesazhe</string>
-  <string name="debug_version_fmt">Version: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Version</string>
   <string name="debug_enable_debug_logging_title">Aktivizo regjistrim diagnostikimesh</string>
   <string name="debug_enable_debug_logging_summary">Regjistro të dhëna ekstra diagnostikimesh</string>
   <string name="debug_enable_sensitive_logging_title">Regjistro të dhëna konfidenciale</string>

--- a/app/ui/src/main/res/values-sq/strings.xml
+++ b/app/ui/src/main/res/values-sq/strings.xml
@@ -55,7 +55,7 @@ Ju lutemi, parashtrim njoftimesh për të meta, kontribute për veçori të reaj
   <string name="open_market">Hap Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Autorë: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Të dhëna versioni: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Të dhëna versioni</string>
   <string name="app_libraries">Përdorim libraritë vijuese nga palë të treta: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lexoni Email-e</string>
   <string name="read_messages_desc">I lejon këtij aplikacioni të lexojë email-et tuaj.</string>

--- a/app/ui/src/main/res/values-sq/strings.xml
+++ b/app/ui/src/main/res/values-sq/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Të drejta kopjimi 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Të drejta kopjimi Mbi Pjesë 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Licencuar sipas licencës Apache License, Version 2.0.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Mirë se vini te K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-sq/strings.xml
+++ b/app/ui/src/main/res/values-sq/strings.xml
@@ -61,7 +61,7 @@ Ju lutemi, parashtrim njoftimesh për të meta, kontribute për veçori të reaj
   <string name="read_messages_desc">I lejon këtij aplikacioni të lexojë email-et tuaj.</string>
   <string name="delete_messages_label">Fshiji Email-et</string>
   <string name="delete_messages_desc">I lejon këtij aplikacioni të fshijë email-et tuaj.</string>
-  <string name="about_title_fmt">Mbi <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Mbi K-9 Mail</string>
   <string name="accounts_title">Llogari</string>
   <string name="folders_title">Dosje</string>
   <string name="advanced">Të mëtejshme</string>

--- a/app/ui/src/main/res/values-sr/strings.xml
+++ b/app/ui/src/main/res/values-sr/strings.xml
@@ -54,7 +54,7 @@
   <string name="open_market">Отвори Плеј продавницу</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Аутори: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Подаци о ревизији: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Подаци о ревизији</string>
   <string name="app_libraries">Користимо следеће библиотеке треће стране: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">читање е-порука</string>
   <string name="read_messages_desc">Дозвољава овој апликацији читање ваших е-порука.</string>

--- a/app/ui/src/main/res/values-sr/strings.xml
+++ b/app/ui/src/main/res/values-sr/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Гугл, К-9 Шетачи паса.</string>
   <string name="app_copyright_fmt">Ауторска права 2008-<xliff:g>%s</xliff:g> „K-9 Dog Walkers“. Део ауторских права 2006-<xliff:g>%s</xliff:g> Андроид пројекат отвореног ко̂да.</string>
-  <string name="app_license">Лиценцирано под Апачи лиценцом, издање 2.0.</string>
+  <string name="app_license">Апачи лиценцом, издање 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Добро дошли у К-9 Пошту</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-sr/strings.xml
+++ b/app/ui/src/main/res/values-sr/strings.xml
@@ -203,7 +203,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Архива)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Нежељене)</string>
   <string name="send_failure_subject">Неуспех слања неких порука</string>
-  <string name="debug_version_fmt">Издање: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Издање</string>
   <string name="debug_enable_debug_logging_title">Укључи бележење за отклањање грешака</string>
   <string name="debug_enable_debug_logging_summary">Бележи додатне дијагностичке податке</string>
   <string name="debug_enable_sensitive_logging_title">Бележи осетљиве податке</string>

--- a/app/ui/src/main/res/values-sr/strings.xml
+++ b/app/ui/src/main/res/values-sr/strings.xml
@@ -60,7 +60,7 @@
   <string name="read_messages_desc">Дозвољава овој апликацији читање ваших е-порука.</string>
   <string name="delete_messages_label">брисање е-порука</string>
   <string name="delete_messages_desc">Дозвољава овој апликацији брисање ваших е-порука.</string>
-  <string name="about_title_fmt">О <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">О K-9 Mail</string>
   <string name="accounts_title">Налози</string>
   <string name="folders_title">Фасцикле</string>
   <string name="advanced">Напредно</string>

--- a/app/ui/src/main/res/values-sv/strings.xml
+++ b/app/ui/src/main/res/values-sv/strings.xml
@@ -54,7 +54,7 @@ Skicka gärna in rapporter om buggar, eller bidra med nya funktioner eller stäl
   <string name="open_market">Öppna Play butik</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Upphovsmän: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Revisionsinformation: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Revisionsinformation</string>
   <string name="app_libraries">Vi använder följande tredjepartsbibliotek: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Läs e-post</string>
   <string name="read_messages_desc">Ger applikationen tillåtelse att läsa din e-post.</string>

--- a/app/ui/src/main/res/values-sv/strings.xml
+++ b/app/ui/src/main/res/values-sv/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Vissa delar har Copyright 2006-<xliff:g>%s</xliff:g> Android Open Source Project.</string>
-  <string name="app_license">Licensierat under Apache-licensen, version 2.0.</string>
+  <string name="app_license">Apache-licensen, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Välkommen till K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-sv/strings.xml
+++ b/app/ui/src/main/res/values-sv/strings.xml
@@ -60,7 +60,7 @@ Skicka gärna in rapporter om buggar, eller bidra med nya funktioner eller stäl
   <string name="read_messages_desc">Ger applikationen tillåtelse att läsa din e-post.</string>
   <string name="delete_messages_label">Ta bort e-post</string>
   <string name="delete_messages_desc">Ger applikationen tillåtelse att radera din e-post.</string>
-  <string name="about_title_fmt">Om <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Om K-9 Mail</string>
   <string name="accounts_title">Konton</string>
   <string name="folders_title">Mappar</string>
   <string name="advanced">Avancerat</string>

--- a/app/ui/src/main/res/values-sv/strings.xml
+++ b/app/ui/src/main/res/values-sv/strings.xml
@@ -203,7 +203,7 @@ Skicka gärna in rapporter om buggar, eller bidra med nya funktioner eller stäl
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arkiv)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Skräppost)</string>
   <string name="send_failure_subject">Misslyckades med att skicka några brev</string>
-  <string name="debug_version_fmt">Version: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Version</string>
   <string name="debug_enable_debug_logging_title">Aktivera felsöksloggning</string>
   <string name="debug_enable_debug_logging_summary">Logga extra diagnostisk information</string>
   <string name="debug_enable_sensitive_logging_title">Logga känslig information</string>

--- a/app/ui/src/main/res/values-tr/strings.xml
+++ b/app/ui/src/main/res/values-tr/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Telif Hakkı 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Telif hakkı 2006-<xliff:g>%s</xliff:g> Android Açık Kaynak Projesi.</string>
-  <string name="app_license">Apache License, Sürüm 2.0 altında lisanslanmıştır.</string>
+  <string name="app_license">Apache License, Sürüm 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">K-9 Posta\'ya Hoşgeldiniz</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-tr/strings.xml
+++ b/app/ui/src/main/res/values-tr/strings.xml
@@ -54,7 +54,7 @@ Microsoft Exchange ile konuşurken bazı tuhaflıklar yaşadığını not ediniz
   <string name="open_market">Play Store\'u Aç</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Yazarlar: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Gözden Geçirme Bilgileri: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Gözden Geçirme Bilgileri</string>
   <string name="app_libraries">K-9 posta kaynak kodları içerir: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">E-postaları oku</string>
   <string name="read_messages_desc">Bu uygulamaya E-postalarınızı okumaya izin ver.</string>

--- a/app/ui/src/main/res/values-tr/strings.xml
+++ b/app/ui/src/main/res/values-tr/strings.xml
@@ -60,7 +60,7 @@ Microsoft Exchange ile konuşurken bazı tuhaflıklar yaşadığını not ediniz
   <string name="read_messages_desc">Bu uygulamaya E-postalarınızı okumaya izin ver.</string>
   <string name="delete_messages_label">E-postaları sil</string>
   <string name="delete_messages_desc">Bu uygulamaya E-postalarınızı silmeye izin ver.</string>
-  <string name="about_title_fmt">Hakkında <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Hakkında K-9 Mail</string>
   <string name="accounts_title">Hesaplar</string>
   <string name="folders_title">Klasörler</string>
   <string name="advanced">Gelişmiş</string>

--- a/app/ui/src/main/res/values-tr/strings.xml
+++ b/app/ui/src/main/res/values-tr/strings.xml
@@ -202,7 +202,7 @@ Microsoft Exchange ile konuşurken bazı tuhaflıklar yaşadığını not ediniz
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Arşiv)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Bazı iletilerin gönderilmesi başarısız</string>
-  <string name="debug_version_fmt">Sürüm: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Sürüm</string>
   <string name="debug_enable_debug_logging_title">Onarma günlüğünü etkinleştir</string>
   <string name="debug_enable_debug_logging_summary">Extra tanı bilgisini günlüğe kaydet</string>
   <string name="debug_enable_sensitive_logging_title">Hassas bilgi günlüğü tut</string>

--- a/app/ui/src/main/res/values-uk/strings.xml
+++ b/app/ui/src/main/res/values-uk/strings.xml
@@ -55,7 +55,7 @@ K-9 Mail — це вільний клієнт електронної пошти 
   <string name="open_market">Відкрити Play Google</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">Автори: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">Інформація про зміни: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">Інформація про зміни</string>
   <string name="app_libraries">Ми використовуємо такі бібліотеки сторонніх розробників: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">читати листи</string>
   <string name="read_messages_desc">Дозволити цій програмі читати ваші листи.</string>

--- a/app/ui/src/main/res/values-uk/strings.xml
+++ b/app/ui/src/main/res/values-uk/strings.xml
@@ -200,7 +200,7 @@ K-9 Mail — це вільний клієнт електронної пошти 
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g> (Archive)</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
   <string name="send_failure_subject">Не вдалося надіслати повідомлення</string>
-  <string name="debug_version_fmt">Версія: <xliff:g id="version">%s</xliff:g></string>
+  <string name="version">Версія</string>
   <string name="debug_enable_debug_logging_title">Увімкнути ведення журналу налагодження</string>
   <string name="debug_enable_debug_logging_summary">Запис додаткової діагностичної інформації</string>
   <string name="debug_enable_sensitive_logging_title">Запис конфіденційної інформації</string>

--- a/app/ui/src/main/res/values-uk/strings.xml
+++ b/app/ui/src/main/res/values-uk/strings.xml
@@ -61,7 +61,7 @@ K-9 Mail — це вільний клієнт електронної пошти 
   <string name="read_messages_desc">Дозволити цій програмі читати ваші листи.</string>
   <string name="delete_messages_label">Видалити листи</string>
   <string name="delete_messages_desc">Дозволити цій програмі видаляти ваші листи.</string>
-  <string name="about_title_fmt">Про <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">Про K-9 Mail</string>
   <string name="accounts_title">Облікові записи</string>
   <string name="folders_title">Теки</string>
   <string name="advanced">Додатково</string>

--- a/app/ui/src/main/res/values-uk/strings.xml
+++ b/app/ui/src/main/res/values-uk/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">Ліцензія Apache License, Version 2.0.</string>
+  <string name="app_license">Apache License, Version 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">Ласкаво просимо до K-9 Mail</string>
   <string name="accounts_welcome"><![CDATA[

--- a/app/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/src/main/res/values-zh-rCN/strings.xml
@@ -193,7 +193,7 @@ https://github.com/k9mail/k-9/20
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g>（归档）</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g>（垃圾邮件）</string>
   <string name="send_failure_subject">一些邮件没有成功发送</string>
-  <string name="version">版本：<xliff:g id="version">%s</xliff:g></string>
+  <string name="version">版本：</string>
   <string name="debug_enable_debug_logging_title">启用调试日志</string>
   <string name="debug_enable_debug_logging_summary">记录额外的调试信息</string>
   <string name="debug_enable_sensitive_logging_title">记录敏感信息</string>

--- a/app/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/src/main/res/values-zh-rCN/strings.xml
@@ -56,7 +56,7 @@ https://github.com/k9mail/k-9/20
   <string name="read_messages_desc">允许该程序读取邮件。</string>
   <string name="delete_messages_label">删除邮件</string>
   <string name="delete_messages_desc">允许该程序删除邮件。</string>
-  <string name="about_title_fmt">关于 <xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">关于 K-9 Mail</string>
   <string name="accounts_title">账户</string>
   <string name="folders_title">文件夹</string>
   <string name="advanced">高级</string>

--- a/app/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/src/main/res/values-zh-rCN/strings.xml
@@ -193,7 +193,7 @@ https://github.com/k9mail/k-9/20
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g>（归档）</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g>（垃圾邮件）</string>
   <string name="send_failure_subject">一些邮件没有成功发送</string>
-  <string name="debug_version_fmt">版本：<xliff:g id="version">%s</xliff:g></string>
+  <string name="version">版本：<xliff:g id="version">%s</xliff:g></string>
   <string name="debug_enable_debug_logging_title">启用调试日志</string>
   <string name="debug_enable_debug_logging_summary">记录额外的调试信息</string>
   <string name="debug_enable_sensitive_logging_title">记录敏感信息</string>

--- a/app/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/src/main/res/values-zh-rCN/strings.xml
@@ -11,7 +11,7 @@
   <!--Used in the about dialog-->
   <string name="app_authors">Google, The K-9 Dog Walkers.</string>
   <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
-  <string name="app_license">根据 Apache License 2.0 协议授权。</string>
+  <string name="app_license">Apache License 2.0</string>
   <!--Welcome message-->
   <string name="welcome_message_title">欢迎使用 K-9 Mail</string>
   <string name="accounts_welcome">

--- a/app/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/src/main/res/values-zh-rCN/strings.xml
@@ -50,7 +50,7 @@ https://github.com/k9mail/k-9/20
   <string name="open_market">打开 Play Store</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">作者: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">更新日志: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">更新日志</string>
   <string name="app_libraries">我们是用了以下的第三方库： <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">显示邮件</string>
   <string name="read_messages_desc">允许该程序读取邮件。</string>

--- a/app/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/src/main/res/values-zh-rTW/strings.xml
@@ -24,7 +24,7 @@
   <string name="open_market">開啟GOOGLE PLAY商店</string>
   <!--=== General strings ==================================================================-->
   <string name="app_authors_fmt">作者: <xliff:g id="app_authors">%s</xliff:g></string>
-  <string name="app_revision_fmt">更新日誌: <xliff:g id="app_revision_url">%s</xliff:g></string>
+  <string name="app_revision">更新日誌</string>
   <string name="app_libraries">我們目前使用第三方的函式庫: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">顯示郵件</string>
   <string name="read_messages_desc">允許該程式讀取郵件。</string>

--- a/app/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/src/main/res/values-zh-rTW/strings.xml
@@ -148,7 +148,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g>（歸檔）</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g>（垃圾郵件）</string>
   <string name="send_failure_subject">部分郵件沒有成功寄送</string>
-  <string name="debug_version_fmt">版本：<xliff:g id="version">%s</xliff:g></string>
+  <string name="version">版本：<xliff:g id="version">%s</xliff:g></string>
   <string name="debug_enable_debug_logging_title">啟用除錯日誌</string>
   <string name="debug_enable_debug_logging_summary">記錄額外的除錯訊息</string>
   <string name="debug_enable_sensitive_logging_title">記錄敏感訊息</string>

--- a/app/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/src/main/res/values-zh-rTW/strings.xml
@@ -30,7 +30,7 @@
   <string name="read_messages_desc">允許該程式讀取郵件。</string>
   <string name="delete_messages_label">刪除郵件</string>
   <string name="delete_messages_desc">允許該程式刪除郵件。</string>
-  <string name="about_title_fmt">關於<xliff:g id="app_name">%s</xliff:g></string>
+  <string name="about_title">關於K-9 Mail</string>
   <string name="accounts_title">帳戶</string>
   <string name="folders_title">信件匣</string>
   <string name="advanced">進階</string>

--- a/app/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/src/main/res/values-zh-rTW/strings.xml
@@ -148,7 +148,7 @@
   <string name="special_mailbox_name_archive_fmt"><xliff:g id="folder">%s</xliff:g>（歸檔）</string>
   <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g>（垃圾郵件）</string>
   <string name="send_failure_subject">部分郵件沒有成功寄送</string>
-  <string name="version">版本：<xliff:g id="version">%s</xliff:g></string>
+  <string name="version">版本：</string>
   <string name="debug_enable_debug_logging_title">啟用除錯日誌</string>
   <string name="debug_enable_debug_logging_summary">記錄額外的除錯訊息</string>
   <string name="debug_enable_sensitive_logging_title">記錄敏感訊息</string>

--- a/app/ui/src/main/res/values/attrs.xml
+++ b/app/ui/src/main/res/values/attrs.xml
@@ -84,6 +84,9 @@
         <attr name="tintColorBulletPointNeutral" format="reference|color"/>
         <attr name="tintColorBulletPointNegative" format="reference|color"/>
 
+        <attr name="iconAboutAuthors" format="reference"/>
+        <attr name="iconAboutLicense" format="reference"/>
+
         <attr name="openpgp_black" format="reference|color" />
         <attr name="openpgp_orange" format="reference|color" />
         <attr name="openpgp_red" format="reference|color" />

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -18,6 +18,7 @@
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
     <string name="app_license">Licensed under the Apache License, Version 2.0.</string>
+    <string name="app_license_url">https://www.apache.org/licenses/LICENSE-2.0</string>
 
 
     <!-- Welcome message -->

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -80,7 +80,7 @@ Please submit bug reports, contribute new features and ask questions at
     <!-- === General strings ================================================================== -->
 
     <string name="app_authors_fmt">Authors: <xliff:g id="app_authors">%s</xliff:g></string>
-    <string name="app_revision_fmt">Revision Information: <xliff:g id="app_revision_url">%s</xliff:g></string>
+    <string name="app_revision">Revision Information</string>
     <string name="app_libraries">We\'re using the following third-party libraries: <xliff:g id="app_libraries_list">%s</xliff:g></string>
 
     <string name="read_messages_label">Read Emails</string>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -260,7 +260,7 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="send_failure_subject">Failed to send some messages</string>
 
-    <string name="debug_version_fmt">Version: <xliff:g id="version">%s</xliff:g></string>
+    <string name="version">Version</string>
     <string name="debug_enable_debug_logging_title">Enable debug logging</string>
     <string name="debug_enable_debug_logging_summary">Log extra diagnostic information</string>
     <string name="debug_enable_sensitive_logging_title">Log sensitive information</string>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -19,7 +19,7 @@
     <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
     <string name="source_code">Source</string>
     <string name="app_source_url">https://github.com/k9mail/k-9</string>
-    <string name="app_license">Licensed under the Apache License, Version 2.0.</string>
+    <string name="app_license">Apache License, Version 2.0</string>
     <string name="app_license_url">https://www.apache.org/licenses/LICENSE-2.0</string>
 
 

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -22,6 +22,7 @@
     <string name="app_source_url">https://github.com/k9mail/k-9</string>
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="app_license_url">https://www.apache.org/licenses/LICENSE-2.0</string>
+    <string name="about_libraries">Libraries</string>
 
 
     <!-- Welcome message -->

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -17,6 +17,8 @@
     <!-- Used in the about dialog -->
     <string name="app_authors">The K-9 Dog Walkers</string>
     <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
+    <string name="source_code">Source</string>
+    <string name="app_source_url">https://github.com/k9mail/k-9</string>
     <string name="app_license">Licensed under the Apache License, Version 2.0.</string>
     <string name="app_license_url">https://www.apache.org/licenses/LICENSE-2.0</string>
 
@@ -1161,7 +1163,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="fetching_attachment_dialog_message">Fetching attachment…</string>
 
     <string name="auth_external_error">Unable to authenticate.  The server does not advertise the SASL EXTERNAL capability.  This could be due to a problem with the client certificate (expired, unknown certificate authority) or some other configuration problem.</string>
-    
+
     <!-- === Client certificates specific ================================================================== -->
     <string name="account_setup_basics_client_certificate">Use client certificate</string>
     <string name="client_certificate_spinner_empty">No client certificate</string>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -16,6 +16,7 @@
 
     <!-- Used in the about dialog -->
     <string name="app_authors">The K-9 Dog Walkers</string>
+    <string name="app_authors_url">https://github.com/k9mail/k-9/graphs/contributors</string>
     <string name="app_copyright_fmt">Copyright 2008-<xliff:g>%s</xliff:g> The K-9 Dog Walkers. Portions Copyright 2006-<xliff:g>%s</xliff:g> the Android Open Source Project.</string>
     <string name="source_code">Source</string>
     <string name="app_source_url">https://github.com/k9mail/k-9</string>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -86,7 +86,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="delete_messages_label">Delete Emails</string>
     <string name="delete_messages_desc">Allows this application to delete your Emails.</string>
 
-    <string name="about_title_fmt">About <xliff:g id="app_name">%s</xliff:g></string>
+    <string name="about_title">About K-9 Mail</string>
     <string name="accounts_title">Accounts</string>
     <string name="folders_title">Folders</string>
     <string name="advanced">Advanced</string>

--- a/app/ui/src/main/res/values/themes.xml
+++ b/app/ui/src/main/res/values/themes.xml
@@ -103,6 +103,9 @@
         <item name="tintColorBulletPointNegative">#dd2222</item>
         <item name="tintColorBulletPointNeutral">#888</item>
 
+        <item name="iconAboutAuthors">@drawable/ic_code_light</item>
+        <item name="iconAboutLicense">@drawable/ic_description_light</item>
+
         <item name="openpgp_black">#000</item>
         <item name="openpgp_orange">#FF8800</item>
         <item name="openpgp_red">#CC0000</item>
@@ -205,6 +208,9 @@
         <item name="tintColorBulletPointPositive">#77aa22</item>
         <item name="tintColorBulletPointNegative">#dd2222</item>
         <item name="tintColorBulletPointNeutral">#bbb</item>
+
+        <item name="iconAboutAuthors">@drawable/ic_code_dark</item>
+        <item name="iconAboutLicense">@drawable/ic_description_dark</item>
 
         <item name="openpgp_black">#fff</item>
         <item name="openpgp_orange">#ee7700</item>


### PR DESCRIPTION
Replaces the WebView with a normal layout  
I've done my best to adjust existing strings for:
  - debug_version_fmt (-> version)
  - app_license
  - about_title_fmt (-> about_title)

Roughly follows the design from [#1859](https://github.com/k9mail/k-9/issues/1859#issuecomment-270029045)

![aboutredesign](https://user-images.githubusercontent.com/26379999/50056058-d7bbd980-014e-11e9-8945-53bae1f3de91.png)

I thought there was an issue specifically for this, but it seems it was just my imagination

### Added stuff
- icons (Google's `code` and `description`)
- link to source code
- link to contributors list
- libraries list their licenses

### TODO
- localize about_libraries
- make an `openURL` method for links?
- final XML cleanup