### PR TITLE
Add missing methods to AppCompatPreferenceActivity

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/AppCompatPreferenceActivity.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/AppCompatPreferenceActivity.java
@@ -15,11 +15,13 @@ package com.fsck.k9.activity;
  * limitations under the License.
  */
 
+import android.content.Context;
 import android.content.res.Configuration;
 import android.os.Bundle;
 import android.preference.PreferenceActivity;
 import androidx.annotation.LayoutRes;
 import androidx.annotation.Nullable;
+import androidx.annotation.StyleRes;
 import androidx.appcompat.app.ActionBar;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.appcompat.widget.Toolbar;
@@ -38,10 +40,21 @@ public abstract class AppCompatPreferenceActivity extends PreferenceActivity {
     private AppCompatDelegate mDelegate;
 
     @Override
+    protected void attachBaseContext(Context newBase) {
+        super.attachBaseContext(getDelegate().attachBaseContext2(newBase));
+    }
+
+    @Override
     protected void onCreate(Bundle savedInstanceState) {
         getDelegate().installViewFactory();
         getDelegate().onCreate(savedInstanceState);
         super.onCreate(savedInstanceState);
+    }
+
+    @Override
+    public void setTheme(@StyleRes final int resId) {
+        super.setTheme(resId);
+        getDelegate().setTheme(resId);
     }
 
     @Override


### PR DESCRIPTION
Manual theme overrides never really worked for sub classes of `AppCompatPreferenceActivity` because of the missing hook for `attachBaseContext()` :disappointed: 