### PR TITLE
ignoreMaximumMessageAgeDuringSearch

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,18 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <option name="AUTODETECT_INDENTS" value="false" />
-    <option name="LINE_SEPARATOR" value="&#10;" />
-    <option name="RIGHT_MARGIN" value="120" />
-    <option name="SOFT_MARGINS" value="120" />
-    <JetCodeStyleSettings>
-      <option name="PACKAGES_TO_USE_STAR_IMPORTS">
-        <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
-        </value>
-      </option>
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />
-      <option name="NAME_COUNT_TO_USE_STAR_IMPORT_FOR_MEMBERS" value="2147483647" />
-    </JetCodeStyleSettings>
     <codeStyleSettings language="XML">
       <indentOptions>
         <option name="CONTINUATION_INDENT_SIZE" value="4" />
@@ -124,20 +111,6 @@
           </section>
         </rules>
       </arrangement>
-    </codeStyleSettings>
-    <codeStyleSettings language="kotlin">
-      <option name="KEEP_BLANK_LINES_IN_DECLARATIONS" value="1" />
-      <option name="KEEP_BLANK_LINES_IN_CODE" value="1" />
-      <option name="KEEP_BLANK_LINES_BEFORE_RBRACE" value="0" />
-      <option name="ALIGN_MULTILINE_PARAMETERS" value="false" />
-      <option name="CALL_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="CALL_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_LPAREN_ON_NEXT_LINE" value="true" />
-      <option name="METHOD_PARAMETERS_RPAREN_ON_NEXT_LINE" value="true" />
-      <option name="ASSIGNMENT_WRAP" value="1" />
-      <indentOptions>
-        <option name="CONTINUATION_INDENT_SIZE" value="4" />
-      </indentOptions>
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,5 +1,0 @@
-<component name="ProjectCodeStyleConfiguration">
-  <state>
-    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
-  </state>
-</component>

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -165,6 +165,7 @@ public class Account implements BaseAccount, StoreConfig {
     private Searchable searchableFolders;
     private boolean subscribedFoldersOnly;
     private int maximumPolledMessageAge;
+    private boolean ignoreMaximumPolledMessageAgeDuringSearch;
     private int maximumAutoDownloadMessageSize;
     // Tracks if we have sent a notification for this account for
     // current set of fetched messages
@@ -795,9 +796,16 @@ public class Account implements BaseAccount, StoreConfig {
     public synchronized int getMaximumPolledMessageAge() {
         return maximumPolledMessageAge;
     }
+    public synchronized boolean getIgnoreMaximumPolledMessageAgeDuringSearch()
+    {
+        return ignoreMaximumPolledMessageAgeDuringSearch;
+    }
 
     public synchronized void setMaximumPolledMessageAge(int maximumPolledMessageAge) {
         this.maximumPolledMessageAge = maximumPolledMessageAge;
+    }
+    public synchronized void setIgnoreMaximumPolledMessageAgeDuringSearch(boolean ignoreMaximumPolledMessageAgeDuringSearch) {
+        this.ignoreMaximumPolledMessageAgeDuringSearch = ignoreMaximumPolledMessageAgeDuringSearch;
     }
 
     public synchronized int getMaximumAutoDownloadMessageSize() {
@@ -807,7 +815,14 @@ public class Account implements BaseAccount, StoreConfig {
     public synchronized void setMaximumAutoDownloadMessageSize(int maximumAutoDownloadMessageSize) {
         this.maximumAutoDownloadMessageSize = maximumAutoDownloadMessageSize;
     }
-
+    public Date getEarliestSearchPollDate()
+    {
+        boolean ignore_maximum_message_age_during_search = getIgnoreMaximumPolledMessageAgeDuringSearch();
+        if (ignore_maximum_message_age_during_search)
+            return null;
+        else
+            return getEarliestPollDate();
+    }
     public Date getEarliestPollDate() {
         int age = getMaximumPolledMessageAge();
         if (age >= 0) {

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -86,6 +86,7 @@ class AccountPreferenceSerializer(
             isGoToUnreadMessageSearch = storage.getBoolean("$accountUuid.goToUnreadMessageSearch", false)
             isSubscribedFoldersOnly = storage.getBoolean("$accountUuid.subscribedFoldersOnly", false)
             maximumPolledMessageAge = storage.getInt("$accountUuid.maximumPolledMessageAge", -1)
+            ignoreMaximumPolledMessageAgeDuringSearch= storage.getBoolean("$accountUuid.ignoreMaximumPolledMessageAgeDuringSearch", true)
             maximumAutoDownloadMessageSize = storage.getInt("$accountUuid.maximumAutoDownloadMessageSize", 32768)
             messageFormat = getEnumStringPref<MessageFormat>(storage, "$accountUuid.messageFormat", DEFAULT_MESSAGE_FORMAT)
             val messageFormatAuto = storage.getBoolean("$accountUuid.messageFormatAuto", DEFAULT_MESSAGE_FORMAT_AUTO)
@@ -531,6 +532,7 @@ class AccountPreferenceSerializer(
             isGoToUnreadMessageSearch = false
             isSubscribedFoldersOnly = false
             maximumPolledMessageAge = -1
+            ignoreMaximumPolledMessageAgeDuringSearch=true;
             maximumAutoDownloadMessageSize = 32768
             messageFormat = DEFAULT_MESSAGE_FORMAT
             isMessageFormatAuto = DEFAULT_MESSAGE_FORMAT_AUTO

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -86,7 +86,7 @@ class AccountPreferenceSerializer(
             isGoToUnreadMessageSearch = storage.getBoolean("$accountUuid.goToUnreadMessageSearch", false)
             isSubscribedFoldersOnly = storage.getBoolean("$accountUuid.subscribedFoldersOnly", false)
             maximumPolledMessageAge = storage.getInt("$accountUuid.maximumPolledMessageAge", -1)
-            ignoreMaximumPolledMessageAgeDuringSearch= storage.getBoolean("$accountUuid.ignoreMaximumPolledMessageAgeDuringSearch", true)
+            ignoreMaximumPolledMessageAgeDuringSearch = storage.getBoolean("$accountUuid.ignoreMaximumPolledMessageAgeDuringSearch", true)
             maximumAutoDownloadMessageSize = storage.getInt("$accountUuid.maximumAutoDownloadMessageSize", 32768)
             messageFormat = getEnumStringPref<MessageFormat>(storage, "$accountUuid.messageFormat", DEFAULT_MESSAGE_FORMAT)
             val messageFormatAuto = storage.getBoolean("$accountUuid.messageFormatAuto", DEFAULT_MESSAGE_FORMAT_AUTO)
@@ -532,7 +532,7 @@ class AccountPreferenceSerializer(
             isGoToUnreadMessageSearch = false
             isSubscribedFoldersOnly = false
             maximumPolledMessageAge = -1
-            ignoreMaximumPolledMessageAgeDuringSearch=true;
+            ignoreMaximumPolledMessageAgeDuringSearch = true
             maximumAutoDownloadMessageSize = 32768
             messageFormat = DEFAULT_MESSAGE_FORMAT
             isMessageFormatAuto = DEFAULT_MESSAGE_FORMAT_AUTO

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -737,7 +737,15 @@ public class MessagingController {
                     K9.DEFAULT_VISIBLE_LIMIT,
                     SYNC_FLAGS);
     }
-
+    private SyncConfig createSearchSyncConfig(Account account) {
+        return new SyncConfig(
+                account.getExpungePolicy().toBackendExpungePolicy(),
+                account.getEarliestSearchPollDate(),
+                account.isSyncRemoteDeletions(),
+                account.getMaximumAutoDownloadMessageSize(),
+                K9.DEFAULT_VISIBLE_LIMIT,
+                SYNC_FLAGS);
+    }
     private void updateFolderStatus(Account account, String folderServerId, String status) {
         try {
             LocalStore localStore = localStoreProvider.getInstance(account);
@@ -1319,8 +1327,8 @@ public class MessagingController {
                 Backend backend = getBackend(account);
 
                 if (loadPartialFromSearch) {
-                    SyncConfig syncConfig = createSyncConfig(account);
-                    backend.downloadMessage(syncConfig, folder, uid);
+                    SyncConfig searchsyncConfig = createSearchSyncConfig(account);
+                    backend.downloadMessage(searchsyncConfig, folder, uid);
                 } else {
                     FetchProfile fp = new FetchProfile();
                     fp.add(FetchProfile.Item.BODY);

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettings.java
@@ -129,6 +129,9 @@ public class AccountSettings {
         s.put("maximumPolledMessageAge", Settings.versions(
                 new V(1, new IntegerResourceSetting(-1, R.array.message_age_values))
         ));
+        s.put("ignoreMaximumPolledMessageAgeDuringSearch", Settings.versions(
+                new V(62, new BooleanSetting(true))
+        ));
         s.put("messageFormat", Settings.versions(
                 new V(1, new EnumSetting<>(MessageFormat.class, AccountPreferenceSerializer.DEFAULT_MESSAGE_FORMAT))
         ));
@@ -326,6 +329,36 @@ public class AccountSettings {
         public Integer fromString(String value) throws InvalidSettingValueException {
             try {
                 return Integer.parseInt(value);
+            } catch (NumberFormatException e) {
+                throw new InvalidSettingValueException();
+            }
+        }
+    }
+    private static class BooleanResourceSetting extends PseudoEnumSetting<Boolean> {
+        private final Context context = DI.get(Context.class);
+        private final Map<Boolean, String> mapping;
+
+        BooleanResourceSetting(boolean defaultValue, int resId) {
+            super(defaultValue);
+
+            Map<Boolean, String> mapping = new HashMap<>();
+            String[] values = context.getResources().getStringArray(resId);
+            for (String value : values) {
+                boolean boolValue = Boolean.parseBoolean(value);
+                mapping.put(boolValue, value);
+            }
+            this.mapping = Collections.unmodifiableMap(mapping);
+        }
+
+        @Override
+        protected Map<Boolean, String> getMapping() {
+            return mapping;
+        }
+
+        @Override
+        public Boolean fromString(String value) throws InvalidSettingValueException {
+            try {
+                return Boolean.parseBoolean(value);
             } catch (NumberFormatException e) {
                 throw new InvalidSettingValueException();
             }

--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -41,7 +41,7 @@ android {
         testApplicationId "com.fsck.k9.tests"
 
         versionCode 27001
-        versionName '5.702-SNAPSHOT'
+        versionName '5.703'
 
         minSdkVersion buildConfig.minSdk
         targetSdkVersion buildConfig.targetSdk

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -36,6 +36,7 @@ class AccountSettingsDataStore(
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject
             "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts
             "remote_search_enabled" -> account.isAllowRemoteSearch
+            "account_ignore_message_age_during_search" -> account.ignoreMaximumPolledMessageAgeDuringSearch
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual
             "upload_sent_messages" -> account.isUploadSentMessages
             else -> defValue
@@ -66,6 +67,7 @@ class AccountSettingsDataStore(
             "account_notify_sync" -> account.isNotifySync = value
             "notification_opens_unread" -> account.isGoToUnreadMessageSearch = value
             "remote_search_enabled" -> account.isAllowRemoteSearch = value
+            "account_ignore_message_age_during_search" -> account.ignoreMaximumPolledMessageAgeDuringSearch = value
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly = value
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject = value
             "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts = value
@@ -156,6 +158,7 @@ class AccountSettingsDataStore(
             "show_pictures_enum" -> account.showPictures = Account.ShowPictures.valueOf(value)
             "account_display_count" -> account.displayCount = value.toInt()
             "account_message_age" -> account.maximumPolledMessageAge = value.toInt()
+            "account_ignore_message_age_during_search" -> account.ignoreMaximumPolledMessageAgeDuringSearch = value.toBoolean()
             "account_autodownload_size" -> account.maximumAutoDownloadMessageSize = value.toInt()
             "account_check_frequency" -> {
                 if (account.setAutomaticCheckIntervalMinutes(value.toInt())) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -70,6 +70,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         initializeDeletePolicy(account)
         initializeExpungePolicy(account)
         initializeMessageAge(account)
+        initializeIgnoreMessageAgeDuringSearch(account)
         initializeAdvancedPushSettings(account)
         initializeCryptoSettings(account)
         initializeFolderSettings(account)
@@ -169,7 +170,13 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
             }
         }
     }
-
+    private fun initializeIgnoreMessageAgeDuringSearch(account: Account) {
+        findPreference<Preference>(PREFERENCE_IGNORE_MESSAGE_AGE_DURING_SEARCH)?.apply {
+            if (!messagingController.supportsSearchByDate(account)) {
+                remove()
+            }
+        }
+    }
     private fun initializeAdvancedPushSettings(account: Account) {
         /* Temporarily disabled. See GH-4253
         if (!messagingController.isPushCapable(account)) {
@@ -364,6 +371,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         private const val PREFERENCE_DELETE_POLICY = "delete_policy"
         private const val PREFERENCE_EXPUNGE_POLICY = "expunge_policy"
         private const val PREFERENCE_MESSAGE_AGE = "account_message_age"
+        private const val PREFERENCE_IGNORE_MESSAGE_AGE_DURING_SEARCH = "account_ignore_message_age_during_search"
         private const val PREFERENCE_PUSH_MODE = "folder_push_mode"
         private const val PREFERENCE_ADVANCED_PUSH_SETTINGS = "push_advanced"
         private const val PREFERENCE_REMOTE_SEARCH = "search"

--- a/app/ui/src/main/res/layout/empty_message_view.xml
+++ b/app/ui/src/main/res/layout/empty_message_view.xml
@@ -7,7 +7,6 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_centerHorizontal="true"
-        android:layout_centerVertical="true"
         android:text="@string/message_view_empty"
         android:textColor="?android:attr/textColorSecondary" />
 

--- a/app/ui/src/main/res/values-de/strings.xml
+++ b/app/ui/src/main/res/values-de/strings.xml
@@ -848,6 +848,9 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="account_settings_remote_search_enabled_summary">Nachrichten nicht nur auf dem Gerät, sondern auch auf dem Server suchen</string>
   <string name="action_remote_search">Nachrichten auf Server suchen</string>
   <string name="remote_search_unavailable_no_network">Serverseitige Suche kann ohne Netzverbindung nicht durchgeführt werden.</string>
+  <string name="account_settings_ignore_message_age_during_search">Ignoriere maximales Nachrichtenalter</string>
+  <string name="account_settings_ignore_message_age_during_search_summary">Das in den Einstellungen zur Synchronisation gesetzte maximale Alter der abzurufenden Nachrichten wird bei der server-seitigen Suche ignoriert.</string>
+
   <string name="global_settings_background_as_unread_indicator_label">Farbe ändern, wenn gelesen</string>
   <string name="global_settings_background_as_unread_indicator_summary">Ein anderer Hintergrund zeigt, dass die Nachricht gelesen wurde</string>
   <string name="global_settings_threaded_view_label">Nachrichten gruppieren</string>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -1030,6 +1030,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_remote_search_enabled_summary">Search messages on the server in addition to those on your device</string>
     <string name="action_remote_search">Search messages on server</string>
     <string name="remote_search_unavailable_no_network">A network connection is required for server search.</string>
+    <string name="account_settings_ignore_message_age_during_search">Ignore maximum message age</string>
+    <string name="account_settings_ignore_message_age_during_search_summary">The maximum message age that is specified in the account settings is ignored during server-side search.</string>
 
     <string name="global_settings_background_as_unread_indicator_label">Change colour when read</string>
     <string name="global_settings_background_as_unread_indicator_summary">A different background will show that the message has been read</string>

--- a/app/ui/src/main/res/xml/account_settings.xml
+++ b/app/ui/src/main/res/xml/account_settings.xml
@@ -416,6 +416,11 @@
             android:key="account_remote_search_num_results"
             android:summary="%s"
             android:title="@string/account_settings_remote_search_num_label" />
+        <CheckBoxPreference
+            android:dependency="remote_search_enabled"
+            android:key="account_ignore_message_age_during_search"
+            android:summary="@string/account_settings_ignore_message_age_during_search_summary"
+            android:title="@string/account_settings_ignore_message_age_during_search" />
 
     </PreferenceScreen>
 

--- a/build.gradle
+++ b/build.gradle
@@ -49,7 +49,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.2'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:${versions.kotlin}"
         classpath "org.jetbrains.kotlin:kotlin-android-extensions:${versions.kotlin}"
         classpath "org.jlleitschuh.gradle:ktlint-gradle:9.1.1"


### PR DESCRIPTION
Addresses "Empty message body when opening mail from server search results Issue #3111" and adds a setting in search preferences dialog to allow to ignore the maximum message age setting during a server-side search when trying to download message bodies of messages that are normally too old to be synced. 


