### PR TITLE
Disable Jetifier

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 android.useAndroidX=true
-android.enableJetifier=true
+android.enableJetifier=false
 org.gradle.jvmargs=-Xmx1400m
 org.gradle.parallel=true


### PR DESCRIPTION
All of our dependencies now use AndroidX. So we can finally disable Jetifier.

/cc: @runningcode 