### PR TITLE
 Make "manage folders" screens use database ID to refer to folders

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepositoryManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepositoryManager.kt
@@ -1,10 +1,11 @@
 package com.fsck.k9.mailstore
 
 import com.fsck.k9.Account
+import com.fsck.k9.Preferences
 
 class FolderRepositoryManager(
     private val localStoreProvider: LocalStoreProvider,
-    private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy
+    private val preferences: Preferences
 ) {
-    fun getFolderRepository(account: Account) = FolderRepository(localStoreProvider, account)
+    fun getFolderRepository(account: Account) = FolderRepository(localStoreProvider, preferences, account)
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -376,6 +376,10 @@ public class LocalStore {
         return new LocalFolder(this, serverId);
     }
 
+    public LocalFolder getFolder(long folderId) {
+        return new LocalFolder(this, folderId);
+    }
+
     public LocalFolder getFolder(String serverId, String name, FolderType type) {
         return new LocalFolder(this, serverId, name, type);
     }

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderListItem.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderListItem.kt
@@ -8,12 +8,11 @@ import com.fsck.k9.ui.R
 import com.mikepenz.fastadapter.items.AbstractItem
 
 class FolderListItem(
-    override var identifier: Long,
+    val folderId: Long,
     private val folderIconResource: Int,
-    val displayName: String,
-    val serverId: String
+    val displayName: String
 ) : AbstractItem<FolderListViewHolder>() {
-
+    override var identifier: Long = folderId
     override val layoutRes = R.layout.folder_list_item
     override val type: Int = 1
 

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
@@ -25,10 +25,9 @@ class FolderSettingsFragment : PreferenceFragmentCompat() {
 
         val arguments = arguments ?: error("Arguments missing")
         val accountUuid = arguments.getString(EXTRA_ACCOUNT) ?: error("Missing argument '$EXTRA_ACCOUNT'")
-        val folderServerId = arguments.getString(EXTRA_FOLDER_SERVER_ID)
-            ?: error("Missing argument '$EXTRA_FOLDER_SERVER_ID'")
+        val folderId = arguments.getLong(EXTRA_FOLDER_ID)
 
-        viewModel.getFolderSettingsLiveData(accountUuid, folderServerId)
+        viewModel.getFolderSettingsLiveData(accountUuid, folderId)
             .observeNotNull(viewLifecycleOwner) { folderSettings ->
                 preferenceManager.preferenceDataStore = folderSettings.dataStore
                 setPreferencesFromResource(R.xml.folder_settings_preferences, null)
@@ -44,7 +43,7 @@ class FolderSettingsFragment : PreferenceFragmentCompat() {
 
     companion object {
         const val EXTRA_ACCOUNT = "account"
-        const val EXTRA_FOLDER_SERVER_ID = "folderServerId"
+        const val EXTRA_FOLDER_ID = "folderId"
 
         private const val PREFERENCE_TOP_CATEGORY = "folder_settings"
     }

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
@@ -2,6 +2,7 @@ package com.fsck.k9.ui.managefolders
 
 import android.os.Bundle
 import android.view.View
+import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.folders.FolderNameFormatter
@@ -28,12 +29,23 @@ class FolderSettingsFragment : PreferenceFragmentCompat() {
         val folderId = arguments.getLong(EXTRA_FOLDER_ID)
 
         viewModel.getFolderSettingsLiveData(accountUuid, folderId)
-            .observeNotNull(viewLifecycleOwner) { folderSettings ->
-                preferenceManager.preferenceDataStore = folderSettings.dataStore
-                setPreferencesFromResource(R.xml.folder_settings_preferences, null)
-
-                setCategoryTitle(folderSettings)
+            .observeNotNull(viewLifecycleOwner) { folderSettingsResult ->
+                when (folderSettingsResult) {
+                    is FolderNotFound -> navigateBack()
+                    is FolderSettingsData -> initPreferences(folderSettingsResult)
+                }
             }
+    }
+
+    private fun navigateBack() {
+        findNavController().popBackStack()
+    }
+
+    private fun initPreferences(folderSettings: FolderSettingsData) {
+        preferenceManager.preferenceDataStore = folderSettings.dataStore
+        setPreferencesFromResource(R.xml.folder_settings_preferences, null)
+
+        setCategoryTitle(folderSettings)
     }
 
     private fun setCategoryTitle(folderSettings: FolderSettingsData) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/KoinModule.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/KoinModule.kt
@@ -5,5 +5,5 @@ import org.koin.dsl.module
 
 val manageFoldersUiModule = module {
     viewModel { ManageFoldersViewModel(foldersLiveDataFactory = get()) }
-    viewModel { FolderSettingsViewModel(preferences = get(), localStoreProvider = get()) }
+    viewModel { FolderSettingsViewModel(preferences = get(), folderRepositoryManager = get()) }
 }

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
@@ -65,7 +65,7 @@ class ManageFoldersFragment : Fragment() {
         val folderListAdapter = FastAdapter.with(itemAdapter).apply {
             setHasStableIds(true)
             onClickListener = { _, _, item: FolderListItem, _ ->
-                openFolderSettings(item.serverId)
+                openFolderSettings(item.folderId)
                 true
             }
         }
@@ -79,18 +79,17 @@ class ManageFoldersFragment : Fragment() {
             val databaseId = displayFolder.folder.id
             val folderIconResource = folderIconProvider.getFolderIcon(displayFolder.folder.type)
             val displayName = folderNameFormatter.displayName(displayFolder.folder)
-            val serverId = displayFolder.folder.serverId
 
-            FolderListItem(databaseId, folderIconResource, displayName, serverId)
+            FolderListItem(databaseId, folderIconResource, displayName)
         }
 
         itemAdapter.set(folderListItems)
     }
 
-    private fun openFolderSettings(folderServerId: String) {
+    private fun openFolderSettings(folderId: Long) {
         val folderSettingsArguments = bundleOf(
             FolderSettingsFragment.EXTRA_ACCOUNT to account.uuid,
-            FolderSettingsFragment.EXTRA_FOLDER_SERVER_ID to folderServerId
+            FolderSettingsFragment.EXTRA_FOLDER_ID to folderId
         )
         findNavController().navigate(R.id.action_manageFoldersScreen_to_folderSettingsScreen, folderSettingsArguments)
     }


### PR DESCRIPTION
First step towards using folder database ID instead of folder server ID to refer to a folder in UI code.

See #3220