### PR TITLE
Fixed crash when changing theme

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsActivity.kt
@@ -36,8 +36,8 @@ class GeneralSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback, S
                 add(R.id.generalSettingsContainer, GeneralSettingsFragment.create())
             }
         } else {
-            searchQuery = savedInstanceState.getString(KEY_SEARCH_QUERY) ?: error("Missing instance state")
-            searchEnabled = savedInstanceState.getBoolean(KEY_SEARCH_ENABLED)
+            searchQuery = savedInstanceState.getString(KEY_SEARCH_QUERY, "")
+            searchEnabled = savedInstanceState.getBoolean(KEY_SEARCH_ENABLED, false)
         }
     }
 
@@ -47,9 +47,11 @@ class GeneralSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback, S
     }
 
     override fun onSaveInstanceState(outState: Bundle) {
-        outState.putString(KEY_SEARCH_QUERY, searchPreferenceActionView.query.toString())
-        outState.putBoolean(KEY_SEARCH_ENABLED, !searchPreferenceActionView.isIconified)
-        searchPreferenceActionView.onBackPressed()
+        if (::searchPreferenceActionView.isInitialized) {
+            outState.putString(KEY_SEARCH_QUERY, searchPreferenceActionView.query.toString())
+            outState.putBoolean(KEY_SEARCH_ENABLED, !searchPreferenceActionView.isIconified)
+            searchPreferenceActionView.onBackPressed()
+        }
         super.onSaveInstanceState(outState)
     }
 


### PR DESCRIPTION
When recreating the Activity during theme switch, `onSaveInstanceState` is called before `onCreateOptionsMenu`. It's **save**InstanceState, not **restore**InstanceState, so I have no idea why this would be called before `onCreateOptionsMenu`. Maybe the activity is recreated twice quickly? I don't understand what code switches the theme after changing the setting but this PR suppresses the crash.

Closes #4341