### PR TITLE
Allow removal of special folders

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorage.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorage.kt
@@ -111,7 +111,6 @@ class K9BackendStorage(
 
         override fun deleteFolders(folderServerIds: List<String>) {
             folderServerIds.asSequence()
-                .filterNot { account.isSpecialFolder(it) }
                 .map { localStore.getFolder(it) }
                 .forEach { it.delete() }
         }


### PR DESCRIPTION
In the past we apparently didn't remove special folders when they were deleted from the server. This was probably fine since we also created special folders on the server if necessary.
Nowadays we don't automatically create special folders. And we handle the removal of special folders just fine. So we now remove special folders from the database if they have been removed from the server.