### PR TITLE
Fix launcher shortcuts and home screen widgets

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -347,7 +347,7 @@
         </receiver>
 
         <receiver
-            android:name=".widget.unread.UnreadWidgetProvider"
+            android:name=".provider.UnreadWidgetProvider"
             android:icon="@drawable/ic_launcher"
             android:label="@string/unread_widget_label">
             <intent-filter>

--- a/app/k9mail/src/main/java/com/fsck/k9/provider/UnreadWidgetProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/provider/UnreadWidgetProvider.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.provider
 
 import android.app.PendingIntent
+import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.Context
@@ -75,7 +76,7 @@ class UnreadWidgetProvider : AppWidgetProvider(), EarlyInit {
         }
         clickIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
 
-        val pendingIntent = PendingIntent.getActivity(context, appWidgetId, clickIntent, 0)
+        val pendingIntent = PendingIntent.getActivity(context, appWidgetId, clickIntent, FLAG_UPDATE_CURRENT)
         remoteViews.setOnClickPendingIntent(R.id.unread_widget_layout, pendingIntent)
 
         appWidgetManager.updateAppWidget(appWidgetId, remoteViews)

--- a/app/k9mail/src/main/java/com/fsck/k9/provider/UnreadWidgetProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/provider/UnreadWidgetProvider.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.widget.unread
+package com.fsck.k9.provider
 
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
@@ -10,8 +10,19 @@ import android.widget.RemoteViews
 import com.fsck.k9.EarlyInit
 import com.fsck.k9.R
 import com.fsck.k9.inject
+import com.fsck.k9.widget.unread.UnreadWidgetConfigurationActivity
+import com.fsck.k9.widget.unread.UnreadWidgetData
+import com.fsck.k9.widget.unread.UnreadWidgetRepository
 import timber.log.Timber
 
+/**
+ * Unread home screen widget "provider"
+ *
+ * IMPORTANT: This class must not be renamed or moved, otherwise unread widgets added to the home screen using an older
+ * version of the app will stop working.
+ *
+ * The rest of the unread widget specific code can be found in the package [com.fsck.k9.widget.unread].
+ */
 class UnreadWidgetProvider : AppWidgetProvider(), EarlyInit {
     private val repository: UnreadWidgetRepository by inject()
 

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetUpdater.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetUpdater.kt
@@ -4,6 +4,7 @@ import android.appwidget.AppWidgetManager
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
+import com.fsck.k9.provider.UnreadWidgetProvider
 
 class UnreadWidgetUpdater(private val context: Context) {
     private val appWidgetManager = AppWidgetManager.getInstance(context)

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -495,14 +495,19 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         if (search == null) {
             String accountUuid = intent.getStringExtra("account");
             if (accountUuid != null) {
-                // We've most likely been started by an old unread widget
+                // We've most likely been started by an old unread widget or accounts shortcut
                 String folderServerId = intent.getStringExtra("folder");
+                if (folderServerId == null) {
+                    account = preferences.getAccount(accountUuid);
+                    folderServerId = account.getAutoExpandFolder();
+                    if (folderServerId == null) {
+                        folderServerId = account.getInboxFolder();
+                    }
+                }
 
                 search = new LocalSearch(folderServerId);
                 search.addAccountUuid(accountUuid);
-                if (folderServerId != null) {
-                    search.addAllowedFolder(folderServerId);
-                }
+                search.addAllowedFolder(folderServerId);
             } else {
                 account = preferences.getDefaultAccount();
                 search = new LocalSearch();


### PR DESCRIPTION
A couple of changes so "K-9 Accounts" shortcuts and "K-9 Unread" home screen widgets created with K-9 Mail 5.600 continue to work.

