### PR TITLE
De-emphasize signature when displaying text/plain part

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/html/DisplayHtml.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/DisplayHtml.kt
@@ -42,4 +42,8 @@ class DisplayHtml(private val settings: HtmlSettings) {
                 " {white-space: pre-wrap; word-wrap:break-word; " +
                 "font-family: " + font + "; margin-top: 0px}</style>"
     }
+
+    fun cssStyleSignature(): String {
+        return """<style type="text/css">.k9mail-signature { opacity: 0.5 }</style>"""
+    }
 }

--- a/app/core/src/main/java/com/fsck/k9/message/html/DividerReplacer.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/DividerReplacer.kt
@@ -21,5 +21,9 @@ internal object DividerReplacer : TextToHtml.HtmlModifier {
         override fun replace(textToHtml: TextToHtml) {
             textToHtml.appendHtml("<hr>")
         }
+
+        override fun toString(): String {
+            return "Divider{startIndex=$startIndex, endIndex=$endIndex}"
+        }
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/message/html/HtmlProcessor.java
+++ b/app/core/src/main/java/com/fsck/k9/message/html/HtmlProcessor.java
@@ -24,7 +24,8 @@ public class HtmlProcessor {
     private void addCustomHeadContents(Document document) {
         document.head().append("<meta name=\"viewport\" content=\"width=device-width\"/>" +
                 displayHtml.cssStyleTheme() +
-                displayHtml.cssStylePre());
+                displayHtml.cssStylePre() +
+                displayHtml.cssStyleSignature());
     }
 
     public static String toCompactString(Document document) {

--- a/app/core/src/main/java/com/fsck/k9/message/html/SignatureWrapper.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/SignatureWrapper.kt
@@ -1,0 +1,24 @@
+package com.fsck.k9.message.html
+
+internal object SignatureWrapper : TextToHtml.HtmlModifier {
+    private val SIGNATURE_REGEX = "(?m)^-- $".toRegex()
+
+    override fun findModifications(text: CharSequence): List<HtmlModification> {
+        val matchResult = SIGNATURE_REGEX.find(text) ?: return emptyList()
+        return listOf(Signature(matchResult.range.first, text.lastIndex))
+    }
+
+    class Signature(startIndex: Int, endIndex: Int) : HtmlModification.Wrap(startIndex, endIndex) {
+        override fun appendPrefix(textToHtml: TextToHtml) {
+            textToHtml.appendHtml("<div class='k9mail-signature'>")
+        }
+
+        override fun appendSuffix(textToHtml: TextToHtml) {
+            textToHtml.appendHtml("</div>")
+        }
+
+        override fun toString(): String {
+            return "Signature{startIndex=$startIndex, endIndex=$endIndex}"
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/message/html/TextToHtml.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/TextToHtml.kt
@@ -81,7 +81,7 @@ class TextToHtml private constructor(private val text: CharSequence, private val
     }
 
     companion object {
-        private val HTML_MODIFIERS = listOf(DividerReplacer, UriLinkifier)
+        private val HTML_MODIFIERS = listOf(DividerReplacer, UriLinkifier, SignatureWrapper)
         private const val HTML_NEWLINE = "<br>"
         private const val TEXT_TO_HTML_EXTRA_BUFFER_LENGTH = 512
 

--- a/app/core/src/main/java/com/fsck/k9/message/html/UriLinkifier.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/UriLinkifier.kt
@@ -22,5 +22,9 @@ internal object UriLinkifier : TextToHtml.HtmlModifier {
         override fun appendSuffix(textToHtml: TextToHtml) {
             textToHtml.appendHtml("</a>")
         }
+
+        override fun toString(): String {
+            return "LinkifyUri{startIndex=$startIndex, endIndex=$endIndex, uri='$uri'}"
+        }
     }
 }


### PR DESCRIPTION
Display the signature with an opacity of 50%.

<img src="https://user-images.githubusercontent.com/218061/95109326-c0434b80-073c-11eb-830f-1f3c33b15c2d.png" alt="k9mail_signature_containing_url" width="300"> <img src="https://user-images.githubusercontent.com/218061/95109322-bfaab500-073c-11eb-837d-86aa6e310d2e.png" alt="k9mail_signature_containing_url_dark" width="300">

Closes #3168