### PR TITLE
Compact messages_fulltext table after messages destroyed

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -1636,6 +1636,8 @@ public class LocalFolder {
                 }
             }
 
+            compactFulltextEntries(db);
+
             return null;
         });
     }
@@ -1822,6 +1824,10 @@ public class LocalFolder {
     void deleteFulltextIndexEntry(SQLiteDatabase db, long messageId) {
         String[] idArg = { Long.toString(messageId) };
         db.delete("messages_fulltext", "docid = ?", idArg);
+    }
+
+    void compactFulltextEntries(SQLiteDatabase db) {
+        db.execSQL("INSERT INTO messages_fulltext(messages_fulltext) VALUES('optimize')");
     }
 
     void deleteMessagePartsAndDataFromDisk(final long rootMessagePartId) throws MessagingException {


### PR DESCRIPTION
Fixes the 'messages_fulltext_segdir' entries left after emptying the trash folder.

To test:

1. Send the message from different or same mailbox with text

```
meowmeowmeowmeowmeowmeowmeowmeowmeowmeowmeowmeow
meowmeowmeowmeowmeowmeowmeowmeowmeowmeowmeowmeow
meowmeowmeowmeowmeowmeowmeowmeowmeowmeowmeowmeow
```

2. Grep the database files in `/data/data/com.fsck.k9/databases`:

``` shell
grep -R meow /data/data/com.fsck.k9/databases
```

to see :cat: is there in plaintext.

3. Remove the message and empty trash then grep once more to see no more :cat: :)