### PR TITLE
fix direct share: wrong package name specified

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -267,7 +267,7 @@
 
             <meta-data
                 android:name="android.service.chooser.chooser_target_service"
-                android:value="com.fsck.k9.service.K9ChooserTargetService" />
+                android:value="com.fsck.k9.directshare.K9ChooserTargetService" />
         </activity>
 
         <!-- Search Activity - searchable -->


### PR DESCRIPTION
Fix https://github.com/k9mail/k-9/issues/4196

With master K-9 does not show any recipient, because the specified package name was wrong.

With this fix it shows the recipient:
![2019-09-27-135551](https://user-images.githubusercontent.com/5836855/65767654-bef54100-e12e-11e9-89b2-701ca2ad7e8d.png)
