### PR TITLE
Restore 'Clear mailbox messages' functionality

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -323,7 +323,7 @@ public class LocalStore {
 
                 // Don't delete deleted messages. They are essentially placeholders for UIDs of messages that have
                 // been deleted locally.
-                db.delete("messages", "deleted = 0", null);
+                db.delete("messages", null, null);
 
                 // We don't need the search data now either
                 db.delete("messages_fulltext", null, null);

--- a/app/k9mail-jmap/src/main/AndroidManifest.xml
+++ b/app/k9mail-jmap/src/main/AndroidManifest.xml
@@ -268,6 +268,10 @@
             android:name="com.fsck.k9.account.AccountRemoverService"
             android:permission="android.permission.BIND_JOB_SERVICE"/>
 
+        <service
+            android:name="com.fsck.k9.account.AccountCleanerService"
+            android:permission="android.permission.BIND_JOB_SERVICE"/>
+
         <provider
             android:name="com.fsck.k9.provider.AttachmentProvider"
             android:authorities="${applicationId}.attachmentprovider"

--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -359,6 +359,10 @@
             android:name="com.fsck.k9.account.AccountRemoverService"
             android:permission="android.permission.BIND_JOB_SERVICE"/>
 
+        <service
+            android:name="com.fsck.k9.account.AccountCleanerService"
+            android:permission="android.permission.BIND_JOB_SERVICE"/>
+
         <provider
             android:name=".provider.AttachmentProvider"
             android:authorities="${applicationId}.attachmentprovider"

--- a/app/ui/src/main/java/com/fsck/k9/account/AccountCleaner.kt
+++ b/app/ui/src/main/java/com/fsck/k9/account/AccountCleaner.kt
@@ -1,0 +1,39 @@
+package com.fsck.k9.account
+
+import com.fsck.k9.Core
+import com.fsck.k9.Preferences
+import com.fsck.k9.mailstore.LocalStoreProvider
+import com.fsck.k9.controller.MessagingController
+import timber.log.Timber
+
+/**
+ * Cleans an account and all associated data.
+ */
+class AccountCleaner(
+    private val messagingController: MessagingController,
+    private val preferences: Preferences
+) {
+
+    fun clearAccount(accountUuid: String) {
+        val account = preferences.getAccount(accountUuid)
+        if (account == null) {
+            Timber.w("Can't clean account with UUID %s because it doesn't exist.", accountUuid)
+            return
+        }
+
+        val accountName = account.description
+        Timber.v("Cleaning account '%s'…", accountName)
+
+        try {
+            messagingController.clear(account, null)
+        } catch (e: Exception) {
+            Timber.w(e, "Error cleaning message database for account '%s'", accountName)
+
+            // Ignore, this may lead to localStores on sd-cards that are currently not inserted to be left
+        }
+
+        Core.setServicesEnabled()
+
+        Timber.v("Finished cleaning account '%s'.", accountName)
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/account/AccountCleanerService.kt
+++ b/app/ui/src/main/java/com/fsck/k9/account/AccountCleanerService.kt
@@ -1,0 +1,34 @@
+package com.fsck.k9.account
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.JobIntentService
+import org.koin.core.KoinComponent
+import org.koin.core.inject
+
+/**
+ * A [JobIntentService] to clean an account in the background.
+ */
+class AccountCleanerService : JobIntentService(), KoinComponent {
+    private val accountCleaner: AccountCleaner by inject()
+
+    override fun onHandleWork(intent: Intent) {
+        val accountUuid = intent.getStringExtra(ARG_ACCOUNT_UUID)
+                ?: throw IllegalArgumentException("No account UUID provided")
+
+        accountCleaner.clearAccount(accountUuid)
+    }
+
+    companion object {
+        private const val JOB_ID = 1
+        private const val ARG_ACCOUNT_UUID = "accountUuid"
+
+        fun enqueueClearAccountJob(context: Context, accountUuid: String) {
+            val workIntent = Intent().apply {
+                putExtra(ARG_ACCOUNT_UUID, accountUuid)
+            }
+
+            JobIntentService.enqueueWork(context, AccountCleanerService::class.java, JOB_ID, workIntent)
+        }
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/account/BackgroundAccountCleaner.kt
+++ b/app/ui/src/main/java/com/fsck/k9/account/BackgroundAccountCleaner.kt
@@ -1,0 +1,12 @@
+package com.fsck.k9.account
+
+import android.content.Context
+
+/**
+ * Triggers asynchronous cleanup of an account.
+ */
+class BackgroundAccountCleaner(private val context: Context) {
+    fun clearAccountAsync(accountUuid: String) {
+        AccountCleanerService.enqueueClearAccountJob(context, accountUuid)
+    }
+}

--- a/app/ui/src/main/java/com/fsck/k9/account/KoinModule.kt
+++ b/app/ui/src/main/java/com/fsck/k9/account/KoinModule.kt
@@ -6,4 +6,6 @@ val accountModule = module {
     factory { AccountRemover(get(), get(), get()) }
     factory { BackgroundAccountRemover(get()) }
     factory { AccountCreator(get(), get()) }
+    factory { AccountCleaner(get(), get()) }
+    factory { BackgroundAccountCleaner(get()) }
 }

--- a/app/ui/src/main/res/values-bg/strings.xml
+++ b/app/ui/src/main/res/values-bg/strings.xml
@@ -108,6 +108,7 @@ K-9 Mail е мощен, безплатен имейл клиент за Андр
   <string name="folders_action">Управление на папки</string>
   <string name="account_settings_action">Настройки на профила</string>
   <string name="remove_account_action">Премахни профила</string>
+  <string name="account_settings_clear_account_action">Изтрий всички съобщения (опасно!)</string>
   <string name="mark_as_read_action">Маркирай като прочетено</string>
   <string name="send_alternate_action">Сподели</string>
   <string name="send_alternate_chooser_title">Избери изпращащ</string>

--- a/app/ui/src/main/res/values-br/strings.xml
+++ b/app/ui/src/main/res/values-br/strings.xml
@@ -108,6 +108,7 @@ Danevellit beugoù, kenlabourit war keweriusterioù nevez ha savit goulennoù wa
   <string name="folders_action">Merañ an teuliadoù</string>
   <string name="account_settings_action">Arventennoù ar gont</string>
   <string name="remove_account_action">Dilemel ar gont</string>
+  <string name="account_settings_clear_account_action">Skarzhañ ar c’hemennadennoù (arvarus!)</string>
   <string name="mark_as_read_action">Merkañ evel lennet</string>
   <string name="send_alternate_action">Rannañ</string>
   <string name="send_alternate_chooser_title">Dibab ar c’haser</string>

--- a/app/ui/src/main/res/values-ca/strings.xml
+++ b/app/ui/src/main/res/values-ca/strings.xml
@@ -109,6 +109,7 @@ Si us plau, envieu informes d\'errors, contribuïu-hi amb noves millores i feu p
   <string name="folders_action">Gestioneu les carpetes</string>
   <string name="account_settings_action">Configuració del compte</string>
   <string name="remove_account_action">Elimina el compte</string>
+  <string name="account_settings_clear_account_action">Neteja els missatges (Compte!)</string>
   <string name="mark_as_read_action">Marca com a llegit</string>
   <string name="send_alternate_action">Comparteix</string>
   <string name="send_alternate_chooser_title">Selecciona remitent</string>

--- a/app/ui/src/main/res/values-cs/strings.xml
+++ b/app/ui/src/main/res/values-cs/strings.xml
@@ -108,6 +108,7 @@ Hlášení o chyb, úpravy pro nové funkce a dotazy zadávejte prostřednictví
   <string name="folders_action">Spravovat složky</string>
   <string name="account_settings_action">Nastavení účtu</string>
   <string name="remove_account_action">Odstranit účet</string>
+  <string name="account_settings_clear_account_action">Vyčistit zprávy (nebezpečné!)</string>
   <string name="mark_as_read_action">Označit jako přečtené</string>
   <string name="send_alternate_action">Sdílet</string>
   <string name="send_alternate_chooser_title">Vybrat odesílatele</string>

--- a/app/ui/src/main/res/values-cy/strings.xml
+++ b/app/ui/src/main/res/values-cy/strings.xml
@@ -109,6 +109,7 @@ Plîs rho wybod am unrhyw wallau, syniadau am nodweddion newydd, neu ofyn cwesti
   <string name="folders_action">Rheoli ffolderi</string>
   <string name="account_settings_action">Gosodiadau cyfrif</string>
   <string name="remove_account_action">Tynnu\'r cyfrif</string>
+  <string name="account_settings_clear_account_action">Clirio negeseuon (pergyl!)</string>
   <string name="mark_as_read_action">Nodi wedi eu darllen</string>
   <string name="send_alternate_action">Rhannu</string>
   <string name="send_alternate_chooser_title">Dewis anfonwr</string>

--- a/app/ui/src/main/res/values-da/strings.xml
+++ b/app/ui/src/main/res/values-da/strings.xml
@@ -108,6 +108,7 @@ Rapporter venligst fejl, forslag til nye funktioner eller stil spørgsmål på:
   <string name="folders_action">Håndtere mapper</string>
   <string name="account_settings_action">Konto opsætning</string>
   <string name="remove_account_action">Slet konto</string>
+  <string name="account_settings_clear_account_action">Ryd mails (farligt!)</string>
   <string name="mark_as_read_action">Marker som læst</string>
   <string name="send_alternate_action">Del</string>
   <string name="send_alternate_chooser_title">Vælg afsender</string>

--- a/app/ui/src/main/res/values-de/strings.xml
+++ b/app/ui/src/main/res/values-de/strings.xml
@@ -110,6 +110,7 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="folders_action">Ordner verwalten</string>
   <string name="account_settings_action">Kontoeinstellungen</string>
   <string name="remove_account_action">Konto entfernen</string>
+  <string name="account_settings_clear_account_action">Alle Daten löschen (Vorsicht!)</string>
   <string name="mark_as_read_action">Als gelesen markieren</string>
   <string name="send_alternate_action">Teilen</string>
   <string name="send_alternate_chooser_title">Absender auswählen</string>

--- a/app/ui/src/main/res/values-el/strings.xml
+++ b/app/ui/src/main/res/values-el/strings.xml
@@ -100,6 +100,7 @@
   <string name="preferences_action">Ρυθμίσεις</string>
   <string name="account_settings_action">Ρυθμίσεις λογαριασμού</string>
   <string name="remove_account_action">Διαγραφή λογαριασμού</string>
+  <string name="account_settings_clear_account_action">Καθαρισμός μηνυμάτων (Κίνδυνος!)</string>
   <string name="mark_as_read_action">Σήμανση ως αναγνωσμένου</string>
   <string name="send_alternate_action">Διανομή</string>
   <string name="send_alternate_chooser_title">Επιλογή αποστολέα</string>

--- a/app/ui/src/main/res/values-eo/strings.xml
+++ b/app/ui/src/main/res/values-eo/strings.xml
@@ -108,6 +108,7 @@ Bonvolu raporti erarojn, kontribui novajn eblojn kaj peti pri novaj funkcioj per
   <string name="folders_action">Administri mesaĝujojn</string>
   <string name="account_settings_action">Agordoj de konto</string>
   <string name="remove_account_action">Forigi konton</string>
+  <string name="account_settings_clear_account_action">Forigi ĉiujn mesaĝojn (danĝere!)</string>
   <string name="mark_as_read_action">Marki kiel legitan</string>
   <string name="send_alternate_action">Kunhavigi</string>
   <string name="send_alternate_chooser_title">Elekti sendanton</string>

--- a/app/ui/src/main/res/values-es/strings.xml
+++ b/app/ui/src/main/res/values-es/strings.xml
@@ -108,6 +108,7 @@ Por favor informe de fallos, aporte nueva funcionalidad o envíe sus preguntas a
   <string name="folders_action">Administrar carpetas</string>
   <string name="account_settings_action">Configuración de cuenta</string>
   <string name="remove_account_action">Eliminar cuenta</string>
+  <string name="account_settings_clear_account_action">Limpiar mensajes (¡peligroso!)</string>
   <string name="mark_as_read_action">Marcar como leído</string>
   <string name="send_alternate_action">Compartir</string>
   <string name="send_alternate_chooser_title">Seleccionar remitente</string>

--- a/app/ui/src/main/res/values-et/strings.xml
+++ b/app/ui/src/main/res/values-et/strings.xml
@@ -79,6 +79,7 @@
   <string name="folders_action">Halda kaustu</string>
   <string name="account_settings_action">Konto sätted</string>
   <string name="remove_account_action">Eemalda konto</string>
+  <string name="account_settings_clear_account_action">Kustuta kirjad (ohtlik!)</string>
   <string name="mark_as_read_action">Märgi loetuks</string>
   <string name="send_alternate_action">Jaga</string>
   <string name="send_alternate_chooser_title">Vali saatja</string>

--- a/app/ui/src/main/res/values-eu/strings.xml
+++ b/app/ui/src/main/res/values-eu/strings.xml
@@ -108,6 +108,7 @@ Mesedez akatsen berri emateko, ezaugarri berriak gehitzeko eta galderak egiteko
   <string name="folders_action">Kudeatu karpetak</string>
   <string name="account_settings_action">Kontu ezarpenak</string>
   <string name="remove_account_action">Kendu kontua</string>
+  <string name="account_settings_clear_account_action">Mezuak garbitu (kontuz!)</string>
   <string name="mark_as_read_action">Markatu irakurritako gisa</string>
   <string name="send_alternate_action">Partekatu</string>
   <string name="send_alternate_chooser_title">Aukeratu bidaltzailea</string>

--- a/app/ui/src/main/res/values-fa/strings.xml
+++ b/app/ui/src/main/res/values-fa/strings.xml
@@ -109,6 +109,7 @@
   <string name="folders_action">مدیریت پوشه‌ها</string>
   <string name="account_settings_action">تنظیمات حساب</string>
   <string name="remove_account_action">حذف حساب</string>
+  <string name="account_settings_clear_account_action">پاک کردن پیام ها (خطر)</string>
   <string name="mark_as_read_action">خوانده شد</string>
   <string name="send_alternate_action">اشتراک‌گذاری</string>
   <string name="send_alternate_chooser_title">انتخاب فرستنده</string>

--- a/app/ui/src/main/res/values-fi/strings.xml
+++ b/app/ui/src/main/res/values-fi/strings.xml
@@ -109,6 +109,7 @@ Ilmoita virheistä, ota osaa sovelluskehitykseen ja esitä kysymyksiä osoittees
   <string name="folders_action">Hallitse kansioita</string>
   <string name="account_settings_action">Tilin asetukset</string>
   <string name="remove_account_action">Poista tili</string>
+  <string name="account_settings_clear_account_action">Tyhjennä viestit (vaarallinen!)</string>
   <string name="mark_as_read_action">Merkitse luetuksi</string>
   <string name="send_alternate_action">Jaa</string>
   <string name="send_alternate_chooser_title">Valitse lähettäjä</string>

--- a/app/ui/src/main/res/values-fr/strings.xml
+++ b/app/ui/src/main/res/values-fr/strings.xml
@@ -110,6 +110,7 @@ Rapportez les bogues, recommandez de nouvelles fonctions et posez vos questions 
   <string name="folders_action">Gérer les dossiers</string>
   <string name="account_settings_action">Paramètres du compte</string>
   <string name="remove_account_action">Supprimer le compte</string>
+  <string name="account_settings_clear_account_action">Vider les courriels (dangeru00A0!)</string>
   <string name="mark_as_read_action">Marquer comme lu</string>
   <string name="send_alternate_action">Partager</string>
   <string name="send_alternate_chooser_title">Choisir l’expéditeur</string>

--- a/app/ui/src/main/res/values-gd/strings.xml
+++ b/app/ui/src/main/res/values-gd/strings.xml
@@ -97,6 +97,7 @@ Fàilte air bugaichean, com-pàirteachas, iarrtasan airson gleusan ùra is ceist
   <string name="preferences_action">Roghainnean</string>
   <string name="account_settings_action">Roghainnean a’ chunntais</string>
   <string name="remove_account_action">Thoir an cunntas air falbh</string>
+  <string name="account_settings_clear_account_action">Falamhaich na teachdaireachdan (cunnartach!)</string>
   <string name="mark_as_read_action">Comharraich gun deach a leughadh</string>
   <string name="send_alternate_action">Co-roinn</string>
   <string name="send_alternate_chooser_title">Tagh seòladair</string>

--- a/app/ui/src/main/res/values-gl-rES/strings.xml
+++ b/app/ui/src/main/res/values-gl-rES/strings.xml
@@ -65,6 +65,7 @@
   <string name="preferences_action">Axustes</string>
   <string name="account_settings_action">Axustes da conta</string>
   <string name="remove_account_action">Eliminar conta</string>
+  <string name="account_settings_clear_account_action">Limpar mensaxes (perigoso!)</string>
   <string name="mark_as_read_action">Marcar como lida</string>
   <string name="send_alternate_action">Compartir</string>
   <string name="send_alternate_chooser_title">Seleccionar remitente</string>

--- a/app/ui/src/main/res/values-gl/strings.xml
+++ b/app/ui/src/main/res/values-gl/strings.xml
@@ -100,6 +100,7 @@ Por favor envíen informes de fallos, contribúa con novas características e co
   <string name="preferences_action">Configuración</string>
   <string name="account_settings_action">Configurar conta</string>
   <string name="remove_account_action">Eliminar conta</string>
+  <string name="account_settings_clear_account_action">Limpar mensaxes (perigroso!)</string>
   <string name="mark_as_read_action">Marcar coma Lido</string>
   <string name="send_alternate_action">Compartir</string>
   <string name="send_alternate_chooser_title">Seleccionar Remitente</string>

--- a/app/ui/src/main/res/values-hr/strings.xml
+++ b/app/ui/src/main/res/values-hr/strings.xml
@@ -79,6 +79,7 @@
   <string name="folders_action">Upravljanje mapama</string>
   <string name="account_settings_action">Postavke računa</string>
   <string name="remove_account_action">Obriši račun</string>
+  <string name="account_settings_clear_account_action">Očisti poruke (opasno!)</string>
   <string name="mark_as_read_action">Označi pročitanim</string>
   <string name="send_alternate_action">Podijeli</string>
   <string name="send_alternate_chooser_title">Odaberi pošiljatelja</string>

--- a/app/ui/src/main/res/values-hu/strings.xml
+++ b/app/ui/src/main/res/values-hu/strings.xml
@@ -110,6 +110,7 @@ Küldjön hibajelentéseket, járuljon hozzá új funkciókkal, és tegyen fel k
   <string name="folders_action">Mappák kezelése</string>
   <string name="account_settings_action">Fiók beállításai</string>
   <string name="remove_account_action">Fiók eltávolítása</string>
+  <string name="account_settings_clear_account_action">Üzenetek törlése!</string>
   <string name="mark_as_read_action">Megjelölés olvasottként</string>
   <string name="send_alternate_action">Megosztás</string>
   <string name="send_alternate_chooser_title">Feladó kiválasztása</string>

--- a/app/ui/src/main/res/values-in/strings.xml
+++ b/app/ui/src/main/res/values-in/strings.xml
@@ -100,6 +100,7 @@ Kirimkan laporan bug, kontribusikan fitur baru dan ajukan pertanyaan di
   <string name="preferences_action">Pengaturan</string>
   <string name="account_settings_action">Pengaturan akun</string>
   <string name="remove_account_action">Buang akun</string>
+  <string name="account_settings_clear_account_action">Bersihkan pesan (bahaya!)</string>
   <string name="mark_as_read_action">Tandai sudah dibaca</string>
   <string name="send_alternate_action">Bagikan</string>
   <string name="send_alternate_chooser_title">Pilih pengirim</string>

--- a/app/ui/src/main/res/values-is/strings.xml
+++ b/app/ui/src/main/res/values-is/strings.xml
@@ -108,6 +108,7 @@ Sendu inn villuskýrslur, leggðu fram nýja eiginleika og spurðu spurninga á
   <string name="folders_action">Sýsla með möppur</string>
   <string name="account_settings_action">Aðgangsstillingar</string>
   <string name="remove_account_action">Fjarlægja aðganginn</string>
+  <string name="account_settings_clear_account_action">Hreinsa skilaboð (áhættusamt!)</string>
   <string name="mark_as_read_action">Merkja sem lesið</string>
   <string name="send_alternate_action">Deila</string>
   <string name="send_alternate_chooser_title">Veldu sendanda</string>

--- a/app/ui/src/main/res/values-it/strings.xml
+++ b/app/ui/src/main/res/values-it/strings.xml
@@ -110,6 +110,7 @@ Invia segnalazioni di bug, contribuisci con nuove funzionalità e poni domande s
   <string name="folders_action">Gestisci cartelle</string>
   <string name="account_settings_action">Impostazioni account</string>
   <string name="remove_account_action">Rimuovi account</string>
+  <string name="account_settings_clear_account_action">Cancella i messaggi (pericolo!)</string>
   <string name="mark_as_read_action">Marca come letto</string>
   <string name="send_alternate_action">Condividi</string>
   <string name="send_alternate_chooser_title">Scegli il mittente</string>

--- a/app/ui/src/main/res/values-iw/strings.xml
+++ b/app/ui/src/main/res/values-iw/strings.xml
@@ -67,6 +67,7 @@
   <string name="preferences_action">הגדרות</string>
   <string name="account_settings_action">הגדרות חשבון</string>
   <string name="remove_account_action">מחק חשבון</string>
+  <string name="account_settings_clear_account_action">נקה ההודעות (סכנה!)</string>
   <string name="mark_as_read_action">סמן כנקרא</string>
   <string name="send_alternate_action">שתף</string>
   <string name="send_alternate_chooser_title">בחר את השולח</string>

--- a/app/ui/src/main/res/values-ja/strings.xml
+++ b/app/ui/src/main/res/values-ja/strings.xml
@@ -110,6 +110,7 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
   <string name="folders_action">フォルダ管理</string>
   <string name="account_settings_action">アカウント設定</string>
   <string name="remove_account_action">アカウント削除</string>
+  <string name="account_settings_clear_account_action">アカウントクリア (危険！)</string>
   <string name="mark_as_read_action">既読にする</string>
   <string name="send_alternate_action">共有</string>
   <string name="send_alternate_chooser_title">アプリケーションを選択</string>

--- a/app/ui/src/main/res/values-ko/strings.xml
+++ b/app/ui/src/main/res/values-ko/strings.xml
@@ -70,6 +70,7 @@
   <string name="preferences_action">설정</string>
   <string name="account_settings_action">계정 설정</string>
   <string name="remove_account_action">계정 삭제</string>
+  <string name="account_settings_clear_account_action">편지 비우기 (위험!)</string>
   <string name="mark_as_read_action">읽은 메일로 표시</string>
   <string name="send_alternate_action">공유</string>
   <string name="send_alternate_chooser_title">발신자 선택</string>

--- a/app/ui/src/main/res/values-lt/strings.xml
+++ b/app/ui/src/main/res/values-lt/strings.xml
@@ -65,6 +65,7 @@
   <string name="preferences_action">Nustatymai</string>
   <string name="account_settings_action">Paskyros nustatymai</string>
   <string name="remove_account_action">Pašalinti paskyrą</string>
+  <string name="account_settings_clear_account_action">Išvalyti laiškus (pavojinga!)</string>
   <string name="mark_as_read_action">Pažymėti kaip skaitytą</string>
   <string name="send_alternate_action">Dalintis</string>
   <string name="send_alternate_chooser_title">Pasirinkti siuntėją</string>

--- a/app/ui/src/main/res/values-lv/strings.xml
+++ b/app/ui/src/main/res/values-lv/strings.xml
@@ -99,6 +99,7 @@ Lūdzu, iesniedziet kļūdu ziņojumus, ierosiniet jaunas iespējas un uzdodiet 
   <string name="preferences_action">Iestatījumi</string>
   <string name="account_settings_action">Konta iestatījumi</string>
   <string name="remove_account_action">Noņemt kontu</string>
+  <string name="account_settings_clear_account_action">Izmest vēstules (bīstami!)</string>
   <string name="mark_as_read_action">Atzīmēt kā izlasītu</string>
   <string name="send_alternate_action">Dalīties</string>
   <string name="send_alternate_chooser_title">Izvēlēties sūtītāju</string>

--- a/app/ui/src/main/res/values-nb/strings.xml
+++ b/app/ui/src/main/res/values-nb/strings.xml
@@ -109,6 +109,7 @@ Send feilmeldinger, bidra med nye funksjoner og still spørsmål her:
   <string name="folders_action">Behandle mapper</string>
   <string name="account_settings_action">Kontoinnstillinger</string>
   <string name="remove_account_action">Fjern konto</string>
+  <string name="account_settings_clear_account_action">Tøm meldinger (fare!)</string>
   <string name="mark_as_read_action">Marker som lest</string>
   <string name="send_alternate_action">Del</string>
   <string name="send_alternate_chooser_title">Velg avsender</string>

--- a/app/ui/src/main/res/values-nl/strings.xml
+++ b/app/ui/src/main/res/values-nl/strings.xml
@@ -105,6 +105,7 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   <string name="folders_action">Beheer mappen</string>
   <string name="account_settings_action">Account instellingen</string>
   <string name="remove_account_action">Verwijder account</string>
+  <string name="account_settings_clear_account_action">Wis berichten (gevaar!)</string>
   <string name="mark_as_read_action">Markeer als gelezen</string>
   <string name="send_alternate_action">Delen</string>
   <string name="send_alternate_chooser_title">Kies afzender</string>

--- a/app/ui/src/main/res/values-pl/strings.xml
+++ b/app/ui/src/main/res/values-pl/strings.xml
@@ -109,6 +109,7 @@ Wysłane za pomocą K-9 Mail.</string>
   <string name="folders_action">Zarządzaj folderami</string>
   <string name="account_settings_action">Ustawienia konta</string>
   <string name="remove_account_action">Usuń konto</string>
+  <string name="account_settings_clear_account_action">Usuń wszystkie dane (niebezpieczne!)</string>
   <string name="mark_as_read_action">Oznacz jako przeczytane</string>
   <string name="send_alternate_action">Prześlij dalej (alternatywne)</string>
   <string name="send_alternate_chooser_title">Wybierz nadawcę</string>

--- a/app/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/src/main/res/values-pt-rBR/strings.xml
@@ -108,6 +108,7 @@ Por favor encaminhe relatórios de bugs, contribua com novos recursos e tire dú
   <string name="folders_action">Gerenciar pastas</string>
   <string name="account_settings_action">Configurações da conta</string>
   <string name="remove_account_action">Remover a conta</string>
+  <string name="account_settings_clear_account_action">Limpar mensagens (perigoso!)</string>
   <string name="mark_as_read_action">Marcar como lida</string>
   <string name="send_alternate_action">Compartilhar</string>
   <string name="send_alternate_chooser_title">Escolher o remetente</string>

--- a/app/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/src/main/res/values-pt-rPT/strings.xml
@@ -109,6 +109,7 @@ Por favor envie relatórios de falhas, contribua com novas funcionalidades e col
   <string name="folders_action">Gerir pastas</string>
   <string name="account_settings_action">Configurações da conta</string>
   <string name="remove_account_action">Remover conta</string>
+  <string name="account_settings_clear_account_action">Limpar mensagens (perigo!)</string>
   <string name="mark_as_read_action">Marcar como lido</string>
   <string name="send_alternate_action">Partilhar</string>
   <string name="send_alternate_chooser_title">Escolher remetente</string>

--- a/app/ui/src/main/res/values-ro/strings.xml
+++ b/app/ui/src/main/res/values-ro/strings.xml
@@ -108,6 +108,7 @@ Vă rugăm să ne raportați defecte, să contribuiți cu funcționalități noi
   <string name="folders_action">Gestionează dosarele</string>
   <string name="account_settings_action">Opțiuni cont</string>
   <string name="remove_account_action">Ștergeți contul</string>
+  <string name="account_settings_clear_account_action">Curăţă mesajele (pericol!)</string>
   <string name="mark_as_read_action">Marchează ca citit</string>
   <string name="send_alternate_action">Distribuie</string>
   <string name="send_alternate_chooser_title">Alege expeditor</string>

--- a/app/ui/src/main/res/values-ru/strings.xml
+++ b/app/ui/src/main/res/values-ru/strings.xml
@@ -108,6 +108,7 @@ K-9 Mail — почтовый клиент для Android.
   <string name="folders_action">Выбрать папки</string>
   <string name="account_settings_action">Настройки ящика</string>
   <string name="remove_account_action">Удалить ящик</string>
+  <string name="account_settings_clear_account_action">Стереть сообщения (!)</string>
   <string name="mark_as_read_action">Прочитано</string>
   <string name="send_alternate_action">Передать</string>
   <string name="send_alternate_chooser_title">Способ передачи</string>

--- a/app/ui/src/main/res/values-sk/strings.xml
+++ b/app/ui/src/main/res/values-sk/strings.xml
@@ -97,6 +97,7 @@ Prosím, nahlasujte prípadné chyby, prispievajte novými funkciami a pýtajte 
   <string name="preferences_action">Nastavenia</string>
   <string name="account_settings_action">Nastavenia účtu</string>
   <string name="remove_account_action">Odstrániť účet</string>
+  <string name="account_settings_clear_account_action">Vyčistiť správy (nebezpečné)</string>
   <string name="mark_as_read_action">Označiť ako prečítané</string>
   <string name="send_alternate_action">Zdieľať</string>
   <string name="send_alternate_chooser_title">Vybrať odosielateľa</string>

--- a/app/ui/src/main/res/values-sl/strings.xml
+++ b/app/ui/src/main/res/values-sl/strings.xml
@@ -109,6 +109,7 @@ Poročila o napakah, predloge za nove funkcije in vprašanja lahko pošljete na
   <string name="folders_action">Upravljanje z mapami</string>
   <string name="account_settings_action">Nastavitve računa</string>
   <string name="remove_account_action">Odstrani račun</string>
+  <string name="account_settings_clear_account_action">Izbriši vsa sporočila računa (!)</string>
   <string name="mark_as_read_action">Označi kot prebrano</string>
   <string name="send_alternate_action">Objavi z …</string>
   <string name="send_alternate_chooser_title">Izberi pošiljatelja</string>

--- a/app/ui/src/main/res/values-sq/strings.xml
+++ b/app/ui/src/main/res/values-sq/strings.xml
@@ -110,6 +110,7 @@ Ju lutemi, parashtrim njoftimesh për të meta, kontribute për veçori të reaj
   <string name="folders_action">Administroni dosje</string>
   <string name="account_settings_action">Rregullime llogarie</string>
   <string name="remove_account_action">Hiqe llogarinë</string>
+  <string name="account_settings_clear_account_action">Pastroji mesazhet (rrezik!)</string>
   <string name="mark_as_read_action">Shënoje si të lexuar</string>
   <string name="send_alternate_action">Ndajeni me të tjerë</string>
   <string name="send_alternate_chooser_title">Zgjidhni dërgues</string>

--- a/app/ui/src/main/res/values-sr/strings.xml
+++ b/app/ui/src/main/res/values-sr/strings.xml
@@ -101,6 +101,7 @@
   <string name="preferences_action">Поставке</string>
   <string name="account_settings_action">Поставке налога</string>
   <string name="remove_account_action">Уклони налог</string>
+  <string name="account_settings_clear_account_action">Очисти поруке (пажња!)</string>
   <string name="mark_as_read_action">Означи као прочитано</string>
   <string name="send_alternate_action">Подели</string>
   <string name="send_alternate_chooser_title">Изаберите пошиљаоца</string>

--- a/app/ui/src/main/res/values-sv/strings.xml
+++ b/app/ui/src/main/res/values-sv/strings.xml
@@ -109,6 +109,7 @@ Skicka gärna in felrapporter, bidra med nya funktioner och ställ frågor på
   <string name="folders_action">Hantera mappar</string>
   <string name="account_settings_action">Kontoinställningar</string>
   <string name="remove_account_action">Ta bort konto</string>
+  <string name="account_settings_clear_account_action">Ta bort meddelanden (varning!)</string>
   <string name="mark_as_read_action">Markera som läst</string>
   <string name="send_alternate_action">Dela</string>
   <string name="send_alternate_chooser_title">Välj avsändare</string>

--- a/app/ui/src/main/res/values-tr/strings.xml
+++ b/app/ui/src/main/res/values-tr/strings.xml
@@ -109,6 +109,7 @@ Microsoft Exchange ile konuşurken bazı tuhaflıklar yaşadığını not ediniz
   <string name="folders_action">Klasörleri yönet</string>
   <string name="account_settings_action">Hesap Ayarları</string>
   <string name="remove_account_action">Hesabı Kaldır</string>
+  <string name="account_settings_clear_account_action">İletileri temizle (riskli!)</string>
   <string name="mark_as_read_action">Okundu olarak işaretle</string>
   <string name="send_alternate_action">Paylaş</string>
   <string name="send_alternate_chooser_title">Gönderici Seç</string>

--- a/app/ui/src/main/res/values-uk/strings.xml
+++ b/app/ui/src/main/res/values-uk/strings.xml
@@ -109,6 +109,7 @@ K-9 Mail — це вільний клієнт електронної пошти 
   <string name="folders_action">Керування теками</string>
   <string name="account_settings_action">Налаштування облікового запису</string>
   <string name="remove_account_action">Видалити обліковий запис</string>
+  <string name="account_settings_clear_account_action">Вилучити повідомлення (небезпечно!)</string>
   <string name="mark_as_read_action">Позначити прочитаним</string>
   <string name="send_alternate_action">Поділитися</string>
   <string name="send_alternate_chooser_title">Вибрати відправника</string>

--- a/app/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/src/main/res/values-zh-rCN/strings.xml
@@ -110,6 +110,7 @@ K-9 Mail 是 Android 上一款功能强大的自由 email 客户端。
   <string name="folders_action">管理文件夹</string>
   <string name="account_settings_action">账户设置</string>
   <string name="remove_account_action">移除账户</string>
+  <string name="account_settings_clear_account_action">清除邮件（慎用）</string>
   <string name="mark_as_read_action">标记为已读</string>
   <string name="send_alternate_action">分享</string>
   <string name="send_alternate_chooser_title">选择发件人</string>

--- a/app/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/src/main/res/values-zh-rTW/strings.xml
@@ -64,6 +64,7 @@
   <string name="preferences_action">設定</string>
   <string name="account_settings_action">帳戶設定</string>
   <string name="remove_account_action">刪除帳戶</string>
+  <string name="account_settings_clear_account_action">清除郵件（慎用）</string>
   <string name="mark_as_read_action">標記為已讀</string>
   <string name="send_alternate_action">分享</string>
   <string name="send_alternate_chooser_title">選擇寄件人</string>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -132,6 +132,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="folders_action">Manage folders</string>
     <string name="account_settings_action">Account settings</string>
     <string name="remove_account_action">Remove account</string>
+    <string name="account_settings_clear_account_action">Clear messages (danger!)</string>
 
     <string name="mark_as_read_action">Mark as read</string>
     <string name="send_alternate_action">Share</string>

--- a/app/ui/src/main/res/xml/account_settings.xml
+++ b/app/ui/src/main/res/xml/account_settings.xml
@@ -27,6 +27,10 @@
             android:title="@string/account_settings_color_label"
             app:pref_colors="@array/account_colors" />
 
+        <Preference
+            android:key="account_settings_clear_action"
+            android:title="@string/account_settings_clear_account_action" />
+
     </PreferenceScreen>
 
     <PreferenceScreen


### PR DESCRIPTION
@cketti 

As discussed in https://github.com/k9mail/k-9/issues/4684 and https://github.com/k9mail/k-9/issues/4100, I have restored the 'Clear mailbox messages' using asynchronous service.

The button is located under Settings - Account Settings = General Settings and has all localized strings from 5.600 along with confirmation dialog.

It might be a good alternative to 'Clear local messages' per-folder for those fetching some IMAP folders only as needed and clearing the local cache to save space after the branch is not used (i.e for backups stored as email attachments). I don't know @nhfo's workflow, but having this as a last resort trigger in combination with the change you pushed (assuming it works as expected) will allow me to stop building K-9 with my own couple of patches and switch to F-Droid weekly.

