### PR TITLE
Fix OpenPGP provider on-off switch

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -10,6 +10,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.widget.Toast
 import com.fsck.k9.Account
+import com.fsck.k9.Preferences
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.ui.R
 import com.fsck.k9.activity.ManageIdentities
@@ -199,11 +200,11 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
 
     private fun initializeCryptoSettings(account: Account) {
         findPreference(PREFERENCE_OPENPGP)?.let {
-            configureCryptoPreferences(account)
+            configureCryptoPreferences(account, false)
         }
     }
 
-    private fun configureCryptoPreferences(account: Account) {
+    private fun configureCryptoPreferences(account: Account, needSave: Boolean) {
         var pgpProviderName: String? = null
         var pgpProvider = account.openPgpProvider
         val isPgpConfigured = pgpProvider != null
@@ -221,6 +222,11 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         configureEnablePgpSupport(account, isPgpConfigured, pgpProviderName)
         configurePgpKey(account, pgpProvider)
         configureAutocryptTransfer(account)
+
+        if (needSave) {
+            val context = requireContext().applicationContext
+            Preferences.getPreferences(context).saveAccount(account);
+        }
     }
 
     private fun getOpenPgpProviderName(pgpProvider: String?): String? {
@@ -238,7 +244,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
                     val openPgpProviderPackages = OpenPgpProviderUtil.getOpenPgpProviderPackages(context)
                     if (openPgpProviderPackages.size == 1) {
                         account.openPgpProvider = openPgpProviderPackages[0]
-                        configureCryptoPreferences(account)
+                        configureCryptoPreferences(account, true)
                     } else {
                         summary = getString(R.string.account_settings_crypto_summary_config)
                         OpenPgpAppSelectDialog.startOpenPgpChooserActivity(requireActivity(), account)
@@ -250,7 +256,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
                 oneTimeClickListener {
                     account.openPgpProvider = null
                     account.openPgpKey = Account.NO_OPENPGP_KEY
-                    configureCryptoPreferences(account)
+                    configureCryptoPreferences(account, true)
                 }
             }
         }

--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpKeyPreference.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/util/OpenPgpKeyPreference.java
@@ -136,7 +136,9 @@ public class OpenPgpKeyPreference extends Preference implements OpenPgpApiManage
         data.putExtra(OpenPgpApi.EXTRA_PRESELECT_KEY_ID, keyId);
         data.putExtra(OpenPgpApi.EXTRA_SHOW_AUTOCRYPT_HINT, showAutocryptHint);
         OpenPgpApi api = openPgpApiManager.getOpenPgpApi();
-        api.executeApiAsync(data, null, null, openPgpCallback);
+        if (api != null) {
+            api.executeApiAsync(data, null, null, openPgpCallback);
+        }
     }
 
     private IOpenPgpCallback openPgpCallback = new IOpenPgpCallback() {


### PR DESCRIPTION
The first patch fixes the crash if the end-user switches off the OpenPGP provider toggle in
Account settings - End-to-End Encryption.

Steps to reproduce:

1. Open Account Settings - End-to-end encryption
2. Switch off the OpenPGP support toggle
3. Press Back button to quit from Encryption Settings
4. Experience app crash

The second patch fixes the persistence of openPgpProvider preference.

The appropriate code saves the preference to database only in
OpenPgpAppSelectDialog, but the value changed by settings pane switch
is not stored.

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


