### PR TITLE
Remove launchMode attribute from 'MessageList'

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -192,11 +192,7 @@
             android:targetActivity=".activity.MessageList"
             android:exported="true" />
 
-        <activity
-            android:name=".activity.MessageList"
-            android:configChanges="locale"
-            android:launchMode="singleTop"
-            android:uiOptions="splitActionBarWhenNarrow">
+        <activity android:name=".activity.MessageList">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>
 

--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -117,6 +117,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         intent.putExtra(EXTRA_SEARCH, ParcelableUtil.marshall(search));
         intent.putExtra(EXTRA_NO_THREADING, noThreading);
 
+        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         if (clearTop) {
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         }
@@ -131,6 +132,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         Intent intent = new Intent(context, MessageList.class);
         intent.setAction(ACTION_SHORTCUT);
         intent.putExtra(EXTRA_SPECIAL_FOLDER, specialFolder);
+        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
 
@@ -150,6 +152,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     public static Intent actionDisplayMessageIntent(Context context,
             MessageReference messageReference) {
         Intent intent = new Intent(context, MessageList.class);
+        intent.addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.putExtra(EXTRA_MESSAGE_REFERENCE, messageReference.toIdentityString());
         return intent;


### PR DESCRIPTION
Without this change backgrounding the app and then going back to it will call `onNewIntent()`, which in turn will open the default folder.

Fixes #4379

