### PR TITLE
Avoid NullPointerException when reading attachment

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/loader/AttachmentContentLoader.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/loader/AttachmentContentLoader.java
@@ -60,6 +60,13 @@ public class AttachmentContentLoader extends AsyncTaskLoader<Attachment> {
 
             SafeContentResolver safeContentResolver = SafeContentResolver.newInstance(context);
             InputStream in = safeContentResolver.openInputStream(sourceAttachment.uri);
+            if (in == null) {
+                Timber.w("Error opening attachment for reading: %s", sourceAttachment.uri);
+
+                cachedResultAttachment = sourceAttachment.deriveWithLoadCancelled();
+                return cachedResultAttachment;
+            }
+
             try {
                 FileOutputStream out = new FileOutputStream(file);
                 try {


### PR DESCRIPTION
Fixes #4790
