### PR TITLE
Fixes drawer when folders are updates

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -236,6 +236,10 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
             return
         }
 
+        if (accountHeader.isSelectionListShown) {
+            accountHeader.toggleSelectionList(parent);
+        }
+
         var openedFolderDrawerId: Long = -1
         for (i in folders.indices.reversed()) {
             val displayFolder = folders[i]


### PR DESCRIPTION
Basically fixes #4333 by closing the account selection when folders are updated
