### PR TITLE
Update TokenAutoComplete

### DIFF
--- a/app/ui/legacy/build.gradle
+++ b/app/ui/legacy/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation "androidx.swiperefreshlayout:swiperefreshlayout:1.1.0"
     implementation "com.google.android.material:material:${versions.materialComponents}"
     implementation "de.cketti.library.changelog:ckchangelog:1.2.1"
-    implementation "com.splitwise:tokenautocomplete:2.0.7"
+    implementation "com.splitwise:tokenautocomplete:4.0.0-beta01"
     implementation "de.cketti.safecontentresolver:safe-content-resolver-v21:1.0.0"
     implementation "com.xwray:groupie:2.8.0"
     implementation "com.xwray:groupie-kotlin-android-extensions:2.8.0"

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -29,6 +29,15 @@ import com.fsck.k9.view.RecipientSelectView.Recipient;
 import com.fsck.k9.view.RecipientSelectView.TokenListener;
 import com.fsck.k9.view.ToolableViewAnimator;
 
+import static com.fsck.k9.FontSizes.FONT_10SP;
+import static com.fsck.k9.FontSizes.FONT_12SP;
+import static com.fsck.k9.FontSizes.FONT_16SP;
+import static com.fsck.k9.FontSizes.FONT_20SP;
+import static com.fsck.k9.FontSizes.FONT_DEFAULT;
+import static com.fsck.k9.FontSizes.LARGE;
+import static com.fsck.k9.FontSizes.MEDIUM;
+import static com.fsck.k9.FontSizes.SMALL;
+
 
 public class RecipientMvpView implements OnFocusChangeListener, OnClickListener {
     private static final int VIEW_INDEX_HIDDEN = -1;
@@ -210,9 +219,26 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
     }
 
     public void setFontSizes(FontSizes fontSizes, int fontSize) {
+        int tokenTextSize = getTokenTextSize(fontSize);
+        toView.setTokenTextSize(tokenTextSize);
+        ccView.setTokenTextSize(tokenTextSize);
+        bccView.setTokenTextSize(tokenTextSize);
         fontSizes.setViewTextSize(toView, fontSize);
         fontSizes.setViewTextSize(ccView, fontSize);
         fontSizes.setViewTextSize(bccView, fontSize);
+    }
+
+    private int getTokenTextSize(int fontSize) {
+        switch (fontSize) {
+            case FONT_10SP: return FONT_10SP;
+            case FONT_12SP: return FONT_12SP;
+            case SMALL: return SMALL;
+            case FONT_16SP: return 15;
+            case MEDIUM: return FONT_16SP;
+            case FONT_20SP: return MEDIUM;
+            case LARGE: return FONT_20SP;
+            default: return FONT_DEFAULT;
+        }
     }
 
     public void addRecipients(RecipientType recipientType, Recipient... recipients) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientMvpView.java
@@ -112,6 +112,11 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
             public void onTokenChanged(Recipient recipient) {
                 presenter.onToTokenChanged();
             }
+
+            @Override
+            public void onTokenIgnored(Recipient token) {
+                // Do nothing
+            }
         });
 
         ccView.setTokenListener(new TokenListener<Recipient>() {
@@ -129,6 +134,11 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
             public void onTokenChanged(Recipient recipient) {
                 presenter.onCcTokenChanged();
             }
+
+            @Override
+            public void onTokenIgnored(Recipient token) {
+                // Do nothing
+            }
         });
 
         bccView.setTokenListener(new TokenListener<Recipient>() {
@@ -145,6 +155,11 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
             @Override
             public void onTokenChanged(Recipient recipient) {
                 presenter.onBccTokenChanged();
+            }
+
+            @Override
+            public void onTokenIgnored(Recipient token) {
+                // Do nothing
             }
         });
     }
@@ -220,11 +235,9 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
     public void silentlyAddBccAddresses(Recipient... recipients) {
         removeAllTextChangedListeners(bccView);
 
-        // The actual modification of the view is deferred via View.post()…
         bccView.addRecipients(recipients);
 
-        // … so we do the same to add back the listeners.
-        bccView.post(() -> addAllTextChangedListeners(bccView));
+        addAllTextChangedListeners(bccView);
     }
 
     public void silentlyRemoveBccAddresses(Address[] addressesToRemove) {
@@ -238,13 +251,11 @@ public class RecipientMvpView implements OnFocusChangeListener, OnClickListener 
 
             for (Address address : addressesToRemove) {
                 if (recipient.address.equals(address)) {
-                    // The actual modification of the view is deferred via View.post()…
-                    bccView.removeObject(recipient);
+                    bccView.removeObjectSync(recipient);
                 }
             }
 
-            // … so we do the same to add back the listeners.
-            bccView.post(() -> addAllTextChangedListeners(bccView));
+            addAllTextChangedListeners(bccView);
         }
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/compose/RecipientTokenConstraintLayout.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/compose/RecipientTokenConstraintLayout.kt
@@ -1,0 +1,26 @@
+package com.fsck.k9.ui.compose
+
+import android.content.Context
+import android.util.AttributeSet
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+
+/**
+ * Custom [ConstraintLayout] that returns an appropriate baseline value for our recipient token layout.
+ */
+class RecipientTokenConstraintLayout @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ConstraintLayout(context, attrs, defStyleAttr) {
+    private lateinit var textView: TextView
+
+    override fun onFinishInflate() {
+        super.onFinishInflate()
+        textView = findViewById(android.R.id.text1)
+    }
+
+    override fun getBaseline(): Int {
+        return textView.top + textView.baseline
+    }
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -754,12 +754,7 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
                 return null;
             }
 
-            String displayName = address.getPersonal();
-            if (addressLabel != null) {
-                displayName += " (" + addressLabel + ")";
-            }
-
-            return displayName;
+            return address.getPersonal();
         }
 
         @NonNull

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -24,7 +24,6 @@ import android.text.TextUtils;
 import android.util.AttributeSet;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
-import android.view.MotionEvent;
 import android.view.View;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.ListPopupWindow;
@@ -150,26 +149,6 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
             boolean isVerified = recipient.cryptoStatus == RecipientCryptoStatus.AVAILABLE_TRUSTED;
             holder.showAdvancedCryptoState(isAvailable, isVerified);
         }
-    }
-
-    @Override
-    public boolean onTouchEvent(@NonNull MotionEvent event) {
-        int action = event.getActionMasked();
-        Editable text = getText();
-
-        if (text != null && action == MotionEvent.ACTION_UP) {
-            int offset = getOffsetForPosition(event.getX(), event.getY());
-
-            if (offset != -1) {
-                TokenImageSpan[] links = text.getSpans(offset, offset, RecipientTokenSpan.class);
-                if (links.length > 0) {
-                    showAlternates(links[0].getToken());
-                    return true;
-                }
-            }
-        }
-
-        return super.onTouchEvent(event);
     }
 
     @Override
@@ -537,6 +516,11 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
         public RecipientTokenSpan(View view, Recipient recipient) {
             super(view, recipient);
             this.view = view;
+        }
+
+        @Override
+        public void onClick() {
+            showAlternates(getToken());
         }
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -338,6 +338,15 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
     }
 
     @Override
+    public boolean onKeyPreIme(int keyCode, KeyEvent event) {
+        if (keyCode == KeyEvent.KEYCODE_BACK && alternatesPopup.isShowing()) {
+            alternatesPopup.dismiss();
+            return true;
+        }
+        return super.onKeyPreIme(keyCode, event);
+    }
+
+    @Override
     public boolean onKeyDown(int keyCode, @NonNull KeyEvent event) {
         alternatesPopup.dismiss();
         return super.onKeyDown(keyCode, event);

--- a/app/ui/legacy/src/main/res/drawable/ic_status_corner.xml
+++ b/app/ui/legacy/src/main/res/drawable/ic_status_corner.xml
@@ -1,6 +1,12 @@
-<vector android:autoMirrored="true" android:height="24dp"
-    android:viewportHeight="100.0" android:viewportWidth="49.999996"
-    android:width="12dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="#FF000000" android:pathData="m0,0h50v50z"
-        android:strokeColor="#000" android:strokeWidth="1"/>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="12dp"
+    android:autoMirrored="true"
+    android:viewportWidth="50"
+    android:viewportHeight="50">
+    <path
+        android:fillColor="#FF000000"
+        android:pathData="m0,0h50v50z"
+        android:strokeWidth="1"
+        android:strokeColor="#000" />
 </vector>

--- a/app/ui/legacy/src/main/res/layout/message_compose_recipients.xml
+++ b/app/ui/legacy/src/main/res/layout/message_compose_recipients.xml
@@ -215,7 +215,6 @@
             android:layout_marginEnd="30dp"
             android:inputType="textEmailAddress|textMultiLine"
             android:imeOptions="actionNext"
-            android:textAppearance="?android:attr/textAppearanceMedium"
             android:background="@android:color/transparent"
             android:paddingTop="10dp"
             android:paddingBottom="10dp"

--- a/app/ui/legacy/src/main/res/layout/message_compose_recipients.xml
+++ b/app/ui/legacy/src/main/res/layout/message_compose_recipients.xml
@@ -221,7 +221,7 @@
             android:dropDownWidth="wrap_content"
             android:dropDownAnchor="@id/to_wrapper"
             tools:text="Recipient"
-            style="@style/ComposeEditText"
+            style="@style/RecipientEditText"
             />
 
         <ViewAnimator
@@ -291,7 +291,7 @@
             android:paddingBottom="10dp"
             android:dropDownWidth="wrap_content"
             android:dropDownAnchor="@id/cc_wrapper"
-            style="@style/ComposeEditText"
+            style="@style/RecipientEditText"
             />
 
     </LinearLayout>
@@ -337,7 +337,7 @@
             android:paddingBottom="10dp"
             android:dropDownWidth="wrap_content"
             android:dropDownAnchor="@id/bcc_wrapper"
-            style="@style/ComposeEditText"
+            style="@style/RecipientEditText"
             />
 
     </LinearLayout>

--- a/app/ui/legacy/src/main/res/layout/recipient_token_item.xml
+++ b/app/ui/legacy/src/main/res/layout/recipient_token_item.xml
@@ -1,104 +1,135 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="horizontal"
     android:layout_width="wrap_content"
-    android:layout_height="32dp">
+    android:layout_height="wrap_content">
+
+    <View
+        android:id="@+id/background"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:background="?attr/contactTokenBackgroundColor"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@id/background_position_helper"
+        app:layout_constraintTop_toTopOf="parent" />
 
     <de.hdodenhof.circleimageview.CircleImageView
-        android:layout_width="32dp"
-        android:layout_height="32dp"
-        android:gravity="center_vertical"
         android:id="@+id/contact_photo"
-        tools:src="@drawable/ic_contact_picture"
-        />
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:contentDescription="@null"
+        app:layout_constraintBottom_toBottomOf="@android:id/text1"
+        app:layout_constraintDimensionRatio="1:1"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@android:id/text1"
+        tools:src="@drawable/ic_contact_picture" />
 
-    <LinearLayout
+    <View
+        android:id="@+id/background_position_helper"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="@+id/contact_photo"
+        app:layout_constraintEnd_toEndOf="@+id/contact_photo"
+        app:layout_constraintStart_toStartOf="@+id/contact_photo"
+        app:layout_constraintTop_toTopOf="@+id/contact_photo" />
+
+    <TextView
+        android:id="@android:id/text1"
         android:layout_width="wrap_content"
-        android:layout_height="match_parent"
-        android:background="?attr/contactTokenBackgroundColor"
-        android:layout_marginLeft="-16dp"
-        >
+        android:layout_height="wrap_content"
+        android:layout_marginStart="8dp"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:paddingTop="4dp"
+        android:paddingEnd="14dp"
+        android:paddingBottom="4dp"
+        android:textAppearance="@android:style/TextAppearance.Medium"
+        android:textSize="15sp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/contact_photo"
+        app:layout_constraintTop_toTopOf="parent"
+        tools:text="Jane Doe" />
 
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@android:id/text1"
-            android:layout_gravity="center_vertical"
-            android:layout_marginLeft="24dp"
-            android:layout_marginRight="8dp"
-            android:maxLines="1"
-            android:ellipsize="end"
-            tools:text="Name"
-            />
+    <ImageView
+        android:id="@+id/contact_crypto_status_icon_simple"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_status_corner"
+        app:tint="?openpgp_black"
+        tools:visibility="gone" />
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/contact_crypto_status_icon_simple"
-            app:srcCompat="@drawable/ic_status_corner"
-            android:visibility="gone"
-            android:tint="?openpgp_black"
-            tools:visibility="visible"
-            />
+    <ImageView
+        android:id="@+id/contact_crypto_status_icon_simple_enabled"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_status_corner"
+        app:tint="?openpgp_green"
+        tools:visibility="gone" />
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/contact_crypto_status_icon_simple_enabled"
-            app:srcCompat="@drawable/ic_status_corner"
-            android:visibility="gone"
-            android:tint="?openpgp_green"
-            tools:visibility="visible"
-            />
+    <ImageView
+        android:id="@+id/contact_crypto_status_icon_simple_error"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/ic_status_corner"
+        app:tint="?openpgp_red"
+        tools:visibility="gone" />
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:id="@+id/contact_crypto_status_icon_simple_error"
-            app:srcCompat="@drawable/ic_status_corner"
-            android:visibility="gone"
-            android:tint="?openpgp_red"
-            tools:visibility="visible"
-            />
+    <ImageView
+        android:id="@+id/contact_crypto_status_red"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="6dp"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@android:id/text1"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/status_dots_1"
+        app:tint="?attr/openpgp_red"
+        tools:visibility="gone" />
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="6dp"
-            android:layout_marginEnd="6dp"
-            android:layout_gravity="center_vertical"
-            android:id="@+id/contact_crypto_status_red"
-            app:srcCompat="@drawable/status_dots_1"
-            android:tint="?attr/openpgp_red"
-            android:visibility="gone"
-            />
+    <ImageView
+        android:id="@+id/contact_crypto_status_orange"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginEnd="6dp"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@android:id/text1"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/status_dots_2"
+        app:tint="?attr/openpgp_orange"
+        tools:visibility="gone" />
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="6dp"
-            android:layout_marginEnd="6dp"
-            android:layout_gravity="center_vertical"
-            android:id="@+id/contact_crypto_status_orange"
-            app:srcCompat="@drawable/status_dots_2"
-            android:tint="?attr/openpgp_orange"
-            android:visibility="gone"
-            />
+    <ImageView
+        android:id="@+id/contact_crypto_status_green"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:contentDescription="@null"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@android:id/text1"
+        app:layout_constraintTop_toTopOf="parent"
+        app:srcCompat="@drawable/status_dots_3"
+        app:tint="?attr/openpgp_green" />
 
-        <ImageView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginRight="6dp"
-            android:layout_marginEnd="6dp"
-            android:layout_gravity="center_vertical"
-            android:id="@+id/contact_crypto_status_green"
-            app:srcCompat="@drawable/status_dots_3"
-            android:tint="?attr/openpgp_green"
-            android:visibility="gone"
-            />
-
-    </LinearLayout>
-
-</LinearLayout>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/ui/legacy/src/main/res/layout/recipient_token_item.xml
+++ b/app/ui/legacy/src/main/res/layout/recipient_token_item.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.fsck.k9.ui.compose.RecipientTokenConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="wrap_content"
@@ -20,6 +20,7 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         android:contentDescription="@null"
+        android:minHeight="32dp"
         app:layout_constraintBottom_toBottomOf="@android:id/text1"
         app:layout_constraintDimensionRatio="1:1"
         app:layout_constraintStart_toStartOf="parent"
@@ -132,4 +133,4 @@
         app:srcCompat="@drawable/status_dots_3"
         app:tint="?attr/openpgp_green" />
 
-</androidx.constraintlayout.widget.ConstraintLayout>
+</com.fsck.k9.ui.compose.RecipientTokenConstraintLayout>

--- a/app/ui/legacy/src/main/res/values/ids.xml
+++ b/app/ui/legacy/src/main/res/values/ids.xml
@@ -13,4 +13,6 @@
     <item type="id" name="settings_import_list_general_item"/>
     <item type="id" name="settings_import_list_account_item"/>
 
+    <item type="id" name="recipient_token_recipient_value"/>
+
 </resources>

--- a/app/ui/legacy/src/main/res/values/styles.xml
+++ b/app/ui/legacy/src/main/res/values/styles.xml
@@ -6,8 +6,11 @@
         <item name="android:textColor">#aaa</item>
     </style>
     <style name="ComposeEditText" parent="@android:style/TextAppearance.Medium">
-        <item name="android:textSize">15sp</item>
+        <item name="android:textSize">16sp</item>
         <item name="android:textColorHint">#aaa</item>
+    </style>
+    <style name="RecipientEditText" parent="ComposeEditText">
+        <item name="android:lineSpacingExtra">4dp</item>
     </style>
     <style name="ComposeEditTextLarge" parent="@android:style/TextAppearance.Medium">
         <item name="android:textColorHint">#aaa</item>


### PR DESCRIPTION
This updates to the latest version of TokenAutoComplete which uses AndroidX. After this has been merged we'll be able to turn off Jetifier.

Changes unrelated to the version update:
- The popup to select alternate email addresses can now be dismissed by using the back button
- Text inside the recipient chips (and the contact image) will scale with the configured "text input fields" text size
- Address labels (Home, Work, etc) are no longer displayed in the recipient chips