### PR TITLE
Fix "Bcc all messages to" when switching accounts

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -80,7 +80,6 @@ import com.fsck.k9.helper.MailTo;
 import com.fsck.k9.helper.ReplyToParser;
 import com.fsck.k9.helper.SimpleTextWatcher;
 import com.fsck.k9.helper.Utility;
-import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Message.RecipientType;
@@ -422,13 +421,6 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                     Parcelable cachedDecryptionResult = intent.getParcelableExtra(EXTRA_MESSAGE_DECRYPTION_RESULT);
                     messageLoaderHelper.asyncStartOrResumeLoadingMessage(
                             relatedMessageReference, cachedDecryptionResult);
-                }
-            }
-
-            if (action != Action.EDIT_DRAFT) {
-                String alwaysBccString = account.getAlwaysBcc();
-                if (!TextUtils.isEmpty(alwaysBccString)) {
-                    recipientPresenter.addBccAddresses(Address.parse(alwaysBccString));
                 }
             }
         }

--- a/app/ui/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -1,6 +1,7 @@
 package com.fsck.k9.activity.compose;
 
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -194,6 +195,21 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
             case BCC: {
                 bccView.addRecipients(recipients);
                 break;
+            }
+        }
+    }
+
+    public void removeBccAddresses(Address[] addressesToRemove) {
+        if (addressesToRemove.length == 0) {
+            return;
+        }
+
+        List<Recipient> bccRecipients = new ArrayList<>(getBccRecipients());
+        for (Recipient recipient : bccRecipients) {
+            for (Address address : addressesToRemove) {
+                if (recipient.address.equals(address)) {
+                    bccView.removeObject(recipient);
+                }
             }
         }
     }

--- a/app/ui/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -78,6 +78,7 @@ public class RecipientPresenter {
     private final AutocryptDraftStateHeaderParser draftStateHeaderParser;
     private ReplyToParser replyToParser;
     private Account account;
+    private Address[] alwaysBccAddresses;
     private Boolean hasContactPicker;
     @Nullable
     private ComposeCryptoStatus cachedCryptoStatus;
@@ -287,14 +288,19 @@ public class RecipientPresenter {
     public void addBccAddresses(Address... bccRecipients) {
         if (bccRecipients.length > 0) {
             addRecipientsFromAddresses(RecipientType.BCC, bccRecipients);
-            String bccAddress = account.getAlwaysBcc();
-
-            // If the auto-bcc is the only entry in the BCC list, don't show the Bcc fields.
-            boolean alreadyVisible = recipientMvpView.isBccVisible();
-            boolean singleBccRecipientFromAccount =
-                    bccRecipients.length == 1 && bccRecipients[0].toString().equals(bccAddress);
-            recipientMvpView.setBccVisibility(alreadyVisible || !singleBccRecipientFromAccount);
+            recipientMvpView.setBccVisibility(true);
             updateRecipientExpanderVisibility();
+        }
+    }
+
+    public void addAlwaysBcc() {
+        alwaysBccAddresses = Address.parse(account.getAlwaysBcc());
+        addRecipientsFromAddresses(RecipientType.BCC, alwaysBccAddresses);
+    }
+
+    private void removeAlwaysBcc() {
+        if (alwaysBccAddresses != null) {
+            recipientMvpView.removeBccAddresses(alwaysBccAddresses);
         }
     }
 
@@ -338,6 +344,9 @@ public class RecipientPresenter {
             recipientMvpView.setBccVisibility(true);
             updateRecipientExpanderVisibility();
         }
+
+        removeAlwaysBcc();
+        addAlwaysBcc();
 
         String openPgpProvider = account.getOpenPgpProvider();
         recipientMvpView.setCryptoProvider(openPgpProvider);


### PR DESCRIPTION
Remove "Bcc all messages to" recipients from the old account and add those of the new account when switching accounts in the message compose screen.