### PR TITLE
Use io extension functions to make code more concise.

### DIFF
--- a/app/core/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/preferences/SettingsExporterTest.kt
@@ -4,7 +4,6 @@ import com.fsck.k9.K9RobolectricTest
 import com.fsck.k9.Preferences
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.mailstore.FolderRepositoryManager
-import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import org.jdom2.Document
 import org.jdom2.input.SAXBuilder
@@ -72,6 +71,6 @@ class SettingsExporterTest : K9RobolectricTest() {
     }
 
     private fun parseXml(xml: ByteArray): Document {
-        return SAXBuilder().build(ByteArrayInputStream(xml))
+        return SAXBuilder().build(xml.inputStream())
     }
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeHeader.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeHeader.kt
@@ -2,10 +2,8 @@ package com.fsck.k9.mail.internet
 
 import com.fsck.k9.mail.internet.MimeHeader.Field.NameValueField
 import com.fsck.k9.mail.internet.MimeHeader.Field.RawField
-import java.io.BufferedWriter
 import java.io.IOException
 import java.io.OutputStream
-import java.io.OutputStreamWriter
 import java.nio.charset.Charset
 import java.util.ArrayList
 import java.util.LinkedHashSet
@@ -60,7 +58,7 @@ class MimeHeader {
 
     @Throws(IOException::class)
     fun writeTo(out: OutputStream) {
-        val writer = BufferedWriter(OutputStreamWriter(out), 1024)
+        val writer = out.writer().buffered(1024)
         writer.appendFields()
         writer.flush()
     }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
@@ -16,7 +16,6 @@ import com.fsck.k9.mail.internet.MimeHeader
 import com.fsck.k9.mail.internet.MimeMessageHelper
 import com.fsck.k9.mail.internet.MimeMultipart
 import com.fsck.k9.mail.internet.MimeUtility
-import java.io.ByteArrayInputStream
 import java.io.IOException
 import java.io.InputStream
 import java.text.SimpleDateFormat
@@ -621,7 +620,7 @@ class ImapFolder internal constructor(
                         if (literal != null) {
                             when (literal) {
                                 is String -> {
-                                    val bodyStream: InputStream = ByteArrayInputStream(literal.toByteArray())
+                                    val bodyStream: InputStream = literal.toByteArray().inputStream()
                                     message.parse(bodyStream)
                                 }
                                 is Int -> {
@@ -697,7 +696,7 @@ class ImapFolder internal constructor(
                                 MimeMessageHelper.setBody(part, literal as Body?)
                             }
                             is String -> {
-                                val bodyStream: InputStream = ByteArrayInputStream(literal.toByteArray())
+                                val bodyStream: InputStream = literal.toByteArray().inputStream()
                                 val contentTransferEncoding =
                                     part.getHeader(MimeHeader.HEADER_CONTENT_TRANSFER_ENCODING)[0]
                                 val contentType = part.getHeader(MimeHeader.HEADER_CONTENT_TYPE)[0]


### PR DESCRIPTION
+ This change replaces a few usages of `BufferedWriter`, `ByteArrayInputStream`, `OutputStreamWriter` with their equivalent Kotlin extension functions.
