### PR TITLE
Improve Outbox

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1899,6 +1899,10 @@ public class MessagingController {
                 if (draftSavedSuccessfully) {
                     message.destroy();
                 }
+
+                for (MessagingListener listener : getListeners()) {
+                    listener.folderStatusChanged(account, folderId);
+                }
             } catch (MessagingException e) {
                 Timber.e(e, "Error loading message. Draft was not saved.");
             }

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1384,6 +1384,7 @@ public class MessagingController {
             LocalStore localStore = localStoreProvider.getInstance(account);
             LocalFolder localFolder = localStore.getFolder(account.getOutboxFolderId());
             localFolder.open();
+            message.setFlag(Flag.SEEN, true);
             localFolder.appendMessages(Collections.singletonList(message));
             LocalMessage localMessage = localFolder.getMessage(message.getUid());
             long messageId = localMessage.getDatabaseId();

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1138,18 +1138,22 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 toggleTheme.setVisible(true);
             }
 
-            // Set title of menu item to toggle the read state of the currently displayed message
-            int[] drawableAttr;
-            if (messageViewFragment.isMessageRead()) {
-                menu.findItem(R.id.toggle_unread).setTitle(R.string.mark_as_unread_action);
-                drawableAttr = new int[] { R.attr.iconActionMarkAsUnread };
+            if (messageViewFragment.isOutbox()) {
+                menu.findItem(R.id.toggle_unread).setVisible(false);
             } else {
-                menu.findItem(R.id.toggle_unread).setTitle(R.string.mark_as_read_action);
-                drawableAttr = new int[] { R.attr.iconActionMarkAsRead };
+                // Set title of menu item to toggle the read state of the currently displayed message
+                int[] drawableAttr;
+                if (messageViewFragment.isMessageRead()) {
+                    menu.findItem(R.id.toggle_unread).setTitle(R.string.mark_as_unread_action);
+                    drawableAttr = new int[] { R.attr.iconActionMarkAsUnread };
+                } else {
+                    menu.findItem(R.id.toggle_unread).setTitle(R.string.mark_as_read_action);
+                    drawableAttr = new int[] { R.attr.iconActionMarkAsRead };
+                }
+                TypedArray ta = obtainStyledAttributes(drawableAttr);
+                menu.findItem(R.id.toggle_unread).setIcon(ta.getDrawable(0));
+                ta.recycle();
             }
-            TypedArray ta = obtainStyledAttributes(drawableAttr);
-            menu.findItem(R.id.toggle_unread).setIcon(ta.getDrawable(0));
-            ta.recycle();
 
             menu.findItem(R.id.delete).setVisible(K9.isMessageViewDeleteActionVisible());
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1026,6 +1026,9 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
         } else if (id == R.id.copy || id == R.id.refile_copy) {
             messageViewFragment.onCopy();
             return true;
+        } else if (id == R.id.move_to_drafts) {
+            messageViewFragment.onMoveToDrafts();
+            return true;
         } else if (id == R.id.show_headers || id == R.id.hide_headers) {
             messageViewFragment.onToggleAllHeadersView();
             updateMenu();
@@ -1187,6 +1190,10 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
                 menu.findItem(R.id.spam).setVisible(false);
 
                 menu.findItem(R.id.refile).setVisible(false);
+            }
+
+            if (messageViewFragment.isOutbox()) {
+                menu.findItem(R.id.move_to_drafts).setVisible(true);
             }
 
             if (messageViewFragment.allHeadersVisible()) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.java
@@ -1213,8 +1213,7 @@ public class MessageList extends K9Activity implements MessageListFragmentListen
             menu.findItem(R.id.set_sort).setVisible(true);
             menu.findItem(R.id.select_all).setVisible(true);
             menu.findItem(R.id.compose).setVisible(true);
-            menu.findItem(R.id.mark_all_as_read).setVisible(
-                    messageListFragment.isMarkAllAsReadSupported());
+            menu.findItem(R.id.mark_all_as_read).setVisible(messageListFragment.isMarkAllAsReadSupported());
 
             if (!messageListFragment.isSingleAccountMode()) {
                 menu.findItem(R.id.expunge).setVisible(false);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -491,10 +491,11 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
 
     private MessageListAppearance getMessageListAppearance() {
         boolean showAccountChip = !isSingleAccountMode();
+        boolean showStars = !isOutbox() && K9.isShowMessageListStars();
         return new MessageListAppearance(
                 K9.getFontSizes(),
                 K9.getMessageListPreviewLines(),
-                K9.isShowMessageListStars(),
+                showStars,
                 K9.isMessageListSenderAboveSubject(),
                 K9.isShowContactPicture(),
                 showingThreadedList,
@@ -1600,6 +1601,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         private MenuItem mMarkAsUnread;
         private MenuItem mFlag;
         private MenuItem mUnflag;
+        private boolean disableMarkAsRead;
+        private boolean disableFlag;
 
         @Override
         public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
@@ -1731,6 +1734,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
                 menu.findItem(R.id.unflag).setVisible(false);
                 menu.findItem(R.id.spam).setVisible(false);
                 menu.findItem(R.id.move).setVisible(false);
+                disableMarkAsRead = true;
+                disableFlag = true;
 
                 if (account.hasDraftsFolder()) {
                     menu.findItem(R.id.move_to_drafts).setVisible(true);
@@ -1745,14 +1750,14 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         }
 
         public void showMarkAsRead(boolean show) {
-            if (actionMode != null) {
+            if (actionMode != null && !disableMarkAsRead) {
                 mMarkAsRead.setVisible(show);
                 mMarkAsUnread.setVisible(!show);
             }
         }
 
         public void showFlag(boolean show) {
-            if (actionMode != null) {
+            if (actionMode != null && !disableFlag) {
                 mFlag.setVisible(show);
                 mUnflag.setVisible(!show);
             }
@@ -2349,7 +2354,7 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
     }
 
     public boolean isMarkAllAsReadSupported() {
-        return (isSingleAccountMode() && isSingleFolderMode());
+        return isSingleAccountMode() && isSingleFolderMode() && !isOutbox();
     }
 
     public void confirmMarkAllAsRead() {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.java
@@ -207,8 +207,8 @@ public class MessageTopView extends LinearLayout {
         return mHeaderContainer;
     }
 
-    public void setHeaders(Message message, Account account) {
-        mHeaderContainer.populate(message, account);
+    public void setHeaders(Message message, Account account, boolean showStar) {
+        mHeaderContainer.populate(message, account, showStar);
         mHeaderContainer.setVisibility(View.VISIBLE);
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -2,6 +2,7 @@ package com.fsck.k9.ui.messageview;
 
 
 import java.util.Collections;
+import java.util.List;
 import java.util.Locale;
 
 import android.app.Activity;
@@ -414,6 +415,16 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         }
 
         startRefileActivity(ACTIVITY_CHOOSE_FOLDER_COPY);
+    }
+
+    public void onMoveToDrafts() {
+        Account account = mAccount;
+        long folderId = mMessageReference.getFolderId();
+        List<MessageReference> messages = Collections.singletonList(mMessageReference);
+
+        mFragmentListener.showNextMessageOrReturn();
+
+        mController.moveToDraftsFolder(account, folderId, messages);
     }
 
     public void onArchive() {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -267,7 +267,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
 
     }
 
-    public void populate(final Message message, final Account account) {
+    public void populate(final Message message, final Account account, boolean showStar) {
         Address fromAddress = null;
         Address[] fromAddresses = message.getFrom();
         if (fromAddresses.length > 0) {
@@ -323,7 +323,13 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
         updateAddressField(mBccView, bcc, mBccLabel);
         mAnsweredIcon.setVisibility(message.isSet(Flag.ANSWERED) ? View.VISIBLE : View.GONE);
         mForwardedIcon.setVisibility(message.isSet(Flag.FORWARDED) ? View.VISIBLE : View.GONE);
-        mFlagged.setChecked(message.isSet(Flag.FLAGGED));
+
+        if (showStar) {
+            mFlagged.setVisibility(View.VISIBLE);
+            mFlagged.setChecked(message.isSet(Flag.FLAGGED));
+        } else {
+            mFlagged.setVisibility(View.GONE);
+        }
 
         mChip.setBackgroundColor(mAccount.getChipColor());
 

--- a/app/ui/legacy/src/main/res/menu/message_list_option.xml
+++ b/app/ui/legacy/src/main/res/menu/message_list_option.xml
@@ -85,6 +85,13 @@
 
     <!-- MessageView -->
     <item
+        android:id="@+id/move_to_drafts"
+        android:title="@string/move_to_drafts_action"
+        app:showAsAction="never"
+        android:visible="false"/>
+
+    <!-- MessageView -->
+    <item
         android:id="@+id/single_message_options"
         android:icon="?attr/iconActionSingleMessageOptions"
         app:showAsAction="ifRoom"


### PR DESCRIPTION
- Show number of messages in the Outbox in the folder list (previously only the number of unread message was displayed)
- Don't allow messages in the Outbox to be marked as read/unread or add/remove star by the user
- Display "Move to Drafts" action when viewing messages in the Outbox; hide regular move/copy actions
