### PR TITLE
Reduce font size in contact picture fallback image

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapCreator.kt
+++ b/app/ui/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapCreator.kt
@@ -25,7 +25,7 @@ class ContactLetterBitmapCreator(
             isAntiAlias = true
             style = Paint.Style.FILL
             setARGB(255, 255, 255, 255)
-            textSize = (pictureSizeInPx * 3 / 4).toFloat() // just scale this down a bit
+            textSize = pictureSizeInPx.toFloat() * 0.65f
         }
 
         val rect = Rect()


### PR DESCRIPTION
Before and after:
<img src="https://user-images.githubusercontent.com/218061/61809213-26e09000-ae3d-11e9-937d-90abc0b007ec.png" alt="k9mail_contact_picture_placeholder_before" width="300">&nbsp;&nbsp;<img src="https://user-images.githubusercontent.com/218061/61809212-2647f980-ae3d-11e9-9a29-4aec1ccc5fb5.png" alt="k9mail_contact_picture_placeholder_after" width="300">

Part of #4110 
