### PR TITLE
Fix bug where EditText for message body wasn't growing properly

### DIFF
--- a/app/ui/src/main/res/layout/message_compose_content.xml
+++ b/app/ui/src/main/res/layout/message_compose_content.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <ScrollView
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:scrollbarStyle="insideOverlay"
@@ -58,7 +59,7 @@
             class="com.fsck.k9.ui.EolConvertingEditText"
             android:id="@+id/message_content"
             android:layout_width="fill_parent"
-            android:layout_height="0dp"
+            android:layout_height="wrap_content"
             android:layout_weight="1"
             android:gravity="top"
             android:hint="@string/message_compose_content_hint"
@@ -68,7 +69,7 @@
             android:paddingLeft="12dip"
             android:paddingRight="12dip"
             style="@style/ComposeEditTextLarge"
-            />
+            tools:ignore="InefficientWeight" />
 
         <view
             class="com.fsck.k9.ui.EolConvertingEditText"


### PR DESCRIPTION
This was introduced with PR #3589 which fixed a bunch of Lint warnings. This was despite us having a comment explaining why we do things in a way Lint flags as performance problem :disappointed: 

https://github.com/k9mail/k-9/blob/e4cc7b9a91b6ac5ed6ede396c490c6f3126dffcc/app/ui/src/main/res/layout/message_compose_content.xml#L55-L56

Hopefully, the `tools:ignore="InefficientWeight"` will help to not make the same mistake when someone decides to tackle Lint warnings in the future.

Fixes #4342