### PR TITLE
Remove optional buildTools

### DIFF
--- a/app/autodiscovery/build.gradle
+++ b/app/autodiscovery/build.gradle
@@ -23,7 +23,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/app/core/build.gradle
+++ b/app/core/build.gradle
@@ -43,7 +43,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/app/crypto-openpgp/build.gradle
+++ b/app/crypto-openpgp/build.gradle
@@ -13,7 +13,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/app/k9mail-jmap/build.gradle
+++ b/app/k9mail-jmap/build.gradle
@@ -40,7 +40,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         applicationId "com.fsck.k9.jmap"

--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -34,7 +34,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         applicationId "com.fsck.k9"

--- a/app/storage/build.gradle
+++ b/app/storage/build.gradle
@@ -24,7 +24,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/app/testing/build.gradle
+++ b/app/testing/build.gradle
@@ -16,7 +16,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/app/ui/build.gradle
+++ b/app/ui/build.gradle
@@ -65,7 +65,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/backend/api/build.gradle
+++ b/backend/api/build.gradle
@@ -10,7 +10,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/backend/imap/build.gradle
+++ b/backend/imap/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/backend/jmap/build.gradle
+++ b/backend/jmap/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/backend/pop3/build.gradle
+++ b/backend/pop3/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/backend/webdav/build.gradle
+++ b/backend/webdav/build.gradle
@@ -21,7 +21,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
                 'compileSdk': 29,
                 'targetSdk': 28,
                 'minSdk': 21,
-                'buildTools': '29.0.3',
                 'robolectricSdk': 28
         ]
 

--- a/mail/common/build.gradle
+++ b/mail/common/build.gradle
@@ -25,7 +25,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/mail/protocols/imap/build.gradle
+++ b/mail/protocols/imap/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/mail/protocols/pop3/build.gradle
+++ b/mail/protocols/pop3/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/mail/protocols/smtp/build.gradle
+++ b/mail/protocols/smtp/build.gradle
@@ -22,7 +22,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/mail/protocols/webdav/build.gradle
+++ b/mail/protocols/webdav/build.gradle
@@ -24,7 +24,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/mail/testing/build.gradle
+++ b/mail/testing/build.gradle
@@ -14,7 +14,6 @@ dependencies {
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk

--- a/plugins/openpgp-api-lib/openpgp-api/build.gradle
+++ b/plugins/openpgp-api-lib/openpgp-api/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion buildConfig.compileSdk
-    buildToolsVersion buildConfig.buildTools
 
     defaultConfig {
         minSdkVersion buildConfig.minSdk


### PR DESCRIPTION
In the past is was mandatory, but now it's just a source more of pointless maintenance