### PR TITLE
Throw exception when a database downgrade situation is encountered

### DIFF
--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -35,6 +35,11 @@ public class K9StoragePersister implements StoragePersister {
 
         db.beginTransaction();
         try {
+            if (db.getVersion() > DB_VERSION) {
+                throw new AssertionError("Database downgrades are not supported. " +
+                        "Please fix the database '" + DB_NAME + "' manually or clear app data.");
+            }
+
             if (db.getVersion() < 1) {
                 createStorageDatabase(db);
             } else {

--- a/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -46,6 +46,13 @@ class StoreSchemaDefinition implements SchemaDefinition {
 
         db.beginTransaction();
         try {
+            if (db.getVersion() > DB_VERSION) {
+                String accountUuid = migrationsHelper.getAccount().getUuid();
+                throw new AssertionError("Database downgrades are not supported. " +
+                        "Please fix the account database '" + accountUuid + "' manually or " +
+                        "clear app data.");
+            }
+
             // schema version 29 was when we moved to incremental updates
             // in the case of a new db or a < v29 db, we blow away and start from scratch
             if (db.getVersion() < 29) {


### PR DESCRIPTION
Database downgrades are not supported by the app. It's a situation that can only be encountered during development. With this change the app will crash with what I hope is a useful error message.

Closes #4111