### PR TITLE
Design message list

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapConfig.kt
+++ b/app/ui/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapConfig.kt
@@ -8,11 +8,12 @@ import com.fsck.k9.activity.K9ActivityCommon
 import com.fsck.k9.ui.R
 
 class ContactLetterBitmapConfig(context: Context) {
-    val hasDefaultBackgroundColor: Boolean = !K9.isColorizeMissingContactPictures
+    val hasDefaultColor: Boolean = !K9.isColorizeMissingContactPictures
     val defaultBackgroundColor: Int
+    val defaultForegroundColor: Int
 
     init {
-        defaultBackgroundColor = if (hasDefaultBackgroundColor) {
+        defaultBackgroundColor = if (hasDefaultColor) {
             val outValue = TypedValue()
             val themedContext = ContextThemeWrapper(context, K9ActivityCommon.getK9ThemeResourceId())
             themedContext.theme.resolveAttribute(R.attr.contactPictureFallbackDefaultBackgroundColor, outValue, true)
@@ -20,5 +21,6 @@ class ContactLetterBitmapConfig(context: Context) {
         } else {
             0
         }
+        defaultForegroundColor = 0xffffff
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapCreator.kt
+++ b/app/ui/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapCreator.kt
@@ -1,9 +1,7 @@
 package com.fsck.k9.contacts
 
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.Rect
+import android.graphics.*
+
 import com.fsck.k9.mail.Address
 
 /**
@@ -16,15 +14,17 @@ class ContactLetterBitmapCreator(
     fun drawBitmap(bitmap: Bitmap, pictureSizeInPx: Int, address: Address): Bitmap {
         val canvas = Canvas(bitmap)
 
-        val backgroundColor = calcUnknownContactColor(address)
+        val backgroundColor = calcUnknownContactBackgroundColor(address)
         bitmap.eraseColor(backgroundColor)
+
+        val foregroundColor = calcUnknownContactForegroundColor(address)
 
         val letter = letterExtractor.extractContactLetter(address)
 
         val paint = Paint().apply {
             isAntiAlias = true
             style = Paint.Style.FILL
-            setARGB(255, 255, 255, 255)
+            color = foregroundColor
             textSize = (pictureSizeInPx * 3 / 4).toFloat() // just scale this down a bit
         }
 
@@ -39,8 +39,8 @@ class ContactLetterBitmapCreator(
         return bitmap
     }
 
-    private fun calcUnknownContactColor(address: Address): Int {
-        if (config.hasDefaultBackgroundColor) {
+    private fun calcUnknownContactBackgroundColor(address: Address): Int {
+        if (config.hasDefaultColor) {
             return config.defaultBackgroundColor
         }
 
@@ -49,18 +49,31 @@ class ContactLetterBitmapCreator(
         return BACKGROUND_COLORS[colorIndex]
     }
 
+    private fun calcUnknownContactForegroundColor(address: Address): Int {
+        if (config.hasDefaultColor) {
+           return config.defaultForegroundColor
+        }
+
+        val hash = address.hashCode()
+        val colorIndex = (hash and Integer.MAX_VALUE) % BACKGROUND_COLORS.size
+        return FOREGROUND_COLORS[colorIndex]
+    }
+
     companion object {
         private val BACKGROUND_COLORS = intArrayOf(
-                0xff33B5E5L.toInt(),
-                0xffAA66CCL.toInt(),
-                0xff99CC00L.toInt(),
-                0xffFFBB33L.toInt(),
-                0xffFF4444L.toInt(),
-                0xff0099CCL.toInt(),
-                0xff9933CCL.toInt(),
-                0xff669900L.toInt(),
-                0xffFF8800L.toInt(),
-                0xffCC0000L.toInt()
+                0xffb3e5fcL.toInt(),
+                0xffc8e6c9L.toInt(),
+                0xffd1c4e9L.toInt(),
+                0xfffdefbaL.toInt(),
+                0xffffccbcL.toInt()
         )
+        private val FOREGROUND_COLORS = intArrayOf(
+                0xff86acd7L.toInt(),
+                0xff9eb7a3L.toInt(),
+                0xffa191cfL.toInt(),
+                0xffecbe8cL.toInt(),
+                0xffcb9f92L.toInt()
+        )
+
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/contacts/ContactPictureLoader.kt
+++ b/app/ui/src/main/java/com/fsck/k9/contacts/ContactPictureLoader.kt
@@ -38,7 +38,7 @@ class ContactPictureLoader(
     private val contactsHelper: Contacts = Contacts.getInstance(context)
     private val pictureSizeInPx: Int = PICTURE_SIZE.toDip(context)
     private val backgroundCacheId: String = with(contactLetterBitmapCreator.config) {
-        if (hasDefaultBackgroundColor) defaultBackgroundColor.toString() else "*"
+        if (hasDefaultColor) defaultBackgroundColor.toString() else "*"
     }
 
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
@@ -53,8 +53,7 @@ public class MessageListAdapter extends CursorAdapter {
     private int previewTextColor;
     private int activeItemBackgroundColor;
     private int selectedItemBackgroundColor;
-    private int readItemBackgroundColor;
-    private int unreadItemBackgroundColor;
+    private int unselectedItemBackgroundColor;
     private FontSizes fontSizes = K9.getFontSizes();
 
     MessageListAdapter(MessageListFragment fragment) {
@@ -68,8 +67,7 @@ public class MessageListAdapter extends CursorAdapter {
                 R.attr.messageListPreviewTextColor,
                 R.attr.messageListActiveItemBackgroundColor,
                 R.attr.messageListSelectedBackgroundColor,
-                R.attr.messageListReadItemBackgroundColor,
-                R.attr.messageListUnreadItemBackgroundColor
+                R.attr.messageListItemBackgroundColor,
         };
 
         Theme theme = fragment.requireActivity().getTheme();
@@ -82,8 +80,7 @@ public class MessageListAdapter extends CursorAdapter {
         previewTextColor = array.getColor(3, Color.BLACK);
         activeItemBackgroundColor = array.getColor(4, Color.BLACK);
         selectedItemBackgroundColor = array.getColor(5, Color.BLACK);
-        readItemBackgroundColor = array.getColor(6, Color.BLACK);
-        unreadItemBackgroundColor = array.getColor(7, Color.BLACK);
+        unselectedItemBackgroundColor = array.getColor(6, Color.BLACK);
 
         array.recycle();
     }
@@ -215,7 +212,7 @@ public class MessageListAdapter extends CursorAdapter {
         if (holder.contactBadge != null) {
             updateContactBadge(holder, counterpartyAddress);
         }
-        setBackgroundColor(view, selected, read);
+        setBackgroundColor(view, selected);
         if (fragment.activeMessage != null) {
             changeBackgroundColorIfActiveMessage(cursor, account, view);
         }
@@ -327,15 +324,13 @@ public class MessageListAdapter extends CursorAdapter {
         return null;
     }
 
-    private void setBackgroundColor(View view, boolean selected, boolean read) {
+    private void setBackgroundColor(View view, boolean selected) {
         if (selected || K9.isUseBackgroundAsUnreadIndicator()) {
             int color;
             if (selected) {
                 color = selectedItemBackgroundColor;
-            } else if (read) {
-                color = readItemBackgroundColor;
-            } else {
-                color = unreadItemBackgroundColor;
+            }  else {
+                color = unselectedItemBackgroundColor;
             }
 
             view.setBackgroundColor(color);

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -737,6 +737,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         listView.setFastScrollEnabled(true);
         listView.setScrollingCacheEnabled(false);
         listView.setOnItemClickListener(this);
+        listView.setDividerHeight(0);
 
         registerForContextMenu(listView);
     }

--- a/app/ui/src/main/res/drawable/message_list_item_background.xml
+++ b/app/ui/src/main/res/drawable/message_list_item_background.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+        <item android:top="-2dp" android:right="-2dp" android:left="-2dp">
+            <shape>
+                <solid android:color="@android:color/transparent" />
+                <stroke
+                    android:width="1dp"
+                    android:color="?messageListDividerColor" />
+            </shape>
+        </item>
+</layer-list>
+

--- a/app/ui/src/main/res/layout/message_list_item.xml
+++ b/app/ui/src/main/res/layout/message_list_item.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:layout_width="match_parent"
-              android:layout_height="wrap_content"
-              android:orientation="horizontal"
-              android:layout_gravity="center_vertical"
-        >
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="horizontal"
+    android:layout_gravity="center_vertical">
 
     <View
             android:id="@+id/chip"
@@ -39,19 +39,25 @@
 
     </LinearLayout>
 
-    <com.fsck.k9.ui.ContactBadge
-            android:id="@+id/contact_badge"
-            android:layout_marginRight="8dip"
-            android:layout_marginTop="4dip"
-            android:layout_marginBottom="3dip"
-            android:layout_height="40dip"
-            android:layout_width="40dip"
-            android:layout_gravity="center_vertical"
-            android:layout_marginLeft="4dp"
-            android:src="@drawable/ic_contact_picture"
-            style="?android:attr/quickContactBadgeStyleWindowLarge"
-            android:background="@android:color/transparent"/>
 
+    <androidx.cardview.widget.CardView
+        android:layout_width="40dip"
+        android:layout_height="40dip"
+        android:layout_gravity="center_vertical"
+        android:layout_marginRight="12dip"
+        android:layout_marginTop="4dip"
+        android:layout_marginBottom="3dip"
+        android:layout_marginLeft="8dp"
+        app:cardElevation="0dp"
+        app:cardCornerRadius="20dip">
+        <com.fsck.k9.ui.ContactBadge
+                android:id="@+id/contact_badge"
+                android:layout_height="match_parent"
+                android:layout_width="match_parent"
+                android:src="@drawable/ic_contact_picture"
+                style="?android:attr/quickContactBadgeStyleWindowLarge"
+                android:background="@android:color/transparent"/>
+    </androidx.cardview.widget.CardView>
 
     <RelativeLayout
             android:id="@+id/list_item_inner"

--- a/app/ui/src/main/res/layout/message_list_item.xml
+++ b/app/ui/src/main/res/layout/message_list_item.xml
@@ -59,16 +59,18 @@
                 android:background="@android:color/transparent"/>
     </androidx.cardview.widget.CardView>
 
+
     <RelativeLayout
             android:id="@+id/list_item_inner"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingTop="5dip"
+            android:paddingTop="10dip"
             android:clickable="false"
             android:focusable="false"
             android:focusableInTouchMode="false"
             android:layout_gravity="center_vertical"
-            android:paddingBottom="6dp">
+            android:background="@drawable/message_list_item_background"
+            android:paddingBottom="13dip">
 
         <TextView
                 android:id="@+id/preview"
@@ -127,7 +129,7 @@
                     android:layout_marginLeft="1dip"
                     android:ellipsize="marquee"
                     android:singleLine="true"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
+                    android:textAppearance="?android:attr/textAppearanceMedium"
                     android:textColor="?android:attr/textColorPrimary"
                     />
 
@@ -200,6 +202,7 @@
 
 
     </RelativeLayout>
+
 
 
 </LinearLayout>

--- a/app/ui/src/main/res/layout/message_view_header.xml
+++ b/app/ui/src/main/res/layout/message_view_header.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
-<com.fsck.k9.view.MessageHeader
-    xmlns:android="http://schemas.android.com/apk/res/android"
+<com.fsck.k9.view.MessageHeader xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/header_container"
     android:layout_width="match_parent"
     android:orientation="vertical"
@@ -79,12 +79,19 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical" >
 
-                    <com.fsck.k9.ui.ContactBadge
-                        android:id="@+id/contact_badge"
-                        android:layout_width="40dp"
-                        android:layout_height="40dp"
+                    <androidx.cardview.widget.CardView
+                        android:layout_width="40dip"
+                        android:layout_height="40dip"
+                        android:layout_gravity="center_vertical"
                         android:layout_marginTop="8dp"
-                        android:layout_marginLeft="8dp" />
+                        android:layout_marginLeft="8dp"
+                        app:cardElevation="0dp"
+                        app:cardCornerRadius="20dip">
+                        <com.fsck.k9.ui.ContactBadge
+                            android:id="@+id/contact_badge"
+                            android:layout_width="match_parent"
+                            android:layout_height="match_parent" />
+                    </androidx.cardview.widget.CardView>
 
                     <!-- State icons -->
                     <LinearLayout

--- a/app/ui/src/main/res/values/attrs.xml
+++ b/app/ui/src/main/res/values/attrs.xml
@@ -69,8 +69,7 @@
         <attr name="textColorSecondaryRecipientDropdown" format="reference" />
         <attr name="backgroundColorChooseAccountHeader" format="color" />
         <attr name="messageListSelectedBackgroundColor" format="reference|color"/>
-        <attr name="messageListReadItemBackgroundColor" format="reference|color"/>
-        <attr name="messageListUnreadItemBackgroundColor" format="reference|color"/>
+        <attr name="messageListItemBackgroundColor" format="reference|color"/>
         <attr name="messageListThreadCountForegroundColor" format="reference|color"/>
         <attr name="messageListThreadCountBackground" format="reference|color"/>
         <attr name="messageListActiveItemBackgroundColor" format="reference|color"/>

--- a/app/ui/src/main/res/values/themes.xml
+++ b/app/ui/src/main/res/values/themes.xml
@@ -94,8 +94,7 @@
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_light</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_light</item>
         <item name="messageListSelectedBackgroundColor">#8038B8E2</item>
-        <item name="messageListReadItemBackgroundColor">#c0cdcdcd</item>
-        <item name="messageListUnreadItemBackgroundColor">#00ffffff</item>
+        <item name="messageListItemBackgroundColor">#00ffffff</item>
         <item name="messageListThreadCountForegroundColor">?android:attr/colorBackground</item>
         <item name="messageListThreadCountBackground">@drawable/thread_count_box_light</item>
         <item name="messageListActiveItemBackgroundColor">#ff2ea7d1</item>
@@ -213,8 +212,7 @@
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_dark</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_dark</item>
         <item name="messageListSelectedBackgroundColor">#8038B8E2</item>
-        <item name="messageListReadItemBackgroundColor">#00000000</item>
-        <item name="messageListUnreadItemBackgroundColor">#c05a5a5a</item>
+        <item name="messageListItemBackgroundColor">#00000000</item>
         <item name="messageListThreadCountForegroundColor">?android:attr/colorBackground</item>
         <item name="messageListThreadCountBackground">@drawable/thread_count_box_dark</item>
         <item name="messageListActiveItemBackgroundColor">#ff33b5e5</item>


### PR DESCRIPTION
Implements some of the changes suggested in #1859.

In particular it:

- Rounds corners on contact badges
- Changes placeholder contact badges colours
- Increases font size of subject line
- Removes different background colours for read and unread messages in the themes
- Adds a "half" bottom border

Hastily redacted screenshot:
![Untitled](https://user-images.githubusercontent.com/2918499/57221463-46fb7280-6ff7-11e9-8605-3c776805f5ca.png)
