### PR TITLE
Update to targetSdkVersion 29

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v1
-    - name: set up JDK 1.8
+    - name: set up JDK 11
       uses: actions/setup-java@v1
       with:
-        java-version: 8.0.252
+        java-version: 11
     - name: Build with Gradle
       run: ./gradlew assembleDebug testDebugUnitTest ktlintCheck

--- a/app/core/src/test/java/com/fsck/k9/message/quote/QuoteDateFormatterTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/message/quote/QuoteDateFormatterTest.kt
@@ -35,7 +35,7 @@ class QuoteDateFormatterTest {
 
         val formattedDate = quoteDateFormatter.format("2020-09-19T20:00:00+00:00".toDate())
 
-        assertThat(formattedDate).isEqualTo("September 19, 2020 8:00:00 PM UTC")
+        assertThat(formattedDate).isEqualTo("September 19, 2020 at 8:00:00 PM UTC")
     }
 
     @Test
@@ -45,7 +45,7 @@ class QuoteDateFormatterTest {
 
         val formattedDate = quoteDateFormatter.format("2020-09-19T20:00:00+00:00".toDate())
 
-        assertThat(formattedDate).isEqualTo("19. September 2020 20:00:00 UTC")
+        assertThat(formattedDate).isEqualTo("19. September 2020 um 20:00:00 UTC")
     }
 
     @Test
@@ -55,7 +55,7 @@ class QuoteDateFormatterTest {
 
         val formattedDate = quoteDateFormatter.format("2020-09-19T20:00:00+00:00".toDate())
 
-        assertThat(formattedDate).isEqualTo("September 19, 2020 10:00:00 PM GMT+02:00")
+        assertThat(formattedDate).isEqualTo("September 19, 2020 at 10:00:00 PM GMT+02:00")
     }
 
     @Test
@@ -65,7 +65,7 @@ class QuoteDateFormatterTest {
 
         val formattedDate = quoteDateFormatter.format("2020-09-19T20:00:00+00:00".toDate())
 
-        assertThat(formattedDate).isEqualTo("19. September 2020 22:00:00 GMT+02:00")
+        assertThat(formattedDate).isEqualTo("19. September 2020 um 22:00:00 GMT+02:00")
     }
 
     private fun String.toDate() = Date(ZonedDateTime.parse(this).toEpochSecond() * 1000L)

--- a/build.gradle
+++ b/build.gradle
@@ -2,10 +2,10 @@ buildscript {
     ext {
         buildConfig = [
                 'compileSdk': 29,
-                'targetSdk': 28,
+                'targetSdk': 29,
                 'minSdk': 21,
                 'buildTools': '29.0.3',
-                'robolectricSdk': 28
+                'robolectricSdk': 29
         ]
 
         versions = [


### PR DESCRIPTION
Robolectric requires Java 9 when targeting API 29. But we'll use Java 11 instead. It's a long-term support version and also the version that is used by Android Studio (4.2 canary 11).