### PR TITLE
Fix moving messages not containing a Message-ID header

### DIFF
--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/ThreadMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/ThreadMessageOperations.kt
@@ -85,7 +85,7 @@ internal class ThreadMessageOperations(private val localStore: LocalStore) {
 internal data class ThreadInfo(
     val threadId: Long?,
     val messageId: Long?,
-    val messageIdHeader: String,
+    val messageIdHeader: String?,
     val rootId: Long?,
     val parentId: Long?
 )

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/MessageDatabaseHelpers.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/MessageDatabaseHelpers.kt
@@ -50,7 +50,7 @@ fun SQLiteDatabase.createMessage(
     replyToList: String = "",
     attachmentCount: Int = 0,
     internalDate: Long = 0L,
-    messageId: String = "",
+    messageIdHeader: String? = null,
     previewType: DatabasePreviewType = DatabasePreviewType.NONE,
     preview: String = "",
     mimeType: String = "text/plain",
@@ -77,7 +77,7 @@ fun SQLiteDatabase.createMessage(
         put("reply_to_list", replyToList)
         put("attachment_count", attachmentCount)
         put("internal_date", internalDate)
-        put("message_id", messageId)
+        put("message_id", messageIdHeader)
         put("preview_type", previewType.databaseValue)
         put("preview", preview)
         put("mime_type", mimeType)

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/MoveMessageOperationsTest.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/MoveMessageOperationsTest.kt
@@ -24,7 +24,7 @@ class MoveMessageOperationsTest : RobolectricTest() {
             folderId = SOURCE_FOLDER_ID,
             uid = "uid1",
             subject = "Move me",
-            messageId = MESSAGE_ID_HEADER
+            messageIdHeader = MESSAGE_ID_HEADER
         )
         val originalMessage = sqliteDatabase.readMessages().first()
         val messageThreader = createMessageThreader(
@@ -73,14 +73,14 @@ class MoveMessageOperationsTest : RobolectricTest() {
             folderId = SOURCE_FOLDER_ID,
             uid = "uid1",
             subject = "Move me",
-            messageId = MESSAGE_ID_HEADER,
+            messageIdHeader = MESSAGE_ID_HEADER,
             read = false
         )
         val originalMessage = sqliteDatabase.readMessages().first()
         val placeholderMessageId = sqliteDatabase.createMessage(
             empty = true,
             folderId = DESTINATION_FOLDER_ID,
-            messageId = MESSAGE_ID_HEADER,
+            messageIdHeader = MESSAGE_ID_HEADER,
             uid = ""
         )
         val messageThreader = createMessageThreader(
@@ -111,6 +111,54 @@ class MoveMessageOperationsTest : RobolectricTest() {
 
         val destinationMessage = messages.find { it.id == destinationMessageId }
             ?: fail("Destination message not found in database")
+        assertThat(destinationMessage.uid).startsWith(K9.LOCAL_UID_PREFIX)
+        assertThat(destinationMessage).isEqualTo(
+            originalMessage.copy(
+                id = destinationMessageId,
+                folderId = DESTINATION_FOLDER_ID,
+                uid = destinationMessage.uid,
+                deleted = 0,
+                empty = 0
+            )
+        )
+    }
+
+    @Test
+    fun `move message not containing a message-id header`() {
+        val originalMessageId = sqliteDatabase.createMessage(
+            folderId = SOURCE_FOLDER_ID,
+            uid = "uid1",
+            subject = "Move me",
+            messageIdHeader = null
+        )
+        val originalMessage = sqliteDatabase.readMessages().first()
+        val messageThreader = createMessageThreader(
+            ThreadInfo(
+                threadId = null,
+                messageId = null,
+                messageIdHeader = null,
+                rootId = null,
+                parentId = null
+            )
+        )
+        val moveMessageOperations = MoveMessageOperations(lockableDatabase, messageThreader)
+
+        val destinationMessageId = moveMessageOperations.moveMessage(
+            messageId = originalMessageId,
+            destinationFolderId = DESTINATION_FOLDER_ID
+        )
+
+        val messages = sqliteDatabase.readMessages()
+        assertThat(messages).hasSize(2)
+
+        val sourceMessage = messages.find { it.id == originalMessageId }
+            ?: fail("Original message not found")
+        assertThat(sourceMessage.folderId).isEqualTo(SOURCE_FOLDER_ID)
+        assertThat(sourceMessage.uid).isEqualTo("uid1")
+        assertPlaceholderEntry(sourceMessage)
+
+        val destinationMessage = messages.find { it.id == destinationMessageId }
+            ?: fail("Destination message not found")
         assertThat(destinationMessage.uid).startsWith(K9.LOCAL_UID_PREFIX)
         assertThat(destinationMessage).isEqualTo(
             originalMessage.copy(


### PR DESCRIPTION
Fix `ThreadInfo` to allow `messageIdHeader` being `null`.

Fixes #5026 