### PR TITLE
Properly persist OpenPGP provider settings

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -204,7 +204,7 @@ class AccountSettingsDataStore(
         saveSettingsInBackground()
     }
 
-    private fun saveSettingsInBackground() {
+    fun saveSettingsInBackground() {
         executorService.execute {
             saveSettings()
         }


### PR DESCRIPTION
Based on @basilgello's work in PR #4030.

- persist changes to `Account.openPgpProvider`
- make sure to always set `OpenPgpKeyPreference` to the current value of `Account.openPgpKey`; the value may have changed since the widget was initialized