### PR TITLE
Fix build problems with a fresh forked k-9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 android:
  components:
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-27
     - extra-android-m2repository
 

--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion '28.0.3'
+    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         applicationId "com.fsck.k9"
@@ -46,7 +46,7 @@ android {
         versionName '5.700-SNAPSHOT'
 
         minSdkVersion buildConfig.minSdk
-        targetSdkVersion 26
+        targetSdkVersion 23
 
         generatedDensities = ['mdpi', 'hdpi', 'xhdpi']
 
@@ -94,8 +94,7 @@ android {
         exclude 'META-INF/NOTICE.txt'
         exclude 'META-INF/README'
         exclude 'LICENSE.txt'
-        exclude 'META-INF/imap_debug.kotlin_module'
-        exclude 'META-INF/imap_release.kotlin_module'
+        exclude 'META-INF/*.kotlin_module'
     }
 
     compileOptions {

--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.fsck.k9"
@@ -46,7 +46,7 @@ android {
         versionName '5.700-SNAPSHOT'
 
         minSdkVersion buildConfig.minSdk
-        targetSdkVersion 23
+        targetSdkVersion 26
 
         generatedDensities = ['mdpi', 'hdpi', 'xhdpi']
 
@@ -94,6 +94,8 @@ android {
         exclude 'META-INF/NOTICE.txt'
         exclude 'META-INF/README'
         exclude 'LICENSE.txt'
+        exclude 'META-INF/imap_debug.kotlin_module'
+        exclude 'META-INF/imap_release.kotlin_module'
     }
 
     compileOptions {

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@ buildscript {
         buildConfig = [
                 'compileSdk': 27,
                 'minSdk': 19,
-                'buildTools': '27.0.3'
+                'buildTools': '28.0.3'
         ]
 
         versions = [
-                'kotlin': '1.2.41',
+                'kotlin': '1.2.71',
                 'supportLibrary': '27.1.1',
                 'preferencesFix': '27.1.1.1',
                 'lifecycleExtensions': '1.1.0',
@@ -33,7 +33,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:${versions.kotlin}"
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,0 @@
-org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.jvmargs=-Xmx2g -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Feb 17 03:09:27 CET 2018
+#Mon Jan 14 21:39:12 CET 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/plugins/HoloColorPicker/AndroidManifest.xml
+++ b/plugins/HoloColorPicker/AndroidManifest.xml
@@ -4,8 +4,4 @@
     android:versionCode="1"
     android:versionName="1.0" >
 
-    <uses-sdk
-        android:minSdkVersion="8"
-        android:targetSdkVersion="16" />
-
 </manifest>


### PR DESCRIPTION
At the moment, when you checkout K-9 from scratch and install the latest
Android Studio, there are severeral problems with `gradle build`:

- removed uses-sdk from AndroidManifest.xml
- updated buildTools to 28.0.3
- updated kotlin to 1.2.71
- set Gradle jvmargs to prevent from OutOfMemory
- set targetSdk to 26 as AS sees all <26 as an Error because of
  Google Play.
- upgrade to latest Gradle 4.x version

I also excluded 2 Files from packaging as they are created more than
twice. Don't know why this happens and it should be fixed sometime but
as the files are empty I hope this is ok.

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


