### PR TITLE
Don't show recipient names in Inbox, Archive, Spam and Trash folders

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/helper/DisplayAddressHelper.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/helper/DisplayAddressHelper.kt
@@ -5,6 +5,10 @@ import com.fsck.k9.Account
 object DisplayAddressHelper {
     fun shouldShowRecipients(account: Account, folderId: Long): Boolean {
         return when (folderId) {
+            account.inboxFolderId -> false
+            account.archiveFolderId -> false
+            account.spamFolderId -> false
+            account.trashFolderId -> false
             account.sentFolderId -> true
             account.draftsFolderId -> true
             account.outboxFolderId -> true


### PR DESCRIPTION
Some people assign e.g. the 'Sent' role to the Inbox. In that case we need to treat the folder like the Inbox rather than the Sent folder when it comes to deciding whether or not to display the recipient address in the message list.

Fixes #5030