### PR TITLE
Reduce importance of sync notifications

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
@@ -101,7 +101,7 @@ class NotificationChannelManager(
         val channelName = resourceProvider.miscellaneousChannelName
         val channelDescription = resourceProvider.miscellaneousChannelDescription
         val channelId = getChannelIdFor(account, ChannelType.MISCELLANEOUS)
-        val importance = NotificationManager.IMPORTANCE_DEFAULT
+        val importance = NotificationManager.IMPORTANCE_LOW
         val channelGroupId = account.uuid
 
         val miscellaneousChannel = NotificationChannel(channelId, channelName, importance)


### PR DESCRIPTION
Before this change synchronization notifications were displayed with default importance. That means checking for e-mail generated sound or vibration that looked like an arriving message.

This change reduces importance to `IMPORTANCE_LOW`. That still shows the notification but does not generate any sounds or vibration by default (this can still be adjusted by the user).

I'm running `master` daily and this default importance of syncs is kind of annoying :)

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). :heavy_check_mark: 
* Does not break any unit tests. :heavy_check_mark: 
* Contains a reference to the issue that it fixes. I didn't bother with the issue as the change is really small.
* For cosmetic changes add one or multiple images, if possible. N/A


