### PR TITLE
Add link on how to retrieve logs to issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -17,3 +17,5 @@ K-9 Mail version:
 Android version:
 
 Account type (IMAP, POP3, WebDAV/Exchange):
+
+Please take some time to [retrieve logs](https://github.com/k9mail/k-9/wiki/LoggingErrors) and attach them here:


### PR DESCRIPTION
This is a very helpful link which I believe should be included in the issue template. Might need a better wording, though to not get people scared to report.

- [x] Does not break any unit tests.

