### PR TITLE
Remove MessagingController.listFolders() and associated callbacks

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingListener.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingListener.java
@@ -9,17 +9,11 @@ import android.content.Context;
 import com.fsck.k9.Account;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Part;
-import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 
 
 public interface MessagingListener {
     void accountSizeChanged(Account account, long oldSize, long newSize);
-
-    void listFoldersStarted(Account account);
-    void listFolders(Account account, List<LocalFolder> folders);
-    void listFoldersFinished(Account account);
-    void listFoldersFailed(Account account, String message);
 
     void listLocalMessagesAddMessages(Account account, String folderServerId, List<LocalMessage> messages);
     void listLocalMessagesFinished();

--- a/app/core/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/SimpleMessagingListener.java
@@ -9,29 +9,12 @@ import android.content.Context;
 import com.fsck.k9.Account;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Part;
-import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 
 
 public abstract class SimpleMessagingListener implements MessagingListener {
     @Override
     public void accountSizeChanged(Account account, long oldSize, long newSize) {
-    }
-
-    @Override
-    public void listFoldersStarted(Account account) {
-    }
-
-    @Override
-    public void listFolders(Account account, List<LocalFolder> folders) {
-    }
-
-    @Override
-    public void listFoldersFinished(Account account) {
-    }
-
-    @Override
-    public void listFoldersFailed(Account account, String message) {
     }
 
     @Override

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -55,7 +55,6 @@ import org.mockito.stubbing.Answer;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.shadows.ShadowLog;
 
-import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Matchers.any;
@@ -103,8 +102,6 @@ public class MessagingControllerTest extends K9RobolectricTest {
     private NotificationController notificationController;
     @Mock
     private NotificationStrategy notificationStrategy;
-    @Captor
-    private ArgumentCaptor<List<LocalFolder>> localFolderListCaptor;
     @Captor
     private ArgumentCaptor<FetchProfile> fetchProfileCaptor;
     @Captor
@@ -199,65 +196,9 @@ public class MessagingControllerTest extends K9RobolectricTest {
         verify(localFolder, atLeastOnce()).close();
     }
 
-    @Test()
-    public void clearFolderSynchronous_shouldListFolders() throws MessagingException {
-        controller.clearFolderSynchronous(account, FOLDER_NAME, listener);
-
-        verify(listener, atLeastOnce()).listFoldersStarted(account);
-    }
-
-    @Test
-    public void listFoldersSynchronous_shouldNotifyTheListenerListingStarted() throws MessagingException {
-        List<LocalFolder> folders = Collections.singletonList(localFolder);
-        when(localStore.getPersonalNamespaces(false)).thenReturn(folders);
-
-        controller.listFoldersSynchronous(account, false, listener);
-
-        verify(listener).listFoldersStarted(account);
-    }
-
-    @Test
-    public void listFoldersSynchronous_shouldNotifyTheListenerOfTheListOfFolders() throws MessagingException {
-        List<LocalFolder> folders = Collections.singletonList(localFolder);
-        when(localStore.getPersonalNamespaces(false)).thenReturn(folders);
-
-        controller.listFoldersSynchronous(account, false, listener);
-
-        verify(listener).listFolders(eq(account), localFolderListCaptor.capture());
-        assertEquals(folders, localFolderListCaptor.getValue());
-    }
-
-    @Test
-    public void listFoldersSynchronous_shouldNotifyFailureOnException() throws MessagingException {
-        when(localStore.getPersonalNamespaces(false)).thenThrow(new MessagingException("Test"));
-
-        controller.listFoldersSynchronous(account, true, listener);
-
-        verify(listener).listFoldersFailed(account, "Test");
-    }
-
-    @Test
-    public void listFoldersSynchronous_shouldNotNotifyFinishedAfterFailure() throws MessagingException {
-        when(localStore.getPersonalNamespaces(false)).thenThrow(new MessagingException("Test"));
-
-        controller.listFoldersSynchronous(account, true, listener);
-
-        verify(listener, never()).listFoldersFinished(account);
-    }
-
-    @Test
-    public void listFoldersSynchronous_shouldNotifyFinishedAfterSuccess() throws MessagingException {
-        List<LocalFolder> folders = Collections.singletonList(localFolder);
-        when(localStore.getPersonalNamespaces(false)).thenReturn(folders);
-
-        controller.listFoldersSynchronous(account, false, listener);
-
-        verify(listener).listFoldersFinished(account);
-    }
-
     @Test
     public void refreshRemoteSynchronous_shouldCallBackend() throws MessagingException {
-        controller.refreshRemoteSynchronous(account, listener);
+        controller.refreshFolderListSynchronous(account);
 
         verify(backend).refreshFolderList();
     }

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupCheckSettings.java
@@ -503,7 +503,7 @@ public class AccountSetupCheckSettings extends K9Activity implements OnClickList
             if (isWebDavAccount()) {
                 publishProgress(R.string.account_setup_check_settings_fetch);
             }
-            MessagingController.getInstance(getApplication()).listFoldersSynchronous(account, true, null);
+            MessagingController.getInstance(getApplication()).refreshFolderListSynchronous(account);
             MessagingController.getInstance(getApplication())
                     .synchronizeMailbox(account, account.getInboxFolder(), null);
         }

--- a/app/ui/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -180,7 +180,7 @@ class ChooseFolderActivity : K9Activity() {
     }
 
     private fun refreshFolderList() {
-        messagingController.listFolders(account, true, null)
+        messagingController.refreshFolderList(account)
     }
 
     private fun setDisplayMode(displayMode: FolderMode) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
@@ -187,7 +187,7 @@ class ManageFoldersActivity : K9Activity() {
     }
 
     private fun refreshFolderList() {
-        messagingController.listFolders(account, true, messagingListener)
+        messagingController.refreshFolderList(account)
     }
 
     private fun compactAccount() {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/import/AccountActivator.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/import/AccountActivator.kt
@@ -25,7 +25,7 @@ class AccountActivator(
         Core.setServicesEnabled(context)
 
         // Get list of folders from remote server
-        messagingController.listFolders(account, true, null)
+        messagingController.refreshFolderList(account)
     }
 
     private fun setAccountPasswords(


### PR DESCRIPTION
We now use `FolderRepository` to retrieve the folder list. `MessagingController.listFolders()` was only used to refresh the folder list from the server. So now we only do that.


