### PR TITLE
Make default progress 0%

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -203,7 +203,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     private void setWindowProgress() {
-        int level = MAX_PROGRESS;
+        int level = 0;
 
         if (currentFolder != null && currentFolder.loading) {
             int folderTotal = activityListener.getFolderTotal();


### PR DESCRIPTION
When refreshing, the progress bar flashes 100% for a short time before actually doing anything. I think it would look better to flash 0% instead.