### PR TITLE
Fix test in 'SmtpTransportTest'

### DIFF
--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
@@ -139,7 +139,7 @@ public class SmtpTransportTest {
             assertEquals("Authentication methods SASL PLAIN and LOGIN are unavailable.", e.getMessage());
         }
 
-        server.verifyConnectionStillOpen();
+        server.verifyConnectionClosed();
         server.verifyInteractionCompleted();
     }
 


### PR DESCRIPTION
We tested whether the connection was still open. But we should test whether the connection was closed. The test passed most of the time because closing a connection takes some time.

