### PR TITLE
compare flag in MessageReference equals method

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessageReference.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessageReference.java
@@ -82,11 +82,21 @@ public class MessageReference {
             return false;
         }
         MessageReference other = (MessageReference) o;
-        return equals(other.accountUuid, other.folderServerId, other.uid);
+        return equals(other.accountUuid, other.folderServerId, other.uid, other.flag);
     }
 
     public boolean equals(String accountUuid, String folderServerId, String uid) {
         return this.accountUuid.equals(accountUuid) && this.folderServerId.equals(folderServerId) && this.uid.equals(uid);
+    }
+
+    public boolean equals(String accountUuid, String folderServerId, String uid, Flag flag) {
+        if (this.flag == null && flag == null) {
+            return equals(accountUuid, folderServerId, uid);
+        } else if (this.flag == null || flag == null) {
+            return false;
+        } else {
+            return this.accountUuid.equals(accountUuid) && this.folderServerId.equals(folderServerId) && this.uid.equals(uid) && this.flag.equals(flag);
+        }
     }
 
     @Override

--- a/app/core/src/test/java/com/fsck/k9/controller/MessageReferenceTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessageReferenceTest.java
@@ -122,9 +122,24 @@ public class MessageReferenceTest {
     }
 
     @Test
+    public void equalsWithSameMessageReferenceWithFlagShouldReturnTrue() {
+        MessageReference messageReference = createMessageReferenceWithFlag("account", "folder", "uid", Flag.ANSWERED);
+
+        assertTrue(messageReference.equals(messageReference));
+    }
+
+    @Test
     public void equalsWithMessageReferenceContainingSameDataShouldReturnTrue() {
         MessageReference messageReferenceOne = createMessageReference("account", "folder", "uid");
         MessageReference messageReferenceTwo = createMessageReference("account", "folder", "uid");
+
+        assertEqualsReturnsTrueSymmetrically(messageReferenceOne, messageReferenceTwo);
+    }
+
+    @Test
+    public void equalsWithMessageReferenceWithFlagContainingSameDataShouldReturnTrue() {
+        MessageReference messageReferenceOne = createMessageReferenceWithFlag("account", "folder", "uid", Flag.ANSWERED);
+        MessageReference messageReferenceTwo = createMessageReferenceWithFlag("account", "folder", "uid", Flag.ANSWERED);
 
         assertEqualsReturnsTrueSymmetrically(messageReferenceOne, messageReferenceTwo);
     }
@@ -154,10 +169,27 @@ public class MessageReferenceTest {
     }
 
     @Test
+    public void equalsWithMessageReferenceContainingDifferentFlagShouldReturnFalse() {
+        MessageReference messageReferenceOne = createMessageReference("account", "folder", "uid");
+        MessageReference messageReferenceTwo = messageReferenceOne.withModifiedFlag(Flag.ANSWERED);
+
+        assertEqualsReturnsFalseSymmetrically(messageReferenceOne, messageReferenceTwo);
+    }
+
+    @Test
     public void alternativeEquals() {
         MessageReference messageReference = createMessageReference("account", "folder", "uid");
 
         boolean equalsResult = messageReference.equals("account", "folder", "uid");
+
+        assertTrue(equalsResult);
+    }
+
+    @Test
+    public void alternativeEqualsWithFlag() {
+        MessageReference messageReference = createMessageReferenceWithFlag("account", "folder", "uid", Flag.ANSWERED);
+
+        boolean equalsResult = messageReference.equals("account", "folder", "uid", Flag.ANSWERED);
 
         assertTrue(equalsResult);
     }
@@ -185,6 +217,15 @@ public class MessageReferenceTest {
         MessageReference messageReference = createMessageReference("account", "folder", "uid");
 
         boolean equalsResult = messageReference.equals("account", "folder", null);
+
+        assertFalse(equalsResult);
+    }
+
+    @Test
+    public void equals_withNullFlag_shouldReturnFalse() {
+        MessageReference messageReference = createMessageReferenceWithFlag("account", "folder", "uid", Flag.ANSWERED);
+
+        boolean equalsResult = messageReference.equals("account", "folder", "uid",null);
 
         assertFalse(equalsResult);
     }


### PR DESCRIPTION
Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
seems OK.
* Does not break any unit tests.
got 129 passed, but 4 ignored (?)
* Contains a reference to the issue that it fixes.
Fixing the issue https://github.com/k9mail/k-9/issues/4658


