### PR TITLE
Add account selection spinner to account settings

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
@@ -17,14 +17,16 @@ import kotlinx.android.synthetic.main.account_list_item.view.*
 class AccountSelectionSpinner : Spinner {
     var selection: Account
         get() = selectedItem as Account
-        set(value) {
-            selectedAccount = value
+        set(account) {
+            selectedAccount = account
             val adapter = adapter as AccountsAdapter
-            Spinner@setSelection(adapter.getPosition(value), false)
+            val adapterPosition = adapter.getPosition(account)
+            setSelection(adapterPosition, false)
         }
 
     private val cachedBackground: Drawable
-    private var selectedAccount = Account("")
+    private var selectedAccount: Account? = null
+
 
     constructor(context: Context) : super(context)
     constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
@@ -34,33 +36,36 @@ class AccountSelectionSpinner : Spinner {
         cachedBackground = background
     }
 
-    public fun setTitle(title: CharSequence) {
+    fun setTitle(title: CharSequence) {
         val adapter = adapter as AccountsAdapter
         adapter.title = title
         adapter.notifyDataSetChanged()
     }
 
-    public fun setAccounts(accounts: List<Account>) {
+    fun setAccounts(accounts: List<Account>) {
         val adapter = adapter as AccountsAdapter
         adapter.clear()
         adapter.addAll(accounts)
-        selection = selectedAccount
 
-        setEnabled(accounts.size > 1)
-        background = if (accounts.size > 1) cachedBackground else null
+        selectedAccount?.let { selection = it }
+
+        val showAccountSwitcher = accounts.size > 1
+        isEnabled = showAccountSwitcher
+        background = if (showAccountSwitcher) cachedBackground else null
     }
 
-    internal class AccountsAdapter(context: Context) : ArrayAdapter<Account>(context, 0)  {
+
+    internal class AccountsAdapter(context: Context) : ArrayAdapter<Account>(context, 0) {
         var title: CharSequence = ""
+
 
         override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
             val account = getItem(position)
 
-            val view = convertView
-                ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_item, parent, false)
+            val view = convertView ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_item, parent, false)
 
             return view.apply {
-                name.text = AccountsAdapter@title
+                name.text = title
                 email.text = account.email
             }
         }
@@ -69,7 +74,7 @@ class AccountSelectionSpinner : Spinner {
             val account = getItem(position)
 
             val view = convertView
-                ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_dropdown_item, parent, false)
+                    ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_dropdown_item, parent, false)
 
             return view.apply {
                 name.text = account.description

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
@@ -1,0 +1,80 @@
+package com.fsck.k9.ui.settings.account
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.ArrayAdapter
+import android.widget.Spinner
+
+import com.fsck.k9.Account
+import com.fsck.k9.ui.R
+
+import kotlinx.android.synthetic.main.account_list_item.view.*
+
+class AccountSelectionSpinner : Spinner {
+    var selection: Account
+        get() = selectedItem as Account
+        set(value) {
+            selectedAccount = value
+            val adapter = adapter as AccountsAdapter
+            Spinner@setSelection(adapter.getPosition(value), false)
+        }
+
+    private val cachedBackground: Drawable
+    private var selectedAccount = Account("")
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    init {
+        adapter = AccountsAdapter(context)
+        cachedBackground = background
+    }
+
+    public fun setTitle(title: CharSequence) {
+        val adapter = adapter as AccountsAdapter
+        adapter.title = title
+        adapter.notifyDataSetChanged()
+    }
+
+    public fun setAccounts(accounts: List<Account>) {
+        val adapter = adapter as AccountsAdapter
+        adapter.clear()
+        adapter.addAll(accounts)
+        selection = selectedAccount
+
+        setEnabled(accounts.size > 1)
+        background = if (accounts.size > 1) cachedBackground else null
+    }
+
+    internal class AccountsAdapter(context: Context) : ArrayAdapter<Account>(context, 0)  {
+        var title: CharSequence = ""
+
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+            val account = getItem(position)
+
+            val view = convertView
+                ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_item, parent, false)
+
+            return view.apply {
+                name.text = AccountsAdapter@title
+                email.text = account.email
+            }
+        }
+
+        override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View {
+            val account = getItem(position)
+
+            val view = convertView
+                ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_dropdown_item, parent, false)
+
+            return view.apply {
+                name.text = account.description
+                email.text = account.email
+            }
+        }
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
@@ -2,26 +2,40 @@ package com.fsck.k9.ui.settings.account
 
 import android.content.Context
 import android.content.Intent
+import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.support.v7.preference.PreferenceFragmentCompat
 import android.support.v7.preference.PreferenceFragmentCompat.OnPreferenceStartScreenCallback
 import android.support.v7.preference.PreferenceScreen
+import android.util.AttributeSet
+import android.view.LayoutInflater
 import android.view.MenuItem
+import android.view.MotionEvent
+import android.view.View
+import android.view.ViewGroup
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.Spinner
+import com.fsck.k9.Account
+import com.fsck.k9.Preferences
 import com.fsck.k9.activity.K9Activity
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.fragmentTransaction
 import com.fsck.k9.ui.fragmentTransactionWithBackStack
 import com.fsck.k9.ui.observe
+import com.fsck.k9.ui.observeNotNull
+import com.fsck.k9.ui.settings.SettingsViewModel
+import kotlinx.android.synthetic.main.account_list_item.view.*
+import kotlinx.android.synthetic.main.activity_account_settings.*
+import kotlinx.android.synthetic.main.toolbar.*
 import org.koin.android.architecture.ext.viewModel
 import timber.log.Timber
 
-
-class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback {
-    private val viewModel: AccountSettingsViewModel by viewModel()
+class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback, AdapterView.OnItemSelectedListener {
+    private val accountViewModel: AccountSettingsViewModel by viewModel()
     private lateinit var accountUuid: String
     private var startScreenKey: String? = null
     private var fragmentAdded = false
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -38,9 +52,31 @@ class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback {
         loadAccount()
     }
 
+    override fun onItemSelected(parent: AdapterView<*>, view: View, position: Int, id: Long) {
+        val uuid = accountSpinner.selection.uuid
+
+        if (uuid == accountUuid)
+            return;
+
+        start(this, uuid)
+        finish()
+    }
+
+    override fun onNothingSelected(parent: AdapterView<*>) {}
+
     private fun initializeActionBar() {
         val actionBar = supportActionBar ?: throw RuntimeException("getSupportActionBar() == null")
         actionBar.setDisplayHomeAsUpEnabled(true)
+        actionBar.setDisplayShowTitleEnabled(false)
+
+        accountSpinner.title = title
+
+        accountSpinner.onItemSelectedListener = this
+        val prefs = Preferences.getPreferences(this)
+        val viewModel: SettingsViewModel by viewModel()
+        viewModel.accounts.observeNotNull(this) {
+            accountSpinner.loadAccounts(prefs.accounts)
+        }
     }
 
     private fun decodeArguments(): Boolean {
@@ -50,14 +86,14 @@ class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback {
     }
 
     private fun loadAccount() {
-        viewModel.getAccount(accountUuid).observe(this) { account ->
+        accountViewModel.getAccount(accountUuid).observe(this) { account ->
             if (account == null) {
                 Timber.w("Account with UUID %s not found", accountUuid)
                 finish()
                 return@observe
             }
 
-            supportActionBar!!.subtitle = account.email
+            accountSpinner.selection = account
             addAccountSettingsFragment()
         }
     }
@@ -88,9 +124,16 @@ class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback {
             replace(R.id.accountSettingsContainer, AccountSettingsFragment.create(accountUuid, preferenceScreen.key))
         }
 
+        accountSpinner.title = preferenceScreen.title
+
         return true
     }
 
+    override fun onBackPressed() {
+        super.onBackPressed()
+
+        accountSpinner.title = title
+    }
 
     companion object {
         private const val ARG_ACCOUNT_UUID = "accountUuid"
@@ -111,6 +154,72 @@ class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback {
                 putExtra(ARG_START_SCREEN_KEY, AccountSettingsFragment.PREFERENCE_OPENPGP)
             }
             context.startActivity(intent)
+        }
+    }
+}
+
+class AccountSelectionSpinner : Spinner {
+    var selection: Account
+        get() = selectedItem as Account
+        set(value) {
+            val adapter = adapter as AccountsAdapter
+            Spinner@setSelection(adapter.getPosition(value))
+        }
+
+    var title: CharSequence = ""
+        set(value) {
+            val adapter = adapter as AccountsAdapter
+            adapter.title = value
+            adapter.notifyDataSetChanged()
+        }
+
+    private lateinit var cachedBackground: Drawable
+
+    constructor(context: Context) : super(context)
+    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
+
+    init {
+        adapter = AccountsAdapter(context)
+        cachedBackground = background
+    }
+
+    public fun loadAccounts(accounts: List<Account>) {
+        val adapter = adapter as AccountsAdapter
+        adapter.clear()
+        adapter.addAll(accounts)
+
+        setEnabled(accounts.size > 1)
+        background = if (accounts.size > 1) cachedBackground else null
+    }
+
+    internal class AccountsAdapter(context: Context) : ArrayAdapter<Account>(context, 0)  {
+        var title: CharSequence = ""
+
+        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
+            val account = getItem(position)
+
+            val view = convertView
+                ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_item, parent, false)
+
+            return view.apply {
+                setPadding(0, paddingTop, paddingRight, paddingBottom)
+                name.text = AccountsAdapter@title
+                email.text = account.email
+            }
+        }
+
+        override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View
+        {
+            val account = getItem(position)
+
+            val view = convertView
+                ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_item, parent, false)
+
+            return view.apply {
+                setPadding(paddingLeft, paddingLeft / 2, paddingLeft, paddingLeft / 2)
+                name.text = account.description
+                email.text = account.email
+            }
         }
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
@@ -9,15 +9,12 @@ import android.support.v7.preference.PreferenceScreen
 import android.view.MenuItem
 import android.view.View
 import android.widget.AdapterView
-import com.fsck.k9.Account
-import com.fsck.k9.Preferences
 import com.fsck.k9.activity.K9Activity
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.fragmentTransaction
 import com.fsck.k9.ui.fragmentTransactionWithBackStack
 import com.fsck.k9.ui.observe
 import com.fsck.k9.ui.observeNotNull
-import com.fsck.k9.ui.settings.SettingsViewModel
 import kotlinx.android.synthetic.main.activity_account_settings.*
 import org.koin.android.architecture.ext.viewModel
 import timber.log.Timber
@@ -50,19 +47,21 @@ class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback {
 
         accountSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
             override fun onItemSelected(parent: AdapterView<*>, view: View, position: Int, id: Long) {
-                val selectedAccountUuid = accountSpinner.selection.uuid
-
-                if (selectedAccountUuid == accountUuid) return
-
-                start(this@AccountSettingsActivity, selectedAccountUuid)
-                finish()
+                onAccountSelected(selectedAccountUuid = accountSpinner.selection.uuid)
             }
 
-            override fun onNothingSelected(parent: AdapterView<*>) {}
+            override fun onNothingSelected(parent: AdapterView<*>) = Unit
         }
 
         accountViewModel.accounts.observeNotNull(this) { accounts ->
             accountSpinner.setAccounts(accounts)
+        }
+    }
+
+    private fun onAccountSelected(selectedAccountUuid: String) {
+        if (selectedAccountUuid != accountUuid) {
+            start(this, selectedAccountUuid)
+            finish()
         }
     }
 
@@ -114,14 +113,11 @@ class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback {
         return true
     }
 
-    override fun onBackPressed() {
-        super.onBackPressed()
-    }
-
     override fun setTitle(title: CharSequence) {
         super.setTitle(title)
         accountSpinner.setTitle(title)
     }
+
 
     companion object {
         private const val ARG_ACCOUNT_UUID = "accountUuid"

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
@@ -2,20 +2,13 @@ package com.fsck.k9.ui.settings.account
 
 import android.content.Context
 import android.content.Intent
-import android.graphics.drawable.Drawable
 import android.os.Bundle
 import android.support.v7.preference.PreferenceFragmentCompat
 import android.support.v7.preference.PreferenceFragmentCompat.OnPreferenceStartScreenCallback
 import android.support.v7.preference.PreferenceScreen
-import android.util.AttributeSet
-import android.view.LayoutInflater
 import android.view.MenuItem
-import android.view.MotionEvent
 import android.view.View
-import android.view.ViewGroup
 import android.widget.AdapterView
-import android.widget.ArrayAdapter
-import android.widget.Spinner
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import com.fsck.k9.activity.K9Activity
@@ -25,9 +18,7 @@ import com.fsck.k9.ui.fragmentTransactionWithBackStack
 import com.fsck.k9.ui.observe
 import com.fsck.k9.ui.observeNotNull
 import com.fsck.k9.ui.settings.SettingsViewModel
-import kotlinx.android.synthetic.main.account_list_item.view.*
 import kotlinx.android.synthetic.main.activity_account_settings.*
-import kotlinx.android.synthetic.main.toolbar.*
 import org.koin.android.architecture.ext.viewModel
 import timber.log.Timber
 
@@ -154,72 +145,6 @@ class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback, A
                 putExtra(ARG_START_SCREEN_KEY, AccountSettingsFragment.PREFERENCE_OPENPGP)
             }
             context.startActivity(intent)
-        }
-    }
-}
-
-class AccountSelectionSpinner : Spinner {
-    var selection: Account
-        get() = selectedItem as Account
-        set(value) {
-            val adapter = adapter as AccountsAdapter
-            Spinner@setSelection(adapter.getPosition(value))
-        }
-
-    var title: CharSequence = ""
-        set(value) {
-            val adapter = adapter as AccountsAdapter
-            adapter.title = value
-            adapter.notifyDataSetChanged()
-        }
-
-    private lateinit var cachedBackground: Drawable
-
-    constructor(context: Context) : super(context)
-    constructor(context: Context, attrs: AttributeSet) : super(context, attrs)
-
-    init {
-        adapter = AccountsAdapter(context)
-        cachedBackground = background
-    }
-
-    public fun loadAccounts(accounts: List<Account>) {
-        val adapter = adapter as AccountsAdapter
-        adapter.clear()
-        adapter.addAll(accounts)
-
-        setEnabled(accounts.size > 1)
-        background = if (accounts.size > 1) cachedBackground else null
-    }
-
-    internal class AccountsAdapter(context: Context) : ArrayAdapter<Account>(context, 0)  {
-        var title: CharSequence = ""
-
-        override fun getView(position: Int, convertView: View?, parent: ViewGroup): View {
-            val account = getItem(position)
-
-            val view = convertView
-                ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_item, parent, false)
-
-            return view.apply {
-                setPadding(0, paddingTop, paddingRight, paddingBottom)
-                name.text = AccountsAdapter@title
-                email.text = account.email
-            }
-        }
-
-        override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup): View
-        {
-            val account = getItem(position)
-
-            val view = convertView
-                ?: LayoutInflater.from(context).inflate(R.layout.account_spinner_item, parent, false)
-
-            return view.apply {
-                setPadding(paddingLeft, paddingLeft / 2, paddingLeft, paddingLeft / 2)
-                name.text = account.description
-                email.text = account.email
-            }
         }
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -7,6 +7,7 @@ import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import com.fsck.k9.mailstore.FolderRepositoryManager
 import com.fsck.k9.mailstore.RemoteFolderInfo
+import com.fsck.k9.ui.account.AccountsLiveData
 import kotlinx.coroutines.experimental.android.UI
 import kotlinx.coroutines.experimental.launch
 import org.jetbrains.anko.coroutines.experimental.bg
@@ -15,6 +16,7 @@ class AccountSettingsViewModel(
         private val preferences: Preferences,
         private val folderRepositoryManager: FolderRepositoryManager
 ) : ViewModel() {
+    public val accounts = AccountsLiveData(preferences)
     private val accountLiveData = MutableLiveData<Account>()
     private val foldersLiveData = MutableLiveData<RemoteFolderInfo>()
 

--- a/app/ui/src/main/res/layout/account_spinner_dropdown_item.xml
+++ b/app/ui/src/main/res/layout/account_spinner_dropdown_item.xml
@@ -5,6 +5,9 @@
     android:layout_height="match_parent"
     android:gravity="center_vertical"
     android:orientation="vertical"
+    android:paddingTop="8dp"
+    android:paddingBottom="8dp"
+    android:paddingLeft="16dp"
     android:paddingRight="16dp">
 
     <TextView

--- a/app/ui/src/main/res/layout/account_spinner_item.xml
+++ b/app/ui/src/main/res/layout/account_spinner_item.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center_vertical"
+    android:orientation="vertical"
+    android:paddingLeft="16dp"
+    android:paddingRight="16dp">
+
+    <TextView
+        android:id="@+id/name"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+        android:autoSizeTextType="uniform"
+        tools:text="Personal" />
+
+    <TextView
+        android:id="@+id/email"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:ellipsize="end"
+        android:singleLine="true"
+        android:textAppearance="?android:attr/textAppearanceSmall"
+        android:autoSizeTextType="uniform"
+        tools:text="test@example.org" />
+</LinearLayout>

--- a/app/ui/src/main/res/layout/activity_account_settings.xml
+++ b/app/ui/src/main/res/layout/activity_account_settings.xml
@@ -4,7 +4,17 @@
               android:layout_height="fill_parent"
               android:layout_width="fill_parent">
 
-    <include layout="@layout/toolbar" />
+    <android.support.v7.widget.Toolbar
+                android:id="@+id/toolbar"
+                android:layout_width="match_parent"
+                android:layout_height="?attr/actionBarSize"
+                android:background="?attr/colorPrimary"
+                android:elevation="4dp">
+        <com.fsck.k9.ui.settings.account.AccountSelectionSpinner
+                    android:id="@+id/accountSpinner"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content" />
+    </android.support.v7.widget.Toolbar>
 
     <FrameLayout
             android:id="@+id/accountSettingsContainer"

--- a/app/ui/src/main/res/layout/activity_account_settings.xml
+++ b/app/ui/src/main/res/layout/activity_account_settings.xml
@@ -1,25 +1,27 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:orientation="vertical"
-              android:layout_height="fill_parent"
-              android:layout_width="fill_parent">
+    android:layout_width="fill_parent"
+    android:layout_height="fill_parent"
+    android:orientation="vertical">
 
     <android.support.v7.widget.Toolbar
-                android:id="@+id/toolbar"
-                android:layout_width="match_parent"
-                android:layout_height="?attr/actionBarSize"
-                android:background="?attr/colorPrimary"
-                android:elevation="4dp">
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="?attr/colorPrimary"
+        android:elevation="4dp">
+
         <com.fsck.k9.ui.settings.account.AccountSelectionSpinner
-                    android:id="@+id/accountSpinner"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content" />
+            android:id="@+id/accountSpinner"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
     </android.support.v7.widget.Toolbar>
 
     <FrameLayout
-            android:id="@+id/accountSettingsContainer"
-            android:layout_width="match_parent"
-            android:layout_height="0dip"
-            android:layout_weight="1"/>
+        android:id="@+id/accountSettingsContainer"
+        android:layout_width="match_parent"
+        android:layout_height="0dip"
+        android:layout_weight="1" />
 
 </LinearLayout>

--- a/app/ui/src/main/res/layout/activity_account_settings.xml
+++ b/app/ui/src/main/res/layout/activity_account_settings.xml
@@ -12,7 +12,7 @@
                 android:elevation="4dp">
         <com.fsck.k9.ui.settings.account.AccountSelectionSpinner
                     android:id="@+id/accountSpinner"
-                    android:layout_width="fill_parent"
+                    android:layout_width="wrap_content"
                     android:layout_height="wrap_content" />
     </android.support.v7.widget.Toolbar>
 


### PR DESCRIPTION
This brings together the first pages of general settings and account settings into a tabbed layout:

![generalsettingsredesign](https://user-images.githubusercontent.com/26379999/50486672-efb71700-09f2-11e9-9ef2-8a78d8373cdc.png)
![accountsettingsredesign](https://user-images.githubusercontent.com/26379999/50486671-ef1e8080-09f2-11e9-923c-ff8e90b209f7.png)

Fixes #3747 
Roughly follows design from https://github.com/k9mail/k-9/issues/1859#issuecomment-268657013 and https://github.com/k9mail/k-9/issues/1859#issuecomment-270029045

### TODO
- add search action to activity
- fix import and export
  - only currently works when 'Start in Unified Inbox' is enabled
- account deletion (using method introduced by https://github.com/k9mail/k-9/pull/3840)
- summaries for account settings categories
- use account color as the background for the spinner
- add vertical padding to spinner drop-down