### PR TITLE
Remove keyboard shortcuts for menu items

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -722,6 +722,10 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
      * @return {@code true} if this event was consumed.
      */
     public boolean onCustomKeyDown(final int keyCode, final KeyEvent event) {
+        if (!event.hasNoModifiers()) {
+            return false;
+        }
+
         switch (keyCode) {
             case KeyEvent.KEYCODE_VOLUME_UP: {
                 if (messageViewFragment != null && displayMode != DisplayMode.MESSAGE_LIST &&

--- a/app/ui/src/main/res/menu/manage_identities_option.xml
+++ b/app/ui/src/main/res/menu/manage_identities_option.xml
@@ -2,7 +2,6 @@
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item
         android:id="@+id/new_identity"
-        android:alphabeticShortcut="n"
         android:title="@string/new_identity_action"
         android:icon="?attr/iconActionAdd"
     />

--- a/app/ui/src/main/res/menu/message_compose_option.xml
+++ b/app/ui/src/main/res/menu/message_compose_option.xml
@@ -3,74 +3,62 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/add_attachment"
-        android:alphabeticShortcut="n"
         android:title="@string/add_attachment_action"
         android:icon="?attr/iconActionAddAttachment"
         app:showAsAction="always"
     />
     <item
         android:id="@+id/send"
-        android:alphabeticShortcut="s"
         android:title="@string/send_action"
         android:icon="?attr/iconActionSend"
         app:showAsAction="always"
     />
     <item
         android:id="@+id/add_from_contacts"
-        android:alphabeticShortcut="a"
         android:title="@string/add_from_contacts"
     />
     <item
         android:id="@+id/save"
-        android:alphabeticShortcut="d"
         android:title="@string/save_draft_action"
         android:icon="?attr/iconActionSave"
         />
     <item
         android:id="@+id/discard"
-        android:alphabeticShortcut="q"
         android:title="@string/discard_action"
         android:icon="?attr/iconActionCancel"
     />
     <item
         android:id="@+id/read_receipt"
-        android:alphabeticShortcut="r"
         android:title="@string/read_receipt"
         android:icon="?attr/iconActionRequestReadReceipt"
     />
     <item
         android:id="@+id/openpgp_encrypt_enable"
-        android:alphabeticShortcut="c"
         android:title="@string/enable_encryption"
         app:showAsAction="never"
         />
     <item
         android:id="@+id/openpgp_encrypt_disable"
-        android:alphabeticShortcut="c"
         android:title="@string/disable_encryption"
         app:showAsAction="never"
         />
     <item
         android:id="@+id/openpgp_sign_only"
-        android:alphabeticShortcut="g"
         android:title="@string/enable_sign_only"
         app:showAsAction="never"
         />
     <item
         android:id="@+id/openpgp_sign_only_disable"
-        android:alphabeticShortcut="g"
         android:title="@string/disable_sign_only"
         app:showAsAction="never"
         />
     <item
         android:id="@+id/openpgp_inline_enable"
-        android:alphabeticShortcut="i"
         android:title="@string/enable_inline_pgp"
         app:showAsAction="never"
         />
     <item
         android:id="@+id/openpgp_inline_disable"
-        android:alphabeticShortcut="i"
         android:title="@string/disable_inline_pgp"
         app:showAsAction="never"
         />

--- a/app/ui/src/main/res/menu/message_list_option.xml
+++ b/app/ui/src/main/res/menu/message_list_option.xml
@@ -36,7 +36,6 @@
     <!-- MessageView -->
     <item
         android:id="@+id/delete"
-        android:alphabeticShortcut="q"
         android:icon="?attr/iconActionDelete"
         app:showAsAction="always"
         android:title="@string/delete_action"/>
@@ -45,7 +44,6 @@
     <item
         android:id="@+id/toggle_unread"
         android:icon="?attr/iconActionMarkAsUnread"
-        android:alphabeticShortcut="u"
         app:showAsAction="always"
         android:title="@string/mark_as_unread_action"/>
 
@@ -152,7 +150,6 @@
     <!-- always -->
     <item
         android:id="@+id/compose"
-        android:alphabeticShortcut="c"
         android:icon="?attr/iconActionCompose"
         app:showAsAction="ifRoom"
         android:title="@string/compose_action"/>
@@ -204,7 +201,6 @@
     <!-- MessageList -->
     <item
         android:id="@+id/send_messages"
-        android:alphabeticShortcut="r"
         android:icon="?attr/iconActionUpload"
         app:showAsAction="never"
         android:title="@string/send_messages_action"/>
@@ -212,7 +208,6 @@
     <!-- MessageList -->
     <item
         android:id="@+id/empty_trash"
-        android:alphabeticShortcut="e"
         android:title="@string/empty_trash_action"
         app:showAsAction="never" />
 


### PR DESCRIPTION
Some devices use the CTRL key with the `alphabeticShortcut` value to enable keyboard shortcuts for menu items. In some cases this collides with useful system shortcuts like CTRL+C, CTRL+A etc.

Additionally, the keyboard shortcuts in the message list/view screen now only work when no modifier key (e.g. CTRL) is pressed.

Fixes #3057