### PR TITLE
allow backups

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -59,7 +59,7 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.K9.Startup"
         android:resizeableActivity="true"
-        android:allowBackup="false">
+        android:allowBackup="true">
 
         <meta-data
             android:name="android.app.default_searchable"


### PR DESCRIPTION
I switch phones frequently for rom development and backups not being enabled is a real pain.

This one tiny change will make my life a lot easier, and presents no added security risk as you must approve on an unlocked device.

