### PR TITLE
Use api instead of implementation.

### DIFF
--- a/app/core/build.gradle
+++ b/app/core/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     api project(":mail:common")
     api project(":backend:api")
 
-    api project(':plugins:openpgp-api-lib:openpgp-api')
+    implementation project(':plugins:openpgp-api-lib:openpgp-api')
 
     api "org.koin:koin-androidx-viewmodel:${versions.koin}"
 

--- a/app/k9mail-jmap/build.gradle
+++ b/app/k9mail-jmap/build.gradle
@@ -29,6 +29,9 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:${versions.androidxLifecycle}"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:${versions.androidxLifecycle}"
 
+    // Required for DependencyInjectionTest to be able to resolve OpenPgpApiManager
+    testImplementation project(':plugins:openpgp-api-lib:openpgp-api')
+
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"

--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -26,6 +26,9 @@ dependencies {
 
     debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.3'
 
+    // Required for DependencyInjectionTest to be able to resolve OpenPgpApiManager
+    testImplementation project(':plugins:openpgp-api-lib:openpgp-api')
+
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"


### PR DESCRIPTION
This improves the build times when making incremental changes.
See [this slide](https://speakerdeck.com/runningcode/beyond-modularization-scaling-your-android-build-with-gradle?slide=97) for the performance improvements.