### PR TITLE
Remove unused "Gestures" setting and unused code

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -220,8 +220,6 @@ object K9 : EarlyInit {
     @JvmStatic
     var isMessageViewShowNext = false
 
-    var isGesturesEnabled = true
-
     @JvmStatic
     var isUseVolumeKeysForNavigation = false
 
@@ -338,7 +336,6 @@ object K9 : EarlyInit {
         isDebugLoggingEnabled = storage.getBoolean("enableDebugLogging", DEVELOPER_MODE)
         isSensitiveDebugLoggingEnabled = storage.getBoolean("enableSensitiveLogging", false)
         isShowAnimations = storage.getBoolean("animations", true)
-        isGesturesEnabled = storage.getBoolean("gesturesEnabled", false)
         isUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false)
         isUseVolumeKeysForListNavigation = storage.getBoolean("useVolumeKeysForListNavigation", false)
         isHideSpecialAccounts = storage.getBoolean("hideSpecialAccounts", false)
@@ -416,7 +413,6 @@ object K9 : EarlyInit {
         editor.putBoolean("enableSensitiveLogging", isSensitiveDebugLoggingEnabled)
         editor.putEnum("backgroundOperations", backgroundOps)
         editor.putBoolean("animations", isShowAnimations)
-        editor.putBoolean("gesturesEnabled", isGesturesEnabled)
         editor.putBoolean("useVolumeKeysForNavigation", isUseVolumeKeysForNavigation)
         editor.putBoolean("useVolumeKeysForListNavigation", isUseVolumeKeysForListNavigation)
         editor.putBoolean("autofitWidth", isAutoFitWidth)

--- a/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GlobalSettings.java
@@ -128,10 +128,6 @@ public class GlobalSettings {
         s.put("fontSizeMessageViewTo", Settings.versions(
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
         ));
-        s.put("gesturesEnabled", Settings.versions(
-                new V(1, new BooleanSetting(true)),
-                new V(4, new BooleanSetting(false))
-        ));
         s.put("hideSpecialAccounts", Settings.versions(
                 new V(1, new BooleanSetting(false))
         ));

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 64;
+    public static final int VERSION = 65;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/ui/src/main/java/com/fsck/k9/activity/K9Activity.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/K9Activity.java
@@ -10,7 +10,6 @@ import androidx.core.app.ActivityCompat;
 import androidx.core.content.ContextCompat;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
-import android.view.MotionEvent;
 
 import android.view.View;
 import com.fsck.k9.ui.R;
@@ -41,12 +40,6 @@ public abstract class K9Activity extends AppCompatActivity {
     protected void onResume() {
         base.preOnResume();
         super.onResume();
-    }
-
-    @Override
-    public boolean dispatchTouchEvent(MotionEvent event) {
-        base.preDispatchTouchEvent(event);
-        return super.dispatchTouchEvent(event);
     }
 
     protected void setLayout(@LayoutRes int layoutResId) {

--- a/app/ui/src/main/java/com/fsck/k9/activity/K9ActivityCommon.kt
+++ b/app/ui/src/main/java/com/fsck/k9/activity/K9ActivityCommon.kt
@@ -3,8 +3,6 @@ package com.fsck.k9.activity
 import android.app.Activity
 import android.content.res.Resources
 import android.text.TextUtils
-import android.view.GestureDetector
-import android.view.MotionEvent
 import com.fsck.k9.K9
 import com.fsck.k9.ui.Theme
 import com.fsck.k9.ui.ThemeManager
@@ -21,7 +19,6 @@ class K9ActivityCommon(
     private val activity: Activity,
     private val themeType: ThemeType
 ) {
-    private var gestureDetector: GestureDetector? = null
     private lateinit var currentLanguage: String
     private lateinit var currentTheme: Theme
 
@@ -49,13 +46,6 @@ class K9ActivityCommon(
         if (currentLanguage != K9.k9Language) {
             activity.recreate()
         }
-    }
-
-    /**
-     * Call this before calling `super.dispatchTouchEvent(MotionEvent)`.
-     */
-    fun preDispatchTouchEvent(event: MotionEvent) {
-        gestureDetector?.onTouchEvent(event)
     }
 
     private fun setLanguage(language: String) {

--- a/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -16,7 +16,6 @@ import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
-import android.graphics.Rect;
 import android.os.Bundle;
 import android.os.Parcelable;
 import android.text.TextUtils;
@@ -24,7 +23,6 @@ import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
@@ -910,45 +908,6 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
     public void onSendPendingMessages() {
         messagingController.sendPendingMessages(account, null);
-    }
-
-    public void onSwipeRightToLeft(final MotionEvent e1, final MotionEvent e2) {
-        // Handle right-to-left as an un-select
-        handleSwipe(e1, false);
-    }
-
-    public void onSwipeLeftToRight(final MotionEvent e1, final MotionEvent e2) {
-        // Handle left-to-right as a select.
-        handleSwipe(e1, true);
-    }
-
-    /**
-     * Handle a select or unselect swipe event.
-     *
-     * @param downMotion
-     *         Event that started the swipe
-     * @param selected
-     *         {@code true} if this was an attempt to select (i.e. left to right).
-     */
-    private void handleSwipe(final MotionEvent downMotion, final boolean selected) {
-        int x = (int) downMotion.getRawX();
-        int y = (int) downMotion.getRawY();
-
-        Rect headerRect = new Rect();
-        listView.getGlobalVisibleRect(headerRect);
-
-        // Only handle swipes in the visible area of the message list
-        if (headerRect.contains(x, y)) {
-            int[] listPosition = new int[2];
-            listView.getLocationOnScreen(listPosition);
-
-            int listX = x - listPosition[0];
-            int listY = y - listPosition[1];
-
-            int listViewPosition = listView.pointToPosition(listX, listY);
-
-            toggleMessageSelect(listViewPosition);
-        }
     }
 
     private int listViewToAdapterPosition(int position) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -34,7 +34,6 @@ class GeneralSettingsDataStore(
             "threaded_view" -> K9.isThreadedViewEnabled
             "messageview_fixedwidth_font" -> K9.isUseMessageViewFixedWidthFont
             "messageview_autofit_width" -> K9.isAutoFitWidth
-            "gestures" -> K9.isGesturesEnabled
             "messageview_return_to_list" -> K9.isMessageViewReturnToList
             "messageview_show_next" -> K9.isMessageViewShowNext
             "quiet_time_enabled" -> K9.isQuietTimeEnabled
@@ -63,7 +62,6 @@ class GeneralSettingsDataStore(
             "threaded_view" -> K9.isThreadedViewEnabled = value
             "messageview_fixedwidth_font" -> K9.isUseMessageViewFixedWidthFont = value
             "messageview_autofit_width" -> K9.isAutoFitWidth = value
-            "gestures" -> K9.isGesturesEnabled = value
             "messageview_return_to_list" -> K9.isMessageViewReturnToList = value
             "messageview_show_next" -> K9.isMessageViewShowNext = value
             "quiet_time_enabled" -> K9.isQuietTimeEnabled = value

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -812,8 +812,6 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="animations_title">Animation</string>
     <string name="animations_summary">Use gaudy visual effects</string>
-    <string name="gestures_title">Gestures</string>
-    <string name="gestures_summary">Enable gesture control</string>
 
     <string name="volume_navigation_title">Volume key navigation</string>
     <string name="volume_navigation_message">In message views</string>

--- a/app/ui/src/main/res/xml/general_settings.xml
+++ b/app/ui/src/main/res/xml/general_settings.xml
@@ -360,11 +360,6 @@
         android:title="@string/interaction_preferences"
         search:ignore="true">
 
-        <CheckBoxPreference
-            android:key="gestures"
-            android:summary="@string/gestures_summary"
-            android:title="@string/gestures_title" />
-
         <MultiSelectListPreference
             android:dialogTitle="@string/volume_navigation_title"
             android:entries="@array/volume_navigation_entries"


### PR DESCRIPTION
This removes the code that was used for the "swipe to select" action. The functionality itself was disabled some time ago because the way it was implemented interferes with the code to open the drawer using a "bezel swipe".

Closes #3957

Note: We still plan to implement "swipe to action" (#1426). Selection will be possible using long-press (#4188) or tapping contact icons (#1391).