### PR TITLE
Client ID Security added for IMAP and SMTP

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -115,6 +115,7 @@ public class Account implements BaseAccount, StoreConfig {
 
     private final String accountUuid;
     private String storeUri;
+    private String imei;
 
     /**
      * Storage provider ID, used to locate and manage the underlying DB/file
@@ -244,6 +245,11 @@ public class Account implements BaseAccount, StoreConfig {
         this.accountUuid = uuid;
     }
 
+    public Account(String uuid, String imei) {
+        this.accountUuid = uuid;
+        this.imei = imei;
+    }
+
     public synchronized void setChipColor(int color) {
         chipColor = color;
     }
@@ -255,6 +261,26 @@ public class Account implements BaseAccount, StoreConfig {
     @Override
     public String getUuid() {
         return accountUuid;
+    }
+
+    public String getImei() {
+        return imei;
+    }
+
+    public String getClientID() {
+        if (imei != null) {
+            return imei;
+        } else {
+            return accountUuid;
+        }
+    }
+
+    public String getClientIDType() {
+        if (imei != null) {
+            return "K9-IMEI";
+        } else {
+            return "K9-UUID";
+        }
     }
 
     public synchronized String getStoreUri() {

--- a/app/core/src/main/java/com/fsck/k9/Preferences.java
+++ b/app/core/src/main/java/com/fsck/k9/Preferences.java
@@ -104,10 +104,11 @@ public class Preferences {
             accounts = new HashMap<>();
             accountsInOrder = new LinkedList<>();
             String accountUuids = getStorage().getString("accountUuids", null);
+            String imei = getStorage().getString("imei", null);
             if ((accountUuids != null) && (accountUuids.length() != 0)) {
                 String[] uuids = accountUuids.split(",");
                 for (String uuid : uuids) {
-                    Account newAccount = new Account(uuid);
+                    Account newAccount = new Account(uuid, imei);
                     accountPreferenceSerializer.loadAccount(newAccount, storage);
                     accounts.put(uuid, newAccount);
                     accountsInOrder.add(newAccount);
@@ -169,8 +170,9 @@ public class Preferences {
 
     public Account newAccount() {
         synchronized (accountLock) {
+            String imei = getStorage().getString("imei", null);
             String accountUuid = UUID.randomUUID().toString();
-            newAccount = new Account(accountUuid);
+            newAccount = new Account(accountUuid, imei);
             accountPreferenceSerializer.loadDefaults(newAccount);
             accounts.put(newAccount.getUuid(), newAccount);
             accountsInOrder.add(newAccount);

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerPushReceiver.java
@@ -90,6 +90,11 @@ public class MessagingControllerPushReceiver implements PushReceiver {
         controller.handleAuthenticationFailure(account, true);
     }
 
+    @Override
+    public void ClientIDFailure() {
+        controller.handleClientIDFailure(account, true);
+    }
+
     public String getPushState(String folderServerId) {
         LocalFolder localFolder = null;
         try {

--- a/app/core/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotifications.java
+++ b/app/core/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotifications.java
@@ -65,4 +65,31 @@ class AuthenticationErrorNotifications {
     private NotificationManagerCompat getNotificationManager() {
         return notificationHelper.getNotificationManager();
     }
+
+    public void showClientIDErrorNotification(Account account, boolean incoming) {
+        int notificationId = NotificationIds.getAuthenticationErrorNotificationId(account, incoming);
+
+        PendingIntent editServerSettingsPendingIntent = createContentIntent(account, incoming);
+        String title = resourceProvider.clientIDErrorTitle();
+        String text = resourceProvider.clientIDErrorBody();
+
+        NotificationCompat.Builder builder = notificationHelper
+                .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
+                .setSmallIcon(resourceProvider.getIconWarning())
+                .setWhen(System.currentTimeMillis())
+                .setAutoCancel(true)
+                .setTicker(title)
+                .setContentTitle(title)
+                .setContentText(text)
+                .setContentIntent(editServerSettingsPendingIntent)
+                .setStyle(new BigTextStyle().bigText(text))
+                .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+                .setCategory(NotificationCompat.CATEGORY_ERROR);
+
+        notificationHelper.configureNotification(builder, null, null,
+                NOTIFICATION_LED_FAILURE_COLOR,
+                NOTIFICATION_LED_BLINK_FAST, true);
+
+        getNotificationManager().notify(notificationId, builder.build());
+    }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationController.java
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationController.java
@@ -87,4 +87,8 @@ public class NotificationController {
     public void clearNewMailNotifications(Account account) {
         newMailNotifications.clearNewMailNotifications(account);
     }
+
+    public void showClientIDErrorNotification(Account account, boolean incoming) {
+        authenticationErrorNotifications.showClientIDErrorNotification(account, incoming);
+    }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationResourceProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationResourceProvider.kt
@@ -22,6 +22,8 @@ interface NotificationResourceProvider {
     fun authenticationErrorTitle(): String
     fun authenticationErrorBody(accountName: String): String
 
+    fun clientIDErrorBody(): String
+
     fun certificateErrorTitle(accountName: String): String
     fun certificateErrorBody(): String
 
@@ -34,6 +36,7 @@ interface NotificationResourceProvider {
     fun recipientDisplayName(recipientDisplayName: String): String
     fun noSender(): String
 
+    fun sendFailedClientIDTitle() : String
     fun sendFailedTitle(): String
     fun sendingMailTitle(): String
     fun sendingMailBody(accountName: String): String
@@ -50,4 +53,5 @@ interface NotificationResourceProvider {
     fun actionArchive(): String
     fun actionArchiveAll(): String
     fun actionMarkAsSpam(): String
+    fun clientIDErrorTitle(): String
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotifications.java
+++ b/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotifications.java
@@ -7,6 +7,7 @@ import androidx.core.app.NotificationManagerCompat;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.helper.ExceptionHelper;
+import com.fsck.k9.mail.MessagingException;
 
 import static com.fsck.k9.notification.NotificationHelper.NOTIFICATION_LED_BLINK_FAST;
 import static com.fsck.k9.notification.NotificationHelper.NOTIFICATION_LED_FAILURE_COLOR;
@@ -27,6 +28,11 @@ class SendFailedNotifications {
 
     public void showSendFailedNotification(Account account, Exception exception) {
         String title = resourceProvider.sendFailedTitle();
+
+        if (exception instanceof MessagingException && ((MessagingException) exception).isClientIDFailure()) {
+            title = resourceProvider.sendFailedClientIDTitle();
+        }
+
         String text = ExceptionHelper.getRootCauseMessage(exception);
 
         int notificationId = NotificationIds.getSendFailedNotificationId(account);
@@ -42,6 +48,7 @@ class SendFailedNotifications {
                 .setContentTitle(title)
                 .setContentText(text)
                 .setContentIntent(folderListPendingIntent)
+                .setStyle(new NotificationCompat.BigTextStyle().bigText(text))
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setCategory(NotificationCompat.CATEGORY_ERROR);
 

--- a/app/core/src/test/java/com/fsck/k9/notification/TestNotificationResourceProvider.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/TestNotificationResourceProvider.kt
@@ -19,6 +19,12 @@ class TestNotificationResourceProvider : NotificationResourceProvider {
     override val miscellaneousChannelName = "Miscellaneous"
     override val miscellaneousChannelDescription = "Miscellaneous notifications like errors etc."
 
+    override fun clientIDErrorBody(): String  = "An error has occured while sending the IMAP command (CLIENTID)"
+
+    override fun sendFailedClientIDTitle(): String = "An error has occured while sending the SMTP command (CLIENTID)"
+
+    override fun clientIDErrorTitle(): String = "IMAP Connection Failure"
+
     override fun authenticationErrorTitle(): String = "Authentication failed"
 
     override fun authenticationErrorBody(accountName: String): String =

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -37,6 +37,9 @@ class ImapBackendFactory(
     private fun createImapStore(account: Account): ImapStore {
         val oAuth2TokenProvider: OAuth2TokenProvider? = null
         val serverSettings = ImapStoreUriDecoder.decode(account.storeUri)
+        serverSettings.setAccountUuid(account.uuid)
+        serverSettings.setImei(account.imei)
+
         return ImapStore(
                 serverSettings,
                 account,
@@ -49,6 +52,8 @@ class ImapBackendFactory(
     private fun createSmtpTransport(account: Account): SmtpTransport {
         val serverSettings = decodeTransportUri(account.transportUri)
         val oauth2TokenProvider: OAuth2TokenProvider? = null
+        serverSettings.setAccountUuid(account.uuid)
+        serverSettings.setImei(account.imei)
         return SmtpTransport(serverSettings, trustedSocketFactory, oauth2TokenProvider)
     }
 

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
@@ -32,6 +32,10 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override fun authenticationErrorBody(accountName: String): String =
             context.getString(R.string.notification_authentication_error_text, accountName)
 
+    override fun clientIDErrorBody(): String = context.getString(R.string.notification_clientID_error_text)
+
+    override fun clientIDErrorTitle(): String = context.getString(R.string.notification_clientID_error_title)
+
     override fun certificateErrorTitle(accountName: String): String =
             context.getString(R.string.notification_certificate_error_title, accountName)
 
@@ -59,6 +63,8 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override fun noSender(): String = context.getString(R.string.general_no_sender)
 
     override fun sendFailedTitle(): String = context.getString(R.string.send_failure_subject)
+
+    override fun sendFailedClientIDTitle(): String = context.getString(R.string.send_failure_clientID)
 
     override fun sendingMailTitle(): String = context.getString(R.string.notification_bg_send_title)
 

--- a/app/ui/src/main/AndroidManifest.xml
+++ b/app/ui/src/main/AndroidManifest.xml
@@ -1,2 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.fsck.k9.ui" />
+<manifest package="com.fsck.k9.ui"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:installLocation="auto">
+    <uses-permission android:name="android.permission.READ_PHONE_STATE"/>
+</manifest>

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -440,15 +440,27 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
 
             } catch (AuthenticationFailedException afe) {
                 Timber.e(afe, "Error while testing settings");
+
+                String message = afe.getMessage() == null ? "" : afe.getMessage();
+                int dialogStringInt = R.string.account_setup_failed_dlg_auth_message_fmt;
+
+                if (afe.isClientIDFailure()) {
+                    dialogStringInt = R.string.account_setup_failed_dlg_clientID_IMAP_message_fmt;
+                }
+
                 showErrorDialog(
-                        R.string.account_setup_failed_dlg_auth_message_fmt,
-                        afe.getMessage() == null ? "" : afe.getMessage());
+                        dialogStringInt,
+                        message);
             } catch (CertificateValidationException cve) {
                 handleCertificateValidationException(cve);
             } catch (Exception e) {
                 Timber.e(e, "Error while testing settings");
                 String message = e.getMessage() == null ? "" : e.getMessage();
-                showErrorDialog(R.string.account_setup_failed_dlg_server_message_fmt, message);
+                int dialogStringInt = R.string.account_setup_failed_dlg_server_message_fmt;
+                if (((MessagingException) e).isClientIDFailure()) {
+                    dialogStringInt = R.string.account_setup_failed_dlg_clientID_SMTP_message_fmt;
+                }
+                showErrorDialog(dialogStringInt, message);
             }
             return null;
         }

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/WelcomeMessage.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/WelcomeMessage.java
@@ -1,17 +1,29 @@
 package com.fsck.k9.activity.setup;
 
+import android.Manifest;
+import android.app.Activity;
+import android.app.AlertDialog;
 import android.content.Context;
+import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.pm.PackageManager;
 import android.os.Bundle;
+import android.telephony.TelephonyManager;
 import android.text.method.LinkMovementMethod;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.TextView;
 
+import com.fsck.k9.Preferences;
+import com.fsck.k9.preferences.StorageEditor;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.activity.Accounts;
 import com.fsck.k9.activity.K9Activity;
 import com.fsck.k9.message.html.HtmlConverter;
+
+import androidx.annotation.NonNull;
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
 
 /**
  * Displays a welcome message when no accounts have been created yet.
@@ -35,6 +47,7 @@ public class WelcomeMessage extends K9Activity implements OnClickListener{
 
         findViewById(R.id.next).setOnClickListener(this);
         findViewById(R.id.import_settings).setOnClickListener(this);
+        checkPhoneStatePermission();
     }
 
     @Override
@@ -48,4 +61,46 @@ public class WelcomeMessage extends K9Activity implements OnClickListener{
             finish();
         }
     }
+
+    private boolean hasReadPhoneStatePermission() {
+        return ContextCompat.checkSelfPermission(this.getApplicationContext(),
+                Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED;
+    }
+
+    private void checkPhoneStatePermission() {
+        if (!hasReadPhoneStatePermission()) {
+            AlertDialog.Builder alertBuilder = new AlertDialog.Builder(this);
+            alertBuilder.setCancelable(true);
+            alertBuilder.setTitle(getString(R.string.clientID_security_request_title));
+            alertBuilder.setMessage(getString(R.string.clientID_security_request_details_message));
+            final Activity thisActivity = this;
+            alertBuilder.setPositiveButton(android.R.string.yes, new DialogInterface.OnClickListener() {
+                public void onClick(DialogInterface dialog, int which) {
+                    ActivityCompat.requestPermissions(thisActivity, new String[]{Manifest.permission.READ_PHONE_STATE}, 2);
+                }
+            });
+            alertBuilder.setNegativeButton(android.R.string.no, null);
+            AlertDialog alert = alertBuilder.create();
+            alert.show();
+        } else {
+            addImei();
+        }
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, @NonNull
+                                           String[] permissions, @NonNull int[] grantResults) {
+        if (hasReadPhoneStatePermission()) {
+           addImei();
+        }
+    }
+
+    private void addImei() {
+        Preferences newPreference = Preferences.getPreferences(this);
+        TelephonyManager telephonyManager = (TelephonyManager) getApplicationContext().getSystemService(TELEPHONY_SERVICE);
+        String imei = telephonyManager.getDeviceId();
+        StorageEditor editor = newPreference.createStorageEditor();
+        editor.putString("imei", imei).commit();
+    }
+
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -145,6 +145,8 @@ class AccountSettingsDataStore(
             "account_remote_search_num_results" -> account.remoteSearchNumResults.toString()
             "local_storage_provider" -> account.localStorageProviderId
             "account_ringtone" -> account.notificationSetting.ringtone
+            "clientID_value" -> account.clientID
+            "clientID_type" -> account.clientIDType
             else -> defValue
         }
     }

--- a/app/ui/src/main/res/values-es/strings.xml
+++ b/app/ui/src/main/res/values-es/strings.xml
@@ -479,6 +479,9 @@ Por favor informe de fallos, aporte nueva funcionalidad o envíe sus preguntas a
   <string name="account_settings_crypto_key">Configurar clave de extremo a extremo</string>
   <string name="account_settings_crypto_summary_off">Sin aplicación OpenPGP configurada</string>
   <string name="account_settings_crypto_summary_on">Conectado a %s</string>
+  <string name="account_settings_clientID_title">Identificación del cliente</string>
+  <string name="account_settings_clientID_type">Tipo de identificación del cliente</string>
+  <string name="account_settings_clientID_value">Valor de identificación del cliente</string>
   <string name="account_settings_no_openpgp_provider_configured">No hay aplicación de OpenPGP configurada</string>
   <string name="account_settings_no_openpgp_provider_installed">Aplicación OpenPGP no encontrada - Pulsar para instalar</string>
   <string name="account_settings_mail_check_frequency_label">Frecuencia de comprobación</string>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -35,6 +35,7 @@ K-9 Mail is a powerful free email client for Android.
 Its improved features include:
 </p>
 <ul>
+  <li>Client ID Security</i>
   <li>Push mail using IMAP IDLE</li>
   <li>Better performance</li>
   <li>Message refiling</li>
@@ -225,6 +226,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="notification_certificate_error_title">Certificate error for <xliff:g id="account">%s</xliff:g></string>
     <string name="notification_certificate_error_text">Check your server settings</string>
 
+    <string name="notification_clientID_error_title">IMAP Connection Failure</string>
+    <string name="notification_clientID_error_text">An error has occurred while sending the IMAP command (CLIENTID)</string>
     <string name="notification_authentication_error_title">Authentication failed</string>
     <string name="notification_authentication_error_text">Authentication failed for <xliff:g id="account">%s</xliff:g>. Update your server settings.</string>
 
@@ -254,6 +257,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="special_mailbox_name_spam_fmt"><xliff:g id="folder">%s</xliff:g> (Spam)</string>
 
     <string name="send_failure_subject">Failed to send some messages</string>
+    <string name="send_failure_clientID">SMTP Connection Failure</string>
 
     <string name="version">Version</string>
     <string name="debug_enable_debug_logging_title">Enable debug logging</string>
@@ -604,6 +608,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_crypto_encrypt_all_drafts">Store all drafts encrypted</string>
     <string name="account_settings_crypto_encrypt_all_drafts_on">All drafts will be stored encrypted</string>
     <string name="account_settings_crypto_encrypt_all_drafts_off">Encrypt drafts only if encryption is enabled</string>
+    <string name="account_settings_clientID_title">Client ID</string>
+    <string name="account_settings_clientID_type">Your Client ID Type: </string>
+    <string name="account_settings_clientID_value">Your Client ID Value: </string>
 
     <string name="account_settings_mail_check_frequency_label">Folder poll frequency</string>
 
@@ -1346,4 +1353,8 @@ You can keep this message and use it as a backup for your secret key. If you wan
     <!-- permissions -->
     <string name="permission_contacts_rationale_title">Allow access to contacts</string>
     <string name="permission_contacts_rationale_message">To be able to provide contact suggestions and to display contact names and photos, the app needs access to your contacts.</string>
+    <string name="account_setup_failed_dlg_clientID_IMAP_message_fmt">\An error occurred while sending the IMAP command.\n(<xliff:g id="error">%s</xliff:g>)</string>
+    <string name="account_setup_failed_dlg_clientID_SMTP_message_fmt">\An error occurred while sending the SMTP command.\n(<xliff:g id="error">%s</xliff:g>)</string>
+    <string name="clientID_security_request_title">K9 Mail Is Requesting Additional Security Features</string>
+    <string name="clientID_security_request_details_message">Your phone\'s IMEI will be used for CLIENT ID security only</string>
 </resources>

--- a/app/ui/src/main/res/xml/account_settings.xml
+++ b/app/ui/src/main/res/xml/account_settings.xml
@@ -477,4 +477,21 @@
 
     </PreferenceScreen>
 
+    <PreferenceScreen
+        android:icon="?attr/iconPreferencesPrivacy"
+        android:key="clientID"
+        android:title="@string/account_settings_clientID_title">
+
+        <com.takisoft.preferencex.AutoSummaryEditTextPreference
+            android:editable="false"
+            android:key="clientID_type"
+            android:title="@string/account_settings_clientID_type" />
+
+        <com.takisoft.preferencex.AutoSummaryEditTextPreference
+            android:editable="false"
+            android:key="clientID_value"
+            android:title="@string/account_settings_clientID_value" />
+
+    </PreferenceScreen>
+
 </PreferenceScreen>

--- a/mail/common/src/main/java/com/fsck/k9/mail/MessagingException.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/MessagingException.java
@@ -5,6 +5,7 @@ public class MessagingException extends Exception {
     public static final long serialVersionUID = -1;
 
     private boolean permanentFailure = false;
+    private boolean ClientIDFailure = false;
 
     public MessagingException(String message) {
         super(message);
@@ -26,6 +27,14 @@ public class MessagingException extends Exception {
 
     public boolean isPermanentFailure() {
         return permanentFailure;
+    }
+
+    public boolean isClientIDFailure() {
+        return ClientIDFailure;
+    }
+
+    public void setClientIDFailure(boolean ClientIDfailure) {
+        this.ClientIDFailure = ClientIDfailure;
     }
 
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/PushReceiver.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/PushReceiver.java
@@ -16,4 +16,5 @@ public interface PushReceiver {
     void authenticationFailed();
     void setPushActive(String folderServerId, boolean enabled);
     void sleep(WakeLock wakeLock, long millis);
+    void ClientIDFailure();
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/ServerSettings.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/ServerSettings.java
@@ -71,6 +71,8 @@ public class ServerSettings {
      */
     private final Map<String, String> extra;
 
+    private String accountUuid;
+    private String imei;
 
     /**
      * Creates a new {@code ServerSettings} object.
@@ -162,6 +164,14 @@ public class ServerSettings {
         extra = null;
     }
 
+    public void setAccountUuid(String accountUuid) {
+        this.accountUuid = accountUuid;
+    }
+
+    public void setImei(String imei) {
+        this.imei = imei;
+    }
+
     /**
      * Returns store- or transport-specific settings as key/value pair.
      *
@@ -214,5 +224,13 @@ public class ServerSettings {
                 (password == null ? that.password == null : password.equals(that.password)) &&
                 (clientCertificateAlias == null ? that.clientCertificateAlias == null :
                         clientCertificateAlias.equals(that.clientCertificateAlias));
+    }
+
+    public String getAccountUuid() {
+        return this.accountUuid;
+    }
+
+    public String getImei() {
+        return this.imei;
     }
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
@@ -16,4 +16,5 @@ class Capabilities {
     public static final String SPECIAL_USE = "SPECIAL-USE";
     public static final String UID_PLUS = "UIDPLUS";
     public static final String LIST_EXTENDED = "LIST-EXTENDED";
+    public static final String CLIENT_ID = "CLIENTID";
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderPusher.java
@@ -193,7 +193,11 @@ class ImapFolderPusher extends ImapFolder {
                         Timber.e(e, "Authentication failed. Stopping ImapFolderPusher.");
                     }
 
-                    pushReceiver.authenticationFailed();
+                    if (e.isClientIDFailure()) {
+                        pushReceiver.ClientIDFailure();
+                    } else {
+                        pushReceiver.authenticationFailed();
+                    }
                     stop = true;
                 } catch (CertificateValidationException e) {
                     reacquireWakeLockAndCleanUp();

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapSettings.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapSettings.java
@@ -35,4 +35,8 @@ interface ImapSettings {
     String getCombinedPrefix();
 
     void setCombinedPrefix(String prefix);
+
+    String getAccountUuid();
+
+    String getImei();
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -40,6 +40,8 @@ public class ImapStore extends RemoteStore {
     private ConnectivityManager connectivityManager;
     private OAuth2TokenProvider oauthTokenProvider;
 
+    private String imei;
+    private String accountUuid;
     private String host;
     private int port;
     private String username;
@@ -67,6 +69,8 @@ public class ImapStore extends RemoteStore {
             OAuth2TokenProvider oauthTokenProvider) {
         super(storeConfig, trustedSocketFactory);
 
+        imei = serverSettings.getImei();
+        accountUuid = serverSettings.getAccountUuid();
         host = serverSettings.host;
         port = serverSettings.port;
 
@@ -426,6 +430,16 @@ public class ImapStore extends RemoteStore {
         @Override
         public void setCombinedPrefix(String prefix) {
             combinedPrefix = prefix;
+        }
+
+        @Override
+        public String getAccountUuid() {
+            return accountUuid;
+        }
+
+        @Override
+        public String getImei() {
+            return imei;
         }
     }
 }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/SimpleImapSettings.java
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/SimpleImapSettings.java
@@ -17,6 +17,8 @@ class SimpleImapSettings implements ImapSettings {
     private String pathDelimiter;
     private String combinedPrefix;
     private boolean useCompression = false;
+    private String imei;
+    private String accountUuid;
 
 
     @Override
@@ -88,6 +90,12 @@ class SimpleImapSettings implements ImapSettings {
     public void setCombinedPrefix(String prefix) {
         combinedPrefix = prefix;
     }
+
+    @Override
+    public String getImei() { return imei; }
+
+    @Override
+    public String getAccountUuid() { return accountUuid; }
 
     void setHost(String host) {
         this.host = host;


### PR DESCRIPTION
--------
General:
--------

This patch introduces new "Client ID" security technology to K-9 mail. This technology allows for an extra layer of security surrounding a unique identifier sent as an IMAP or SMTP command.

Our intention is to allow K-9 mail to send client ID commands at the SmtpTransport and ImapConnection level. This will enable servers and domains that support client ID to apply to add support for users who use K-9 mail.

The RFCs for client ID in draft form can be found here:

* SMTP: https://tools.ietf.org/html/draft-storey-smtp-client-id-06

* IMAP: https://tools.ietf.org/html/draft-yu-imap-client-id-01#section-3.1

The two unique identifiers used in this implementation are the device imei and if this is not found (eg: tablet with no mobility SIM card) the accountUuid.

----------
Rationale:
----------

How we achieve Client ID integration:

1) Retrieve the unique identifiers and store them in the Account class as member variables

2) Enable access to the unique identifiers in the SmtpTransport and ImapConnection classes

3) Verify that the connection objects at the SmptTransport and ImapConnection have "CLIENTID" as a capability 

4) Send the "CLIENTID" command and handle any client ID specific errors that may result 

5) Display the client ID to users in Account Settings 

--------------
Summary Of Changes:
--------------

* Added a checkPhoneStatePermission() method which prompts the user to allow us to access their imei for client ID security purposes. 

	* This occurs only once on a fresh installation of the app (requires READ_PHONE_STATE permission)

	* If the user grants permission the imei is stored physically using the storageEditor class

	* If the user does not grant permission the imei is stored as null and the accountUuid is used instead

* Added an imei parameter to the Account constructor so our unique identifier can be stored inside each account
	
	* When we retrieve accounts on launching the app we now also retrieve their associated imei if it has been saved

* Added setters to the Preferences class to set the accountUuid and imei in ImapBackendFactory
	
	* This allows us to use the Account object to pass the imei and accountUuid to ImapConnection and SmtpFactory classes for use in commands

* Created method(s) to set and get client ID error flags in MessagingException for error handling
	
	* This allows us to have messages for client ID command specific failures in account setup, refreshing the mailbox, or sending a message
	* The original K-9 error messages will remain for all non client ID command failures

* Added checks to set and detect error flags for client ID commands in ImapConnection and SmtpTransport classes

* Added push notifications / dialogs with client ID specific error messages triggered by these error flags

* Added capability / extensions / and secureConnection checks to ensure we only send client ID commands when advertised by the server

* Added a client ID page to view details (not editable) in Account Settings

--------------
Checks:
--------------

* follows existing codestyle (x)
* passes all JUnit tests (x)

--------------
UI Changes:
--------------
Below is the added menu option for viewing client ID in account settings:

![Client_ID_Account_Settings](https://user-images.githubusercontent.com/48767176/56249067-42c6df80-605f-11e9-9b43-c1def754562f.png)


Below is the client ID details page which allows users to view their current client ID value if it is stored:

![Client_ID_Details](https://user-images.githubusercontent.com/48767176/56249068-42c6df80-605f-11e9-8c7f-6d9f2e85205b.png)
