### PR TITLE
Default folder

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -29,11 +29,6 @@ import org.jetbrains.annotations.Nullable;
  */
 public class Account implements BaseAccount, StoreConfig {
     /**
-     * Default value for the inbox folder (never changes for POP3 and IMAP)
-     */
-    public static final String INBOX = "INBOX";
-
-    /**
      * This local folder is used to store messages to be sent.
      */
     public static final String OUTBOX = "K9MAIL_INTERNAL_OUTBOX";

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -6,7 +6,6 @@ import com.fsck.k9.Account.DEFAULT_SYNC_INTERVAL
 import com.fsck.k9.Account.DeletePolicy
 import com.fsck.k9.Account.Expunge
 import com.fsck.k9.Account.FolderMode
-import com.fsck.k9.Account.INBOX
 import com.fsck.k9.Account.MessageFormat
 import com.fsck.k9.Account.NO_OPENPGP_KEY
 import com.fsck.k9.Account.QuoteStyle
@@ -52,7 +51,7 @@ class AccountPreferenceSerializer(
             isNotifyContactsMailOnly = storage.getBoolean("$accountUuid.notifyContactsMailOnly", false)
             isNotifySync = storage.getBoolean("$accountUuid.notifyMailCheck", false)
             deletePolicy = DeletePolicy.fromInt(storage.getInt("$accountUuid.deletePolicy", DeletePolicy.NEVER.setting))
-            inboxFolder = storage.getString("$accountUuid.inboxFolderName", INBOX)
+            inboxFolder = storage.getString("$accountUuid.inboxFolderName", null)
 
             val draftsFolder = storage.getString("$accountUuid.draftsFolderName", null)
             val draftsFolderSelection = getEnumStringPref<SpecialFolderSelection>(storage, "$accountUuid.draftsFolderSelection",
@@ -104,7 +103,7 @@ class AccountPreferenceSerializer(
                 setCompression(type, useCompression)
             }
 
-            autoExpandFolder = storage.getString("$accountUuid.autoExpandFolderName", INBOX)
+            autoExpandFolder = storage.getString("$accountUuid.autoExpandFolderName", null)
 
             accountNumber = storage.getInt("$accountUuid.accountNumber", UNASSIGNED_ACCOUNT_NUMBER)
 
@@ -525,8 +524,8 @@ class AccountPreferenceSerializer(
             showPictures = ShowPictures.NEVER
             isSignatureBeforeQuotedText = false
             expungePolicy = Expunge.EXPUNGE_IMMEDIATELY
-            autoExpandFolder = INBOX
-            inboxFolder = INBOX
+            autoExpandFolder = null
+            inboxFolder = null
             maxPushFolders = 10
             isGoToUnreadMessageSearch = false
             isSubscribedFoldersOnly = false

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -105,9 +105,6 @@ public class AccountSettings {
         s.put("idleRefreshMinutes", Settings.versions(
                 new V(1, new IntegerResourceSetting(24, R.array.idle_refresh_period_values))
         ));
-        s.put("inboxFolderName", Settings.versions(
-                new V(1, new StringSetting("INBOX"))
-        ));
         s.put("led", Settings.versions(
                 new V(1, new BooleanSetting(true))
         ));

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 61;
+    public static final int VERSION = 62;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
@@ -20,6 +20,7 @@ import com.fsck.k9.activity.setup.AccountSetupIncoming;
 import com.fsck.k9.activity.setup.AccountSetupOutgoing;
 import com.fsck.k9.search.AccountSearchConditions;
 import com.fsck.k9.search.LocalSearch;
+import com.fsck.k9.ui.messagelist.DefaultFolderProvider;
 
 
 /**
@@ -35,6 +36,7 @@ import com.fsck.k9.search.LocalSearch;
 class K9NotificationActionCreator implements NotificationActionCreator {
     private final Context context;
     private final AccountSearchConditions accountSearchConditions = DI.get(AccountSearchConditions.class);
+    private final DefaultFolderProvider defaultFolderProvider = DI.get(DefaultFolderProvider.class);
 
 
     public K9NotificationActionCreator(Context context) {
@@ -210,10 +212,7 @@ class K9NotificationActionCreator implements NotificationActionCreator {
     }
 
     private Intent createMessageListIntent(Account account) {
-        String folderServerId = account.getAutoExpandFolder();
-        if (folderServerId == null) {
-            folderServerId = account.getInboxFolder();
-        }
+        String folderServerId = defaultFolderProvider.getDefaultFolder(account);
         LocalSearch search = new LocalSearch(folderServerId);
         search.addAllowedFolder(folderServerId);
         search.addAccountUuid(account.getUuid());

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
@@ -4,7 +4,7 @@ import org.koin.dsl.module
 
 val unreadWidgetModule = module {
     single { UnreadWidgetRepository(get(), get()) }
-    single { UnreadWidgetDataProvider(get(), get(), get()) }
+    single { UnreadWidgetDataProvider(get(), get(), get(), get()) }
     single { UnreadWidgetUpdater(get()) }
     single { UnreadWidgetUpdateListener(get()) }
 }

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetDataProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetDataProvider.kt
@@ -9,11 +9,13 @@ import com.fsck.k9.activity.MessageList
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.search.LocalSearch
 import com.fsck.k9.search.SearchAccount
+import com.fsck.k9.ui.messagelist.DefaultFolderProvider
 
 class UnreadWidgetDataProvider(
     private val context: Context,
     private val preferences: Preferences,
-    private val messagingController: MessagingController
+    private val messagingController: MessagingController,
+    private val defaultFolderProvider: DefaultFolderProvider
 ) {
     fun loadUnreadWidgetData(configuration: UnreadWidgetConfiguration): UnreadWidgetData? = with(configuration) {
         if (SearchAccount.UNIFIED_INBOX == accountUuid) {
@@ -49,7 +51,7 @@ class UnreadWidgetDataProvider(
     }
 
     private fun getClickIntentForAccount(account: Account): Intent {
-        val folderServerId = account.autoExpandFolder ?: account.inboxFolder
+        val folderServerId = defaultFolderProvider.getDefaultFolder(account)
         return getClickIntentForFolder(account, folderServerId)
     }
 

--- a/app/k9mail/src/test/java/com/fsck/k9/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/app/k9mail/src/test/java/com/fsck/k9/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -6,6 +6,7 @@ import com.fsck.k9.AppRobolectricTest
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.search.SearchAccount
+import com.fsck.k9.ui.messagelist.DefaultFolderProvider
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doReturn
@@ -19,7 +20,8 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
     val account = createAccount()
     val preferences = createPreferences()
     val messagingController = createMessagingController()
-    val provider = UnreadWidgetDataProvider(context, preferences, messagingController)
+    val defaultFolderStrategy = createDefaultFolderStrategy()
+    val provider = UnreadWidgetDataProvider(context, preferences, messagingController, defaultFolderStrategy)
 
     @Test
     fun unifiedInbox() {
@@ -72,7 +74,6 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
     fun createAccount(): Account = mock {
         on { uuid } doReturn ACCOUNT_UUID
         on { description } doReturn ACCOUNT_DESCRIPTION
-        on { autoExpandFolder } doReturn FOLDER_SERVER_ID
     }
 
     fun createPreferences(): Preferences = mock {
@@ -83,6 +84,10 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
         on { getUnreadMessageCount(any<SearchAccount>()) } doReturn SEARCH_ACCOUNT_UNREAD_COUNT
         on { getUnreadMessageCount(account) } doReturn ACCOUNT_UNREAD_COUNT
         on { getFolderUnreadMessageCount(eq(account), eq(FOLDER_SERVER_ID)) } doReturn FOLDER_UNREAD_COUNT
+    }
+
+    fun createDefaultFolderStrategy(): DefaultFolderProvider = mock {
+        on { getDefaultFolder(account) } doReturn FOLDER_SERVER_ID
     }
 
     companion object {

--- a/app/ui/src/main/java/com/fsck/k9/UiKoinModules.kt
+++ b/app/ui/src/main/java/com/fsck/k9/UiKoinModules.kt
@@ -6,6 +6,7 @@ import com.fsck.k9.autodiscovery.autodiscoveryModule
 import com.fsck.k9.contacts.contactsModule
 import com.fsck.k9.fragment.fragmentModule
 import com.fsck.k9.ui.endtoend.endToEndUiModule
+import com.fsck.k9.ui.messagelist.messageListUiModule
 import com.fsck.k9.ui.settings.settingsUiModule
 import com.fsck.k9.ui.uiModule
 import com.fsck.k9.view.viewModule
@@ -15,6 +16,7 @@ val uiModules = listOf(
         uiModule,
         settingsUiModule,
         endToEndUiModule,
+        messageListUiModule,
         fragmentModule,
         contactsModule,
         accountModule,

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -104,6 +104,8 @@ import com.fsck.k9.ui.R;
 import com.fsck.k9.ui.ThemeManager;
 import com.fsck.k9.ui.compose.QuotedMessageMvpView;
 import com.fsck.k9.ui.compose.QuotedMessagePresenter;
+import com.fsck.k9.ui.messagelist.DefaultFolderProvider;
+
 import org.openintents.openpgp.OpenPgpApiManager;
 import org.openintents.openpgp.util.OpenPgpApi;
 import timber.log.Timber;
@@ -169,6 +171,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private static final Pattern PREFIX = Pattern.compile("^AW[:\\s]\\s*", Pattern.CASE_INSENSITIVE);
 
     private final MessageLoaderHelperFactory messageLoaderHelperFactory = DI.get(MessageLoaderHelperFactory.class);
+    private final DefaultFolderProvider defaultFolderProvider = DI.get(DefaultFolderProvider.class);
 
     private QuotedMessagePresenter quotedMessagePresenter;
     private MessageLoaderHelper messageLoaderHelper;
@@ -783,7 +786,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         internalMessageHandler.sendEmptyMessage(MSG_DISCARDED_DRAFT);
         changesMadeSinceLastSave = false;
         if (navigateUp) {
-            openAutoExpandFolder();
+            openDefaultFolder();
         } else {
             finish();
         }
@@ -1052,7 +1055,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 onDiscard();
             } else {
                 if (navigateUp) {
-                    openAutoExpandFolder();
+                    openDefaultFolder();
                 } else {
                     super.onBackPressed();
                 }
@@ -1060,8 +1063,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
     }
 
-    private void openAutoExpandFolder() {
-        String folder = account.getAutoExpandFolder();
+    private void openDefaultFolder() {
+        String folder = defaultFolderProvider.getDefaultFolder(account);
         LocalSearch search = new LocalSearch(folder);
         search.addAccountUuid(account.getUuid());
         search.addAllowedFolder(folder);

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -56,6 +56,7 @@ import com.fsck.k9.ui.BuildConfig;
 import com.fsck.k9.ui.K9Drawer;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.ui.Theme;
+import com.fsck.k9.ui.messagelist.DefaultFolderProvider;
 import com.fsck.k9.ui.messageview.MessageViewFragment;
 import com.fsck.k9.ui.messageview.MessageViewFragment.MessageViewFragmentListener;
 import com.fsck.k9.ui.onboarding.OnboardingActivity;
@@ -136,10 +137,8 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     }
 
     public static Intent shortcutIntentForAccount(Context context, Account account) {
-        String folderServerId = account.getAutoExpandFolder();
-        if (folderServerId == null) {
-            folderServerId = account.getInboxFolder();
-        }
+        DefaultFolderProvider defaultFolderProvider = DI.get(DefaultFolderProvider.class);
+        String folderServerId = defaultFolderProvider.getDefaultFolder(account);
 
         LocalSearch search = new LocalSearch();
         search.addAccountUuid(account.getUuid());
@@ -174,6 +173,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     private StorageManager.StorageListener mStorageListener = new StorageListenerImplementation();
     private final Preferences preferences = DI.get(Preferences.class);
     private final NotificationChannelManager channelUtils = DI.get(NotificationChannelManager.class);
+    private final DefaultFolderProvider defaultFolderProvider = DI.get(DefaultFolderProvider.class);
 
     private ActionBar actionBar;
     private ActionBarDrawerToggle drawerToggle;
@@ -499,10 +499,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 String folderServerId = intent.getStringExtra("folder");
                 if (folderServerId == null) {
                     account = preferences.getAccount(accountUuid);
-                    folderServerId = account.getAutoExpandFolder();
-                    if (folderServerId == null) {
-                        folderServerId = account.getInboxFolder();
-                    }
+                    folderServerId = defaultFolderProvider.getDefaultFolder(account);
                 }
 
                 search = new LocalSearch(folderServerId);
@@ -512,10 +509,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 account = preferences.getDefaultAccount();
                 search = new LocalSearch();
                 search.addAccountUuid(account.getUuid());
-                String folderServerId = account.getAutoExpandFolder();
-                if (folderServerId == null) {
-                    folderServerId = account.getInboxFolder();
-                }
+                String folderServerId = defaultFolderProvider.getDefaultFolder(account);
                 search.addAllowedFolder(folderServerId);
             }
         }
@@ -651,10 +645,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     }
 
     public void openRealAccount(Account account) {
-        String folderServerId = account.getAutoExpandFolder();
-        if (folderServerId == null) {
-            folderServerId = account.getInboxFolder();
-        }
+        String folderServerId = defaultFolderProvider.getDefaultFolder(account);
 
         LocalSearch search = new LocalSearch();
         search.addAllowedFolder(folderServerId);

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/DefaultFolderProvider.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/DefaultFolderProvider.kt
@@ -1,0 +1,14 @@
+package com.fsck.k9.ui.messagelist
+
+import com.fsck.k9.Account
+
+/**
+ * Decides which folder to display when an account is selected.
+ */
+class DefaultFolderProvider {
+    fun getDefaultFolder(account: Account): String {
+        // Until the UI can handle the case where no remote folders have been fetched yet, we fall back to the Outbox
+        // which should always exist.
+        return account.autoExpandFolder ?: account.inboxFolder ?: account.outboxFolder
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/KoinModule.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/KoinModule.kt
@@ -1,0 +1,7 @@
+package com.fsck.k9.ui.messagelist
+
+import org.koin.dsl.module
+
+val messageListUiModule = module {
+    factory { DefaultFolderProvider() }
+}


### PR DESCRIPTION
`MessageList` is currently crashing if we try to open a folder that does not exist. This change makes it a bit less likely to get into that situation. It's not a complete fix, though.


