### PR TITLE
Startup theme

### DIFF
--- a/app/ui/src/main/res/values-v21/themes.xml
+++ b/app/ui/src/main/res/values-v21/themes.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-    <style name="Theme.K9.Dark.Base" parent="Theme.AppCompat.NoActionBar">
-        <item name="android:navigationBarColor">#000000</item>
-    </style>
-</resources>

--- a/app/ui/src/main/res/values-v28/themes.xml
+++ b/app/ui/src/main/res/values-v28/themes.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.K9.Startup" parent="Theme.K9.DayNight" />
+</resources>

--- a/app/ui/src/main/res/values/themes.xml
+++ b/app/ui/src/main/res/values/themes.xml
@@ -131,6 +131,7 @@
     </style>
 
     <style name="Theme.K9.Dark.Common" parent="Theme.K9.Dark.Base">
+        <item name="android:navigationBarColor">#000000</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
         <item name="colorPrimary">@color/md_grey_900</item>


### PR DESCRIPTION
Optimize startup theme for users not overriding the system theme

This will bring back the "white flash" for users on Android 9+ who use a light theme for the system UI but configured K-9 Mail to use its dark theme. But it gives a much better user experience when using the default theme setting ("Use system default").

