### PR TITLE
Switch MessageListAdapter away from CursorAdapter

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -23,5 +23,8 @@ data class MessageListItem(
     val hasAttachments: Boolean,
     val uniqueId: Long,
     val folderServerId: String,
-    val messageUid: String
+    val messageUid: String,
+    val databaseId: Long,
+    val senderAddress: String?,
+    val threadRoot: Long
 )


### PR DESCRIPTION
Now `MessageListAdapter` doesn't know anything about `Cursor` at all. Also, aside from `CursorLoader`-related code, `MessageListFragment` is now `Cursor`-free.

Next step: Remove `CursorLoader` and do both loading and conversion to `MessageListItem` in a background thread.