### PR TITLE
Let WebView handle bidirectional text

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/html/EmailTextToHtml.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/EmailTextToHtml.kt
@@ -22,7 +22,7 @@ class EmailTextToHtml private constructor(private val text: String) {
     }
 
     private fun appendHtmlPrefix() {
-        html.append("<pre class=\"$K9MAIL_CSS_CLASS\">")
+        html.append("<pre dir=\"auto\" class=\"$K9MAIL_CSS_CLASS\">")
     }
 
     private fun appendHtmlSuffix() {

--- a/app/core/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/MessageViewInfoExtractorTest.java
@@ -124,7 +124,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         ViewableExtractedText container = messageViewInfoExtractor.extractTextFromViewables(outputViewableParts);
 
         String expectedHtml =
-                "<pre class=\"k9mail\">" +
+                "<pre dir=\"auto\" class=\"k9mail\">" +
                 "K-9 Mail rocks :&gt;" +
                 "</pre>";
 
@@ -151,7 +151,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         String expectedText = "K-9 Mail rocks :> flowed line\r\n" +
                 "not flowed line";
         String expectedHtml =
-                "<pre class=\"k9mail\">" +
+                "<pre dir=\"auto\" class=\"k9mail\">" +
                         "K-9 Mail rocks :&gt; flowed line<br>not flowed line" +
                         "</pre>";
 
@@ -212,12 +212,12 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 "------------------------------------------------------------------------\r\n\r\n" +
                 bodyText2;
         String expectedHtml =
-                "<pre class=\"k9mail\">" +
+                "<pre dir=\"auto\" class=\"k9mail\">" +
                 bodyText1 +
                 "</pre>" +
                 "<p style=\"margin-top: 2.5em; margin-bottom: 1em; " +
                         "border-bottom: 1px solid #000\"></p>" +
-                "<pre class=\"k9mail\">" +
+                "<pre dir=\"auto\" class=\"k9mail\">" +
                 bodyText2 +
                 "</pre>";
 
@@ -278,7 +278,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 "\r\n" +
                 innerBodyText;
         String expectedHtml =
-                "<pre class=\"k9mail\">" +
+                "<pre dir=\"auto\" class=\"k9mail\">" +
                         BODY_TEXT_HTML +
                 "</pre>" +
                 "<p style=\"margin-top: 2.5em; margin-bottom: 1em; border-bottom: " +
@@ -298,7 +298,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 "<td>Subject</td>" +
                 "</tr>" +
                 "</table>" +
-                "<pre class=\"k9mail\">" +
+                "<pre dir=\"auto\" class=\"k9mail\">" +
                 innerBodyText +
                 "</pre>";
 
@@ -354,12 +354,12 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         String expectedHtmlText = "<table style=\"border: 0\">" +
                 "<tr><th style=\"text-align: left; vertical-align: top;\">Subject:</th><td>(No subject)</td></tr>" +
                 "</table>" +
-                "<pre class=\"k9mail\">text body of first message<br></pre>" +
+                "<pre dir=\"auto\" class=\"k9mail\">text body of first message<br></pre>" +
                 "<p style=\"margin-top: 2.5em; margin-bottom: 1em; border-bottom: 1px solid #000\"></p>" +
                 "<table style=\"border: 0\">" +
                 "<tr><th style=\"text-align: left; vertical-align: top;\">Subject:</th><td>subject of second message</td></tr>" +
                 "</table>" +
-                "<pre class=\"k9mail\">text part of second message<br></pre>";
+                "<pre dir=\"auto\" class=\"k9mail\">text part of second message<br></pre>";
 
 
         assertEquals(4, outputViewableParts.size());
@@ -387,7 +387,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 false);
 
 
-        assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">text</pre>", messageViewInfo.text);
         assertSame(attachmentViewInfo, messageViewInfo.attachments.get(0));
         assertNull(messageViewInfo.cryptoResultAnnotation);
         assertTrue(messageViewInfo.extraAttachments.isEmpty());
@@ -409,7 +409,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 false);
 
 
-        assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">text</pre>", messageViewInfo.text);
         assertSame(annotation, messageViewInfo.cryptoResultAnnotation);
         assertSame(message, messageViewInfo.message);
         assertSame(message, messageViewInfo.rootPart);
@@ -434,7 +434,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 false);
 
 
-        assertEquals("<pre class=\"k9mail\">replacement text</pre>", messageViewInfo.text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">replacement text</pre>", messageViewInfo.text);
         assertSame(annotation, messageViewInfo.cryptoResultAnnotation);
         assertSame(message, messageViewInfo.message);
         assertSame(replacementPart, messageViewInfo.rootPart);
@@ -462,7 +462,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 false);
 
 
-        assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">text</pre>", messageViewInfo.text);
         assertSame(annotation, messageViewInfo.cryptoResultAnnotation);
         assertEquals("extra text", messageViewInfo.extraText);
         assertTrue(messageViewInfo.attachments.isEmpty());
@@ -492,7 +492,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 false);
 
 
-        assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">text</pre>", messageViewInfo.text);
         assertSame(annotation, messageViewInfo.cryptoResultAnnotation);
         assertSame(attachmentViewInfo, messageViewInfo.extraAttachments.get(0));
         assertTrue(messageViewInfo.attachments.isEmpty());
@@ -533,7 +533,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 true);
 
         assertSame(openPgpResultAnnotation, messageViewInfo.cryptoResultAnnotation);
-        assertEquals("<pre class=\"k9mail\">encrypted text</pre>", messageViewInfo.text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">encrypted text</pre>", messageViewInfo.text);
         assertTrue(messageViewInfo.attachments.isEmpty());
         assertTrue(messageViewInfo.extraAttachments.isEmpty());
     }
@@ -560,7 +560,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
                 true);
 
         assertSame(openPgpResultAnnotation, messageViewInfo.cryptoResultAnnotation);
-        assertEquals("<pre class=\"k9mail\">encrypted text</pre>", messageViewInfo.text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">encrypted text</pre>", messageViewInfo.text);
         assertEquals(PROTECTED_SUBJECT, messageViewInfo.subject);
         assertTrue(messageViewInfo.attachments.isEmpty());
         assertTrue(messageViewInfo.extraAttachments.isEmpty());
@@ -578,7 +578,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null,
                 false);
 
-        assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">text</pre>", messageViewInfo.text);
         assertNull(messageViewInfo.cryptoResultAnnotation);
         assertTrue(messageViewInfo.attachments.isEmpty());
         assertTrue(messageViewInfo.extraAttachments.isEmpty());
@@ -602,7 +602,7 @@ public class MessageViewInfoExtractorTest extends K9RobolectricTest {
         MessageViewInfo messageViewInfo = messageViewInfoExtractor.extractMessageForView(message, null,
                 false);
 
-        assertEquals("<pre class=\"k9mail\">text</pre>", messageViewInfo.text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">text</pre>", messageViewInfo.text);
         assertNull(messageViewInfo.cryptoResultAnnotation);
         assertSame(mock, messageViewInfo.attachments.get(0));
         assertTrue(messageViewInfo.extraAttachments.isEmpty());

--- a/app/core/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
+++ b/app/core/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
@@ -23,7 +23,7 @@ public class HtmlConverterTest {
 
         String result = HtmlConverter.textToHtml(message);
 
-        assertEquals("<pre class=\"k9mail\">"
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">"
                 + "Panama!<br>"
                 + "<br>"
                 + "Bob Barker &lt;bob@aol.com&gt; wrote:<br>"
@@ -63,7 +63,7 @@ public class HtmlConverterTest {
 
         String result = HtmlConverter.textToHtml(message);
 
-        assertEquals("<pre class=\"k9mail\">"
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">"
                 + "*facepalm*<br>"
                 + "<br>"
                 + "Bob Barker &lt;bob@aol.com&gt; wrote:<br>"
@@ -89,7 +89,7 @@ public class HtmlConverterTest {
 
         String result = HtmlConverter.textToHtml(message);
 
-        assertEquals("<pre class=\"k9mail\">"
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">"
                 + "zero<br>"
                 + "<blockquote class=\"gmail_quote\" style=\"margin: 0pt 0pt 1ex 0.8ex; border-left: 1px solid #729fcf; padding-left: 1ex;\">"
                 +   "one<br>"
@@ -120,7 +120,7 @@ public class HtmlConverterTest {
 
         String result = HtmlConverter.textToHtml(message);
 
-        assertEquals("<pre class=\"k9mail\">"
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">"
                 + "foo<br>"
                 + " bar<br>"
                 + "  baz<br>"
@@ -138,7 +138,7 @@ public class HtmlConverterTest {
 
         String result = HtmlConverter.textToHtml(message);
 
-        assertEquals("<pre class=\"k9mail\">"
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">"
                 + " <br>"
                 + "  &amp;<br>"
                 + "    <br>"
@@ -163,7 +163,7 @@ public class HtmlConverterTest {
                 "-- 8< --\n" +
                 "end";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">text<hr>" +
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">text<hr>" +
                 "some other text<hr>" +
                 "more text<hr>" +
                 "scissors below<hr>" +
@@ -176,7 +176,7 @@ public class HtmlConverterTest {
     public void dashesContainingSpacesIgnoredAsHR() {
         String text = "hello\n--- --- --- --- ---\nfoo bar";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">hello<br>--- --- --- --- ---<br>foo bar</pre>",
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">hello<br>--- --- --- --- ---<br>foo bar</pre>",
                 result);
     }
 
@@ -184,70 +184,70 @@ public class HtmlConverterTest {
     public void mergeConsecutiveBreaksIntoOne() {
         String text = "hello\n------------\n---------------\nfoo bar";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">hello<hr>foo bar</pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">hello<hr>foo bar</pre>", result);
     }
 
     @Test
     public void dashedHorizontalRulePrefixedWithTextIgnoredAsHR() {
         String text = "hello----\n\n";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">hello----<br><br></pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">hello----<br><br></pre>", result);
     }
 
     @Test
     public void doubleMinusIgnoredAsHR() {
         String text = "--\n";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">--<br></pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">--<br></pre>", result);
     }
 
     @Test
     public void doubleEqualsIgnoredAsHR() {
         String text = "==\n";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">==<br></pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">==<br></pre>", result);
     }
 
     @Test
     public void doubleUnderscoreIgnoredAsHR() {
         String text = "__\n";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">__<br></pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">__<br></pre>", result);
     }
 
     @Test
     public void anyTripletIsHRuledOut() {
         String text = "--=\n-=-\n===\n___\n\n";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\"><hr></pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\"><hr></pre>", result);
     }
 
     @Test
     public void replaceSpaceSeparatedDashesWithHR() {
         String text = "hello\n---------------------------\nfoo bar";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">hello<hr>foo bar</pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">hello<hr>foo bar</pre>", result);
     }
 
     @Test
     public void replacementWithHRAtBeginning() {
         String text = "---------------------------\nfoo bar";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\"><hr>foo bar</pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\"><hr>foo bar</pre>", result);
     }
 
     @Test
     public void replacementWithHRAtEnd() {
         String text = "hello\n__________________________________";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">hello<hr></pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">hello<hr></pre>", result);
     }
 
     @Test
     public void replacementOfScissorsByHR() {
         String text = "hello\n-- %< -------------- >8 --\nworld\n";
         String result = HtmlConverter.textToHtml(text);
-        assertEquals("<pre class=\"k9mail\">hello<hr>world<br></pre>", result);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">hello<hr>world<br></pre>", result);
     }
 
     @Test


### PR DESCRIPTION
This is a simple fix for #3391. It adds `dir="auto"` to the `html` tag when converting a text message to html. This deligates detecting text direction to the underlying Android component, i.e. WebView. Android Text and Web components already cover lots of complicated RTL and BiDi logic, so this is the best thing to do.

There are a few things to keep in mind, however. This will not magically fix all RTL issues. If a message is sent as HTML, it is the responsibility of the mail client to add proper direction tags. For example Evolution does not do this. If you write RTL, it will not add any direction tags. If you compose it in Gmail however, it adds those tags per paragraph (but not when you paste RTL text to their compose window, only if you write it. That's how their web client works).

Fixes #3391