### PR TITLE
Fixed "Manual Setup back button closes app" issue 

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -332,8 +332,6 @@ public class AccountSetupBasics extends K9Activity
         mAccount.setTransportUri(transportUri);
 
         AccountSetupAccountType.actionSelectAccountType(this, mAccount, false);
-
-        finish();
     }
 
     public void onClick(View v) {


### PR DESCRIPTION
the finish() method was not allowing the user to go back to the previous activity. It doesn't close the app if we press the back button when in the Manual Setup now.

