### PR TITLE
Improve periodic mail sync

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -189,6 +189,7 @@ public class Account implements BaseAccount {
     private boolean remoteSearchFullText;
     private int remoteSearchNumResults;
     private boolean uploadSentMessages;
+    private long lastSyncTime;
 
     private boolean changedVisibleLimits = false;
 
@@ -1123,6 +1124,14 @@ public class Account implements BaseAccount {
 
     public void setRemoteSearchFullText(boolean val) {
         remoteSearchFullText = val;
+    }
+
+    public synchronized long getLastSyncTime() {
+        return lastSyncTime;
+    }
+
+    public synchronized void setLastSyncTime(long lastSyncTime) {
+        this.lastSyncTime = lastSyncTime;
     }
 
     boolean isChangedVisibleLimits() {

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -162,6 +162,7 @@ class AccountPreferenceSerializer(
             isMarkMessageAsReadOnView = storage.getBoolean("$accountUuid.markMessageAsReadOnView", true)
             isMarkMessageAsReadOnDelete = storage.getBoolean("$accountUuid.markMessageAsReadOnDelete", true)
             isAlwaysShowCcBcc = storage.getBoolean("$accountUuid.alwaysShowCcBcc", false)
+            lastSyncTime = storage.getLong("$accountUuid.lastSyncTime", 0L)
 
             // Use email address as account description if necessary
             if (description == null) {
@@ -321,6 +322,7 @@ class AccountPreferenceSerializer(
             editor.putString("$accountUuid.ringtone", notificationSetting.ringtone)
             editor.putBoolean("$accountUuid.led", notificationSetting.isLedEnabled)
             editor.putInt("$accountUuid.ledColor", notificationSetting.ledColor)
+            editor.putLong("$accountUuid.lastSyncTime", lastSyncTime)
 
             for (type in NetworkType.values()) {
                 val useCompression = compressionMap[type]
@@ -443,6 +445,7 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.archiveFolderId")
         editor.remove("$accountUuid.spamFolderId")
         editor.remove("$accountUuid.autoExpandFolderId")
+        editor.remove("$accountUuid.lastSyncTime")
 
         for (type in NetworkType.values()) {
             editor.remove("$accountUuid.useCompression." + type.name)
@@ -581,6 +584,7 @@ class AccountPreferenceSerializer(
             isMarkMessageAsReadOnView = true
             isMarkMessageAsReadOnDelete = true
             isAlwaysShowCcBcc = false
+            lastSyncTime = 0L
 
             setArchiveFolderId(null, SpecialFolderSelection.AUTOMATIC)
             setDraftsFolderId(null, SpecialFolderSelection.AUTOMATIC)

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2266,7 +2266,7 @@ public class MessagingController {
 
     public void performPeriodicMailSync(Account account) {
         final CountDownLatch latch = new CountDownLatch(1);
-        checkMail(context, account, true, false, new SimpleMessagingListener() {
+        checkMail(context, account, false, false, new SimpleMessagingListener() {
             @Override
             public void checkMailFinished(Context context, Account account) {
                 latch.countDown();

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2265,7 +2265,7 @@ public class MessagingController {
         context.startActivity(chooserIntent);
     }
 
-    public void performPeriodicMailSync(Account account) {
+    public boolean performPeriodicMailSync(Account account) {
         final CountDownLatch latch = new CountDownLatch(1);
         MutableBoolean syncError = new MutableBoolean(false);
         checkMail(context, account, false, false, new SimpleMessagingListener() {
@@ -2296,6 +2296,8 @@ public class MessagingController {
             account.setLastSyncTime(now);
             Preferences.getPreferences(context).saveAccount(account);
         }
+
+        return success;
     }
 
     /**

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2264,7 +2264,7 @@ public class MessagingController {
         context.startActivity(chooserIntent);
     }
 
-    public void checkMailBlocking(Account account) {
+    public void performPeriodicMailSync(Account account) {
         final CountDownLatch latch = new CountDownLatch(1);
         checkMail(context, account, true, false, new SimpleMessagingListener() {
             @Override
@@ -2273,11 +2273,11 @@ public class MessagingController {
             }
         });
 
-        Timber.v("checkMailBlocking(%s) about to await latch release", account.getDescription());
+        Timber.v("performPeriodicMailSync(%s) about to await latch release", account.getDescription());
 
         try {
             latch.await();
-            Timber.v("checkMailBlocking(%s) got latch release", account.getDescription());
+            Timber.v("performPeriodicMailSync(%s) got latch release", account.getDescription());
         } catch (Exception e) {
             Timber.e(e, "Interrupted while awaiting latch release");
         }

--- a/app/core/src/main/java/com/fsck/k9/helper/MutableBoolean.kt
+++ b/app/core/src/main/java/com/fsck/k9/helper/MutableBoolean.kt
@@ -1,0 +1,3 @@
+package com.fsck.k9.helper
+
+class MutableBoolean(var value: Boolean)

--- a/app/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.job
 
 import androidx.work.WorkManager
+import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import timber.log.Timber
 
@@ -14,16 +15,21 @@ class K9JobManager(
         scheduleMailSync()
     }
 
-    fun scheduleMailSync() {
+    fun scheduleMailSync(account: Account) {
+        mailSyncWorkerManager.cancelMailSync(account)
+        mailSyncWorkerManager.scheduleMailSync(account)
+    }
+
+    fun schedulePusherRefresh() {
+        // Push is temporarily disabled. See GH-4253
+    }
+
+    private fun scheduleMailSync() {
         cancelAllMailSyncJobs()
 
         preferences.availableAccounts?.forEach { account ->
             mailSyncWorkerManager.scheduleMailSync(account)
         }
-    }
-
-    fun schedulePusherRefresh() {
-        // Push is temporarily disabled. See GH-4253
     }
 
     private fun cancelAllMailSyncJobs() {

--- a/app/core/src/main/java/com/fsck/k9/job/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/KoinModule.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.job
 
 import androidx.work.WorkerFactory
+import com.fsck.k9.Clock
 import org.koin.dsl.module
 
 val jobModule = module {
@@ -8,5 +9,5 @@ val jobModule = module {
     single<WorkerFactory> { K9WorkerFactory(get(), get()) }
     single { get<WorkManagerProvider>().getWorkManager() }
     single { K9JobManager(get(), get(), get()) }
-    factory { MailSyncWorkerManager(get()) }
+    factory { MailSyncWorkerManager(get(), Clock.INSTANCE) }
 }

--- a/app/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
@@ -39,9 +39,9 @@ class MailSyncWorker(
             return Result.success()
         }
 
-        messagingController.performPeriodicMailSync(account)
+        val success = messagingController.performPeriodicMailSync(account)
 
-        return Result.success()
+        return if (success) Result.success() else Result.retry()
     }
 
     private fun isBackgroundSyncDisabled(): Boolean {

--- a/app/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
@@ -4,6 +4,7 @@ import android.content.ContentResolver
 import android.content.Context
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import com.fsck.k9.Account
 import com.fsck.k9.K9
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
@@ -27,9 +28,18 @@ class MailSyncWorker(
             return Result.success()
         }
 
-        preferences.getAccount(accountUuid)?.let { account ->
-            messagingController.checkMailBlocking(account)
+        val account = preferences.getAccount(accountUuid)
+        if (account == null) {
+            Timber.e("Account %s not found. Can't perform mail sync.", accountUuid)
+            return Result.failure()
         }
+
+        if (account.isPeriodicMailSyncDisabled) {
+            Timber.d("Periodic mail sync has been disabled for this account. Skipping mail sync.")
+            return Result.success()
+        }
+
+        messagingController.performPeriodicMailSync(account)
 
         return Result.success()
     }
@@ -41,6 +51,9 @@ class MailSyncWorker(
             K9.BACKGROUND_OPS.WHEN_CHECKED_AUTO_SYNC -> !ContentResolver.getMasterSyncAutomatically()
         }
     }
+
+    private val Account.isPeriodicMailSyncDisabled
+        get() = automaticCheckIntervalMinutes <= 0
 
     companion object {
         const val EXTRA_ACCOUNT_UUID = "accountUuid"

--- a/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
@@ -13,6 +13,12 @@ import timber.log.Timber
 
 class MailSyncWorkerManager(private val workManager: WorkManager) {
 
+    fun cancelMailSync(account: Account) {
+        Timber.v("Canceling mail sync worker for %s", account.description)
+        val uniqueWorkName = createUniqueWorkName(account.uuid)
+        workManager.cancelUniqueWork(uniqueWorkName)
+    }
+
     fun scheduleMailSync(account: Account) {
         if (isNeverSyncInBackground()) return
 

--- a/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.job
 
+import androidx.work.BackoffPolicy
 import androidx.work.Constraints
 import androidx.work.ExistingPeriodicWorkPolicy
 import androidx.work.NetworkType
@@ -42,6 +43,7 @@ class MailSyncWorkerManager(private val workManager: WorkManager, val clock: Clo
 
             val mailSyncRequest = PeriodicWorkRequestBuilder<MailSyncWorker>(syncInterval)
                 .setInitialDelay(initialDelay)
+                .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, INITIAL_BACKOFF_DELAY)
                 .setConstraints(constraints)
                 .setInputData(data)
                 .addTag(MAIL_SYNC_TAG)
@@ -80,5 +82,6 @@ class MailSyncWorkerManager(private val workManager: WorkManager, val clock: Clo
 
     companion object {
         const val MAIL_SYNC_TAG = "MailSync"
+        private val INITIAL_BACKOFF_DELAY = Duration.ofMinutes(5)
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
@@ -7,12 +7,15 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import com.fsck.k9.Account
+import com.fsck.k9.K9
 import java.util.concurrent.TimeUnit
 import timber.log.Timber
 
 class MailSyncWorkerManager(private val workManager: WorkManager) {
 
     fun scheduleMailSync(account: Account) {
+        if (isNeverSyncInBackground()) return
+
         getSyncIntervalInMinutesIfEnabled(account)?.let { syncInterval ->
             Timber.v("Scheduling mail sync worker for %s", account.description)
 
@@ -33,6 +36,8 @@ class MailSyncWorkerManager(private val workManager: WorkManager) {
             workManager.enqueueUniquePeriodicWork(uniqueWorkName, ExistingPeriodicWorkPolicy.REPLACE, mailSyncRequest)
         }
     }
+
+    private fun isNeverSyncInBackground() = K9.backgroundOps == K9.BACKGROUND_OPS.NEVER
 
     private fun getSyncIntervalInMinutesIfEnabled(account: Account): Long? {
         val intervalMinutes = account.automaticCheckIntervalMinutes

--- a/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
@@ -7,11 +7,12 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import com.fsck.k9.Account
+import com.fsck.k9.Clock
 import com.fsck.k9.K9
-import java.util.concurrent.TimeUnit
+import java.time.Duration
 import timber.log.Timber
 
-class MailSyncWorkerManager(private val workManager: WorkManager) {
+class MailSyncWorkerManager(private val workManager: WorkManager, val clock: Clock) {
 
     fun cancelMailSync(account: Account) {
         Timber.v("Canceling mail sync worker for %s", account.description)
@@ -22,21 +23,29 @@ class MailSyncWorkerManager(private val workManager: WorkManager) {
     fun scheduleMailSync(account: Account) {
         if (isNeverSyncInBackground()) return
 
-        getSyncIntervalInMinutesIfEnabled(account)?.let { syncInterval ->
+        getSyncIntervalIfEnabled(account)?.let { syncInterval ->
             Timber.v("Scheduling mail sync worker for %s", account.description)
+            Timber.v("  sync interval: %d minutes", syncInterval.toMinutes())
 
             val constraints = Constraints.Builder()
-                    .setRequiredNetworkType(NetworkType.CONNECTED)
-                    .setRequiresStorageNotLow(true)
-                    .build()
+                .setRequiredNetworkType(NetworkType.CONNECTED)
+                .setRequiresStorageNotLow(true)
+                .build()
+
+            val lastSyncTime = account.lastSyncTime
+            Timber.v("  last sync time: %tc", lastSyncTime)
+
+            val initialDelay = calculateInitialDelay(lastSyncTime, syncInterval)
+            Timber.v("  initial delay: %d minutes", initialDelay.toMinutes())
 
             val data = workDataOf(MailSyncWorker.EXTRA_ACCOUNT_UUID to account.uuid)
 
-            val mailSyncRequest = PeriodicWorkRequestBuilder<MailSyncWorker>(syncInterval, TimeUnit.MINUTES)
-                    .setConstraints(constraints)
-                    .setInputData(data)
-                    .addTag(MAIL_SYNC_TAG)
-                    .build()
+            val mailSyncRequest = PeriodicWorkRequestBuilder<MailSyncWorker>(syncInterval)
+                .setInitialDelay(initialDelay)
+                .setConstraints(constraints)
+                .setInputData(data)
+                .addTag(MAIL_SYNC_TAG)
+                .build()
 
             val uniqueWorkName = createUniqueWorkName(account.uuid)
             workManager.enqueueUniquePeriodicWork(uniqueWorkName, ExistingPeriodicWorkPolicy.REPLACE, mailSyncRequest)
@@ -45,13 +54,24 @@ class MailSyncWorkerManager(private val workManager: WorkManager) {
 
     private fun isNeverSyncInBackground() = K9.backgroundOps == K9.BACKGROUND_OPS.NEVER
 
-    private fun getSyncIntervalInMinutesIfEnabled(account: Account): Long? {
+    private fun getSyncIntervalIfEnabled(account: Account): Duration? {
         val intervalMinutes = account.automaticCheckIntervalMinutes
         if (intervalMinutes <= Account.INTERVAL_MINUTES_NEVER) {
             return null
         }
 
-        return intervalMinutes.toLong()
+        return Duration.ofMinutes(intervalMinutes.toLong())
+    }
+
+    private fun calculateInitialDelay(lastSyncTime: Long, syncInterval: Duration): Duration {
+        val now = clock.time
+        val nextSyncTime = lastSyncTime + syncInterval.toMillis()
+
+        return if (lastSyncTime > now || nextSyncTime <= now) {
+            Duration.ZERO
+        } else {
+            Duration.ofMillis(nextSyncTime - now)
+        }
     }
 
     private fun createUniqueWorkName(accountUuid: String): String {

--- a/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -215,7 +215,7 @@ class AccountSettingsDataStore(
     }
 
     private fun reschedulePoll() {
-        jobManager.scheduleMailSync()
+        jobManager.scheduleMailSync(account)
     }
 
     private fun restartPushers() {


### PR DESCRIPTION
Save the last time an account was synced and use that value to set the initial delay the next time periodic sync for this account is canceled and then rescheduled (we currently do that every time the app is started). This way we won't sync the account too often.

Fixes #4704