### PR TITLE
Use correct OpenPGP key when sending signed-only email

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientPresenter.java
@@ -364,6 +364,7 @@ public class RecipientPresenter {
     public void onSwitchIdentity(Identity identity) {
 
         // TODO decide what actually to do on identity switch?
+        asyncUpdateCryptoStatus();
         /*
         if (mIdentityChanged) {
             mBccWrapper.setVisibility(View.VISIBLE);


### PR DESCRIPTION
Update crypto state when switching accounts in message compose screen.

Fixes #4914