### PR TITLE
Add settings import to settings screen

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/helper/Timing.kt
+++ b/app/core/src/main/java/com/fsck/k9/helper/Timing.kt
@@ -10,3 +10,13 @@ inline fun measureRealtimeMillis(block: () -> Unit): Long {
     block()
     return SystemClock.elapsedRealtime() - start
 }
+
+/**
+ * Executes the given [block] and returns pair of elapsed realtime in milliseconds and result of the code block.
+ */
+inline fun <T> measureRealtimeMillisWithResult(block: () -> T): Pair<Long, T> {
+    val start = SystemClock.elapsedRealtime()
+    val result = block()
+    val elapsedTime = SystemClock.elapsedRealtime() - start
+    return elapsedTime to result
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsImporter.java
@@ -78,15 +78,19 @@ public class SettingsImporter {
         public final boolean overwritten;
         public final boolean incomingPasswordNeeded;
         public final boolean outgoingPasswordNeeded;
+        public final String incomingServerName;
+        public final String outgoingServerName;
 
         private AccountDescriptionPair(AccountDescription original, AccountDescription imported,
-                boolean overwritten, boolean incomingPasswordNeeded,
-                boolean outgoingPasswordNeeded) {
+                boolean overwritten, boolean incomingPasswordNeeded, boolean outgoingPasswordNeeded,
+                String incomingServerName, String outgoingServerName) {
             this.original = original;
             this.imported = imported;
             this.overwritten = overwritten;
             this.incomingPasswordNeeded = incomingPasswordNeeded;
             this.outgoingPasswordNeeded = outgoingPasswordNeeded;
+            this.incomingServerName = incomingServerName;
+            this.outgoingServerName = outgoingServerName;
         }
     }
 
@@ -370,6 +374,7 @@ public class SettingsImporter {
         String storeUri = backendManager.createStoreUri(incoming);
         putString(editor, accountKeyPrefix + AccountPreferenceSerializer.STORE_URI_KEY, Base64.encode(storeUri));
 
+        String incomingServerName = incoming.host;
         boolean incomingPasswordNeeded = AuthType.EXTERNAL != incoming.authenticationType &&
                 (incoming.password == null || incoming.password.isEmpty());
 
@@ -379,6 +384,7 @@ public class SettingsImporter {
             throw new InvalidSettingValueException();
         }
 
+        String outgoingServerName = null;
         boolean outgoingPasswordNeeded = false;
         if (account.outgoing != null) {
             // Write outgoing server settings (transportUri)
@@ -397,6 +403,8 @@ public class SettingsImporter {
                     outgoing.username != null &&
                     !outgoing.username.isEmpty() &&
                     (outgoing.password == null || outgoing.password.isEmpty());
+
+            outgoingServerName = outgoing.host;
         }
 
         boolean createAccountDisabled = incomingPasswordNeeded || outgoingPasswordNeeded;
@@ -457,7 +465,7 @@ public class SettingsImporter {
 
         AccountDescription imported = new AccountDescription(accountName, uuid);
         return new AccountDescriptionPair(original, imported, mergeImportedAccount,
-                incomingPasswordNeeded, outgoingPasswordNeeded);
+                incomingPasswordNeeded, outgoingPasswordNeeded, incomingServerName, outgoingServerName);
     }
 
     private static void importFolder(StorageEditor editor, int contentVersion, String uuid, ImportedFolder folder,

--- a/app/ui/build.gradle
+++ b/app/ui/build.gradle
@@ -29,6 +29,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:${versions.androidxNavigation}"
     implementation "androidx.navigation:navigation-ui-ktx:${versions.androidxNavigation}"
     implementation "androidx.constraintlayout:constraintlayout:${versions.androidxConstraintLayout}"
+    implementation "com.google.android.material:material:${versions.materialComponents}"
     implementation "de.cketti.library.changelog:ckchangelog:1.2.1"
     implementation "com.github.bumptech.glide:glide:3.6.1"
     implementation "com.splitwise:tokenautocomplete:2.0.7"

--- a/app/ui/src/main/java/com/fsck/k9/ui/BundleExtensions.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/BundleExtensions.kt
@@ -1,0 +1,12 @@
+package com.fsck.k9.ui
+
+import android.os.Bundle
+
+fun <T : Enum<T>> Bundle.putEnum(key: String, value: T) {
+    putString(key, value.name)
+}
+
+inline fun <reified T : Enum<T>> Bundle.getEnum(key: String, defaultValue: T): T {
+    val value = getString(key) ?: return defaultValue
+    return enumValueOf(value)
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
@@ -6,6 +6,8 @@ import com.fsck.k9.ui.settings.account.AccountSettingsDataStoreFactory
 import com.fsck.k9.ui.settings.account.AccountSettingsViewModel
 import com.fsck.k9.ui.settings.export.SettingsExportViewModel
 import com.fsck.k9.ui.settings.general.GeneralSettingsDataStore
+import com.fsck.k9.ui.settings.import.AccountActivator
+import com.fsck.k9.ui.settings.import.SettingsImportViewModel
 import org.koin.android.architecture.ext.viewModel
 import org.koin.dsl.module.applicationContext
 import java.util.concurrent.Executors
@@ -23,4 +25,7 @@ val settingsUiModule = applicationContext {
     bean { AccountSettingsDataStoreFactory(get(), get(), get("SaveSettingsExecutorService")) }
 
     viewModel { SettingsExportViewModel(get(), get()) }
+    viewModel { SettingsImportViewModel(get(), get()) }
+
+    bean { AccountActivator(get(), get(), get(), get()) }
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
@@ -101,6 +101,13 @@ class SettingsListFragment : Fragment() {
                     R.attr.iconSettingsExport
             )
             add(exportSettingsActionItem)
+
+            val importSettingsActionItem = SettingsActionItem(
+                    getString(R.string.settings_import_title),
+                    R.id.action_settingsListScreen_to_settingsImportScreen,
+                    R.attr.iconSettingsImport
+            )
+            add(importSettingsActionItem)
         }
         backupSection.setHeader(SettingsDividerItem(getString(R.string.settings_list_backup_category)))
         settingsAdapter.add(backupSection)

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/import/AccountActivator.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/import/AccountActivator.kt
@@ -1,0 +1,52 @@
+package com.fsck.k9.ui.settings.import
+
+import android.content.Context
+import com.fsck.k9.Account
+import com.fsck.k9.Core
+import com.fsck.k9.Preferences
+import com.fsck.k9.backend.BackendManager
+import com.fsck.k9.controller.MessagingController
+
+/**
+ * Activate account after server password(s) have been provided on settings import.
+ */
+class AccountActivator(
+        private val context: Context,
+        private val preferences: Preferences,
+        private val messagingController: MessagingController,
+        private val backendManager: BackendManager
+) {
+    fun enableAccount(accountUuid: String, incomingServerPassword: String?, outgoingServerPassword: String?) {
+        val account = preferences.getAccount(accountUuid)
+
+        setAccountPasswords(account, incomingServerPassword, outgoingServerPassword)
+
+        // Start services if necessary
+        Core.setServicesEnabled(context)
+
+        // Get list of folders from remote server
+        messagingController.listFolders(account, true, null)
+    }
+
+    private fun setAccountPasswords(
+            account: Account,
+            incomingServerPassword: String?,
+            outgoingServerPassword: String?
+    ) {
+        if (incomingServerPassword != null) {
+            val incomingServerSettings = backendManager.decodeStoreUri(account.storeUri)
+            val newIncomingServerSettings = incomingServerSettings.newPassword(incomingServerPassword)
+            account.storeUri = backendManager.createStoreUri(newIncomingServerSettings)
+        }
+
+        if (outgoingServerPassword != null) {
+            val outgoingServerSettings = backendManager.decodeTransportUri(account.transportUri)
+            val newOutgoingServerSettings = outgoingServerSettings.newPassword(outgoingServerPassword)
+            account.transportUri = backendManager.createTransportUri(newOutgoingServerSettings)
+        }
+
+        account.isEnabled = true
+
+        preferences.saveAccount(account)
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/import/PasswordPromptDialogFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/import/PasswordPromptDialogFragment.kt
@@ -1,0 +1,139 @@
+package com.fsck.k9.ui.settings.import
+
+import android.annotation.SuppressLint
+import android.app.Activity
+import android.app.Dialog
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import androidx.appcompat.app.AlertDialog
+import androidx.core.os.bundleOf
+import androidx.core.view.isGone
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.Fragment
+import com.fsck.k9.ui.R
+import kotlinx.android.synthetic.main.password_prompt_dialog.view.*
+
+class PasswordPromptDialogFragment : DialogFragment() {
+    private lateinit var accountUuid: String
+    private var inputOutgoingServerPassword: Boolean = false
+    private var inputIncomingServerPassword: Boolean = false
+
+    private lateinit var dialogView: View
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val arguments = this.arguments ?: error("Fragment arguments missing")
+
+        accountUuid = arguments.getString(ARG_ACCOUNT_UUID) ?: error("Missing account UUID")
+        val accountName = arguments.getString(ARG_ACCOUNT_NAME) ?: error("Missing account name")
+        val incomingServerName = arguments.getString(ARG_INCOMING_SERVER_NAME)
+        val outgoingServerName = arguments.getString(ARG_OUTGOING_SERVER_NAME)
+
+        inputIncomingServerPassword = arguments.getBoolean(ARG_INPUT_INCOMING_SERVER_PASSWORD)
+        inputOutgoingServerPassword = arguments.getBoolean(ARG_INPUT_OUTGOING_SERVER_PASSWORD)
+        if (!inputIncomingServerPassword && !inputOutgoingServerPassword) {
+            error("Not prompting for any password")
+        }
+
+        dialogView = createView(
+                accountName,
+                inputIncomingServerPassword,
+                incomingServerName,
+                inputOutgoingServerPassword,
+                outgoingServerName
+        )
+
+        return AlertDialog.Builder(requireContext())
+                .setView(dialogView)
+                .setPositiveButton(R.string.okay_action) { _, _ -> deliverPasswordPromptResult() }
+                .setNegativeButton(R.string.cancel_action, null)
+                .create()
+    }
+
+    @SuppressLint("InflateParams")
+    private fun createView(
+            accountName: String,
+            inputIncomingServerPassword: Boolean,
+            incomingServerName: String?,
+            inputOutgoingServerPassword: Boolean,
+            outgoingServerName: String?
+    ): View {
+        val layoutInflater = LayoutInflater.from(requireContext())
+        val view = layoutInflater.inflate(R.layout.password_prompt_dialog, null)
+
+        val quantity = if (inputIncomingServerPassword && inputOutgoingServerPassword) 2 else 1
+        view.passwordPromptIntro.text = resources.getQuantityString(
+                R.plurals.settings_import_password_prompt,
+                quantity,
+                accountName
+        )
+        view.incomingServerName.text = getString(R.string.server_name_format, incomingServerName)
+        view.outgoingServerName.text = getString(R.string.server_name_format, outgoingServerName)
+
+        val incomingServerGroup = view.incomingServerGroup
+        val outgoingServerGroup = view.outgoingServerGroup
+        incomingServerGroup.isGone = !inputIncomingServerPassword
+        outgoingServerGroup.isGone = !inputOutgoingServerPassword
+
+        val useSamePasswordCheckbox = view.useSamePasswordCheckbox
+        if (inputIncomingServerPassword && inputOutgoingServerPassword) {
+            useSamePasswordCheckbox.isChecked = true
+            outgoingServerGroup.isGone = true
+
+            useSamePasswordCheckbox.setOnCheckedChangeListener { _, isChecked ->
+                outgoingServerGroup.isGone = isChecked
+            }
+        } else {
+            useSamePasswordCheckbox.isGone = true
+        }
+
+        return view
+    }
+
+    private fun deliverPasswordPromptResult() {
+        val incomingServerPassword = when {
+            !inputIncomingServerPassword -> null
+            else -> dialogView.incomingServerPassword.text.toString()
+        }
+        val outgoingServerPassword = when {
+            !inputOutgoingServerPassword -> null
+            dialogView.useSamePasswordCheckbox.isChecked -> incomingServerPassword
+            else -> dialogView.outgoingServerPassword.text.toString()
+        }
+
+        val resultIntent = PasswordPromptResult(accountUuid, incomingServerPassword, outgoingServerPassword).asIntent()
+
+        targetFragment!!.onActivityResult(targetRequestCode, Activity.RESULT_OK, resultIntent)
+    }
+
+
+    companion object {
+        private const val ARG_ACCOUNT_UUID = "accountUuid"
+        private const val ARG_ACCOUNT_NAME = "accountName"
+        private const val ARG_INPUT_INCOMING_SERVER_PASSWORD = "inputIncomingServerPassword"
+        private const val ARG_INCOMING_SERVER_NAME = "incomingServerName"
+        private const val ARG_INPUT_OUTGOING_SERVER_PASSWORD = "inputOutgoingServerPassword"
+        private const val ARG_OUTGOING_SERVER_NAME = "outgoingServerName"
+
+        fun create(
+                accountUuid: String,
+                accountName: String,
+                inputIncomingServerPassword: Boolean,
+                incomingServerName: String?,
+                inputOutgoingServerPassword: Boolean,
+                outgoingServerName: String?,
+                targetFragment: Fragment,
+                requestCode: Int
+        ) = PasswordPromptDialogFragment().apply {
+            arguments = bundleOf(
+                    ARG_ACCOUNT_UUID to accountUuid,
+                    ARG_ACCOUNT_NAME to accountName,
+                    ARG_INPUT_INCOMING_SERVER_PASSWORD to inputIncomingServerPassword,
+                    ARG_INCOMING_SERVER_NAME to incomingServerName,
+                    ARG_INPUT_OUTGOING_SERVER_PASSWORD to inputOutgoingServerPassword,
+                    ARG_OUTGOING_SERVER_NAME to outgoingServerName
+            )
+            setTargetFragment(targetFragment, requestCode)
+        }
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/import/PasswordPromptResult.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/import/PasswordPromptResult.kt
@@ -1,0 +1,30 @@
+package com.fsck.k9.ui.settings.import
+
+import android.content.Intent
+
+data class PasswordPromptResult(
+        val accountUuid: String,
+        val incomingServerPassword: String?,
+        val outgoingServerPassword: String?
+) {
+    fun asIntent() = Intent().apply {
+        putExtra(EXTRA_ACCOUNT_UUID, accountUuid)
+        putExtra(EXTRA_INCOMING_SERVER_PASSWORD, incomingServerPassword)
+        putExtra(EXTRA_OUTGOING_SERVER_PASSWORD, outgoingServerPassword)
+    }
+
+
+    companion object {
+        private const val EXTRA_ACCOUNT_UUID = "accountUuid"
+        private const val EXTRA_INCOMING_SERVER_PASSWORD = "incomingServerPassword"
+        private const val EXTRA_OUTGOING_SERVER_PASSWORD = "outgoingServerPassword"
+
+        fun fromIntent(intent: Intent): PasswordPromptResult {
+            val accountUuid = intent.getStringExtra(EXTRA_ACCOUNT_UUID) ?: error("Missing account UUID")
+            val incomingServerPassword = intent.getStringExtra(EXTRA_INCOMING_SERVER_PASSWORD)
+            val outgoingServerPassword = intent.getStringExtra(EXTRA_OUTGOING_SERVER_PASSWORD)
+
+            return PasswordPromptResult(accountUuid, incomingServerPassword, outgoingServerPassword)
+        }
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportFragment.kt
@@ -1,0 +1,195 @@
+package com.fsck.k9.ui.settings.import
+
+import android.app.Activity
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.core.view.isGone
+import androidx.core.view.isInvisible
+import androidx.core.view.isVisible
+import androidx.fragment.app.Fragment
+import androidx.navigation.fragment.findNavController
+import androidx.recyclerview.widget.RecyclerView
+import com.fsck.k9.ui.R
+import com.fsck.k9.ui.observeNotNull
+import com.mikepenz.fastadapter.commons.adapters.FastItemAdapter
+import kotlinx.android.synthetic.main.fragment_settings_import.*
+import org.koin.android.architecture.ext.viewModel
+
+class SettingsImportFragment : Fragment() {
+    private val viewModel: SettingsImportViewModel by viewModel()
+
+    private lateinit var settingsImportAdapter: FastItemAdapter<ImportListItem>
+
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_settings_import, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        if (savedInstanceState != null) {
+            viewModel.initializeFromSavedState(savedInstanceState)
+        }
+
+        initializeSettingsImportList(view)
+        pickDocumentButton.setOnClickListener { viewModel.onPickDocumentButtonClicked() }
+        importButton.setOnClickListener { viewModel.onImportButtonClicked() }
+        closeButton.setOnClickListener { viewModel.onCloseButtonClicked() }
+
+        viewModel.getUiModel().observeNotNull(this) { updateUi(it) }
+        viewModel.getActionEvents().observeNotNull(this) { handleActionEvents(it) }
+    }
+
+    private fun initializeSettingsImportList(view: View) {
+        settingsImportAdapter = FastItemAdapter<ImportListItem>().apply {
+            setHasStableIds(true)
+            withOnClickListener { _, _, _, position ->
+                viewModel.onSettingsListItemClicked(position)
+                true
+            }
+            withEventHook(ImportListItemClickEvent { position ->
+                viewModel.onSettingsListItemClicked(position)
+            })
+        }
+
+        val recyclerView = view.findViewById<RecyclerView>(R.id.settingsImportList)
+        recyclerView.adapter = settingsImportAdapter
+    }
+
+    private fun updateUi(model: SettingsImportUiModel) {
+        when (model.importButton) {
+            ButtonState.DISABLED -> {
+                importButton.isVisible = true
+                importButton.isEnabled = false
+            }
+            ButtonState.ENABLED -> {
+                importButton.isVisible = true
+                importButton.isEnabled = true
+            }
+            ButtonState.INVISIBLE -> importButton.isInvisible = true
+            ButtonState.GONE -> importButton.isGone = true
+        }
+
+        closeButton.isGone = model.closeButton == ButtonState.GONE
+        when (model.closeButtonLabel) {
+            CloseButtonLabel.OK -> closeButton.setText(R.string.okay_action)
+            CloseButtonLabel.LATER -> closeButton.setText(R.string.settings_import_later_button)
+        }
+
+        settingsImportList.isVisible = model.isSettingsListVisible
+        pickDocumentButton.isInvisible = !model.isPickDocumentButtonVisible
+        pickDocumentButton.isEnabled = model.isPickDocumentButtonEnabled
+        loadingProgressBar.isVisible = model.isLoadingProgressVisible
+        importProgressBar.isVisible = model.isImportProgressVisible
+
+        statusText.isVisible = model.statusText != StatusText.HIDDEN
+        when (model.statusText) {
+            StatusText.IMPORTING_PROGRESS -> {
+                statusText.text = getString(R.string.settings_importing)
+            }
+            StatusText.IMPORT_SUCCESS -> {
+                statusText.text = getString(R.string.settings_import_success_generic)
+            }
+            StatusText.IMPORT_SUCCESS_PASSWORD_REQUIRED -> {
+                statusText.text = getString(R.string.settings_import_password_required)
+            }
+            StatusText.IMPORT_READ_FAILURE -> {
+                statusText.text = getString(R.string.settings_import_read_failure)
+            }
+            StatusText.IMPORT_PARTIAL_FAILURE -> {
+                statusText.text = getString(R.string.settings_import_partial_failure)
+            }
+            StatusText.IMPORT_FAILURE -> {
+                statusText.text = getString(R.string.settings_import_failure)
+            }
+            StatusText.HIDDEN -> statusText.text = null
+        }
+
+        setSettingsList(model.settingsList, model.isSettingsListEnabled)
+    }
+
+    //TODO: Update list instead of replacing it completely
+    private fun setSettingsList(items: List<SettingsListItem>, enable: Boolean) {
+        val importListItems = items.map { item ->
+            val checkBoxItem = when (item) {
+                is SettingsListItem.GeneralSettings -> GeneralSettingsItem(item.importStatus)
+                is SettingsListItem.Account -> AccountItem(item)
+            }
+
+            checkBoxItem
+                    .withSetSelected(item.selected)
+                    .withEnabled(item.enabled && enable)
+        }
+
+        settingsImportAdapter.set(importListItems)
+
+        settingsImportList.isEnabled = enable
+    }
+
+    private fun handleActionEvents(action: Action) {
+        when (action) {
+            is Action.Close -> findNavController().popBackStack()
+            is Action.PickDocument -> pickDocument()
+            is Action.PasswordPrompt -> showPasswordPrompt(action)
+        }
+    }
+
+    private fun pickDocument() {
+        val createDocumentIntent = Intent(Intent.ACTION_GET_CONTENT).apply {
+            type = "*/*"
+            addCategory(Intent.CATEGORY_OPENABLE)
+        }
+        startActivityForResult(createDocumentIntent, REQUEST_PICK_DOCUMENT)
+    }
+
+    private fun showPasswordPrompt(action: Action.PasswordPrompt) {
+        val dialogFragment = PasswordPromptDialogFragment.create(
+                action.accountUuid,
+                action.accountName,
+                action.inputIncomingServerPassword,
+                action.incomingServerName,
+                action.inputOutgoingServerPassword,
+                action.outgoingServerName,
+                targetFragment = this,
+                requestCode = REQUEST_PASSWORD_PROMPT
+        )
+        dialogFragment.show(fragmentManager, null)
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+        viewModel.saveInstanceState(outState)
+    }
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, data: Intent?) {
+        when (requestCode) {
+            REQUEST_PICK_DOCUMENT -> handlePickDocumentResult(resultCode, data)
+            REQUEST_PASSWORD_PROMPT -> handlePasswordPromptResult(resultCode, data)
+        }
+    }
+
+    private fun handlePickDocumentResult(resultCode: Int, data: Intent?) {
+        val contentUri = data?.data
+        if (resultCode == Activity.RESULT_OK && contentUri != null) {
+            viewModel.onDocumentPicked(contentUri)
+        } else {
+            viewModel.onDocumentPickCanceled()
+        }
+    }
+
+    private fun handlePasswordPromptResult(resultCode: Int, data: Intent?) {
+        if (resultCode == Activity.RESULT_OK) {
+            val resultIntent = data ?: error("No result intent received")
+            val result = PasswordPromptResult.fromIntent(resultIntent)
+            viewModel.onPasswordPromptResult(result)
+        }
+    }
+
+
+    companion object {
+        private const val REQUEST_PICK_DOCUMENT = Activity.RESULT_FIRST_USER
+        private const val REQUEST_PASSWORD_PROMPT = Activity.RESULT_FIRST_USER + 1
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportListItems.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportListItems.kt
@@ -1,0 +1,102 @@
+package com.fsck.k9.ui.settings.import
+
+import android.view.View
+import android.widget.CheckBox
+import android.widget.ImageView
+import androidx.core.view.isVisible
+import androidx.recyclerview.widget.RecyclerView
+import com.fsck.k9.ui.R
+import com.mikepenz.fastadapter.FastAdapter
+import com.mikepenz.fastadapter.items.AbstractItem
+import com.mikepenz.fastadapter.listeners.ClickEventHook
+import kotlinx.android.extensions.LayoutContainer
+import kotlinx.android.synthetic.main.settings_import_account_list_item.*
+
+private const val GENERAL_SETTINGS_ID = 0L
+private const val ACCOUNT_ITEMS_ID_OFFSET = 1L
+
+abstract class ImportListItem(private val id: Long, private val importStatus: ImportStatus)
+    : AbstractItem<ImportListItem, ImportCheckBoxViewHolder>() {
+
+    override fun getIdentifier(): Long = id
+
+    override fun getViewHolder(view: View): ImportCheckBoxViewHolder {
+        return ImportCheckBoxViewHolder(view)
+    }
+
+    override fun bindView(viewHolder: ImportCheckBoxViewHolder, payloads: List<Any>) {
+        super.bindView(viewHolder, payloads)
+        viewHolder.checkBox.isChecked = isSelected
+        viewHolder.itemView.isEnabled = isEnabled
+        viewHolder.checkBox.isEnabled = isEnabled
+
+        viewHolder.checkBox.isVisible = importStatus == ImportStatus.NOT_AVAILABLE
+        viewHolder.statusIcon.isVisible = importStatus != ImportStatus.NOT_AVAILABLE
+
+        if (importStatus != ImportStatus.NOT_AVAILABLE) {
+            val imageLevel = when (importStatus) {
+                ImportStatus.IMPORT_SUCCESS -> 0
+                ImportStatus.IMPORT_SUCCESS_PASSWORD_REQUIRED -> 1
+                ImportStatus.NOT_SELECTED -> 2
+                ImportStatus.IMPORT_FAILURE -> 3
+                else -> error("Unexpected import status: $importStatus")
+            }
+            viewHolder.statusIcon.setImageLevel(imageLevel)
+
+            val contentDescriptionStringResId = when (importStatus) {
+                ImportStatus.IMPORT_SUCCESS -> R.string.settings_import_status_success
+                ImportStatus.IMPORT_SUCCESS_PASSWORD_REQUIRED -> R.string.settings_import_status_password_required
+                ImportStatus.NOT_SELECTED -> R.string.settings_import_status_not_imported
+                ImportStatus.IMPORT_FAILURE -> R.string.settings_import_status_error
+                else -> error("Unexpected import status: $importStatus")
+            }
+            val context = viewHolder.containerView.context
+            viewHolder.statusIcon.contentDescription = context.getString(contentDescriptionStringResId)
+        }
+    }
+}
+
+class ImportCheckBoxViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView), LayoutContainer {
+    val checkBox: CheckBox = itemView.findViewById(R.id.checkBox)
+    val statusIcon: ImageView = itemView.findViewById(R.id.statusIcon)
+
+    override val containerView = itemView
+}
+
+class ImportListItemClickEvent(val action: (position: Int) -> Unit) : ClickEventHook<ImportListItem>() {
+
+    override fun onBind(viewHolder: RecyclerView.ViewHolder): View? {
+        return if (viewHolder is ImportCheckBoxViewHolder) viewHolder.checkBox else null
+    }
+
+    override fun onClick(
+            view: View,
+            position: Int,
+            fastAdapter: FastAdapter<ImportListItem>,
+            item: ImportListItem
+    ) {
+        action(position)
+    }
+}
+
+class GeneralSettingsItem(importStatus: ImportStatus) : ImportListItem(GENERAL_SETTINGS_ID, importStatus) {
+
+    override fun getType(): Int = R.id.settings_import_list_general_item
+
+    override fun getLayoutRes(): Int = R.layout.settings_import_general_list_item
+}
+
+class AccountItem(account: SettingsListItem.Account)
+    : ImportListItem(account.accountIndex + ACCOUNT_ITEMS_ID_OFFSET, account.importStatus) {
+
+    private val displayName = account.displayName
+
+    override fun getType(): Int = R.id.settings_import_list_account_item
+
+    override fun getLayoutRes(): Int = R.layout.settings_import_account_list_item
+
+    override fun bindView(viewHolder: ImportCheckBoxViewHolder, payloads: List<Any>) {
+        super.bindView(viewHolder, payloads)
+        viewHolder.accountDisplayName.text = displayName
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportUiModel.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportUiModel.kt
@@ -1,0 +1,194 @@
+package com.fsck.k9.ui.settings.import
+
+class SettingsImportUiModel {
+    var settingsList: List<SettingsListItem> = emptyList()
+    var isSettingsListVisible = false
+    var isSettingsListEnabled = true
+    var importButton: ButtonState = ButtonState.DISABLED
+    var closeButton: ButtonState = ButtonState.GONE
+    var closeButtonLabel: CloseButtonLabel = CloseButtonLabel.OK
+    var isPickDocumentButtonVisible = true
+    var isPickDocumentButtonEnabled = true
+    var isLoadingProgressVisible = false
+    var isImportProgressVisible = false
+    var statusText = StatusText.HIDDEN
+
+    val hasImportStarted
+        get() = importButton == ButtonState.GONE
+
+    val hasDocumentBeenRead
+        get() = isSettingsListVisible
+
+    fun enablePickDocumentButton() {
+        isPickDocumentButtonEnabled = true
+    }
+
+    fun disablePickDocumentButton() {
+        statusText = StatusText.HIDDEN
+        isPickDocumentButtonEnabled = false
+    }
+
+    private fun enableImportButton() {
+        importButton = ButtonState.ENABLED
+        isImportProgressVisible = false
+        isSettingsListEnabled = true
+    }
+
+    private fun disableImportButton() {
+        importButton = ButtonState.DISABLED
+        isImportProgressVisible = false
+    }
+
+    fun showLoadingProgress() {
+        isLoadingProgressVisible = true
+        isPickDocumentButtonVisible = false
+        isSettingsListEnabled = false
+        statusText = StatusText.HIDDEN
+    }
+
+    fun showImportingProgress() {
+        isImportProgressVisible = true
+        isSettingsListEnabled = false
+        importButton = ButtonState.INVISIBLE
+        statusText = StatusText.IMPORTING_PROGRESS
+    }
+
+    private fun showSuccessText() {
+        importButton = ButtonState.GONE
+        closeButton = ButtonState.ENABLED
+        closeButtonLabel = CloseButtonLabel.OK
+        isImportProgressVisible = false
+        isSettingsListEnabled = true
+        statusText = StatusText.IMPORT_SUCCESS
+    }
+
+    private fun showPasswordRequiredText() {
+        importButton = ButtonState.GONE
+        closeButton = ButtonState.ENABLED
+        closeButtonLabel = CloseButtonLabel.LATER
+        isImportProgressVisible = false
+        isSettingsListEnabled = true
+        statusText = StatusText.IMPORT_SUCCESS_PASSWORD_REQUIRED
+    }
+
+    fun showReadFailureText() {
+        isLoadingProgressVisible = false
+        isPickDocumentButtonVisible = true
+        isPickDocumentButtonEnabled = true
+        statusText = StatusText.IMPORT_READ_FAILURE
+        importButton = ButtonState.DISABLED
+    }
+
+    fun showImportErrorText() {
+        isLoadingProgressVisible = false
+        isImportProgressVisible = false
+        isSettingsListVisible = false
+        isPickDocumentButtonVisible = true
+        isPickDocumentButtonEnabled = true
+        statusText = StatusText.IMPORT_FAILURE
+        importButton = ButtonState.DISABLED
+    }
+
+    private fun showPartialImportErrorText() {
+        importButton = ButtonState.GONE
+        closeButton = ButtonState.ENABLED
+        closeButtonLabel = CloseButtonLabel.OK
+        isImportProgressVisible = false
+        isSettingsListEnabled = true
+        statusText = StatusText.IMPORT_PARTIAL_FAILURE
+    }
+
+    fun initializeSettingsList(list: List<SettingsListItem>) {
+        settingsList = list
+        isSettingsListVisible = true
+        isLoadingProgressVisible = false
+        isPickDocumentButtonVisible = false
+        updateImportButtonFromSelection()
+    }
+
+    fun toggleSettingsListItemSelection(position: Int) {
+        val settingsListItem = settingsList[position]
+        settingsListItem.selected = !settingsListItem.selected
+        statusText = StatusText.HIDDEN
+        updateImportButtonFromSelection()
+    }
+
+    fun setSettingsListState(position: Int, status: ImportStatus) {
+        settingsList[position].importStatus = status
+        settingsList[position].enabled = status == ImportStatus.IMPORT_SUCCESS_PASSWORD_REQUIRED
+    }
+
+    private fun updateImportButtonFromSelection() {
+        if (isImportProgressVisible) return
+
+        val atLeastOnceSelected = settingsList.any { it.selected }
+        if (atLeastOnceSelected) {
+            enableImportButton()
+        } else {
+            disableImportButton()
+        }
+    }
+
+    fun updateCloseButtonAndImportStatusText() {
+        val errorsOnly = settingsList.none {
+            it.importStatus == ImportStatus.IMPORT_SUCCESS ||
+            it.importStatus == ImportStatus.IMPORT_SUCCESS_PASSWORD_REQUIRED
+        }
+        if (errorsOnly) {
+            showImportErrorText()
+            return
+        }
+
+        val passwordsMissing = settingsList.any { it.importStatus == ImportStatus.IMPORT_SUCCESS_PASSWORD_REQUIRED }
+        if (passwordsMissing) {
+            showPasswordRequiredText()
+            return
+        }
+
+        val partialImportError = settingsList.any { it.importStatus == ImportStatus.IMPORT_FAILURE }
+        if (partialImportError) {
+            showPartialImportErrorText()
+        } else {
+            showSuccessText()
+        }
+    }
+}
+
+sealed class SettingsListItem {
+    var selected: Boolean = true
+    var enabled: Boolean = true
+    var importStatus: ImportStatus = ImportStatus.NOT_AVAILABLE
+
+    class GeneralSettings : SettingsListItem()
+    class Account(val accountIndex: Int, var displayName: String) : SettingsListItem()
+}
+
+enum class ImportStatus {
+    NOT_AVAILABLE,
+    NOT_SELECTED,
+    IMPORT_SUCCESS,
+    IMPORT_SUCCESS_PASSWORD_REQUIRED,
+    IMPORT_FAILURE
+}
+
+enum class ButtonState {
+    DISABLED,
+    ENABLED,
+    INVISIBLE,
+    GONE
+}
+
+enum class StatusText {
+    HIDDEN,
+    IMPORTING_PROGRESS,
+    IMPORT_SUCCESS,
+    IMPORT_SUCCESS_PASSWORD_REQUIRED,
+    IMPORT_READ_FAILURE,
+    IMPORT_PARTIAL_FAILURE,
+    IMPORT_FAILURE
+}
+
+enum class CloseButtonLabel {
+    OK,
+    LATER
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportViewModel.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportViewModel.kt
@@ -1,0 +1,445 @@
+package com.fsck.k9.ui.settings.import
+
+import android.content.Context
+import android.net.Uri
+import android.os.Bundle
+import android.os.Parcelable
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import com.fsck.k9.helper.SingleLiveEvent
+import com.fsck.k9.helper.measureRealtimeMillisWithResult
+import com.fsck.k9.preferences.SettingsImporter
+import com.fsck.k9.preferences.SettingsImporter.ImportResults
+import com.fsck.k9.ui.getEnum
+import com.fsck.k9.ui.helper.CoroutineScopeViewModel
+import com.fsck.k9.ui.putEnum
+import kotlinx.android.parcel.Parcelize
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+private typealias AccountUuid = String
+private typealias AccountNumber = Int
+
+class SettingsImportViewModel(
+        private val context: Context,
+        private val accountActivator: AccountActivator
+) : CoroutineScopeViewModel() {
+    private val uiModelLiveData = MutableLiveData<SettingsImportUiModel>()
+    private val actionLiveData = SingleLiveEvent<Action>()
+
+    private val uiModel = SettingsImportUiModel()
+    private var accountsMap: MutableMap<AccountNumber, AccountUuid> = mutableMapOf()
+    private val accountStateMap: MutableMap<AccountNumber, AccountState> = mutableMapOf()
+    private var contentUri: Uri? = null
+
+    private val includeGeneralSettings: Boolean
+        get() = uiModel.settingsList.first { it is SettingsListItem.GeneralSettings }.selected
+
+    private val generalSettingsImportStatus
+        get() = uiModel.settingsList.first { it is SettingsListItem.GeneralSettings }.importStatus
+
+    private val selectedAccounts: Set<AccountUuid>
+        get() {
+            return uiModel.settingsList.asSequence()
+                    .filterIsInstance<SettingsListItem.Account>()
+                    .filter { it.selected }
+                    .map {
+                        accountsMap[it.accountIndex] ?: error("Unknown account index: ${it.accountIndex}")
+                    }
+                    .toSet()
+        }
+
+
+    fun getActionEvents(): LiveData<Action> = actionLiveData
+
+    fun getUiModel(): LiveData<SettingsImportUiModel> {
+        if (uiModelLiveData.value == null) {
+            uiModelLiveData.value = uiModel
+        }
+
+        return uiModelLiveData
+    }
+
+
+    fun initializeFromSavedState(savedInstanceState: Bundle) {
+        contentUri = savedInstanceState.getParcelable(STATE_CONTENT_URI)
+
+        updateUiModel {
+            isSettingsListVisible = savedInstanceState.getBoolean(STATE_SETTINGS_LIST_VISIBLE)
+            isSettingsListEnabled = savedInstanceState.getBoolean(STATE_SETTINGS_LIST_ENABLED)
+            importButton = savedInstanceState.getEnum(STATE_IMPORT_BUTTON, ButtonState.DISABLED)
+            closeButton = savedInstanceState.getEnum(STATE_CLOSE_BUTTON, ButtonState.DISABLED)
+            closeButtonLabel = savedInstanceState.getEnum(STATE_CLOSE_BUTTON_LABEL, CloseButtonLabel.OK)
+            isPickDocumentButtonVisible = savedInstanceState.getBoolean(STATE_PICK_DOCUMENT_BUTTON_VISIBLE)
+            isPickDocumentButtonEnabled = savedInstanceState.getBoolean(STATE_PICK_DOCUMENT_BUTTON_ENABLED)
+
+            isLoadingProgressVisible = savedInstanceState.getBoolean(STATE_LOADING_PROGRESS_VISIBLE)
+            isImportProgressVisible = savedInstanceState.getBoolean(STATE_IMPORT_PROGRESS_VISIBLE)
+            statusText = savedInstanceState.getEnum(STATE_STATUS_TEXT, StatusText.HIDDEN)
+
+            if (!hasDocumentBeenRead) return@updateUiModel
+
+            val includeGeneralSettings = savedInstanceState.getBoolean(STATE_INCLUDE_GENERAL_SETTINGS)
+            val generalSettingsImportState = savedInstanceState.getEnum(STATE_GENERAL_SETTINGS_IMPORT_STATUS,
+                    ImportStatus.NOT_AVAILABLE)
+
+            val generalSettingsItem = SettingsListItem.GeneralSettings().apply {
+                selected = includeGeneralSettings
+                importStatus = generalSettingsImportState
+                enabled = !hasImportStarted
+            }
+
+            val savedAccountList = savedInstanceState.getParcelableArrayList<SavedAccountState>(STATE_ACCOUNT_LIST)!!
+
+            savedAccountList.forEach { saved ->
+                accountsMap[saved.accountIndex] = saved.accountUuid
+                accountStateMap[saved.accountIndex] = AccountState(
+                        saved.incomingServerName,
+                        saved.outgoingServerName,
+                        saved.incomingServerPasswordNeeded,
+                        saved.outgoingServerPasswordNeeded
+                )
+            }
+
+            val accountSettingsItems = savedAccountList.map { saved ->
+                SettingsListItem.Account(saved.accountIndex, saved.displayName).apply {
+                    selected = saved.selected
+                    importStatus = saved.importStatus
+                    enabled = if (hasImportStarted) {
+                        saved.importStatus == ImportStatus.IMPORT_SUCCESS_PASSWORD_REQUIRED
+                    } else {
+                        true
+                    }
+                }
+            }
+
+            settingsList = listOf(generalSettingsItem) + accountSettingsItems
+        }
+    }
+
+    fun saveInstanceState(outState: Bundle) {
+        with(uiModel) {
+            outState.putBoolean(STATE_SETTINGS_LIST_VISIBLE, isSettingsListVisible)
+            outState.putBoolean(STATE_SETTINGS_LIST_ENABLED, isSettingsListEnabled)
+            outState.putEnum(STATE_IMPORT_BUTTON, importButton)
+            outState.putEnum(STATE_CLOSE_BUTTON, closeButton)
+            outState.putEnum(STATE_CLOSE_BUTTON_LABEL, closeButtonLabel)
+            outState.putBoolean(STATE_PICK_DOCUMENT_BUTTON_VISIBLE, isPickDocumentButtonVisible)
+            outState.putBoolean(STATE_PICK_DOCUMENT_BUTTON_ENABLED, isPickDocumentButtonEnabled)
+            outState.putBoolean(STATE_LOADING_PROGRESS_VISIBLE, isLoadingProgressVisible)
+            outState.putBoolean(STATE_IMPORT_PROGRESS_VISIBLE, isImportProgressVisible)
+            outState.putEnum(STATE_STATUS_TEXT, statusText)
+
+            if (hasDocumentBeenRead) {
+                outState.putBoolean(STATE_INCLUDE_GENERAL_SETTINGS, includeGeneralSettings)
+                outState.putEnum(STATE_GENERAL_SETTINGS_IMPORT_STATUS, generalSettingsImportStatus)
+                outState.putParcelableArrayList(STATE_ACCOUNT_LIST, createSavedAccountList())
+            }
+        }
+
+        outState.putParcelable(STATE_CONTENT_URI, contentUri)
+    }
+
+    fun onPickDocumentButtonClicked() {
+        updateUiModel {
+            disablePickDocumentButton()
+        }
+
+        sendActionEvent(Action.PickDocument)
+    }
+
+    fun onDocumentPickCanceled() {
+        updateUiModel {
+            enablePickDocumentButton()
+        }
+    }
+
+    fun onDocumentPicked(contentUri: Uri) {
+        updateUiModel {
+            showLoadingProgress()
+        }
+
+        startReadSettingsFile(contentUri)
+    }
+
+    fun onImportButtonClicked() {
+        updateUiModel {
+            showImportingProgress()
+        }
+
+        startImportSettings()
+    }
+
+    fun onCloseButtonClicked() {
+        sendActionEvent(Action.Close)
+    }
+
+    fun onSettingsListItemClicked(position: Int) {
+        val settingsListItem = uiModel.settingsList[position]
+        when (settingsListItem.importStatus) {
+            ImportStatus.NOT_AVAILABLE -> updateUiModel {
+                toggleSettingsListItemSelection(position)
+            }
+            ImportStatus.IMPORT_SUCCESS_PASSWORD_REQUIRED -> {
+                showPasswordPromptDialog(settingsListItem as SettingsListItem.Account)
+            }
+            else -> Unit
+        }
+    }
+
+    fun onPasswordPromptResult(result: PasswordPromptResult) {
+        updateUiModel {
+            val index = getListIndexOfAccount(result.accountUuid)
+            setSettingsListState(index, ImportStatus.IMPORT_SUCCESS)
+
+            updateCloseButtonAndImportStatusText()
+        }
+
+        GlobalScope.launch(Dispatchers.IO) {
+            with(result) {
+                accountActivator.enableAccount(accountUuid, incomingServerPassword, outgoingServerPassword)
+            }
+        }
+    }
+
+    private fun getListIndexOfAccount(accountUuid: String): Int {
+        return uiModel.settingsList.indexOfFirst {
+            it is SettingsListItem.Account && accountsMap[it.accountIndex] == accountUuid
+        }
+    }
+
+    private fun startReadSettingsFile(contentUri: Uri) {
+        this.contentUri = contentUri
+
+        launch {
+            try {
+                val (elapsed, contents) = measureRealtimeMillisWithResult {
+                    withContext(Dispatchers.IO) {
+                        readSettings(contentUri)
+                    }
+                }
+
+                if (elapsed < MIN_PROGRESS_DURATION) {
+                    delay(MIN_PROGRESS_DURATION - elapsed)
+                }
+
+                accountsMap = contents.accounts
+                        .asSequence()
+                        .mapIndexed { index, account -> index to account.uuid }
+                        .toMap(mutableMapOf())
+
+                val items = mutableListOf<SettingsListItem>(SettingsListItem.GeneralSettings())
+                contents.accounts.mapIndexedTo(items) { index, accountDescription ->
+                    SettingsListItem.Account(index, accountDescription.name)
+                }
+
+                updateUiModel {
+                    initializeSettingsList(items)
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error reading settings file")
+
+                updateUiModel {
+                    showReadFailureText()
+                }
+            }
+        }
+    }
+
+    private fun startImportSettings() {
+        val contentUri = this.contentUri ?: error("contentUri is missing")
+        launch {
+            try {
+                val importGeneralSettings = includeGeneralSettings
+                val importAccounts = selectedAccounts.toList()
+
+                val (elapsed, importResults) = measureRealtimeMillisWithResult {
+                    withContext(Dispatchers.IO) {
+                        importSettings(contentUri, importGeneralSettings, importAccounts)
+                    }
+                }
+
+                if (elapsed < MIN_PROGRESS_DURATION) {
+                    delay(MIN_PROGRESS_DURATION - elapsed)
+                }
+
+
+                updateUiModel {
+                    setGeneralSettingsImportStatus(importResults, importGeneralSettings)
+                    setAccountsImportStatus(importResults)
+
+                    updateCloseButtonAndImportStatusText()
+                }
+            } catch (e: Exception) {
+                Timber.e(e, "Error importing settings")
+
+                updateUiModel {
+                    showImportErrorText()
+                }
+            }
+        }
+    }
+
+    private fun SettingsImportUiModel.setGeneralSettingsImportStatus(
+            importResults: ImportResults,
+            importGeneralSettings: Boolean
+    ) {
+        val importStatus = when {
+            importResults.globalSettings -> ImportStatus.IMPORT_SUCCESS
+            importGeneralSettings -> ImportStatus.IMPORT_FAILURE
+            else -> ImportStatus.NOT_SELECTED
+        }
+        setSettingsListState(0, importStatus)
+    }
+
+    private fun SettingsImportUiModel.setAccountsImportStatus(importResults: ImportResults) {
+        val failedToImport = importResults.erroneousAccounts.map { it.uuid }.toHashSet()
+        settingsList.forEachIndexed { index, listItem ->
+            if (listItem !is SettingsListItem.Account) return@forEachIndexed
+
+            val accountIndex = listItem.accountIndex
+            val accountUuid = accountsMap[accountIndex]
+
+            if (accountUuid in failedToImport) {
+                setSettingsListState(index, ImportStatus.IMPORT_FAILURE)
+            } else {
+                val accountPair = importResults.importedAccounts.firstOrNull { it.original.uuid == accountUuid }
+                if (accountPair != null) {
+                    accountsMap[accountIndex] = accountPair.imported.uuid
+                    listItem.displayName = accountPair.imported.name
+
+                    if (accountPair.incomingPasswordNeeded || accountPair.outgoingPasswordNeeded) {
+                        accountStateMap[accountIndex] = AccountState(
+                                accountPair.incomingServerName,
+                                accountPair.outgoingServerName,
+                                accountPair.incomingPasswordNeeded,
+                                accountPair.outgoingPasswordNeeded
+                        )
+
+                        setSettingsListState(index, ImportStatus.IMPORT_SUCCESS_PASSWORD_REQUIRED)
+                    } else {
+                        setSettingsListState(index, ImportStatus.IMPORT_SUCCESS)
+                    }
+                } else {
+                    setSettingsListState(index, ImportStatus.NOT_SELECTED)
+                }
+            }
+        }
+    }
+
+    private fun readSettings(contentUri: Uri): SettingsImporter.ImportContents {
+        return context.contentResolver.openInputStream(contentUri).use { inputStream ->
+            SettingsImporter.getImportStreamContents(inputStream)
+        }
+    }
+
+    private fun importSettings(contentUri: Uri, generalSettings: Boolean, accounts: List<AccountUuid>): ImportResults {
+        return context.contentResolver.openInputStream(contentUri).use { inputStream ->
+            SettingsImporter.importSettings(context, inputStream, generalSettings, accounts, false)
+        }
+    }
+
+    private fun showPasswordPromptDialog(settingsListItem: SettingsListItem.Account) {
+        val accountIndex = settingsListItem.accountIndex
+
+        val accountUuid = accountsMap[accountIndex]!!
+        val accountState = accountStateMap[accountIndex]!!
+
+        sendActionEvent(Action.PasswordPrompt(
+                accountUuid,
+                settingsListItem.displayName,
+                accountState.incomingServerPasswordNeeded,
+                accountState.incomingServerName,
+                accountState.outgoingServerPasswordNeeded,
+                accountState.outgoingServerName
+        ))
+    }
+
+    private fun updateUiModel(block: SettingsImportUiModel.() -> Unit) {
+        uiModel.block()
+        uiModelLiveData.value = uiModel
+    }
+
+    private fun sendActionEvent(action: Action) {
+        actionLiveData.value = action
+    }
+
+    private fun createSavedAccountList(): ArrayList<SavedAccountState> {
+        return uiModel.settingsList
+                .asSequence()
+                .filterIsInstance<SettingsListItem.Account>()
+                .map { accountItem ->
+                    val accountIndex = accountItem.accountIndex
+                    val accountState = accountStateMap[accountIndex]
+                    SavedAccountState(
+                            accountIndex = accountIndex,
+                            displayName = accountItem.displayName,
+                            accountUuid = accountsMap[accountIndex]!!,
+                            selected = accountItem.selected,
+                            importStatus = accountItem.importStatus,
+                            incomingServerName = accountState?.incomingServerName,
+                            outgoingServerName = accountState?.outgoingServerName,
+                            incomingServerPasswordNeeded = accountState?.incomingServerPasswordNeeded ?: false,
+                            outgoingServerPasswordNeeded = accountState?.outgoingServerPasswordNeeded ?: false
+                    )
+                }
+                .toCollection(ArrayList(uiModel.settingsList.size - 1))
+    }
+
+
+    companion object {
+        private const val MIN_PROGRESS_DURATION = 500L
+
+        private const val STATE_SETTINGS_LIST_VISIBLE = "settingsListVisible"
+        private const val STATE_SETTINGS_LIST_ENABLED = "settingsListEnabled"
+        private const val STATE_IMPORT_BUTTON = "importButton"
+        private const val STATE_CLOSE_BUTTON = "closeButton"
+        private const val STATE_CLOSE_BUTTON_LABEL = "closeButtonLabel"
+        private const val STATE_PICK_DOCUMENT_BUTTON_VISIBLE = "pickDocumentButtonVisible"
+        private const val STATE_PICK_DOCUMENT_BUTTON_ENABLED = "pickDocumentButtonEnabled"
+        private const val STATE_LOADING_PROGRESS_VISIBLE = "loadingProgressVisible"
+        private const val STATE_IMPORT_PROGRESS_VISIBLE = "importProgressVisible"
+        private const val STATE_STATUS_TEXT = "statusText"
+        private const val STATE_INCLUDE_GENERAL_SETTINGS = "includeGeneralSettings"
+        private const val STATE_CONTENT_URI = "contentUri"
+        private const val STATE_GENERAL_SETTINGS_IMPORT_STATUS = "generalSettingsImportStatus"
+        private const val STATE_ACCOUNT_LIST = "accountList"
+    }
+}
+
+sealed class Action {
+    object Close : Action()
+    object PickDocument : Action()
+    class PasswordPrompt(
+            val accountUuid: String,
+            val accountName: String,
+            val inputIncomingServerPassword: Boolean,
+            val incomingServerName: String?,
+            val inputOutgoingServerPassword: Boolean,
+            val outgoingServerName: String?
+    ) : Action()
+}
+
+private class AccountState(
+        val incomingServerName: String?,
+        val outgoingServerName: String?,
+        val incomingServerPasswordNeeded: Boolean,
+        val outgoingServerPasswordNeeded: Boolean
+)
+
+@Parcelize
+private class SavedAccountState(
+        val accountIndex: Int,
+        val displayName: String,
+        val accountUuid: String,
+        val selected: Boolean,
+        val importStatus: ImportStatus,
+        val incomingServerName: String?,
+        val outgoingServerName: String?,
+        val incomingServerPasswordNeeded: Boolean,
+        val outgoingServerPasswordNeeded: Boolean
+) : Parcelable

--- a/app/ui/src/main/res/drawable-anydpi/ic_check_circle_dark.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_check_circle_dark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_check_circle_light.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_check_circle_light.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:alpha="0.54"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM10,17l-5,-5 1.41,-1.41L10,14.17l7.59,-7.59L19,8l-9,9z"/>
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_error_dark.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_error_dark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2L11,7h2v6z"/>
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_error_light.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_error_light.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:alpha="0.54"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM13,17h-2v-2h2v2zM13,13h-2L11,7h2v6z"/>
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_import_dark.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_import_dark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FFFFFF"
+      android:pathData="M11,3L11,12L8,12L12,16L16,12L13,12L13,3L11,3zM4,19L4,21L20,21L20,19L4,19z"/>
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_import_light.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_import_light.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:alpha="0.54"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M11,3L11,12L8,12L12,16L16,12L13,12L13,3L11,3zM4,19L4,21L20,21L20,19L4,19z"/>
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_key_dark.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_key_dark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12.65,10C11.83,7.67 9.61,6 7,6c-3.31,0 -6,2.69 -6,6s2.69,6 6,6c2.61,0 4.83,-1.67 5.65,-4H17v4h4v-4h2v-4H12.65zM7,14c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2z"/>
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_key_light.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_key_light.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:alpha="0.54"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12.65,10C11.83,7.67 9.61,6 7,6c-3.31,0 -6,2.69 -6,6s2.69,6 6,6c2.61,0 4.83,-1.67 5.65,-4H17v4h4v-4h2v-4H12.65zM7,14c-1.1,0 -2,-0.9 -2,-2s0.9,-2 2,-2 2,0.9 2,2 -0.9,2 -2,2z"/>
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_not_imported_dark.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_not_imported_dark.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FFFFFFFF"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8 0,-1.85 0.63,-3.55 1.69,-4.9L16.9,18.31C15.55,19.37 13.85,20 12,20zM18.31,16.9L7.1,5.69C8.45,4.63 10.15,4 12,4c4.42,0 8,3.58 8,8 0,1.85 -0.63,3.55 -1.69,4.9z"/>
+</vector>

--- a/app/ui/src/main/res/drawable-anydpi/ic_not_imported_light.xml
+++ b/app/ui/src/main/res/drawable-anydpi/ic_not_imported_light.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+        android:width="24dp"
+        android:height="24dp"
+        android:alpha="0.54"
+        android:viewportWidth="24.0"
+        android:viewportHeight="24.0">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="M12,2C6.48,2 2,6.48 2,12s4.48,10 10,10 10,-4.48 10,-10S17.52,2 12,2zM12,20c-4.42,0 -8,-3.58 -8,-8 0,-1.85 0.63,-3.55 1.69,-4.9L16.9,18.31C15.55,19.37 13.85,20 12,20zM18.31,16.9L7.1,5.69C8.45,4.63 10.15,4 12,4c4.42,0 8,3.58 8,8 0,1.85 -0.63,3.55 -1.69,4.9z"/>
+</vector>

--- a/app/ui/src/main/res/drawable/ic_import_status_dark.xml
+++ b/app/ui/src/main/res/drawable/ic_import_status_dark.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<level-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/ic_check_circle_dark"
+        android:maxLevel="0"
+        android:minLevel="0" />
+    <item
+        android:drawable="@drawable/ic_key_dark"
+        android:maxLevel="1"
+        android:minLevel="1" />
+    <item
+        android:drawable="@drawable/ic_not_imported_dark"
+        android:maxLevel="2"
+        android:minLevel="2" />
+    <item
+        android:drawable="@drawable/ic_error_dark"
+        android:maxLevel="3"
+        android:minLevel="3" />
+</level-list>

--- a/app/ui/src/main/res/drawable/ic_import_status_light.xml
+++ b/app/ui/src/main/res/drawable/ic_import_status_light.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<level-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:drawable="@drawable/ic_check_circle_light"
+        android:maxLevel="0"
+        android:minLevel="0" />
+    <item
+        android:drawable="@drawable/ic_key_light"
+        android:maxLevel="1"
+        android:minLevel="1" />
+    <item
+        android:drawable="@drawable/ic_not_imported_light"
+        android:maxLevel="2"
+        android:minLevel="2" />
+    <item
+        android:drawable="@drawable/ic_error_light"
+        android:maxLevel="3"
+        android:minLevel="3" />
+</level-list>

--- a/app/ui/src/main/res/layout/fragment_settings_import.xml
+++ b/app/ui/src/main/res/layout/fragment_settings_import.xml
@@ -1,0 +1,122 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/settingsImportList"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        app:layout_constraintBottom_toTopOf="@+id/bottomBar"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:listitem="@layout/settings_import_account_list_item" />
+
+    <Button
+        android:id="@+id/pickDocumentButton"
+        style="@style/Widget.AppCompat.Button.Colored"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="16dp"
+        android:text="@string/settings_import_pick_document_button"
+        app:layout_constraintBottom_toTopOf="@+id/bottomBar"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/loadingProgressBar"
+        style="?android:attr/progressBarStyle"
+        android:layout_width="32dp"
+        android:layout_height="32dp"
+        android:indeterminate="true"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/pickDocumentButton"
+        app:layout_constraintEnd_toEndOf="@+id/pickDocumentButton"
+        app:layout_constraintStart_toStartOf="@+id/pickDocumentButton"
+        app:layout_constraintTop_toTopOf="@+id/pickDocumentButton" />
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/bottomBar"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/bottomBarBackground"
+        android:elevation="8dp"
+        android:minHeight="56dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        tools:ignore="UnusedAttribute">
+
+        <Button
+            android:id="@+id/importButton"
+            style="@style/Widget.AppCompat.Button.Colored"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="4dp"
+            android:enabled="false"
+            android:text="@string/settings_import_button"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@id/buttonBarrier" />
+
+        <Button
+            android:id="@+id/closeButton"
+            style="@style/Widget.AppCompat.Button.Colored"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginEnd="8dp"
+            android:layout_marginBottom="4dp"
+            android:text="@string/okay_action"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintStart_toEndOf="@id/buttonBarrier" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/buttonBarrier"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="left" />
+
+        <ProgressBar
+            android:id="@+id/importProgressBar"
+            style="?android:attr/progressBarStyle"
+            android:layout_width="32dp"
+            android:layout_height="32dp"
+            android:indeterminate="true"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="@+id/importButton"
+            app:layout_constraintEnd_toEndOf="@+id/importButton"
+            app:layout_constraintStart_toStartOf="@+id/importButton"
+            app:layout_constraintTop_toTopOf="@+id/importButton" />
+
+        <TextView
+            android:id="@+id/statusText"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginEnd="16dp"
+            android:layout_marginBottom="8dp"
+            android:visibility="gone"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/buttonBarrier"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:text="Importing…"
+            tools:visibility="visible" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>
+

--- a/app/ui/src/main/res/layout/password_prompt_dialog.xml
+++ b/app/ui/src/main/res/layout/password_prompt_dialog.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:padding="16dp">
+
+        <TextView
+            android:id="@+id/passwordPromptIntro"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            tools:text="To be able to use the account &quot;Test&quot; you need to provide the server passwords."
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="?android:attr/textColorPrimary"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/incomingServerPasswordLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/passwordPromptIntro"
+            app:passwordToggleEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/incomingServerPassword"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/settings_import_incoming_server_password_hint"
+                android:inputType="textPassword" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView
+            android:id="@+id/incomingServerName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="Server: imap.server.example"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/incomingServerPasswordLayout" />
+
+        <CheckBox
+            android:id="@+id/useSamePasswordCheckbox"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:checked="true"
+            android:text="@string/settings_import_use_same_password_for_outgoing_server"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/incomingServerName" />
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:id="@+id/outgoingServerPasswordLayout"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/useSamePasswordCheckbox"
+            app:passwordToggleEnabled="true">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:id="@+id/outgoingServerPassword"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:hint="@string/settings_import_outgoing_server_password_hint"
+                android:inputType="textPassword" />
+
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <TextView
+            android:id="@+id/outgoingServerName"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            tools:text="Server: smtp.server.example"
+            android:textAppearance="?android:attr/textAppearanceSmall"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/outgoingServerPasswordLayout" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/incomingServerGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="incomingServerPasswordLayout,incomingServerName" />
+
+        <androidx.constraintlayout.widget.Group
+            android:id="@+id/outgoingServerGroup"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:constraint_referenced_ids="outgoingServerPasswordLayout,outgoingServerName" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</ScrollView>

--- a/app/ui/src/main/res/layout/settings_import_account_list_item.xml
+++ b/app/ui/src/main/res/layout/settings_import_account_list_item.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall">
+
+    <CheckBox
+        android:id="@+id/checkBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:focusable="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/statusIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:contentDescription="@null"
+        android:focusable="false"
+        android:src="?attr/iconSettingsImportStatus"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/accountDisplayName"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:duplicateParentState="true"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guideline"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintVertical_chainStyle="packed"
+        tools:text="Account name" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="72dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/ui/src/main/res/layout/settings_import_general_list_item.xml
+++ b/app/ui/src/main/res/layout/settings_import_general_list_item.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="?attr/selectableItemBackground"
+    android:clickable="true"
+    android:focusable="true"
+    android:minHeight="?android:attr/listPreferredItemHeightSmall">
+
+    <CheckBox
+        android:id="@+id/checkBox"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="12dp"
+        android:focusable="false"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <ImageView
+        android:id="@+id/statusIcon"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginStart="16dp"
+        android:contentDescription="@null"
+        android:focusable="false"
+        android:src="?attr/iconSettingsImportStatus"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/title"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginEnd="16dp"
+        android:layout_marginBottom="8dp"
+        android:duplicateParentState="true"
+        android:text="@string/general_settings_title"
+        android:textAppearance="?android:attr/textAppearanceListItem"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="@+id/guideline"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintGuide_begin="72dp" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/ui/src/main/res/navigation/navigation_settings.xml
+++ b/app/ui/src/main/res/navigation/navigation_settings.xml
@@ -25,6 +25,9 @@
         <action
             android:id="@+id/action_settingsListScreen_to_settingsExportScreen"
             app:destination="@id/settingsExportScreen" />
+        <action
+            android:id="@+id/action_settingsListScreen_to_settingsImportScreen"
+            app:destination="@id/settingsImportScreen" />
     </fragment>
 
     <activity
@@ -49,5 +52,11 @@
         android:name="com.fsck.k9.ui.settings.export.SettingsExportFragment"
         android:label="@string/settings_export_title"
         tools:layout="@layout/fragment_settings_export"/>
+
+    <fragment
+        android:id="@+id/settingsImportScreen"
+        android:name="com.fsck.k9.ui.settings.import.SettingsImportFragment"
+        android:label="@string/settings_import_title"
+        tools:layout="@layout/fragment_settings_import"/>
 
 </navigation>

--- a/app/ui/src/main/res/values/attrs.xml
+++ b/app/ui/src/main/res/values/attrs.xml
@@ -65,6 +65,8 @@
         <attr name="iconSettingsAccount" format="reference" />
         <attr name="iconSettingsAccountAdd" format="reference" />
         <attr name="iconSettingsExport" format="reference" />
+        <attr name="iconSettingsImport" format="reference" />
+        <attr name="iconSettingsImportStatus" format="reference" />
         <attr name="textColorPrimaryRecipientDropdown" format="reference" />
         <attr name="textColorSecondaryRecipientDropdown" format="reference" />
         <attr name="backgroundColorChooseAccountHeader" format="color" />

--- a/app/ui/src/main/res/values/ids.xml
+++ b/app/ui/src/main/res/values/ids.xml
@@ -10,5 +10,7 @@
 
     <item type="id" name="settings_export_list_general_item"/>
     <item type="id" name="settings_export_list_account_item"/>
+    <item type="id" name="settings_import_list_general_item"/>
+    <item type="id" name="settings_import_list_account_item"/>
 
 </resources>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -994,6 +994,21 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="settings_export_success_generic">Settings successfully exported</string>
     <string name="settings_export_failure">Failed to export settings</string>
 
+    <string name="settings_import_title">Import settings</string>
+    <string name="settings_import_pick_document_button">Select file</string>
+    <string name="settings_import_button">Import</string>
+    <string name="settings_import_progress_text">Importing settings…</string>
+    <string name="settings_import_success_generic">Settings successfully imported</string>
+    <string name="settings_import_password_required">Please enter passwords</string>
+    <string name="settings_import_failure">Failed to import settings</string>
+    <string name="settings_import_read_failure">Failed to read settings file</string>
+    <string name="settings_import_partial_failure">Failed to import some settings</string>
+    <string name="settings_import_status_success">Imported successfully</string>
+    <string name="settings_import_status_password_required">Password required</string>
+    <string name="settings_import_status_not_imported">Not imported</string>
+    <string name="settings_import_status_error">Import failure</string>
+    <string name="settings_import_later_button">Later</string>
+
     <string name="import_export_action">Settings Import &amp; Export</string>
     <string name="settings_export_account">Export account settings</string>
     <string name="settings_export_all">Export settings and accounts</string>
@@ -1012,7 +1027,6 @@ Please submit bug reports, contribute new features and ask questions at
         <item quantity="one">1 account</item>
         <item quantity="other"><xliff:g id="numAccounts">%s</xliff:g> accounts</item>
     </plurals>
-    <string name="settings_import_failure">Failed to import any settings</string>
     <string name="settings_export_success_header">Export succeeded</string>
     <string name="settings_export_failed_header">Export failed</string>
     <string name="settings_import_success_header">Import succeeded</string>
@@ -1023,6 +1037,16 @@ Please submit bug reports, contribute new features and ask questions at
         <item quantity="one">server password</item>
         <item quantity="other">server passwords</item>
     </plurals>
+
+    <plurals name="settings_import_password_prompt">
+        <item quantity="one">To be able to use the account \"<xliff:g id="account">%s</xliff:g>\" you need to provide the server password.</item>
+        <item quantity="other">To be able to use the account \"<xliff:g id="account">%s</xliff:g>\" you need to provide the server passwords.</item>
+    </plurals>
+    <string name="settings_import_incoming_server_password_hint">Incoming server password</string>
+    <string name="settings_import_outgoing_server_password_hint">Outgoing server password</string>
+    <string name="settings_import_use_same_password_for_outgoing_server">Use same password for outgoing server</string>
+    <string name="server_name_format">Server name: <xliff:g id="hostname">%s</xliff:g></string>
+
     <string name="settings_import_incoming_server">Incoming server (<xliff:g id="hostname">%s</xliff:g>):</string>
     <string name="settings_import_outgoing_server">Outgoing server (<xliff:g id="hostname">%s</xliff:g>):</string>
     <plurals name="settings_import_setting_passwords">

--- a/app/ui/src/main/res/values/themes.xml
+++ b/app/ui/src/main/res/values/themes.xml
@@ -91,6 +91,8 @@
         <item name="iconSettingsAccount">@drawable/ic_account_light</item>
         <item name="iconSettingsAccountAdd">@drawable/ic_account_plus_light</item>
         <item name="iconSettingsExport">@drawable/ic_export_light</item>
+        <item name="iconSettingsImport">@drawable/ic_import_light</item>
+        <item name="iconSettingsImportStatus">@drawable/ic_import_status_light</item>
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_light</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_light</item>
         <item name="messageListSelectedBackgroundColor">#8038B8E2</item>
@@ -211,6 +213,8 @@
         <item name="iconSettingsAccount">@drawable/ic_account_dark</item>
         <item name="iconSettingsAccountAdd">@drawable/ic_account_plus_dark</item>
         <item name="iconSettingsExport">@drawable/ic_export_dark</item>
+        <item name="iconSettingsImport">@drawable/ic_import_dark</item>
+        <item name="iconSettingsImportStatus">@drawable/ic_import_status_dark</item>
         <item name="textColorPrimaryRecipientDropdown">@android:color/primary_text_dark</item>
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_dark</item>
         <item name="messageListSelectedBackgroundColor">#8038B8E2</item>

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ buildscript {
                 'androidxAnnotation': '1.0.1',
                 'androidxNavigation': '2.0.0',
                 'androidxConstraintLayout': '1.1.3',
+                'materialComponents': '1.0.0',
                 'coreKtx': '1.0.1',
                 'preferencesFix': '1.0.0',
                 'okio': '1.14.0',

--- a/images/drawable-src/ic_import.svg
+++ b/images/drawable-src/ic_import.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg6"
+   sodipodi:docname="ic_import.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <metadata
+     id="metadata12">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs10" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1859"
+     inkscape:window-height="1145"
+     id="namedview8"
+     showgrid="false"
+     inkscape:zoom="27.812866"
+     inkscape:cx="13.198736"
+     inkscape:cy="10.262807"
+     inkscape:window-x="61"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6" />
+  <path
+     d="M0 0h24v24H0z"
+     fill="none"
+     id="path4" />
+  <path
+     d="M 11 3 L 11 12 L 8 12 L 12 16 L 16 12 L 13 12 L 13 3 L 11 3 z M 4 19 L 4 21 L 20 21 L 20 19 L 4 19 z "
+     id="path818" />
+</svg>


### PR DESCRIPTION
This adds a new user interface rather than reusing the existing code from `Accounts`.

<img src="https://user-images.githubusercontent.com/218061/67151515-9e507f00-f2c7-11e9-990a-0fbc78db4d45.png" alt="k9mail_import_01_select_file" width=300> <img src="https://user-images.githubusercontent.com/218061/67151514-9e507f00-f2c7-11e9-8632-aba483f5077f.png" alt="k9mail_import_02_import_selection" width=300>

<img src="https://user-images.githubusercontent.com/218061/67151513-9db7e880-f2c7-11e9-986b-6edff9fa2c6c.png" alt="k9mail_import_03_accounts_created" width=300> <img src="https://user-images.githubusercontent.com/218061/67151512-9db7e880-f2c7-11e9-99cc-ca43e1f9e6b6.png" alt="k9mail_import_04_password_input" width=300>

<img src="https://user-images.githubusercontent.com/218061/67151511-9db7e880-f2c7-11e9-8ae8-6f5672f6e9ab.png" alt="k9mail_import_05_import_complete" width=300>

Note: `MessageList` currently doesn't handle situations where the folder list for an account hasn't been retrieved from the server. That's all accounts where the password isn't provided during import. But also when accounts are imported while the device is offline (or the mail server is otherwise unreachable).