### PR TITLE
Design rounded corners

### DIFF
--- a/app/ui/build.gradle
+++ b/app/ui/build.gradle
@@ -40,6 +40,7 @@ dependencies {
     implementation 'com.mikepenz:fontawesome-typeface:5.3.1.1@aar'
     implementation 'com.github.ByteHamster:SearchPreference:v1.1.4'
     implementation 'com.mikepenz:fastadapter:3.3.1'
+    implementation 'de.hdodenhof:circleimageview:3.0.0'
 
     implementation "commons-io:commons-io:${versions.commonsIo}"
     implementation "androidx.core:core-ktx:${versions.coreKtx}"

--- a/app/ui/src/main/java/com/fsck/k9/ui/ContactBadge.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/ContactBadge.java
@@ -21,11 +21,11 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.accessibility.AccessibilityEvent;
 import android.view.accessibility.AccessibilityNodeInfo;
-import android.widget.ImageView;
 import android.widget.Toast;
 
 import com.fsck.k9.mail.Address;
 
+import de.hdodenhof.circleimageview.CircleImageView;
 
 /**
  * ContactBadge replaces the android ContactBadge for custom drawing.
@@ -33,7 +33,7 @@ import com.fsck.k9.mail.Address;
  * Based on QuickContactBadge:
  * https://android.googlesource.com/platform/frameworks/base/+/master/core/java/android/widget/QuickContactBadge.java
  */
-public class ContactBadge extends ImageView implements OnClickListener {
+public class ContactBadge extends CircleImageView implements OnClickListener {
     private static final int TOKEN_EMAIL_LOOKUP = 0;
     private static final int TOKEN_EMAIL_LOOKUP_AND_TRIGGER = 1;
 

--- a/app/ui/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/app/ui/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -27,7 +27,6 @@ import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
-import android.widget.ImageView;
 import android.widget.ListPopupWindow;
 import android.widget.ListView;
 import android.widget.TextView;
@@ -43,6 +42,7 @@ import com.fsck.k9.view.RecipientSelectView.Recipient;
 import com.tokenautocomplete.TokenCompleteTextView;
 import org.apache.james.mime4j.util.CharsetUtil;
 import timber.log.Timber;
+import de.hdodenhof.circleimageview.CircleImageView;
 
 
 public class RecipientSelectView extends TokenCompleteTextView<Recipient> implements LoaderCallbacks<List<Recipient>>,
@@ -120,7 +120,10 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
     @SuppressLint("InflateParams")
     private View inflateLayout() {
         LayoutInflater layoutInflater = LayoutInflater.from(getContext());
-        return layoutInflater.inflate(R.layout.recipient_token_item, null, false);
+        View layout = layoutInflater.inflate(R.layout.recipient_token_item, null, false);
+        View contactPhoto = layout.findViewById(R.id.contact_photo);
+        contactPhoto.setZ(1.f);
+        return layout;
     }
 
     private void bindObjectView(Recipient recipient, View view) {
@@ -536,7 +539,7 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
 
     private static class RecipientTokenViewHolder {
         final TextView vName;
-        final ImageView vContactPhoto;
+        final CircleImageView vContactPhoto;
         final View cryptoStatusRed;
         final View cryptoStatusOrange;
         final View cryptoStatusGreen;

--- a/app/ui/src/main/res/layout/message_list_item.xml
+++ b/app/ui/src/main/res/layout/message_list_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:orientation="horizontal"
@@ -48,8 +49,7 @@
             android:layout_width="40dip"
             android:layout_gravity="center_vertical"
             android:layout_marginLeft="4dp"
-            android:src="@drawable/ic_contact_picture"
-            style="?android:attr/quickContactBadgeStyleWindowLarge"
+            tools:src="@drawable/ic_contact_picture"
             android:background="@android:color/transparent"/>
 
 

--- a/app/ui/src/main/res/layout/recipient_dropdown_item.xml
+++ b/app/ui/src/main/res/layout/recipient_dropdown_item.xml
@@ -7,7 +7,7 @@
     android:gravity="center"
     android:orientation="horizontal">
 
-    <ImageView
+    <de.hdodenhof.circleimageview.CircleImageView
         android:layout_width="36dp"
         android:layout_height="36dp"
         android:layout_marginLeft="12dp"

--- a/app/ui/src/main/res/layout/recipient_token_item.xml
+++ b/app/ui/src/main/res/layout/recipient_token_item.xml
@@ -3,10 +3,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:orientation="horizontal"
     android:layout_width="wrap_content"
-    android:layout_height="32dp"
-    android:background="?attr/contactTokenBackgroundColor">
+    android:layout_height="32dp">
 
-    <ImageView
+    <de.hdodenhof.circleimageview.CircleImageView
         android:layout_width="32dp"
         android:layout_height="32dp"
         android:gravity="center_vertical"
@@ -14,82 +13,91 @@
         tools:src="@drawable/ic_contact_picture"
         />
 
-    <TextView
+    <LinearLayout
         android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@android:id/text1"
-        android:layout_gravity="center_vertical"
-        android:layout_marginLeft="8dp"
-        android:layout_marginRight="8dp"
-        android:maxLines="1"
-        android:ellipsize="end"
-        tools:text="Name"
-        />
+        android:layout_height="match_parent"
+        android:background="?attr/contactTokenBackgroundColor"
+        android:layout_marginLeft="-16dp"
+        >
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/contact_crypto_status_icon_simple"
-        android:src="@drawable/ic_status_corner"
-        android:visibility="gone"
-        android:tint="?openpgp_black"
-        tools:visibility="visible"
-        />
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@android:id/text1"
+            android:layout_gravity="center_vertical"
+            android:layout_marginLeft="24dp"
+            android:layout_marginRight="8dp"
+            android:maxLines="1"
+            android:ellipsize="end"
+            tools:text="Name"
+            />
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/contact_crypto_status_icon_simple_enabled"
-        android:src="@drawable/ic_status_corner"
-        android:visibility="gone"
-        android:tint="?openpgp_green"
-        tools:visibility="visible"
-        />
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/contact_crypto_status_icon_simple"
+            android:src="@drawable/ic_status_corner"
+            android:visibility="gone"
+            android:tint="?openpgp_black"
+            tools:visibility="visible"
+            />
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:id="@+id/contact_crypto_status_icon_simple_error"
-        android:src="@drawable/ic_status_corner"
-        android:visibility="gone"
-        android:tint="?openpgp_red"
-        tools:visibility="visible"
-        />
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/contact_crypto_status_icon_simple_enabled"
+            android:src="@drawable/ic_status_corner"
+            android:visibility="gone"
+            android:tint="?openpgp_green"
+            tools:visibility="visible"
+            />
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginRight="6dp"
-        android:layout_marginEnd="6dp"
-        android:layout_gravity="center_vertical"
-        android:id="@+id/contact_crypto_status_red"
-        android:src="@drawable/status_dots_1"
-        android:tint="?attr/openpgp_red"
-        android:visibility="gone"
-        />
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/contact_crypto_status_icon_simple_error"
+            android:src="@drawable/ic_status_corner"
+            android:visibility="gone"
+            android:tint="?openpgp_red"
+            tools:visibility="visible"
+            />
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginRight="6dp"
-        android:layout_marginEnd="6dp"
-        android:layout_gravity="center_vertical"
-        android:id="@+id/contact_crypto_status_orange"
-        android:src="@drawable/status_dots_2"
-        android:tint="?attr/openpgp_orange"
-        android:visibility="gone"
-        />
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="6dp"
+            android:layout_marginEnd="6dp"
+            android:layout_gravity="center_vertical"
+            android:id="@+id/contact_crypto_status_red"
+            android:src="@drawable/status_dots_1"
+            android:tint="?attr/openpgp_red"
+            android:visibility="gone"
+            />
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginRight="6dp"
-        android:layout_marginEnd="6dp"
-        android:layout_gravity="center_vertical"
-        android:id="@+id/contact_crypto_status_green"
-        android:src="@drawable/status_dots_3"
-        android:tint="?attr/openpgp_green"
-        android:visibility="gone"
-        />
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="6dp"
+            android:layout_marginEnd="6dp"
+            android:layout_gravity="center_vertical"
+            android:id="@+id/contact_crypto_status_orange"
+            android:src="@drawable/status_dots_2"
+            android:tint="?attr/openpgp_orange"
+            android:visibility="gone"
+            />
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginRight="6dp"
+            android:layout_marginEnd="6dp"
+            android:layout_gravity="center_vertical"
+            android:id="@+id/contact_crypto_status_green"
+            android:src="@drawable/status_dots_3"
+            android:tint="?attr/openpgp_green"
+            android:visibility="gone"
+            />
+
+    </LinearLayout>
 
 </LinearLayout>


### PR DESCRIPTION
Teasing apart the changes in #4038 

This pull request rounds contact images.  It does this by replacing a number of `ImageView`s with `CircleImageView` from [this](https://github.com/hdodenhof/CircleImageView) package.

It also adjusts the padding in the message recipient box in the email composition activity to align more to the design in #1859.

![photo_2019-07-11_20-43-23](https://user-images.githubusercontent.com/2918499/61080314-b4bf8280-a41c-11e9-9899-d38d1cfcdfe3.jpg)


