### PR TITLE
Display up to 3 lines of the subject by default

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -48,6 +48,8 @@ import timber.log.Timber;
 
 
 public class MessageHeader extends LinearLayout implements OnClickListener, OnLongClickListener {
+    private static final int DEFAULT_SUBJECT_LINES = 3;
+
     private final ClipboardManager clipboardManager = DI.get(ClipboardManager.class);
 
     private Context mContext;
@@ -130,6 +132,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
 
         singleMessageOptionIcon.setOnClickListener(this);
 
+        mSubjectView.setOnClickListener(this);
         mFromView.setOnClickListener(this);
         mToView.setOnClickListener(this);
         mCcView.setOnClickListener(this);
@@ -151,7 +154,9 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
     @Override
     public void onClick(View view) {
         int id = view.getId();
-        if (id == R.id.from) {
+        if (id == R.id.subject) {
+            toggleSubjectViewMaxLines();
+        } else if (id == R.id.from) {
             onAddSenderToContacts();
         } else if (id == R.id.to || id == R.id.cc || id == R.id.bcc) {
             expand((TextView)view, ((TextView)view).getEllipsize() != null);
@@ -177,6 +182,14 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         }
 
         return true;
+    }
+
+    private void toggleSubjectViewMaxLines() {
+        if (mSubjectView.getMaxLines() == DEFAULT_SUBJECT_LINES) {
+            mSubjectView.setMaxLines(Integer.MAX_VALUE);
+        } else {
+            mSubjectView.setMaxLines(DEFAULT_SUBJECT_LINES);
+        }
     }
 
     private void onAddSenderToContacts() {

--- a/app/ui/legacy/src/main/res/layout/message_view_header.xml
+++ b/app/ui/legacy/src/main/res/layout/message_view_header.xml
@@ -39,7 +39,7 @@
                     android:layout_marginTop="4dp"
                     android:layout_marginBottom="4dp"
                     android:ellipsize="end"
-                    android:maxLines="2"
+                    android:maxLines="3"
                     android:textColor="?android:attr/textColorPrimary"
                     android:textAppearance="?android:attr/textAppearanceMedium"
                     tools:text="(no subject)"


### PR DESCRIPTION
Clicking the subject text will toggle between showing 3 lines max and showing all lines.

Fixes #4360 