### PR TITLE
Store folder display mode

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/ChooseFolder.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/ChooseFolder.java
@@ -224,6 +224,8 @@ public class ChooseFolder extends K9ListActivity {
     }
 
     private void setDisplayMode(FolderMode aMode) {
+        mAccount.setFolderTargetMode(aMode);
+        Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
         mMode = aMode;
         // invalidate the current filter as it is working on an inval
         if (mMyFilter != null) {


### PR DESCRIPTION
Without this PR, I have to manually change the folder display mode every time I move a message because K9 hides important target folders.

Before this change, the method `setFolderTargetMode` was only used when de-serializing the preferences. The method was never called from the UI.