### PR TITLE
Fix loading original message when replying

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -60,7 +60,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -322,10 +321,6 @@ public class LocalFolder {
         FolderClass pushClass = LocalFolder.this.pushClass;
         boolean inTopGroup = isInTopGroup;
         boolean integrate = isIntegrate;
-    }
-
-    public void close() {
-        databaseId = -1;
     }
 
     public int getMessageCount() throws MessagingException {

--- a/app/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
+++ b/app/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
@@ -196,7 +196,6 @@ public class RawMessageProvider extends ContentProvider {
             FetchProfile fetchProfile = new FetchProfile();
             fetchProfile.add(FetchProfile.Item.BODY);
             localFolder.fetch(Collections.singletonList(message), fetchProfile, null);
-            localFolder.close();
 
             return message;
         } catch (MessagingException e) {

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -170,30 +170,11 @@ public class MessagingControllerTest extends K9RobolectricTest {
         verify(localFolder).clearAllMessages();
     }
 
-    @Test
-    public void clearFolderSynchronous_shouldCloseTheFolder() throws MessagingException {
-        controller.clearFolderSynchronous(account, FOLDER_ID);
-
-        verify(localFolder, atLeastOnce()).close();
-    }
-
     @Test(expected = UnavailableAccountException.class)
     public void clearFolderSynchronous_whenStorageUnavailable_shouldThrowUnavailableAccountException() throws MessagingException {
         doThrow(new UnavailableStorageException("Test")).when(localFolder).open();
 
         controller.clearFolderSynchronous(account, FOLDER_ID);
-    }
-
-    @Test()
-    public void clearFolderSynchronous_whenExceptionThrown_shouldStillCloseFolder() throws MessagingException {
-        doThrow(new RuntimeException("Test")).when(localFolder).open();
-
-        try {
-            controller.clearFolderSynchronous(account, FOLDER_ID);
-        } catch (Exception ignored){
-        }
-
-        verify(localFolder, atLeastOnce()).close();
     }
 
     @Test


### PR DESCRIPTION
`LocalMessage.makeMessageReference()` was creating a `MessageReference` instance with `folderId` set to -1 because the `LocalFolder` instance was closed (which wrote -1 to `databaseId`).
Since `LocalFolder.close()` doesn't do anything useful I decided to get rid of it.

Fixes #4742

The diff should probably be viewed with ['hide whitespace changes'](https://github.com/k9mail/k-9/pull/4743/files?diff=unified&w=1) turned on.