### PR TITLE
add intent filter to main activty to provide default email application setting

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -194,6 +194,7 @@
 
                 <category android:name="android.intent.category.DEFAULT"/>
                 <category android:name="android.intent.category.LAUNCHER"/>
+                <category android:name="android.intent.category.APP_EMAIL"/>
 
                 <!-- TODO: Remove once minSdkVersion has been changed to 24+ -->
                 <category android:name="android.intent.category.MULTIWINDOW_LAUNCHER"/>


### PR DESCRIPTION
Adds intent filter [ `CATEGORY_APP_EMAIL`](https://developer.android.com/reference/android/content/Intent.html#CATEGORY_APP_EMAIL) in order to provide the app's activity as possible default email application. This must be interpreted by Android and [set by the user outside of the application](https://github.com/k9mail/k-9/issues/3231#issuecomment-515759615).

- [x] Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
- [x] Does not break any unit tests.
- [x] Contains a reference to the issue that it fixes.  
  Fixes #3231 
- ~~For cosmetic changes add one or multiple images, if possible.~~
- [ ] Test, that the changes have a positive effect.


