### PR TITLE
Check arguments when creating PendingCommand instances

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -805,46 +805,23 @@ public class MessagingController {
         }
     }
 
-    private void queueMoveOrCopy(Account account, String srcFolder, String destFolder,
-                                 MoveOrCopyFlavor operation, List<String> uids) {
+    private void queueMoveOrCopy(Account account, String srcFolder, String destFolder, MoveOrCopyFlavor operation,
+            Map<String, String> uidMap) {
         PendingCommand command;
         switch (operation) {
             case MOVE:
-                command = PendingMoveOrCopy.create(srcFolder, destFolder, false, uids);
+                command = PendingMoveOrCopy.create(srcFolder, destFolder, false, uidMap);
                 break;
             case COPY:
-                command = PendingMoveOrCopy.create(srcFolder, destFolder, true, uids);
+                command = PendingMoveOrCopy.create(srcFolder, destFolder, true, uidMap);
                 break;
             case MOVE_AND_MARK_AS_READ:
-                command = PendingMoveAndMarkAsRead.create(srcFolder, destFolder, uids);
+                command = PendingMoveAndMarkAsRead.create(srcFolder, destFolder, uidMap);
                 break;
             default:
                 return;
         }
         queuePendingCommand(account, command);
-    }
-
-    private void queueMoveOrCopy(Account account, String srcFolder, String destFolder,
-                                 MoveOrCopyFlavor operation, List<String> uids, Map<String, String> uidMap) {
-        if (uidMap == null || uidMap.isEmpty()) {
-            queueMoveOrCopy(account, srcFolder, destFolder, operation, uids);
-        } else {
-            PendingCommand command;
-            switch (operation) {
-                case MOVE:
-                    command = PendingMoveOrCopy.create(srcFolder, destFolder, false, uidMap);
-                    break;
-                case COPY:
-                    command = PendingMoveOrCopy.create(srcFolder, destFolder, true, uidMap);
-                    break;
-                case MOVE_AND_MARK_AS_READ:
-                    command = PendingMoveAndMarkAsRead.create(srcFolder, destFolder, uidMap);
-                    break;
-                default:
-                    return;
-            }
-            queuePendingCommand(account, command);
-        }
     }
 
     void processPendingMoveOrCopy(PendingMoveOrCopy command, Account account) throws MessagingException {
@@ -1899,8 +1876,7 @@ public class MessagingController {
                     }
                 }
 
-                List<String> origUidKeys = new ArrayList<>(origUidMap.keySet());
-                queueMoveOrCopy(account, srcFolder, destFolder, operation, origUidKeys, uidMap);
+                queueMoveOrCopy(account, srcFolder, destFolder, operation, uidMap);
             }
 
             processPendingCommands(account);
@@ -2107,10 +2083,10 @@ public class MessagingController {
                         queueDelete(account, folder, syncedMessageUids);
                     } else if (account.isMarkMessageAsReadOnDelete()) {
                         queueMoveOrCopy(account, folder, account.getTrashFolder(),
-                                MoveOrCopyFlavor.MOVE_AND_MARK_AS_READ, syncedMessageUids, uidMap);
+                                MoveOrCopyFlavor.MOVE_AND_MARK_AS_READ, uidMap);
                     } else {
                         queueMoveOrCopy(account, folder, account.getTrashFolder(),
-                                MoveOrCopyFlavor.MOVE, syncedMessageUids, uidMap);
+                                MoveOrCopyFlavor.MOVE, uidMap);
                     }
                     processPendingCommands(account);
                 } else if (account.getDeletePolicy() == DeletePolicy.MARK_AS_READ) {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -838,9 +838,8 @@ public class MessagingController {
     void processPendingMoveAndRead(PendingMoveAndMarkAsRead command, Account account) throws MessagingException {
         String srcFolder = command.srcFolder;
         String destFolder = command.destFolder;
-
         Map<String, String> newUidMap = command.newUidMap;
-        List<String> uids = newUidMap != null ? new ArrayList<>(newUidMap.keySet()) : command.uids;
+        List<String> uids = new ArrayList<>(newUidMap.keySet());
 
         processPendingMoveOrCopy(account, srcFolder, destFolder, uids,
                 MoveOrCopyFlavor.MOVE_AND_MARK_AS_READ, newUidMap);

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -69,24 +69,16 @@ public class MessagingControllerCommands {
     public static class PendingMoveAndMarkAsRead extends PendingCommand {
         public final String srcFolder;
         public final String destFolder;
-        public final List<String> uids;
         public final Map<String, String> newUidMap;
 
 
-        public static PendingMoveAndMarkAsRead create(String srcFolder, String destFolder,
-                                                      Map<String, String> uidMap) {
-            return new PendingMoveAndMarkAsRead(srcFolder, destFolder, null, uidMap);
+        public static PendingMoveAndMarkAsRead create(String srcFolder, String destFolder, Map<String, String> uidMap) {
+            return new PendingMoveAndMarkAsRead(srcFolder, destFolder, uidMap);
         }
 
-        public static PendingMoveAndMarkAsRead create(String srcFolder, String destFolder, List<String> uids) {
-            return new PendingMoveAndMarkAsRead(srcFolder, destFolder, uids, null);
-        }
-
-        private PendingMoveAndMarkAsRead(String srcFolder, String destFolder, List<String> uids,
-                                         Map<String, String> newUidMap) {
+        private PendingMoveAndMarkAsRead(String srcFolder, String destFolder, Map<String, String> newUidMap) {
             this.srcFolder = srcFolder;
             this.destFolder = destFolder;
-            this.uids = uids;
             this.newUidMap = newUidMap;
         }
 

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -8,6 +8,9 @@ import com.fsck.k9.Account;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.MessagingException;
 
+import static com.fsck.k9.controller.Preconditions.requireValidUids;
+import static com.fsck.k9.helper.Preconditions.checkNotNull;
+
 
 public class MessagingControllerCommands {
     static final String COMMAND_APPEND = "append";
@@ -39,6 +42,9 @@ public class MessagingControllerCommands {
 
         public static PendingMoveOrCopy create(String srcFolder, String destFolder, boolean isCopy,
                 Map<String, String> uidMap) {
+            checkNotNull(srcFolder);
+            checkNotNull(destFolder);
+            requireValidUids(uidMap);
             return new PendingMoveOrCopy(srcFolder, destFolder, isCopy, null, uidMap);
         }
 
@@ -73,6 +79,9 @@ public class MessagingControllerCommands {
 
 
         public static PendingMoveAndMarkAsRead create(String srcFolder, String destFolder, Map<String, String> uidMap) {
+            checkNotNull(srcFolder);
+            checkNotNull(destFolder);
+            requireValidUids(uidMap);
             return new PendingMoveAndMarkAsRead(srcFolder, destFolder, uidMap);
         }
 
@@ -117,6 +126,9 @@ public class MessagingControllerCommands {
 
 
         public static PendingSetFlag create(String folder, boolean newState, Flag flag, List<String> uids) {
+            checkNotNull(folder);
+            checkNotNull(flag);
+            requireValidUids(uids);
             return new PendingSetFlag(folder, newState, flag, uids);
         }
 
@@ -144,6 +156,8 @@ public class MessagingControllerCommands {
 
 
         public static PendingAppend create(String folderServerId, String uid) {
+            checkNotNull(folderServerId);
+            checkNotNull(uid);
             return new PendingAppend(folderServerId, uid);
         }
 
@@ -168,6 +182,7 @@ public class MessagingControllerCommands {
 
 
         public static PendingMarkAllAsRead create(String folder) {
+            checkNotNull(folder);
             return new PendingMarkAllAsRead(folder);
         }
 
@@ -192,6 +207,8 @@ public class MessagingControllerCommands {
 
 
         public static PendingDelete create(String folder, List<String> uids) {
+            checkNotNull(folder);
+            requireValidUids(uids);
             return new PendingDelete(folder, uids);
         }
 
@@ -216,6 +233,7 @@ public class MessagingControllerCommands {
 
 
         public static PendingExpunge create(String folderServerId) {
+            checkNotNull(folderServerId);
             return new PendingExpunge(folderServerId);
         }
 

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -42,7 +42,7 @@ public class MessagingControllerCommands {
             return new PendingMoveOrCopy(srcFolder, destFolder, isCopy, null, uidMap);
         }
 
-        public static PendingMoveOrCopy create(String srcFolder, String destFolder, boolean isCopy, List<String> uids) {
+        public static PendingMoveOrCopy createLegacy(String srcFolder, String destFolder, boolean isCopy, List<String> uids) {
             return new PendingMoveOrCopy(srcFolder, destFolder, isCopy, uids, null);
         }
 

--- a/app/core/src/main/java/com/fsck/k9/controller/Preconditions.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/Preconditions.kt
@@ -1,0 +1,24 @@
+@file:JvmName("Preconditions")
+package com.fsck.k9.controller
+
+import com.fsck.k9.K9
+
+fun requireValidUids(uidMap: Map<String?, String?>?) {
+    requireNotNull(uidMap)
+    for ((sourceUid, destinationUid) in uidMap) {
+        requireNotLocalUid(sourceUid)
+        requireNotNull(destinationUid)
+    }
+}
+
+fun requireValidUids(uids: List<String?>?) {
+    requireNotNull(uids)
+    for (uid in uids) {
+        requireNotLocalUid(uid)
+    }
+}
+
+private fun requireNotLocalUid(uid: String?) {
+    requireNotNull(uid)
+    require(!uid.startsWith(K9.LOCAL_UID_PREFIX)) { "Local UID found: $uid" }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo60.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo60.java
@@ -130,7 +130,7 @@ class MigrationTo60 {
         String destFolder = command.arguments[2];
         boolean isCopy = Boolean.parseBoolean(command.arguments[3]);
 
-        return PendingMoveOrCopy.create(srcFolder, destFolder, isCopy, singletonList(uid));
+        return PendingMoveOrCopy.createLegacy(srcFolder, destFolder, isCopy, singletonList(uid));
     }
 
     private static PendingCommand migrateCommandMoveOrCopyBulkNew(OldPendingCommand command) {
@@ -151,7 +151,7 @@ class MigrationTo60 {
             List<String> uids = new ArrayList<>(command.arguments.length - 4);
             uids.addAll(Arrays.asList(command.arguments).subList(4, command.arguments.length));
 
-            return PendingMoveOrCopy.create(srcFolder, destFolder, isCopy, uids);
+            return PendingMoveOrCopy.createLegacy(srcFolder, destFolder, isCopy, uids);
         }
     }
 


### PR DESCRIPTION
Try to catch errors earlier by checking the arguments when creating `PendingCommand` instances.

Also, get rid of some unused code.