### PR TITLE
Fix replacing drafts on the server

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -20,7 +20,7 @@ internal class DraftOperations(private val messagingController: MessagingControl
         message: Message,
         existingDraftId: Long?,
         plaintextSubject: String?
-    ): Message? {
+    ): Long? {
         return try {
             val draftsFolderId = account.draftsFolderId ?: error("No Drafts folder configured")
 
@@ -39,7 +39,7 @@ internal class DraftOperations(private val messagingController: MessagingControl
                 localMessage.setCachedDecryptedSubject(plaintextSubject)
             }
 
-            localMessage
+            localMessage.databaseId
         } catch (e: MessagingException) {
             Timber.e(e, "Unable to save message as draft.")
             null

--- a/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -13,8 +13,7 @@ internal class DraftOperations(private val messagingController: MessagingControl
         account: Account,
         message: Message,
         existingDraftId: Long?,
-        plaintextSubject: String?,
-        saveRemotely: Boolean
+        plaintextSubject: String?
     ): Message? {
         return try {
             val draftsFolderId = account.draftsFolderId ?: error("No Drafts folder configured")
@@ -38,7 +37,7 @@ internal class DraftOperations(private val messagingController: MessagingControl
                 localMessage.setCachedDecryptedSubject(plaintextSubject)
             }
 
-            if (saveRemotely && messagingController.supportsUpload(account)) {
+            if (messagingController.supportsUpload(account)) {
                 val command = PendingAppend.create(localFolder.databaseId, localMessage.uid)
                 messagingController.queuePendingCommand(account, command)
                 messagingController.processPendingCommands(account)

--- a/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -1,0 +1,53 @@
+package com.fsck.k9.controller
+
+import com.fsck.k9.Account
+import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend
+import com.fsck.k9.mail.Flag
+import com.fsck.k9.mail.Message
+import com.fsck.k9.mail.MessagingException
+import timber.log.Timber
+
+internal class DraftOperations(private val messagingController: MessagingController) {
+
+    fun saveDraft(
+        account: Account,
+        message: Message,
+        existingDraftId: Long,
+        plaintextSubject: String?,
+        saveRemotely: Boolean
+    ): Message? {
+        return try {
+            val draftsFolderId = account.draftsFolderId ?: error("No Drafts folder configured")
+
+            val localStore = messagingController.getLocalStoreOrThrow(account)
+            val localFolder = localStore.getFolder(draftsFolderId)
+            localFolder.open()
+
+            if (existingDraftId != MessagingController.INVALID_MESSAGE_ID) {
+                val uid = localFolder.getMessageUidById(existingDraftId)
+                message.uid = uid
+            }
+
+            // Save the message to the store.
+            localFolder.appendMessages(listOf(message))
+
+            // Fetch the message back from the store.  This is the Message that's returned to the caller.
+            val localMessage = localFolder.getMessage(message.uid)
+            localMessage.setFlag(Flag.X_DOWNLOADED_FULL, true)
+            if (plaintextSubject != null) {
+                localMessage.setCachedDecryptedSubject(plaintextSubject)
+            }
+
+            if (saveRemotely && messagingController.supportsUpload(account)) {
+                val command = PendingAppend.create(localFolder.databaseId, localMessage.uid)
+                messagingController.queuePendingCommand(account, command)
+                messagingController.processPendingCommands(account)
+            }
+
+            localMessage
+        } catch (e: MessagingException) {
+            Timber.e(e, "Unable to save message as draft.")
+            null
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -12,7 +12,7 @@ internal class DraftOperations(private val messagingController: MessagingControl
     fun saveDraft(
         account: Account,
         message: Message,
-        existingDraftId: Long,
+        existingDraftId: Long?,
         plaintextSubject: String?,
         saveRemotely: Boolean
     ): Message? {
@@ -23,7 +23,7 @@ internal class DraftOperations(private val messagingController: MessagingControl
             val localFolder = localStore.getFolder(draftsFolderId)
             localFolder.open()
 
-            if (existingDraftId != MessagingController.INVALID_MESSAGE_ID) {
+            if (existingDraftId != null) {
                 val uid = localFolder.getMessageUidById(existingDraftId)
                 message.uid = uid
             }

--- a/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -1,10 +1,16 @@
 package com.fsck.k9.controller
 
 import com.fsck.k9.Account
+import com.fsck.k9.K9
+import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend
+import com.fsck.k9.controller.MessagingControllerCommands.PendingReplace
+import com.fsck.k9.mail.FetchProfile
 import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.MessagingException
+import com.fsck.k9.mailstore.LocalFolder
+import com.fsck.k9.mailstore.LocalMessage
 import timber.log.Timber
 
 internal class DraftOperations(private val messagingController: MessagingController) {
@@ -22,25 +28,15 @@ internal class DraftOperations(private val messagingController: MessagingControl
             val localFolder = localStore.getFolder(draftsFolderId)
             localFolder.open()
 
-            if (existingDraftId != null) {
-                val uid = localFolder.getMessageUidById(existingDraftId)
-                message.uid = uid
+            val localMessage = if (messagingController.supportsUpload(account)) {
+                saveAndUploadDraft(account, message, localFolder, existingDraftId)
+            } else {
+                saveDraftLocally(message, localFolder, existingDraftId)
             }
 
-            // Save the message to the store.
-            localFolder.appendMessages(listOf(message))
-
-            // Fetch the message back from the store.  This is the Message that's returned to the caller.
-            val localMessage = localFolder.getMessage(message.uid)
             localMessage.setFlag(Flag.X_DOWNLOADED_FULL, true)
             if (plaintextSubject != null) {
                 localMessage.setCachedDecryptedSubject(plaintextSubject)
-            }
-
-            if (messagingController.supportsUpload(account)) {
-                val command = PendingAppend.create(localFolder.databaseId, localMessage.uid)
-                messagingController.queuePendingCommand(account, command)
-                messagingController.processPendingCommands(account)
             }
 
             localMessage
@@ -48,5 +44,113 @@ internal class DraftOperations(private val messagingController: MessagingControl
             Timber.e(e, "Unable to save message as draft.")
             null
         }
+    }
+
+    private fun saveAndUploadDraft(
+        account: Account,
+        message: Message,
+        localFolder: LocalFolder,
+        existingDraftId: Long?
+    ): LocalMessage {
+        localFolder.appendMessages(listOf(message))
+
+        val localMessage = localFolder.getMessage(message.uid)
+        val previousDraftMessage = if (existingDraftId != null) localFolder.getMessage(existingDraftId) else null
+
+        val folderId = localFolder.databaseId
+        if (previousDraftMessage != null) {
+            previousDraftMessage.delete()
+
+            val uploadMessageId = localMessage.databaseId
+            val deleteMessageId = previousDraftMessage.databaseId
+            val command = PendingReplace.create(folderId, uploadMessageId, deleteMessageId)
+            messagingController.queuePendingCommand(account, command)
+        } else {
+            val command = PendingAppend.create(folderId, localMessage.uid)
+            messagingController.queuePendingCommand(account, command)
+        }
+
+        messagingController.processPendingCommands(account)
+
+        return localMessage
+    }
+
+    private fun saveDraftLocally(message: Message, localFolder: LocalFolder, existingDraftId: Long?): LocalMessage {
+        if (existingDraftId != null) {
+            // Setting the UID will cause LocalFolder.appendMessages() to replace the existing draft.
+            message.uid = localFolder.getMessageUidById(existingDraftId)
+        }
+
+        localFolder.appendMessages(listOf(message))
+
+        return localFolder.getMessage(message.uid)
+    }
+
+    fun processPendingReplace(command: PendingReplace, account: Account) {
+        val localStore = messagingController.getLocalStoreOrThrow(account)
+        val localFolder = localStore.getFolder(command.folderId)
+        localFolder.open()
+
+        val backend = messagingController.getBackend(account)
+
+        val uploadMessageId = command.uploadMessageId
+        val localMessage = localFolder.getMessage(uploadMessageId)
+        if (localMessage == null) {
+            Timber.w("Couldn't find local copy of message to upload [ID: %d]", uploadMessageId)
+            return
+        } else if (!localMessage.uid.startsWith(K9.LOCAL_UID_PREFIX)) {
+            Timber.i("Message [ID: %d] to be uploaded already has a server ID set. Skipping upload.", uploadMessageId)
+        } else {
+            uploadMessage(backend, account, localFolder, localMessage)
+        }
+
+        deleteMessage(backend, localFolder, command.deleteMessageId)
+    }
+
+    private fun uploadMessage(
+        backend: Backend,
+        account: Account,
+        localFolder: LocalFolder,
+        localMessage: LocalMessage
+    ) {
+        val folderServerId = localFolder.serverId
+        Timber.d("Uploading message [ID: %d] to remote folder '%s'", localMessage.databaseId, folderServerId)
+
+        val fetchProfile = FetchProfile().apply {
+            add(FetchProfile.Item.BODY)
+        }
+        localFolder.fetch(listOf(localMessage), fetchProfile, null)
+
+        val messageServerId = backend.uploadMessage(folderServerId, localMessage)
+
+        if (messageServerId == null) {
+            Timber.w(
+                "Failed to get a server ID for the uploaded message. Removing local copy [ID: %d]",
+                localMessage.databaseId
+            )
+            localMessage.destroy()
+        } else {
+            val oldUid = localMessage.uid
+
+            localMessage.uid = messageServerId
+            localFolder.changeUid(localMessage)
+
+            for (listener in messagingController.listeners) {
+                listener.messageUidChanged(account, localFolder.databaseId, oldUid, localMessage.uid)
+            }
+        }
+    }
+
+    private fun deleteMessage(backend: Backend, localFolder: LocalFolder, messageId: Long) {
+        val messageServerId = localFolder.getMessageUidById(messageId) ?: run {
+            Timber.i("Couldn't find local copy of message [ID: %d] to be deleted. Skipping delete.", messageId)
+            return
+        }
+
+        val messageServerIds = listOf(messageServerId)
+        val folderServerId = localFolder.serverId
+        backend.deleteMessages(folderServerId, messageServerIds)
+
+        messagingController.destroyPlaceholderMessages(localFolder, messageServerIds)
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -743,13 +743,13 @@ public class MessagingController {
                     Timber.d("Done processing pending command '%s'", command);
                 } catch (MessagingException me) {
                     if (me.isPermanentFailure()) {
-                        Timber.e("Failure of command '%s' was permanent, removing command from queue", command);
+                        Timber.e(me, "Failure of command '%s' was permanent, removing command from queue", command);
                         localStore.removePendingCommand(processingCommand);
                     } else {
                         throw me;
                     }
                 } catch (Exception e) {
-                    Timber.e("Unexpected exception with command '%s', removing command from queue", command);
+                    Timber.e(e, "Unexpected exception with command '%s', removing command from queue", command);
                     localStore.removePendingCommand(processingCommand);
 
                     if (K9.DEVELOPER_MODE) {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1893,9 +1893,9 @@ public class MessagingController {
         for (MessageReference messageReference : messages) {
             try {
                 Message message = loadMessage(account, folderId, messageReference.getUid());
-                Message draftMessage = saveDraft(account, message, null, message.getSubject());
+                Long draftMessageId = saveDraft(account, message, null, message.getSubject());
 
-                boolean draftSavedSuccessfully = draftMessage != null;
+                boolean draftSavedSuccessfully = draftMessageId != null;
                 if (draftSavedSuccessfully) {
                     message.destroy();
                 }
@@ -2541,7 +2541,7 @@ public class MessagingController {
     /**
      * Save a draft message.
      */
-    public Message saveDraft(Account account, Message message, Long existingDraftId, String plaintextSubject) {
+    public Long saveDraft(Account account, Message message, Long existingDraftId, String plaintextSubject) {
         return draftOperations.saveDraft(account, message, existingDraftId, plaintextSubject);
     }
 

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -105,8 +105,6 @@ import static com.fsck.k9.search.LocalSearchExtensions.getAccountsFromLocalSearc
  */
 @SuppressWarnings("unchecked") // TODO change architecture to actually work with generics
 public class MessagingController {
-    public static final long INVALID_MESSAGE_ID = -1;
-
     public static final Set<Flag> SYNC_FLAGS = EnumSet.of(Flag.SEEN, Flag.FLAGGED, Flag.ANSWERED, Flag.FORWARDED);
 
     private static final long FOLDER_LIST_STALENESS_THRESHOLD = 30 * 60 * 1000L;
@@ -1890,7 +1888,7 @@ public class MessagingController {
         for (MessageReference messageReference : messages) {
             try {
                 Message message = loadMessage(account, folderId, messageReference.getUid());
-                Message draftMessage = saveDraft(account, message, INVALID_MESSAGE_ID, message.getSubject(), true);
+                Message draftMessage = saveDraft(account, message, null, message.getSubject(), true);
 
                 boolean draftSavedSuccessfully = draftMessage != null;
                 if (draftSavedSuccessfully) {
@@ -2538,21 +2536,18 @@ public class MessagingController {
     /**
      * Save a draft message.
      */
-    public Message saveDraft(Account account, Message message, long existingDraftId, String plaintextSubject,
+    public Message saveDraft(Account account, Message message, Long existingDraftId, String plaintextSubject,
             boolean saveRemotely) {
         return draftOperations.saveDraft(account, message, existingDraftId, plaintextSubject, saveRemotely);
     }
 
-    public long getId(Message message) {
-        long id;
+    public Long getId(Message message) {
         if (message instanceof LocalMessage) {
-            id = ((LocalMessage) message).getDatabaseId();
+            return ((LocalMessage) message).getDatabaseId();
         } else {
             Timber.w("MessagingController.getId() called without a LocalMessage");
-            id = INVALID_MESSAGE_ID;
+            return null;
         }
-
-        return id;
     }
 
     private static AtomicInteger sequencing = new AtomicInteger(0);

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -51,6 +51,7 @@ import com.fsck.k9.controller.MessagingControllerCommands.PendingExpunge;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingMarkAllAsRead;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingMoveAndMarkAsRead;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingMoveOrCopy;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingReplace;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingSetFlag;
 import com.fsck.k9.controller.ProgressBodyFactory.ProgressListener;
 import com.fsck.k9.helper.MutableBoolean;
@@ -268,7 +269,7 @@ public class MessagingController {
         throw new Error(e);
     }
 
-    private Backend getBackend(Account account) {
+    Backend getBackend(Account account) {
         return backendManager.getBackend(account);
     }
 
@@ -846,6 +847,10 @@ public class MessagingController {
         }
     }
 
+    void processPendingReplace(PendingReplace pendingReplace, Account account) {
+        draftOperations.processPendingReplace(pendingReplace, account);
+    }
+
     private void queueMoveOrCopy(Account account, long srcFolderId, long destFolderId, MoveOrCopyFlavor operation,
             Map<String, String> uidMap) {
         PendingCommand command;
@@ -957,7 +962,7 @@ public class MessagingController {
         }
     }
 
-    private void destroyPlaceholderMessages(LocalFolder localFolder, List<String> uids) throws MessagingException {
+    void destroyPlaceholderMessages(LocalFolder localFolder, List<String> uids) throws MessagingException {
         for (String uid : uids) {
             LocalMessage placeholderMessage = localFolder.getMessage(uid);
             if (placeholderMessage == null) {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1888,7 +1888,7 @@ public class MessagingController {
         for (MessageReference messageReference : messages) {
             try {
                 Message message = loadMessage(account, folderId, messageReference.getUid());
-                Message draftMessage = saveDraft(account, message, null, message.getSubject(), true);
+                Message draftMessage = saveDraft(account, message, null, message.getSubject());
 
                 boolean draftSavedSuccessfully = draftMessage != null;
                 if (draftSavedSuccessfully) {
@@ -2536,9 +2536,8 @@ public class MessagingController {
     /**
      * Save a draft message.
      */
-    public Message saveDraft(Account account, Message message, Long existingDraftId, String plaintextSubject,
-            boolean saveRemotely) {
-        return draftOperations.saveDraft(account, message, existingDraftId, plaintextSubject, saveRemotely);
+    public Message saveDraft(Account account, Message message, Long existingDraftId, String plaintextSubject) {
+        return draftOperations.saveDraft(account, message, existingDraftId, plaintextSubject);
     }
 
     public Long getId(Message message) {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingControllerCommands.java
@@ -14,6 +14,7 @@ import static com.fsck.k9.helper.Preconditions.checkNotNull;
 
 public class MessagingControllerCommands {
     static final String COMMAND_APPEND = "append";
+    static final String COMMAND_REPLACE = "replace";
     static final String COMMAND_MARK_ALL_AS_READ = "mark_all_as_read";
     static final String COMMAND_SET_FLAG = "set_flag";
     static final String COMMAND_DELETE = "delete";
@@ -164,6 +165,33 @@ public class MessagingControllerCommands {
         @Override
         public void execute(MessagingController controller, Account account) throws MessagingException {
             controller.processPendingAppend(this, account);
+        }
+    }
+
+    public static class PendingReplace extends PendingCommand {
+        public final long folderId;
+        public final long uploadMessageId;
+        public final long deleteMessageId;
+
+
+        public static PendingReplace create(long folderId, long uploadMessageId, long deleteMessageId) {
+            return new PendingReplace(folderId, uploadMessageId, deleteMessageId);
+        }
+
+        private PendingReplace(long folderId, long uploadMessageId, long deleteMessageId) {
+            this.folderId = folderId;
+            this.uploadMessageId = uploadMessageId;
+            this.deleteMessageId = deleteMessageId;
+        }
+
+        @Override
+        public String getCommandName() {
+            return COMMAND_REPLACE;
+        }
+
+        @Override
+        public void execute(MessagingController controller, Account account) throws MessagingException {
+            controller.processPendingReplace(this, account);
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/controller/PendingCommandSerializer.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/PendingCommandSerializer.java
@@ -15,6 +15,7 @@ import com.fsck.k9.controller.MessagingControllerCommands.PendingExpunge;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingMarkAllAsRead;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingMoveAndMarkAsRead;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingMoveOrCopy;
+import com.fsck.k9.controller.MessagingControllerCommands.PendingReplace;
 import com.fsck.k9.controller.MessagingControllerCommands.PendingSetFlag;
 import com.squareup.moshi.JsonAdapter;
 import com.squareup.moshi.Moshi;
@@ -35,6 +36,7 @@ public class PendingCommandSerializer {
         adapters.put(MessagingControllerCommands.COMMAND_MOVE_AND_MARK_AS_READ,
                 moshi.adapter(PendingMoveAndMarkAsRead.class));
         adapters.put(MessagingControllerCommands.COMMAND_APPEND, moshi.adapter(PendingAppend.class));
+        adapters.put(MessagingControllerCommands.COMMAND_REPLACE, moshi.adapter(PendingReplace.class));
         adapters.put(MessagingControllerCommands.COMMAND_EMPTY_TRASH, moshi.adapter(PendingEmptyTrash.class));
         adapters.put(MessagingControllerCommands.COMMAND_EXPUNGE, moshi.adapter(PendingExpunge.class));
         adapters.put(MessagingControllerCommands.COMMAND_MARK_ALL_AS_READ, moshi.adapter(PendingMarkAllAsRead.class));

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -51,6 +51,12 @@ public class LocalMessage extends MimeMessage {
         this.mFolder = folder;
     }
 
+    LocalMessage(LocalStore localStore, long databaseId, LocalFolder folder) {
+        this.localStore = localStore;
+        this.databaseId = databaseId;
+        this.mFolder = folder;
+    }
+
 
     void populateFromGetMessageCursor(Cursor cursor) throws MessagingException {
         final String subject = cursor.getString(LocalStore.MSG_INDEX_SUBJECT);
@@ -300,7 +306,7 @@ public class LocalMessage extends MimeMessage {
      * If a message is being marked as deleted we want to clear out its content. Delete will not actually remove the
      * row since we need to retain the UID for synchronization purposes.
      */
-    private void delete() throws MessagingException {
+    public void delete() throws MessagingException {
         try {
             localStore.getDatabase().execute(true, new DbCallback<Void>() {
                 @Override

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1540,7 +1540,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             }
 
             new SaveMessageTask(getApplicationContext(), account, contacts, internalMessageHandler,
-                    message, draftMessageId, plaintextSubject, true).execute();
+                    message, draftMessageId, plaintextSubject).execute();
             if (finishAfterDraftSaved) {
                 finish();
             } else {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1535,10 +1535,6 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             changesMadeSinceLastSave = false;
             currentMessageBuilder = null;
 
-            if (action == Action.EDIT_DRAFT && relatedMessageReference != null) {
-                message.setUid(relatedMessageReference.getUid());
-            }
-
             new SaveMessageTask(getApplicationContext(), account, contacts, internalMessageHandler,
                     message, draftMessageId, plaintextSubject).execute();
             if (finishAfterDraftSaved) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -131,8 +131,6 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private static final int DIALOG_CHOOSE_IDENTITY = 3;
     private static final int DIALOG_CONFIRM_DISCARD = 4;
 
-    private static final long INVALID_DRAFT_ID = MessagingController.INVALID_MESSAGE_ID;
-
     public static final String ACTION_COMPOSE = "com.fsck.k9.intent.action.COMPOSE";
     public static final String ACTION_REPLY = "com.fsck.k9.intent.action.REPLY";
     public static final String ACTION_REPLY_ALL = "com.fsck.k9.intent.action.REPLY_ALL";
@@ -214,12 +212,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     private boolean alreadyNotifiedUserOfEmptySubject = false;
     private boolean changesMadeSinceLastSave = false;
 
-    /**
-     * The database ID of this message's draft. This is used when saving drafts so the message in
-     * the database is updated instead of being created anew. This property is INVALID_DRAFT_ID
-     * until the first save.
-     */
-    private long draftId = INVALID_DRAFT_ID;
+    private Long draftMessageId = null;
 
     private Action action;
 
@@ -617,7 +610,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         super.onSaveInstanceState(outState);
 
         outState.putBoolean(STATE_KEY_SOURCE_MESSAGE_PROCED, relatedMessageProcessed);
-        outState.putLong(STATE_KEY_DRAFT_ID, draftId);
+        if (draftMessageId != null) {
+            outState.putLong(STATE_KEY_DRAFT_ID, draftMessageId);
+        }
         outState.putParcelable(STATE_IDENTITY, identity);
         outState.putBoolean(STATE_IDENTITY_CHANGED, identityChanged);
         outState.putString(STATE_IN_REPLY_TO, repliedToMessageId);
@@ -651,7 +646,11 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         quotedMessagePresenter.onRestoreInstanceState(savedInstanceState);
         attachmentPresenter.onRestoreInstanceState(savedInstanceState);
 
-        draftId = savedInstanceState.getLong(STATE_KEY_DRAFT_ID);
+        if (savedInstanceState.containsKey(STATE_KEY_DRAFT_ID)) {
+            draftMessageId = savedInstanceState.getLong(STATE_KEY_DRAFT_ID);
+        } else {
+            draftMessageId = null;
+        }
         identity = savedInstanceState.getParcelable(STATE_IDENTITY);
         identityChanged = savedInstanceState.getBoolean(STATE_IDENTITY_CHANGED);
         repliedToMessageId = savedInstanceState.getString(STATE_IN_REPLY_TO);
@@ -786,9 +785,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     }
 
     private void onDiscard() {
-        if (draftId != INVALID_DRAFT_ID) {
-            MessagingController.getInstance(getApplication()).deleteDraft(account, draftId);
-            draftId = INVALID_DRAFT_ID;
+        if (draftMessageId != null) {
+            MessagingController.getInstance(getApplication()).deleteDraft(account, draftMessageId);
+            draftMessageId = null;
         }
         internalMessageHandler.sendEmptyMessage(MSG_DISCARDED_DRAFT);
         changesMadeSinceLastSave = false;
@@ -865,12 +864,12 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             }
 
             // test whether there is something to save
-            if (changesMadeSinceLastSave || (draftId != INVALID_DRAFT_ID)) {
-                final long previousDraftId = draftId;
+            if (changesMadeSinceLastSave || (draftMessageId != null)) {
+                final Long previousDraftId = draftMessageId;
                 final Account previousAccount = this.account;
 
                 // make current message appear as new
-                draftId = INVALID_DRAFT_ID;
+                draftMessageId = null;
 
                 // actual account switch
                 this.account = account;
@@ -878,7 +877,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 Timber.v("Account switch, saving new draft in new account");
                 checkToSaveDraftImplicitly();
 
-                if (previousDraftId != INVALID_DRAFT_ID) {
+                if (previousDraftId != null) {
                     Timber.v("Account switch, deleting draft from previous account: %d", previousDraftId);
 
                     MessagingController.getInstance(getApplication()).deleteDraft(previousAccount,
@@ -1056,7 +1055,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             }
         } else {
             // Check if editing an existing draft.
-            if (draftId == INVALID_DRAFT_ID) {
+            if (draftMessageId == null) {
                 onDiscard();
             } else {
                 if (navigateUp) {
@@ -1324,7 +1323,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
     private void processDraftMessage(MessageViewInfo messageViewInfo) {
         Message message = messageViewInfo.message;
-        draftId = MessagingController.getInstance(getApplication()).getId(message);
+        draftMessageId = MessagingController.getInstance(getApplication()).getId(message);
         subjectView.setText(messageViewInfo.subject);
 
         recipientPresenter.initFromDraftMessage(message);
@@ -1541,7 +1540,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             }
 
             new SaveMessageTask(getApplicationContext(), account, contacts, internalMessageHandler,
-                    message, draftId, plaintextSubject, true).execute();
+                    message, draftMessageId, plaintextSubject, true).execute();
             if (finishAfterDraftSaved) {
                 finish();
             } else {
@@ -1550,7 +1549,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         } else {
             currentMessageBuilder = null;
             new SendMessageTask(getApplicationContext(), account, contacts, message,
-                    draftId != INVALID_DRAFT_ID ? draftId : null, plaintextSubject, relatedMessageReference).execute();
+                    draftMessageId, plaintextSubject, relatedMessageReference).execute();
             finish();
         }
     }
@@ -1856,7 +1855,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                     setProgressBarIndeterminateVisibility(false);
                     break;
                 case MSG_SAVED_DRAFT:
-                    draftId = (Long) msg.obj;
+                    draftMessageId = (Long) msg.obj;
                     Toast.makeText(
                             MessageCompose.this,
                             getString(R.string.message_saved_toast),

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
@@ -18,10 +18,9 @@ public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
     Message message;
     Long draftId;
     String plaintextSubject;
-    boolean saveRemotely;
 
-    public SaveMessageTask(Context context, Account account, Contacts contacts,
-                           Handler handler, Message message, Long draftId, String plaintextSubject, boolean saveRemotely) {
+    public SaveMessageTask(Context context, Account account, Contacts contacts, Handler handler, Message message,
+            Long draftId, String plaintextSubject) {
         this.context = context;
         this.account = account;
         this.contacts = contacts;
@@ -29,13 +28,12 @@ public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
         this.message = message;
         this.draftId = draftId;
         this.plaintextSubject = plaintextSubject;
-        this.saveRemotely = saveRemotely;
     }
 
     @Override
     protected Void doInBackground(Void... params) {
         final MessagingController messagingController = MessagingController.getInstance(context);
-        Message draftMessage = messagingController.saveDraft(account, message, draftId, plaintextSubject, saveRemotely);
+        Message draftMessage = messagingController.saveDraft(account, message, draftId, plaintextSubject);
         draftId = messagingController.getId(draftMessage);
 
         android.os.Message msg = android.os.Message.obtain(handler, MessageCompose.MSG_SAVED_DRAFT, draftId);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
@@ -16,12 +16,12 @@ public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
     Contacts contacts;
     Handler handler;
     Message message;
-    long draftId;
+    Long draftId;
     String plaintextSubject;
     boolean saveRemotely;
 
     public SaveMessageTask(Context context, Account account, Contacts contacts,
-                           Handler handler, Message message, long draftId, String plaintextSubject, boolean saveRemotely) {
+                           Handler handler, Message message, Long draftId, String plaintextSubject, boolean saveRemotely) {
         this.context = context;
         this.account = account;
         this.contacts = contacts;

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/SaveMessageTask.java
@@ -33,8 +33,7 @@ public class SaveMessageTask extends AsyncTask<Void, Void, Void> {
     @Override
     protected Void doInBackground(Void... params) {
         final MessagingController messagingController = MessagingController.getInstance(context);
-        Message draftMessage = messagingController.saveDraft(account, message, draftId, plaintextSubject);
-        draftId = messagingController.getId(draftMessage);
+        draftId = messagingController.saveDraft(account, message, draftId, plaintextSubject);
 
         android.os.Message msg = android.os.Message.obtain(handler, MessageCompose.MSG_SAVED_DRAFT, draftId);
         handler.sendMessage(msg);


### PR DESCRIPTION
This adds a new "pending command" to replace a message on the server. Because we currently don't have any backends that actually support replacing messages, this operation is not passed through to `Backend`. Instead it's implemented as "upload new message, then delete old message" at the `MessagingController` layer.

Previously there was a lot of magic involved to support replacing drafts on the server. I accidentally broke it when I removed code that I believed was unnecessary. Hopefully the code is much clearer now so this won't happen again in the future.

Fixes #4871