### PR TITLE
Remove message list compact mode

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.java
@@ -107,23 +107,8 @@ public class MessageListAdapter extends CursorAdapter {
         holder.chip = view.findViewById(R.id.chip);
         holder.attachment = view.findViewById(R.id.attachment);
         holder.status = view.findViewById(R.id.status);
-
-
-        if (fragment.previewLines == 0 && fragment.contactsPictureLoader == null) {
-            view.findViewById(R.id.preview).setVisibility(View.GONE);
-            holder.preview = view.findViewById(R.id.sender_compact);
-            holder.flagged = view.findViewById(R.id.flagged_center_right);
-            view.findViewById(R.id.flagged_bottom_right).setVisibility(View.GONE);
-
-
-
-        } else {
-            view.findViewById(R.id.sender_compact).setVisibility(View.GONE);
-            holder.preview = view.findViewById(R.id.preview);
-            holder.flagged = view.findViewById(R.id.flagged_bottom_right);
-            view.findViewById(R.id.flagged_center_right).setVisibility(View.GONE);
-
-        }
+        holder.preview = view.findViewById(R.id.preview);
+        holder.flagged = view.findViewById(R.id.star);
 
         ContactBadge contactBadge = view.findViewById(R.id.contact_badge);
         if (fragment.contactsPictureLoader != null) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageViewHolder.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageViewHolder.java
@@ -36,7 +36,7 @@ public class MessageViewHolder implements View.OnClickListener {
             int id = view.getId();
             if (id == R.id.selected_checkbox) {
                 fragment.toggleMessageSelectWithAdapterPosition(position);
-            } else if (id == R.id.flagged_bottom_right || id == R.id.flagged_center_right) {
+            } else if (id == R.id.star) {
                 fragment.toggleMessageFlagWithAdapterPosition(position);
             }
         }

--- a/app/ui/src/main/res/layout/message_list_item.xml
+++ b/app/ui/src/main/res/layout/message_list_item.xml
@@ -69,7 +69,7 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
-                android:layout_toLeftOf="@+id/flagged_bottom_right"
+                android:layout_toLeftOf="@+id/star"
                 android:layout_marginLeft="1dip"
                 android:layout_marginRight="3dip"
                 android:bufferType="spannable"
@@ -100,19 +100,6 @@
                 android:layout_toRightOf="@+id/status">
 
             <TextView
-                    android:id="@+id/sender_compact"
-                    android:layout_height="wrap_content"
-                    android:layout_width="0dp"
-                    android:layout_weight="0.3"
-                    android:ellipsize="end"
-                    android:singleLine="true"
-                    android:layout_marginBottom="1dip"
-                    android:layout_marginLeft="1dip"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"
-                    />
-
-            <TextView
                     android:id="@+id/subject"
                     android:layout_width="0dp"
                     android:layout_weight="0.7"
@@ -140,20 +127,6 @@
                     />
         </LinearLayout>
 
-        <CheckBox
-                android:id="@+id/flagged_center_right"
-                style="?android:attr/starStyle"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_alignParentRight="true"
-                android:layout_centerVertical="true"
-                android:paddingTop="3dip"
-                android:paddingLeft="2dip"
-                android:paddingRight="4dip"
-                android:focusable="false"
-                android:visibility="gone"
-                />
-
         <ImageView
                 android:id="@+id/attachment"
                 android:layout_width="wrap_content"
@@ -171,7 +144,7 @@
                 android:layout_alignTop="@+id/subject_wrapper"
                 android:layout_alignWithParentIfMissing="true"
                 android:layout_centerVertical="true"
-                android:layout_toLeftOf="@+id/flagged_center_right"
+                android:layout_alignParentRight="true"
                 android:paddingLeft="3dip"
                 android:paddingRight="8dip"
                 android:singleLine="true"
@@ -179,7 +152,7 @@
                 android:textColor="?android:attr/textColorSecondary"/>
 
         <CheckBox
-                android:id="@+id/flagged_bottom_right"
+                android:id="@+id/star"
                 style="?android:attr/starStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="fill_parent"


### PR DESCRIPTION
For historical reasons K-9 Mail supports a "compact mode" where sender name, subject, date, etc are all displayed in one line. But, compared to the early days of Android, phone screens are huge now. Also, few people probably know this mode exists, because it's enabled by setting preview lines to 0 and disabling contact pictures. I don't think many people will miss this feature. As a maintainer, I certainly won't.
