### PR TITLE
Remove "Start in Unified Inbox" setting

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -233,9 +233,6 @@ object K9 : EarlyInit {
     var isUseVolumeKeysForListNavigation = false
 
     @JvmStatic
-    var isStartInUnifiedInbox = false
-
-    @JvmStatic
     var isHideSpecialAccounts = false
 
     @JvmStatic
@@ -352,7 +349,6 @@ object K9 : EarlyInit {
         isGesturesEnabled = storage.getBoolean("gesturesEnabled", false)
         isUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false)
         isUseVolumeKeysForListNavigation = storage.getBoolean("useVolumeKeysForListNavigation", false)
-        isStartInUnifiedInbox = storage.getBoolean("startIntegratedInbox", false)
         isHideSpecialAccounts = storage.getBoolean("hideSpecialAccounts", false)
         isMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false)
         isShowMessageListStars = storage.getBoolean("messageListStars", true)
@@ -438,7 +434,6 @@ object K9 : EarlyInit {
         editor.putString("quietTimeStarts", quietTimeStarts)
         editor.putString("quietTimeEnds", quietTimeEnds)
 
-        editor.putBoolean("startIntegratedInbox", isStartInUnifiedInbox)
         editor.putBoolean("messageListSenderAboveSubject", isMessageListSenderAboveSubject)
         editor.putBoolean("hideSpecialAccounts", isHideSpecialAccounts)
         editor.putBoolean("messageListStars", isShowMessageListStars)

--- a/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -181,9 +181,6 @@ public class GlobalSettings {
         s.put("sortAscending", Settings.versions(
                 new V(10, new BooleanSetting(Account.DEFAULT_SORT_ASCENDING))
         ));
-        s.put("startIntegratedInbox", Settings.versions(
-                new V(1, new BooleanSetting(false))
-        ));
         s.put("theme", Settings.versions(
                 new V(1, new LegacyThemeSetting(AppTheme.LIGHT)),
                 new V(58, new ThemeSetting(AppTheme.FOLLOW_SYSTEM))

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 59;
+    public static final int VERSION = 60;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -35,7 +35,6 @@ class GeneralSettingsDataStore(
             "threaded_view" -> K9.isThreadedViewEnabled
             "messageview_fixedwidth_font" -> K9.isUseMessageViewFixedWidthFont
             "messageview_autofit_width" -> K9.isAutoFitWidth
-            "start_integrated_inbox" -> K9.isStartInUnifiedInbox
             "gestures" -> K9.isGesturesEnabled
             "messageview_return_to_list" -> K9.isMessageViewReturnToList
             "messageview_show_next" -> K9.isMessageViewShowNext
@@ -66,7 +65,6 @@ class GeneralSettingsDataStore(
             "threaded_view" -> K9.isThreadedViewEnabled = value
             "messageview_fixedwidth_font" -> K9.isUseMessageViewFixedWidthFont = value
             "messageview_autofit_width" -> K9.isAutoFitWidth = value
-            "start_integrated_inbox" -> K9.isStartInUnifiedInbox = value
             "gestures" -> K9.isGesturesEnabled = value
             "messageview_return_to_list" -> K9.isMessageViewReturnToList = value
             "messageview_show_next" -> K9.isMessageViewShowNext = value

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsFragment.kt
@@ -18,7 +18,6 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
         setPreferencesFromResource(R.xml.general_settings, rootKey)
 
         initializeTheme()
-        initializeStartInUnifiedInbox()
     }
 
     override fun onActivityCreated(savedInstanceState: Bundle?) {
@@ -36,21 +35,9 @@ class GeneralSettingsFragment : PreferenceFragmentCompat() {
         }
     }
 
-    private fun initializeStartInUnifiedInbox() {
-        findPreference(PREFERENCE_START_IN_UNIFIED_INBOX)?.apply {
-            if (hideSpecialAccounts()) {
-                isEnabled = false
-            }
-        }
-    }
-
-    private fun hideSpecialAccounts() = dataStore.getBoolean(PREFERENCE_HIDE_SPECIAL_ACCOUNTS, false)
-
 
     companion object {
         private const val PREFERENCE_THEME = "theme"
-        private const val PREFERENCE_START_IN_UNIFIED_INBOX = "start_integrated_inbox"
-        private const val PREFERENCE_HIDE_SPECIAL_ACCOUNTS = "hide_special_accounts"
 
         fun create(rootKey: String? = null) = GeneralSettingsFragment().withArguments(ARG_PREFERENCE_ROOT to rootKey)
     }

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -826,8 +826,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="volume_navigation_message">In message views</string>
     <string name="volume_navigation_list">In list views</string>
 
-    <string name="start_integrated_inbox_title">Start in Unified Inbox</string>
-
     <string name="hide_special_accounts_title">Hide Unified Inbox</string>
 
     <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>

--- a/app/ui/src/main/res/xml/general_settings.xml
+++ b/app/ui/src/main/res/xml/general_settings.xml
@@ -211,10 +211,6 @@
         search:ignore="true">
 
         <CheckBoxPreference
-            android:key="start_integrated_inbox"
-            android:title="@string/start_integrated_inbox_title" />
-
-        <CheckBoxPreference
             android:key="gestures"
             android:summary="@string/gestures_summary"
             android:title="@string/gestures_title" />


### PR DESCRIPTION
The same can be accomplished by using the "K-9 accounts" home screen widget/shortcut.

Closes #4287

