### PR TITLE
Add flag to allow a Backend to opt out of the "move to Trash folder" behavior

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2179,11 +2179,14 @@ public class MessagingController {
                 }
             }
 
+            Backend backend = getBackend(account);
+
             LocalStore localStore = localStoreProvider.getInstance(account);
             localFolder = localStore.getFolder(folder);
             Map<String, String> uidMap = null;
-            if (folder.equals(account.getTrashFolder()) || !account.hasTrashFolder()) {
-                Timber.d("Deleting messages in trash folder or trash set to -None-, not copying");
+            if (folder.equals(account.getTrashFolder()) || !account.hasTrashFolder() ||
+                    !backend.isDeleteMoveToTrash()) {
+                Timber.d("Not moving deleted messages to local Trash folder. Removing local copies.");
 
                 if (!localOnlyMessages.isEmpty()) {
                     localFolder.destroyMessages(localOnlyMessages);
@@ -2217,7 +2220,7 @@ public class MessagingController {
                 processPendingCommands(account);
             } else if (!syncedMessageUids.isEmpty()) {
                 if (account.getDeletePolicy() == DeletePolicy.ON_DELETE) {
-                    if (folder.equals(account.getTrashFolder())) {
+                    if (folder.equals(account.getTrashFolder()) || !backend.isDeleteMoveToTrash()) {
                         queueSetFlag(account, folder, true, Flag.DELETED, syncedMessageUids);
                     } else {
                         queueMoveOrCopy(account, folder, account.getTrashFolder(), false,

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
@@ -21,6 +21,7 @@ interface Backend {
     val supportsTrashFolder: Boolean
     val supportsSearchByDate: Boolean
     val isPushCapable: Boolean
+    val isDeleteMoveToTrash: Boolean
 
     @Throws(MessagingException::class)
     fun refreshFolderList()

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.java
@@ -103,6 +103,11 @@ public class ImapBackend implements Backend {
     }
 
     @Override
+    public boolean isDeleteMoveToTrash() {
+        return true;
+    }
+
+    @Override
     public void refreshFolderList() {
         commandRefreshFolderList.refreshFolderList();
     }

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
@@ -35,6 +35,7 @@ class Pop3Backend(
     override val supportsTrashFolder = false
     override val supportsSearchByDate = false
     override val isPushCapable = false
+    override val isDeleteMoveToTrash = false
 
     override fun refreshFolderList() {
         commandRefreshFolderList.refreshFolderList()

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavBackend.kt
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavBackend.kt
@@ -39,6 +39,7 @@ class WebDavBackend(
     override val supportsTrashFolder = true
     override val supportsSearchByDate = false
     override val isPushCapable = false
+    override val isDeleteMoveToTrash = true
 
     override fun refreshFolderList() {
         commandGetFolders.refreshFolderList()


### PR DESCRIPTION
This is not relevant for any of K-9 Mail's backends. So there shouldn't be any behavior changes.