### PR TITLE
Removed unused interface OnLayoutChangedListener.

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -35,14 +35,13 @@ import com.fsck.k9.mail.Address;
 import com.fsck.k9.mailstore.AttachmentResolver;
 import com.fsck.k9.mailstore.AttachmentViewInfo;
 import com.fsck.k9.mailstore.MessageViewInfo;
-import com.fsck.k9.view.MessageHeader.OnLayoutChangedListener;
 import com.fsck.k9.view.MessageWebView;
 import com.fsck.k9.view.MessageWebView.OnPageFinishedListener;
 
 import static android.app.DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED;
 
 
-public class MessageContainerView extends LinearLayout implements OnLayoutChangedListener, OnCreateContextMenuListener {
+public class MessageContainerView extends LinearLayout implements OnCreateContextMenuListener {
     private static final int MENU_ITEM_LINK_VIEW = Menu.FIRST;
     private static final int MENU_ITEM_LINK_SHARE = Menu.FIRST + 1;
     private static final int MENU_ITEM_LINK_COPY = Menu.FIRST + 2;
@@ -503,13 +502,6 @@ public class MessageContainerView extends LinearLayout implements OnLayoutChange
          * is now hidden.
          */
         clearDisplayedContent();
-    }
-
-    @Override
-    public void onLayoutChanged() {
-        if (mMessageContentView != null) {
-            mMessageContentView.invalidate();
-        }
     }
 
     public void enableAttachmentButtons(AttachmentViewInfo attachment) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -66,7 +66,6 @@ public class MessageTopView extends LinearLayout {
         super.onFinishInflate();
 
         mHeaderContainer = findViewById(R.id.header_container);
-        // mHeaderContainer.setOnLayoutChangedListener(this);
         mInflater = LayoutInflater.from(getContext());
 
         viewAnimator = findViewById(R.id.message_layout_animator);

--- a/app/ui/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/app/ui/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -79,7 +79,6 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
     private ContactPictureLoader mContactsPictureLoader;
     private ContactBadge mContactBadge;
 
-    private OnLayoutChangedListener mOnLayoutChangedListener;
     private OnCryptoClickListener onCryptoClickListener;
     private OnMenuItemClickListener onMenuItemClickListener;
 
@@ -168,7 +167,6 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
             onAddSenderToContacts();
         } else if (id == R.id.to || id == R.id.cc || id == R.id.bcc) {
             expand((TextView)view, ((TextView)view).getEllipsize() != null);
-            layoutChanged();
         } else if (id == R.id.crypto_status_icon) {
             onCryptoClickListener.onCryptoClick();
         } else if (id == R.id.icon_single_message_options) {
@@ -399,7 +397,6 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
             expand(mToView, true);
             expand(mCcView, true);
         }
-        layoutChanged();
     }
 
 
@@ -519,20 +516,6 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         public void writeToParcel(Parcel out, int flags) {
             super.writeToParcel(out, flags);
             out.writeInt((this.additionalHeadersVisible) ? 1 : 0);
-        }
-    }
-
-    public interface OnLayoutChangedListener {
-        void onLayoutChanged();
-    }
-
-    public void setOnLayoutChangedListener(OnLayoutChangedListener listener) {
-        mOnLayoutChangedListener = listener;
-    }
-
-    private void layoutChanged() {
-        if (mOnLayoutChangedListener != null) {
-            mOnLayoutChangedListener.onLayoutChanged();
         }
     }
 


### PR DESCRIPTION
Rationale
------------
As the member mOnLayoutChangedListener was never populated, the only method of the interface was never called. Thus the complete interface has been removed.
Also the only method which would have called the interface method was removed. That method did nothing else.

Apparently the removed parts were not needed anymore as I did not find any functionality missing during tests.

Overall objective: [Remove unused / dead code.](https://dev.to/codebyamir/the-risks-of-dead-code-5bg)

Checks
---------
> Please ensure that your pull request meets the following requirements - thanks !

* [x] Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle). 
  :heavy_check_mark: Coding guidelines have been applied with the help of  `k-9/tools/android-studio/settings.jar`.
* [x] Does not break any unit tests. 
  :heavy_check_mark: Unit tests have been executed: 
```
./gradlew testDebug
BUILD SUCCESSFUL in 4m 32s
336 actionable tasks: 103 executed, 233 up-to-date
```
* [ ] Contains a reference to the issue that it fixes. 
  I did not find any issues matching those changes. I assume an issue is not necessary as it is a pure code maintenance change.
* [x] For cosmetic changes add one or multiple images, if possible. 
  Not applicable as no changes intended or visible.