### PR TITLE
update com.takisoft.preferencex:preferencex to 1.1.0

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/PreferenceExtras.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/PreferenceExtras.kt
@@ -10,7 +10,7 @@ inline fun Preference.onClick(crossinline action: () -> Unit) = setOnPreferenceC
     true
 }
 
-fun Preference.remove() = parent?.removePreference(this)
+fun Preference?.remove() = this?.parent?.removePreference(this)
 
 fun ListPreference.removeEntry(entryValue: String) {
     val deleteIndex = entryValues.indexOf(entryValue)

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -8,6 +8,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.widget.Toast
 import androidx.preference.ListPreference
+import androidx.preference.Preference
 import androidx.preference.SwitchPreference
 import com.fsck.k9.Account
 import com.fsck.k9.account.BackgroundAccountRemover
@@ -105,25 +106,25 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun initializeIncomingServer() {
-        findPreference(PREFERENCE_INCOMING_SERVER)?.onClick {
+        findPreference<Preference>(PREFERENCE_INCOMING_SERVER)?.onClick {
             AccountSetupIncoming.actionEditIncomingSettings(requireActivity(), accountUuid)
         }
     }
 
     private fun initializeComposition() {
-        findPreference(PREFERENCE_COMPOSITION)?.onClick {
+        findPreference<Preference>(PREFERENCE_COMPOSITION)?.onClick {
             AccountSetupComposition.actionEditCompositionSettings(requireActivity(), accountUuid)
         }
     }
 
     private fun initializeManageIdentities() {
-        findPreference(PREFERENCE_MANAGE_IDENTITIES)?.onClick {
+        findPreference<Preference>(PREFERENCE_MANAGE_IDENTITIES)?.onClick {
             ManageIdentities.start(requireActivity(), accountUuid)
         }
     }
 
     private fun initializeUploadSentMessages(account: Account) {
-        findPreference(PREFERENCE_UPLOAD_SENT_MESSAGES)?.apply {
+        findPreference<Preference>(PREFERENCE_UPLOAD_SENT_MESSAGES)?.apply {
             if (!messagingController.supportsUpload(account)) {
                 remove()
             }
@@ -131,13 +132,13 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun initializeOutgoingServer() {
-        findPreference(PREFERENCE_OUTGOING_SERVER)?.onClick {
+        findPreference<Preference>(PREFERENCE_OUTGOING_SERVER)?.onClick {
             AccountSetupOutgoing.actionEditOutgoingSettings(requireActivity(), accountUuid)
         }
     }
 
     private fun initializeQuoteStyle() {
-        findPreference(PREFERENCE_QUOTE_STYLE)?.apply {
+        findPreference<Preference>(PREFERENCE_QUOTE_STYLE)?.apply {
             setOnPreferenceChangeListener { _, newValue ->
                 val quoteStyle = Account.QuoteStyle.valueOf(newValue.toString())
                 notifyDependencyChange(quoteStyle == Account.QuoteStyle.HEADER)
@@ -155,7 +156,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun initializeExpungePolicy(account: Account) {
-        findPreference(PREFERENCE_EXPUNGE_POLICY)?.apply {
+        findPreference<Preference>(PREFERENCE_EXPUNGE_POLICY)?.apply {
             if (!messagingController.supportsExpunge(account)) {
                 remove()
             }
@@ -163,7 +164,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun initializeMessageAge(account: Account) {
-        findPreference(PREFERENCE_MESSAGE_AGE)?.apply {
+        findPreference<Preference>(PREFERENCE_MESSAGE_AGE)?.apply {
             if (!messagingController.supportsSearchByDate(account)) {
                 remove()
             }
@@ -181,9 +182,9 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun initializeNotifications() {
-        findPreference(PREFERENCE_OPEN_NOTIFICATION_SETTINGS)?.let {
+        findPreference<Preference>(PREFERENCE_OPEN_NOTIFICATION_SETTINGS)?.let {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                PRE_SDK26_NOTIFICATION_PREFERENCES.forEach { findPreference(it).remove() }
+                PRE_SDK26_NOTIFICATION_PREFERENCES.forEach { findPreference<Preference>(it).remove() }
             } else {
                 it.remove()
             }
@@ -191,7 +192,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun initializeCryptoSettings(account: Account) {
-        findPreference(PREFERENCE_OPENPGP)?.let {
+        findPreference<Preference>(PREFERENCE_OPENPGP)?.let {
             configureCryptoPreferences(account)
         }
     }
@@ -222,7 +223,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun configureEnablePgpSupport(account: Account, isPgpConfigured: Boolean, pgpProviderName: String?) {
-        (findPreference(PREFERENCE_OPENPGP_ENABLE) as SwitchPreference).apply {
+        (findPreference<Preference>(PREFERENCE_OPENPGP_ENABLE) as SwitchPreference).apply {
             if (!isPgpConfigured) {
                 isChecked = false
                 setSummary(R.string.account_settings_crypto_summary_off)
@@ -249,7 +250,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun configurePgpKey(account: Account, pgpProvider: String?) {
-        (findPreference(PREFERENCE_OPENPGP_KEY) as OpenPgpKeyPreference).apply {
+        (findPreference<Preference>(PREFERENCE_OPENPGP_KEY) as OpenPgpKeyPreference).apply {
             value = account.openPgpKey
             setOpenPgpProvider(openPgpApiManager, pgpProvider)
             setIntentSenderFragment(this@AccountSettingsFragment)
@@ -259,20 +260,20 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     private fun configureAutocryptTransfer(account: Account) {
-        findPreference(PREFERENCE_AUTOCRYPT_TRANSFER).onClick {
+        findPreference<Preference>(PREFERENCE_AUTOCRYPT_TRANSFER)!!.onClick {
             val intent = AutocryptKeyTransferActivity.createIntent(requireContext(), account.uuid)
             startActivity(intent)
         }
     }
 
     private fun initializeFolderSettings(account: Account) {
-        findPreference(PREFERENCE_FOLDERS)?.let {
+        findPreference<Preference>(PREFERENCE_FOLDERS)?.let {
             if (!messagingController.isMoveCapable(account)) {
-                findPreference(PREFERENCE_ARCHIVE_FOLDER).remove()
-                findPreference(PREFERENCE_DRAFTS_FOLDER).remove()
-                findPreference(PREFERENCE_SENT_FOLDER).remove()
-                findPreference(PREFERENCE_SPAM_FOLDER).remove()
-                findPreference(PREFERENCE_TRASH_FOLDER).remove()
+                findPreference<Preference>(PREFERENCE_ARCHIVE_FOLDER).remove()
+                findPreference<Preference>(PREFERENCE_DRAFTS_FOLDER).remove()
+                findPreference<Preference>(PREFERENCE_SENT_FOLDER).remove()
+                findPreference<Preference>(PREFERENCE_SPAM_FOLDER).remove()
+                findPreference<Preference>(PREFERENCE_TRASH_FOLDER).remove()
             }
 
             loadFolders(account)

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AutocryptPreferEncryptDialogFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AutocryptPreferEncryptDialogFragment.kt
@@ -11,6 +11,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.widget.CheckBox
 import android.widget.TextView
+import androidx.preference.Preference
 import com.fsck.k9.ui.R
 
 class AutocryptPreferEncryptDialogFragment : DialogFragment() {
@@ -18,7 +19,7 @@ class AutocryptPreferEncryptDialogFragment : DialogFragment() {
         val preferenceKey = arguments?.getString(ARG_KEY) ?: throw IllegalStateException("Argument $ARG_KEY missing")
         val fragment = targetFragment as DialogPreference.TargetFragment
 
-        fragment.findPreference(preferenceKey) as AutocryptPreferEncryptPreference
+        fragment.findPreference<AutocryptPreferEncryptPreference>(preferenceKey)!!
     }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ buildscript {
                 'androidxLocalBroadcastManager': '1.0.0',
                 'materialComponents': '1.0.0',
                 'coreKtx': '1.0.1',
-                'preferencesFix': '1.0.0',
+                'preferencesFix': '1.1.0',
                 'okio': '1.14.0',
                 'timber': '4.5.1',
                 'koin': '2.0.1',


### PR DESCRIPTION
This updates ``com.takisoft.preferencex:preferencex`` to 1.1.0

related changes due to:
>    Refactored findPreference() to return \<T extends Preference> This means that you do not need to explicitly cast Preferences when using findPreference(). For example, EditTextPreference preference = findPreference(“edit_text”) is now valid code."

(https://developer.android.com/jetpack/androidx/releases/preference#1.1.0-alpha02)

and

>    Adds missing nullability annotations to findPreference()

(https://developer.android.com/jetpack/androidx/releases/preference#1.1.0-alpha04)

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


