### PR TITLE
add instructions for testing to documentation

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -34,3 +34,17 @@ classes. Each class is colour-coded by its top-level project.
 ## Sending email
 
 ![send email sequence](SendEmail.png)
+
+# Running Unit Tests
+
+## System Requirements
+
+ * [Oracle Java SE SDK 1.8](https://www.oracle.com/technetwork/java/javase/downloads/jdk8-downloads-2133151.html)
+
+## Instructions
+
+Run at project folder path:
+
+```
+./gradlew assembleDebug testDebugUnitTest ktlintCheck
+```


### PR DESCRIPTION
Before I push to a public repository I run tests. In particular I like to run the automatic tests which will be run be the continuous integration. For k-9 I check the most recent run by the CI and try to run the test locally before pushing my commits. 

I had problems as I did not use the correct Java SDK. I tried JDK 11 and JDK 13 before I was successful with JDK 8. I could have saved some time if I had known what the proper test setup requirements are.

I suggest to document some system requirements for running the unit tests.

I orientated the documentation to fit the [Android CI build](https://github.com/k9mail/k-9/runs/397705017) on the most recent commit on `master` (2505a7b0cdeeda10e8b38e8c4ae21b4d963306f1).
