### PR TITLE
SOCKS Proxy added.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: android
 android:
  components:
     - tools
-    - build-tools-27.0.3
+    - build-tools-28.0.3
     - android-27
     - extra-android-m2repository
 

--- a/app/core/src/main/java/com/fsck/k9/K9.java
+++ b/app/core/src/main/java/com/fsck/k9/K9.java
@@ -194,6 +194,10 @@ public class K9 {
     private static int pgpInlineDialogCounter;
     private static int pgpSignOnlyDialogCounter;
 
+    //Proxy
+    private static boolean useProxy = false;
+    private static String proxyAddress = "127.0.0.1:9050";
+
 
     /**
      * @see #areDatabasesUpToDate()
@@ -318,6 +322,9 @@ public class K9 {
 
         editor.putInt("pgpInlineDialogCounter", pgpInlineDialogCounter);
         editor.putInt("pgpSignOnlyDialogCounter", pgpSignOnlyDialogCounter);
+
+        editor.putBoolean("useProxy", useProxy);
+        editor.putString("proxyAddress", proxyAddress);
 
         fontSizes.save(editor);
     }
@@ -511,6 +518,25 @@ public class K9 {
         themeValue = storage.getInt("messageComposeTheme", Theme.USE_GLOBAL.ordinal());
         K9.setK9ComposerThemeSetting(Theme.values()[themeValue]);
         K9.setUseFixedMessageViewTheme(storage.getBoolean("fixedMessageViewTheme", true));
+
+        useProxy = storage.getBoolean("useProxy", false);
+        proxyAddress = storage.getString("proxyAddress", "127.0.0.1:9050");
+    }
+
+    public static void setProxy(boolean useProxy) {
+        K9.useProxy = useProxy;
+    }
+
+    public static Boolean isProxy() {
+        return K9.useProxy;
+    }
+
+    public static void setProxyAddress(String newAddress) {
+        K9.proxyAddress = newAddress;
+    }
+
+    public static String getProxyAddress() {
+        return proxyAddress;
     }
 
     public static String getK9Language() {

--- a/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -291,6 +291,12 @@ public class GlobalSettings {
                 new V(49, new BooleanSetting(false)),
                 new V(56, null)
         ));
+        s.put("useProxy", Settings.versions(
+                new V(58, new BooleanSetting(false))
+        ));
+        s.put("proxyAddress", Settings.versions(
+                new V(58, new Settings.StringSetting("127.0.0.1:9050"))
+        ));
 
         SETTINGS = Collections.unmodifiableMap(s);
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 57;
+    public static final int VERSION = 58;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         applicationId "com.fsck.k9"

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -45,6 +45,7 @@ class GeneralSettingsDataStore(
             "privacy_hide_timezone" -> K9.hideTimeZone()
             "debug_logging" -> K9.isDebug()
             "sensitive_logging" -> K9.DEBUG_SENSITIVE
+            "network_use_socks_proxy" -> K9.isProxy()
             else -> defValue
         }
     }
@@ -79,6 +80,7 @@ class GeneralSettingsDataStore(
             "privacy_hide_timezone" -> K9.setHideTimeZone(value)
             "debug_logging" -> K9.setDebug(value)
             "sensitive_logging" -> K9.DEBUG_SENSITIVE = value
+            "network_use_socks_proxy" -> K9.setProxy(value)
             else -> return
         }
 
@@ -116,6 +118,7 @@ class GeneralSettingsDataStore(
             "notification_hide_subject" -> K9.getNotificationHideSubject().name
             "quiet_time_starts" -> K9.getQuietTimeStarts()
             "quiet_time_ends" -> K9.getQuietTimeEnds()
+            "network_socks_proxy_address" -> K9.getProxyAddress()
             else -> defValue
         }
     }
@@ -137,6 +140,7 @@ class GeneralSettingsDataStore(
             "notification_hide_subject" -> K9.setNotificationHideSubject(K9.NotificationHideSubject.valueOf(value))
             "quiet_time_starts" -> K9.setQuietTimeStarts(value)
             "quiet_time_ends" -> K9.setQuietTimeEnds(value)
+            "network_socks_proxy_address" -> K9.setProxyAddress(value)
             else -> return
         }
 

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -854,6 +854,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="background_ops_always">Always</string>
     <string name="background_ops_auto_sync_only">When \'Auto-sync\' is checked</string>
 
+    <string name="network_use_proxy_label">Use Socks Proxy</string>
+    <string name="network_proxy_label">Socks Proxy</string>
+
     <string name="batch_select_all">Select all</string>
 
     <string name="account_setup_push_limit_label">Max folders to check with push</string>

--- a/app/ui/src/main/res/xml/general_settings.xml
+++ b/app/ui/src/main/res/xml/general_settings.xml
@@ -330,6 +330,21 @@
             search:summary=""
             android:title="@string/background_ops_label" />
 
+        <CheckBoxPreference
+            android:title="@string/network_use_proxy_label"
+            android:key="network_use_socks_proxy"
+            android:summary="Use socks proxy for connections"
+            />
+
+        <EditTextPreference
+            android:title="@string/network_proxy_label"
+            android:key="network_socks_proxy_address"
+            android:summary="Enter the ip address and port of socks proxy"
+            android:dependency="network_use_socks_proxy"
+            android:dialogTitle="Socks Proxy"
+            android:defaultValue="127.0.0.1:9050"
+            />
+
     </PreferenceScreen>
 
     <PreferenceScreen

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@ buildscript {
         buildConfig = [
                 'compileSdk': 27,
                 'minSdk': 19,
-                'buildTools': '27.0.3'
+                'buildTools': '28.0.3'
         ]
 
         versions = [
-                'kotlin': '1.2.41',
+                'kotlin': '1.2.51',
                 'supportLibrary': '27.1.1',
                 'preferencesFix': '27.1.1.1',
                 'lifecycleExtensions': '1.1.0',
@@ -33,7 +33,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.2.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:${versions.kotlin}"
     }

--- a/mail/protocols/imap/build.gradle
+++ b/mail/protocols/imap/build.gradle
@@ -10,27 +10,25 @@ if (rootProject.testCoverage) {
 
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${versions.kotlin}"
-
-    api project(":mail:common")
-
-    implementation "com.jcraft:jzlib:1.0.7"
-    implementation "com.beetstra.jutf7:jutf7:1.0.0"
+    api project(':mail:common')
+    implementation 'com.jcraft:jzlib:1.0.7'
+    implementation 'com.beetstra.jutf7:jutf7:1.0.0'
     implementation "commons-io:commons-io:${versions.commonsIo}"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
     implementation "com.android.support:support-annotations:${versions.supportLibrary}"
-
-    testImplementation project(":mail:testing")
+    testImplementation project(':mail:testing')
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "com.squareup.okio:okio:${versions.okio}"
     testImplementation "org.apache.james:apache-mime4j-core:${versions.mime4j}"
+    implementation project(':app:core')
 }
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -223,7 +223,7 @@ class ImapConnection {
             if (settings.getHost().toLowerCase().endsWith("onion")) { //TOR Onion address
                 return connectToOnionAddress();
             } else {
-                throw new MessagingException("Cannot connect to host", connectException);
+                throw new UnknownHostException("Cannot resolve " + settings.getHost());
             }
         }
 

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.java
@@ -222,6 +222,8 @@ class ImapConnection {
         } catch (UnknownHostException e) {
             if (settings.getHost().toLowerCase().endsWith("onion")) { //TOR Onion address
                 return connectToOnionAddress();
+            } else {
+                throw new MessagingException("Cannot connect to host", connectException);
             }
         }
 

--- a/mail/protocols/pop3/build.gradle
+++ b/mail/protocols/pop3/build.gradle
@@ -8,24 +8,23 @@ if (rootProject.testCoverage) {
 }
 
 dependencies {
-    api project(":mail:common")
-
+    api project(':mail:common')
     implementation "com.jakewharton.timber:timber:${versions.timber}"
     implementation "com.android.support:support-annotations:${versions.supportLibrary}"
-
-    testImplementation project(":mail:testing")
+    testImplementation project(':mail:testing')
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "com.squareup.okio:okio:${versions.okio}"
-    testImplementation "com.jcraft:jzlib:1.0.7"
+    testImplementation 'com.jcraft:jzlib:1.0.7'
     testImplementation "commons-io:commons-io:${versions.commonsIo}"
+    implementation project(':app:core')
 }
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
+++ b/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
@@ -5,9 +5,12 @@ import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.net.UnknownHostException;
 import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
 import java.security.MessageDigest;
@@ -17,6 +20,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
 
+import com.fsck.k9.K9;
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.Authentication;
 import com.fsck.k9.mail.AuthenticationFailedException;
@@ -28,7 +32,9 @@ import com.fsck.k9.mail.filter.Base64;
 import com.fsck.k9.mail.filter.Hex;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
 import com.fsck.k9.mail.store.RemoteStore;
+
 import javax.net.ssl.SSLException;
+
 import timber.log.Timber;
 
 import static com.fsck.k9.mail.CertificateValidationException.Reason.MissingCapability;
@@ -53,22 +59,53 @@ class Pop3Connection {
     private boolean topNotAdvertised;
 
     Pop3Connection(Pop3Settings settings,
-            TrustedSocketFactory trustedSocketFactory) {
+                   TrustedSocketFactory trustedSocketFactory) {
         this.settings = settings;
         this.trustedSocketFactory = trustedSocketFactory;
     }
 
     void open() throws MessagingException {
         try {
+            try {
+                InetAddress.getAllByName(settings.getHost());
+            } catch (UnknownHostException ex) {
+                if (settings.getHost().toLowerCase().endsWith("onion")) {
+                    socket = createOnionSocket();
+                }
+            }
             SocketAddress socketAddress = new InetSocketAddress(settings.getHost(), settings.getPort());
-            if (settings.getConnectionSecurity() == ConnectionSecurity.SSL_TLS_REQUIRED) {
-                socket = trustedSocketFactory.createSocket(null, settings.getHost(),
-                        settings.getPort(), settings.getClientCertificateAlias());
-            } else {
-                socket = new Socket();
+
+            if (socket == null || !socket.isConnected()) {
+
+                Socket underlying;
+
+                if (K9.isProxy()) {
+                    String proxyAddress = K9.getProxyAddress().split(":")[0];
+                    int proxyPort = Integer.parseInt(K9.getProxyAddress().split(":")[1]);
+
+                    Timber.d("Connecting to SOCKS proxy at %s as %s", proxyAddress, proxyPort);
+
+                    SocketAddress sa = new InetSocketAddress(proxyAddress, proxyPort);
+                    Proxy p = new Proxy(Proxy.Type.SOCKS, sa);
+                    underlying = new Socket(p);
+                } else {
+                    underlying = new Socket();
+                }
+
+                underlying.connect(socketAddress, RemoteStore.SOCKET_CONNECT_TIMEOUT);
+
+                if (settings.getConnectionSecurity() == ConnectionSecurity.SSL_TLS_REQUIRED) {
+                    socket = trustedSocketFactory.createSocket(underlying, settings.getHost(),
+                            settings.getPort(), settings.getClientCertificateAlias());
+                } else {
+                    socket = underlying;
+                }
             }
 
-            socket.connect(socketAddress, RemoteStore.SOCKET_CONNECT_TIMEOUT);
+            if (!socket.isConnected()) {
+                socket.connect(socketAddress, RemoteStore.SOCKET_CONNECT_TIMEOUT);
+            }
+
             in = new BufferedInputStream(socket.getInputStream(), 1024);
             out = new BufferedOutputStream(socket.getOutputStream(), 512);
 
@@ -101,6 +138,42 @@ class Pop3Connection {
         }
     }
 
+    private Socket createOnionSocket() throws MessagingException, IOException, NoSuchAlgorithmException, KeyManagementException {
+
+        if (!K9.isProxy()) {
+            Timber.e("Proxy is needed in order to connect %s", settings.getHost());
+            throw new MessagingException("Proxy is needed to be set for connecting Onion addresses.");
+        }
+
+        String ip;
+        int proxyPort;
+
+        ip = K9.getProxyAddress().split(":")[0];
+        proxyPort = Integer.parseInt(K9.getProxyAddress().split(":")[1]);
+
+
+        InetSocketAddress HiddenerProxyAddress = new InetSocketAddress(ip, proxyPort);
+        Proxy HiddenProxy = new Proxy(Proxy.Type.SOCKS, HiddenerProxyAddress);
+        Socket underlying = new Socket(HiddenProxy);
+        InetSocketAddress sa = InetSocketAddress.createUnresolved(settings.getHost(), settings.getPort());
+
+        //Connect
+        underlying.connect(sa, RemoteStore.SOCKET_CONNECT_TIMEOUT);
+
+        Socket socket;
+        if (settings.getConnectionSecurity() == ConnectionSecurity.SSL_TLS_REQUIRED) {
+            socket = trustedSocketFactory.createSocket(underlying, settings.getHost(), settings.getPort(), settings.getClientCertificateAlias());
+        } else {
+            socket = underlying;
+        }
+
+        if (!socket.isConnected()) {
+            socket.connect(sa, RemoteStore.SOCKET_CONNECT_TIMEOUT);
+        }
+
+        return socket;
+    }
+
     /*
      * If STARTTLS is not available throws a CertificateValidationException which in K-9
      * triggers a "Certificate error" notification that takes the user to the incoming
@@ -108,7 +181,7 @@ class Pop3Connection {
      * "STARTTLS (if available)" setting.
      */
     private void performStartTlsUpgrade(TrustedSocketFactory trustedSocketFactory,
-            String host, int port, String clientCertificateAlias)
+                                        String host, int port, String clientCertificateAlias)
             throws MessagingException, NoSuchAlgorithmException, KeyManagementException, IOException {
         if (capabilities.stls) {
             executeSimpleCommand(STLS_COMMAND);
@@ -162,7 +235,7 @@ class Pop3Connection {
 
             default:
                 throw new MessagingException(
-                        "Unhandled authentication method: "+authType+" found in the server settings (bug).");
+                        "Unhandled authentication method: " + authType + " found in the server settings (bug).");
         }
 
     }
@@ -374,13 +447,13 @@ class Pop3Connection {
             throw new IOException("End of stream reached while trying to read line.");
         }
         do {
-            if (((char)d) == '\r') {
+            if (((char) d) == '\r') {
                 //noinspection UnnecessaryContinue Makes it easier to follow
                 continue;
-            } else if (((char)d) == '\n') {
+            } else if (((char) d) == '\n') {
                 break;
             } else {
-                sb.append((char)d);
+                sb.append((char) d);
             }
         } while ((d = in.read()) != -1);
         String ret = sb.toString();

--- a/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
+++ b/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
@@ -71,6 +71,8 @@ class Pop3Connection {
             } catch (UnknownHostException ex) {
                 if (settings.getHost().toLowerCase().endsWith("onion")) {
                     socket = createOnionSocket();
+                } else {
+                    throw new UnknownHostException("Cannot resolve " + settings.getHost());
                 }
             }
             SocketAddress socketAddress = new InetSocketAddress(settings.getHost(), settings.getPort());

--- a/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
+++ b/mail/protocols/pop3/src/main/java/com/fsck/k9/mail/store/pop3/Pop3Connection.java
@@ -71,8 +71,6 @@ class Pop3Connection {
             } catch (UnknownHostException ex) {
                 if (settings.getHost().toLowerCase().endsWith("onion")) {
                     socket = createOnionSocket();
-                } else {
-                    throw new UnknownHostException("Cannot resolve " + settings.getHost());
                 }
             }
             SocketAddress socketAddress = new InetSocketAddress(settings.getHost(), settings.getPort());
@@ -90,17 +88,17 @@ class Pop3Connection {
                     SocketAddress sa = new InetSocketAddress(proxyAddress, proxyPort);
                     Proxy p = new Proxy(Proxy.Type.SOCKS, sa);
                     underlying = new Socket(p);
-                } else {
-                    underlying = new Socket();
-                }
 
-                underlying.connect(socketAddress, RemoteStore.SOCKET_CONNECT_TIMEOUT);
+                    underlying.connect(socketAddress, RemoteStore.SOCKET_CONNECT_TIMEOUT);
+                } else {
+                    underlying = null;
+                }
 
                 if (settings.getConnectionSecurity() == ConnectionSecurity.SSL_TLS_REQUIRED) {
                     socket = trustedSocketFactory.createSocket(underlying, settings.getHost(),
                             settings.getPort(), settings.getClientCertificateAlias());
                 } else {
-                    socket = underlying;
+                    socket = (underlying == null ? new Socket() : underlying);
                 }
             }
 

--- a/mail/protocols/smtp/build.gradle
+++ b/mail/protocols/smtp/build.gradle
@@ -8,24 +8,23 @@ if (rootProject.testCoverage) {
 }
 
 dependencies {
-    api project(":mail:common")
-
+    api project(':mail:common')
     implementation "commons-io:commons-io:${versions.commonsIo}"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
     implementation "com.android.support:support-annotations:${versions.supportLibrary}"
-
-    testImplementation project(":mail:testing")
+    testImplementation project(':mail:testing')
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
     testImplementation "com.squareup.okio:okio:${versions.okio}"
-    testImplementation "com.jcraft:jzlib:1.0.7"
+    testImplementation 'com.jcraft:jzlib:1.0.7'
+    implementation project(':app:core')
 }
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.java
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.java
@@ -119,6 +119,8 @@ public class SmtpTransport extends Transport {
             } catch (UnknownHostException e) {
                 if (host.toLowerCase().endsWith("onion")) {
                     socket = createOnionSocket();
+                } else {
+                    throw new UnknownHostException("Cannot resolve " + host);
                 }
             }
 

--- a/mail/protocols/webdav/build.gradle
+++ b/mail/protocols/webdav/build.gradle
@@ -8,26 +8,24 @@ if (rootProject.testCoverage) {
 }
 
 dependencies {
-    api project(":mail:common")
-
+    api project(':mail:common')
     implementation "commons-io:commons-io:${versions.commonsIo}"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
     implementation "com.android.support:support-annotations:${versions.supportLibrary}"
-
-    testImplementation project(":mail:testing")
+    testImplementation project(':mail:testing')
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"
-
     // The Android Gradle plugin doesn't seem to put the Apache HTTP Client on the runtime classpath anymore when
     // running JVM tests.
-    testImplementation "org.apache.httpcomponents:httpclient:4.5.5"
+    testImplementation 'org.apache.httpcomponents:httpclient:4.5.5'
+    implementation project(':app:core')
 }
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
+    buildToolsVersion '28.0.3'
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
+++ b/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/store/webdav/WebDavStore.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.UnsupportedEncodingException;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.KeyManagementException;
@@ -16,6 +17,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+import com.fsck.k9.K9;
 import com.fsck.k9.mail.CertificateValidationException;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.Folder;
@@ -777,6 +779,12 @@ public class WebDavStore extends RemoteStore {
 
             // Setup a cookie store for forms-based authentication.
             httpContext = new BasicHttpContext();
+            if (K9.isProxy()) {
+                String proxyAddress = K9.getProxyAddress().split(":")[0];
+                int proxyPort = Integer.parseInt(K9.getProxyAddress().split(":")[1]);
+                InetSocketAddress socksaddr = new InetSocketAddress(proxyAddress, proxyPort);
+                httpContext.setAttribute("socks.address", socksaddr);
+            }
             authCookies = new BasicCookieStore();
             httpContext.setAttribute(ClientContext.COOKIE_STORE, authCookies);
 


### PR DESCRIPTION
Dear Sir,
I'm Mir Saman Tajbakhsh, PhD. from Urmia University in the IT field. I'm interested in anonymity networks. You may check my posts in my site ([https://mstajbakhsh.ir](https://mstajbakhsh.ir)).

The K-9 project is very useful email client I've ever worked with and I saw some issues about socks proxy such as: #980 #861 #704
Therefore, I've added SOCKs proxy support into K-9 client and added two shared preferences: one for enabling proxy and the other for proxy address.

Furthermore, for the aim of supporting onion addresses, I added code for checking the destination host and if it ends with .onion, it will use proxy.

Regards,
Saman

