### PR TITLE
Lay groundwork for optional in/out server discovery

### DIFF
--- a/app/autodiscovery/build.gradle
+++ b/app/autodiscovery/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     testImplementation project(':app:testing')
     testImplementation project(":backend:imap")
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
+    testImplementation "androidx.test:core:${versions.androidxCore}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/ConnectionSettingsDiscovery.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/ConnectionSettingsDiscovery.kt
@@ -1,5 +1,25 @@
 package com.fsck.k9.autodiscovery
 
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+
 interface ConnectionSettingsDiscovery {
-    fun discover(email: String): ConnectionSettings?
+    fun discover(email: String, target: DiscoveryTarget): DiscoveryResults?
 }
+
+enum class DiscoveryTarget(val outgoing: Boolean, val incoming: Boolean) {
+    OUTGOING(true, false),
+    INCOMING(false, true),
+    INCOMING_AND_OUTGOING(true, true)
+}
+
+data class DiscoveryResults(val incoming: List<DiscoveredServerSettings>, val outgoing: List<DiscoveredServerSettings>)
+
+data class DiscoveredServerSettings(
+    val protocol: String,
+    val host: String,
+    val port: Int,
+    val security: ConnectionSecurity,
+    val authType: AuthType?,
+    val username: String?
+)

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscovery.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscovery.kt
@@ -17,6 +17,10 @@ class ProvidersXmlDiscovery(
 ) : ConnectionSettingsDiscovery {
 
     override fun discover(email: String): ConnectionSettings? {
+        return discover(email, outgoing = true, incoming = true)
+    }
+
+    private fun discover(email: String, outgoing: Boolean, incoming: Boolean): ConnectionSettings? {
         val password = ""
 
         val user = EmailHelper.getLocalPartFromEmailAddress(email) ?: return null

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscovery.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscovery.kt
@@ -43,7 +43,7 @@ class ProvidersXmlDiscovery(
                     it.port,
                     it.connectionSecurity,
                     it.authenticationType,
-                    email
+                    it.username
                 ))
             }
 
@@ -62,7 +62,7 @@ class ProvidersXmlDiscovery(
                     it.port,
                     it.connectionSecurity,
                     it.authenticationType,
-                    email
+                    it.username
                 ))
             }
 

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
@@ -10,7 +10,12 @@ import com.fsck.k9.mail.ServerSettings
 class SrvServiceDiscovery(
     private val srvResolver: MiniDnsSrvResolver
 ) : ConnectionSettingsDiscovery {
+
     override fun discover(email: String): ConnectionSettings? {
+        return discover(email, outgoing = true, incoming = true)
+    }
+
+    fun discover(email: String, outgoing: Boolean, incoming: Boolean): ConnectionSettings? {
         val domain = EmailHelper.getDomainFromEmailAddress(email) ?: return null
         val pickMailService = compareBy<MailService> { it.priority }.thenByDescending { it.security }
 

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
@@ -16,11 +16,15 @@ class SrvServiceDiscovery(
         val domain = EmailHelper.getDomainFromEmailAddress(email) ?: return null
         val pickMailService = compareBy<MailService> { it.priority }.thenByDescending { it.security }
 
-        val outgoingSettings = listOf(SrvType.SUBMISSIONS, SrvType.SUBMISSION)
-            .flatMap { srvResolver.lookup(domain, it) }.sortedWith(pickMailService).map{ newServerSettings(it, email) }
+        val outgoingSettings = if (target.outgoing)
+            listOf(SrvType.SUBMISSIONS, SrvType.SUBMISSION).flatMap { srvResolver.lookup(domain, it) }
+                .sortedWith(pickMailService).map { newServerSettings(it, email) }
+        else listOf()
 
-        val incomingSettings = listOf(SrvType.IMAPS, SrvType.IMAP)
-            .flatMap { srvResolver.lookup(domain, it) }.sortedWith(pickMailService).map{ newServerSettings(it, email) }
+        val incomingSettings = if (target.incoming)
+            listOf(SrvType.IMAPS, SrvType.IMAP).flatMap { srvResolver.lookup(domain, it) }
+                .sortedWith(pickMailService).map { newServerSettings(it, email) }
+        else listOf()
 
         return DiscoveryResults(incoming = incomingSettings, outgoing = outgoingSettings)
     }

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
@@ -1,52 +1,40 @@
 package com.fsck.k9.autodiscovery.srvrecords
 
-import com.fsck.k9.autodiscovery.ConnectionSettings
 import com.fsck.k9.autodiscovery.ConnectionSettingsDiscovery
+import com.fsck.k9.autodiscovery.DiscoveredServerSettings
+import com.fsck.k9.autodiscovery.DiscoveryResults
+import com.fsck.k9.autodiscovery.DiscoveryTarget
 import com.fsck.k9.helper.EmailHelper
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
-import com.fsck.k9.mail.ServerSettings
 
 class SrvServiceDiscovery(
     private val srvResolver: MiniDnsSrvResolver
 ) : ConnectionSettingsDiscovery {
 
-    override fun discover(email: String): ConnectionSettings? {
-        return discover(email, outgoing = true, incoming = true)
-    }
-
-    fun discover(email: String, outgoing: Boolean, incoming: Boolean): ConnectionSettings? {
+    override fun discover(email: String, target: DiscoveryTarget): DiscoveryResults? {
         val domain = EmailHelper.getDomainFromEmailAddress(email) ?: return null
         val pickMailService = compareBy<MailService> { it.priority }.thenByDescending { it.security }
 
-        val outgoingService = listOf(SrvType.SUBMISSIONS, SrvType.SUBMISSION).flatMap { srvResolver.lookup(domain, it) }
-            .minWith(pickMailService) ?: return null
-        val incomingService = listOf(SrvType.IMAPS, SrvType.IMAP).flatMap { srvResolver.lookup(domain, it) }
-            .minWith(pickMailService) ?: return null
+        val outgoingSettings = listOf(SrvType.SUBMISSIONS, SrvType.SUBMISSION)
+            .flatMap { srvResolver.lookup(domain, it) }.sortedWith(pickMailService).map{ newServerSettings(it, email) }
 
-        return ConnectionSettings(
-            incoming = ServerSettings(
-                incomingService.srvType.protocol,
-                incomingService.host,
-                incomingService.port,
-                incomingService.security,
-                AuthType.PLAIN,
-                email,
-                null,
-                null
-            ),
-            outgoing = ServerSettings(
-                outgoingService.srvType.protocol,
-                outgoingService.host,
-                outgoingService.port,
-                outgoingService.security,
-                AuthType.PLAIN,
-                email,
-                null,
-                null
-            )
-        )
+        val incomingSettings = listOf(SrvType.IMAPS, SrvType.IMAP)
+            .flatMap { srvResolver.lookup(domain, it) }.sortedWith(pickMailService).map{ newServerSettings(it, email) }
+
+        return DiscoveryResults(incoming = incomingSettings, outgoing = outgoingSettings)
     }
+}
+
+fun newServerSettings(service: MailService, email: String): DiscoveredServerSettings {
+    return DiscoveredServerSettings(
+        service.srvType.protocol,
+        service.host,
+        service.port,
+        service.security,
+        AuthType.PLAIN,
+        email
+    )
 }
 
 enum class SrvType(val label: String, val protocol: String, val assumeTls: Boolean) {
@@ -61,5 +49,5 @@ data class MailService(
     val host: String,
     val port: Int,
     val priority: Int,
-    val security: ConnectionSecurity?
+    val security: ConnectionSecurity
 )

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscovery.kt
@@ -14,16 +14,16 @@ class SrvServiceDiscovery(
 
     override fun discover(email: String, target: DiscoveryTarget): DiscoveryResults? {
         val domain = EmailHelper.getDomainFromEmailAddress(email) ?: return null
-        val pickMailService = compareBy<MailService> { it.priority }.thenByDescending { it.security }
+        val mailServicePriority = compareBy<MailService> { it.priority }.thenByDescending { it.security }
 
         val outgoingSettings = if (target.outgoing)
             listOf(SrvType.SUBMISSIONS, SrvType.SUBMISSION).flatMap { srvResolver.lookup(domain, it) }
-                .sortedWith(pickMailService).map { newServerSettings(it, email) }
+                .sortedWith(mailServicePriority).map { newServerSettings(it, email) }
         else listOf()
 
         val incomingSettings = if (target.incoming)
             listOf(SrvType.IMAPS, SrvType.IMAP).flatMap { srvResolver.lookup(domain, it) }
-                .sortedWith(pickMailService).map { newServerSettings(it, email) }
+                .sortedWith(mailServicePriority).map { newServerSettings(it, email) }
         else listOf()
 
         return DiscoveryResults(incoming = incomingSettings, outgoing = outgoingSettings)

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigParser.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigParser.kt
@@ -1,9 +1,9 @@
 package com.fsck.k9.autodiscovery.thunderbird
 
-import com.fsck.k9.autodiscovery.ConnectionSettings
+import com.fsck.k9.autodiscovery.DiscoveredServerSettings
+import com.fsck.k9.autodiscovery.DiscoveryResults
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
-import com.fsck.k9.mail.ServerSettings
 import java.io.IOException
 import java.io.InputStream
 import java.io.InputStreamReader
@@ -16,9 +16,9 @@ import org.xmlpull.v1.XmlPullParserFactory
  * [Autoconfig file format](https://wiki.mozilla.org/Thunderbird:Autoconfiguration:ConfigFileFormat)
  */
 class ThunderbirdAutoconfigParser {
-    fun parseSettings(stream: InputStream, email: String): ConnectionSettings? {
-        var incoming: ServerSettings? = null
-        var outgoing: ServerSettings? = null
+    fun parseSettings(stream: InputStream, email: String): DiscoveryResults? {
+        var incoming: DiscoveredServerSettings? = null
+        var outgoing: DiscoveredServerSettings? = null
 
         val factory = XmlPullParserFactory.newInstance()
         val xpp = factory.newPullParser()
@@ -38,7 +38,7 @@ class ThunderbirdAutoconfigParser {
                 }
 
                 if (incoming != null && outgoing != null) {
-                    return ConnectionSettings(incoming, outgoing)
+                    return DiscoveryResults(listOf(incoming), listOf(outgoing))
                 }
             }
             eventType = xpp.next()
@@ -46,7 +46,7 @@ class ThunderbirdAutoconfigParser {
         return null
     }
 
-    private fun parseServer(xpp: XmlPullParser, nodeName: String, email: String): ServerSettings {
+    private fun parseServer(xpp: XmlPullParser, nodeName: String, email: String): DiscoveredServerSettings {
         val type = xpp.getAttributeValue(null, "type")
         var host: String? = null
         var username: String? = null
@@ -78,7 +78,7 @@ class ThunderbirdAutoconfigParser {
             eventType = xpp.next()
         }
 
-        return ServerSettings(type, host, port!!, connectionSecurity, authType, username, null, null)
+        return DiscoveredServerSettings(type, host!!, port!!, connectionSecurity!!, authType, username)
     }
 
     private fun parseAuthType(authentication: String): AuthType? {

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigParser.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigParser.kt
@@ -17,33 +17,28 @@ import org.xmlpull.v1.XmlPullParserFactory
  */
 class ThunderbirdAutoconfigParser {
     fun parseSettings(stream: InputStream, email: String): DiscoveryResults? {
-        var incoming: DiscoveredServerSettings? = null
-        var outgoing: DiscoveredServerSettings? = null
-
         val factory = XmlPullParserFactory.newInstance()
         val xpp = factory.newPullParser()
 
         xpp.setInput(InputStreamReader(stream))
 
+        val incomingServers = mutableListOf<DiscoveredServerSettings>()
+        val outgoingServers = mutableListOf<DiscoveredServerSettings>()
         var eventType = xpp.eventType
         while (eventType != XmlPullParser.END_DOCUMENT) {
             if (eventType == XmlPullParser.START_TAG) {
                 when (xpp.name) {
                     "incomingServer" -> {
-                        incoming = parseServer(xpp, "incomingServer", email)
+                        incomingServers += parseServer(xpp, "incomingServer", email)
                     }
                     "outgoingServer" -> {
-                        outgoing = parseServer(xpp, "outgoingServer", email)
+                        outgoingServers += parseServer(xpp, "outgoingServer", email)
                     }
-                }
-
-                if (incoming != null && outgoing != null) {
-                    return DiscoveryResults(listOf(incoming), listOf(outgoing))
                 }
             }
             eventType = xpp.next()
         }
-        return null
+        return DiscoveryResults(incomingServers, outgoingServers)
     }
 
     private fun parseServer(xpp: XmlPullParser, nodeName: String, email: String): DiscoveredServerSettings {

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdDiscovery.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdDiscovery.kt
@@ -1,18 +1,15 @@
 package com.fsck.k9.autodiscovery.thunderbird
 
-import com.fsck.k9.autodiscovery.ConnectionSettings
 import com.fsck.k9.autodiscovery.ConnectionSettingsDiscovery
+import com.fsck.k9.autodiscovery.DiscoveryResults
+import com.fsck.k9.autodiscovery.DiscoveryTarget
 
 class ThunderbirdDiscovery(
     private val fetcher: ThunderbirdAutoconfigFetcher,
     private val parser: ThunderbirdAutoconfigParser
 ) : ConnectionSettingsDiscovery {
 
-    override fun discover(email: String): ConnectionSettings? {
-        return discover(email, outgoing = true, incoming = true)
-    }
-
-    private fun discover(email: String, outgoing: Boolean, incoming: Boolean): ConnectionSettings? {
+    override fun discover(email: String, target: DiscoveryTarget): DiscoveryResults? {
         val autoconfigInputStream = fetcher.fetchAutoconfigFile(email) ?: return null
 
         return autoconfigInputStream.use {

--- a/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdDiscovery.kt
+++ b/app/autodiscovery/src/main/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdDiscovery.kt
@@ -9,6 +9,10 @@ class ThunderbirdDiscovery(
 ) : ConnectionSettingsDiscovery {
 
     override fun discover(email: String): ConnectionSettings? {
+        return discover(email, outgoing = true, incoming = true)
+    }
+
+    private fun discover(email: String, outgoing: Boolean, incoming: Boolean): ConnectionSettings? {
         val autoconfigInputStream = fetcher.fetchAutoconfigFile(email) ?: return null
 
         return autoconfigInputStream.use {

--- a/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
+++ b/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.autodiscovery.providersxml
 
 import com.fsck.k9.RobolectricTest
+import com.fsck.k9.autodiscovery.DiscoveryTarget
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.backend.imap.ImapStoreUriDecoder
 import com.fsck.k9.mail.AuthType
@@ -25,19 +26,19 @@ class ProvidersXmlDiscoveryTest : RobolectricTest() {
 
     @Test
     fun discover_withGmailDomain_shouldReturnCorrectSettings() {
-        val connectionSettings = providersXmlDiscovery.discover("user@gmail.com")
+        val connectionSettings = providersXmlDiscovery.discover("user@gmail.com", DiscoveryTarget.INCOMING_AND_OUTGOING)
 
         assertThat(connectionSettings).isNotNull()
-        with(connectionSettings!!.incoming) {
+        with(connectionSettings!!.incoming.first()) {
             assertThat(host).isEqualTo("imap.gmail.com")
-            assertThat(connectionSecurity).isEqualTo(ConnectionSecurity.SSL_TLS_REQUIRED)
-            assertThat(authenticationType).isEqualTo(AuthType.PLAIN)
+            assertThat(security).isEqualTo(ConnectionSecurity.SSL_TLS_REQUIRED)
+            assertThat(authType).isEqualTo(AuthType.PLAIN)
             assertThat(username).isEqualTo("user@gmail.com")
         }
-        with(connectionSettings.outgoing) {
+        with(connectionSettings.outgoing.first()) {
             assertThat(host).isEqualTo("smtp.gmail.com")
-            assertThat(connectionSecurity).isEqualTo(ConnectionSecurity.SSL_TLS_REQUIRED)
-            assertThat(authenticationType).isEqualTo(AuthType.PLAIN)
+            assertThat(security).isEqualTo(ConnectionSecurity.SSL_TLS_REQUIRED)
+            assertThat(authType).isEqualTo(AuthType.PLAIN)
             assertThat(username).isEqualTo("user@gmail.com")
         }
     }
@@ -45,7 +46,7 @@ class ProvidersXmlDiscoveryTest : RobolectricTest() {
     @Test
     fun discover_withUnknownDomain_shouldReturnNull() {
         val connectionSettings = providersXmlDiscovery.discover(
-            "user@not.present.in.providers.xml.example")
+            "user@not.present.in.providers.xml.example", DiscoveryTarget.INCOMING_AND_OUTGOING)
 
         assertThat(connectionSettings).isNull()
     }

--- a/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
+++ b/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.autodiscovery.providersxml
 
+import androidx.test.core.app.ApplicationProvider
 import com.fsck.k9.RobolectricTest
 import com.fsck.k9.autodiscovery.DiscoveryTarget
 import com.fsck.k9.backend.BackendManager
@@ -12,17 +13,16 @@ import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.mock
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyString
-import org.robolectric.RuntimeEnvironment
 
 class ProvidersXmlDiscoveryTest : RobolectricTest() {
-    val backendManager = mock<BackendManager> {
+    private val backendManager = mock<BackendManager> {
         on { decodeStoreUri(anyString()) } doAnswer { mock -> ImapStoreUriDecoder.decode(mock.getArgument(0)) }
         on { decodeTransportUri(anyString()) } doAnswer { mock ->
             SmtpTransportUriDecoder.decodeSmtpUri(mock.getArgument(0))
         }
     }
-    val xmlProvider = ProvidersXmlProvider(RuntimeEnvironment.application)
-    val providersXmlDiscovery = ProvidersXmlDiscovery(backendManager, xmlProvider)
+    private val xmlProvider = ProvidersXmlProvider(ApplicationProvider.getApplicationContext())
+    private val providersXmlDiscovery = ProvidersXmlDiscovery(backendManager, xmlProvider)
 
     @Test
     fun discover_withGmailDomain_shouldReturnCorrectSettings() {

--- a/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
+++ b/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
@@ -44,7 +44,8 @@ class ProvidersXmlDiscoveryTest : RobolectricTest() {
 
     @Test
     fun discover_withUnknownDomain_shouldReturnNull() {
-        val connectionSettings = providersXmlDiscovery.discover("user@not.present.in.providers.xml.example")
+        val connectionSettings = providersXmlDiscovery.discover(
+            "user@not.present.in.providers.xml.example")
 
         assertThat(connectionSettings).isNull()
     }

--- a/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscoveryTest.kt
+++ b/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/srvrecords/SrvServiceDiscoveryTest.kt
@@ -41,7 +41,7 @@ class SrvServiceDiscoveryTest : RobolectricTest() {
         ))
 
         val srvServiceDiscovery = SrvServiceDiscovery(srvResolver)
-        val result = srvServiceDiscovery.discover("test@example.com")
+        val result = srvServiceDiscovery.discover("test@example.com", outgoing = true, incoming = true)
 
         assertNull(result)
     }
@@ -79,7 +79,7 @@ class SrvServiceDiscoveryTest : RobolectricTest() {
         ))
 
         val srvServiceDiscovery = SrvServiceDiscovery(srvResolver)
-        val result = srvServiceDiscovery.discover("test@example.com")
+        val result = srvServiceDiscovery.discover("test@example.com", outgoing = true, incoming = true)
 
         assertEquals("smtp3.example.com", result?.outgoing?.host)
         assertEquals("imaps1.example.com", result?.incoming?.host)

--- a/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigTest.kt
+++ b/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigTest.kt
@@ -1,6 +1,10 @@
 package com.fsck.k9.autodiscovery.thunderbird
 
 import com.fsck.k9.RobolectricTest
+import com.fsck.k9.autodiscovery.DiscoveredServerSettings
+import com.fsck.k9.autodiscovery.DiscoveryResults
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
 
@@ -42,9 +46,9 @@ class ThunderbirdAutoconfigTest : RobolectricTest() {
         assertThat(connectionSettings!!.incoming).isNotNull()
         assertThat(connectionSettings.outgoing).isNotNull()
         with(connectionSettings.incoming.first()) {
-            assertThat(this.port).isEqualTo(993)
-            assertThat(this.host).isEqualTo("imap.googlemail.com")
-            assertThat(this.username).isEqualTo("test@metacode.biz")
+            assertThat(host).isEqualTo("imap.googlemail.com")
+            assertThat(port).isEqualTo(993)
+            assertThat(username).isEqualTo("test@metacode.biz")
         }
         with(connectionSettings.outgoing.first()) {
             assertThat(host).isEqualTo("smtp.googlemail.com")
@@ -54,7 +58,7 @@ class ThunderbirdAutoconfigTest : RobolectricTest() {
     }
 
     @Test
-    fun pickFirstServer() {
+    fun multipleServers() {
         val input = """<?xml version="1.0"?>
             <clientConfig version="1.1">
                 <emailProvider id="metacode.biz">
@@ -92,12 +96,17 @@ class ThunderbirdAutoconfigTest : RobolectricTest() {
         </clientConfig>
         """.trimIndent().byteInputStream()
 
-        val connectionSettings = parser.parseSettings(input, "test@metacode.biz")
+        val discoveryResults = parser.parseSettings(input, "test@metacode.biz")
 
-        assertThat(connectionSettings).isNotNull()
-        assertThat(connectionSettings!!.outgoing).isNotNull()
-        with(connectionSettings.outgoing.first()) {
+        assertThat(discoveryResults).isNotNull()
+        assertThat(discoveryResults!!.outgoing).isNotNull()
+        with(discoveryResults.outgoing[0]) {
             assertThat(host).isEqualTo("first")
+            assertThat(port).isEqualTo(465)
+            assertThat(username).isEqualTo("test@metacode.biz")
+        }
+        with(discoveryResults.outgoing[1]) {
+            assertThat(host).isEqualTo("second")
             assertThat(port).isEqualTo(465)
             assertThat(username).isEqualTo("test@metacode.biz")
         }
@@ -113,7 +122,7 @@ class ThunderbirdAutoconfigTest : RobolectricTest() {
 
         val connectionSettings = parser.parseSettings(input, "test@metacode.biz")
 
-        assertThat(connectionSettings).isNull()
+        assertThat(connectionSettings).isEqualTo(DiscoveryResults(listOf(), listOf()))
     }
 
     @Test
@@ -137,7 +146,12 @@ class ThunderbirdAutoconfigTest : RobolectricTest() {
 
         val connectionSettings = parser.parseSettings(input, "test@metacode.biz")
 
-        assertThat(connectionSettings).isNull()
+        assertThat(connectionSettings).isEqualTo(DiscoveryResults(listOf(
+            DiscoveredServerSettings(
+                protocol = "imap", host = "imap.googlemail.com", port = 993,
+                security = ConnectionSecurity.SSL_TLS_REQUIRED, authType = AuthType.PLAIN,
+                username = "test@metacode.biz")
+        ), listOf()))
     }
 
     @Test

--- a/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigTest.kt
+++ b/app/autodiscovery/src/test/java/com/fsck/k9/autodiscovery/thunderbird/ThunderbirdAutoconfigTest.kt
@@ -41,12 +41,12 @@ class ThunderbirdAutoconfigTest : RobolectricTest() {
         assertThat(connectionSettings).isNotNull()
         assertThat(connectionSettings!!.incoming).isNotNull()
         assertThat(connectionSettings.outgoing).isNotNull()
-        with(connectionSettings.incoming) {
-            assertThat(host).isEqualTo("imap.googlemail.com")
-            assertThat(port).isEqualTo(993)
-            assertThat(username).isEqualTo("test@metacode.biz")
+        with(connectionSettings.incoming.first()) {
+            assertThat(this.port).isEqualTo(993)
+            assertThat(this.host).isEqualTo("imap.googlemail.com")
+            assertThat(this.username).isEqualTo("test@metacode.biz")
         }
-        with(connectionSettings.outgoing) {
+        with(connectionSettings.outgoing.first()) {
             assertThat(host).isEqualTo("smtp.googlemail.com")
             assertThat(port).isEqualTo(465)
             assertThat(username).isEqualTo("test@metacode.biz")
@@ -96,7 +96,7 @@ class ThunderbirdAutoconfigTest : RobolectricTest() {
 
         assertThat(connectionSettings).isNotNull()
         assertThat(connectionSettings!!.outgoing).isNotNull()
-        with(connectionSettings.outgoing) {
+        with(connectionSettings.outgoing.first()) {
             assertThat(host).isEqualTo("first")
             assertThat(port).isEqualTo(465)
             assertThat(username).isEqualTo("test@metacode.biz")

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -268,7 +268,7 @@ public class AccountSetupBasics extends K9Activity
 
     private ConnectionSettings providersXmlDiscoveryDiscover(String email, DiscoveryTarget discoveryTarget) {
         DiscoveryResults discoveryResults = providersXmlDiscovery.discover(email, DiscoveryTarget.INCOMING_AND_OUTGOING);
-        if (discoveryResults == null || (discoveryResults.getIncoming().size() != 1 || discoveryResults.getOutgoing().size() != 1)) {
+        if (discoveryResults == null || (discoveryResults.getIncoming().size() < 1 || discoveryResults.getOutgoing().size() < 1)) {
             return null;
         }
         DiscoveredServerSettings incoming = discoveryResults.getIncoming().get(0);

--- a/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -259,6 +259,7 @@ public class AccountSetupBasics extends K9Activity
         ServerSettings outgoingServerSettings = connectionSettings.getOutgoing().newPassword(password);
         String transportUri = backendManager.createTransportUri(outgoingServerSettings);
         mAccount.setTransportUri(transportUri);
+
         mAccount.setDeletePolicy(accountCreator.getDefaultDeletePolicy(incomingServerSettings.type));
 
         // Check incoming here.  Then check outgoing in onActivityResult()


### PR DESCRIPTION
Components to update (including tests):
- [x]  ConnectionSettingsDiscovery interface
- [x] SrvServiceDiscovery
- [x] ProviderXmlDiscovery*
- [x] ThunderbirdDiscovery

* This appears to be designed such that there is one SMTP and one IMAP server for each email provider. The current implementation hasn't really been changed to support multiple SMTP ot multiple IMAP servers.

Addresses: https://github.com/k9mail/k-9/issues/4759