### PR TITLE
Made it easier to see progress bar

### DIFF
--- a/app/ui/src/main/res/layout/message_list.xml
+++ b/app/ui/src/main/res/layout/message_list.xml
@@ -1,29 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<RelativeLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-    <include layout="@layout/toolbar" />
+    <include
+        layout="@layout/toolbar"
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:layout_alignParentTop="true"/>
 
     <ProgressBar
         android:id="@+id/message_list_progress"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-2dp"
-        android:elevation="4dp"
+        android:layout_marginTop="-6dp"
+        android:elevation="8dp"
         android:max="10000"
-        android:maxHeight="2dp"
-        android:minHeight="2dp"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        android:layout_below="@id/toolbar" />
 
     <com.fsck.k9.view.ViewSwitcher
             android:id="@+id/container"
             android:layout_width="match_parent"
-            android:layout_height="0dip"
-            android:layout_weight="1">
+            android:layout_height="match_parent"
+            android:layout_below="@id/toolbar">
 
         <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/message_list_container"
@@ -37,4 +41,4 @@
 
     </com.fsck.k9.view.ViewSwitcher>
 
-</LinearLayout>
+</RelativeLayout>

--- a/app/ui/src/main/res/layout/split_message_list.xml
+++ b/app/ui/src/main/res/layout/split_message_list.xml
@@ -1,32 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
+<RelativeLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:tools="http://schemas.android.com/tools"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
 
-    <include layout="@layout/toolbar" />
+    <include
+        layout="@layout/toolbar"
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:layout_alignParentTop="true" />
 
     <ProgressBar
         android:id="@+id/message_list_progress"
         style="@style/Widget.AppCompat.ProgressBar.Horizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_marginTop="-2dp"
-        android:elevation="4dp"
+        android:layout_marginTop="-6dp"
+        android:elevation="8dp"
         android:max="10000"
-        android:maxHeight="2dp"
-        android:minHeight="2dp"
-        android:visibility="invisible" />
+        android:visibility="invisible"
+        android:layout_below="@id/toolbar" />
 
     <LinearLayout
             android:id="@+id/container"
-            android:layout_width="fill_parent"
-            android:layout_height="0dip"
-            android:layout_weight="1"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
             android:baselineAligned="false"
-            android:orientation="horizontal">
+            android:orientation="horizontal"
+            android:layout_below="@id/toolbar">
 
         <androidx.fragment.app.FragmentContainerView
                 android:id="@+id/message_list_container"
@@ -48,4 +52,4 @@
                 android:layout_weight="3"/>
 
     </LinearLayout>
-</LinearLayout>
+</RelativeLayout>


### PR DESCRIPTION
Issue #4724 might be a regression because of my change #4477. I still think that it is good to not have the progress bar jump to 100% during refresh. Setting it to indeterminate caused visual jumps, too. Now it has the default height instead of 2dp, which makes it a lot easier to see, even if it is at 0%.

Closes #4724.