### PR TITLE
Fix local outbox

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -960,10 +960,14 @@ public class LocalStore {
     }
 
     public long createLocalFolder(String folderName, FolderType type) throws MessagingException {
+        return createLocalFolder(folderName, folderName, type);
+    }
+
+    public long createLocalFolder(String folderServerId, String folderName, FolderType type) throws MessagingException {
         return database.execute(true, (DbCallback<Long>) db -> {
             ContentValues values = new ContentValues();
             values.put("name", folderName);
-            values.put("server_id", folderName);
+            values.put("server_id", folderServerId);
             values.put("local_only", 1);
             values.put("type", FolderTypeConverter.toDatabaseFolderType(type));
             values.put("visible_limit", 0);

--- a/app/core/src/main/java/com/fsck/k9/mailstore/SpecialLocalFoldersCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/SpecialLocalFoldersCreator.kt
@@ -14,7 +14,7 @@ class SpecialLocalFoldersCreator(
 
         val localStore = localStoreProvider.getInstance(account)
 
-        account.outboxFolderId = localStore.createLocalFolder(OUTBOX_FOLDER_NAME, FolderType.OUTBOX)
+        account.outboxFolderId = localStore.createLocalFolder(OUTBOX_SERVER_ID, OUTBOX_FOLDER_NAME, FolderType.OUTBOX)
 
         if (account.isPop3()) {
             check(account.draftsFolderId == null) { "Drafts folder was already set up" }
@@ -37,6 +37,7 @@ class SpecialLocalFoldersCreator(
     private fun Account.isPop3() = storeUri.startsWith("pop3")
 
     companion object {
+        private const val OUTBOX_SERVER_ID = Account.OUTBOX
         private const val OUTBOX_FOLDER_NAME = Account.OUTBOX_NAME
         private const val DRAFTS_FOLDER_NAME = "Drafts"
         private const val SENT_FOLDER_NAME = "Sent"

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/backends/JmapAccountCreator.kt
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/backends/JmapAccountCreator.kt
@@ -52,7 +52,7 @@ class JmapAccountCreator(
 
     private fun createOutboxFolder(account: Account) {
         val localStore = localStoreProvider.getInstance(account)
-        account.outboxFolderId = localStore.createLocalFolder(Account.OUTBOX_NAME, FolderType.OUTBOX)
+        account.outboxFolderId = localStore.createLocalFolder(Account.OUTBOX, Account.OUTBOX_NAME, FolderType.OUTBOX)
     }
 
     private fun fetchFolderList(account: Account) {

--- a/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -12,7 +12,7 @@ import timber.log.Timber;
 
 
 class StoreSchemaDefinition implements SchemaDefinition {
-    static final int DB_VERSION = 76;
+    static final int DB_VERSION = 77;
 
     private final MigrationsHelper migrationsHelper;
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo77.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo77.kt
@@ -1,0 +1,17 @@
+package com.fsck.k9.storage.migrations
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+
+/**
+ * Make sure local Outbox folder has correct 'server_id' value
+ */
+internal class MigrationTo77(private val db: SQLiteDatabase) {
+    fun cleanUpOutboxServerId() {
+        val values = ContentValues().apply {
+            put("server_id", "K9MAIL_INTERNAL_OUTBOX")
+        }
+
+        db.update("folders", values, "name = 'Outbox' AND local_only = 1", null)
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
@@ -22,5 +22,6 @@ object Migrations {
         if (oldVersion < 74) MigrationTo74(db, migrationsHelper.account).removeDeletedMessages()
         if (oldVersion < 75) MigrationTo75(db, migrationsHelper).updateAccountWithSpecialFolderIds()
         if (oldVersion < 76) MigrationTo76(db, migrationsHelper).cleanUpSpecialLocalFolders()
+        if (oldVersion < 77) MigrationTo77(db).cleanUpOutboxServerId()
     }
 }


### PR DESCRIPTION
`SpecialLocalFoldersCreator` created the local outbox folder with a `server_id` value of "Outbox" instead of "K9MAIL_INTERNAL_OUTBOX". This leads to a conflict when the server contains a folder with the server ID "Outbox" :cry: 

The proper fix is to not use the `server_id` column for local folders at all. Unfortunately, this requires changes in a lot of places.

Fixes #4798