### PR TITLE
Keep drawer open after selecting an account

### DIFF
--- a/app/ui/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -139,7 +139,7 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
                             val account = (profile as ProfileDrawerItem).tag as Account
                             parent.openRealAccount(account)
                             updateUserAccountsAndFolders(account)
-                            return false
+                            return true
                         }
                     }
                 })


### PR DESCRIPTION
After selecting an account in the drawer, the drawer will now stay open and show the list of folders of that account. The default folder will be loaded in the message list (behind the drawer).
Users can either close the drawer and end up in the default folder or select another folder from the drawer.
Selecting the Unified Inbox will still close the drawer right away (there are no folders that a user could select).