### PR TITLE
Treat all whitespace as separator when detecting URIs

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/html/UriMatcher.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/UriMatcher.kt
@@ -13,7 +13,7 @@ object UriMatcher {
         )
     }.invoke(HttpUriParser())
 
-    private const val SCHEME_SEPARATORS = " (\\n<"
+    private const val SCHEME_SEPARATORS = "\\s(\\n<"
     private const val ALLOWED_SEPARATORS_PATTERN = "(?:^|[$SCHEME_SEPARATORS])"
     private val URI_SCHEME = Regex(
             "$ALLOWED_SEPARATORS_PATTERN(${ SUPPORTED_URIS.keys.joinToString("|") })",

--- a/app/core/src/test/java/com/fsck/k9/message/html/UriMatcherTest.java
+++ b/app/core/src/test/java/com/fsck/k9/message/html/UriMatcherTest.java
@@ -30,6 +30,11 @@ public class UriMatcherTest {
     }
 
     @Test
+    public void uriPrecededByTab() {
+        assertUrisFound("\thttp://example.org", "http://example.org");
+    }
+
+    @Test
     public void uriPrecededByOpeningParenthesis() {
         assertUrisFound("(http://example.org", "http://example.org");
     }


### PR DESCRIPTION
Make sure the app also linkifies URLs preceded by a tab.

Fixes #3357