### PR TITLE
K9Drawer.kt: Declare parameter of selectFolder as nullable

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -265,7 +265,7 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) {
         userFolderDrawerIds.clear()
     }
 
-    fun selectFolder(folderServerId: String) {
+    fun selectFolder(folderServerId: String?) {
         unifiedInboxSelected = false
         openedFolderServerId = folderServerId
         for (drawerId in userFolderDrawerIds) {


### PR DESCRIPTION
Fixes the "IllegalArgumentException: Parameter specified as non-null is
null" exception at com.fsck.k9.activity.MessageList.configureDrawer()
(app/ui/src/main/java/com/fsck/k9/activity/MessageList.java:1667)

The reason is that Kotlin assumes the parameters as non-nullable unless
the safe call modifier (?) or explicit null-check modifier (!!) is
appended to parameter definition:

https://stackoverflow.com/questions/44885783/illegalargumentexception-
parameter-specified-as-non-null-is-null

Signed-off-by: Vasyl Gello <vasek.gello@gmail.com>

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


