### PR TITLE
fix NPE when replying to un-decrypted message

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/AttachmentResolver.java
@@ -58,7 +58,9 @@ public class AttachmentResolver {
 
         while (!partsToCheck.isEmpty()) {
             Part part = partsToCheck.pop();
-
+            if (part == null) {
+                continue;
+            }
             Body body = part.getBody();
             if (body instanceof Multipart) {
                 Multipart multipart = (Multipart) body;

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
@@ -965,6 +965,9 @@ public class MimeUtility {
 
 
     public static Part findFirstPartByMimeType(Part part, String mimeType) {
+        if (part == null) {
+            return null;
+        }
         if (part.getBody() instanceof Multipart) {
             Multipart multipart = (Multipart)part.getBody();
             for (BodyPart bodyPart : multipart.getBodyParts()) {


### PR DESCRIPTION
Fixes #3266.

This makes it possible to reply to encrypted emails, when you don't have openKeyChain installed, or probably if you didn't bother to decrypt a message/decryption failed.

One thing that's still happening is that the subject of the reply is empty. It should populate the normal reply subject which is either available in unencrypted form or it should reply to the placeholder subject. (This is how thunderbird behaves as well.)

But hey, at least we don't crash anymore. :-)