### PR TITLE
Display progress when syncing a folder

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -28,6 +28,7 @@ import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.view.animation.AnimationUtils;
+import android.widget.ProgressBar;
 import android.widget.Toast;
 
 import com.fsck.k9.Account;
@@ -66,7 +67,6 @@ import com.fsck.k9.view.ViewSwitcher.OnSwitchCompleteListener;
 import com.mikepenz.materialdrawer.Drawer.OnDrawerListener;
 import de.cketti.library.changelog.ChangeLog;
 import timber.log.Timber;
-
 
 
 /**
@@ -185,6 +185,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     private FragmentTransaction openFolderTransaction;
     private Menu menu;
 
+    private ProgressBar progressBar;
     private ViewGroup messageViewContainer;
     private View messageViewPlaceHolder;
 
@@ -394,6 +395,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     }
 
     private void initializeLayout() {
+        progressBar = findViewById(R.id.message_list_progress);
         messageViewContainer = findViewById(R.id.message_view_container);
 
         LayoutInflater layoutInflater = getLayoutInflater();
@@ -1203,8 +1205,13 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
     }
 
     @Override
+    public void setMessageListProgressEnabled(boolean enable) {
+        progressBar.setVisibility(enable ? View.VISIBLE : View.INVISIBLE);
+    }
+
+    @Override
     public void setMessageListProgress(int progress) {
-        setProgress(progress);
+        progressBar.setProgress(progress);
     }
 
     @Override

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -29,7 +29,6 @@ import android.view.MenuItem;
 import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.Window;
 import android.widget.AdapterView;
 import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.AdapterView.OnItemClickListener;
@@ -74,6 +73,7 @@ import net.jcip.annotations.GuardedBy;
 import timber.log.Timber;
 
 import static com.fsck.k9.Account.Expunge.EXPUNGE_MANUALLY;
+import static com.fsck.k9.fragment.MessageListFragment.MessageListFragmentListener.MAX_PROGRESS;
 import static com.fsck.k9.search.LocalSearchExtensions.getAccountsFromLocalSearch;
 
 
@@ -203,14 +203,14 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     private void setWindowProgress() {
-        int level = Window.PROGRESS_END;
+        int level = MAX_PROGRESS;
 
         if (currentFolder != null && currentFolder.loading && activityListener.getFolderTotal() > 0) {
             int divisor = activityListener.getFolderTotal();
             if (divisor != 0) {
-                level = (Window.PROGRESS_END / divisor) * (activityListener.getFolderCompleted()) ;
-                if (level > Window.PROGRESS_END) {
-                    level = Window.PROGRESS_END;
+                level = (MAX_PROGRESS / divisor) * (activityListener.getFolderCompleted()) ;
+                if (level > MAX_PROGRESS) {
+                    level = MAX_PROGRESS;
                 }
             }
         }
@@ -238,6 +238,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         if (swipeRefreshLayout != null && !progress) {
             swipeRefreshLayout.setRefreshing(false);
         }
+        fragmentListener.setMessageListProgressEnabled(progress);
     }
 
     @Override
@@ -1147,8 +1148,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
             } else {
                 handler.updateFooter(null);
             }
-            fragmentListener.setMessageListProgress(Window.PROGRESS_END);
-
         }
 
         @Override
@@ -1161,7 +1160,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 handler.updateFooter(context.getResources().getQuantityString(R.plurals.remote_search_downloading,
                         numResults, numResults));
             }
-            fragmentListener.setMessageListProgress(Window.PROGRESS_START);
+
+            informUserOfStatus();
         }
 
         private void informUserOfStatus() {
@@ -2181,6 +2181,9 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     public interface MessageListFragmentListener {
+        int MAX_PROGRESS = 10000;
+
+        void setMessageListProgressEnabled(boolean enable);
         void setMessageListProgress(int level);
         void showThread(Account account, String folderServerId, long rootId);
         void showMoreFromSameSender(String senderAddress);

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -205,10 +205,10 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     private void setWindowProgress() {
         int level = MAX_PROGRESS;
 
-        if (currentFolder != null && currentFolder.loading && activityListener.getFolderTotal() > 0) {
-            int divisor = activityListener.getFolderTotal();
-            if (divisor != 0) {
-                level = (MAX_PROGRESS / divisor) * (activityListener.getFolderCompleted()) ;
+        if (currentFolder != null && currentFolder.loading) {
+            int folderTotal = activityListener.getFolderTotal();
+            if (folderTotal > 0) {
+                level = (MAX_PROGRESS * activityListener.getFolderCompleted()) / folderTotal;
                 if (level > MAX_PROGRESS) {
                     level = MAX_PROGRESS;
                 }

--- a/app/ui/src/main/res/layout/message_list.xml
+++ b/app/ui/src/main/res/layout/message_list.xml
@@ -7,6 +7,18 @@
 
     <include layout="@layout/toolbar" />
 
+    <ProgressBar
+        android:id="@+id/message_list_progress"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-2dp"
+        android:elevation="4dp"
+        android:max="10000"
+        android:maxHeight="2dp"
+        android:minHeight="2dp"
+        android:visibility="invisible" />
+
     <com.fsck.k9.view.ViewSwitcher
             android:id="@+id/container"
             android:layout_width="match_parent"

--- a/app/ui/src/main/res/layout/split_message_list.xml
+++ b/app/ui/src/main/res/layout/split_message_list.xml
@@ -8,6 +8,18 @@
 
     <include layout="@layout/toolbar" />
 
+    <ProgressBar
+        android:id="@+id/message_list_progress"
+        style="@style/Widget.AppCompat.ProgressBar.Horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="-2dp"
+        android:elevation="4dp"
+        android:max="10000"
+        android:maxHeight="2dp"
+        android:minHeight="2dp"
+        android:visibility="invisible" />
+
     <LinearLayout
             android:id="@+id/container"
             android:layout_width="fill_parent"


### PR DESCRIPTION
Use a horizontal progress bar at the bottom of the toolbar instead of the deprecated (and no longer working) `Activity.setProgress()` mechanism.
