### PR TITLE
Make BackendFolder not hand out local messages

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
@@ -5,6 +5,7 @@ import android.database.sqlite.SQLiteDatabase
 import androidx.core.database.getLongOrNull
 import androidx.core.database.getStringOrNull
 import com.fsck.k9.Account
+import com.fsck.k9.K9
 import com.fsck.k9.Preferences
 import com.fsck.k9.backend.api.BackendFolder
 import com.fsck.k9.backend.api.BackendFolder.MoreMessages
@@ -61,7 +62,7 @@ class K9BackendFolder(
 
     override fun getAllMessagesAndEffectiveDates(): Map<String, Long?> {
         return database.rawQuery("SELECT uid, date FROM messages" +
-                " WHERE empty = 0 AND deleted = 0 AND folder_id = ?" +
+                " WHERE empty = 0 AND deleted = 0 AND folder_id = ? AND uid NOT LIKE '${K9.LOCAL_UID_PREFIX}%'" +
                 " ORDER BY date DESC", databaseId) { cursor ->
             val result = mutableMapOf<String, Long?>()
             while (cursor.moveToNext()) {

--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendFolder.kt
@@ -202,6 +202,8 @@ class K9BackendFolder(
 
     // TODO: Move implementation from LocalFolder to this class
     override fun saveCompleteMessage(message: Message) {
+        requireMessageServerId(message)
+
         localFolder.appendMessages(listOf(message))
 
         val localMessage = localFolder.getMessage(message.uid)
@@ -210,6 +212,8 @@ class K9BackendFolder(
 
     // TODO: Move implementation from LocalFolder to this class
     override fun savePartialMessage(message: Message) {
+        requireMessageServerId(message)
+
         localFolder.appendMessages(listOf(message))
 
         val localMessage = localFolder.getMessage(message.uid)
@@ -367,5 +371,11 @@ class K9BackendFolder(
         MoreMessages.UNKNOWN -> "unknown"
         MoreMessages.FALSE -> "false"
         MoreMessages.TRUE -> "true"
+    }
+
+    private fun requireMessageServerId(message: Message) {
+        if (message.uid.isNullOrEmpty()) {
+            error("Message requires a server ID to be set")
+        }
     }
 }

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/BackendFolder.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/BackendFolder.kt
@@ -36,9 +36,4 @@ interface BackendFolder {
         FALSE,
         TRUE
     }
-
-    companion object {
-        // TODO: Change the interface to be able to hide this (ugly) implementation detail.
-        const val LOCAL_UID_PREFIX = "K9LOCAL:"
-    }
 }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandMoveOrCopyMessages.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandMoveOrCopyMessages.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import com.fsck.k9.backend.api.BackendFolder;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.store.imap.ImapFolder;
@@ -44,10 +43,7 @@ class CommandMoveOrCopyMessages {
             List<Message> messages = new ArrayList<>();
 
             for (String uid : uids) {
-                // TODO: Local messages should never end up here. Throw in debug builds.
-                if (!uid.startsWith(BackendFolder.LOCAL_UID_PREFIX)) {
-                    messages.add(remoteSrcFolder.getMessage(uid));
-                }
+                messages.add(remoteSrcFolder.getMessage(uid));
             }
 
             if (messages.isEmpty()) {

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandSetFlag.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/CommandSetFlag.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.fsck.k9.backend.api.BackendFolder;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
@@ -37,9 +36,7 @@ class CommandSetFlag {
             }
             List<Message> messages = new ArrayList<>();
             for (String uid : messageServerIds) {
-                if (!uid.startsWith(BackendFolder.LOCAL_UID_PREFIX)) {
-                    messages.add(remoteFolder.getMessage(uid));
-                }
+                messages.add(remoteFolder.getMessage(uid));
             }
 
             if (messages.isEmpty()) {

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapSync.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapSync.java
@@ -172,8 +172,7 @@ class ImapSync {
             if (syncConfig.getSyncRemoteDeletions()) {
                 List<String> destroyMessageUids = new ArrayList<>();
                 for (String localMessageUid : localUidMap.keySet()) {
-                    if (!localMessageUid.startsWith(BackendFolder.LOCAL_UID_PREFIX) &&
-                            remoteUidMap.get(localMessageUid) == null) {
+                    if (remoteUidMap.get(localMessageUid) == null) {
                         destroyMessageUids.add(localMessageUid);
                     }
                 }

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/CommandSetFlag.java
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/CommandSetFlag.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.fsck.k9.backend.api.BackendFolder;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
@@ -34,9 +33,7 @@ class CommandSetFlag {
             remoteFolder.open();
             List<Message> messages = new ArrayList<>();
             for (String uid : messageServerIds) {
-                if (!uid.startsWith(BackendFolder.LOCAL_UID_PREFIX)) {
-                    messages.add(remoteFolder.getMessage(uid));
-                }
+                messages.add(remoteFolder.getMessage(uid));
             }
 
             if (messages.isEmpty()) {

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Sync.java
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Sync.java
@@ -162,8 +162,7 @@ class Pop3Sync {
             if (syncConfig.getSyncRemoteDeletions()) {
                 List<String> destroyMessageUids = new ArrayList<>();
                 for (String localMessageUid : localUidMap.keySet()) {
-                    if (!localMessageUid.startsWith(BackendFolder.LOCAL_UID_PREFIX) &&
-                            remoteUidMap.get(localMessageUid) == null) {
+                    if (remoteUidMap.get(localMessageUid) == null) {
                         destroyMessageUids.add(localMessageUid);
                     }
                 }

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/CommandMoveOrCopyMessages.java
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/CommandMoveOrCopyMessages.java
@@ -6,7 +6,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import com.fsck.k9.backend.api.BackendFolder;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.store.webdav.WebDavFolder;
@@ -44,10 +43,7 @@ class CommandMoveOrCopyMessages {
             List<Message> messages = new ArrayList<>();
 
             for (String uid : uids) {
-                // TODO: Local messages should never end up here. Throw in debug builds.
-                if (!uid.startsWith(BackendFolder.LOCAL_UID_PREFIX)) {
-                    messages.add(remoteSrcFolder.getMessage(uid));
-                }
+                messages.add(remoteSrcFolder.getMessage(uid));
             }
 
             if (messages.isEmpty()) {

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/CommandSetFlag.java
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/CommandSetFlag.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.fsck.k9.backend.api.BackendFolder;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessagingException;
@@ -31,9 +30,7 @@ class CommandSetFlag {
 
             List<Message> messages = new ArrayList<>();
             for (String uid : messageServerIds) {
-                if (!uid.startsWith(BackendFolder.LOCAL_UID_PREFIX)) {
-                    messages.add(remoteFolder.getMessage(uid));
-                }
+                messages.add(remoteFolder.getMessage(uid));
             }
 
             if (messages.isEmpty()) {

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavSync.java
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavSync.java
@@ -163,8 +163,7 @@ class WebDavSync {
             if (syncConfig.getSyncRemoteDeletions()) {
                 List<String> destroyMessageUids = new ArrayList<>();
                 for (String localMessageUid : localUidMap.keySet()) {
-                    if (!localMessageUid.startsWith(BackendFolder.LOCAL_UID_PREFIX) &&
-                            remoteUidMap.get(localMessageUid) == null) {
+                    if (remoteUidMap.get(localMessageUid) == null) {
                         destroyMessageUids.add(localMessageUid);
                     }
                 }


### PR DESCRIPTION
Backends shouldn't have to know about local messages. With this change they don't. 

This also prevents accidentally creating local messages by calling `savePartialMessage()` or `saveCompleteMessage()` without a server ID (UID) set.