### PR TITLE
Remove LocalFolder.purgeToVisibleLimit()

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
@@ -8,7 +8,6 @@ import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import com.fsck.k9.backend.api.BackendFolder
 import com.fsck.k9.backend.api.BackendFolder.MoreMessages
-import com.fsck.k9.backend.api.MessageRemovalListener
 import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.Message
 import java.util.Date
@@ -114,11 +113,6 @@ class K9BackendFolder(
 
     override fun setPushState(pushState: String?) {
         return database.setString(column = "push_state", value = pushState)
-    }
-
-    // TODO: Move implementation from LocalFolder to this class
-    override fun purgeToVisibleLimit(listener: MessageRemovalListener) {
-        localFolder.purgeToVisibleLimit(listener)
     }
 
     override fun isMessagePresent(messageServerId: String): Boolean {

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -445,47 +445,6 @@ public class LocalFolder extends Folder<LocalMessage> {
         return visibleLimit;
     }
 
-    public void purgeToVisibleLimit(final MessageRemovalListener listener) throws MessagingException {
-        // don't purge messages while a Search is active since it might throw away search results
-        if (searchStatusManager.isActive()) {
-            return;
-        }
-
-        if (visibleLimit == 0) {
-            return;
-        }
-
-        open(OPEN_MODE_RW);
-
-        localStore.getDatabase().execute(false, new DbCallback<Void>() {
-            @Override
-            public Void doDbWork(final SQLiteDatabase db) {
-                Cursor cursor = db.rawQuery("SELECT uid " +
-                                "FROM messages " +
-                                "WHERE empty = 0 AND deleted = 0 AND folder_id = ? ORDER BY date DESC " +
-                                " LIMIT -1 OFFSET ?",
-                        new String[] { Long.toString(getDatabaseId()), Integer.toString(visibleLimit) });
-
-                try {
-                    while (cursor.moveToNext()) {
-                        String uid = cursor.getString(0);
-                        LocalMessage localMessage = getMessage(uid);
-
-                        if (listener != null) {
-                            listener.messageRemoved(localMessage);
-                        }
-                        destroyMessage(localMessage);
-                    }
-                } catch (Exception e) {
-                    Timber.d(e, "Got an exception");
-                } finally {
-                    Utility.closeQuietly(cursor);
-                }
-                return null;
-            }
-        });
-    }
-
     public void setVisibleLimit(final int visibleLimit) throws MessagingException {
         updateMoreMessagesOnVisibleLimitChange(visibleLimit, this.visibleLimit);
 

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/BackendFolder.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/BackendFolder.kt
@@ -19,7 +19,6 @@ interface BackendFolder {
     fun setStatus(status: String?)
     fun getPushState(): String?
     fun setPushState(pushState: String?)
-    fun purgeToVisibleLimit(listener: MessageRemovalListener)
     fun isMessagePresent(messageServerId: String): Boolean
     fun getMessageFlags(messageServerId: String): Set<Flag>
     fun setMessageFlag(messageServerId: String, flag: Flag, value: Boolean)

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapSync.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapSync.java
@@ -15,7 +15,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.fsck.k9.backend.api.BackendFolder;
 import com.fsck.k9.backend.api.BackendFolder.MoreMessages;
 import com.fsck.k9.backend.api.BackendStorage;
-import com.fsck.k9.backend.api.MessageRemovalListener;
 import com.fsck.k9.backend.api.SyncConfig;
 import com.fsck.k9.backend.api.SyncConfig.ExpungePolicy;
 import com.fsck.k9.backend.api.SyncListener;
@@ -393,16 +392,6 @@ class ImapSync {
         refreshLocalMessageFlags(syncConfig, remoteFolder, backendFolder, syncFlagMessages, progress, todo, listener);
 
         Timber.d("SYNC: Synced remote messages for folder %s, %d new messages", folder, newMessages.get());
-
-        if (purgeToVisibleLimit) {
-            backendFolder.purgeToVisibleLimit(new MessageRemovalListener() {
-                @Override
-                public void messageRemoved(Message message) {
-                    listener.syncRemovedMessage(folder, message.getUid());
-                }
-
-            });
-        }
 
         return newMessages.get();
     }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapSync.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapSync.java
@@ -207,7 +207,7 @@ class ImapSync {
              * Now we download the actual content of messages.
              */
             int newMessages = downloadMessages(syncConfig, remoteFolder, backendFolder, remoteMessages, false,
-                    true, lastUid, listener);
+                    lastUid, listener);
 
             int unreadMessageCount = backendFolder.getUnreadMessageCount();
             listener.folderStatusChanged(folder, unreadMessageCount);
@@ -270,7 +270,6 @@ class ImapSync {
                     backendFolder,
                     Collections.singletonList(remoteMessage),
                     false,
-                    false,
                     null,
                     new SimpleSyncListener());
         } finally {
@@ -290,15 +289,12 @@ class ImapSync {
      *         A list of messages objects that store the UIDs of which messages to download.
      * @param flagSyncOnly
      *         Only flags will be fetched from the remote store if this is {@code true}.
-     * @param purgeToVisibleLimit
-     *         If true, local messages will be purged down to the limit of visible messages.
-     *
      * @return The number of downloaded messages that are not flagged as {@link Flag#SEEN}.
      *
      * @throws MessagingException
      */
     private int downloadMessages(SyncConfig syncConfig, Folder remoteFolder, BackendFolder backendFolder,
-            List<Message> inputMessages, boolean flagSyncOnly, boolean purgeToVisibleLimit, Long lastUid,
+            List<Message> inputMessages, boolean flagSyncOnly, Long lastUid,
             final SyncListener listener) throws MessagingException {
 
         final Date earliestDate = syncConfig.getEarliestPollDate();

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Sync.java
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Sync.java
@@ -193,7 +193,7 @@ class Pop3Sync {
             /*
              * Now we download the actual content of messages.
              */
-            int newMessages = downloadMessages(syncConfig, remoteFolder, backendFolder, remoteMessages, false, true,
+            int newMessages = downloadMessages(syncConfig, remoteFolder, backendFolder, remoteMessages, false,
                     listener);
 
             int unreadMessageCount = backendFolder.getUnreadMessageCount();
@@ -257,7 +257,7 @@ class Pop3Sync {
 
     private int downloadMessages(final SyncConfig syncConfig, final Folder remoteFolder,
             final BackendFolder backendFolder, List<Message> inputMessages, boolean flagSyncOnly,
-            boolean purgeToVisibleLimit, final SyncListener listener) throws MessagingException {
+            final SyncListener listener) throws MessagingException {
 
         final Date earliestDate = syncConfig.getEarliestPollDate();
         Date downloadStarted = new Date(); // now

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Sync.java
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Sync.java
@@ -15,7 +15,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.fsck.k9.backend.api.BackendFolder;
 import com.fsck.k9.backend.api.BackendFolder.MoreMessages;
 import com.fsck.k9.backend.api.BackendStorage;
-import com.fsck.k9.backend.api.MessageRemovalListener;
 import com.fsck.k9.backend.api.SyncConfig;
 import com.fsck.k9.backend.api.SyncListener;
 import com.fsck.k9.helper.ExceptionHelper;
@@ -342,16 +341,6 @@ class Pop3Sync {
         refreshLocalMessageFlags(syncConfig, remoteFolder, backendFolder, syncFlagMessages, progress, todo, listener);
 
         Timber.d("SYNC: Synced remote messages for folder %s, %d new messages", folder, newMessages.get());
-
-        if (purgeToVisibleLimit) {
-            backendFolder.purgeToVisibleLimit(new MessageRemovalListener() {
-                @Override
-                public void messageRemoved(Message message) {
-                    listener.syncRemovedMessage(folder, message.getUid());
-                }
-
-            });
-        }
 
         // If the oldest message seen on this sync is newer than
         // the oldest message seen on the previous sync, then

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavSync.java
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavSync.java
@@ -15,7 +15,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.fsck.k9.backend.api.BackendFolder;
 import com.fsck.k9.backend.api.BackendFolder.MoreMessages;
 import com.fsck.k9.backend.api.BackendStorage;
-import com.fsck.k9.backend.api.MessageRemovalListener;
 import com.fsck.k9.backend.api.SyncConfig;
 import com.fsck.k9.backend.api.SyncListener;
 import com.fsck.k9.helper.ExceptionHelper;
@@ -342,16 +341,6 @@ class WebDavSync {
         refreshLocalMessageFlags(syncConfig, remoteFolder, backendFolder, syncFlagMessages, progress, todo, listener);
 
         Timber.d("SYNC: Synced remote messages for folder %s, %d new messages", folder, newMessages.get());
-
-        if (purgeToVisibleLimit) {
-            backendFolder.purgeToVisibleLimit(new MessageRemovalListener() {
-                @Override
-                public void messageRemoved(Message message) {
-                    listener.syncRemovedMessage(folder, message.getUid());
-                }
-
-            });
-        }
 
         // If the oldest message seen on this sync is newer than
         // the oldest message seen on the previous sync, then

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavSync.java
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavSync.java
@@ -193,7 +193,7 @@ class WebDavSync {
             /*
              * Now we download the actual content of messages.
              */
-            int newMessages = downloadMessages(syncConfig, remoteFolder, backendFolder, remoteMessages, false, true,
+            int newMessages = downloadMessages(syncConfig, remoteFolder, backendFolder, remoteMessages, false,
                     listener);
 
             int unreadMessageCount = backendFolder.getUnreadMessageCount();
@@ -257,7 +257,7 @@ class WebDavSync {
 
     private int downloadMessages(final SyncConfig syncConfig, final Folder remoteFolder,
             final BackendFolder backendFolder, List<Message> inputMessages, boolean flagSyncOnly,
-            boolean purgeToVisibleLimit, final SyncListener listener) throws MessagingException {
+            final SyncListener listener) throws MessagingException {
 
         final Date earliestDate = syncConfig.getEarliestPollDate();
         Date downloadStarted = new Date(); // now


### PR DESCRIPTION
The method was only called at the end of a mailbox sync. But during sync another mechanism already destroyed messages outside of the sync window.

From the logs provided in #4296 it looks like under certain circumstances `purgeToVisibleLimit()` removed all messages in a folder. I wasn't able to reproduce this. But getting rid of this method should also get rid of the bug.
