### PR TITLE
Fix About text size, padding, and localization 

### DIFF
--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -131,7 +131,7 @@
                         android:paddingLeft="30dp"
                         android:orientation="vertical">
                     <TextView
-                            android:text="License"
+                            android:text="@string/license"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:textColor="?android:attr/textColorPrimary" />

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -31,23 +31,24 @@
                     android:gravity="center_vertical"
                     android:text="@string/about_title"
                     android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="34sp"/>
+                    android:textAppearance="?android:attr/textAppearanceLarge" />
 
             <LinearLayout
                     android:id="@+id/versionLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingTop="16dp"
-                    android:paddingBottom="16dp"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp"
                     android:paddingLeft="16dp"
+                    android:paddingRight="16dp"
                     android:gravity="center_vertical"
                     android:clickable="true"
                     android:focusable="true"
                     android:background="?attr/selectableItemBackground">
                 <ImageView
                         android:src="?attr/iconSettingsAbout"
-                        android:layout_width="28dp"
-                        android:layout_height="28dp"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
                         android:layout_gravity="center" />
 
                 <LinearLayout
@@ -60,15 +61,12 @@
                             android:text="@string/version"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:textColor="?android:attr/textColorPrimary"
-                            android:textAppearance="?android:attr/textAppearanceMedium" />
-
+                            android:textColor="?android:attr/textColorPrimary" />
                     <TextView
                             android:id="@+id/version"
                             android:text="Version"
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                            android:layout_height="wrap_content" />
                 </LinearLayout>
             </LinearLayout>
 
@@ -76,17 +74,18 @@
                     android:id="@+id/authorsLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingTop="16dp"
-                    android:paddingBottom="16dp"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp"
                     android:paddingLeft="16dp"
+                    android:paddingRight="16dp"
                     android:gravity="center_vertical"
                     android:clickable="true"
                     android:focusable="true"
                     android:background="?attr/selectableItemBackground">
                 <ImageView
                         android:src="?attr/iconAboutAuthors"
-                        android:layout_width="28dp"
-                        android:layout_height="28dp"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
                         android:layout_gravity="center" />
 
                 <LinearLayout
@@ -99,14 +98,12 @@
                             android:text="Authors"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:textColor="?android:attr/textColorPrimary"
-                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                            android:textColor="?android:attr/textColorPrimary" />
 
                     <TextView
                             android:text="@string/app_authors"
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                            android:layout_height="wrap_content" />
                 </LinearLayout>
             </LinearLayout>
 
@@ -114,17 +111,18 @@
                     android:id="@+id/licenseLayout"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingTop="16dp"
-                    android:paddingBottom="16dp"
+                    android:paddingTop="8dp"
+                    android:paddingBottom="8dp"
                     android:paddingLeft="16dp"
+                    android:paddingRight="16dp"
                     android:gravity="center_vertical"
                     android:clickable="true"
                     android:focusable="true"
                     android:background="?attr/selectableItemBackground">
                 <ImageView
                         android:src="?attr/iconAboutLicense"
-                        android:layout_width="28dp"
-                        android:layout_height="28dp"
+                        android:layout_width="24dp"
+                        android:layout_height="24dp"
                         android:layout_gravity="center" />
 
                 <LinearLayout
@@ -136,27 +134,27 @@
                             android:text="License"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
-                            android:textColor="?android:attr/textColorPrimary"
-                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                            android:textColor="?android:attr/textColorPrimary" />
 
                     <TextView
                             android:text="@string/app_license"
                             android:layout_width="match_parent"
-                            android:layout_height="wrap_content"
-                            android:textAppearance="?android:attr/textAppearanceMedium" />
+                            android:layout_height="wrap_content" />
                 </LinearLayout>
             </LinearLayout>
 
             <LinearLayout
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:paddingTop="16dp"
+                    android:layout_marginTop="16dp"
                     android:layout_gravity="center">
                 <Button
                         android:id="@+id/source"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginRight="10dp"
+                        android:layout_marginLeft="8dp"
+                        android:layout_gravity="center_vertical"
+                        android:padding="8dp"
                         android:background="?android:attr/selectableItemBackground"
                         android:text="@string/source_code"
                         android:textAllCaps="true" />
@@ -165,7 +163,9 @@
                         android:id="@+id/changelog"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
-                        android:layout_marginRight="10dp"
+                        android:layout_marginLeft="8dp"
+                        android:layout_gravity="center_vertical"
+                        android:padding="8dp"
                         android:background="?android:attr/selectableItemBackground"
                         android:text="@string/changelog_full_title"
                         android:textAllCaps="true" />
@@ -174,6 +174,10 @@
                         android:id="@+id/revisions"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:layout_marginLeft="8dp"
+                        android:layout_marginRight="8dp"
+                        android:layout_gravity="center_vertical"
+                        android:padding="8dp"
                         android:background="?android:attr/selectableItemBackground"
                         android:text="@string/app_revision"
                         android:textAllCaps="true" />
@@ -183,10 +187,7 @@
                     android:id="@+id/copyright"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:paddingTop="16dp"
-                    android:paddingBottom="16dp"
-                    android:paddingLeft="16dp"
-                    android:paddingRight="16dp"
+                    android:padding="16dp"
                     android:gravity="center_vertical"
                     android:textAppearance="?android:attr/textAppearanceSmall" />
 
@@ -204,7 +205,7 @@
                     android:gravity="center_vertical"
                     android:text="@string/about_libraries"
                     android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="34sp"/>
+                    android:textAppearance="?android:attr/textAppearanceLarge" />
 
             <android.support.v7.widget.RecyclerView
                     android:id="@+id/libraries"

--- a/app/ui/src/main/res/layout/about.xml
+++ b/app/ui/src/main/res/layout/about.xml
@@ -95,7 +95,7 @@
                         android:orientation="vertical">
 
                     <TextView
-                            android:text="Authors"
+                            android:text="@string/authors"
                             android:layout_width="match_parent"
                             android:layout_height="wrap_content"
                             android:textColor="?android:attr/textColorPrimary" />

--- a/app/ui/src/main/res/layout/about_library.xml
+++ b/app/ui/src/main/res/layout/about_library.xml
@@ -16,8 +16,7 @@
                 android:layout_height="wrap_content"
                 android:gravity="center_vertical"
                 android:text="Test"
-                android:textColor="?android:attr/textColorPrimary"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
+                android:textColor="?android:attr/textColorPrimary" />
 
         <TextView
                 android:id="@+id/license"
@@ -28,6 +27,5 @@
                 android:ellipsize="end"
                 android:maxLines="1"
                 android:text="Test"
-                android:textColor="?android:attr/textColorSecondary"
-                android:textAppearance="?android:attr/textAppearanceMedium" />
+                android:textColor="?android:attr/textColorSecondary" />
 </LinearLayout>

--- a/app/ui/src/main/res/values-bg/strings.xml
+++ b/app/ui/src/main/res/values-bg/strings.xml
@@ -53,7 +53,7 @@ K-9 Mail е мощен, безплатен имейл клиент за Андр
   <string name="import_dialog_error_message">Моля инсталирайте файлов менажер за да продължите с внасянето.</string>
   <string name="open_market">Отвори Play магазина</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Автори: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Автори</string>
   <string name="app_revision">Информация за версиите</string>
   <string name="app_libraries">Използваме следните библиотеки от трети страни: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Прочитане на имейли</string>

--- a/app/ui/src/main/res/values-br/strings.xml
+++ b/app/ui/src/main/res/values-br/strings.xml
@@ -53,7 +53,7 @@ Danevellit beugoù, kenlabourit war keweriusterioù nevez ha savit goulennoù wa
   <string name="import_dialog_error_message">Staliit un ardoer restroù evit kenderc’hel gant an enporzhiañ.</string>
   <string name="open_market">Digeriñ ar Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Aozerien: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Aozerien</string>
   <string name="app_revision">TItouroù an handelv</string>
   <string name="app_libraries">Arverañ a reomp al levraouegoù da-heul: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lenn ar posteloù</string>

--- a/app/ui/src/main/res/values-ca/strings.xml
+++ b/app/ui/src/main/res/values-ca/strings.xml
@@ -53,7 +53,7 @@ Si us plau, envieu informes d\'errors, contribuïu-hi amb noves millores i feu p
   <string name="import_dialog_error_message">Si us plau, instal·leu un gestor de fitxers per continuar aquesta importació.</string>
   <string name="open_market">Obre la Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autors: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autors</string>
   <string name="app_revision">Informació de la revisió</string>
   <string name="app_libraries">Fem servir les següents biblioteques de tercers: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Llegeix els correus</string>

--- a/app/ui/src/main/res/values-cs/strings.xml
+++ b/app/ui/src/main/res/values-cs/strings.xml
@@ -53,7 +53,7 @@ Chybová hlášení prosím posílejte, přispívejte novými funkcemi a ptejte 
   <string name="import_dialog_error_message">Prosím nainstalujte nějaký file manager pro pokračování v importu.</string>
   <string name="open_market">Otevřít obchod Google Play</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autoři: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autoři</string>
   <string name="app_revision">Informace o revizi</string>
   <string name="app_libraries">Používáme tyto knihovny třetích stran: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Číst zprávy</string>

--- a/app/ui/src/main/res/values-cy/strings.xml
+++ b/app/ui/src/main/res/values-cy/strings.xml
@@ -54,7 +54,7 @@ Plîs rhowch wybod am unrhyw wallau, syniadau am nodweddion newydd, neu ofyn cwe
   <string name="import_dialog_error_message">Rhaid gosod rheolwr ffeiliau er mwyn parhau gyda\'r mewnforio.</string>
   <string name="open_market">Agor Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Awduron: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Awduron</string>
   <string name="app_revision">Gwybodaeth Adolygu</string>
   <string name="app_libraries">Rydym yn defnyddio\'r llyfrgelloedd trydydd parti canlynol: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Darllen E-bost</string>

--- a/app/ui/src/main/res/values-da/strings.xml
+++ b/app/ui/src/main/res/values-da/strings.xml
@@ -53,7 +53,7 @@ Rapporter venligst fejl, forslag til nye funktioner eller stil spørgsmål på:
   <string name="import_dialog_error_message">Du skal have en filemanager installeret for at kunne importere.</string>
   <string name="open_market">Åben Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Ophavsmænd: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Ophavsmænd</string>
   <string name="app_revision">Revisions information</string>
   <string name="app_libraries">Vi anvender følgende 3je parts biblioteker: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Læs mails</string>

--- a/app/ui/src/main/res/values-de/strings.xml
+++ b/app/ui/src/main/res/values-de/strings.xml
@@ -54,7 +54,7 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="import_dialog_error_message">Es wurde keine geeignete Anwendung gefunden, um den Import durchzuführen. Bitte installieren Sie einen Dateimanager aus dem Play Store.</string>
   <string name="open_market">Play Store öffnen</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autoren: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autoren</string>
   <string name="app_revision">Versionsinformationen</string>
   <string name="app_libraries">Wir verwenden die folgenden externen Bibliotheken: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">E-Mails lesen</string>

--- a/app/ui/src/main/res/values-el/strings.xml
+++ b/app/ui/src/main/res/values-el/strings.xml
@@ -54,7 +54,7 @@
   <string name="import_dialog_error_message">Δεν υπάρχει κατάλληλη εφαρμογή για να χειριστεί την εισαγωγή. Εγκαταστήστε μια εφαρμογή επόπτη αρχείων από το Android Market</string>
   <string name="open_market">Open Market</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Συγγραφείς: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Συγγραφείς</string>
   <string name="app_revision">Πληροφορίες αναθεωρήσεων</string>
   <string name="app_libraries">Χρησιμοποιούνται οι ακόλουθες βιβλιοθήκες τρίτων: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ανάγνωση μηνυμάτων</string>

--- a/app/ui/src/main/res/values-eo/strings.xml
+++ b/app/ui/src/main/res/values-eo/strings.xml
@@ -52,7 +52,7 @@ Bonvolu raporti erarojn, kontribui novajn eblojn kaj peti pri novaj funkcioj per
   <string name="import_dialog_error_message">Bonvolu instali dosier-esprolilon por pluigi enporti.</string>
   <string name="open_market">Malfermi vendejon Play</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Aŭtoroj: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Aŭtoroj</string>
   <string name="app_revision">Informoj pri eldono</string>
   <string name="app_libraries">La jenaj bibliotekoj de eksteraj liverantoj estas uzataj: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Legi retleterojn</string>

--- a/app/ui/src/main/res/values-es/strings.xml
+++ b/app/ui/src/main/res/values-es/strings.xml
@@ -53,7 +53,7 @@ Por favor informe de fallos, aporte nueva funcionalidad o envíe sus preguntas a
   <string name="import_dialog_error_message">Por favor, instale un gestor de archivos para continuar con la importación.</string>
   <string name="open_market">Abrir Google Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autores</string>
   <string name="app_revision">Información de la revisión</string>
   <string name="app_libraries">Estamos usando las siguientes librerías de terceros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Leer correos</string>

--- a/app/ui/src/main/res/values-et/strings.xml
+++ b/app/ui/src/main/res/values-et/strings.xml
@@ -24,7 +24,7 @@
   <string name="import_dialog_error_message">Selle impordi jätkamiseks installi failihaldur.</string>
   <string name="open_market">Ava Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autorid: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autorid</string>
   <string name="app_revision">Parandusteave</string>
   <string name="app_libraries">me kasutame järgnevaid kolmanda osapoole teeke: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Loe meilisõnumeid</string>

--- a/app/ui/src/main/res/values-eu/strings.xml
+++ b/app/ui/src/main/res/values-eu/strings.xml
@@ -53,7 +53,7 @@ Mesedez akatsen berri emateko, ezaugarri berriak gehitzeko eta galderak egiteko
   <string name="import_dialog_error_message">Inportazio honekin jarraitzeko instalatu fitxategi kudeatzaile bat, mesedez.</string>
   <string name="open_market">Ireki Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Egileak: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Egileak</string>
   <string name="app_revision">Berrikuspenaren Informazioa</string>
   <string name="app_libraries">Hirugarrenen liburutegi hauek erabiltzen ari gara: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Irakurri posta</string>

--- a/app/ui/src/main/res/values-fi/strings.xml
+++ b/app/ui/src/main/res/values-fi/strings.xml
@@ -53,7 +53,7 @@ Ilmoita virheistä, ota osaa sovelluskehitykseen ja esitä kysymyksiä osoittees
   <string name="import_dialog_error_message">Tuontitoiminnon käsittelemiseen ei ole sopivaa sovellusta. Asenna Google Play Kaupasta jokin tiedostonhallintasovellus.</string>
   <string name="open_market">Avaa Play-kauppa</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Tekijät: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Tekijät</string>
   <string name="app_revision">Versiotiedot</string>
   <string name="app_libraries">Käytämme seuraavia kolmannen osapuolen kirjastoja: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lue sähköpostit</string>

--- a/app/ui/src/main/res/values-fr/strings.xml
+++ b/app/ui/src/main/res/values-fr/strings.xml
@@ -53,7 +53,7 @@ Veuillez rapporter les bogues, recommander de nouvelles fonctions et poser vos q
   <string name="import_dialog_error_message">Veuillez installer un gestionnaire de fichiers pour continuer cette importation.</string>
   <string name="open_market">Ouvrir le Google Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Auteurs\u00A0: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Auteurs</string>
   <string name="app_revision">Informations de révision</string>
   <string name="app_libraries">Nous utilisons les bibliothèques tierces suivantes\u00A0: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lire les courriels</string>

--- a/app/ui/src/main/res/values-gd/strings.xml
+++ b/app/ui/src/main/res/values-gd/strings.xml
@@ -54,7 +54,7 @@ Fàilte air bugaichean, com-pàirteachas, iarrtasan airson gleusan ùra is ceist
   <string name="import_dialog_error_message">Stàlaich manaidsear fhaidhlichean mus lean thu air adhart leis an ion-phortadh seo.</string>
   <string name="open_market">Fosgail Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Na h-ùghdaran: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Na h-ùghdaran</string>
   <string name="app_revision">Fiosrachadh mun lèireamhas</string>
   <string name="app_libraries">Tha sinn a’ cleachdadh na leabhar-lannan a leanas a tha le treas-phàrtaidhean: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Puist-d a leughadh</string>

--- a/app/ui/src/main/res/values-gl-rES/strings.xml
+++ b/app/ui/src/main/res/values-gl-rES/strings.xml
@@ -24,7 +24,7 @@
   <string name="import_dialog_error_message">Por favor, selecciona un xestor de ficheiros para continuar con esta importación.</string>
   <string name="open_market">Abrir Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autores</string>
   <string name="app_revision">Revisión da información</string>
   <string name="app_libraries">Estamos a usar as seguintes librarías de terceiros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ler correos</string>

--- a/app/ui/src/main/res/values-gl/strings.xml
+++ b/app/ui/src/main/res/values-gl/strings.xml
@@ -54,7 +54,7 @@ Por favor envíen informes de fallos, contribúa con novas características e co
   <string name="import_dialog_error_message">Por favor, instala un xestor de ficheiros para continuar coa importación.</string>
   <string name="open_market">Abrir Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autores</string>
   <string name="app_revision">Información da revisión</string>
   <string name="app_libraries">Usamos as seguintes librerías de terceiros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ler correos</string>

--- a/app/ui/src/main/res/values-hr/strings.xml
+++ b/app/ui/src/main/res/values-hr/strings.xml
@@ -24,7 +24,7 @@
   <string name="import_dialog_error_message">Molimo vas instalirajte upravitelj datoteka za nastavak uvoza.</string>
   <string name="open_market">Otvorite Trgovinu Play</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autori</string>
   <string name="app_revision">Informacije Revizije</string>
   <string name="app_libraries">Mi koristimo slijedeće biblioteke treće strane: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Čitanje E-Pošte</string>

--- a/app/ui/src/main/res/values-hu/strings.xml
+++ b/app/ui/src/main/res/values-hu/strings.xml
@@ -54,7 +54,7 @@ Kérünk küldj hibajelentést, hozzájárulva az új verziókhoz, és tegyél f
   <string name="import_dialog_error_message">Az importálás folytatásához, telepítsen egy fájlkezelőt.</string>
   <string name="open_market">Play áruház megnyitása</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Készítők: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Készítők</string>
   <string name="app_revision">Verzió információk</string>
   <string name="app_libraries">A következő könyvtárakat használjuk: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Email-ek olvasása</string>

--- a/app/ui/src/main/res/values-in/strings.xml
+++ b/app/ui/src/main/res/values-in/strings.xml
@@ -54,7 +54,7 @@ https://github.com/k9mail/k-9/<a href="https://github.com/k9mail/k-9/">.
   <string name="import_dialog_error_message">Mohon pasang pengelola berkas untuk melanjutkan mengimpor.</string>
   <string name="open_market">Buka Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Pengembang: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Pengembang</string>
   <string name="app_revision">Informasi Revisi</string>
   <string name="app_libraries">Kami menggunakan pustaka pihak ketiga berikut: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Baca Email</string>

--- a/app/ui/src/main/res/values-is/strings.xml
+++ b/app/ui/src/main/res/values-is/strings.xml
@@ -53,7 +53,7 @@ Sendu inn villuskýrslur, leggðu fram nýja eiginleika og spurðu spurninga á
   <string name="import_dialog_error_message">Settu upp skráastjóra til að halda áfram með innflutning á þessu.</string>
   <string name="open_market">Opna Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Höfundar: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Höfundar</string>
   <string name="app_revision">Upplýsingar útgáfu</string>
   <string name="app_libraries">Við erum að nota eftirfarandi aðgerðasöfn frá öðrum aðilum: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lesa tölvupósta</string>

--- a/app/ui/src/main/res/values-it/strings.xml
+++ b/app/ui/src/main/res/values-it/strings.xml
@@ -54,7 +54,7 @@ Per favore invia segnalazioni di errori, contribuisci con nuove funzionalità e 
   <string name="import_dialog_error_message">Installa un gestore file per procedere con questa importazione.</string>
   <string name="open_market">Apri il Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autori</string>
   <string name="app_revision">Informazioni di versione</string>
   <string name="app_libraries">Ci avvaliamo delle seguenti librerie di terze parti: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Leggi i messaggi</string>

--- a/app/ui/src/main/res/values-iw/strings.xml
+++ b/app/ui/src/main/res/values-iw/strings.xml
@@ -24,7 +24,7 @@
   <string name="import_dialog_error_message">התקן מנהל קבצים כדי לבצע את הייבוא.</string>
   <string name="open_market">פתח את חנות האפליקציות</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">מפתחים: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">מפתחים</string>
   <string name="app_revision">מידע על גירסאות</string>
   <string name="app_libraries">אנחנו משתמשים בספריות הבאות של ספקים חיצוניים: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">קרא אימיילים</string>

--- a/app/ui/src/main/res/values-ja/strings.xml
+++ b/app/ui/src/main/res/values-ja/strings.xml
@@ -54,7 +54,7 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
   <string name="import_dialog_error_message">設定をインポートするにはファイルマネージャをインストールしてください。</string>
   <string name="open_market">マーケット</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Authors: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Authors</string>
   <string name="app_revision">Revision Information</string>
   <string name="app_libraries">以下のライブラリを利用しています: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">メールを読む</string>

--- a/app/ui/src/main/res/values-ko/strings.xml
+++ b/app/ui/src/main/res/values-ko/strings.xml
@@ -24,7 +24,7 @@
   <string name="import_dialog_error_message">가져오기에 적합한 애플리케이션이 없습니다. 구글 플레이 스토어에서 파일 관리자를 설치하십시오.</string>
   <string name="open_market">플레이 스토어 열기</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">작성자들: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">작성자들</string>
   <string name="app_revision">배포 정보</string>
   <string name="app_libraries">K-9 메일은 다음 제3자 라이브러리들을 이용합니다. <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">이메일 읽기</string>

--- a/app/ui/src/main/res/values-lt/strings.xml
+++ b/app/ui/src/main/res/values-lt/strings.xml
@@ -23,7 +23,7 @@
   <string name="import_dialog_error_message">Norėdami tęsti importavimą turite įdiegti failų tvarkyklę.</string>
   <string name="open_market">Atverti „Play Store“</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autoriai: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autoriai</string>
   <string name="app_revision">Laidos informacija</string>
   <string name="app_libraries">Mes naudojame šias trečiųjų šalių bibliotekas: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Skaityti laiškus</string>

--- a/app/ui/src/main/res/values-lv/strings.xml
+++ b/app/ui/src/main/res/values-lv/strings.xml
@@ -53,7 +53,7 @@ Lūdzu, iesniedziet kļūdu ziņojumus, ierosiniet jaunas iespējas un uzdodiet 
   <string name="import_dialog_error_message">Lūdzu, uzinstalējiet failu pārvaldnieku, lai turpinātu importēt datus.</string>
   <string name="open_market">Atvērt Play veikalu</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autori</string>
   <string name="app_revision">Revīzijas informācija</string>
   <string name="app_libraries">Mēs izmantojam sekojošas trešo pušu bibliotēkas: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Izlasīt e-pastus</string>

--- a/app/ui/src/main/res/values-nb/strings.xml
+++ b/app/ui/src/main/res/values-nb/strings.xml
@@ -54,7 +54,7 @@ Send feilmeldinger, bidra med nye funksjoner og still spørsmål her:
   <string name="import_dialog_error_message">Installer en filbehandler for å fortsette importeringen.</string>
   <string name="open_market">Åpne Play-butikken</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Utviklere: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Utviklere</string>
   <string name="app_revision">Revisjonsinformasjon</string>
   <string name="app_libraries">Vi bruker følgende tredjepartsbiblioteker: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Les e-poster</string>

--- a/app/ui/src/main/res/values-nl/strings.xml
+++ b/app/ui/src/main/res/values-nl/strings.xml
@@ -49,7 +49,7 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   <string name="import_dialog_error_message">Installeer een bestandsbeheer-app om verder te gaan met deze import.</string>
   <string name="open_market">Open Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Auteurs: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Auteurs</string>
   <string name="app_revision">Revisie Informatie</string>
   <string name="app_libraries">De volgende externe bibliotheken worden gebruikt: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">E-mails lezen</string>

--- a/app/ui/src/main/res/values-pl/strings.xml
+++ b/app/ui/src/main/res/values-pl/strings.xml
@@ -54,7 +54,7 @@ Wysłane za pomocą K-9 Mail.</string>
   <string name="import_dialog_error_message">Brak aplikacji do obsługi plików importu. Zainastaluj jakąś aplikację z Google Play.</string>
   <string name="open_market">Otwórz Google Play</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autorzy: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autorzy</string>
   <string name="app_revision">Historia zmian</string>
   <string name="app_libraries">K-9 mail zawiera kod źródłowy: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Czytaj pocztę</string>

--- a/app/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/src/main/res/values-pt-rBR/strings.xml
@@ -53,7 +53,7 @@ Por favor encaminhe relatórios de bugs, contribua com novos recursos e tire dú
   <string name="import_dialog_error_message">Por favor, instale um gerenciador de arquivos para continuar com essa importação.</string>
   <string name="open_market">Abrir a Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autores</string>
   <string name="app_revision">Informações da revisão</string>
   <string name="app_libraries">Estamos usando as seguintes bibliotecas de terceiros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ler e-mails</string>

--- a/app/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/src/main/res/values-pt-rPT/strings.xml
@@ -54,7 +54,7 @@ Por favor envie relatórios de falhas, contribua com novas funcionalidades e col
   <string name="import_dialog_error_message">Por favor instale um gestor de ficheiros para continuar com a importação.</string>
   <string name="open_market">Abrir Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autores: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autores</string>
   <string name="app_revision">Informação da revisão</string>
   <string name="app_libraries">Estamos a usar as seguintes bibliotecas de terceiros: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Ler Emails</string>

--- a/app/ui/src/main/res/values-ro/strings.xml
+++ b/app/ui/src/main/res/values-ro/strings.xml
@@ -53,7 +53,7 @@ Vă rugăm să ne raportați defecte, să contribuiți cu funcționalități noi
   <string name="import_dialog_error_message">Vă rugăm să instalați un manager de fișiere pentru a continua cu acest import.</string>
   <string name="open_market">Deschide magazinul Play</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autori</string>
   <string name="app_revision">Informații despre versiune</string>
   <string name="app_libraries">Folosim următoarele biblioteci externe: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Citire emailuri</string>

--- a/app/ui/src/main/res/values-ru/strings.xml
+++ b/app/ui/src/main/res/values-ru/strings.xml
@@ -53,7 +53,7 @@ K-9 Mail — почтовый клиент для Android.
   <string name="import_dialog_error_message">Для импорта необходим менеджер файлов</string>
   <string name="open_market">Google Play</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Авторы: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Авторы</string>
   <string name="app_revision">Изменения</string>
   <string name="app_libraries">Сторонние компоненты: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Чтение почты</string>

--- a/app/ui/src/main/res/values-sk/strings.xml
+++ b/app/ui/src/main/res/values-sk/strings.xml
@@ -54,7 +54,7 @@ Prosím, nahlasujte prípadné chyby, prispievajte novými funkciami a pýtajte 
   <string name="import_dialog_error_message">Nainštalujte, prosím, správcu súborov pre pokračovanie v tomto importovaní.</string>
   <string name="open_market">Otvoriť Obchod Play</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autori: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autori</string>
   <string name="app_revision">Informácie o revízii</string>
   <string name="app_libraries">Používame tieto knižnice tretích strán: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Čítať správy</string>

--- a/app/ui/src/main/res/values-sl/strings.xml
+++ b/app/ui/src/main/res/values-sl/strings.xml
@@ -53,7 +53,7 @@ Poročila o napakah, predloge za nove funkcije in vprašanja lahko pošljete na
   <string name="import_dialog_error_message">Za nadaljevanje uvažanja je treba namestiti upravljalnik datotek.</string>
   <string name="open_market">Odpri Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Avtorstvo: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Avtorstvo</string>
   <string name="app_revision">Podrobnosti različice</string>
   <string name="app_libraries">Vključene so naslednje zunanje knjižnice: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Preberi pošto</string>

--- a/app/ui/src/main/res/values-sq/strings.xml
+++ b/app/ui/src/main/res/values-sq/strings.xml
@@ -54,7 +54,7 @@ Ju lutemi, parashtrim njoftimesh për të meta, kontribute për veçori të reaj
   <string name="import_dialog_error_message">Që të vazhdohet importimi, ju lutemi, instaloni një përgjegjës kartelash.</string>
   <string name="open_market">Hap Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Autorë: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Autorë</string>
   <string name="app_revision">Të dhëna versioni</string>
   <string name="app_libraries">Përdorim libraritë vijuese nga palë të treta: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Lexoni Email-e</string>

--- a/app/ui/src/main/res/values-sr/strings.xml
+++ b/app/ui/src/main/res/values-sr/strings.xml
@@ -53,7 +53,7 @@
   <string name="import_dialog_error_message">Инсталирајте менаџер фајлова да бисте наставили овај увоз.</string>
   <string name="open_market">Отвори Плеј продавницу</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Аутори: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Аутори</string>
   <string name="app_revision">Подаци о ревизији</string>
   <string name="app_libraries">Користимо следеће библиотеке треће стране: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">читање е-порука</string>

--- a/app/ui/src/main/res/values-sv/strings.xml
+++ b/app/ui/src/main/res/values-sv/strings.xml
@@ -53,7 +53,7 @@ Skicka gärna in rapporter om buggar, eller bidra med nya funktioner eller stäl
   <string name="import_dialog_error_message">Installera en filhanterare för att fortsätta med denna import.</string>
   <string name="open_market">Öppna Play butik</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Upphovsmän: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Upphovsmän</string>
   <string name="app_revision">Revisionsinformation</string>
   <string name="app_libraries">Vi använder följande tredjepartsbibliotek: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">Läs e-post</string>

--- a/app/ui/src/main/res/values-tr/strings.xml
+++ b/app/ui/src/main/res/values-tr/strings.xml
@@ -53,7 +53,7 @@ Microsoft Exchange ile konuşurken bazı tuhaflıklar yaşadığını not ediniz
   <string name="import_dialog_error_message">İçeri aktarma işlemini gerçekleştirebilecek uygun bir uygulama bulunamadı. Lütfen Google Play Store\'dan bir dosya yönetici uygulaması edinin.</string>
   <string name="open_market">Play Store\'u Aç</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Yazarlar: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Yazarlar</string>
   <string name="app_revision">Gözden Geçirme Bilgileri</string>
   <string name="app_libraries">K-9 posta kaynak kodları içerir: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">E-postaları oku</string>

--- a/app/ui/src/main/res/values-uk/strings.xml
+++ b/app/ui/src/main/res/values-uk/strings.xml
@@ -54,7 +54,7 @@ K-9 Mail — це вільний клієнт електронної пошти 
   <string name="import_dialog_error_message">Немає відповідної програми для завершення операції імпорту. Будь ласка інсталюйте файловий менеджер з Play Google.</string>
   <string name="open_market">Відкрити Play Google</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">Автори: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">Автори</string>
   <string name="app_revision">Інформація про зміни</string>
   <string name="app_libraries">Ми використовуємо такі бібліотеки сторонніх розробників: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">читати листи</string>

--- a/app/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/src/main/res/values-zh-rCN/strings.xml
@@ -49,7 +49,7 @@ https://github.com/k9mail/k-9/20
   <string name="import_dialog_error_message">要继续导入，请先安装一款文件管理器。</string>
   <string name="open_market">打开 Play Store</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">作者: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">作者</string>
   <string name="app_revision">更新日志</string>
   <string name="app_libraries">我们是用了以下的第三方库： <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">显示邮件</string>

--- a/app/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/src/main/res/values-zh-rTW/strings.xml
@@ -23,7 +23,7 @@
   <string name="import_dialog_error_message">沒有找到合適的應用程式來處理匯入操作。請從GOOGLE PLAY商店下載安裝檔案管理應用程式。</string>
   <string name="open_market">開啟GOOGLE PLAY商店</string>
   <!--=== General strings ==================================================================-->
-  <string name="app_authors_fmt">作者: <xliff:g id="app_authors">%s</xliff:g></string>
+  <string name="authors">作者</string>
   <string name="app_revision">更新日誌</string>
   <string name="app_libraries">我們目前使用第三方的函式庫: <xliff:g id="app_libraries_list">%s</xliff:g></string>
   <string name="read_messages_label">顯示郵件</string>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -72,7 +72,7 @@ Please submit bug reports, contribute new features and ask questions at
 
     <!-- === General strings ================================================================== -->
 
-    <string name="app_authors_fmt">Authors: <xliff:g id="app_authors">%s</xliff:g></string>
+    <string name="authors">Authors</string>
     <string name="app_revision">Revision Information</string>
     <string name="app_libraries">We\'re using the following third-party libraries: <xliff:g id="app_libraries_list">%s</xliff:g></string>
 

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -23,6 +23,7 @@
     <string name="app_license">Apache License, Version 2.0</string>
     <string name="app_license_url">https://www.apache.org/licenses/LICENSE-2.0</string>
     <string name="about_libraries">Libraries</string>
+    <string name="license">License</string>
 
 
     <!-- Welcome message -->


### PR DESCRIPTION
Fixes #3852

Reduces the font sizes used, adds some margins and padding
I noticed the "Authors" string wasn't localized, so I've done that by removing the string interpolation symbols in app_fmt_authors
The a new string has been added for "License"

Screenshot with high 'display size' setting:
![aboutlayoutfixes](https://user-images.githubusercontent.com/26379999/50496293-b7313080-0a26-11e9-8dda-0ceb597678dc.png)