### PR TITLE
Changed clumsy German translation to common term

### DIFF
--- a/app/ui/legacy/src/main/res/values-de/strings.xml
+++ b/app/ui/legacy/src/main/res/values-de/strings.xml
@@ -644,7 +644,7 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="setting_theme_follow_system">Systemvorgabe verwenden</string>
   <string name="display_preferences">Anzeige</string>
   <string name="global_preferences">Globale Einstellungen</string>
-  <string name="debug_preferences">Fehlersuchvorgang</string>
+  <string name="debug_preferences">Debugging</string>
   <string name="privacy_preferences">Datenschutz</string>
   <string name="network_preferences">Netzwerk</string>
   <string name="interaction_preferences">Interaktion</string>


### PR DESCRIPTION
Never heard or read the word "Fehlersuchvorgang".
It wasn't helping when following instructions and searching the "debugging" option. 
To me "Fehlersuchvorgang" sounds like "Microsoft German" (using German words instead of the common English terms for computer related stuff at all cost) or straight from an automatic translator.
I'm certainly prefer existing German vocabulary over Anglicisms, but please just call it "debugging".
Or at least "Fehlersuche".

Please ensure that your pull request meets the following requirements - thanks !

* Follows our existing [codestyle](https://github.com/k9mail/k-9/wiki/CodeStyle).
* Does not break any unit tests.
* Contains a reference to the issue that it fixes.
* For cosmetic changes add one or multiple images, if possible.


