### PR TITLE
Show image previews even when wrong MIME type is used

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/AttachmentViewInfo.java
@@ -4,6 +4,7 @@ package com.fsck.k9.mailstore;
 import android.net.Uri;
 
 import com.fsck.k9.mail.Part;
+import com.fsck.k9.mail.internet.MimeUtility;
 
 
 public class AttachmentViewInfo {
@@ -40,5 +41,15 @@ public class AttachmentViewInfo {
 
     public void setContentAvailable() {
         this.contentAvailable = true;
+    }
+
+    public boolean isSupportedImage() {
+        if (mimeType == null) {
+            return false;
+        }
+
+        return MimeUtility.isSupportedImageType(mimeType) || (
+                MimeUtility.isSameMimeType(MimeUtility.DEFAULT_ATTACHMENT_MIME_TYPE, mimeType) &&
+                MimeUtility.isSupportedImageExtension(displayName));
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -89,7 +89,6 @@ import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Message.RecipientType;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.internet.MimeMessage;
-import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.MessageViewInfo;
 import com.fsck.k9.message.AutocryptStatusInteractor;
@@ -1789,7 +1788,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             View progressBar = view.findViewById(R.id.progressBar);
             boolean isLoadingComplete = (attachment.state == Attachment.LoadingState.COMPLETE);
             if (isLoadingComplete) {
-                if (MimeUtility.isSupportedImageType(attachment.contentType)) {
+                if (attachment.isSupportedImage()) {
                     ImageView attachmentTypeView = view.findViewById(R.id.attachment_type);
                     attachmentTypeView.setImageResource(R.drawable.ic_attachment_image);
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/misc/Attachment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/misc/Attachment.java
@@ -4,6 +4,8 @@ import android.net.Uri;
 import android.os.Parcel;
 import android.os.Parcelable;
 
+import com.fsck.k9.mail.internet.MimeUtility;
+
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -92,6 +94,16 @@ public class Attachment implements Parcelable, com.fsck.k9.message.Attachment {
     @Override
     public Long getSize() {
         return size;
+    }
+
+    public boolean isSupportedImage() {
+        if (contentType == null) {
+            return false;
+        }
+
+        return MimeUtility.isSupportedImageType(contentType) || (
+                MimeUtility.isSameMimeType(MimeUtility.DEFAULT_ATTACHMENT_MIME_TYPE, contentType) &&
+                MimeUtility.isSupportedImageExtension(filename));
     }
 
     private Attachment(Uri uri, LoadingState state, int loaderId, String contentType, boolean allowMessageType,

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/AttachmentView.java
@@ -12,7 +12,6 @@ import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.fsck.k9.K9;
-import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.ui.helper.SizeFormatter;
 import com.fsck.k9.mailstore.AttachmentViewInfo;
@@ -79,7 +78,7 @@ public class AttachmentView extends FrameLayout implements OnClickListener {
 
         setAttachmentSize(attachment.size);
 
-        if (MimeUtility.isSupportedImageType(attachment.mimeType)) {
+        if (attachment.isSupportedImage()) {
             attachmentType.setImageResource(R.drawable.ic_attachment_image);
             if (attachment.isContentAvailable()) {
                 refreshThumbnail();

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeUtility.java
@@ -1136,4 +1136,9 @@ public class MimeUtility {
         return isSameMimeType(mimeType, "image/jpeg") || isSameMimeType(mimeType, "image/png") ||
                 isSameMimeType(mimeType, "image/gif") || isSameMimeType(mimeType, "image/webp");
     }
+
+    public static boolean isSupportedImageExtension(String filename) {
+        String mimeType = getMimeTypeByExtension(filename);
+        return isSupportedImageType(mimeType);
+    }
 }


### PR DESCRIPTION
More precisely, show image preview when the MIME type is `application/octet-stream` and the file extension maps to a supported image MIME type.

Fixes #4935