### PR TITLE
* STAR to flag messages now uses the color of the respective account.

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
@@ -209,7 +209,11 @@ public class MessageListAdapter extends CursorAdapter {
             holder.selected.setChecked(selected);
         }
         if (fragment.stars) {
-            holder.flagged.setChecked(flagged);
+            final int iAttr = flagged ? R.attr.iconActionFlag : R.attr.iconActionUnflag;
+            final TypedArray attrArray = holder.flagged.getContext().getTheme().obtainStyledAttributes(new int[] { iAttr });
+            final int attributeResourceId = attrArray.getResourceId(0, 0);
+            holder.flagged.setImageResource(attributeResourceId);
+            attrArray.recycle();
         }
         holder.position = cursor.getPosition();
         if (holder.contactBadge != null) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageViewHolder.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageViewHolder.java
@@ -19,7 +19,7 @@ public class MessageViewHolder implements View.OnClickListener {
     public TextView date;
     public View chip;
     public TextView threadCount;
-    public CheckBox flagged;
+    public ImageView flagged;
     public CheckBox selected;
     public int position = -1;
     public ContactBadge contactBadge;

--- a/app/ui/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/app/ui/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Set;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.Typeface;
 import android.os.Parcel;
 import android.os.Parcelable;
@@ -24,7 +25,6 @@ import android.view.Gravity;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnLongClickListener;
-import android.widget.CheckBox;
 import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
@@ -63,7 +63,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
     private ImageView mCryptoStatusIcon;
 
     private View mChip;
-    private CheckBox mFlagged;
+    private ImageView mFlagged;
     private int defaultSubjectColor;
     private TextView mAdditionalHeadersView;
     private View singleMessageOptionIcon;
@@ -334,7 +334,12 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         updateAddressField(mBccView, bcc, mBccLabel);
         mAnsweredIcon.setVisibility(message.isSet(Flag.ANSWERED) ? View.VISIBLE : View.GONE);
         mForwardedIcon.setVisibility(message.isSet(Flag.FORWARDED) ? View.VISIBLE : View.GONE);
-        mFlagged.setChecked(message.isSet(Flag.FLAGGED));
+
+        final int iAttr = message.isSet(Flag.FLAGGED) ? R.attr.iconActionFlag : R.attr.iconActionUnflag;
+        final TypedArray attrArray = mFlagged.getContext().getTheme().obtainStyledAttributes(new int[] { iAttr });
+        final int attributeResourceId = attrArray.getResourceId(0, 0);
+        mFlagged.setImageResource(attributeResourceId);
+        attrArray.recycle();
 
         mChip.setBackgroundColor(mAccount.getChipColor());
 

--- a/app/ui/src/main/res/layout/message_list_item.xml
+++ b/app/ui/src/main/res/layout/message_list_item.xml
@@ -140,11 +140,10 @@
                     />
         </LinearLayout>
 
-        <CheckBox
+        <ImageView
                 android:id="@+id/flagged_center_right"
-                style="?android:attr/starStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
+                android:layout_width="@dimen/flagged_icon_size"
+                android:layout_height="@dimen/flagged_icon_size"
                 android:layout_alignParentRight="true"
                 android:layout_centerVertical="true"
                 android:paddingTop="3dip"
@@ -178,11 +177,10 @@
                 android:textAppearance="?android:attr/textAppearanceSmall"
                 android:textColor="?android:attr/textColorSecondary"/>
 
-        <CheckBox
+        <ImageView
                 android:id="@+id/flagged_bottom_right"
-                style="?android:attr/starStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="fill_parent"
+                android:layout_width="@dimen/flagged_icon_size"
+                android:layout_height="@dimen/flagged_icon_size"
                 android:layout_below="@+id/date"
                 android:layout_alignParentRight="true"
                 android:paddingTop="5dip"

--- a/app/ui/src/main/res/layout/message_view_header.xml
+++ b/app/ui/src/main/res/layout/message_view_header.xml
@@ -56,14 +56,11 @@
                     android:visibility="gone"
                     />
 
-                <CheckBox
+                <ImageView
                     android:id="@+id/flagged"
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
+                    android:layout_width="@dimen/flagged_icon_size"
+                    android:layout_height="@dimen/flagged_icon_size"
                     android:layout_gravity="center_vertical"
-                    android:focusable="false"
-                    android:checked="false"
-                    style="?android:attr/starStyle"
                     />
 
             </LinearLayout>

--- a/app/ui/src/main/res/values/dimensions.xml
+++ b/app/ui/src/main/res/values/dimensions.xml
@@ -2,4 +2,5 @@
 <resources>
     <dimen name="button_minWidth">100sp</dimen>
     <dimen name="widget_padding">8dp</dimen>
+    <dimen name="flagged_icon_size">32dp</dimen>
 </resources>


### PR DESCRIPTION
- Instead of light blue which was difficult to see with dark theme.
- Uses the same shape and color as AccountsAdapter (list of all accounts).

Accounts overview (unchanged) --- has stars in account colors
![01_accountlist_unchanged](https://user-images.githubusercontent.com/52233887/60967548-3e872700-a31b-11e9-8d76-5665dc748739.jpg)

Message list (before changes) --- Hard to see which messages are flagged.
![02_messagelist_before_changes](https://user-images.githubusercontent.com/52233887/60967557-45159e80-a31b-11e9-90b7-bd2611cca484.jpg)

Message lists (after changes):
![03_messagelist-all-accounts_changed](https://user-images.githubusercontent.com/52233887/60967564-49da5280-a31b-11e9-9c92-db5a0490a7b2.jpg)
![04_messagelist-blue-account](https://user-images.githubusercontent.com/52233887/60967585-5494e780-a31b-11e9-9d2c-395782b3c7a9.jpg)
![05_messagelist-green-account](https://user-images.githubusercontent.com/52233887/60967586-5494e780-a31b-11e9-8863-48a44724f1be.jpg)
![06_messagelist-red-account](https://user-images.githubusercontent.com/52233887/60967588-552d7e00-a31b-11e9-9d29-4180d25c1124.jpg)

Sorry, no screenshot of the MessageHeader view. There also the star was light blue, now is in the same color&shape as in the lists.
