### PR TITLE
Fix crash when disabling OpenPGP support in settings

### DIFF
--- a/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/OpenPgpApiManager.java
+++ b/plugins/openpgp-api-lib/openpgp-api/src/main/java/org/openintents/openpgp/OpenPgpApiManager.java
@@ -126,7 +126,9 @@ public class OpenPgpApiManager implements LifecycleObserver {
         getOpenPgpApi().executeApiAsync(intent, null, null, new IOpenPgpCallback() {
             @Override
             public void onReturn(Intent result) {
-                onPgpPermissionCheckResult(result);
+                if (openPgpProviderState != OpenPgpProviderState.UNCONFIGURED) {
+                    onPgpPermissionCheckResult(result);
+                }
             }
         });
     }


### PR DESCRIPTION
Based on @basilgello's work in PR #4030.

Steps to reproduce:
1. Open Account Settings - End-to-end encryption
2. Switch off the OpenPGP support toggle
3. Press Back button to quit from Encryption Settings
4. Experience app crash

