### PR TITLE
Fix unread widget

### DIFF
--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -22,6 +22,7 @@ dependencies {
     implementation "androidx.core:core-ktx:${versions.coreKtx}"
     implementation "com.takisoft.preferencex:preferencex:${versions.preferencesFix}"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}"
 
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
@@ -8,7 +8,9 @@ val unreadWidgetModule = module {
         context = get(),
         preferences = get(),
         messagingController = get(),
-        defaultFolderProvider = get()
+        defaultFolderProvider = get(),
+        folderRepositoryManager = get(),
+        folderNameFormatterFactory = get()
     ) }
     single { UnreadWidgetUpdater(context = get()) }
     single { UnreadWidgetUpdateListener(unreadWidgetUpdater = get()) }

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
@@ -3,8 +3,14 @@ package com.fsck.k9.widget.unread
 import org.koin.dsl.module
 
 val unreadWidgetModule = module {
-    single { UnreadWidgetRepository(get(), get()) }
-    single { UnreadWidgetDataProvider(get(), get(), get(), get()) }
-    single { UnreadWidgetUpdater(get()) }
-    single { UnreadWidgetUpdateListener(get()) }
+    single { UnreadWidgetRepository(context = get(), dataRetriever = get(), migrations = get()) }
+    single { UnreadWidgetDataProvider(
+        context = get(),
+        preferences = get(),
+        messagingController = get(),
+        defaultFolderProvider = get()
+    ) }
+    single { UnreadWidgetUpdater(context = get()) }
+    single { UnreadWidgetUpdateListener(unreadWidgetUpdater = get()) }
+    single { UnreadWidgetMigrations(accountRepository = get(), folderRepositoryManager = get()) }
 }

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetMigrations.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetMigrations.kt
@@ -1,0 +1,45 @@
+package com.fsck.k9.widget.unread
+
+import android.content.SharedPreferences
+import androidx.core.content.edit
+import com.fsck.k9.Preferences
+import com.fsck.k9.mailstore.FolderRepositoryManager
+import com.fsck.k9.widget.unread.UnreadWidgetRepository.Companion.PREFS_VERSION
+import com.fsck.k9.widget.unread.UnreadWidgetRepository.Companion.PREF_VERSION_KEY
+
+internal class UnreadWidgetMigrations(
+    private val accountRepository: Preferences,
+    private val folderRepositoryManager: FolderRepositoryManager
+) {
+    fun upgradePreferences(preferences: SharedPreferences, version: Int) {
+        if (version < 2) rewriteFolderNameToFolderId(preferences)
+
+        preferences.setVersion(PREFS_VERSION)
+    }
+
+    private fun SharedPreferences.setVersion(version: Int) {
+        edit { putInt(PREF_VERSION_KEY, version) }
+    }
+
+    private fun rewriteFolderNameToFolderId(preferences: SharedPreferences) {
+        val widgetIds = preferences.all.keys
+            .filter { it.endsWith(".folder_name") }
+            .map { it.split(".")[1] }
+
+        preferences.edit {
+            for (widgetId in widgetIds) {
+                val accountUuid = preferences.getString("unread_widget.$widgetId", null) ?: continue
+                val account = accountRepository.getAccount(accountUuid) ?: continue
+
+                val folderServerId = preferences.getString("unread_widget.$widgetId.folder_name", null)
+                if (folderServerId != null) {
+                    val folderRepository = folderRepositoryManager.getFolderRepository(account)
+                    val folderId = folderRepository.getFolderId(folderServerId)
+                    putString("unread_widget.$widgetId.folder_id", folderId?.toString())
+                }
+
+                remove("unread_widget.$widgetId.folder_name")
+            }
+        }
+    }
+}

--- a/app/k9mail/src/test/java/com/fsck/k9/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/app/k9mail/src/test/java/com/fsck/k9/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -5,13 +5,20 @@ import com.fsck.k9.Account
 import com.fsck.k9.AppRobolectricTest
 import com.fsck.k9.Preferences
 import com.fsck.k9.controller.MessagingController
+import com.fsck.k9.mail.FolderClass
+import com.fsck.k9.mailstore.Folder
+import com.fsck.k9.mailstore.FolderDetails
+import com.fsck.k9.mailstore.FolderRepository
+import com.fsck.k9.mailstore.FolderRepositoryManager
+import com.fsck.k9.mailstore.FolderType
 import com.fsck.k9.search.SearchAccount
+import com.fsck.k9.ui.folders.FolderNameFormatter
+import com.fsck.k9.ui.folders.FolderNameFormatterFactory
 import com.fsck.k9.ui.messagelist.DefaultFolderProvider
 import com.google.common.truth.Truth.assertThat
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
-import org.junit.Ignore
 import org.junit.Test
 import org.mockito.ArgumentMatchers.eq
 import org.robolectric.RuntimeEnvironment
@@ -22,7 +29,10 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
     val preferences = createPreferences()
     val messagingController = createMessagingController()
     val defaultFolderStrategy = createDefaultFolderStrategy()
-    val provider = UnreadWidgetDataProvider(context, preferences, messagingController, defaultFolderStrategy)
+    val folderRepositoryManager = createFolderRepositoryManager()
+    val folderNameFormatterFactory = createFolderNameFormatterFactory()
+    val provider = UnreadWidgetDataProvider(context, preferences, messagingController, defaultFolderStrategy,
+        folderRepositoryManager, folderNameFormatterFactory)
 
     @Test
     fun unifiedInbox() {
@@ -51,15 +61,13 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
     }
 
     @Test
-    @Ignore("Constructing the title is currently broken")
     fun folder() {
-        val configuration = UnreadWidgetConfiguration(
-                appWidgetId = 4, accountUuid = ACCOUNT_UUID, folderId = FOLDER_ID)
+        val configuration = UnreadWidgetConfiguration(appWidgetId = 4, accountUuid = ACCOUNT_UUID, folderId = FOLDER_ID)
 
         val widgetData = provider.loadUnreadWidgetData(configuration)
 
         with(widgetData!!) {
-            assertThat(title).isEqualTo("$ACCOUNT_DESCRIPTION - $FOLDER_ID")
+            assertThat(title).isEqualTo("$ACCOUNT_DESCRIPTION - $LOCALIZED_FOLDER_NAME")
             assertThat(unreadCount).isEqualTo(FOLDER_UNREAD_COUNT)
         }
     }
@@ -92,6 +100,38 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
         on { getDefaultFolder(account) } doReturn FOLDER_ID
     }
 
+    fun createFolderRepositoryManager(): FolderRepositoryManager {
+        val folderRepository = createFolderRepository()
+        return mock {
+            on { getFolderRepository(account) } doReturn folderRepository
+        }
+    }
+
+    fun createFolderRepository(): FolderRepository {
+        return mock {
+            on { getFolderDetails(FOLDER_ID) } doReturn FolderDetails(
+                folder = FOLDER,
+                isInTopGroup = true,
+                isIntegrate = true,
+                syncClass = FolderClass.NO_CLASS,
+                displayClass = FolderClass.FIRST_CLASS,
+                notifyClass = FolderClass.NO_CLASS,
+                pushClass = FolderClass.NO_CLASS
+            )
+        }
+    }
+
+    private fun createFolderNameFormatterFactory(): FolderNameFormatterFactory {
+        val folderNameFormatter = createFolderNameFormatter()
+        return mock {
+            on { create(any()) } doReturn folderNameFormatter
+        }
+    }
+
+    private fun createFolderNameFormatter(): FolderNameFormatter = mock {
+        on { displayName(FOLDER) } doReturn LOCALIZED_FOLDER_NAME
+    }
+
     companion object {
         const val ACCOUNT_UUID = "00000000-0000-0000-0000-000000000000"
         const val ACCOUNT_DESCRIPTION = "Test account"
@@ -99,5 +139,7 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
         const val SEARCH_ACCOUNT_UNREAD_COUNT = 1
         const val ACCOUNT_UNREAD_COUNT = 2
         const val FOLDER_UNREAD_COUNT = 3
+        const val LOCALIZED_FOLDER_NAME = "Posteingang"
+        val FOLDER = Folder(id = FOLDER_ID, serverId = "irrelevant", name = "INBOX", type = FolderType.INBOX)
     }
 }

--- a/app/ui/build.gradle
+++ b/app/ui/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     implementation "net.jcip:jcip-annotations:1.0"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
     implementation "org.apache.james:apache-mime4j-core:${versions.mime4j}"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.5"
-    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.5"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:${versions.kotlinCoroutines}"
 
     testImplementation project(':mail:testing')
     testImplementation project(':app:storage')

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
 
         versions = [
                 'kotlin': '1.3.72',
+                'kotlinCoroutines': '1.3.5',
                 'androidxAppCompat': '1.2.0-beta01',
                 'androidxRecyclerView': '1.1.0',
                 'androidxLifecycle': '2.2.0',


### PR DESCRIPTION
- load data in a background thread
- rewrite widget configuration created with old app versions to use folder ID instead of folder server ID
- use proper folder display name in widget name