### PR TITLE
Fix crash when enabling openpgp

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/OpenPgpAppSelectDialog.java
@@ -297,8 +297,8 @@ public class OpenPgpAppSelectDialog extends FragmentActivity {
             builder.setPositiveButton(R.string.dialog_openkeychain_info_install, new OnClickListener() {
                 @Override
                 public void onClick(DialogInterface dialogInterface, int i) {
-                    startOpenKeychainInstallActivity();
                     dismiss();
+                    startOpenKeychainInstallActivity();
                 }
             });
 


### PR DESCRIPTION
In onDismiss, getActivity returns null if the fragment is covered by the
chooser intent (F-Droid vs Google Play).

Closes #4121