### PR TITLE
Support for - (minus) in mail pattern search

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
@@ -66,7 +66,14 @@ public class SqlQueryBuilder {
                     if (condition.attribute != Attribute.CONTAINS) {
                         Timber.e("message contents can only be matched!");
                     }
-                    query.append("m.id IN (SELECT docid FROM messages_fulltext WHERE fulltext MATCH ?)");
+                    query.append("m.id IN (SELECT docid FROM messages_fulltext WHERE fulltext MATCH ");
+
+                    if (fulltextQueryString.startsWith("-")) {
+                        fulltextQueryString = fulltextQueryString.replace("-","");
+                        query.append("(printf(\"%c\", 45) || ?))");
+                    } else {
+                        query.append("?)");
+                    }
                     selectionArgs.add(fulltextQueryString);
                     break;
                 }


### PR DESCRIPTION
I used printf sql function for printing ascii 45 character (-) instead of using '-' from search template since it's replacement of NOT operation in SQLIte:
[The NOT operator is not supported. Instead of the NOT operator, the standard query syntax supports a unary "-" operator that may be applied to basic term and term-prefix queries (but not to phrase or NEAR queries) ...](https://sqlite.org/fts3.html#set_operations_using_the_standard_query_syntax)