### PR TITLE
WIP: feature/Data Extractor for Message List Item.

### DIFF
--- a/app/k9mail/src/main/java/com/fsck/k9/external/BroadcastSenderListener.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/external/BroadcastSenderListener.kt
@@ -26,7 +26,7 @@ class BroadcastSenderListener(private val context: Context) : SimpleMessagingLis
         intent.putExtra(BroadcastIntents.EXTRA_FROM_SELF, account.isAnIdentity(message.from))
         context.sendBroadcast(intent)
 
-        Timber.d("Broadcasted: action=ACTION_EMAIL_RECEIVED account=%s folder=%s message uid=%s",
+        Timber.d("Broadcasted: action=ACTION_EMAIL_RECEIVED account=%s folder=%s message messageUid=%s",
                 account.description,
                 folderServerId,
                 message.uid)
@@ -40,7 +40,7 @@ class BroadcastSenderListener(private val context: Context) : SimpleMessagingLis
         intent.putExtra(BroadcastIntents.EXTRA_FOLDER, folderServerId)
         context.sendBroadcast(intent)
 
-        Timber.d("Broadcasted: action=ACTION_EMAIL_DELETED account=%s folder=%s message uid=%s",
+        Timber.d("Broadcasted: action=ACTION_EMAIL_DELETED account=%s folder=%s message messageUid=%s",
                 account.description,
                 folderServerId,
                 messageServerId)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -129,14 +129,13 @@ class MessageListAdapter internal constructor(
         holder.flagged.setOnClickListener(holder)
 
         view.tag = holder
-        view.setTag(EXTRACTOR, MessageListItemExtractor(getAccount(cursor), cursor, messageHelper, res))
 
         return view
     }
 
     override fun bindView(view: View, context: Context, cursor: Cursor) {
         val account = getAccount(cursor)
-        val itemExtractor = view.getTag(EXTRACTOR) as MessageListItemExtractor
+        val itemExtractor = getExtractor(view, cursor)
 
         val displayName = itemExtractor.displayName
         val displayDate = DateUtils.getRelativeTimeSpanString(context, itemExtractor.date)
@@ -203,6 +202,16 @@ class MessageListAdapter internal constructor(
         } else {
             holder.status.visibility = View.GONE
         }
+    }
+
+    private fun getExtractor(view: View, cursor: Cursor): MessageListItemExtractor {
+        if (view.getTag(EXTRACTOR) == null
+                || (view.getTag(EXTRACTOR) as MessageListItemExtractor).cursor != cursor) {
+            val extractor = MessageListItemExtractor(getAccount(cursor), cursor, messageHelper, res)
+            view.setTag(EXTRACTOR, extractor)
+            return extractor
+        }
+        return view.getTag(EXTRACTOR) as MessageListItemExtractor
     }
 
     private fun getAccount(cursor: Cursor): Account {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -29,15 +29,12 @@ import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.ANSWERED_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.CC_LIST_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.DATE_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.FLAGGED_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FORWARDED_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_TYPE_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.READ_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.SENDER_LIST_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.THREAD_COUNT_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.TO_LIST_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
 import com.fsck.k9.helper.MessageHelper
@@ -177,7 +174,6 @@ class MessageListAdapter internal constructor(
         val subject = itemExtractor.subject(threadCount)
 
         val read = cursor.getInt(READ_COLUMN) == 1
-        val flagged = cursor.getInt(FLAGGED_COLUMN) == 1
         val answered = cursor.getInt(ANSWERED_COLUMN) == 1
         val forwarded = cursor.getInt(FORWARDED_COLUMN) == 1
 
@@ -196,9 +192,8 @@ class MessageListAdapter internal constructor(
             holder.chip.setImageDrawable(accountChipDrawable)
         }
 
-        if (appearance.stars) {
-            holder.flagged.isChecked = flagged
-        }
+        holder.flagged.isChecked = appearance.stars && itemExtractor.flagged
+
         holder.position = cursor.position
         if (holder.contactBadge.isVisible) {
             val counterpartyAddress = fetchCounterPartyAddress(fromMe, toAddrs, ccAddrs, fromAddrs)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -111,16 +111,6 @@ class MessageListAdapter internal constructor(
             appearance.fontSizes.messageListSubject
         }
 
-    private fun recipientSigil(toMe: Boolean, ccMe: Boolean): String {
-        return if (toMe) {
-            res.getString(R.string.messagelist_sent_to_me_sigil)
-        } else if (ccMe) {
-            res.getString(R.string.messagelist_sent_cc_me_sigil)
-        } else {
-            ""
-        }
-    }
-
     override fun newView(context: Context, cursor: Cursor, parent: ViewGroup): View {
         val view = layoutInflater.inflate(R.layout.message_list_item, parent, false)
 
@@ -142,12 +132,7 @@ class MessageListAdapter internal constructor(
         holder.flagged.setOnClickListener(holder)
 
         view.tag = holder
-        view.setTag(EXTRACTOR, MessageListItemExtractor(
-                getAccount(cursor),
-                cursor,
-                messageHelper,
-                res
-        ))
+        view.setTag(EXTRACTOR, MessageListItemExtractor(getAccount(cursor), cursor, messageHelper, res))
 
         return view
     }
@@ -161,8 +146,6 @@ class MessageListAdapter internal constructor(
         val ccAddrs = itemExtractor.ccAddresses
 
         val fromMe = messageHelper.toMe(account, fromAddrs)
-        val toMe = messageHelper.toMe(account, toAddrs)
-        val ccMe = messageHelper.toMe(account, ccAddrs)
 
         val displayName = itemExtractor.displayName
         val displayDate = DateUtils.getRelativeTimeSpanString(context, itemExtractor.date)
@@ -201,7 +184,7 @@ class MessageListAdapter internal constructor(
         }
         updateWithThreadCount(holder, threadCount)
         val beforePreviewText = if (appearance.senderAboveSubject) subject else displayName
-        val sigil = recipientSigil(toMe, ccMe)
+        val sigil = itemExtractor.sigil
         val messageStringBuilder = SpannableStringBuilder(sigil)
                 .append(beforePreviewText)
         if (appearance.previewLines > 0) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -141,12 +141,6 @@ class MessageListAdapter internal constructor(
         val account = getAccount(cursor)
         val itemExtractor = view.getTag(EXTRACTOR) as MessageListItemExtractor
 
-        val fromAddrs = itemExtractor.fromAddresses
-        val toAddrs = itemExtractor.toAddresses
-        val ccAddrs = itemExtractor.ccAddresses
-
-        val fromMe = messageHelper.toMe(account, fromAddrs)
-
         val displayName = itemExtractor.displayName
         val displayDate = DateUtils.getRelativeTimeSpanString(context, itemExtractor.date)
 
@@ -175,7 +169,7 @@ class MessageListAdapter internal constructor(
 
         holder.position = cursor.position
         if (holder.contactBadge.isVisible) {
-            val counterpartyAddress = fetchCounterPartyAddress(fromMe, toAddrs, ccAddrs, fromAddrs)
+            val counterpartyAddress = itemExtractor.counterPartyAddresses
             updateContactBadge(holder.contactBadge, counterpartyAddress)
         }
         setBackgroundColor(view, selected, read)
@@ -255,24 +249,6 @@ class MessageListAdapter internal constructor(
             val span = StyleSpan(Typeface.BOLD)
             text.setSpan(span, 0, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
         }
-    }
-
-    private fun fetchCounterPartyAddress(
-            fromMe: Boolean,
-            toAddrs: Array<Address>,
-            ccAddrs: Array<Address>,
-            fromAddrs: Array<Address>
-    ): Address? {
-        if (fromMe) {
-            if (toAddrs.size > 0) {
-                return toAddrs[0]
-            } else if (ccAddrs.size > 0) {
-                return ccAddrs[0]
-            }
-        } else if (fromAddrs.size > 0) {
-            return fromAddrs[0]
-        }
-        return null
     }
 
     private fun updateContactBadge(contactBadge: ContactBadge, counterpartyAddress: Address?) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -27,7 +27,6 @@ import com.fsck.k9.contacts.ContactPictureLoader
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.ANSWERED_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.CC_LIST_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FORWARDED_COLUMN
@@ -177,8 +176,6 @@ class MessageListAdapter internal constructor(
         val answered = cursor.getInt(ANSWERED_COLUMN) == 1
         val forwarded = cursor.getInt(FORWARDED_COLUMN) == 1
 
-        val hasAttachments = cursor.getInt(ATTACHMENT_COUNT_COLUMN) > 0
-
         val holder = view.tag as MessageViewHolder
 
         val maybeBoldTypeface = if (read) Typeface.NORMAL else Typeface.BOLD
@@ -224,7 +221,7 @@ class MessageListAdapter internal constructor(
         }
 
         holder.date.text = displayDate
-        holder.attachment.visibility = if (hasAttachments) View.VISIBLE else View.GONE
+        holder.attachment.isVisible = itemExtractor.hasAttachments
 
         val statusHolder = buildStatusHolder(forwarded, answered)
         if (statusHolder != null) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -154,10 +154,9 @@ class MessageListAdapter internal constructor(
         val account = getAccount(cursor)
         val itemExtractor = view.getTag(EXTRACTOR) as MessageListItemExtractor
 
-        val ccList = cursor.getString(CC_LIST_COLUMN)
         val fromAddrs = itemExtractor.fromAddresses
         val toAddrs = itemExtractor.toAddresses
-        val ccAddrs = Address.unpack(ccList)
+        val ccAddrs = itemExtractor.ccAddresses
 
         val fromMe = messageHelper.toMe(account, fromAddrs)
         val toMe = messageHelper.toMe(account, toAddrs)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -149,7 +149,12 @@ class MessageListAdapter internal constructor(
         if (itemExtractor.isActiveMessage(activeMessage)) {
             view.setBackgroundColor(activeItemBackgroundColor)
         }
-        updateWithThreadCount(holder, threadCount)
+
+        holder.threadCount.isVisible = threadCount > 1
+        if (holder.threadCount.isVisible) {
+            holder.threadCount.text = "%d".format(threadCount)
+        }
+
         val beforePreviewText = if (appearance.senderAboveSubject) subject else displayName
         val sigil = itemExtractor.sigil
         val messageStringBuilder = SpannableStringBuilder(sigil)
@@ -267,15 +272,6 @@ class MessageListAdapter internal constructor(
             view.setBackgroundColor(color)
         } else {
             view.setBackgroundColor(Color.TRANSPARENT)
-        }
-    }
-
-    private fun updateWithThreadCount(holder: MessageViewHolder, threadCount: Int) {
-        if (threadCount > 1) {
-            holder.threadCount.setText(String.format("%d", threadCount))
-            holder.threadCount.visibility = View.VISIBLE
-        } else {
-            holder.threadCount.visibility = View.GONE
         }
     }
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -27,7 +27,6 @@ import com.fsck.k9.contacts.ContactPictureLoader
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.FORWARDED_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
@@ -144,7 +143,7 @@ class MessageListAdapter internal constructor(
 
         val read = itemExtractor.read
         val answered = itemExtractor.answered
-        val forwarded = cursor.getInt(FORWARDED_COLUMN) == 1
+        val forwarded = itemExtractor.forwarded
 
         val holder = view.tag as MessageViewHolder
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -188,7 +188,7 @@ class MessageListAdapter internal constructor(
         val messageStringBuilder = SpannableStringBuilder(sigil)
                 .append(beforePreviewText)
         if (appearance.previewLines > 0) {
-            val preview = getPreview(cursor)
+            val preview = itemExtractor.preview
             messageStringBuilder.append(" ").append(preview)
         }
         holder.preview.setText(messageStringBuilder, TextView.BufferType.SPANNABLE)
@@ -337,25 +337,6 @@ class MessageListAdapter internal constructor(
         } else {
             holder.threadCount.visibility = View.GONE
         }
-    }
-
-    private fun getPreview(cursor: Cursor): String {
-        val previewTypeString = cursor.getString(PREVIEW_TYPE_COLUMN)
-        val previewType = DatabasePreviewType.fromDatabaseValue(previewTypeString)
-
-        when (previewType) {
-            DatabasePreviewType.NONE, DatabasePreviewType.ERROR -> {
-                return ""
-            }
-            DatabasePreviewType.ENCRYPTED -> {
-                return res.getString(R.string.preview_encrypted)
-            }
-            DatabasePreviewType.TEXT -> {
-                return cursor.getString(PREVIEW_COLUMN)
-            }
-        }
-
-        throw AssertionError("Unknown preview type: $previewType")
     }
 
     companion object {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -145,10 +145,8 @@ class MessageListAdapter internal constructor(
             val counterpartyAddress = itemExtractor.counterPartyAddresses
             updateContactBadge(holder.contactBadge, counterpartyAddress)
         }
-        setBackgroundColor(view, selected, read)
-        if (itemExtractor.isActiveMessage(activeMessage)) {
-            view.setBackgroundColor(activeItemBackgroundColor)
-        }
+
+        setBackgroundColor(view, selected, read, itemExtractor.isActiveMessage(activeMessage))
 
         holder.threadCount.isVisible = threadCount > 1
         if (holder.threadCount.isVisible) {
@@ -258,18 +256,18 @@ class MessageListAdapter internal constructor(
         return null
     }
 
-    private fun setBackgroundColor(view: View, selected: Boolean, read: Boolean) {
+    private fun setBackgroundColor(view: View, selected: Boolean, read: Boolean,
+                                   isActive: Boolean) {
         if (selected || appearance.backGroundAsReadIndicator) {
-            val color: Int
-            if (selected) {
-                color = selectedItemBackgroundColor
-            } else if (read) {
-                color = readItemBackgroundColor
-            } else {
-                color = unreadItemBackgroundColor
+            val color: Int = when {
+                selected -> selectedItemBackgroundColor
+                read -> readItemBackgroundColor
+                else -> unreadItemBackgroundColor
             }
 
             view.setBackgroundColor(color)
+        } else if (isActive) {
+            view.setBackgroundColor(activeItemBackgroundColor)
         } else {
             view.setBackgroundColor(Color.TRANSPARENT)
         }

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -37,7 +37,6 @@ import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_TYPE_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.READ_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.SENDER_LIST_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.SUBJECT_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.THREAD_COUNT_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.TO_LIST_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
@@ -150,7 +149,7 @@ class MessageListAdapter internal constructor(
         holder.flagged.setOnClickListener(holder)
 
         view.tag = holder
-        view.setTag(EXTRACTOR, MessageListItemExtractor(cursor))
+        view.setTag(EXTRACTOR, MessageListItemExtractor(cursor, res))
 
         return view
     }
@@ -175,8 +174,7 @@ class MessageListAdapter internal constructor(
 
         val threadCount = if (appearance.showingThreadedList) cursor.getInt(THREAD_COUNT_COLUMN) else 0
 
-        val subject = MlfUtils.buildSubject(cursor.getString(SUBJECT_COLUMN),
-                res.getString(R.string.general_no_subject), threadCount)
+        val subject = itemExtractor.subject(threadCount)
 
         val read = cursor.getInt(READ_COLUMN) == 1
         val flagged = cursor.getInt(FLAGGED_COLUMN) == 1

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -154,10 +154,9 @@ class MessageListAdapter internal constructor(
         val account = getAccount(cursor)
         val itemExtractor = view.getTag(EXTRACTOR) as MessageListItemExtractor
 
-        val toList = cursor.getString(TO_LIST_COLUMN)
         val ccList = cursor.getString(CC_LIST_COLUMN)
         val fromAddrs = itemExtractor.fromAddresses
-        val toAddrs = Address.unpack(toList)
+        val toAddrs = itemExtractor.toAddresses
         val ccAddrs = Address.unpack(ccList)
 
         val fromMe = messageHelper.toMe(account, fromAddrs)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -20,12 +20,10 @@ import android.widget.CursorAdapter
 import android.widget.TextView
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.isVisible
-import com.fsck.k9.Account
 import com.fsck.k9.FontSizes
 import com.fsck.k9.Preferences
 import com.fsck.k9.contacts.ContactPictureLoader
 import com.fsck.k9.controller.MessageReference
-import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
 import com.fsck.k9.ui.ContactBadge
@@ -120,7 +118,6 @@ class MessageListAdapter internal constructor(
     }
 
     override fun bindView(view: View, context: Context, cursor: Cursor) {
-        val account = getAccount(cursor)
         val itemExtractor = getExtractor(view, cursor)
 
         val displayName = itemExtractor.displayName
@@ -143,7 +140,7 @@ class MessageListAdapter internal constructor(
 
         if (appearance.showAccountChip) {
             val accountChipDrawable = holder.chip.drawable.mutate()
-            DrawableCompat.setTint(accountChipDrawable, account.chipColor)
+            DrawableCompat.setTint(accountChipDrawable, itemExtractor.chipColor)
             holder.chip.setImageDrawable(accountChipDrawable)
         }
 
@@ -193,16 +190,11 @@ class MessageListAdapter internal constructor(
     private fun getExtractor(view: View, cursor: Cursor): MessageListItemExtractor {
         if (view.getTag(EXTRACTOR) == null
                 || (view.getTag(EXTRACTOR) as MessageListItemExtractor).cursor != cursor) {
-            val extractor = MessageListItemExtractor(getAccount(cursor), cursor, messageHelper, res)
+            val extractor = MessageListItemExtractor(preferences, cursor, messageHelper, res)
             view.setTag(EXTRACTOR, extractor)
             return extractor
         }
         return view.getTag(EXTRACTOR) as MessageListItemExtractor
-    }
-
-    private fun getAccount(cursor: Cursor): Account {
-        val accountUuid = cursor.getString(ACCOUNT_UUID_COLUMN)
-        return preferences.getAccount(accountUuid)
     }
 
     private fun formatPreviewText(

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -119,22 +119,16 @@ class MessageListAdapter internal constructor(
 
     override fun bindView(view: View, context: Context, cursor: Cursor) {
         val itemExtractor = getExtractor(view, cursor)
+        val holder = view.tag as MessageViewHolder
 
         val displayName = itemExtractor.displayName
         val displayDate = DateUtils.getRelativeTimeSpanString(context, itemExtractor.date)
-
         val threadCount = if (appearance.showingThreadedList) itemExtractor.threadCount else 0
-
         val subject = itemExtractor.subject(threadCount)
-
         val read = itemExtractor.read
         val answered = itemExtractor.answered
         val forwarded = itemExtractor.forwarded
-
-        val holder = view.tag as MessageViewHolder
-
         val maybeBoldTypeface = if (read) Typeface.NORMAL else Typeface.BOLD
-
         val uniqueId = cursor.getLong(uniqueIdColumn)
         val selected = selected.contains(uniqueId)
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -172,7 +172,7 @@ class MessageListAdapter internal constructor(
         val displayName = messageHelper.getDisplayName(account, fromAddrs, toAddrs)
         val displayDate = DateUtils.getRelativeTimeSpanString(context, cursor.getLong(DATE_COLUMN))
 
-        val threadCount = if (appearance.showingThreadedList) cursor.getInt(THREAD_COUNT_COLUMN) else 0
+        val threadCount = if (appearance.showingThreadedList) itemExtractor.threadCount else 0
 
         val subject = itemExtractor.subject(threadCount)
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -172,12 +172,9 @@ class MessageListAdapter internal constructor(
         holder.date.text = displayDate
         holder.attachment.isVisible = itemExtractor.hasAttachments
 
-        val statusHolder = buildStatusHolder(forwarded, answered)
-        if (statusHolder != null) {
-            holder.status.setImageDrawable(statusHolder)
-            holder.status.visibility = View.VISIBLE
-        } else {
-            holder.status.visibility = View.GONE
+        holder.status.isVisible = answered || forwarded
+        if (holder.status.isVisible) {
+            holder.status.setImageDrawable(getStatusDrawable(forwarded, answered))
         }
     }
 
@@ -245,7 +242,7 @@ class MessageListAdapter internal constructor(
         }
     }
 
-    private fun buildStatusHolder(forwarded: Boolean, answered: Boolean): Drawable? {
+    private fun getStatusDrawable(forwarded: Boolean, answered: Boolean): Drawable? {
         if (forwarded && answered) {
             return forwardedAnsweredIcon
         } else if (answered) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -27,14 +27,11 @@ import com.fsck.k9.contacts.ContactPictureLoader
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.ANSWERED_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.CC_LIST_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FORWARDED_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_TYPE_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.READ_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.SENDER_LIST_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.TO_LIST_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
@@ -145,7 +142,12 @@ class MessageListAdapter internal constructor(
         holder.flagged.setOnClickListener(holder)
 
         view.tag = holder
-        view.setTag(EXTRACTOR, MessageListItemExtractor(cursor, res))
+        view.setTag(EXTRACTOR, MessageListItemExtractor(
+                getAccount(cursor),
+                cursor,
+                messageHelper,
+                res
+        ))
 
         return view
     }
@@ -162,7 +164,7 @@ class MessageListAdapter internal constructor(
         val toMe = messageHelper.toMe(account, toAddrs)
         val ccMe = messageHelper.toMe(account, ccAddrs)
 
-        val displayName = messageHelper.getDisplayName(account, fromAddrs, toAddrs)
+        val displayName = itemExtractor.displayName
         val displayDate = DateUtils.getRelativeTimeSpanString(context, itemExtractor.date)
 
         val threadCount = if (appearance.showingThreadedList) itemExtractor.threadCount else 0

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -170,7 +170,7 @@ class MessageListAdapter internal constructor(
         val ccMe = messageHelper.toMe(account, ccAddrs)
 
         val displayName = messageHelper.getDisplayName(account, fromAddrs, toAddrs)
-        val displayDate = DateUtils.getRelativeTimeSpanString(context, cursor.getLong(DATE_COLUMN))
+        val displayDate = DateUtils.getRelativeTimeSpanString(context, itemExtractor.date)
 
         val threadCount = if (appearance.showingThreadedList) itemExtractor.threadCount else 0
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -26,8 +26,6 @@ import com.fsck.k9.Preferences
 import com.fsck.k9.contacts.ContactPictureLoader
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
 import com.fsck.k9.ui.ContactBadge
@@ -84,15 +82,6 @@ class MessageListAdapter internal constructor(
     }
 
     var activeMessage: MessageReference? = null
-
-    private val activeAccountUuid: String?
-        get() = activeMessage?.accountUuid
-
-    private val activeFolderServerId: String?
-        get() = activeMessage?.folderServerId
-
-    private val activeUid: String?
-        get() = activeMessage?.uid
 
     var uniqueIdColumn: Int = 0
 
@@ -166,8 +155,8 @@ class MessageListAdapter internal constructor(
             updateContactBadge(holder.contactBadge, counterpartyAddress)
         }
         setBackgroundColor(view, selected, read)
-        if (activeMessage != null) {
-            changeBackgroundColorIfActiveMessage(cursor, account, view)
+        if (itemExtractor.isActiveMessage(activeMessage)) {
+            view.setBackgroundColor(activeItemBackgroundColor)
         }
         updateWithThreadCount(holder, threadCount)
         val beforePreviewText = if (appearance.senderAboveSubject) subject else displayName
@@ -267,17 +256,6 @@ class MessageListAdapter internal constructor(
         } else {
             contactBadge.assignContactUri(null)
             contactBadge.setImageResource(R.drawable.ic_contact_picture)
-        }
-    }
-
-    private fun changeBackgroundColorIfActiveMessage(cursor: Cursor, account: Account, view: View) {
-        val uid = cursor.getString(UID_COLUMN)
-        val folderServerId = cursor.getString(FOLDER_SERVER_ID_COLUMN)
-
-        if (account.uuid == activeAccountUuid &&
-                folderServerId == activeFolderServerId &&
-                uid == activeUid) {
-            view.setBackgroundColor(activeItemBackgroundColor)
         }
     }
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -154,10 +154,9 @@ class MessageListAdapter internal constructor(
         val account = getAccount(cursor)
         val itemExtractor = view.getTag(EXTRACTOR) as MessageListItemExtractor
 
-        val fromList = cursor.getString(SENDER_LIST_COLUMN)
         val toList = cursor.getString(TO_LIST_COLUMN)
         val ccList = cursor.getString(CC_LIST_COLUMN)
-        val fromAddrs = Address.unpack(fromList)
+        val fromAddrs = itemExtractor.fromAddresses
         val toAddrs = Address.unpack(toList)
         val ccAddrs = Address.unpack(ccList)
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -26,10 +26,8 @@ import com.fsck.k9.Preferences
 import com.fsck.k9.contacts.ContactPictureLoader
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.ANSWERED_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FORWARDED_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.READ_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
@@ -144,8 +142,8 @@ class MessageListAdapter internal constructor(
 
         val subject = itemExtractor.subject(threadCount)
 
-        val read = cursor.getInt(READ_COLUMN) == 1
-        val answered = cursor.getInt(ANSWERED_COLUMN) == 1
+        val read = itemExtractor.read
+        val answered = itemExtractor.answered
         val forwarded = cursor.getInt(FORWARDED_COLUMN) == 1
 
         val holder = view.tag as MessageViewHolder

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -29,13 +29,10 @@ import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.ANSWERED_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FORWARDED_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_COLUMN
-import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_TYPE_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.READ_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
-import com.fsck.k9.mailstore.DatabasePreviewType
 import com.fsck.k9.ui.ContactBadge
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.messagelist.MessageListAppearance

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -20,18 +20,11 @@ import android.widget.CursorAdapter
 import android.widget.TextView
 import androidx.core.graphics.drawable.DrawableCompat
 import androidx.core.view.isVisible
-
 import com.fsck.k9.Account
 import com.fsck.k9.FontSizes
-import com.fsck.k9.ui.R
 import com.fsck.k9.Preferences
 import com.fsck.k9.contacts.ContactPictureLoader
 import com.fsck.k9.controller.MessageReference
-import com.fsck.k9.helper.MessageHelper
-import com.fsck.k9.mail.Address
-import com.fsck.k9.mailstore.DatabasePreviewType
-import com.fsck.k9.ui.messagelist.MessageListAppearance
-
 import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.ANSWERED_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN
@@ -48,8 +41,12 @@ import com.fsck.k9.fragment.MLFProjectionInfo.SUBJECT_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.THREAD_COUNT_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.TO_LIST_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
+import com.fsck.k9.helper.MessageHelper
+import com.fsck.k9.mail.Address
+import com.fsck.k9.mailstore.DatabasePreviewType
 import com.fsck.k9.ui.ContactBadge
-
+import com.fsck.k9.ui.R
+import com.fsck.k9.ui.messagelist.MessageListAppearance
 import kotlin.math.max
 
 class MessageListAdapter internal constructor(
@@ -153,12 +150,14 @@ class MessageListAdapter internal constructor(
         holder.flagged.setOnClickListener(holder)
 
         view.tag = holder
+        view.setTag(EXTRACTOR, MessageListItemExtractor(cursor))
 
         return view
     }
 
     override fun bindView(view: View, context: Context, cursor: Cursor) {
         val account = getAccount(cursor)
+        val itemExtractor = view.getTag(EXTRACTOR) as MessageListItemExtractor
 
         val fromList = cursor.getString(SENDER_LIST_COLUMN)
         val toList = cursor.getString(TO_LIST_COLUMN)
@@ -385,6 +384,10 @@ class MessageListAdapter internal constructor(
         }
 
         throw AssertionError("Unknown preview type: $previewType")
+    }
+
+    companion object {
+        private val EXTRACTOR = R.id.message_list_item_extractor
     }
 }
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -101,15 +101,10 @@ import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
 
 import static com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN;
-import static com.fsck.k9.fragment.MLFProjectionInfo.FLAGGED_COLUMN;
-import static com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.ID_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.PROJECTION;
-import static com.fsck.k9.fragment.MLFProjectionInfo.READ_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.SUBJECT_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.THREADED_PROJECTION;
-import static com.fsck.k9.fragment.MLFProjectionInfo.THREAD_COUNT_COLUMN;
-import static com.fsck.k9.fragment.MLFProjectionInfo.THREAD_ROOT_COLUMN;
 
 
 public class MessageListFragment extends Fragment implements OnItemClickListener,

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -1133,22 +1133,20 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo) {
         super.onCreateContextMenu(menu, v, menuInfo);
 
-        AdapterContextMenuInfo info = (AdapterContextMenuInfo) menuInfo;
-        Cursor cursor = (Cursor) listView.getItemAtPosition(info.position);
+        final AdapterContextMenuInfo info = (AdapterContextMenuInfo) menuInfo;
+        if (adapter.getCount() <= info.position) return;
 
-        if (cursor == null) {
-            return;
-        }
+        final MessageListItem item =  adapter.getItem(info.position);
 
         getActivity().getMenuInflater().inflate(R.menu.message_list_item_context, menu);
         menu.findItem(R.id.debug_delete_locally).setVisible(K9.DEVELOPER_MODE);
 
-        contextMenuUniqueId = cursor.getLong(uniqueIdColumn);
-        Account account = getAccountFromCursor(cursor);
+        contextMenuUniqueId = item.getSelectionIdentifier();
+        final Account account = item.getAccount();
 
-        String subject = cursor.getString(SUBJECT_COLUMN);
-        boolean read = (cursor.getInt(READ_COLUMN) == 1);
-        boolean flagged = (cursor.getInt(FLAGGED_COLUMN) == 1);
+        final String subject = item.getSubject();
+        final boolean read = item.getRead();
+        final boolean flagged = item.getFlagged();
 
         menu.setHeaderTitle(subject);
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -362,20 +362,17 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             return;
         }
 
-        Cursor cursor = (Cursor) parent.getItemAtPosition(position);
-        if (cursor == null) {
-            return;
-        }
+        final MessageListItem item = adapter.getItem(position);
 
         if (selectedCount > 0) {
             toggleMessageSelect(position);
         } else {
-            if (showingThreadedList && cursor.getInt(THREAD_COUNT_COLUMN) > 1) {
-                Account account = getAccountFromCursor(cursor);
-                String folderServerId = cursor.getString(FOLDER_SERVER_ID_COLUMN);
+            if (showingThreadedList && item.getThreadCount() > 0) {
+                final Account account = item.getAccount();
+                String folderServerId = item.getFolderServerId();
 
                 // If threading is enabled and this item represents a thread, display the thread contents.
-                long rootId = cursor.getLong(THREAD_ROOT_COLUMN);
+                long rootId = item.getThreadId();
                 fragmentListener.showThread(account, folderServerId, rootId);
             } else {
                 // This item represents a message; just display the message.

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -97,7 +97,6 @@ import com.fsck.k9.ui.messagelist.ConvertedMessagesReady;
 import com.fsck.k9.ui.messagelist.CursorToMessageListItems;
 import com.fsck.k9.ui.messagelist.MessageListAppearance;
 import com.fsck.k9.ui.messagelist.MessageListItem;
-import kotlin.Unit;
 import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
 
@@ -1572,7 +1571,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             messagingController.setFlagForThreads(account,
                     Collections.singletonList(threadRootId), flag, newState);
         } else {
-            long id = cursor.getLong(ID_COLUMN);
+            final long id = item.getId();
             messagingController.setFlag(account, Collections.singletonList(id), flag,
                     newState);
         }
@@ -1614,7 +1613,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                     }
 
                     // FIXME Why so many IDS?
-                    messageIdList.add(cursor.getLong(ID_COLUMN));
+                    messageIdList.add(item.getId());
                 }
             }
         }
@@ -2272,7 +2271,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
         final String accountUuid = item.getAccount().getUuid();
         final String folderServerId = item.getFolderServerId();
-        final String messageUid = item.getUid();
+        final String messageUid = item.getMessageUid();
         return new MessageReference(accountUuid, folderServerId, messageUid, null);
     }
 
@@ -2299,7 +2298,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
             final String accountUuid = item.getAccount().getUuid();
             final String folderServerId = item.getFolderServerId();
-            final String messageUid = item.getUid();
+            final String messageUid = item.getMessageUid();
 
             if (accountUuid.equals(messageReference.getAccountUuid()) &&
                     folderServerId.equals(messageReference.getFolderServerId()) &&
@@ -2381,7 +2380,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
         final String accountUuid = item.getAccount().getUuid();
         final String folderServerId = item.getFolderServerId();
-        final String messageUid = item.getUid();
+        final String messageUid = item.getMessageUid();
 
         return new MessageReference(accountUuid, folderServerId, messageUid, null);
     }

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -100,10 +100,8 @@ import com.fsck.k9.ui.messagelist.MessageListItem;
 import org.jetbrains.annotations.NotNull;
 import timber.log.Timber;
 
-import static com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.ID_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.PROJECTION;
-import static com.fsck.k9.fragment.MLFProjectionInfo.SUBJECT_COLUMN;
 import static com.fsck.k9.fragment.MLFProjectionInfo.THREADED_PROJECTION;
 
 
@@ -493,8 +491,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             selected[i++] = id;
         }
         outState.putLongArray(STATE_SELECTED_MESSAGES, selected);
-    }
 
+    }
     /**
      * Restore selected messages from a {@link Bundle}.
      */
@@ -2641,8 +2639,9 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             @Override
             public void onItemsReady(@NotNull List<MessageListItem> list) {
                 if (isThreadDisplay) {
-                    if (cursor.moveToFirst()) {
-                        title = cursor.getString(SUBJECT_COLUMN);
+                    final MessageListItem item = list.get(0);
+                    if (item != null) {
+                        title = item.getSubject();
                         if (!TextUtils.isEmpty(title)) {
                             title = Utility.stripSubject(title);
                         }
@@ -2796,11 +2795,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     public void onLoaderReset(Loader<Cursor> loader) {
         selected.clear();
         adapter.clearData();
-    }
-
-    private Account getAccountFromCursor(Cursor cursor) {
-        String accountUuid = cursor.getString(ACCOUNT_UUID_COLUMN);
-        return preferences.getAccount(accountUuid);
     }
 
     void remoteSearchFinished() {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -1566,10 +1566,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         Account account = item.getAccount();
 
         if (showingThreadedList && item.getThreadCount() > 1) {
-            // FIXME WHAT THE FLYING FUCK
-            long threadRootId = cursor.getLong(THREAD_ROOT_COLUMN);
             messagingController.setFlagForThreads(account,
-                    Collections.singletonList(threadRootId), flag, newState);
+                    Collections.singletonList(item.getThreadId()), flag, newState);
         } else {
             final long id = item.getId();
             messagingController.setFlag(account, Collections.singletonList(id), flag,
@@ -1603,8 +1601,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                         threadMap.put(account, threadRootIdList);
                     }
 
-                    // FIXME Thread root column again
-                    threadRootIdList.add(cursor.getLong(THREAD_ROOT_COLUMN));
+                    threadRootIdList.add(item.getThreadId());
                 } else {
                     List<Long> messageIdList = messageMap.get(account);
                     if (messageIdList == null) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
@@ -153,7 +153,7 @@ class MessageListItemAdapter internal constructor(
             updateContactBadge(holder.contactBadge, counterpartyAddress)
         }
 
-        setBackgroundColor(view, selected, read, listItem.isActiveMessage(activeMessage))
+        setBackgroundColor(view, selected, read, isActiveMessage(listItem, activeMessage))
 
         holder.threadCount.isVisible = threadCount > 1
         if (holder.threadCount.isVisible) {
@@ -186,6 +186,20 @@ class MessageListItemAdapter internal constructor(
         if (holder.status.isVisible) {
             holder.status.setImageDrawable(getStatusDrawable(forwarded, answered))
         }
+    }
+
+    private fun isActiveMessage(item: MessageListItem, activeMessage: MessageReference?): Boolean {
+        if (activeMessage == null) return false
+
+        val uid = item.uid
+        val folderServerId = item.folderServerId
+
+        val activeAccountUuid = activeMessage.accountUuid
+        val activeFolderServerId = activeMessage.folderServerId
+        val activeUid = activeMessage.uid
+        return item.account.uuid == activeAccountUuid
+                && folderServerId == activeFolderServerId
+                && uid == activeUid
     }
 
     private fun formatPreviewText(

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
@@ -1,0 +1,266 @@
+package com.fsck.k9.fragment
+
+
+import android.content.res.Resources
+import android.graphics.Color
+import android.graphics.Typeface
+import android.graphics.drawable.Drawable
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.format.DateUtils
+import android.text.style.AbsoluteSizeSpan
+import android.text.style.ForegroundColorSpan
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.BaseAdapter
+import android.widget.TextView
+import androidx.core.graphics.drawable.DrawableCompat
+import androidx.core.view.isVisible
+import com.fsck.k9.FontSizes
+import com.fsck.k9.contacts.ContactPictureLoader
+import com.fsck.k9.controller.MessageReference
+import com.fsck.k9.mail.Address
+import com.fsck.k9.ui.ContactBadge
+import com.fsck.k9.ui.R
+import com.fsck.k9.ui.messagelist.MessageListAppearance
+import com.fsck.k9.ui.messagelist.MessageListItem
+import kotlin.math.max
+
+class MessageListItemAdapter internal constructor(
+        theme: Resources.Theme,
+        res: Resources,
+        private val layoutInflater: LayoutInflater,
+        private val contactsPictureLoader: ContactPictureLoader,
+        private val listItemListener: MessageListItemActionListener,
+        private val appearance: MessageListAppearance
+) : BaseAdapter() {
+
+    var data: List<MessageListItem> = emptyList()
+        set(value) {
+            field = value
+            notifyDataSetChanged()
+        }
+
+    override fun getItem(position: Int): MessageListItem = data[position]
+
+    override fun getItemId(position: Int): Long = position.toLong()
+
+    override fun getCount(): Int = data.size
+
+
+    private val forwardedIcon: Drawable
+    private val answeredIcon: Drawable
+    private val forwardedAnsweredIcon: Drawable
+    private val previewTextColor: Int
+    private val activeItemBackgroundColor: Int
+    private val selectedItemBackgroundColor: Int
+    private val readItemBackgroundColor: Int
+    private val unreadItemBackgroundColor: Int
+
+    init {
+
+        val attributes = intArrayOf(
+                R.attr.messageListAnswered,
+                R.attr.messageListForwarded,
+                R.attr.messageListAnsweredForwarded,
+                R.attr.messageListPreviewTextColor,
+                R.attr.messageListActiveItemBackgroundColor,
+                R.attr.messageListSelectedBackgroundColor,
+                R.attr.messageListReadItemBackgroundColor,
+                R.attr.messageListUnreadItemBackgroundColor
+        )
+
+        val array = theme.obtainStyledAttributes(attributes)
+
+        answeredIcon = res.getDrawable(array.getResourceId(0, R.drawable.ic_messagelist_answered_dark))
+        forwardedIcon = res.getDrawable(array.getResourceId(1, R.drawable.ic_messagelist_forwarded_dark))
+        forwardedAnsweredIcon = res.getDrawable(array.getResourceId(2, R.drawable.ic_messagelist_answered_forwarded_dark))
+        previewTextColor = array.getColor(3, Color.BLACK)
+        activeItemBackgroundColor = array.getColor(4, Color.BLACK)
+        selectedItemBackgroundColor = array.getColor(5, Color.BLACK)
+        readItemBackgroundColor = array.getColor(6, Color.BLACK)
+        unreadItemBackgroundColor = array.getColor(7, Color.BLACK)
+
+        array.recycle()
+    }
+
+    var activeMessage: MessageReference? = null
+
+    var uniqueIdColumn: Int = 0
+
+    var selected: Set<Long> = emptySet()
+
+    private inline val subjectViewFontSize: Int
+        get() = if (appearance.senderAboveSubject) {
+            appearance.fontSizes.messageListSender
+        } else {
+            appearance.fontSizes.messageListSubject
+        }
+
+    override fun getView(position: Int, convertView: View?, parent: ViewGroup?): View {
+        val view = convertView ?: layoutInflater.inflate(R.layout.message_list_item, parent, false)
+        val holder = (convertView?.tag as? MessageViewHolder)
+                ?: MessageViewHolder(view, listItemListener)
+
+        holder.contactBadge.isVisible = appearance.showContactPicture
+        holder.chip.isVisible = appearance.showAccountChip
+
+        appearance.fontSizes.setViewTextSize(holder.subject, subjectViewFontSize)
+
+        appearance.fontSizes.setViewTextSize(holder.date, appearance.fontSizes.messageListDate)
+
+        // 1 preview line is needed even if it is set to 0, because subject is part of the same text view
+        holder.preview.setLines(max(appearance.previewLines, 1))
+        appearance.fontSizes.setViewTextSize(holder.preview, appearance.fontSizes.messageListPreview)
+        appearance.fontSizes.setViewTextSize(holder.threadCount, appearance.fontSizes.messageListSubject) // thread count is next to subject
+
+        holder.flagged.isVisible = appearance.stars
+        holder.flagged.setOnClickListener(holder)
+        bindView(view, position)
+
+        view.tag = holder
+
+        return view
+    }
+
+    private fun bindView(view: View, position: Int) {
+        val listItem = data[position]
+        val holder = view.tag as MessageViewHolder
+
+        val displayName = listItem.displayName
+        val displayDate = DateUtils.getRelativeTimeSpanString(view.context, listItem.date)
+        val threadCount = if (appearance.showingThreadedList) listItem.threadCount else 0
+        val subject = listItem.subject
+        val read = listItem.read
+        val answered = listItem.answered
+        val forwarded = listItem.forwarded
+        val maybeBoldTypeface = if (read) Typeface.NORMAL else Typeface.BOLD
+        val uniqueId = cursor.getLong(uniqueIdColumn)
+        val selected = selected.contains(uniqueId)
+
+        if (appearance.showAccountChip) {
+            val accountChipDrawable = holder.chip.drawable.mutate()
+            DrawableCompat.setTint(accountChipDrawable, listItem.chipColor)
+            holder.chip.setImageDrawable(accountChipDrawable)
+        }
+
+        holder.flagged.isChecked = appearance.stars && listItem.flagged
+
+        holder.position = position
+        if (holder.contactBadge.isVisible) {
+            val counterpartyAddress = listItem.counterPartyAddresses
+            updateContactBadge(holder.contactBadge, counterpartyAddress)
+        }
+
+        setBackgroundColor(view, selected, read, listItem.isActiveMessage(activeMessage))
+
+        holder.threadCount.isVisible = threadCount > 1
+        if (holder.threadCount.isVisible) {
+            holder.threadCount.text = "%d".format(threadCount)
+        }
+
+        val beforePreviewText = if (appearance.senderAboveSubject) subject else displayName
+        val sigil = listItem.sigil
+        val messageStringBuilder = SpannableStringBuilder(sigil)
+                .append(beforePreviewText)
+        if (appearance.previewLines > 0) {
+            val preview = listItem.preview
+            messageStringBuilder.append(" ").append(preview)
+        }
+        holder.preview.setText(messageStringBuilder, TextView.BufferType.SPANNABLE)
+
+        formatPreviewText(holder.preview, beforePreviewText, sigil)
+
+        holder.subject.typeface = Typeface.create(holder.subject.typeface, maybeBoldTypeface)
+        if (appearance.senderAboveSubject) {
+            holder.subject.text = displayName
+        } else {
+            holder.subject.text = subject
+        }
+
+        holder.date.text = displayDate
+        holder.attachment.isVisible = listItem.hasAttachments
+
+        holder.status.isVisible = answered || forwarded
+        if (holder.status.isVisible) {
+            holder.status.setImageDrawable(getStatusDrawable(forwarded, answered))
+        }
+    }
+
+    private fun formatPreviewText(
+            preview: TextView,
+            beforePreviewText: CharSequence,
+            sigil: String
+    ) {
+        val previewText = preview.text as Spannable
+
+        val beforePreviewLength = beforePreviewText.length + sigil.length
+        addBeforePreviewSpan(previewText, beforePreviewLength)
+
+        // Set span (color) for preview message
+        previewText.setSpan(
+                ForegroundColorSpan(previewTextColor),
+                beforePreviewLength,
+                previewText.length,
+                Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+        )
+    }
+
+    private fun addBeforePreviewSpan(text: Spannable, length: Int) {
+        val fontSize = if (appearance.senderAboveSubject) {
+            appearance.fontSizes.messageListSubject
+        } else {
+            appearance.fontSizes.messageListSender
+        }
+
+        if (fontSize != FontSizes.FONT_DEFAULT) {
+            val span = AbsoluteSizeSpan(fontSize, true)
+            text.setSpan(span, 0, length, Spannable.SPAN_EXCLUSIVE_EXCLUSIVE)
+        }
+    }
+
+    private fun updateContactBadge(contactBadge: ContactBadge, counterpartyAddress: Address?) {
+        if (counterpartyAddress != null) {
+            contactBadge.setContact(counterpartyAddress)
+            /*
+                     * At least in Android 2.2 a different background + padding is used when no
+                     * email address is available. ListView reuses the views but ContactBadge
+                     * doesn't reset the padding, so we do it ourselves.
+                     */
+            contactBadge.setPadding(0, 0, 0, 0)
+            contactsPictureLoader.setContactPicture(contactBadge, counterpartyAddress)
+        } else {
+            contactBadge.assignContactUri(null)
+            contactBadge.setImageResource(R.drawable.ic_contact_picture)
+        }
+    }
+
+    private fun getStatusDrawable(forwarded: Boolean, answered: Boolean): Drawable? {
+        if (forwarded && answered) {
+            return forwardedAnsweredIcon
+        } else if (answered) {
+            return answeredIcon
+        } else if (forwarded) {
+            return forwardedIcon
+        }
+        return null
+    }
+
+    private fun setBackgroundColor(view: View, selected: Boolean, read: Boolean,
+                                   isActive: Boolean) {
+        if (selected || appearance.backGroundAsReadIndicator) {
+            val color: Int = when {
+                selected -> selectedItemBackgroundColor
+                read -> readItemBackgroundColor
+                else -> unreadItemBackgroundColor
+            }
+
+            view.setBackgroundColor(color)
+        } else if (isActive) {
+            view.setBackgroundColor(activeItemBackgroundColor)
+        } else {
+            view.setBackgroundColor(Color.TRANSPARENT)
+        }
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.fragment
 
 
-import android.annotation.SuppressLint
 import android.content.res.Resources
 import android.graphics.Color
 import android.graphics.Typeface
@@ -223,7 +222,7 @@ class MessageListItemAdapter internal constructor(
     private fun isActiveMessage(item: MessageListItem, activeMessage: MessageReference?): Boolean {
         if (activeMessage == null) return false
 
-        val uid = item.uid
+        val uid = item.messageUid
         val folderServerId = item.folderServerId
 
         val activeAccountUuid = activeMessage.accountUuid

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.fragment
 
 
+import android.content.Context
 import android.content.res.Resources
 import android.graphics.Color
 import android.graphics.Typeface
@@ -115,16 +116,15 @@ class MessageListItemAdapter internal constructor(
 
         holder.flagged.isVisible = appearance.stars
         holder.flagged.setOnClickListener(holder)
-        bindView(view, position)
-
         view.tag = holder
+        bindView(view, holder, position)
+
 
         return view
     }
 
-    private fun bindView(view: View, position: Int) {
+    private fun bindView(view: View, holder: MessageViewHolder, position: Int) {
         val listItem = data[position]
-        val holder = view.tag as MessageViewHolder
 
         val displayName = listItem.displayName
         val displayDate = DateUtils.getRelativeTimeSpanString(view.context, listItem.date)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
@@ -277,4 +277,8 @@ class MessageListItemAdapter internal constructor(
             view.setBackgroundColor(Color.TRANSPARENT)
         }
     }
+
+    fun clearData() {
+        data = emptyList()
+    }
 }

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemAdapter.kt
@@ -87,8 +87,6 @@ class MessageListItemAdapter internal constructor(
 
     var activeMessage: MessageReference? = null
 
-    var uniqueIdColumn: Int = 0
-
     var selected: Set<Long> = emptySet()
 
     private inline val subjectViewFontSize: Int
@@ -136,8 +134,7 @@ class MessageListItemAdapter internal constructor(
         val answered = listItem.answered
         val forwarded = listItem.forwarded
         val maybeBoldTypeface = if (read) Typeface.NORMAL else Typeface.BOLD
-        val uniqueId = cursor.getLong(uniqueIdColumn)
-        val selected = selected.contains(uniqueId)
+        val selected = selected.contains(listItem.selectionIdentifier)
 
         if (appearance.showAccountChip) {
             val accountChipDrawable = holder.chip.drawable.mutate()

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -2,15 +2,23 @@ package com.fsck.k9.fragment
 
 import android.content.res.Resources
 import android.database.Cursor
+import com.fsck.k9.Account
+import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
 import com.fsck.k9.ui.R
 
 class MessageListItemExtractor(
+        private val account: Account,
         private val cursor: Cursor,
+        private val messageHelper: MessageHelper,
         private val res: Resources
 ) {
+
     val ccAddresses: Array<Address>
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.CC_LIST_COLUMN))
+
+    val displayName: CharSequence
+        get() = messageHelper.getDisplayName(account, fromAddresses, toAddresses)
 
     val date: Long get() = cursor.getLong(MLFProjectionInfo.DATE_COLUMN)
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -2,7 +2,9 @@ package com.fsck.k9.fragment
 
 import android.content.res.Resources
 import android.database.Cursor
+import androidx.annotation.ColorInt
 import com.fsck.k9.Account
+import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
@@ -10,12 +12,14 @@ import com.fsck.k9.mailstore.DatabasePreviewType
 import com.fsck.k9.ui.R
 
 class MessageListItemExtractor(
-        private val account: Account,
+        private val preferences: Preferences,
         val cursor: Cursor,
         private val messageHelper: MessageHelper,
         private val res: Resources
 ) {
 
+    private val account: Account
+        get() = preferences.getAccount(cursor.getString(MLFProjectionInfo.ACCOUNT_UUID_COLUMN))
     private val ccAddresses: Array<Address>
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.CC_LIST_COLUMN))
     private val ccMe: Boolean get() = messageHelper.toMe(account, ccAddresses)
@@ -25,6 +29,7 @@ class MessageListItemExtractor(
     private val toAddresses: Array<Address>
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.TO_LIST_COLUMN))
     private val toMe: Boolean get() = messageHelper.toMe(account, toAddresses)
+
     val answered: Boolean get() = cursor.getInt(MLFProjectionInfo.ANSWERED_COLUMN) == 1
 
     val counterPartyAddresses: Address?
@@ -40,6 +45,9 @@ class MessageListItemExtractor(
             }
             return null
         }
+
+
+    val chipColor: Int @ColorInt get() = account.chipColor
 
     val displayName: CharSequence
         get() = messageHelper.getDisplayName(account, fromAddresses, toAddresses)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -2,6 +2,7 @@ package com.fsck.k9.fragment
 
 import android.content.res.Resources
 import android.database.Cursor
+import com.fsck.k9.mail.Address
 import com.fsck.k9.ui.R
 
 class MessageListItemExtractor(
@@ -12,6 +13,9 @@ class MessageListItemExtractor(
     val date: Long get() = cursor.getLong(MLFProjectionInfo.DATE_COLUMN)
 
     val flagged: Boolean get() = cursor.getInt(MLFProjectionInfo.FLAGGED_COLUMN) == 1
+
+    val fromAddresses: Array<Address>
+        get() = Address.unpack(cursor.getString(MLFProjectionInfo.SENDER_LIST_COLUMN))
 
     val hasAttachments: Boolean get() = cursor.getInt(MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN) > 0
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -15,12 +15,15 @@ class MessageListItemExtractor(
         private val res: Resources
 ) {
 
-    private val ccMe: Boolean get() = messageHelper.toMe(account, ccAddresses)
-    private val fromMe: Boolean get() = messageHelper.toMe(account, fromAddresses)
-    private val toMe: Boolean get() = messageHelper.toMe(account, toAddresses)
-
-    val ccAddresses: Array<Address>
+    private val ccAddresses: Array<Address>
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.CC_LIST_COLUMN))
+    private val ccMe: Boolean get() = messageHelper.toMe(account, ccAddresses)
+    private val fromAddresses: Array<Address>
+        get() = Address.unpack(cursor.getString(MLFProjectionInfo.SENDER_LIST_COLUMN))
+    private val fromMe: Boolean get() = messageHelper.toMe(account, fromAddresses)
+    private val toAddresses: Array<Address>
+        get() = Address.unpack(cursor.getString(MLFProjectionInfo.TO_LIST_COLUMN))
+    private val toMe: Boolean get() = messageHelper.toMe(account, toAddresses)
 
     val counterPartyAddresses: Address?
     get() {
@@ -42,9 +45,6 @@ class MessageListItemExtractor(
     val date: Long get() = cursor.getLong(MLFProjectionInfo.DATE_COLUMN)
 
     val flagged: Boolean get() = cursor.getInt(MLFProjectionInfo.FLAGGED_COLUMN) == 1
-
-    val fromAddresses: Array<Address>
-        get() = Address.unpack(cursor.getString(MLFProjectionInfo.SENDER_LIST_COLUMN))
 
     val hasAttachments: Boolean get() = cursor.getInt(MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN) > 0
 
@@ -77,9 +77,6 @@ class MessageListItemExtractor(
         }
 
     val threadCount: Int get() = cursor.getInt(MLFProjectionInfo.THREAD_COUNT_COLUMN)
-
-    val toAddresses: Array<Address>
-        get() = Address.unpack(cursor.getString(MLFProjectionInfo.TO_LIST_COLUMN))
 
     fun subject(threadCount: Int): String {
         return MlfUtils.buildSubject(cursor.getString(MLFProjectionInfo.SUBJECT_COLUMN),

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -10,7 +10,7 @@ import com.fsck.k9.ui.R
 
 class MessageListItemExtractor(
         private val account: Account,
-        private val cursor: Cursor,
+        val cursor: Cursor,
         private val messageHelper: MessageHelper,
         private val res: Resources
 ) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -24,7 +24,6 @@ class MessageListItemExtractor(
     private val toAddresses: Array<Address>
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.TO_LIST_COLUMN))
     private val toMe: Boolean get() = messageHelper.toMe(account, toAddresses)
-
     val answered: Boolean get() = cursor.getInt(MLFProjectionInfo.ANSWERED_COLUMN) == 1
 
     val counterPartyAddresses: Address?
@@ -47,6 +46,8 @@ class MessageListItemExtractor(
     val date: Long get() = cursor.getLong(MLFProjectionInfo.DATE_COLUMN)
 
     val flagged: Boolean get() = cursor.getInt(MLFProjectionInfo.FLAGGED_COLUMN) == 1
+
+    val forwarded: Boolean get() = cursor.getInt(MLFProjectionInfo.FORWARDED_COLUMN) == 1
 
     val hasAttachments: Boolean get() = cursor.getInt(MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN) > 0
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -13,6 +13,8 @@ class MessageListItemExtractor(
 
     val flagged: Boolean get() = cursor.getInt(MLFProjectionInfo.FLAGGED_COLUMN) == 1
 
+    val hasAttachments: Boolean get() = cursor.getInt(MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN) > 0
+
     val threadCount: Int get() = cursor.getInt(MLFProjectionInfo.THREAD_COUNT_COLUMN)
 
     fun subject(threadCount: Int): String {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -25,19 +25,21 @@ class MessageListItemExtractor(
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.TO_LIST_COLUMN))
     private val toMe: Boolean get() = messageHelper.toMe(account, toAddresses)
 
+    val answered: Boolean get() = cursor.getInt(MLFProjectionInfo.ANSWERED_COLUMN) == 1
+
     val counterPartyAddresses: Address?
-    get() {
-        if (fromMe) {
-            if (toAddresses.isNotEmpty()) {
-                return toAddresses[0]
-            } else if (ccAddresses.isNotEmpty()) {
-                return ccAddresses[0]
+        get() {
+            if (fromMe) {
+                if (toAddresses.isNotEmpty()) {
+                    return toAddresses[0]
+                } else if (ccAddresses.isNotEmpty()) {
+                    return ccAddresses[0]
+                }
+            } else if (fromAddresses.isNotEmpty()) {
+                return fromAddresses[0]
             }
-        } else if (fromAddresses.isNotEmpty()) {
-            return fromAddresses[0]
+            return null
         }
-        return null
-    }
 
     val displayName: CharSequence
         get() = messageHelper.getDisplayName(account, fromAddresses, toAddresses)
@@ -66,6 +68,8 @@ class MessageListItemExtractor(
                 null -> throw AssertionError("Unknown preview type: $previewType")
             }
         }
+
+    val read: Boolean get() = cursor.getInt(MLFProjectionInfo.READ_COLUMN) == 1
 
     val sigil: String
         get() {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -1,0 +1,7 @@
+package com.fsck.k9.fragment
+
+import android.database.Cursor
+
+class MessageListItemExtractor(
+        private val cursor: Cursor
+) 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -34,8 +34,6 @@ class MessageListItemExtractor(
         private val res: Resources
 ) {
 
-    private val account: Account
-        get() = preferences.getAccount(cursor.getString(ACCOUNT_UUID_COLUMN))
     private val ccAddresses: Array<Address>
         get() = Address.unpack(cursor.getString(CC_LIST_COLUMN))
     private val ccMe: Boolean get() = messageHelper.toMe(account, ccAddresses)
@@ -45,6 +43,8 @@ class MessageListItemExtractor(
     private val toAddresses: Array<Address>
         get() = Address.unpack(cursor.getString(TO_LIST_COLUMN))
     private val toMe: Boolean get() = messageHelper.toMe(account, toAddresses)
+    val account: Account
+        get() = preferences.getAccount(cursor.getString(ACCOUNT_UUID_COLUMN))
 
     val answered: Boolean get() = cursor.getInt(ANSWERED_COLUMN) == 1
 
@@ -71,6 +71,8 @@ class MessageListItemExtractor(
     val date: Long get() = cursor.getLong(DATE_COLUMN)
 
     val flagged: Boolean get() = cursor.getInt(FLAGGED_COLUMN) == 1
+
+    val folderServerId: String? get() = cursor.getString(FOLDER_SERVER_ID_COLUMN)
 
     val forwarded: Boolean get() = cursor.getInt(FORWARDED_COLUMN) == 1
 
@@ -107,6 +109,8 @@ class MessageListItemExtractor(
         }
 
     val threadCount: Int get() = cursor.getInt(THREAD_COUNT_COLUMN)
+
+    val uid: String get() = cursor.getString(UID_COLUMN)
 
     fun isActiveMessage(against: MessageReference?): Boolean {
         val uid = cursor.getString(UID_COLUMN)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -21,6 +21,9 @@ class MessageListItemExtractor(
 
     val threadCount: Int get() = cursor.getInt(MLFProjectionInfo.THREAD_COUNT_COLUMN)
 
+    val toAddresses: Array<Address>
+        get() = Address.unpack(cursor.getString(MLFProjectionInfo.TO_LIST_COLUMN))
+
     fun subject(threadCount: Int): String {
         return MlfUtils.buildSubject(cursor.getString(MLFProjectionInfo.SUBJECT_COLUMN),
                 res.getString(R.string.general_no_subject), threadCount)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -21,6 +21,7 @@ import com.fsck.k9.fragment.MLFProjectionInfo.READ_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.SENDER_LIST_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.SUBJECT_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.THREAD_COUNT_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.THREAD_ROOT_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.TO_LIST_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
 import com.fsck.k9.helper.MessageHelper
@@ -112,6 +113,8 @@ class MessageListItemExtractor(
         }
 
     val threadCount: Int get() = cursor.getInt(THREAD_COUNT_COLUMN)
+
+    val threadRootId: Long get() = cursor.getLong(THREAD_ROOT_COLUMN)
 
     val uid: String get() = cursor.getString(UID_COLUMN)
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -9,6 +9,8 @@ class MessageListItemExtractor(
         private val res: Resources
 ) {
 
+    val date: Long get() = cursor.getLong(MLFProjectionInfo.DATE_COLUMN)
+    
     val threadCount: Int get() = cursor.getInt(MLFProjectionInfo.THREAD_COUNT_COLUMN)
 
     fun subject(threadCount: Int): String {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -112,7 +112,13 @@ class MessageListItemExtractor(
             }
         }
 
-    val threadCount: Int get() = cursor.getInt(THREAD_COUNT_COLUMN)
+    val threadCount: Int get() {
+        try {
+            return cursor.getInt(THREAD_COUNT_COLUMN)
+        } catch (_: Exception) {
+            return 0
+        }
+    }
 
     val threadRootId: Long get() = cursor.getLong(THREAD_ROOT_COLUMN)
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -25,12 +25,12 @@ class MessageListItemExtractor(
     val counterPartyAddresses: Address?
     get() {
         if (fromMe) {
-            if (toAddresses.size > 0) {
+            if (toAddresses.isNotEmpty()) {
                 return toAddresses[0]
-            } else if (ccAddresses.size > 0) {
+            } else if (ccAddresses.isNotEmpty()) {
                 return ccAddresses[0]
             }
-        } else if (fromAddresses.size > 0) {
+        } else if (fromAddresses.isNotEmpty()) {
             return fromAddresses[0]
         }
         return null

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -3,6 +3,7 @@ package com.fsck.k9.fragment
 import android.content.res.Resources
 import android.database.Cursor
 import com.fsck.k9.Account
+import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mailstore.DatabasePreviewType
@@ -82,6 +83,18 @@ class MessageListItemExtractor(
         }
 
     val threadCount: Int get() = cursor.getInt(MLFProjectionInfo.THREAD_COUNT_COLUMN)
+
+    fun isActiveMessage(against: MessageReference?): Boolean {
+        val uid = cursor.getString(MLFProjectionInfo.UID_COLUMN)
+        val folderServerId = cursor.getString(MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN)
+
+        val activeAccountUuid = against?.accountUuid
+        val activeFolderServerId = against?.folderServerId
+        val activeUid = against?.uid
+        return account.uuid == activeAccountUuid
+                && folderServerId == activeFolderServerId
+                && uid == activeUid
+    }
 
     fun subject(threadCount: Int): String {
         return MlfUtils.buildSubject(cursor.getString(MLFProjectionInfo.SUBJECT_COLUMN),

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -14,6 +14,9 @@ class MessageListItemExtractor(
         private val res: Resources
 ) {
 
+    private val ccMe: Boolean get() = messageHelper.toMe(account, ccAddresses)
+    private val toMe: Boolean get() = messageHelper.toMe(account, toAddresses)
+
     val ccAddresses: Array<Address>
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.CC_LIST_COLUMN))
 
@@ -28,6 +31,15 @@ class MessageListItemExtractor(
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.SENDER_LIST_COLUMN))
 
     val hasAttachments: Boolean get() = cursor.getInt(MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN) > 0
+
+    val sigil: String
+        get() {
+            return when {
+                toMe -> res.getString(R.string.messagelist_sent_to_me_sigil)
+                ccMe -> res.getString(R.string.messagelist_sent_cc_me_sigil)
+                else -> ""
+            }
+        }
 
     val threadCount: Int get() = cursor.getInt(MLFProjectionInfo.THREAD_COUNT_COLUMN)
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -9,6 +9,8 @@ class MessageListItemExtractor(
         private val res: Resources
 ) {
 
+    val threadCount: Int get() = cursor.getInt(MLFProjectionInfo.THREAD_COUNT_COLUMN)
+
     fun subject(threadCount: Int): String {
         return MlfUtils.buildSubject(cursor.getString(MLFProjectionInfo.SUBJECT_COLUMN),
                 res.getString(R.string.general_no_subject), threadCount)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -1,7 +1,16 @@
 package com.fsck.k9.fragment
 
+import android.content.res.Resources
 import android.database.Cursor
+import com.fsck.k9.ui.R
 
 class MessageListItemExtractor(
-        private val cursor: Cursor
-) 
+        private val cursor: Cursor,
+        private val res: Resources
+) {
+
+    fun subject(threadCount: Int): String {
+        return MlfUtils.buildSubject(cursor.getString(MLFProjectionInfo.SUBJECT_COLUMN),
+                res.getString(R.string.general_no_subject), threadCount)
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -10,7 +10,9 @@ class MessageListItemExtractor(
 ) {
 
     val date: Long get() = cursor.getLong(MLFProjectionInfo.DATE_COLUMN)
-    
+
+    val flagged: Boolean get() = cursor.getInt(MLFProjectionInfo.FLAGGED_COLUMN) == 1
+
     val threadCount: Int get() = cursor.getInt(MLFProjectionInfo.THREAD_COUNT_COLUMN)
 
     fun subject(threadCount: Int): String {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -14,6 +14,7 @@ import com.fsck.k9.fragment.MLFProjectionInfo.DATE_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FLAGGED_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.FORWARDED_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.ID_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_TYPE_COLUMN
 import com.fsck.k9.fragment.MLFProjectionInfo.READ_COLUMN
@@ -77,6 +78,8 @@ class MessageListItemExtractor(
     val forwarded: Boolean get() = cursor.getInt(FORWARDED_COLUMN) == 1
 
     val hasAttachments: Boolean get() = cursor.getInt(ATTACHMENT_COUNT_COLUMN) > 0
+
+    val id: Long get() = cursor.getLong(ID_COLUMN)
 
     val preview: String
         get() {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -128,4 +128,6 @@ class MessageListItemExtractor(
         return MlfUtils.buildSubject(cursor.getString(SUBJECT_COLUMN),
                 res.getString(R.string.general_no_subject), threadCount)
     }
+
+    fun selectionIdentifier(uniqueColumnId: Int): Long = cursor.getLong(uniqueColumnId)
 }

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -5,6 +5,7 @@ import android.database.Cursor
 import com.fsck.k9.Account
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
+import com.fsck.k9.mailstore.DatabasePreviewType
 import com.fsck.k9.ui.R
 
 class MessageListItemExtractor(
@@ -31,6 +32,25 @@ class MessageListItemExtractor(
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.SENDER_LIST_COLUMN))
 
     val hasAttachments: Boolean get() = cursor.getInt(MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN) > 0
+
+    val preview: String
+        get() {
+            val previewTypeString = cursor.getString(MLFProjectionInfo.PREVIEW_TYPE_COLUMN)
+            val previewType = DatabasePreviewType.fromDatabaseValue(previewTypeString)
+
+            return when (previewType) {
+                DatabasePreviewType.NONE, DatabasePreviewType.ERROR -> {
+                    ""
+                }
+                DatabasePreviewType.ENCRYPTED -> {
+                    res.getString(R.string.preview_encrypted)
+                }
+                DatabasePreviewType.TEXT -> {
+                    cursor.getString(MLFProjectionInfo.PREVIEW_COLUMN)
+                }
+                null -> throw AssertionError("Unknown preview type: $previewType")
+            }
+        }
 
     val sigil: String
         get() {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -16,10 +16,25 @@ class MessageListItemExtractor(
 ) {
 
     private val ccMe: Boolean get() = messageHelper.toMe(account, ccAddresses)
+    private val fromMe: Boolean get() = messageHelper.toMe(account, fromAddresses)
     private val toMe: Boolean get() = messageHelper.toMe(account, toAddresses)
 
     val ccAddresses: Array<Address>
         get() = Address.unpack(cursor.getString(MLFProjectionInfo.CC_LIST_COLUMN))
+
+    val counterPartyAddresses: Address?
+    get() {
+        if (fromMe) {
+            if (toAddresses.size > 0) {
+                return toAddresses[0]
+            } else if (ccAddresses.size > 0) {
+                return ccAddresses[0]
+            }
+        } else if (fromAddresses.size > 0) {
+            return fromAddresses[0]
+        }
+        return null
+    }
 
     val displayName: CharSequence
         get() = messageHelper.getDisplayName(account, fromAddresses, toAddresses)

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -9,6 +9,8 @@ class MessageListItemExtractor(
         private val cursor: Cursor,
         private val res: Resources
 ) {
+    val ccAddresses: Array<Address>
+        get() = Address.unpack(cursor.getString(MLFProjectionInfo.CC_LIST_COLUMN))
 
     val date: Long get() = cursor.getLong(MLFProjectionInfo.DATE_COLUMN)
 

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListItemExtractor.kt
@@ -6,6 +6,22 @@ import androidx.annotation.ColorInt
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessageReference
+import com.fsck.k9.fragment.MLFProjectionInfo.ACCOUNT_UUID_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.ANSWERED_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.CC_LIST_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.DATE_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.FLAGGED_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.FORWARDED_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.PREVIEW_TYPE_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.READ_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.SENDER_LIST_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.SUBJECT_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.THREAD_COUNT_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.TO_LIST_COLUMN
+import com.fsck.k9.fragment.MLFProjectionInfo.UID_COLUMN
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mailstore.DatabasePreviewType
@@ -19,18 +35,18 @@ class MessageListItemExtractor(
 ) {
 
     private val account: Account
-        get() = preferences.getAccount(cursor.getString(MLFProjectionInfo.ACCOUNT_UUID_COLUMN))
+        get() = preferences.getAccount(cursor.getString(ACCOUNT_UUID_COLUMN))
     private val ccAddresses: Array<Address>
-        get() = Address.unpack(cursor.getString(MLFProjectionInfo.CC_LIST_COLUMN))
+        get() = Address.unpack(cursor.getString(CC_LIST_COLUMN))
     private val ccMe: Boolean get() = messageHelper.toMe(account, ccAddresses)
     private val fromAddresses: Array<Address>
-        get() = Address.unpack(cursor.getString(MLFProjectionInfo.SENDER_LIST_COLUMN))
+        get() = Address.unpack(cursor.getString(SENDER_LIST_COLUMN))
     private val fromMe: Boolean get() = messageHelper.toMe(account, fromAddresses)
     private val toAddresses: Array<Address>
-        get() = Address.unpack(cursor.getString(MLFProjectionInfo.TO_LIST_COLUMN))
+        get() = Address.unpack(cursor.getString(TO_LIST_COLUMN))
     private val toMe: Boolean get() = messageHelper.toMe(account, toAddresses)
 
-    val answered: Boolean get() = cursor.getInt(MLFProjectionInfo.ANSWERED_COLUMN) == 1
+    val answered: Boolean get() = cursor.getInt(ANSWERED_COLUMN) == 1
 
     val counterPartyAddresses: Address?
         get() {
@@ -52,17 +68,17 @@ class MessageListItemExtractor(
     val displayName: CharSequence
         get() = messageHelper.getDisplayName(account, fromAddresses, toAddresses)
 
-    val date: Long get() = cursor.getLong(MLFProjectionInfo.DATE_COLUMN)
+    val date: Long get() = cursor.getLong(DATE_COLUMN)
 
-    val flagged: Boolean get() = cursor.getInt(MLFProjectionInfo.FLAGGED_COLUMN) == 1
+    val flagged: Boolean get() = cursor.getInt(FLAGGED_COLUMN) == 1
 
-    val forwarded: Boolean get() = cursor.getInt(MLFProjectionInfo.FORWARDED_COLUMN) == 1
+    val forwarded: Boolean get() = cursor.getInt(FORWARDED_COLUMN) == 1
 
-    val hasAttachments: Boolean get() = cursor.getInt(MLFProjectionInfo.ATTACHMENT_COUNT_COLUMN) > 0
+    val hasAttachments: Boolean get() = cursor.getInt(ATTACHMENT_COUNT_COLUMN) > 0
 
     val preview: String
         get() {
-            val previewTypeString = cursor.getString(MLFProjectionInfo.PREVIEW_TYPE_COLUMN)
+            val previewTypeString = cursor.getString(PREVIEW_TYPE_COLUMN)
             val previewType = DatabasePreviewType.fromDatabaseValue(previewTypeString)
 
             return when (previewType) {
@@ -73,13 +89,13 @@ class MessageListItemExtractor(
                     res.getString(R.string.preview_encrypted)
                 }
                 DatabasePreviewType.TEXT -> {
-                    cursor.getString(MLFProjectionInfo.PREVIEW_COLUMN)
+                    cursor.getString(PREVIEW_COLUMN)
                 }
                 null -> throw AssertionError("Unknown preview type: $previewType")
             }
         }
 
-    val read: Boolean get() = cursor.getInt(MLFProjectionInfo.READ_COLUMN) == 1
+    val read: Boolean get() = cursor.getInt(READ_COLUMN) == 1
 
     val sigil: String
         get() {
@@ -90,11 +106,11 @@ class MessageListItemExtractor(
             }
         }
 
-    val threadCount: Int get() = cursor.getInt(MLFProjectionInfo.THREAD_COUNT_COLUMN)
+    val threadCount: Int get() = cursor.getInt(THREAD_COUNT_COLUMN)
 
     fun isActiveMessage(against: MessageReference?): Boolean {
-        val uid = cursor.getString(MLFProjectionInfo.UID_COLUMN)
-        val folderServerId = cursor.getString(MLFProjectionInfo.FOLDER_SERVER_ID_COLUMN)
+        val uid = cursor.getString(UID_COLUMN)
+        val folderServerId = cursor.getString(FOLDER_SERVER_ID_COLUMN)
 
         val activeAccountUuid = against?.accountUuid
         val activeFolderServerId = against?.folderServerId
@@ -105,7 +121,7 @@ class MessageListItemExtractor(
     }
 
     fun subject(threadCount: Int): String {
-        return MlfUtils.buildSubject(cursor.getString(MLFProjectionInfo.SUBJECT_COLUMN),
+        return MlfUtils.buildSubject(cursor.getString(SUBJECT_COLUMN),
                 res.getString(R.string.general_no_subject), threadCount)
     }
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
@@ -37,6 +37,8 @@ class CursorToMessageListItems(
 
     private inline val MessageListItemExtractor.asItem: MessageListItem
         get() = MessageListItem(
+                this.uid,
+                this.folderServerId,
                 this.displayName.toString(),
                 this.subject(this.threadCount),
                 this.date,
@@ -50,7 +52,8 @@ class CursorToMessageListItems(
                 this.flagged,
                 this.hasAttachments,
                 this.preview,
-                this.counterPartyAddresses
+                this.counterPartyAddresses,
+                this.account
         )
 
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
@@ -49,7 +49,8 @@ class CursorToMessageListItems(
                 this.chipColor,
                 this.flagged,
                 this.hasAttachments,
-                this.preview
+                this.preview,
+                this.counterPartyAddresses
         )
 
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
@@ -1,0 +1,55 @@
+package com.fsck.k9.ui.messagelist
+
+import android.content.res.Resources
+import android.database.Cursor
+import com.fsck.k9.Preferences
+import com.fsck.k9.fragment.MessageListItemExtractor
+import com.fsck.k9.helper.MessageHelper
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+
+class CursorToMessageListItems(
+        private val preferences: Preferences,
+        private val helper: MessageHelper,
+        private val resources: Resources
+) {
+
+    private fun messageListItemExtractor(cursor: Cursor) = MessageListItemExtractor(
+            preferences,
+            cursor,
+            helper,
+            resources
+    )
+
+    fun convert(cursor: Cursor, onItemsReady: (List<MessageListItem>) -> Unit) {
+        val extractor = messageListItemExtractor(cursor)
+        GlobalScope.launch {
+            async {
+                val items = arrayListOf<MessageListItem>()
+                while (cursor.moveToNext()) {
+                    items += extractor.asItem
+                }
+                onItemsReady(items)
+            }
+        }
+    }
+
+    private inline val MessageListItemExtractor.asItem: MessageListItem
+        get() = MessageListItem(
+                this.displayName.toString(),
+                this.subject(this.threadCount),
+                this.date,
+                this.sigil,
+                this.threadCount,
+                this.read,
+                this.answered,
+                this.forwarded,
+                false,
+                this.chipColor,
+                this.flagged,
+                this.hasAttachments,
+                this.preview
+        )
+
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
@@ -48,6 +48,7 @@ class CursorToMessageListItems(
                 this.date,
                 this.sigil,
                 this.threadCount,
+                this.threadRootId,
                 this.read,
                 this.answered,
                 this.forwarded,

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
@@ -7,6 +7,7 @@ import com.fsck.k9.fragment.MessageListItemExtractor
 import com.fsck.k9.helper.MessageHelper
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -26,15 +27,15 @@ class CursorToMessageListItems(
 
     fun convert(cursor: Cursor, onItemsReady: ConvertedMessagesReady) {
         val extractor = messageListItemExtractor(cursor)
-        GlobalScope.launch {
-            val itemsRetrieved = withContext(Dispatchers.Default) {
+        GlobalScope.launch(Dispatchers.Main) {
+            val items = async {
                 val items = arrayListOf<MessageListItem>()
                 while (cursor.moveToNext()) {
                     items += extractor.asItem
                 }
                 items
             }
-            onItemsReady.onItemsReady(itemsRetrieved)
+            onItemsReady.onItemsReady(items.await())
         }
     }
 

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
@@ -24,7 +24,7 @@ class CursorToMessageListItems(
             resources
     )
 
-    fun convert(cursor: Cursor, onItemsReady: (List<MessageListItem>) -> Unit) {
+    fun convert(cursor: Cursor, onItemsReady: ConvertedMessagesReady) {
         val extractor = messageListItemExtractor(cursor)
         GlobalScope.launch {
             val itemsRetrieved = withContext(Dispatchers.Default) {
@@ -34,14 +34,14 @@ class CursorToMessageListItems(
                 }
                 items
             }
-            onItemsReady(itemsRetrieved)
+            onItemsReady.onItemsReady(itemsRetrieved)
         }
     }
 
     private inline val MessageListItemExtractor.asItem: MessageListItem
         get() = MessageListItem(
                 this.uid,
-                this.folderServerId,
+                this.folderServerId.orEmpty(),
                 this.displayName.toString(),
                 this.subject(this.threadCount),
                 this.date,
@@ -59,5 +59,8 @@ class CursorToMessageListItems(
                 this.selectionIdentifier(uniqueColumnId)
 
         )
+}
 
+interface ConvertedMessagesReady {
+    fun onItemsReady(list: List<MessageListItem>)
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/CursorToMessageListItems.kt
@@ -40,6 +40,7 @@ class CursorToMessageListItems(
 
     private inline val MessageListItemExtractor.asItem: MessageListItem
         get() = MessageListItem(
+                this.id,
                 this.uid,
                 this.folderServerId.orEmpty(),
                 this.displayName.toString(),

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -1,0 +1,20 @@
+package com.fsck.k9.ui.messagelist
+
+import androidx.annotation.ColorInt
+
+data class MessageListItem(
+        val id: Long,
+        val displayName: String,
+        val subject: String,
+        val displayDate: String,
+        val sigil: String,
+        val threadCount: Int,
+        val read: Boolean,
+        val answered: Boolean,
+        val forwarded: Boolean,
+        val selected: Boolean,
+        @ColorInt val chipColor: Int,
+        val flagged: Boolean,
+        val hasAttachments: Boolean,
+        val preview: String
+)

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.ui.messagelist
 
 import androidx.annotation.ColorInt
+import com.fsck.k9.mail.Address
 
 data class MessageListItem(
         val displayName: String,
@@ -15,5 +16,6 @@ data class MessageListItem(
         @ColorInt val chipColor: Int,
         val flagged: Boolean,
         val hasAttachments: Boolean,
-        val preview: String
+        val preview: String,
+        val counterPartyAddresses: Address?
 )

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -15,11 +15,11 @@ data class MessageListItem(
         val read: Boolean,
         val answered: Boolean,
         val forwarded: Boolean,
-        val selected: Boolean,
         @ColorInt val chipColor: Int,
         val flagged: Boolean,
         val hasAttachments: Boolean,
         val preview: String,
         val counterPartyAddresses: Address?,
-        val account: Account
+        val account: Account,
+        val selectionIdentifier: Long
 )

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -3,10 +3,9 @@ package com.fsck.k9.ui.messagelist
 import androidx.annotation.ColorInt
 
 data class MessageListItem(
-        val id: Long,
         val displayName: String,
         val subject: String,
-        val displayDate: String,
+        val date: Long,
         val sigil: String,
         val threadCount: Int,
         val read: Boolean,

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -13,6 +13,7 @@ data class MessageListItem(
         val date: Long,
         val sigil: String,
         val threadCount: Int,
+        val threadId: Long,
         val read: Boolean,
         val answered: Boolean,
         val forwarded: Boolean,

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -1,9 +1,12 @@
 package com.fsck.k9.ui.messagelist
 
 import androidx.annotation.ColorInt
+import com.fsck.k9.Account
 import com.fsck.k9.mail.Address
 
 data class MessageListItem(
+        val uid: String,
+        val folderServerId: String?,
         val displayName: String,
         val subject: String,
         val date: Long,
@@ -17,5 +20,6 @@ data class MessageListItem(
         val flagged: Boolean,
         val hasAttachments: Boolean,
         val preview: String,
-        val counterPartyAddresses: Address?
+        val counterPartyAddresses: Address?,
+        val account: Account
 )

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -6,7 +6,7 @@ import com.fsck.k9.mail.Address
 
 data class MessageListItem(
         val uid: String,
-        val folderServerId: String?,
+        val folderServerId: String,
         val displayName: String,
         val subject: String,
         val date: Long,

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -5,7 +5,8 @@ import com.fsck.k9.Account
 import com.fsck.k9.mail.Address
 
 data class MessageListItem(
-        val uid: String,
+        val id: Long,
+        val messageUid: String,
         val folderServerId: String,
         val displayName: String,
         val subject: String,

--- a/app/ui/src/main/res/values/ids.xml
+++ b/app/ui/src/main/res/values/ids.xml
@@ -13,4 +13,6 @@
     <item type="id" name="settings_import_list_general_item"/>
     <item type="id" name="settings_import_list_account_item"/>
 
+    <item type="id" name="message_list_item_extractor"/>
+
 </resources>


### PR DESCRIPTION
Hello, back at it again.

This PR is taking a bit longer route, but I think is worth doing. 

This PR basically moves out cursor data extraction logic out of the adapter, leaving behind only the view logic. 
This should prepare us for some data model, some nice `MessageListViewHolder::bind(data:  ListItem)` function down the line.

Is there any preffered threading model so I can offload `cursor to model` transformation to?
