### PR TITLE
Add hasFragileUserData

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -51,7 +51,8 @@
         android:label="@string/app_name"
         android:theme="@style/Theme.K9.Startup"
         android:resizeableActivity="true"
-        android:allowBackup="false">
+        android:allowBackup="false"
+        android:hasFragileUserData="true">
 
         <meta-data
             android:name="android.app.default_searchable"


### PR DESCRIPTION
This is an Android 10 flag that:

> If true the user is prompted to keep the app's data on uninstall

https://developer.android.com/reference/android/R.attr#hasFragileUserData

https://www.xda-developers.com/android-10-manifest-flag-developers-retain-app-data-before-uninstalling/

Maybe this could make it easier for users to switch builds or downgrade without adb (like ``adb uninstall -k`` that uninstalls app without clearing data).
