### PR TITLE
Remove selection checkboxes in message list

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -194,9 +194,6 @@ object K9 : KoinComponent {
     var lockScreenNotificationVisibility = LockScreenNotificationVisibility.MESSAGE_COUNT
 
     @JvmStatic
-    var isShowMessageListCheckboxes = true
-
-    @JvmStatic
     var isShowMessageListStars = true
 
     @JvmStatic
@@ -368,7 +365,6 @@ object K9 : KoinComponent {
         isCountSearchMessages = storage.getBoolean("countSearchMessages", true)
         isHideSpecialAccounts = storage.getBoolean("hideSpecialAccounts", false)
         isMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false)
-        isShowMessageListCheckboxes = storage.getBoolean("messageListCheckboxes", false)
         isShowMessageListStars = storage.getBoolean("messageListStars", true)
         messageListPreviewLines = storage.getInt("messageListPreviewLines", 2)
 
@@ -459,7 +455,6 @@ object K9 : KoinComponent {
         editor.putBoolean("hideSpecialAccounts", isHideSpecialAccounts)
         editor.putBoolean("messageListStars", isShowMessageListStars)
         editor.putInt("messageListPreviewLines", messageListPreviewLines)
-        editor.putBoolean("messageListCheckboxes", isShowMessageListCheckboxes)
         editor.putBoolean("showCorrespondentNames", isShowCorrespondentNames)
         editor.putBoolean("showContactName", isShowContactName)
         editor.putBoolean("showContactPicture", isShowContactPicture)

--- a/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -148,9 +148,6 @@ public class GlobalSettings {
         s.put("measureAccounts", Settings.versions(
                 new V(1, new BooleanSetting(true))
         ));
-        s.put("messageListCheckboxes", Settings.versions(
-                new V(1, new BooleanSetting(false))
-        ));
         s.put("messageListPreviewLines", Settings.versions(
                 new V(1, new IntegerRangeSetting(1, 100, 2))
         ));

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -144,12 +144,9 @@ class MessageListAdapter internal constructor(
         holder.preview.setLines(max(appearance.previewLines, 1))
         appearance.fontSizes.setViewTextSize(holder.preview, appearance.fontSizes.messageListPreview)
         appearance.fontSizes.setViewTextSize(holder.threadCount, appearance.fontSizes.messageListSubject) // thread count is next to subject
-        holder.selectedCheckbox.isVisible = appearance.checkboxes
 
         holder.flagged.isVisible = appearance.stars
         holder.flagged.setOnClickListener(holder)
-
-        holder.selected.setOnClickListener(holder)
 
         view.tag = holder
 
@@ -193,9 +190,6 @@ class MessageListAdapter internal constructor(
         val selected = selected.contains(uniqueId)
 
         holder.chip.setBackgroundColor(account.chipColor)
-        if (appearance.checkboxes) {
-            holder.selected.isChecked = selected
-        }
         if (appearance.stars) {
             holder.flagged.isChecked = flagged
         }
@@ -377,6 +371,5 @@ class MessageListAdapter internal constructor(
 }
 
 interface MessageListItemActionListener {
-    fun toggleMessageSelectWithAdapterPosition(position: Int)
     fun toggleMessageFlagWithAdapterPosition(position: Int)
 }

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -606,7 +606,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     private MessageListAppearance getMessageListAppearance() {
         return new MessageListAppearance(
                 K9.getFontSizes(),
-                K9.isShowMessageListCheckboxes(),
                 K9.getMessageListPreviewLines(),
                 K9.isShowMessageListStars(),
                 K9.isMessageListSenderAboveSubject(),
@@ -1463,8 +1462,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         setFlag(adapterPosition,Flag.FLAGGED, !flagged);
     }
 
-    @Override
-    public void toggleMessageSelectWithAdapterPosition(int adapterPosition) {
+    private void toggleMessageSelectWithAdapterPosition(int adapterPosition) {
         Cursor cursor = (Cursor) adapter.getItem(adapterPosition);
         long uniqueId = cursor.getLong(uniqueIdColumn);
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageViewHolder.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageViewHolder.kt
@@ -23,17 +23,12 @@ class MessageViewHolder(
     val chip: View = view.findViewById(R.id.chip)
     val threadCount: TextView = view.findViewById(R.id.thread_count)
     val flagged: CheckBox = view.findViewById(R.id.star)
-    val selected: CheckBox = view.findViewById(R.id.selected_checkbox)
     val attachment: ImageView = view.findViewById(R.id.attachment)
     val status: ImageView = view.findViewById(R.id.status)
-    val selectedCheckbox: View = view.findViewById(R.id.selected_checkbox_wrapper)
 
     override fun onClick(view: View) {
         if (position != -1) {
-            val id = view.id
-            if (id == R.id.selected_checkbox) {
-                itemActionListener.toggleMessageSelectWithAdapterPosition(position)
-            } else if (id == R.id.star) {
+            if (view.id == R.id.star) {
                 itemActionListener.toggleMessageFlagWithAdapterPosition(position)
             }
         }

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListAppearance.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListAppearance.kt
@@ -4,7 +4,6 @@ import com.fsck.k9.FontSizes
 
 data class MessageListAppearance(
         val fontSizes: FontSizes,
-        val checkboxes: Boolean,
         val previewLines: Int,
         val stars: Boolean,
         val senderAboveSubject: Boolean,

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -27,7 +27,6 @@ class GeneralSettingsDataStore(
             "hide_special_accounts" -> K9.isHideSpecialAccounts
             "folderlist_wrap_folder_name" -> K9.isWrapFolderNames
             "messagelist_stars" -> K9.isShowMessageListStars
-            "messagelist_checkboxes" -> K9.isShowMessageListCheckboxes
             "messagelist_show_correspondent_names" -> K9.isShowCorrespondentNames
             "messagelist_sender_above_subject" -> K9.isMessageListSenderAboveSubject
             "messagelist_show_contact_name" -> K9.isShowContactName
@@ -61,7 +60,6 @@ class GeneralSettingsDataStore(
             "hide_special_accounts" -> K9.isHideSpecialAccounts = value
             "folderlist_wrap_folder_name" -> K9.isWrapFolderNames = value
             "messagelist_stars" -> K9.isShowMessageListStars = value
-            "messagelist_checkboxes" -> K9.isShowMessageListCheckboxes = value
             "messagelist_show_correspondent_names" -> K9.isShowCorrespondentNames = value
             "messagelist_sender_above_subject" -> K9.isMessageListSenderAboveSubject = value
             "messagelist_show_contact_name" -> K9.isShowContactName = value

--- a/app/ui/src/main/res/layout/message_list_item.xml
+++ b/app/ui/src/main/res/layout/message_list_item.xml
@@ -15,31 +15,6 @@
             android:layout_marginRight="4dp"
             />
 
-    <LinearLayout
-            android:id="@+id/selected_checkbox_wrapper"
-            android:layout_width="wrap_content"
-
-            android:layout_height="match_parent"
-            android:orientation="vertical"
-            android:layout_gravity="center"
-            android:visibility="visible"
-            android:textColor="?android:attr/textColorPrimary"
-            android:baselineAligned="false">
-
-        <CheckBox
-                android:id="@+id/selected_checkbox"
-                android:layout_width="wrap_content"
-                android:layout_height="match_parent"
-                android:gravity="center"
-                android:focusable="false"
-                android:clickable="false"
-                android:paddingLeft="4dp"
-                android:paddingRight="0dp"
-                android:visibility="visible"
-                />
-
-    </LinearLayout>
-
     <com.fsck.k9.ui.ContactBadge
             android:id="@+id/contact_badge"
             android:layout_marginRight="8dip"

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -305,8 +305,6 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="global_settings_flag_label">Show stars</string>
     <string name="global_settings_flag_summary">Stars indicate flagged messages</string>
-    <string name="global_settings_checkbox_label">Multi-select checkboxes</string>
-    <string name="global_settings_checkbox_summary">Always show multi-select checkboxes</string>
     <string name="global_settings_preview_lines_label">Preview lines</string>
     <string name="global_settings_show_correspondent_names_label">Show correspondent names</string>
     <string name="global_settings_show_correspondent_names_summary">Show correspondent names rather than their email addresses</string>

--- a/app/ui/src/main/res/xml/general_settings.xml
+++ b/app/ui/src/main/res/xml/general_settings.xml
@@ -131,11 +131,6 @@
                 android:title="@string/global_settings_flag_label" />
 
             <CheckBoxPreference
-                android:key="messagelist_checkboxes"
-                android:summary="@string/global_settings_checkbox_summary"
-                android:title="@string/global_settings_checkbox_label" />
-
-            <CheckBoxPreference
                 android:key="messagelist_show_correspondent_names"
                 android:summary="@string/global_settings_show_correspondent_names_summary"
                 android:title="@string/global_settings_show_correspondent_names_label" />

--- a/app/ui/src/test/java/com/fsck/k9/fragment/MessageListAdapterTest.kt
+++ b/app/ui/src/test/java/com/fsck/k9/fragment/MessageListAdapterTest.kt
@@ -76,45 +76,6 @@ class MessageListAdapterTest : RobolectricTest() {
     }
 
     @Test
-    fun withoutCheckboxes_shouldHideSelectionCheckbox() {
-        val adapter = createAdapter(checkboxes = false)
-
-        val view = adapter.createAndBindView()
-
-        assertTrue(view.selectionCheckBoxContainer.isGone)
-    }
-
-    @Test
-    fun withCheckboxes_shouldShowSelectionCheckbox() {
-        val adapter = createAdapter(checkboxes = true)
-
-        val view = adapter.createAndBindView()
-
-        assertTrue(view.selectionCheckBoxContainer.isVisible)
-    }
-
-    @Test
-    fun withCheckboxesAndMessageSelected_shouldCheckSelectionCheckBox() {
-        val cursor = createCursor(id = 23)
-        val adapter = createAdapter(checkboxes = true)
-        adapter.selected = setOf(23)
-
-        val view = adapter.createAndBindView(cursor)
-
-        assertTrue(view.selectionCheckBox.isChecked)
-    }
-
-    @Test
-    fun withCheckboxesAndMessageNotSelected_shouldNotCheckSelectionCheckBox() {
-        val adapter = createAdapter(checkboxes = true)
-        val cursor = createCursor(id = 23)
-
-        val view = adapter.createAndBindView(cursor)
-
-        assertFalse(view.selectionCheckBox.isChecked)
-    }
-
-    @Test
     fun withoutStars_shouldHideStarCheckBox() {
         val adapter = createAdapter(stars = false)
 
@@ -477,7 +438,6 @@ class MessageListAdapterTest : RobolectricTest() {
 
     fun createAdapter(
             fontSizes: FontSizes = createFontSizes(),
-            checkboxes: Boolean = false,
             previewLines: Int = 0,
             stars: Boolean = true,
             senderAboveSubject: Boolean = false,
@@ -487,7 +447,6 @@ class MessageListAdapterTest : RobolectricTest() {
     ): MessageListAdapter {
         val appearance = MessageListAppearance(
                 fontSizes,
-                checkboxes,
                 previewLines,
                 stars,
                 senderAboveSubject,
@@ -568,8 +527,6 @@ class MessageListAdapterTest : RobolectricTest() {
     fun secondLine(senderOrSubject: String, preview: String)= "$senderOrSubject $preview"
 
     val View.accountChipView: View get() = findViewById(R.id.chip)
-    val View.selectionCheckBoxContainer: View get() = findViewById(R.id.selected_checkbox_wrapper)
-    val View.selectionCheckBox: CheckBox get() = findViewById(R.id.selected_checkbox)
     val View.starView: CheckBox get() = findViewById(R.id.star)
     val View.contactPictureView: ContactBadge get() = findViewById(R.id.contact_badge)
     val View.threadCountView: TextView get() = findViewById(R.id.thread_count)


### PR DESCRIPTION
Get rid of the option to display selection checkboxes in the message list. This is mainly to simplify the layout and reduce the amount of display options that interact with each other.
