### PR TITLE
Made storage migrations more stable

### DIFF
--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -33,6 +33,14 @@ public class K9StoragePersister implements StoragePersister {
     private SQLiteDatabase openDB() {
         SQLiteDatabase db = context.openOrCreateDatabase(DB_NAME, Context.MODE_PRIVATE, null);
 
+        if (db.getVersion() != DB_VERSION) {
+            upgrade(db);
+        }
+
+        return db;
+    }
+
+    private void upgrade(SQLiteDatabase db) {
         db.beginTransaction();
         try {
             if (db.getVersion() < 1) {
@@ -50,8 +58,6 @@ public class K9StoragePersister implements StoragePersister {
         if (db.getVersion() != DB_VERSION) {
             throw new RuntimeException("Storage database upgrade failed!");
         }
-
-        return db;
     }
 
     private void createStorageDatabase(SQLiteDatabase db) {

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo6.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo6.kt
@@ -27,7 +27,11 @@ class StorageMigrationTo6(
     }
 
     private fun rewriteTheme() {
-        val theme = migrationsHelper.readValue(db, "theme")?.toInt()
+        val theme = try {
+            migrationsHelper.readValue(db, "theme")?.toInt()
+        } catch (e : NumberFormatException) {
+            THEME_ORDINAL_LIGHT
+        }
 
         // We used to save the resource ID of the theme. So convert that to the new format if necessary.
         val newTheme = if (theme == THEME_ORDINAL_DARK || theme == android.R.style.Theme) {

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo7.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo7.kt
@@ -35,7 +35,12 @@ class StorageMigrationTo7(
     }
 
     private fun rewriteScreenTheme(key: String) {
-        val newTheme = when (migrationsHelper.readValue(db, key)?.toInt()) {
+        val theme = try {
+            migrationsHelper.readValue(db, key)?.toInt()
+        } catch (e : NumberFormatException) {
+            THEME_ORDINAL_USE_GLOBAL
+        }
+        val newTheme = when (theme) {
             THEME_ORDINAL_DARK -> THEME_DARK
             THEME_ORDINAL_USE_GLOBAL -> THEME_USE_GLOBAL
             else -> THEME_LIGHT


### PR DESCRIPTION
When switching between branches, the database might get downgraded. If you then try to upgrade again, the upgrade fails because of a NumberFormatException. I can no longer reproduce this error, so feel free to reject the PR. I still think that it makes switching between versions more reliable.

Closes #4111
