### PR TITLE
Stop using android.net.MailTo

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/helper/MailTo.java
+++ b/mail/common/src/main/java/com/fsck/k9/helper/MailTo.java
@@ -1,12 +1,12 @@
 package com.fsck.k9.helper;
 
 
-import java.util.ArrayList;
-import java.util.List;
-
 import android.net.Uri;
 
 import com.fsck.k9.mail.Address;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 public final class MailTo {

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/ListHeaders.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/ListHeaders.java
@@ -1,13 +1,14 @@
 package com.fsck.k9.mail.internet;
 
 
+import android.net.Uri;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import android.net.MailTo;
-
+import com.fsck.k9.helper.MailTo;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Message;
 
@@ -63,8 +64,8 @@ public class ListHeaders {
             return null;
         }
 
-        String mailToUri = matcher.group(1);
-        String emailAddress = MailTo.parse(mailToUri).getTo();
-        return new Address(emailAddress);
+        Uri mailToUri = Uri.parse(matcher.group(1));
+        Address[] emailAddress = MailTo.parse(mailToUri).getTo();
+        return emailAddress.length >= 1 ? emailAddress[0] : null;
     }
 }

--- a/mail/common/src/test/java/com/fsck/k9/helper/MailToTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/helper/MailToTest.java
@@ -1,18 +1,20 @@
 package com.fsck.k9.helper;
 
 
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
 import android.net.Uri;
 
-import com.fsck.k9.RobolectricTest;
 import com.fsck.k9.helper.MailTo.CaseInsensitiveParamWrapper;
 import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.K9LibRobolectricTestRunner;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -21,7 +23,8 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 
-public class MailToTest extends RobolectricTest {
+@RunWith(K9LibRobolectricTestRunner.class)
+public class MailToTest {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 


### PR DESCRIPTION
Use our own version of `MailTo` instead of `android.net.MailTo`.