### PR TITLE
Replaced CDATA[] for unknown_recipient and unknown_sender with &lt; a…

### DIFF
--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -1082,8 +1082,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="recipient_bcc">Bcc</string>
     <string name="recipient_to">To</string>
     <string name="recipient_from">From</string>
-    <string name="unknown_recipient"><![CDATA[<Unknown Recipient>]]></string>
-    <string name="unknown_sender"><![CDATA[<Unknown Sender>]]></string>
+    <string name="unknown_recipient">&lt;Unknown Recipient&gt;</string>
+    <string name="unknown_sender">&lt;Unknown Sender&gt;</string>
     <string name="address_type_home">Home</string>
     <string name="address_type_work">Work</string>
     <string name="address_type_other">Other</string>


### PR DESCRIPTION
…nd &gt; in strings.xml

> The strings unknown_sender and unknown_recipient are broken on Transifex and can not be translated properly. See screenshot below. Transifex recognizes the <...> part in <![CDATA[<Unknown Recipient>]]> as a tag. Additionally, I think translators should not be bothered with the CDATA part.

Removed CDATA[...] and replaced it with `&lt;` and `&gt;` for unknown_sender and unknown_recipient.

Fixes #5008 