### PR TITLE
Add tint to account icon to follow the user choice

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/AccountItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/AccountItem.kt
@@ -13,5 +13,6 @@ internal class AccountItem(val account: Account) : Item() {
     override fun bind(viewHolder: ViewHolder, position: Int) {
         viewHolder.name.text = account.description
         viewHolder.email.text = account.email
+        viewHolder.icon.setColorFilter(account.chipColor)
     }
 }

--- a/app/ui/src/main/res/layout/account_list_item.xml
+++ b/app/ui/src/main/res/layout/account_list_item.xml
@@ -11,6 +11,7 @@
     android:paddingLeft="8dp">
 
     <ImageView
+        android:id="@+id/icon"
         android:layout_width="40dp"
         android:layout_height="40dp"
         android:contentDescription="@string/account_settings_action"


### PR DESCRIPTION
Add tint to account icon to follow the user choice and give better visual feedback
![Screenshot_20191207-014700_Courriel_K-9_Mail](https://user-images.githubusercontent.com/56130419/70366519-35818e00-1898-11ea-946c-3cefc72308e3.png)



