### PR TITLE
Add deleteMessages() method to Backend interface

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -13,6 +13,7 @@ public class MessagingControllerCommands {
     static final String COMMAND_APPEND = "append";
     static final String COMMAND_MARK_ALL_AS_READ = "mark_all_as_read";
     static final String COMMAND_SET_FLAG = "set_flag";
+    static final String COMMAND_DELETE = "delete";
     static final String COMMAND_EXPUNGE = "expunge";
     static final String COMMAND_MOVE_OR_COPY = "move_or_copy";
     static final String COMMAND_EMPTY_TRASH = "empty_trash";
@@ -155,6 +156,31 @@ public class MessagingControllerCommands {
         @Override
         public void execute(MessagingController controller, Account account) throws MessagingException {
             controller.processPendingMarkAllAsRead(this, account);
+        }
+    }
+
+    public static class PendingDelete extends PendingCommand {
+        public final String folder;
+        public final List<String> uids;
+
+
+        public static PendingDelete create(String folder, List<String> uids) {
+            return new PendingDelete(folder, uids);
+        }
+
+        private PendingDelete(String folder, List<String> uids) {
+            this.folder = folder;
+            this.uids = uids;
+        }
+
+        @Override
+        public String getCommandName() {
+            return COMMAND_DELETE;
+        }
+
+        @Override
+        public void execute(MessagingController controller, Account account) throws MessagingException {
+            controller.processPendingDelete(this, account);
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/controller/PendingCommandSerializer.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/PendingCommandSerializer.java
@@ -9,6 +9,7 @@ import java.util.Map;
 
 import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingCommand;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingDelete;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingEmptyTrash;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingExpunge;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingMarkAllAsRead;
@@ -35,6 +36,7 @@ public class PendingCommandSerializer {
         adapters.put(MessagingControllerCommands.COMMAND_EXPUNGE, moshi.adapter(PendingExpunge.class));
         adapters.put(MessagingControllerCommands.COMMAND_MARK_ALL_AS_READ, moshi.adapter(PendingMarkAllAsRead.class));
         adapters.put(MessagingControllerCommands.COMMAND_SET_FLAG, moshi.adapter(PendingSetFlag.class));
+        adapters.put(MessagingControllerCommands.COMMAND_DELETE, moshi.adapter(PendingDelete.class));
 
         this.adapters = Collections.unmodifiableMap(adapters);
     }

--- a/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -12,7 +12,7 @@ import timber.log.Timber;
 
 
 class StoreSchemaDefinition implements SchemaDefinition {
-    static final int DB_VERSION = 68;
+    static final int DB_VERSION = 69;
 
     private final MigrationsHelper migrationsHelper;
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo69.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo69.kt
@@ -1,0 +1,41 @@
+package com.fsck.k9.storage.migrations
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import com.fsck.k9.controller.MessagingControllerCommands.PendingDelete
+import com.fsck.k9.controller.MessagingControllerCommands.PendingSetFlag
+import com.fsck.k9.controller.PendingCommandSerializer
+import com.fsck.k9.mail.Flag
+
+
+internal class MigrationTo69(private val db: SQLiteDatabase) {
+    private val serializer: PendingCommandSerializer = PendingCommandSerializer.getInstance()
+
+
+    fun createPendingDelete() {
+        val pendingSetFlagsToConvert = mutableListOf<PendingSetFlag>()
+
+        db.rawQuery("SELECT id, command, data FROM pending_commands WHERE command = 'set_flag'", null).use { cursor ->
+            while (cursor.moveToNext()) {
+                val databaseId = cursor.getLong(0)
+                val commandName = cursor.getString(1)
+                val data = cursor.getString(2)
+
+                val pendingSetFlag = serializer.unserialize(databaseId, commandName, data) as PendingSetFlag
+                if (pendingSetFlag.flag == Flag.DELETED && pendingSetFlag.newState) {
+                    pendingSetFlagsToConvert.add(pendingSetFlag)
+                }
+            }
+        }
+
+        for (pendingSetFlag in pendingSetFlagsToConvert) {
+            val pendingDelete = PendingDelete.create(pendingSetFlag.folder, pendingSetFlag.uids)
+            val contentValues = ContentValues().apply {
+                put("command", "delete")
+                put("data", serializer.serialize(pendingDelete))
+            }
+
+            db.update("pending_commands", contentValues, "id = ?", arrayOf(pendingSetFlag.databaseId.toString()))
+        }
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.java
@@ -94,6 +94,8 @@ public class Migrations {
                 MigrationTo67.addTypeColumnToFoldersTable(db, migrationsHelper);
             case 67:
                 MigrationTo68.addOutboxStateTable(db);
+            case 68:
+                new MigrationTo69(db).createPendingDelete();
         }
 
         if (shouldBuildFtsTable) {

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
@@ -45,6 +45,9 @@ interface Backend {
     fun expungeMessages(folderServerId: String, messageServerIds: List<String>)
 
     @Throws(MessagingException::class)
+    fun deleteMessages(folderServerId: String, messageServerIds: List<String>)
+
+    @Throws(MessagingException::class)
     fun deleteAllMessages(folderServerId: String)
 
     @Throws(MessagingException::class)

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.java
@@ -147,6 +147,12 @@ public class ImapBackend implements Backend {
     }
 
     @Override
+    public void deleteMessages(@NotNull String folderServerId, @NotNull List<String> messageServerIds)
+            throws MessagingException {
+        commandSetFlag.setFlag(folderServerId, messageServerIds, Flag.DELETED, true);
+    }
+
+    @Override
     public void deleteAllMessages(@NotNull String folderServerId) throws MessagingException {
         commandDeleteAll.deleteAll(folderServerId);
     }

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
@@ -65,6 +65,10 @@ class Pop3Backend(
         throw UnsupportedOperationException("not supported")
     }
 
+    override fun deleteMessages(folderServerId: String, messageServerIds: List<String>) {
+        commandSetFlag.setFlag(folderServerId, messageServerIds, Flag.DELETED, true)
+    }
+
     override fun deleteAllMessages(folderServerId: String) {
         commandDeleteAll.deleteAll(folderServerId)
     }

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavBackend.kt
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavBackend.kt
@@ -70,6 +70,10 @@ class WebDavBackend(
         throw UnsupportedOperationException("not supported")
     }
 
+    override fun deleteMessages(folderServerId: String, messageServerIds: List<String>) {
+        commandSetFlag.setFlag(folderServerId, messageServerIds, Flag.DELETED, true)
+    }
+
     override fun deleteAllMessages(folderServerId: String) {
         commandDeleteAll.deleteAll(folderServerId)
     }


### PR DESCRIPTION
The old way to delete a message was to call `setFlag()` with `Flag.DELETED`, which is very IMAP-specific. This is a first step towards cleaning things up.