### PR TITLE
Another attempt at fixing image loading for recipient chips

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/contacts/ContactPictureLoader.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/contacts/ContactPictureLoader.kt
@@ -41,6 +41,7 @@ class ContactPictureLoader(
     private fun setContactPicture(imageView: ImageView, contactPictureUri: Uri) {
         Glide.with(imageView.context)
             .load(contactPictureUri)
+            .placeholder(R.drawable.ic_contact_picture)
             .error(R.drawable.ic_contact_picture)
             .diskCacheStrategy(DiskCacheStrategy.NONE)
             .dontAnimate()

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/compose/RecipientCircleImageView.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/compose/RecipientCircleImageView.kt
@@ -1,0 +1,27 @@
+package com.fsck.k9.ui.compose
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import android.util.AttributeSet
+import com.fsck.k9.view.RecipientSelectView
+import de.hdodenhof.circleimageview.CircleImageView
+
+/**
+ * Custom [CircleImageView] used in recipient chip layout to allow us to invalidate the [RecipientSelectView].
+ */
+class RecipientCircleImageView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : CircleImageView(context, attrs, defStyleAttr) {
+    var onSetImageDrawableListener: OnSetImageDrawableListener? = null
+
+    override fun setImageDrawable(drawable: Drawable?) {
+        super.setImageDrawable(drawable)
+        onSetImageDrawableListener?.onSetImageDrawable()
+    }
+}
+
+interface OnSetImageDrawableListener {
+    fun onSetImageDrawable()
+}

--- a/app/ui/legacy/src/main/res/layout/recipient_token_item.xml
+++ b/app/ui/legacy/src/main/res/layout/recipient_token_item.xml
@@ -15,7 +15,7 @@
         app:layout_constraintStart_toEndOf="@id/background_position_helper"
         app:layout_constraintTop_toTopOf="parent" />
 
-    <de.hdodenhof.circleimageview.CircleImageView
+    <com.fsck.k9.ui.compose.RecipientCircleImageView
         android:id="@+id/contact_photo"
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/app/ui/legacy/src/main/res/values/ids.xml
+++ b/app/ui/legacy/src/main/res/values/ids.xml
@@ -13,6 +13,4 @@
     <item type="id" name="settings_import_list_general_item"/>
     <item type="id" name="settings_import_list_account_item"/>
 
-    <item type="id" name="recipient_token_recipient_value"/>
-
 </resources>


### PR DESCRIPTION
Glide already supports deferring image loading until a view has been measured. So we can get rid of our clunky `OnLayoutChangeListener` (that didn't always work).

Glide's mechanism didn't work for us because the image view in the recipient chip layout is not part of the window's view hierarchy. Things seem to work fine when `RecipientTokenSpan` manually dispatches `onPreDraw` events. Despite the name we do this after drawing because only then can we be sure that the view associated with `RecipientTokenSpan` has been measured.