### PR TITLE
Fix preview text extraction

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/extractors/MessagePreviewCreator.java
+++ b/app/core/src/main/java/com/fsck/k9/message/extractors/MessagePreviewCreator.java
@@ -6,6 +6,8 @@ import androidx.annotation.NonNull;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.Part;
 
+import timber.log.Timber;
+
 
 public class MessagePreviewCreator {
     private final TextPartFinder textPartFinder;
@@ -33,6 +35,10 @@ public class MessagePreviewCreator {
             String previewText = previewTextExtractor.extractPreview(textPart);
             return PreviewResult.text(previewText);
         } catch (PreviewExtractionException e) {
+            Timber.w(e, "Failed to extract preview text");
+            return PreviewResult.error();
+        } catch (Exception e) {
+            Timber.e(e, "Unexpected error while trying to extract preview text");
             return PreviewResult.error();
         }
     }

--- a/app/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/extractors/PreviewTextExtractor.kt
@@ -65,10 +65,9 @@ internal class PreviewTextExtractor {
     }
 
     private fun extractUnquotedText(text: String): String {
+        if (text.isEmpty()) return ""
         val emailSections = EmailSectionExtractor.extract(text)
-        if (emailSections.isEmpty()) {
-            return ""
-        }
+        if (emailSections.isEmpty()) return ""
 
         val firstEmailSection = emailSections.first()
         val replySections = if (firstEmailSection.quoteDepth == 0) {
@@ -99,6 +98,8 @@ internal class PreviewTextExtractor {
     private val EmailSection.quoteHeaderIndex: Int
         get() {
             var quoteHeaderIndex = lastIndex
+            if (quoteHeaderIndex == -1) return -1
+
             while (quoteHeaderIndex > 0 && this[quoteHeaderIndex] == '\n') {
                 quoteHeaderIndex--
             }

--- a/app/core/src/test/java/com/fsck/k9/message/extractors/MessagePreviewCreatorTest.java
+++ b/app/core/src/test/java/com/fsck/k9/message/extractors/MessagePreviewCreatorTest.java
@@ -83,6 +83,19 @@ public class MessagePreviewCreatorTest {
         assertEquals(PreviewType.ERROR, result.getPreviewType());
     }
 
+    @Test
+    public void createPreview_withPreviewTextExtractorThrowingUnexpectedException() throws Exception {
+        Message message = createDummyMessage();
+        Part textPart = createTextPart("text/plain");
+        when(textPartFinder.findFirstTextPart(message)).thenReturn(textPart);
+        when(previewTextExtractor.extractPreview(textPart)).thenThrow(new IllegalStateException(""));
+
+        PreviewResult result = previewCreator.createPreview(message);
+
+        assertFalse(result.isPreviewTextAvailable());
+        assertEquals(PreviewType.ERROR, result.getPreviewType());
+    }
+
     private Message createDummyMessage() {
         return new MimeMessage();
     }

--- a/app/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/message/extractors/PreviewTextExtractorTest.kt
@@ -197,4 +197,14 @@ class PreviewTextExtractorTest {
 
         assertThat(preview).isEqualTo("Reply text")
     }
+
+    @Test
+    fun extractPreview_emptyBody() {
+        val text = ""
+        val part = MessageCreationHelper.createTextPart("text/plain", text)
+
+        val preview = previewTextExtractor.extractPreview(part)
+
+        assertThat(preview).isEqualTo("")
+    }
 }


### PR DESCRIPTION
Preview text extraction failed when an empty string was used as input :see_no_evil: 

Fixes #4984