### PR TITLE
Fix bug in signature detection

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/html/SignatureWrapper.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/SignatureWrapper.kt
@@ -5,7 +5,7 @@ internal object SignatureWrapper : TextToHtml.HtmlModifier {
 
     override fun findModifications(text: CharSequence): List<HtmlModification> {
         val matchResult = SIGNATURE_REGEX.find(text) ?: return emptyList()
-        return listOf(Signature(matchResult.range.first, text.lastIndex))
+        return listOf(Signature(matchResult.range.first, text.length))
     }
 
     class Signature(startIndex: Int, endIndex: Int) : HtmlModification.Wrap(startIndex, endIndex) {

--- a/app/core/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
+++ b/app/core/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
@@ -251,6 +251,18 @@ public class HtmlConverterTest {
     }
 
     @Test
+    public void signatureEndingWithUrl() {
+        String text = "text\n-- \nsignature with url: https://domain.example/";
+        String result = HtmlConverter.textToHtml(text);
+        assertEquals("<pre dir=\"auto\" class=\"k9mail\">" +
+                "text<br>" +
+                "<div class='k9mail-signature'>" +
+                "-- <br>" +
+                "signature with url: <a href=\"https://domain.example/\">https://domain.example/</a>" +
+                "</div></pre>", result);
+    }
+
+    @Test
     public void htmlToText_withLineBreaks() {
         String input = "One<br>Two<br><br>Three";
 


### PR DESCRIPTION
When `SignatureWrapper` detected a signature it would exclude the last character of the text. This lead to an exception being thrown when the signature ended with a URL and the `HtmlModification` instance for the URL would not be fully contained within the one for the signature.

Fixes #4990