### PR TITLE
autodownload_message_size should use symbols for to base2 Bytes

### DIFF
--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -572,20 +572,20 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_mail_display_count_label">Local folder size</string>
 
     <string name="account_settings_autodownload_message_size_label">Fetch messages up to</string>
-    <string name="account_settings_autodownload_message_size_1">1Kb</string>
-    <string name="account_settings_autodownload_message_size_2">2Kb</string>
-    <string name="account_settings_autodownload_message_size_4">4Kb</string>
-    <string name="account_settings_autodownload_message_size_8">8Kb</string>
-    <string name="account_settings_autodownload_message_size_16">16Kb</string>
-    <string name="account_settings_autodownload_message_size_32">32Kb</string>
-    <string name="account_settings_autodownload_message_size_64">64Kb</string>
-    <string name="account_settings_autodownload_message_size_128">128Kb</string>
-    <string name="account_settings_autodownload_message_size_256">256Kb</string>
-    <string name="account_settings_autodownload_message_size_512">512Kb</string>
-    <string name="account_settings_autodownload_message_size_1024">1Mb</string>
-    <string name="account_settings_autodownload_message_size_2048">2Mb</string>
-    <string name="account_settings_autodownload_message_size_5120">5Mb</string>
-    <string name="account_settings_autodownload_message_size_10240">10Mb</string>
+    <string name="account_settings_autodownload_message_size_1">1 KiB</string>
+    <string name="account_settings_autodownload_message_size_2">2 KiB</string>
+    <string name="account_settings_autodownload_message_size_4">4 KiB</string>
+    <string name="account_settings_autodownload_message_size_8">8 KiB</string>
+    <string name="account_settings_autodownload_message_size_16">16 KiB</string>
+    <string name="account_settings_autodownload_message_size_32">32 KiB</string>
+    <string name="account_settings_autodownload_message_size_64">64 KiB</string>
+    <string name="account_settings_autodownload_message_size_128">128 KiB</string>
+    <string name="account_settings_autodownload_message_size_256">256 KiB</string>
+    <string name="account_settings_autodownload_message_size_512">512 KiB</string>
+    <string name="account_settings_autodownload_message_size_1024">1 MiB</string>
+    <string name="account_settings_autodownload_message_size_2048">2 MiB</string>
+    <string name="account_settings_autodownload_message_size_5120">5 MiB</string>
+    <string name="account_settings_autodownload_message_size_10240">10 MiB</string>
     <string name="account_settings_autodownload_message_size_any">any size (no limit)</string>
 
     <string name="account_settings_message_age_label">Sync messages from</string>


### PR DESCRIPTION
Max message size is compared directly with message size, which is retrieved in the case of POP3 by a list command. List returns a size in bytes.

Out of that follows that the values for max download size are actually expressed as kibibytes and mebibytes

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


