### PR TITLE
Add support for server settings autodiscovery

### DIFF
--- a/app/k9mail/proguard-rules.pro
+++ b/app/k9mail/proguard-rules.pro
@@ -26,3 +26,18 @@
 -keepclassmembers class * extends androidx.appcompat.widget.SearchView {
     public <init>(android.content.Context);
 }
+
+# okhttp rules
+# see: https://github.com/square/okhttp/blob/master/okhttp/src/main/resources/META-INF/proguard/okhttp3.pro
+
+# JSR 305 annotations are for embedding nullability information.
+-dontwarn javax.annotation.**
+
+# A resource is loaded with a relative path so the package of this class must be preserved.
+-keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# Animal Sniffer compileOnly dependency to ensure APIs are compatible with older versions of Java.
+-dontwarn org.codehaus.mojo.animal_sniffer.*
+
+# OkHttp platform used only on JVM and when Conscrypt dependency is available.
+-dontwarn okhttp3.internal.platform.ConscryptPlatform

--- a/app/ui/build.gradle
+++ b/app/ui/build.gradle
@@ -44,6 +44,9 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.1.0"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.0"
 
+    // using 3.12 version until we raise minSdkVersion to 21
+    implementation "com.squareup.okhttp3:okhttp:3.12.1"
+
     testImplementation project(':mail:testing')
     testImplementation project(':app:storage')
     testImplementation project(':app:testing')

--- a/app/ui/src/main/java/com/fsck/k9/activity/KoinModule.kt
+++ b/app/ui/src/main/java/com/fsck/k9/activity/KoinModule.kt
@@ -1,7 +1,16 @@
 package com.fsck.k9.activity
 
+import com.fsck.k9.autodiscovery.*
 import org.koin.dsl.module.applicationContext
 
 val activityModule = applicationContext {
     bean { ColorChipProvider() }
+    bean { ProvidersXmlDiscovery(get(), get()) }
+    bean { ThunderbirdAutoconfigParser() }
+    bean { ThunderbirdAutoconfigFetcher() }
+    bean { ThunderbirdDiscovery(get(), get()) }
+    bean { ServerSettingsDiscovery(arrayOf(
+            get<ProvidersXmlDiscovery>(),
+            get<ThunderbirdDiscovery>()
+    )) }
 }

--- a/app/ui/src/main/java/com/fsck/k9/activity/KoinModule.kt
+++ b/app/ui/src/main/java/com/fsck/k9/activity/KoinModule.kt
@@ -1,13 +1,15 @@
 package com.fsck.k9.activity
 
 import com.fsck.k9.autodiscovery.*
+import okhttp3.OkHttpClient
 import org.koin.dsl.module.applicationContext
 
 val activityModule = applicationContext {
     bean { ColorChipProvider() }
     bean { ProvidersXmlDiscovery(get(), get()) }
     bean { ThunderbirdAutoconfigParser() }
-    bean { ThunderbirdAutoconfigFetcher() }
+    bean { OkHttpClient() }
+    bean { ThunderbirdAutoconfigFetcher(get()) }
     bean { ThunderbirdDiscovery(get(), get()) }
     bean { ServerSettingsDiscovery(arrayOf(
             get<ProvidersXmlDiscovery>(),

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -2,16 +2,9 @@
 package com.fsck.k9.activity.setup;
 
 
-import java.io.Serializable;
-import java.net.URI;
-import java.net.URISyntaxException;
-
-import android.app.AlertDialog;
-import android.app.Dialog;
 import android.content.Context;
-import android.content.DialogInterface;
 import android.content.Intent;
-import android.content.res.XmlResourceParser;
+import android.os.AsyncTask;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.InputType;
@@ -29,19 +22,21 @@ import com.fsck.k9.Core;
 import com.fsck.k9.DI;
 import com.fsck.k9.EmailAddressValidator;
 import com.fsck.k9.Preferences;
-import com.fsck.k9.backend.BackendManager;
-import com.fsck.k9.preferences.Protocols;
-import com.fsck.k9.ui.R;
 import com.fsck.k9.account.AccountCreator;
 import com.fsck.k9.activity.K9Activity;
 import com.fsck.k9.activity.setup.AccountSetupCheckSettings.CheckDirection;
-import com.fsck.k9.helper.UrlEncodingHelper;
+import com.fsck.k9.autodiscovery.ServerSettingsDiscovery;
+import com.fsck.k9.autodiscovery.ConnectionSettings;
+import com.fsck.k9.backend.BackendManager;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.ServerSettings;
+import com.fsck.k9.preferences.Protocols;
+import com.fsck.k9.ui.R;
 import com.fsck.k9.view.ClientCertificateSpinner;
 import com.fsck.k9.view.ClientCertificateSpinner.OnClientCertificateChangedListener;
+
 import timber.log.Timber;
 
 /**
@@ -62,6 +57,7 @@ public class AccountSetupBasics extends K9Activity
 
 
     private final BackendManager backendManager = DI.get(BackendManager.class);
+    private final ServerSettingsDiscovery serverSettingsDiscovery = DI.get(ServerSettingsDiscovery.class);
 
     private EditText mEmailView;
     private EditText mPasswordView;
@@ -70,7 +66,6 @@ public class AccountSetupBasics extends K9Activity
     private Button mNextButton;
     private Button mManualSetupButton;
     private Account mAccount;
-    private Provider mProvider;
 
     private EmailAddressValidator mEmailValidator = new EmailAddressValidator();
     private boolean mCheckedIncoming = false;
@@ -116,9 +111,6 @@ public class AccountSetupBasics extends K9Activity
         if (mAccount != null) {
             outState.putString(EXTRA_ACCOUNT, mAccount.getUuid());
         }
-        if (mProvider != null) {
-            outState.putSerializable(STATE_KEY_PROVIDER, mProvider);
-        }
         outState.putBoolean(STATE_KEY_CHECKED_INCOMING, mCheckedIncoming);
     }
 
@@ -129,10 +121,6 @@ public class AccountSetupBasics extends K9Activity
         if (savedInstanceState.containsKey(EXTRA_ACCOUNT)) {
             String accountUuid = savedInstanceState.getString(EXTRA_ACCOUNT);
             mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
-        }
-
-        if (savedInstanceState.containsKey(STATE_KEY_PROVIDER)) {
-            mProvider = (Provider) savedInstanceState.getSerializable(STATE_KEY_PROVIDER);
         }
 
         mCheckedIncoming = savedInstanceState.getBoolean(STATE_KEY_CHECKED_INCOMING);
@@ -253,91 +241,6 @@ public class AccountSetupBasics extends K9Activity
         return name;
     }
 
-    @Override
-    public Dialog onCreateDialog(int id) {
-        if (id == DIALOG_NOTE) {
-            if (mProvider != null && mProvider.note != null) {
-                return new AlertDialog.Builder(this)
-                       .setMessage(mProvider.note)
-                       .setPositiveButton(
-                           getString(R.string.okay_action),
-                new DialogInterface.OnClickListener() {
-                    public void onClick(DialogInterface dialog, int which) {
-                        finishAutoSetup();
-                    }
-                })
-                       .setNegativeButton(
-                           getString(R.string.cancel_action),
-                           null)
-                       .create();
-            }
-        }
-        return null;
-    }
-
-    private void finishAutoSetup() {
-        String email = mEmailView.getText().toString();
-        String password = mPasswordView.getText().toString();
-        String[] emailParts = splitEmail(email);
-        String user = emailParts[0];
-        String domain = emailParts[1];
-        try {
-            String userEnc = UrlEncodingHelper.encodeUtf8(user);
-            String passwordEnc = UrlEncodingHelper.encodeUtf8(password);
-
-            String incomingUsername = mProvider.incomingUsernameTemplate;
-            incomingUsername = incomingUsername.replaceAll("\\$email", email);
-            incomingUsername = incomingUsername.replaceAll("\\$user", userEnc);
-            incomingUsername = incomingUsername.replaceAll("\\$domain", domain);
-
-            URI incomingUriTemplate = mProvider.incomingUriTemplate;
-            URI incomingUri = new URI(incomingUriTemplate.getScheme(), incomingUsername + ":" + passwordEnc,
-                    incomingUriTemplate.getHost(), incomingUriTemplate.getPort(), null, null, null);
-
-            String outgoingUsername = mProvider.outgoingUsernameTemplate;
-
-            URI outgoingUriTemplate = mProvider.outgoingUriTemplate;
-
-
-            URI outgoingUri;
-            if (outgoingUsername != null) {
-                outgoingUsername = outgoingUsername.replaceAll("\\$email", email);
-                outgoingUsername = outgoingUsername.replaceAll("\\$user", userEnc);
-                outgoingUsername = outgoingUsername.replaceAll("\\$domain", domain);
-                outgoingUri = new URI(outgoingUriTemplate.getScheme(), outgoingUsername + ":"
-                                      + passwordEnc, outgoingUriTemplate.getHost(), outgoingUriTemplate.getPort(), null,
-                                      null, null);
-
-            } else {
-                outgoingUri = new URI(outgoingUriTemplate.getScheme(),
-                                      null, outgoingUriTemplate.getHost(), outgoingUriTemplate.getPort(), null,
-                                      null, null);
-
-
-            }
-            if (mAccount == null) {
-                mAccount = Preferences.getPreferences(this).newAccount();
-                mAccount.setChipColor(AccountCreator.pickColor(this));
-            }
-            mAccount.setName(getOwnerName());
-            mAccount.setEmail(email);
-            mAccount.setStoreUri(incomingUri.toString());
-            mAccount.setTransportUri(outgoingUri.toString());
-
-            ServerSettings incomingSettings = backendManager.decodeStoreUri(incomingUri.toString());
-            mAccount.setDeletePolicy(AccountCreator.getDefaultDeletePolicy(incomingSettings.type));
-
-            // Check incoming here.  Then check outgoing in onActivityResult()
-            AccountSetupCheckSettings.actionCheckSettings(this, mAccount, CheckDirection.INCOMING);
-        } catch (URISyntaxException use) {
-            /*
-             * If there is some problem with the URI we give up and go on to
-             * manual setup.
-             */
-            onManualSetup();
-        }
-    }
-
     private void onNext() {
         if (mClientCertificateCheckBox.isChecked()) {
 
@@ -346,24 +249,48 @@ public class AccountSetupBasics extends K9Activity
             return;
         }
 
-        String email = mEmailView.getText().toString();
-        String[] emailParts = splitEmail(email);
-        String domain = emailParts[1];
-        mProvider = findProviderForDomain(domain);
-        if (mProvider == null) {
-            /*
-             * We don't have default settings for this account, start the manual
-             * setup process.
-             */
-            onManualSetup();
-            return;
+        final String email = mEmailView.getText().toString();
+        new AutoDiscoveryTask().execute(email);
+    }
+
+    private class AutoDiscoveryTask extends AsyncTask<String, Void, ConnectionSettings> {
+
+        @Override
+        protected ConnectionSettings doInBackground(String... emails) {
+            return serverSettingsDiscovery.discover(emails[0]);
         }
 
-        if (mProvider.note != null) {
-            showDialog(DIALOG_NOTE);
-        } else {
-            finishAutoSetup();
+        @Override
+        protected void onPostExecute(ConnectionSettings settings) {
+            if (settings == null) {
+                /*
+                 * We don't have default settings for this account, start the manual
+                 * setup process.
+                 */
+                onManualSetup();
+            } else {
+                onSetupWithSettings(settings.getIncoming(), settings.getOutgoing());
+            }
         }
+    }
+
+    private void onSetupWithSettings(ServerSettings storeServer, ServerSettings transportServer) {
+        if (mAccount == null) {
+            mAccount = Preferences.getPreferences(this).newAccount();
+            mAccount.setChipColor(AccountCreator.pickColor(this));
+        }
+
+        mAccount.setName(getOwnerName());
+        mAccount.setEmail(mEmailView.getText().toString());
+
+        String password = mPasswordView.getText().toString();
+
+        String storeUri = backendManager.createStoreUri(storeServer.newPassword(password));
+        String transportUri = backendManager.createTransportUri(transportServer.newPassword(password));
+        mAccount.setStoreUri(storeUri);
+        mAccount.setTransportUri(transportUri);
+
+        AccountSetupCheckSettings.actionCheckSettings(this, mAccount, CheckDirection.INCOMING);
     }
 
     @Override
@@ -432,84 +359,12 @@ public class AccountSetupBasics extends K9Activity
         }
     }
 
-    /**
-     * Attempts to get the given attribute as a String resource first, and if it fails
-     * returns the attribute as a simple String value.
-     * @param xml
-     * @param name
-     * @return
-     */
-    private String getXmlAttribute(XmlResourceParser xml, String name) {
-        int resId = xml.getAttributeResourceValue(null, name, 0);
-        if (resId == 0) {
-            return xml.getAttributeValue(null, name);
-        } else {
-            return getString(resId);
-        }
-    }
-
-    private Provider findProviderForDomain(String domain) {
-        try {
-            XmlResourceParser xml = getResources().getXml(R.xml.providers);
-            int xmlEventType;
-            Provider provider = null;
-            while ((xmlEventType = xml.next()) != XmlResourceParser.END_DOCUMENT) {
-                if (xmlEventType == XmlResourceParser.START_TAG
-                        && "provider".equals(xml.getName())
-                        && domain.equalsIgnoreCase(getXmlAttribute(xml, "domain"))) {
-                    provider = new Provider();
-                    provider.id = getXmlAttribute(xml, "id");
-                    provider.label = getXmlAttribute(xml, "label");
-                    provider.domain = getXmlAttribute(xml, "domain");
-                    provider.note = getXmlAttribute(xml, "note");
-                } else if (xmlEventType == XmlResourceParser.START_TAG
-                           && "incoming".equals(xml.getName())
-                           && provider != null) {
-                    provider.incomingUriTemplate = new URI(getXmlAttribute(xml, "uri"));
-                    provider.incomingUsernameTemplate = getXmlAttribute(xml, "username");
-                } else if (xmlEventType == XmlResourceParser.START_TAG
-                           && "outgoing".equals(xml.getName())
-                           && provider != null) {
-                    provider.outgoingUriTemplate = new URI(getXmlAttribute(xml, "uri"));
-                    provider.outgoingUsernameTemplate = getXmlAttribute(xml, "username");
-                } else if (xmlEventType == XmlResourceParser.END_TAG
-                           && "provider".equals(xml.getName())
-                           && provider != null) {
-                    return provider;
-                }
-            }
-        } catch (Exception e) {
-            Timber.e(e, "Error while trying to load provider settings.");
-        }
-        return null;
-    }
-
     private String[] splitEmail(String email) {
         String[] retParts = new String[2];
         String[] emailParts = email.split("@");
         retParts[0] = (emailParts.length > 0) ? emailParts[0] : "";
         retParts[1] = (emailParts.length > 1) ? emailParts[1] : "";
         return retParts;
-    }
-
-    static class Provider implements Serializable {
-        private static final long serialVersionUID = 8511656164616538989L;
-
-        public String id;
-
-        public String label;
-
-        public String domain;
-
-        public URI incomingUriTemplate;
-
-        public String incomingUsernameTemplate;
-
-        public URI outgoingUriTemplate;
-
-        public String outgoingUsernameTemplate;
-
-        public String note;
     }
 
 }

--- a/app/ui/src/main/java/com/fsck/k9/autodiscovery/ConnectionSettings.kt
+++ b/app/ui/src/main/java/com/fsck/k9/autodiscovery/ConnectionSettings.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.autodiscovery
+
+import com.fsck.k9.mail.ServerSettings
+
+data class ConnectionSettings(val incoming: ServerSettings, val outgoing: ServerSettings)

--- a/app/ui/src/main/java/com/fsck/k9/autodiscovery/ConnectionSettingsDiscovery.kt
+++ b/app/ui/src/main/java/com/fsck/k9/autodiscovery/ConnectionSettingsDiscovery.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.autodiscovery
+
+interface ConnectionSettingsDiscovery {
+    fun discover(email: String): ConnectionSettings?
+}

--- a/app/ui/src/main/java/com/fsck/k9/autodiscovery/ProvidersXmlDiscovery.java
+++ b/app/ui/src/main/java/com/fsck/k9/autodiscovery/ProvidersXmlDiscovery.java
@@ -1,0 +1,165 @@
+package com.fsck.k9.autodiscovery;
+
+import android.app.Application;
+import android.content.res.XmlResourceParser;
+
+import com.fsck.k9.backend.BackendManager;
+import com.fsck.k9.helper.UrlEncodingHelper;
+import com.fsck.k9.mail.ServerSettings;
+import com.fsck.k9.ui.R;
+
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import timber.log.Timber;
+
+public class ProvidersXmlDiscovery implements ConnectionSettingsDiscovery {
+
+    private final BackendManager backendManager;
+
+    private final Application application;
+
+    public ProvidersXmlDiscovery(BackendManager backendManager, Application application) {
+        this.backendManager = backendManager;
+        this.application = application;
+    }
+
+    private String[] splitEmail(String email) {
+        String[] retParts = new String[2];
+        String[] emailParts = email.split("@");
+        retParts[0] = (emailParts.length > 0) ? emailParts[0] : "";
+        retParts[1] = (emailParts.length > 1) ? emailParts[1] : "";
+        return retParts;
+    }
+
+    @Override
+    public ConnectionSettings discover(String email) {
+        String password = "";
+        String[] emailParts = splitEmail(email);
+        String user = emailParts[0];
+        String domain = emailParts[1];
+        Provider mProvider = findProviderForDomain(domain);
+        if (mProvider == null) {
+            return null;
+        }
+        try {
+            String userEnc = UrlEncodingHelper.encodeUtf8(user);
+            String passwordEnc = UrlEncodingHelper.encodeUtf8(password);
+
+            String incomingUsername = mProvider.incomingUsernameTemplate;
+            incomingUsername = incomingUsername.replaceAll("\\$email", email);
+            incomingUsername = incomingUsername.replaceAll("\\$user", userEnc);
+            incomingUsername = incomingUsername.replaceAll("\\$domain", domain);
+
+            URI incomingUriTemplate = mProvider.incomingUriTemplate;
+            URI incomingUri = new URI(incomingUriTemplate.getScheme(), incomingUsername + ":" + passwordEnc,
+                    incomingUriTemplate.getHost(), incomingUriTemplate.getPort(), null, null, null);
+
+            String outgoingUsername = mProvider.outgoingUsernameTemplate;
+
+            URI outgoingUriTemplate = mProvider.outgoingUriTemplate;
+
+
+            URI outgoingUri;
+            if (outgoingUsername != null) {
+                outgoingUsername = outgoingUsername.replaceAll("\\$email", email);
+                outgoingUsername = outgoingUsername.replaceAll("\\$user", userEnc);
+                outgoingUsername = outgoingUsername.replaceAll("\\$domain", domain);
+                outgoingUri = new URI(outgoingUriTemplate.getScheme(), outgoingUsername + ":"
+                        + passwordEnc, outgoingUriTemplate.getHost(), outgoingUriTemplate.getPort(), null,
+                        null, null);
+
+            } else {
+                outgoingUri = new URI(outgoingUriTemplate.getScheme(),
+                        null, outgoingUriTemplate.getHost(), outgoingUriTemplate.getPort(), null,
+                        null, null);
+
+
+            }
+
+            ServerSettings incomingSettings = backendManager.decodeStoreUri(incomingUri.toString());
+            ServerSettings outgoingSettings = backendManager.decodeTransportUri(outgoingUri.toString());
+            return new ConnectionSettings(incomingSettings, outgoingSettings);
+        } catch (URISyntaxException use) {
+            return null;
+        }
+    }
+
+    private Provider findProviderForDomain(String domain) {
+        try {
+            XmlResourceParser xml = application.getResources().getXml(R.xml.providers);
+            int xmlEventType;
+            Provider provider = null;
+            while ((xmlEventType = xml.next()) != XmlResourceParser.END_DOCUMENT) {
+                if (xmlEventType == XmlResourceParser.START_TAG
+                        && "provider".equals(xml.getName())
+                        && domain.equalsIgnoreCase(getXmlAttribute(xml, "domain"))) {
+                    provider = new Provider();
+                    provider.id = getXmlAttribute(xml, "id");
+                    provider.label = getXmlAttribute(xml, "label");
+                    provider.domain = getXmlAttribute(xml, "domain");
+                    provider.note = getXmlAttribute(xml, "note");
+                } else if (xmlEventType == XmlResourceParser.START_TAG
+                        && "incoming".equals(xml.getName())
+                        && provider != null) {
+                    provider.incomingUriTemplate = new URI(getXmlAttribute(xml, "uri"));
+                    provider.incomingUsernameTemplate = getXmlAttribute(xml, "username");
+                } else if (xmlEventType == XmlResourceParser.START_TAG
+                        && "outgoing".equals(xml.getName())
+                        && provider != null) {
+                    provider.outgoingUriTemplate = new URI(getXmlAttribute(xml, "uri"));
+                    provider.outgoingUsernameTemplate = getXmlAttribute(xml, "username");
+                } else if (xmlEventType == XmlResourceParser.END_TAG
+                        && "provider".equals(xml.getName())
+                        && provider != null) {
+                    return provider;
+                }
+            }
+        } catch (Exception e) {
+            Timber.e(e, "Error while trying to load provider settings.");
+        }
+        return null;
+    }
+
+    @Override
+    public String toString() {
+        return "Internal providers.xml";
+    }
+
+    /**
+     * Attempts to get the given attribute as a String resource first, and if it fails
+     * returns the attribute as a simple String value.
+     * @param xml
+     * @param name
+     * @return
+     */
+    private String getXmlAttribute(XmlResourceParser xml, String name) {
+        int resId = xml.getAttributeResourceValue(null, name, 0);
+        if (resId == 0) {
+            return xml.getAttributeValue(null, name);
+        } else {
+            return application.getString(resId);
+        }
+    }
+
+    static class Provider implements Serializable {
+        private static final long serialVersionUID = 8511656164616538989L;
+
+        public String id;
+
+        public String label;
+
+        public String domain;
+
+        public URI incomingUriTemplate;
+
+        public String incomingUsernameTemplate;
+
+        public URI outgoingUriTemplate;
+
+        public String outgoingUsernameTemplate;
+
+        public String note;
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/autodiscovery/ServerSettingsDiscovery.kt
+++ b/app/ui/src/main/java/com/fsck/k9/autodiscovery/ServerSettingsDiscovery.kt
@@ -1,0 +1,21 @@
+package com.fsck.k9.autodiscovery
+
+import timber.log.Timber
+
+class ServerSettingsDiscovery(private val discoveries: Array<ConnectionSettingsDiscovery>) {
+
+    fun discover(email: String): ConnectionSettings? {
+        discoveries.forEach {
+            try {
+                val settings = it.discover(email)
+                if (settings != null) {
+                    Timber.i("Discovered settings for %s using provider %s: %s", email, it, settings)
+                    return settings
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Autodiscovery error for %s using provider %s", email, it)
+            }
+        }
+        return null
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/autodiscovery/ThunderbirdAutoconfigFetcher.kt
+++ b/app/ui/src/main/java/com/fsck/k9/autodiscovery/ThunderbirdAutoconfigFetcher.kt
@@ -1,0 +1,24 @@
+package com.fsck.k9.autodiscovery
+
+import com.fsck.k9.helper.EmailHelper
+import java.io.InputStream
+import java.net.URL
+import java.net.URLEncoder
+
+class ThunderbirdAutoconfigFetcher() {
+
+    fun fetchAutoconfigFile(email: String): InputStream? {
+        val url = URL(getAutodiscoveryAddress(email))
+
+        return url.openConnection().inputStream
+    }
+
+    companion object {
+        // address described at:
+        // https://developer.mozilla.org/en-US/docs/Mozilla/Thunderbird/Autoconfiguration#Configuration_server_at_ISP
+        internal fun getAutodiscoveryAddress(email: String): String {
+            val domain = EmailHelper.getDomainFromEmailAddress(email)
+            return "https://${domain}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress=" + URLEncoder.encode(email, "UTF-8")
+        }
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/autodiscovery/ThunderbirdAutoconfigFetcher.kt
+++ b/app/ui/src/main/java/com/fsck/k9/autodiscovery/ThunderbirdAutoconfigFetcher.kt
@@ -1,16 +1,18 @@
 package com.fsck.k9.autodiscovery
 
 import com.fsck.k9.helper.EmailHelper
+import okhttp3.OkHttpClient
+import okhttp3.Request
 import java.io.InputStream
-import java.net.URL
 import java.net.URLEncoder
 
-class ThunderbirdAutoconfigFetcher() {
+class ThunderbirdAutoconfigFetcher(private val client: OkHttpClient) {
 
     fun fetchAutoconfigFile(email: String): InputStream? {
-        val url = URL(getAutodiscoveryAddress(email))
+        val url = getAutodiscoveryAddress(email)
+        val request = Request.Builder().url(url).build()
 
-        return url.openConnection().inputStream
+        return client.newCall(request).execute().body()?.byteStream()
     }
 
     companion object {

--- a/app/ui/src/main/java/com/fsck/k9/autodiscovery/ThunderbirdAutoconfigParser.kt
+++ b/app/ui/src/main/java/com/fsck/k9/autodiscovery/ThunderbirdAutoconfigParser.kt
@@ -1,0 +1,101 @@
+package com.fsck.k9.autodiscovery
+
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
+import org.xmlpull.v1.XmlPullParser
+import org.xmlpull.v1.XmlPullParserException
+import org.xmlpull.v1.XmlPullParserFactory
+import java.io.IOException
+import java.io.InputStream
+import java.io.InputStreamReader
+
+class ThunderbirdAutoconfigParser {
+    // structure described at:
+    // https://wiki.mozilla.org/Thunderbird:Autoconfiguration:ConfigFileFormat
+    fun parseSettings(stream: InputStream?, email: String): ConnectionSettings? {
+        if (stream == null) {
+            return null
+        }
+
+        var incoming: ServerSettings? = null
+        var outgoing: ServerSettings? = null
+
+        val factory = XmlPullParserFactory.newInstance()
+        val xpp = factory.newPullParser()
+
+        xpp.setInput(InputStreamReader(stream))
+
+        var eventType = xpp.eventType
+        while (eventType != XmlPullParser.END_DOCUMENT) {
+            if (eventType == XmlPullParser.START_TAG) {
+                if ("incomingServer" == xpp.name) {
+                    incoming = parseServer(xpp, "incomingServer", email)
+                } else if ("outgoingServer" == xpp.name) {
+                    outgoing = parseServer(xpp, "outgoingServer", email)
+                }
+
+                if (incoming != null && outgoing != null) {
+                    return ConnectionSettings(incoming, outgoing)
+                }
+            }
+            eventType = xpp.next()
+        }
+        return null
+    }
+
+    private fun parseServer(xpp: XmlPullParser, nodeName: String, email: String): ServerSettings {
+        val type = xpp.getAttributeValue(null, "type")
+        var host: String? = null
+        var username: String? = null
+        var port: Int? = null
+        var authType: AuthType? = null
+        var connectionSecurity: ConnectionSecurity? = null
+
+        var eventType = xpp.eventType
+        while (!(eventType == XmlPullParser.END_TAG && nodeName == xpp.name)) {
+            if (eventType == XmlPullParser.START_TAG) {
+                if (xpp.name == "hostname") {
+                    host = getText(xpp)
+                } else if (xpp.name == "port") {
+                    port = getText(xpp).toInt()
+                } else if (xpp.name == "username") {
+                    username = getText(xpp).replace("%EMAILADDRESS%", email)
+                } else if (xpp.name == "authentication" && authType == null) {
+                    authType = parseAuthType(getText(xpp))
+                } else if (xpp.name == "socketType") {
+                    connectionSecurity = parseSocketType(getText(xpp))
+                }
+            }
+            eventType = xpp.next()
+        }
+
+        return ServerSettings(type, host, port!!, connectionSecurity, authType, username, null, null)
+    }
+
+    private fun parseAuthType(authentication: String): AuthType? {
+        return when (authentication) {
+            "password-cleartext" -> AuthType.PLAIN
+            "TLS-client-cert" -> AuthType.EXTERNAL
+            "secure" -> AuthType.CRAM_MD5
+            else -> null
+        }
+    }
+
+    private fun parseSocketType(socketType: String): ConnectionSecurity? {
+        return when (socketType) {
+            "plain" -> ConnectionSecurity.NONE
+            "SSL" -> ConnectionSecurity.SSL_TLS_REQUIRED
+            "STARTTLS" -> ConnectionSecurity.STARTTLS_REQUIRED
+            else -> null
+        }
+    }
+
+    @Throws(XmlPullParserException::class, IOException::class)
+    private fun getText(xpp: XmlPullParser): String {
+        val eventType = xpp.next()
+        return if (eventType != XmlPullParser.TEXT) {
+            ""
+        } else xpp.text
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/autodiscovery/ThunderbirdDiscovery.kt
+++ b/app/ui/src/main/java/com/fsck/k9/autodiscovery/ThunderbirdDiscovery.kt
@@ -1,0 +1,15 @@
+package com.fsck.k9.autodiscovery
+
+class ThunderbirdDiscovery(
+        private val fetcher: ThunderbirdAutoconfigFetcher,
+        private val parser: ThunderbirdAutoconfigParser
+): ConnectionSettingsDiscovery {
+
+    override fun discover(email: String): ConnectionSettings? {
+        return fetcher.fetchAutoconfigFile(email).use {
+            parser.parseSettings(it, email)
+        }
+    }
+
+    override fun toString(): String = "Thunderbird autoconfig"
+}

--- a/app/ui/src/test/java/com/fsck/k9/autodiscovery/ThunderbirdAutoconfigTest.kt
+++ b/app/ui/src/test/java/com/fsck/k9/autodiscovery/ThunderbirdAutoconfigTest.kt
@@ -1,0 +1,141 @@
+package com.fsck.k9.autodiscovery
+
+import com.fsck.k9.RobolectricTest
+import junit.framework.Assert.*
+import org.junit.Test
+
+class ThunderbirdAutoconfigTest : RobolectricTest() {
+    private val parser = ThunderbirdAutoconfigParser()
+
+    @Test
+    fun settingsExtract() {
+        val settings = parser.parseSettings("""<?xml version="1.0"?>
+<clientConfig version="1.1">
+    <emailProvider id="metacode.biz">
+      <domain>metacode.biz</domain>
+
+      <incomingServer type="imap">
+         <hostname>imap.googlemail.com</hostname>
+         <port>993</port>
+         <socketType>SSL</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>OAuth2</authentication>
+         <authentication>password-cleartext</authentication>
+      </incomingServer>
+
+      <outgoingServer type="smtp">
+         <hostname>smtp.googlemail.com</hostname>
+         <port>465</port>
+         <socketType>SSL</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>OAuth2</authentication>
+         <authentication>password-cleartext</authentication>
+         <addThisServer>true</addThisServer>
+      </outgoingServer>
+    </emailProvider>
+
+</clientConfig>""".byteInputStream(), "test@metacode.biz")
+
+        assertNotNull(settings)
+        assertNotNull(settings?.outgoing)
+        assertNotNull(settings?.incoming)
+
+        assertEquals("imap.googlemail.com", settings?.incoming?.host)
+        assertEquals(993, settings?.incoming?.port)
+        assertEquals("test@metacode.biz", settings?.incoming?.username)
+
+        assertEquals("smtp.googlemail.com", settings?.outgoing?.host)
+        assertEquals(465, settings?.outgoing?.port)
+        assertEquals("test@metacode.biz", settings?.outgoing?.username)
+    }
+
+    @Test
+    fun pickFirstServer() {
+        val settings = parser.parseSettings("""<?xml version="1.0"?>
+<clientConfig version="1.1">
+    <emailProvider id="metacode.biz">
+      <domain>metacode.biz</domain>
+
+      <incomingServer type="imap">
+         <hostname>imap.googlemail.com</hostname>
+         <port>993</port>
+         <socketType>SSL</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>OAuth2</authentication>
+         <authentication>password-cleartext</authentication>
+      </incomingServer>
+
+      <outgoingServer type="smtp">
+         <hostname>first</hostname>
+         <port>465</port>
+         <socketType>SSL</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>OAuth2</authentication>
+         <authentication>password-cleartext</authentication>
+         <addThisServer>true</addThisServer>
+      </outgoingServer>
+
+      <outgoingServer type="smtp">
+         <hostname>second</hostname>
+         <port>465</port>
+         <socketType>SSL</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>OAuth2</authentication>
+         <authentication>password-cleartext</authentication>
+         <addThisServer>true</addThisServer>
+      </outgoingServer>
+    </emailProvider>
+
+</clientConfig>""".byteInputStream(), "test@metacode.biz")
+
+        assertNotNull(settings)
+        assertNotNull(settings?.outgoing)
+        assertNotNull(settings?.incoming)
+
+        assertEquals("first", settings?.outgoing?.host)
+        assertEquals(465, settings?.outgoing?.port)
+        assertEquals("test@metacode.biz", settings?.outgoing?.username)
+    }
+
+    @Test
+    fun invalidResponse() {
+        val settings = parser.parseSettings("""<?xml version="1.0"?>
+<clientConfig version="1.1">
+    <emailProvider id="metacode.biz">
+      <domain>metacode.biz</domain>""".byteInputStream(), "test@metacode.biz")
+
+        assertNull(settings)
+    }
+
+    @Test
+    fun notCompleteConfiguration() {
+        val settings = parser.parseSettings("""<?xml version="1.0"?>
+<clientConfig version="1.1">
+    <emailProvider id="metacode.biz">
+      <domain>metacode.biz</domain>
+
+      <incomingServer type="imap">
+         <hostname>imap.googlemail.com</hostname>
+         <port>993</port>
+         <socketType>SSL</socketType>
+         <username>%EMAILADDRESS%</username>
+         <authentication>OAuth2</authentication>
+         <authentication>password-cleartext</authentication>
+      </incomingServer>
+    </emailProvider>
+</clientConfig>""".byteInputStream(), "test@metacode.biz")
+
+        assertNull(settings)
+    }
+
+    @Test
+    fun generatedUrls() {
+        val email = "test@metacode.biz"
+
+        val actual = ThunderbirdAutoconfigFetcher.getAutodiscoveryAddress(email)
+
+        val expected = "https://metacode.biz/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress=test%40metacode.biz"
+
+        assertEquals(expected, actual)
+    }
+}


### PR DESCRIPTION
This change makes account setup query mail provider's HTTPS server and fills in appropriate settings for store and transport settings.

If there is no such file or the file is malformed the account setup proceeds as usual with the manual setup.

If the user doesn't want to automatically discover server settings they can initiate manual setup by pressing "Manual Setup" button on the first screen.

Currently implemented autodiscovery scheme is Thunderbird Autoconfig but this can be extended to additional methods (e.g. DNS or autodiscover).

Resolves #865.

See: https://wiki.mozilla.org/Thunderbird:Autoconfiguration:ConfigFileFormat

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). 
* Does not break any unit tests. :heavy_check_mark: 
* Contains a reference to the issue that it fixes. :heavy_check_mark: 
* For cosmetic changes add one or multiple images, if possible. *There is no UI, it either works or not very quickly*


