### PR TITLE
Specify full Java version for CI builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -11,6 +11,6 @@ jobs:
     - name: set up JDK 1.8
       uses: actions/setup-java@v1
       with:
-        java-version: 1.8
+        java-version: 8.0.252
     - name: Build with Gradle
       run: ./gradlew assembleDebug testDebugUnitTest ktlintCheck


### PR DESCRIPTION
This is the version I currently use locally and should fix the CI test failures.