### PR TITLE
Don't attempt to perform remote operations on local-only folders

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2536,7 +2536,7 @@ public class MessagingController {
                 localMessage.setCachedDecryptedSubject(plaintextSubject);
             }
 
-            if (saveRemotely) {
+            if (saveRemotely && supportsUpload(account)) {
                 PendingCommand command = PendingAppend.create(localFolder.getDatabaseId(), localMessage.getUid());
                 queuePendingCommand(account, command);
                 processPendingCommands(account);

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1021,7 +1021,7 @@ public class MessagingController {
         }
 
         Backend backend = getBackend(account);
-        if (backend.getSupportsSeenFlag()) {
+        if (backend.getSupportsFlags()) {
             backend.markAllAsRead(folderServerId);
         }
     }
@@ -1652,8 +1652,8 @@ public class MessagingController {
         return getBackend(account).isPushCapable();
     }
 
-    public boolean supportsSeenFlag(Account account) {
-        return getBackend(account).getSupportsSeenFlag();
+    public boolean supportsFlags(Account account) {
+        return getBackend(account).getSupportsFlags();
     }
 
     public boolean supportsExpunge(Account account) {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1601,9 +1601,11 @@ public class MessagingController {
 
             Timber.i("Moved sent message to folder '%s' (%d)", sentFolderServerId, sentFolderId);
 
-            PendingCommand command = PendingAppend.create(sentFolderId, message.getUid());
-            queuePendingCommand(account, command);
-            processPendingCommands(account);
+            if (!sentFolder.isLocalOnly()) {
+                PendingCommand command = PendingAppend.create(sentFolderId, message.getUid());
+                queuePendingCommand(account, command);
+                processPendingCommands(account);
+            }
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2002,7 +2002,7 @@ public class MessagingController {
             Timber.d("Delete policy for account %s is %s", account.getDescription(), account.getDeletePolicy());
 
             Long outboxFolderId = account.getOutboxFolderId();
-            if (outboxFolderId != null && folderId == outboxFolderId) {
+            if (outboxFolderId != null && folderId == outboxFolderId && supportsUpload(account)) {
                 for (Message message : messages) {
                     // If the message was in the Outbox, then it has been copied to local Trash, and has
                     // to be copied to remote trash
@@ -2010,6 +2010,8 @@ public class MessagingController {
                     queuePendingCommand(account, command);
                 }
                 processPendingCommands(account);
+            } else if (localFolder.isLocalOnly()) {
+                // Nothing to do on the remote side
             } else if (!syncedMessageUids.isEmpty()) {
                 if (account.getDeletePolicy() == DeletePolicy.ON_DELETE) {
                     if (!account.hasTrashFolder() || folderId == trashFolderId ||

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -147,7 +147,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
 
     private fun initializeDeletePolicy(account: Account) {
         (findPreference(PREFERENCE_DELETE_POLICY) as? ListPreference)?.apply {
-            if (!messagingController.supportsSeenFlag(account)) {
+            if (!messagingController.supportsFlags(account)) {
                 removeEntry(DELETE_POLICY_MARK_AS_READ)
             }
         }

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/Backend.kt
@@ -8,7 +8,7 @@ import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.mail.Part
 
 interface Backend {
-    val supportsSeenFlag: Boolean
+    val supportsFlags: Boolean
     val supportsExpunge: Boolean
     val supportsMove: Boolean
     val supportsCopy: Boolean

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.java
@@ -60,7 +60,7 @@ public class ImapBackend implements Backend {
     }
 
     @Override
-    public boolean getSupportsSeenFlag() {
+    public boolean getSupportsFlags() {
         return true;
     }
 

--- a/backend/jmap/src/main/java/com/fsck/k9/backend/jmap/JmapBackend.kt
+++ b/backend/jmap/src/main/java/com/fsck/k9/backend/jmap/JmapBackend.kt
@@ -30,7 +30,7 @@ class JmapBackend(
     private val commandDelete = CommandDelete(jmapClient, accountId)
     private val commandMove = CommandMove(jmapClient, accountId)
     private val commandUpload = CommandUpload(jmapClient, okHttpClient, httpAuthentication, accountId)
-    override val supportsSeenFlag = true
+    override val supportsFlags = true
     override val supportsExpunge = false
     override val supportsMove = true
     override val supportsCopy = true

--- a/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
+++ b/backend/pop3/src/main/java/com/fsck/k9/backend/pop3/Pop3Backend.kt
@@ -23,7 +23,7 @@ class Pop3Backend(
     private val commandSetFlag = CommandSetFlag(pop3Store)
     private val commandFetchMessage = CommandFetchMessage(pop3Store)
 
-    override val supportsSeenFlag = false
+    override val supportsFlags = false
     override val supportsExpunge = false
     override val supportsMove = false
     override val supportsCopy = false

--- a/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavBackend.kt
+++ b/backend/webdav/src/main/java/com/fsck/k9/backend/webdav/WebDavBackend.kt
@@ -27,7 +27,7 @@ class WebDavBackend(
     private val commandFetchMessage = CommandFetchMessage(webDavStore)
     private val commandUploadMessage = CommandUploadMessage(webDavStore)
 
-    override val supportsSeenFlag = true
+    override val supportsFlags = true
     override val supportsExpunge = true
     override val supportsMove = true
     override val supportsCopy = true


### PR DESCRIPTION
Now that local-only folders return a server ID value of `null` "remote operations" for these folders are no longer no-ops but throw an exception. We should have never attempted to perform any remote operations for local-only folders in the first place. So this PR fixes that.

Local-only folders can be:
- Outbox for all account types
- Special folders for POP3 accounts: Drafts, Sent, Trash

Operations that lead to failed "pending commands":
- Changing flags of messages in a local-only folder or in a POP3 Inbox
- POP3: Deleting a message from the Outbox
- POP3: Saving a sent message to the Sent folder
- POP3: Saving a draft

