### PR TITLE
Dark theme tweaks for AMOLED displays

### DIFF
--- a/app/ui/src/main/res/layout/message_list_fragment.xml
+++ b/app/ui/src/main/res/layout/message_list_fragment.xml
@@ -4,7 +4,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/swiperefresh"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="?attr/colorPrimaryDark">
 
     <ListView
         android:id="@+id/message_list"

--- a/app/ui/src/main/res/values/themes.xml
+++ b/app/ui/src/main/res/values/themes.xml
@@ -134,8 +134,9 @@
         <item name="android:navigationBarColor">#000000</item>
         <item name="windowActionModeOverlay">true</item>
         <item name="android:windowLightStatusBar" tools:targetApi="23">false</item>
+        <item name="android:colorBackground">@color/md_black_1000</item>
         <item name="colorPrimary">@color/md_grey_900</item>
-        <item name="colorPrimaryDark">@color/md_grey_900</item>
+        <item name="colorPrimaryDark">@color/md_black_1000</item>
         <item name="bottomBarBackground">@color/md_grey_900</item>
 
         <item name="material_drawer_background">@color/material_drawer_dark_background</item>
@@ -218,7 +219,7 @@
         <item name="textColorSecondaryRecipientDropdown">@android:color/secondary_text_dark</item>
         <item name="messageListSelectedBackgroundColor">#8038B8E2</item>
         <item name="messageListReadItemBackgroundColor">#00000000</item>
-        <item name="messageListUnreadItemBackgroundColor">#c05a5a5a</item>
+        <item name="messageListUnreadItemBackgroundColor">#80444444</item>
         <item name="messageListThreadCountForegroundColor">?android:attr/colorBackground</item>
         <item name="messageListThreadCountBackground">@drawable/thread_count_box_dark</item>
         <item name="messageListActiveItemBackgroundColor">#ff33b5e5</item>


### PR DESCRIPTION
- Background of read messages (or all messages with the background colour option disabled) is now solid black
- Unread message background colour (if enabled) is darker
- System status bar is now solid black
- `android:colorBackground`, which is the fullscreen colour displayed when the app is loading and when loading a message, is now solid black

Overall this brings the appearance of the dark theme closer to what I've seen in other apps. It was a bit inconsistent before having AMOLED black in the message view, but grey in the message list.

Before:
![Screenshot_20191201-131355](https://user-images.githubusercontent.com/283772/69914537-80854680-143d-11ea-9f86-b4e542e029e6.png)
After:
![Screenshot_20191201-131332](https://user-images.githubusercontent.com/283772/69914536-80854680-143d-11ea-856e-d8c6c75d1734.png)

Before:
![Screenshot_20191201-131405](https://user-images.githubusercontent.com/283772/69914539-80854680-143d-11ea-872c-5f6bc0c51265.png)
After:
![Screenshot_20191201-131414](https://user-images.githubusercontent.com/283772/69914540-811ddd00-143d-11ea-964c-3697780c8c06.png)
