### PR TITLE
Apply automatic identity selection for forwarding emails based on `to:` field of mail being forwarded

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1278,11 +1278,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         quotedMessagePresenter.initFromReplyToMessage(messageViewInfo, action);
 
         if (action == Action.REPLY || action == Action.REPLY_ALL) {
-            Identity useIdentity = IdentityHelper.getRecipientIdentityFromMessage(account, message);
-            Identity defaultIdentity = account.getIdentity(0);
-            if (useIdentity != defaultIdentity) {
-                switchToIdentity(useIdentity);
-            }
+            setIdentityFromMessage(message);
         }
 
     }
@@ -1314,6 +1310,15 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         } else {
             quotedMessagePresenter.processMessageToForward(messageViewInfo);
             attachmentPresenter.processMessageToForward(messageViewInfo);
+        }
+        setIdentityFromMessage(message);
+    }
+
+    private void setIdentityFromMessage(Message message) {
+        Identity useIdentity = IdentityHelper.getRecipientIdentityFromMessage(account, message);
+        Identity defaultIdentity = account.getIdentity(0);
+        if (useIdentity != defaultIdentity) {
+            switchToIdentity(useIdentity);
         }
     }
 


### PR DESCRIPTION
fixes #4791 

> ### My proposal:
> Include `Action.FORWARD` and `Action.FORWARD_AS_ATTACHMENT` to the if-condition here:
> 
> https://github.com/k9mail/k-9/blob/b9eba6971fa86b95a4855caddbfa7144e5c23884/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java#L1281-L1287

The line number referenced above are inside `processMessageToReplyTo(...)` and so adding logic for forwarded message didn't work(I checked using debugger to make sure). Luckily, right below that block of code is the method `processMessageToForward` - inside which I added the logic highlighted by @simontb. 
 
I had to do some research to understand the use of identity which I think is quite useful! Anyway, after following #935 discussion I think I've understood the goal somewhat. For reply to an email, the to: email is used to check for existing identities and if found, the found identity is used instead of default one to fill inside the from field of the new message. Please correct me if I got something wrong.

What I've achieved is an effect exactly like the reply feature, when I forward a mail sent to id+1@domain.com, the default identity(id@domain.com) is not filled inside from :, instead the identity associated with id+1@domain.com is used. 