### PR TITLE
Don't show account chip in message list when showing single account

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -137,6 +137,7 @@ class MessageListAdapter internal constructor(
         val holder = MessageViewHolder(view, listItemListener)
 
         holder.contactBadge.isVisible = appearance.showContactPicture
+        holder.chip.isVisible = appearance.showAccountChip
 
         appearance.fontSizes.setViewTextSize(holder.subject, subjectViewFontSize)
 
@@ -191,9 +192,11 @@ class MessageListAdapter internal constructor(
         val uniqueId = cursor.getLong(uniqueIdColumn)
         val selected = selected.contains(uniqueId)
 
-        val accountChipDrawable = holder.chip.drawable.mutate()
-        DrawableCompat.setTint(accountChipDrawable, account.chipColor)
-        holder.chip.setImageDrawable(accountChipDrawable)
+        if (appearance.showAccountChip) {
+            val accountChipDrawable = holder.chip.drawable.mutate()
+            DrawableCompat.setTint(accountChipDrawable, account.chipColor)
+            holder.chip.setImageDrawable(accountChipDrawable)
+        }
 
         if (appearance.stars) {
             holder.flagged.isChecked = flagged

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -604,6 +604,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     private MessageListAppearance getMessageListAppearance() {
+        boolean showAccountChip = !isSingleAccountMode();
         return new MessageListAppearance(
                 K9.getFontSizes(),
                 K9.getMessageListPreviewLines(),
@@ -611,7 +612,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 K9.isMessageListSenderAboveSubject(),
                 K9.isShowContactPicture(),
                 showingThreadedList,
-                K9.isUseBackgroundAsUnreadIndicator()
+                K9.isUseBackgroundAsUnreadIndicator(),
+                showAccountChip
         );
     }
 

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListAppearance.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListAppearance.kt
@@ -9,5 +9,6 @@ data class MessageListAppearance(
         val senderAboveSubject: Boolean,
         val showContactPicture: Boolean,
         val showingThreadedList: Boolean,
-        val backGroundAsReadIndicator: Boolean
+        val backGroundAsReadIndicator: Boolean,
+        val showAccountChip: Boolean
 )

--- a/app/ui/src/test/java/com/fsck/k9/fragment/MessageListAdapterTest.kt
+++ b/app/ui/src/test/java/com/fsck/k9/fragment/MessageListAdapterTest.kt
@@ -64,6 +64,24 @@ class MessageListAdapterTest : RobolectricTest() {
 
 
     @Test
+    fun withShowAccountChip_shouldShowAccountChip() {
+        val adapter = createAdapter(showAccountChip = true)
+
+        val view = adapter.createAndBindView()
+
+        assertTrue(view.accountChipView.isVisible)
+    }
+
+    @Test
+    fun withoutShowAccountChip_shouldHideAccountChip() {
+        val adapter = createAdapter(showAccountChip = false)
+
+        val view = adapter.createAndBindView()
+
+        assertTrue(view.accountChipView.isGone)
+    }
+
+    @Test
     fun withoutStars_shouldHideStarCheckBox() {
         val adapter = createAdapter(stars = false)
 
@@ -429,7 +447,8 @@ class MessageListAdapterTest : RobolectricTest() {
             senderAboveSubject: Boolean = false,
             showContactPicture: Boolean = true,
             showingThreadedList: Boolean = true,
-            backGroundAsReadIndicator: Boolean = false
+            backGroundAsReadIndicator: Boolean = false,
+            showAccountChip: Boolean = false
     ): MessageListAdapter {
         val appearance = MessageListAppearance(
                 fontSizes,
@@ -438,7 +457,8 @@ class MessageListAdapterTest : RobolectricTest() {
                 senderAboveSubject,
                 showContactPicture,
                 showingThreadedList,
-                backGroundAsReadIndicator
+                backGroundAsReadIndicator,
+                showAccountChip
         )
 
         return MessageListAdapter(
@@ -512,6 +532,7 @@ class MessageListAdapterTest : RobolectricTest() {
 
     fun secondLine(senderOrSubject: String, preview: String)= "$senderOrSubject $preview"
 
+    val View.accountChipView: View get() = findViewById(R.id.account_color_chip)
     val View.starView: CheckBox get() = findViewById(R.id.star)
     val View.contactPictureView: ContactBadge get() = findViewById(R.id.contact_badge)
     val View.threadCountView: TextView get() = findViewById(R.id.thread_count)


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/218061/64079028-8d7d8700-cce2-11e9-8332-014290cc5193.png" alt="k9mail_hide_account_chip" width="300"> <img src="https://user-images.githubusercontent.com/218061/64079027-8d7d8700-cce2-11e9-8609-ab82c3c17ad4.png" alt="k9mail_account_chip_in_unified_inbox" width="300">



