### PR TITLE
Don't duplicate link URL in angle brackets

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/html/HtmlToPlainText.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/HtmlToPlainText.kt
@@ -52,7 +52,6 @@ private class FormattingVisitor : NodeVisitor {
                     addEmptyLine()
                 }
             }
-
             name == "a" -> {
                 if (node.absUrl("href").isNotEmpty()) {
                     append(" <${node.attr("href")}>")

--- a/app/core/src/main/java/com/fsck/k9/message/html/HtmlToPlainText.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/HtmlToPlainText.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.message.html
 
+import android.webkit.URLUtil
 import org.jsoup.nodes.Element
 import org.jsoup.nodes.Node
 import org.jsoup.nodes.TextNode
@@ -28,7 +29,11 @@ private class FormattingVisitor : NodeVisitor {
     override fun head(node: Node, depth: Int) {
         val name = node.nodeName()
         when {
-            node is TextNode -> append(node.text())
+            node is TextNode -> {
+                if (!URLUtil.isValidUrl(node.text())) {
+                    append(node.text())
+                }
+            }
             name == "li" -> {
                 startNewLine()
                 append("* ")
@@ -47,6 +52,7 @@ private class FormattingVisitor : NodeVisitor {
                     addEmptyLine()
                 }
             }
+
             name == "a" -> {
                 if (node.absUrl("href").isNotEmpty()) {
                     append(" <${node.attr("href")}>")


### PR DESCRIPTION
So the root cause is:
in NodeVisitor.head it pushes text reprecentaion of the link i.e. content of html tag 'a' and in head it added href element content in angle brackets second time.
I removed this for now and we use just text representation and in future I'd suggest to back to this and implement some reasonable logic for use links in angle brackets

Fixes #4872