### PR TITLE
Add TNEF (winmail.dat) extraction support

### DIFF
--- a/app/k9mail/proguard-rules.pro
+++ b/app/k9mail/proguard-rules.pro
@@ -16,6 +16,7 @@
 
 -dontwarn okio.**
 -dontwarn com.squareup.moshi.**
+-dontwarn net.freeutils.tnef.**
 
 # Project specific rules
 -dontnote com.fsck.k9.ui.messageview.**

--- a/app/ui/build.gradle
+++ b/app/ui/build.gradle
@@ -41,6 +41,7 @@ dependencies {
     implementation 'com.github.ByteHamster:SearchPreference:v1.1.4'
     implementation 'com.mikepenz:fastadapter:3.3.1'
     implementation 'de.hdodenhof:circleimageview:3.0.0'
+    implementation 'net.freeutils:jtnef:2.0.0'
 
     implementation "commons-io:commons-io:${versions.commonsIo}"
     implementation "androidx.core:core-ktx:${versions.coreKtx}"

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/AttachmentView.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/AttachmentView.java
@@ -16,13 +16,13 @@ import com.fsck.k9.ui.R;
 import com.fsck.k9.ui.helper.SizeFormatter;
 import com.fsck.k9.mailstore.AttachmentViewInfo;
 
-
 public class AttachmentView extends FrameLayout implements OnClickListener {
     private AttachmentViewInfo attachment;
     private AttachmentViewCallback callback;
 
     private Button viewButton;
     private Button downloadButton;
+    private Button extractButton;
 
 
     public AttachmentView(Context context, AttributeSet attrs, int defStyle) {
@@ -44,11 +44,13 @@ public class AttachmentView extends FrameLayout implements OnClickListener {
     public void enableButtons() {
         viewButton.setEnabled(true);
         downloadButton.setEnabled(true);
+        extractButton.setEnabled(true);
     }
 
     public void disableButtons() {
         viewButton.setEnabled(false);
         downloadButton.setEnabled(false);
+        extractButton.setEnabled(false);
     }
 
     public void setAttachment(AttachmentViewInfo attachment) {
@@ -60,14 +62,21 @@ public class AttachmentView extends FrameLayout implements OnClickListener {
     private void displayAttachmentInformation() {
         viewButton = findViewById(R.id.view);
         downloadButton = findViewById(R.id.download);
+        extractButton = findViewById(R.id.extract);
 
         if (attachment.size > K9.MAX_ATTACHMENT_DOWNLOAD_SIZE) {
             viewButton.setVisibility(View.GONE);
             downloadButton.setVisibility(View.GONE);
+            extractButton.setVisibility(View.GONE);
+        }
+
+        if (!attachment.mimeType.toLowerCase().equals("application/ms-tnef") && !attachment.mimeType.toLowerCase().equals("application/vnd.ms-tnef")) {
+            extractButton.setVisibility(View.GONE);
         }
 
         viewButton.setOnClickListener(this);
         downloadButton.setOnClickListener(this);
+        extractButton.setOnClickListener(this);
 
         TextView attachmentName = findViewById(R.id.attachment_name);
         attachmentName.setText(attachment.displayName);
@@ -94,6 +103,8 @@ public class AttachmentView extends FrameLayout implements OnClickListener {
             onViewButtonClick();
         } else if (id == R.id.download) {
             onSaveButtonClick();
+        } else if (id == R.id.extract) {
+            onExtractButtonClick();
         }
     }
 
@@ -103,6 +114,10 @@ public class AttachmentView extends FrameLayout implements OnClickListener {
 
     private void onSaveButtonClick() {
         callback.onSaveAttachment(attachment);
+    }
+
+    private void onExtractButtonClick() {
+        callback.onExtractAttachment(attachment);
     }
 
     public void setCallback(AttachmentViewCallback callback) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/AttachmentViewCallback.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/AttachmentViewCallback.java
@@ -7,4 +7,5 @@ import com.fsck.k9.mailstore.AttachmentViewInfo;
 interface AttachmentViewCallback {
     void onViewAttachment(AttachmentViewInfo attachment);
     void onSaveAttachment(AttachmentViewInfo attachment);
+    void onExtractAttachment(AttachmentViewInfo attachment);
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -11,9 +11,12 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
 import android.os.Bundle;
+import android.os.Environment;
 import android.os.Handler;
 import android.os.Parcelable;
 import android.os.SystemClock;
+
+import androidx.documentfile.provider.DocumentFile;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -63,6 +66,7 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     private static final int ACTIVITY_CHOOSE_FOLDER_MOVE = 1;
     private static final int ACTIVITY_CHOOSE_FOLDER_COPY = 2;
     private static final int REQUEST_CODE_CREATE_DOCUMENT = 3;
+    private static final int REQUEST_CODE_EXTRACT_DOCUMENT = 4;
 
     public static final int REQUEST_MASK_LOADER_HELPER = (1 << 8);
     public static final int REQUEST_MASK_CRYPTO_PRESENTER = (1 << 9);
@@ -457,6 +461,12 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
                 }
                 break;
             }
+            case REQUEST_CODE_EXTRACT_DOCUMENT: {
+                if (data != null && data.getData() != null) {
+                    getAttachmentController(currentAttachmentViewInfo).extractAttachmentTo(DocumentFile.fromTreeUri(getApplicationContext(), data.getData()));
+                }
+                break;
+            }
             case ACTIVITY_CHOOSE_FOLDER_MOVE:
             case ACTIVITY_CHOOSE_FOLDER_COPY: {
                 if (data == null) {
@@ -815,6 +825,18 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         intent.addCategory(Intent.CATEGORY_OPENABLE);
 
         startActivityForResult(intent, REQUEST_CODE_CREATE_DOCUMENT);
+    }
+
+    @Override
+    public void onExtractAttachment(final AttachmentViewInfo attachment) {
+        currentAttachmentViewInfo = attachment;
+        if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
+            Intent intent = new Intent(Intent.ACTION_OPEN_DOCUMENT_TREE);
+
+            startActivityForResult(intent, REQUEST_CODE_EXTRACT_DOCUMENT);
+        } else {
+            getAttachmentController(attachment).extractAttachmentTo(DocumentFile.fromFile(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_DOWNLOADS)));
+        }
     }
 
     private AttachmentController getAttachmentController(AttachmentViewInfo attachment) {

--- a/app/ui/src/main/res/layout/message_view_attachment.xml
+++ b/app/ui/src/main/res/layout/message_view_attachment.xml
@@ -71,6 +71,19 @@
                 android:layout_alignWithParentIfMissing="true"
                 android:layout_below="@id/attachment_name"
                 android:layout_marginTop="6dip" />
+            <Button
+                android:id="@+id/extract"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                style="?android:attr/buttonStyleSmall"
+                android:paddingLeft="20dip"
+                android:paddingRight="20dip"
+                android:text="@string/message_view_attachment_extract_action"
+                android:singleLine="true"
+                android:layout_toLeftOf="@id/view"
+                android:layout_alignWithParentIfMissing="true"
+                android:layout_below="@id/attachment_name"
+                android:layout_marginTop="6dip" />
         </RelativeLayout>
     </LinearLayout>
     <LinearLayout

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -285,7 +285,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="message_view_bcc_label">Bcc:</string>
     <string name="message_view_attachment_view_action">Open</string>
     <string name="message_view_attachment_download_action">Save</string>
+    <string name="message_view_attachment_extract_action">Extract</string>
     <string name="message_view_status_attachment_not_saved">Unable to save attachment.</string>
+    <string name="message_view_status_attachment_not_extracted">Unable to extract attachment.</string>
     <string name="message_view_show_pictures_action">Show pictures</string>
     <string name="message_view_no_viewer">Unable to find viewer for <xliff:g id="mimetype">%s</xliff:g>.</string>
     <string name="message_view_download_remainder">Download complete message</string>


### PR DESCRIPTION
This pull request adds the option to extract the attachments within a TNEF file.
[TNEF](https://support.mozilla.org/en-US/kb/what-winmaildat-attachment) is the format used for the infamous file `winmail.dat` coming from Microsoft Outlook. 

**How does it work?**

First of all, the library [`net.freeutils.tnef`](https://github.com/jukka/jtnef) gets used to get more information about a TNEF attachment and to extract the attachments inside it.

TNEF-Attachments are still shown as before but there is a new option "Extract" next to "Open" and "Save":
![K9Mail-Extract-Action](https://user-images.githubusercontent.com/6362414/64914834-ee34a700-d759-11e9-8823-d3e5ad4ccbf5.png)

Clicking on the "Extract" button opens the explorer to select the extraction location. For devices with an API lower than 21 the "Downloads" folder gets used.

After selecting the location all files are getting extracted with the correct filename and saved.

The "Extract" button only gets shown for files with the MIME types `application/ms-tnef` and `application/vnd.ms-tnef`.
Theoretically other extractable MIME types could be added later using the same logic.

Hope you enjoy it and please let me know if I should make changes or improve something.

Fixes #967 and #634.
