### PR TITLE
Fix crash when changing focus using hardware keyboard

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -204,6 +204,7 @@ public class AccountSetupBasics extends K9Activity
                 && mEmailValidator.isValidAddressOnly(email);
 
         mNextButton.setEnabled(valid);
+        mNextButton.setFocusable(valid);
         mManualSetupButton.setEnabled(valid);
         /*
          * Dim the next button's icon to 50% if the button is disabled.


### PR DESCRIPTION
This fixes a crash discovered by Google Play's pre-launch report.

To reproduce the crash:
- set up an emulator with a hardware keyboard
- focus the password field
- press the return key while the "Next" button is disabled
