### PR TITLE
Fix MessageListExtractor to only read thread count when requested

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
@@ -48,7 +48,11 @@ class MessageListLoader(
             uniqueIdColumn = MLFProjectionInfo.ID_COLUMN
         }
 
-        return messageListExtractor.extractMessageList(cursor, uniqueIdColumn)
+        return messageListExtractor.extractMessageList(
+            cursor,
+            uniqueIdColumn,
+            threadCountIncluded = config.showingThreadedList
+        )
     }
 
     private fun loadMessageListForAccount(account: Account, config: MessageListConfig): Cursor? {


### PR DESCRIPTION
Turns out that sometimes we do have a column with index `THREAD_COUNT_COLUMN`, but it's the unique ID and not a thread count. In that case the `getIntIfColumnPresent()` logic fails.

Steps to reproduce the issue:
- Set up more than one account
- Disable threaded view
- Go to Unified Inbox
