### PR TITLE
Fix deleting a message when there's no Trash folder

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2255,7 +2255,8 @@ public class MessagingController {
                 processPendingCommands(account);
             } else if (!syncedMessageUids.isEmpty()) {
                 if (account.getDeletePolicy() == DeletePolicy.ON_DELETE) {
-                    if (folder.equals(account.getTrashFolder()) || !backend.isDeleteMoveToTrash()) {
+                    if (!account.hasTrashFolder() || folder.equals(account.getTrashFolder()) ||
+                            !backend.isDeleteMoveToTrash()) {
                         queueDelete(account, folder, syncedMessageUids);
                     } else if (account.isMarkMessageAsReadOnDelete()) {
                         queueMoveOrCopy(account, folder, account.getTrashFolder(),


### PR DESCRIPTION
Previously the app was trying to move the deleted message to a non-existing Trash folder on the server (`account.getTrashFolder()` was returning `null`).

https://github.com/k9mail/k-9/blob/2791ef99200a40524e0c15905b05cf1e0cfa1464/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java#L2201-L2202

Fixes #4436


