### PR TITLE
Properly configure special folders during (initial) folder sync

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
@@ -8,7 +8,6 @@ import com.fsck.k9.mail.Folder.FolderType as RemoteFolderType
 
 class FolderRepository(
     private val localStoreProvider: LocalStoreProvider,
-    private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
     private val account: Account
 ) {
     private val sortForDisplay =
@@ -18,20 +17,7 @@ class FolderRepository(
             .thenByDescending { it.isInTopGroup }
             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.folder.name }
 
-    fun getRemoteFolderInfo(): RemoteFolderInfo {
-        val folders = getRemoteFolders()
-        val automaticSpecialFolders = mapOf(
-                FolderType.ARCHIVE to specialFolderSelectionStrategy.selectSpecialFolder(folders, FolderType.ARCHIVE),
-                FolderType.DRAFTS to specialFolderSelectionStrategy.selectSpecialFolder(folders, FolderType.DRAFTS),
-                FolderType.SENT to specialFolderSelectionStrategy.selectSpecialFolder(folders, FolderType.SENT),
-                FolderType.SPAM to specialFolderSelectionStrategy.selectSpecialFolder(folders, FolderType.SPAM),
-                FolderType.TRASH to specialFolderSelectionStrategy.selectSpecialFolder(folders, FolderType.TRASH)
-        )
-
-        return RemoteFolderInfo(folders, automaticSpecialFolders)
-    }
-
-    private fun getRemoteFolders(): List<Folder> {
+    fun getRemoteFolders(): List<Folder> {
         val folders = localStoreProvider.getInstance(account).getPersonalNamespaces(false)
 
         return folders
@@ -136,8 +122,6 @@ data class DisplayFolder(
     val isInTopGroup: Boolean,
     val unreadCount: Int
 )
-
-data class RemoteFolderInfo(val folders: List<Folder>, val automaticSpecialFolders: Map<FolderType, Folder?>)
 
 enum class FolderType {
     REGULAR,

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
@@ -113,6 +113,30 @@ class FolderRepository(
         RemoteFolderType.SPAM -> FolderType.SPAM
         RemoteFolderType.ARCHIVE -> FolderType.ARCHIVE
     }
+
+    fun setIncludeInUnifiedInbox(serverId: String, includeInUnifiedInbox: Boolean) {
+        val localStore = localStoreProvider.getInstance(account)
+        val folder = localStore.getFolder(serverId)
+        folder.isIntegrate = includeInUnifiedInbox
+    }
+
+    fun setDisplayClass(serverId: String, folderClass: FolderClass) {
+        val localStore = localStoreProvider.getInstance(account)
+        val folder = localStore.getFolder(serverId)
+        folder.displayClass = folderClass
+    }
+
+    fun setSyncClass(serverId: String, folderClass: FolderClass) {
+        val localStore = localStoreProvider.getInstance(account)
+        val folder = localStore.getFolder(serverId)
+        folder.syncClass = folderClass
+    }
+
+    fun setNotificationClass(serverId: String, folderClass: FolderClass) {
+        val localStore = localStoreProvider.getInstance(account)
+        val folder = localStore.getFolder(serverId)
+        folder.notifyClass = folderClass
+    }
 }
 
 data class Folder(val id: Long, val serverId: String, val name: String, val type: FolderType)

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepositoryManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepositoryManager.kt
@@ -6,5 +6,5 @@ class FolderRepositoryManager(
     private val localStoreProvider: LocalStoreProvider,
     private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy
 ) {
-    fun getFolderRepository(account: Account) = FolderRepository(localStoreProvider, specialFolderSelectionStrategy, account)
+    fun getFolderRepository(account: Account) = FolderRepository(localStoreProvider, account)
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
@@ -6,12 +6,18 @@ import com.fsck.k9.Preferences
 class K9BackendStorageFactory(
     private val preferences: Preferences,
     private val folderRepositoryManager: FolderRepositoryManager,
-    private val localStoreProvider: LocalStoreProvider
+    private val localStoreProvider: LocalStoreProvider,
+    private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy
 ) {
     fun createBackendStorage(account: Account): K9BackendStorage {
         val folderRepository = folderRepositoryManager.getFolderRepository(account)
         val localStore = localStoreProvider.getInstance(account)
-        val specialFolderUpdater = SpecialFolderUpdater(preferences, folderRepository, account)
+        val specialFolderUpdater = SpecialFolderUpdater(
+            preferences,
+            folderRepository,
+            specialFolderSelectionStrategy,
+            account
+        )
         val specialFolderListener = SpecialFolderBackendStorageListener(specialFolderUpdater)
         val autoExpandFolderListener = AutoExpandFolderBackendStorageListener(preferences, account)
         val listeners = listOf(specialFolderListener, autoExpandFolderListener)

--- a/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -8,5 +8,5 @@ val mailStoreModule = module {
     single { StorageManager.getInstance(get()) }
     single { SearchStatusManager() }
     single { SpecialFolderSelectionStrategy() }
-    single { K9BackendStorageFactory(get(), get(), get()) }
+    single { K9BackendStorageFactory(get(), get(), get(), get()) }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -914,29 +914,6 @@ public class LocalStore {
                     }
 
                     final  LocalFolder.PreferencesHolder prefHolder = folder.new PreferencesHolder();
-
-                    // When created, special folders should always be displayed
-                    // inbox should be integrated
-                    // and the inbox and drafts folders should be syncced by default
-                    if (account.isSpecialFolder(serverId)) {
-                        prefHolder.inTopGroup = true;
-                        prefHolder.displayClass = LocalFolder.FolderClass.FIRST_CLASS;
-                        if (serverId.equals(account.getInboxFolder())) {
-                            prefHolder.integrate = true;
-                            prefHolder.notifyClass = LocalFolder.FolderClass.FIRST_CLASS;
-                            prefHolder.pushClass = LocalFolder.FolderClass.FIRST_CLASS;
-                        } else {
-                            prefHolder.pushClass = LocalFolder.FolderClass.INHERITED;
-
-                        }
-                        if (serverId.equals(account.getInboxFolder()) || serverId.equals(account.getDraftsFolder())) {
-                            prefHolder.syncClass = LocalFolder.FolderClass.FIRST_CLASS;
-                        } else {
-                            prefHolder.syncClass = LocalFolder.FolderClass.NO_CLASS;
-                        }
-                    }
-                    folder.refresh(serverId, prefHolder);   // Recover settings from Preferences
-
                     db.execSQL("INSERT INTO folders (name, visible_limit, top_group, display_class, poll_class, notify_class, push_class, integrate, server_id, local_only, type) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", new Object[] {
                                    name,
                                    visibleLimit,

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
@@ -23,7 +23,7 @@ val settingsUiModule = module {
         Executors.newSingleThreadExecutor(NamedThreadFactory("SaveSettings"))
     }
 
-    viewModel { AccountSettingsViewModel(get(), get()) }
+    viewModel { AccountSettingsViewModel(get(), get(), get()) }
     single { AccountSettingsDataStoreFactory(get(), get(), get(named("SaveSettingsExecutorService"))) }
 
     viewModel { SettingsExportViewModel(get(), get()) }

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -22,7 +22,6 @@ import com.fsck.k9.fragment.ConfirmationDialogFragment
 import com.fsck.k9.fragment.ConfirmationDialogFragment.ConfirmationDialogFragmentListener
 import com.fsck.k9.mailstore.Folder
 import com.fsck.k9.mailstore.FolderType
-import com.fsck.k9.mailstore.RemoteFolderInfo
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.endtoend.AutocryptKeyTransferActivity
 import com.fsck.k9.ui.observe


### PR DESCRIPTION
The code in `LocalStore` to configure special folders was no longer working. The functionality has now been fixed and moved to `SpecialFolderUpdater`.

Resolves #4408