### PR TITLE
Never open external links in our WebView (API level < 24)

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/view/K9WebViewClient.java
+++ b/app/ui/src/main/java/com/fsck/k9/view/K9WebViewClient.java
@@ -10,6 +10,7 @@ import android.content.ContentResolver;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.Browser;
 import android.text.TextUtils;
 import android.webkit.WebResourceRequest;
@@ -19,6 +20,8 @@ import android.webkit.WebViewClient;
 import android.widget.Toast;
 
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+
 import com.fsck.k9.mailstore.AttachmentResolver;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.view.MessageWebView.OnPageFinishedListener;
@@ -50,7 +53,16 @@ public class K9WebViewClient extends WebViewClient {
 
     @Override
     public boolean shouldOverrideUrlLoading(WebView webView, String url) {
-        Uri uri = Uri.parse(url);
+        return shouldOverrideUrlLoading(webView, Uri.parse(url));
+    }
+
+    @Override
+    @RequiresApi(Build.VERSION_CODES.N)
+    public boolean shouldOverrideUrlLoading(WebView webView, WebResourceRequest request) {
+        return shouldOverrideUrlLoading(webView, request.getUrl());
+    }
+
+    private boolean shouldOverrideUrlLoading(WebView webView, Uri uri) {
         if (CID_SCHEME.equals(uri.getScheme())) {
             return false;
         }
@@ -65,12 +77,6 @@ public class K9WebViewClient extends WebViewClient {
         }
 
         return true;
-    }
-
-    @Override
-    public boolean shouldOverrideUrlLoading(WebView webView, WebResourceRequest request) {
-        Uri uri = request.getUrl();
-        return shouldOverrideUrlLoading(webView, uri.toString());
     }
 
     private Intent createBrowserViewIntent(Uri uri, Context context) {

--- a/app/ui/src/main/java/com/fsck/k9/view/K9WebViewClient.java
+++ b/app/ui/src/main/java/com/fsck/k9/view/K9WebViewClient.java
@@ -49,8 +49,8 @@ public class K9WebViewClient extends WebViewClient {
     }
 
     @Override
-    public boolean shouldOverrideUrlLoading(WebView webView, WebResourceRequest request) {
-        Uri uri = request.getUrl();
+    public boolean shouldOverrideUrlLoading(WebView webView, String url) {
+        Uri uri = Uri.parse(url);
         if (CID_SCHEME.equals(uri.getScheme())) {
             return false;
         }
@@ -65,6 +65,12 @@ public class K9WebViewClient extends WebViewClient {
         }
 
         return true;
+    }
+
+    @Override
+    public boolean shouldOverrideUrlLoading(WebView webView, WebResourceRequest request) {
+        Uri uri = request.getUrl();
+        return shouldOverrideUrlLoading(webView, uri.toString());
     }
 
     private Intent createBrowserViewIntent(Uri uri, Context context) {


### PR DESCRIPTION
Fixes #4498 for older phones.