### PR TITLE
Change appearance of attachment boxes in message compose screen

### DIFF
--- a/app/ui/build.gradle
+++ b/app/ui/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation "androidx.navigation:navigation-fragment-ktx:${versions.androidxNavigation}"
     implementation "androidx.navigation:navigation-ui-ktx:${versions.androidxNavigation}"
     implementation "androidx.constraintlayout:constraintlayout:${versions.androidxConstraintLayout}"
+    implementation "androidx.cardview:cardview:${versions.androidxCardView}"
     implementation "com.google.android.material:material:${versions.materialComponents}"
     implementation "de.cketti.library.changelog:ckchangelog:1.2.1"
     implementation "com.github.bumptech.glide:glide:3.6.1"

--- a/app/ui/src/main/res/drawable/ic_attachment_generic.xml
+++ b/app/ui/src/main/res/drawable/ic_attachment_generic.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M6,2c-1.1,0 -1.99,0.9 -1.99,2L4,20c0,1.1 0.89,2 1.99,2L18,22c1.1,0 2,-0.9 2,-2L20,8l-6,-6L6,2zM13,9L13,3.5L18.5,9L13,9z" />
+</vector>

--- a/app/ui/src/main/res/drawable/ic_attachment_image.xml
+++ b/app/ui/src/main/res/drawable/ic_attachment_image.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportHeight="24.0"
+    android:viewportWidth="24.0">
+    <path
+        android:fillColor="#000000"
+        android:pathData="M21,19V5c0,-1.1 -0.9,-2 -2,-2H5c-1.1,0 -2,0.9 -2,2v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2zM8.5,13.5l2.5,3.01L14.5,12l4.5,6H5l3.5,-4.5z" />
+</vector>

--- a/app/ui/src/main/res/layout/message_compose_attachment.xml
+++ b/app/ui/src/main/res/layout/message_compose_attachment.xml
@@ -1,55 +1,111 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="fill_parent"
-    android:layout_height="54dip"
-    android:paddingRight="6dip"
-    android:paddingTop="6dip"
-    android:paddingBottom="6dip">
+<androidx.cardview.widget.CardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="300dp"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="12dp"
+    android:layout_marginEnd="12dp"
+    android:layout_marginBottom="12dp"
+    android:orientation="vertical"
+    app:cardBackgroundColor="?attr/attachmentCardBackground"
+    app:cardCornerRadius="2dp"
+    app:cardElevation="1dp">
 
-    <ImageButton
-        android:id="@+id/attachment_delete"
-        android:src="@drawable/ic_delete"
-        android:layout_alignParentRight="true"
-        android:layout_height="42dip"
-        android:layout_width="42dip" />
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
 
-    <LinearLayout
-        android:layout_width="1dip"
-        android:layout_height="42dip"
-        android:layout_alignParentLeft="true"
-        android:layout_toLeftOf="@id/attachment_delete"
-        android:layout_marginLeft="6dip"
-        android:layout_marginRight="4dip"
-        android:paddingLeft="36dip"
-        android:gravity="center_vertical"
-        android:background="?attr/messageViewAttachmentBackground"
-        android:orientation="horizontal">
+        <ImageView
+            android:id="@+id/attachment_preview"
+            android:layout_width="match_parent"
+            android:layout_height="150dp"
+            android:background="?android:attr/windowBackground"
+            android:contentDescription="@null"
+            android:visibility="gone"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            tools:visibility="visible" />
+
+        <ImageView
+            android:id="@+id/attachment_type"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:contentDescription="@null"
+            android:src="@drawable/ic_attachment_generic"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/attachment_preview"
+            app:tint="?attr/colorAccent" />
 
         <TextView
             android:id="@+id/attachment_name"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1"
-            android:textAppearance="?android:attr/textAppearanceMedium"
-            android:textColor="?android:attr/textColorSecondary"
+            android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
+            android:ellipsize="start"
             android:singleLine="true"
-            android:ellipsize="start"/>
+            android:textColor="?android:attr/textColorPrimary"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toTopOf="@+id/attachment_size"
+            app:layout_constraintEnd_toStartOf="@id/barrier_button"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toEndOf="@+id/attachment_type"
+            app:layout_constraintTop_toBottomOf="@+id/attachment_preview"
+            app:layout_constraintVertical_chainStyle="packed"
+            tools:text="filename.ext" />
+
+        <TextView
+            android:id="@+id/attachment_size"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginBottom="8dp"
+            android:singleLine="true"
+            android:textColor="?android:attr/textColorSecondary"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/barrier_button"
+            app:layout_constraintHorizontal_bias="0.0"
+            app:layout_constraintStart_toStartOf="@+id/attachment_name"
+            app:layout_constraintTop_toBottomOf="@+id/attachment_name"
+            app:layout_constraintVertical_bias="0.0"
+            tools:text="99 KB" />
+
+        <androidx.constraintlayout.widget.Barrier
+            android:id="@+id/barrier_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            app:barrierDirection="left" />
 
         <ProgressBar
             android:id="@+id/progressBar"
             style="?android:attr/progressBarStyleSmall"
             android:layout_width="32dp"
-            android:layout_height="fill_parent"
-            android:layout_marginLeft="4dp"/>
+            android:layout_height="32dp"
+            android:layout_marginStart="8dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toStartOf="@+id/attachment_delete"
+            app:layout_constraintStart_toEndOf="@id/barrier_button"
+            app:layout_constraintTop_toBottomOf="@+id/attachment_preview" />
 
-    </LinearLayout>
+        <ImageButton
+            android:id="@+id/attachment_delete"
+            android:layout_width="42dp"
+            android:layout_height="42dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/remove_attachment_action"
+            android:src="?attr/iconActionCancel"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/attachment_preview" />
 
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:src="@drawable/ic_email_attachment"
-        android:layout_marginLeft="1dip"
-        android:layout_centerVertical="true" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-</RelativeLayout>
+</androidx.cardview.widget.CardView>

--- a/app/ui/src/main/res/layout/message_compose_content.xml
+++ b/app/ui/src/main/res/layout/message_compose_content.xml
@@ -43,16 +43,6 @@
             android:layout_height="1dp"
             android:background="?android:attr/listDivider" />
 
-        <!--
-            Empty container for storing attachments. We'll stick
-            instances of message_compose_attachment.xml in here.
-        -->
-        <LinearLayout
-            android:id="@+id/attachments"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical" />
-
         <!-- We have to use "wrap_content" (not "0dip") for "layout_height", otherwise the
              EditText won't properly grow in height while the user is typing the message -->
         <view
@@ -148,6 +138,18 @@
             android:hint="@string/message_compose_signature_hint"
             android:inputType="textMultiLine|textAutoCorrect|textCapSentences"
             android:textAppearance="?android:attr/textAppearanceMedium" />
+
+        <!--
+            Empty container for storing attachments. We'll stick
+            instances of message_compose_attachment.xml in here.
+        -->
+        <LinearLayout
+            android:id="@+id/attachments"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="8dp"
+            android:orientation="vertical" />
 
     </LinearLayout>
 

--- a/app/ui/src/main/res/values/attrs.xml
+++ b/app/ui/src/main/res/values/attrs.xml
@@ -86,6 +86,7 @@
         <attr name="messageViewBackgroundColor" format="reference|color"/>
         <attr name="messageViewAttachmentBackground" format="reference"/>
         <attr name="messageComposeAddContactImage" format="reference"/>
+        <attr name="attachmentCardBackground" format="reference|color"/>
         <attr name="composerBackgroundColor" format="color"/>
         <attr name="contactPictureFallbackDefaultBackgroundColor" format="reference|color"/>
         <attr name="contactTokenBackgroundColor" format="reference|color"/>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -250,6 +250,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="message_compose_show_quoted_text_action">Include quoted message</string>
     <string name="message_compose_description_delete_quoted_text">Remove quoted text</string>
     <string name="message_compose_description_edit_quoted_text">Edit quoted text</string>
+    <string name="remove_attachment_action">Remove attachment</string>
 
     <string name="message_view_from_format">From: <xliff:g id="name">%s</xliff:g> &lt;<xliff:g id="email">%s</xliff:g>&gt;</string>
     <string name="message_to_label">To:</string>

--- a/app/ui/src/main/res/values/themes.xml
+++ b/app/ui/src/main/res/values/themes.xml
@@ -111,6 +111,7 @@
         <item name="messageViewBackgroundColor">#ffffffff</item>
         <item name="messageViewAttachmentBackground">@drawable/attachment_text_box_light</item>
         <item name="messageComposeAddContactImage">@drawable/ic_person_plus_light</item>
+        <item name="attachmentCardBackground">#e8e8e8</item>
         <item name="contactPictureFallbackDefaultBackgroundColor">#ffababab</item>
         <item name="contactTokenBackgroundColor">#ccc</item>
         <item name="composerBackgroundColor">@android:color/background_light</item>
@@ -233,6 +234,7 @@
         <item name="messageViewBackgroundColor">#000000</item>
         <item name="messageViewAttachmentBackground">@drawable/attachment_text_box_dark</item>
         <item name="messageComposeAddContactImage">@drawable/ic_person_plus_dark</item>
+        <item name="attachmentCardBackground">#313131</item>
         <item name="contactTokenBackgroundColor">#313131</item>
         <item name="contactPictureFallbackDefaultBackgroundColor">#ff606060</item>
         <item name="composerBackgroundColor">@android:color/background_dark</item>

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
                 'androidxFragment': '1.2.1',
                 'androidxLocalBroadcastManager': '1.0.0',
                 'androidxCore': '1.2.0',
+                'androidxCardView': '1.0.0',
                 'materialComponents': '1.1.0',
                 'preferencesFix': '1.1.0',
                 'okio': '2.4.3',

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
@@ -1131,4 +1131,9 @@ public class MimeUtility {
     public static boolean isSameMimeType(String mimeType, String otherMimeType) {
         return mimeType != null && mimeType.equalsIgnoreCase(otherMimeType);
     }
+
+    public static boolean isSupportedImageType(String mimeType) {
+        return isSameMimeType(mimeType, "image/jpeg") || isSameMimeType(mimeType, "image/png") ||
+                isSameMimeType(mimeType, "image/gif") || isSameMimeType(mimeType, "image/webp");
+    }
 }


### PR DESCRIPTION
Image attachments now show a preview.

<img src="https://user-images.githubusercontent.com/218061/78465044-0fa6b180-76f1-11ea-8ce5-73d57f7ef3e5.png" alt="k9mail__message_compose__image_attachment" width="300">

