### PR TITLE
Restore per-folder clear local messages

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2235,20 +2235,17 @@ public class MessagingController {
         });
     }
 
-    public void clearFolder(final Account account, final String folderServerId, final MessagingListener listener) {
-        putBackground("clearFolder", listener, new Runnable() {
-            @Override
-            public void run() {
-                clearFolderSynchronous(account, folderServerId, listener);
-            }
-        });
+    public void clearFolder(Account account, long folderId) {
+        putBackground("clearFolder", null, () ->
+                clearFolderSynchronous(account, folderId)
+        );
     }
 
     @VisibleForTesting
-    protected void clearFolderSynchronous(Account account, String folderServerId, MessagingListener listener) {
+    protected void clearFolderSynchronous(Account account, long folderId) {
         LocalFolder localFolder = null;
         try {
-            localFolder = localStoreProvider.getInstance(account).getFolder(folderServerId);
+            localFolder = localStoreProvider.getInstance(account).getFolder(folderId);
             localFolder.open();
             localFolder.clearAllMessages();
         } catch (UnavailableStorageException e) {

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -73,6 +73,7 @@ import static org.mockito.Mockito.when;
 
 @SuppressWarnings("unchecked")
 public class MessagingControllerTest extends K9RobolectricTest {
+    private static final long FOLDER_ID = 23;
     private static final String FOLDER_NAME = "Folder";
     private static final String SENT_FOLDER_NAME = "Sent";
     private static final int MAXIMUM_SMALL_MESSAGE_SIZE = 1000;
@@ -158,21 +159,21 @@ public class MessagingControllerTest extends K9RobolectricTest {
 
     @Test
     public void clearFolderSynchronous_shouldOpenFolderForWriting() throws MessagingException {
-        controller.clearFolderSynchronous(account, FOLDER_NAME, listener);
+        controller.clearFolderSynchronous(account, FOLDER_ID);
 
         verify(localFolder).open();
     }
 
     @Test
     public void clearFolderSynchronous_shouldClearAllMessagesInTheFolder() throws MessagingException {
-        controller.clearFolderSynchronous(account, FOLDER_NAME, listener);
+        controller.clearFolderSynchronous(account, FOLDER_ID);
 
         verify(localFolder).clearAllMessages();
     }
 
     @Test
     public void clearFolderSynchronous_shouldCloseTheFolder() throws MessagingException {
-        controller.clearFolderSynchronous(account, FOLDER_NAME, listener);
+        controller.clearFolderSynchronous(account, FOLDER_ID);
 
         verify(localFolder, atLeastOnce()).close();
     }
@@ -181,7 +182,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
     public void clearFolderSynchronous_whenStorageUnavailable_shouldThrowUnavailableAccountException() throws MessagingException {
         doThrow(new UnavailableStorageException("Test")).when(localFolder).open();
 
-        controller.clearFolderSynchronous(account, FOLDER_NAME, listener);
+        controller.clearFolderSynchronous(account, FOLDER_ID);
     }
 
     @Test()
@@ -189,7 +190,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
         doThrow(new RuntimeException("Test")).when(localFolder).open();
 
         try {
-            controller.clearFolderSynchronous(account, FOLDER_NAME, listener);
+            controller.clearFolderSynchronous(account, FOLDER_ID);
         } catch (Exception ignored){
         }
 
@@ -486,6 +487,8 @@ public class MessagingControllerTest extends K9RobolectricTest {
 
     private void configureLocalStore() throws MessagingException {
         when(localStore.getFolder(FOLDER_NAME)).thenReturn(localFolder);
+        when(localStore.getFolder(FOLDER_ID)).thenReturn(localFolder);
+        when(localFolder.getDatabaseId()).thenReturn(FOLDER_ID);
         when(localFolder.getServerId()).thenReturn(FOLDER_NAME);
         when(localStore.getPersonalNamespaces(false)).thenReturn(Collections.singletonList(localFolder));
         when(localStoreProvider.getInstance(account)).thenReturn(localStore);

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
@@ -52,6 +52,9 @@ class FolderSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFra
     override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
         super.onCreateOptionsMenu(menu, inflater)
         inflater.inflate(R.menu.folder_settings_option, menu)
+
+        val clearFolderItem = menu.findItem(R.id.clear_local_folder)
+        clearFolderItem.isVisible = viewModel.showClearFolderInMenu
     }
 
     override fun onOptionsItemSelected(item: MenuItem): Boolean {
@@ -73,6 +76,11 @@ class FolderSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFra
         setPreferencesFromResource(R.xml.folder_settings_preferences, null)
 
         setCategoryTitle(folderSettings)
+        updateMenu()
+    }
+
+    private fun updateMenu() {
+        requireActivity().invalidateOptionsMenu()
     }
 
     private fun setCategoryTitle(folderSettings: FolderSettingsData) {

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
@@ -1,9 +1,14 @@
 package com.fsck.k9.ui.managefolders
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuInflater
+import android.view.MenuItem
 import android.view.View
 import androidx.navigation.fragment.findNavController
 import androidx.preference.Preference
+import com.fsck.k9.fragment.ConfirmationDialogFragment
+import com.fsck.k9.fragment.ConfirmationDialogFragment.ConfirmationDialogFragmentListener
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.folders.FolderNameFormatter
 import com.fsck.k9.ui.observeNotNull
@@ -12,13 +17,33 @@ import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.parameter.parametersOf
 
-class FolderSettingsFragment : PreferenceFragmentCompat() {
+class FolderSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFragmentListener {
     private val viewModel: FolderSettingsViewModel by viewModel()
     private val folderNameFormatter: FolderNameFormatter by inject { parametersOf(requireActivity()) }
 
     override fun onCreatePreferencesFix(savedInstanceState: Bundle?, rootKey: String?) {
         // Set empty preferences resource while data is being loaded
         setPreferencesFromResource(R.xml.empty_preferences, null)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.folder_settings_option, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.clear_local_folder -> {
+                viewModel.showClearFolderConfirmationDialog()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setHasOptionsMenu(true)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -35,6 +60,8 @@ class FolderSettingsFragment : PreferenceFragmentCompat() {
                     is FolderSettingsData -> initPreferences(folderSettingsResult)
                 }
             }
+
+        viewModel.getActionEvents().observeNotNull(this) { handleActionEvents(it) }
     }
 
     private fun navigateBack() {
@@ -53,9 +80,43 @@ class FolderSettingsFragment : PreferenceFragmentCompat() {
         findPreference<Preference>(PREFERENCE_TOP_CATEGORY)!!.title = folderDisplayName
     }
 
+    private fun handleActionEvents(action: Action) {
+        when (action) {
+            is Action.ShowClearFolderConfirmationDialog -> showClearFolderConfirmationDialog()
+        }
+    }
+
+    private fun showClearFolderConfirmationDialog() {
+        val dialogFragment = ConfirmationDialogFragment.newInstance(
+                DIALOG_CLEAR_FOLDER,
+                getString(R.string.dialog_confirm_clear_local_folder_title),
+                getString(R.string.dialog_confirm_clear_local_folder_message),
+                getString(R.string.okay_action),
+                getString(R.string.cancel_action)
+        )
+        dialogFragment.setTargetFragment(this, REQUEST_CLEAR_FOLDER)
+        dialogFragment.show(requireFragmentManager(), TAG_CLEAR_FOLDER_CONFIRMATION)
+    }
+
+    override fun doPositiveClick(dialogId: Int) {
+        when (dialogId) {
+            DIALOG_CLEAR_FOLDER -> {
+                viewModel.onClearFolderConfirmation()
+            }
+        }
+    }
+
+    override fun doNegativeClick(dialogId: Int) = Unit
+
+    override fun dialogCancelled(dialogId: Int) = Unit
+
     companion object {
         const val EXTRA_ACCOUNT = "account"
         const val EXTRA_FOLDER_ID = "folderId"
+
+        private const val DIALOG_CLEAR_FOLDER = 1
+        private const val REQUEST_CLEAR_FOLDER = 1
+        private const val TAG_CLEAR_FOLDER_CONFIRMATION = "clear_folder_confirmation"
 
         private const val PREFERENCE_TOP_CATEGORY = "folder_settings"
     }

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
@@ -21,29 +21,14 @@ class FolderSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFra
     private val viewModel: FolderSettingsViewModel by viewModel()
     private val folderNameFormatter: FolderNameFormatter by inject { parametersOf(requireActivity()) }
 
-    override fun onCreatePreferencesFix(savedInstanceState: Bundle?, rootKey: String?) {
-        // Set empty preferences resource while data is being loaded
-        setPreferencesFromResource(R.xml.empty_preferences, null)
-    }
-
-    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
-        super.onCreateOptionsMenu(menu, inflater)
-        inflater.inflate(R.menu.folder_settings_option, menu)
-    }
-
-    override fun onOptionsItemSelected(item: MenuItem): Boolean {
-        return when (item.itemId) {
-            R.id.clear_local_folder -> {
-                viewModel.showClearFolderConfirmationDialog()
-                true
-            }
-            else -> super.onOptionsItemSelected(item)
-        }
-    }
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
+    }
+
+    override fun onCreatePreferencesFix(savedInstanceState: Bundle?, rootKey: String?) {
+        // Set empty preferences resource while data is being loaded
+        setPreferencesFromResource(R.xml.empty_preferences, null)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -62,6 +47,21 @@ class FolderSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFra
             }
 
         viewModel.getActionEvents().observeNotNull(this) { handleActionEvents(it) }
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu, inflater: MenuInflater) {
+        super.onCreateOptionsMenu(menu, inflater)
+        inflater.inflate(R.menu.folder_settings_option, menu)
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        return when (item.itemId) {
+            R.id.clear_local_folder -> {
+                viewModel.showClearFolderConfirmationDialog()
+                true
+            }
+            else -> super.onOptionsItemSelected(item)
+        }
     }
 
     private fun navigateBack() {
@@ -91,7 +91,7 @@ class FolderSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFra
                 DIALOG_CLEAR_FOLDER,
                 getString(R.string.dialog_confirm_clear_local_folder_title),
                 getString(R.string.dialog_confirm_clear_local_folder_message),
-                getString(R.string.okay_action),
+                getString(R.string.dialog_confirm_clear_local_folder_action),
                 getString(R.string.cancel_action)
         )
         dialogFragment.setTargetFragment(this, REQUEST_CLEAR_FOLDER)

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
@@ -17,6 +17,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import timber.log.Timber
 
+private const val NO_FOLDER_ID = 0L
+
 class FolderSettingsViewModel(
     private val preferences: Preferences,
     private val folderRepositoryManager: FolderRepositoryManager,
@@ -25,11 +27,11 @@ class FolderSettingsViewModel(
     private val actionLiveData = SingleLiveEvent<Action>()
     private var folderSettingsLiveData: LiveData<FolderSettingsResult>? = null
 
-    private lateinit var folderAccount: Account
-    private lateinit var folderServerId: String
+    private lateinit var account: Account
+    private var folderId: Long = NO_FOLDER_ID
 
     val showClearFolderInMenu: Boolean
-        get() = this::folderAccount.isInitialized && this::folderServerId.isInitialized
+        get() = this::account.isInitialized && folderId != NO_FOLDER_ID
 
     fun getFolderSettingsLiveData(accountUuid: String, folderId: Long): LiveData<FolderSettingsResult> {
         return folderSettingsLiveData ?: createFolderSettingsLiveData(accountUuid, folderId).also {
@@ -51,8 +53,8 @@ class FolderSettingsViewModel(
                 return@liveData
             }
 
-            folderAccount = account
-            folderServerId = folderDetails.folder.serverId
+            this@FolderSettingsViewModel.account = account
+            this@FolderSettingsViewModel.folderId = folderId
 
             val folderSettingsData = FolderSettingsData(
                 folder = createFolderObject(account, folderDetails.folder),
@@ -89,7 +91,7 @@ class FolderSettingsViewModel(
     }
 
     fun onClearFolderConfirmation() {
-        messagingController.clearFolder(folderAccount, folderServerId, null)
+        messagingController.clearFolder(account, folderId)
     }
 
     fun getActionEvents(): LiveData<Action> = actionLiveData

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
@@ -39,9 +39,8 @@ class FolderSettingsViewModel(
         folderId: Long
     ): LiveData<FolderSettingsResult> {
         return liveData(context = viewModelScope.coroutineContext) {
-            folderAccount = loadAccount(accountUuid)
-
-            val folderRepository = folderRepositoryManager.getFolderRepository(folderAccount)
+            val account = loadAccount(accountUuid)
+            val folderRepository = folderRepositoryManager.getFolderRepository(account)
             val folderDetails = folderRepository.loadFolderDetails(folderId)
             if (folderDetails == null) {
                 Timber.w("Folder with ID $folderId not found")
@@ -49,10 +48,11 @@ class FolderSettingsViewModel(
                 return@liveData
             }
 
+            folderAccount = account
             folderServerId = folderDetails.folder.serverId
 
             val folderSettingsData = FolderSettingsData(
-                folder = createFolderObject(folderAccount, folderDetails.folder),
+                folder = createFolderObject(account, folderDetails.folder),
                 dataStore = FolderSettingsDataStore(folderRepository, folderDetails)
             )
             emit(folderSettingsData)

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsViewModel.kt
@@ -28,6 +28,9 @@ class FolderSettingsViewModel(
     private lateinit var folderAccount: Account
     private lateinit var folderServerId: String
 
+    val showClearFolderInMenu: Boolean
+        get() = this::folderAccount.isInitialized && this::folderServerId.isInitialized
+
     fun getFolderSettingsLiveData(accountUuid: String, folderId: Long): LiveData<FolderSettingsResult> {
         return folderSettingsLiveData ?: createFolderSettingsLiveData(accountUuid, folderId).also {
             folderSettingsLiveData = it

--- a/app/ui/src/main/java/com/fsck/k9/ui/managefolders/KoinModule.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/managefolders/KoinModule.kt
@@ -5,5 +5,5 @@ import org.koin.dsl.module
 
 val manageFoldersUiModule = module {
     viewModel { ManageFoldersViewModel(foldersLiveDataFactory = get()) }
-    viewModel { FolderSettingsViewModel(preferences = get(), folderRepositoryManager = get()) }
+    viewModel { FolderSettingsViewModel(preferences = get(), folderRepositoryManager = get(), messagingController = get()) }
 }

--- a/app/ui/src/main/res/menu/folder_settings_option.xml
+++ b/app/ui/src/main/res/menu/folder_settings_option.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+
+    <item
+        android:id="@+id/clear_local_folder"
+        android:title="@string/folder_settings_clear_local_folder_action"
+        app:showAsAction="never" />
+
+</menu>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -662,6 +662,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="folder_settings_folder_notify_mode_first_class">1st Class</string>
     <string name="folder_settings_folder_notify_mode_second_class">2nd Class</string>
     <string name="folder_settings_folder_notify_mode_inherited">Same as push class</string>
+    <string name="folder_settings_clear_local_folder_action">Clear local messages</string>
 
     <string name="account_settings_incoming_label">Incoming server</string>
     <string name="account_settings_incoming_summary">Configure the incoming mail server</string>
@@ -892,6 +893,9 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="confirm_discard_draft_message">Are you sure you want to discard this message?</string>
 
     <string name="select_text_now">Select text to copy.</string>
+
+    <string name="dialog_confirm_clear_local_folder_title">Confirm local folder clear</string>
+    <string name="dialog_confirm_clear_local_folder_message">Do you really want to delete all local messages from this folder?</string>
 
     <string name="dialog_confirm_delete_title">Confirm deletion</string>
     <string name="dialog_confirm_delete_message">Do you want to delete this message?</string>

--- a/app/ui/src/main/res/values/strings.xml
+++ b/app/ui/src/main/res/values/strings.xml
@@ -894,8 +894,9 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="select_text_now">Select text to copy.</string>
 
-    <string name="dialog_confirm_clear_local_folder_title">Confirm local folder clear</string>
-    <string name="dialog_confirm_clear_local_folder_message">Do you really want to delete all local messages from this folder?</string>
+    <string name="dialog_confirm_clear_local_folder_title">Clear local messages?</string>
+    <string name="dialog_confirm_clear_local_folder_message">This will remove all local messages from the folder. No messages will be deleted from the server.</string>
+    <string name="dialog_confirm_clear_local_folder_action">Clear messages</string>
 
     <string name="dialog_confirm_delete_title">Confirm deletion</string>
     <string name="dialog_confirm_delete_message">Do you want to delete this message?</string>


### PR DESCRIPTION
Fixes #4684 

The 'Clear local messages' action is located in toolbar menu of folder setting:

![Screenshot_20200428-165122](https://user-images.githubusercontent.com/3913291/80495514-b12bc680-8970-11ea-9712-82a44ee0b403.png)
![Screenshot_20200428-165110](https://user-images.githubusercontent.com/3913291/80495528-b6891100-8970-11ea-8e61-ff4ca7382339.png)
![Screenshot_20200428-165117](https://user-images.githubusercontent.com/3913291/80495542-ba1c9800-8970-11ea-868e-32dd114bbcb4.png)
