### PR TITLE
add background color to adaptive icons

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -48,7 +48,6 @@
         android:allowTaskReparenting="false"
         android:usesCleartextTraffic="true"
         android:icon="@drawable/ic_launcher"
-        android:roundIcon="@drawable/ic_launcher_round"
         android:label="@string/app_name"
         android:theme="@style/Theme.K9.Startup"
         android:resizeableActivity="true"

--- a/app/ui/src/debug/res/values/colors.xml
+++ b/app/ui/src/debug/res/values/colors.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <drawable name="ic_launcher">@mipmap/ic_launcher</drawable>
+    <color name="icon_background">#E4D9FF</color>
 </resources>

--- a/app/ui/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
+++ b/app/ui/src/main/res/mipmap-anydpi-v26/ic_launcher.xml
@@ -2,6 +2,6 @@
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/icon_background"/>
     <foreground>
-        <inset android:drawable="@mipmap/icon" android:inset="20%"/>
+        <inset android:drawable="@mipmap/icon" android:inset="23%"/>
     </foreground>
 </adaptive-icon>

--- a/app/ui/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
+++ b/app/ui/src/main/res/mipmap-anydpi-v26/ic_launcher_round.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/icon_background"/>
-    <foreground>
-        <inset android:drawable="@mipmap/icon" android:inset="24%"/>
-    </foreground>
-</adaptive-icon>

--- a/app/ui/src/main/res/values/colors.xml
+++ b/app/ui/src/main/res/values/colors.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <color name="icon_background">#ffffff</color>
+    <color name="icon_background">#FFDAE1</color>
 
     <color name="light_black">#444444</color>
 

--- a/app/ui/src/main/res/values/drawables.xml
+++ b/app/ui/src/main/res/values/drawables.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <drawable name="ic_launcher">@mipmap/icon</drawable>
-    <drawable name="ic_launcher_round">@mipmap/icon</drawable>
 </resources>


### PR DESCRIPTION
This adds a desaturated version of K9-Mails envelope color as the
adaptive icon background color.

This should look a lot better than a plain white background.

Also slightly enlarge the icon shape.

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


![image](https://user-images.githubusercontent.com/105185/71528675-3af35680-28e1-11ea-9d72-1fbc011ad6f9.png)
