### PR TITLE
Fix parameter types to avoid NullPointerException

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1107,11 +1107,11 @@ open class MessageList :
         }
     }
 
-    override fun onForward(messageReference: MessageReference, decryptionResultForReply: Parcelable) {
+    override fun onForward(messageReference: MessageReference, decryptionResultForReply: Parcelable?) {
         MessageActions.actionForward(this, messageReference, decryptionResultForReply)
     }
 
-    override fun onForwardAsAttachment(messageReference: MessageReference, decryptionResultForReply: Parcelable) {
+    override fun onForwardAsAttachment(messageReference: MessageReference, decryptionResultForReply: Parcelable?) {
         MessageActions.actionForwardAsAttachment(this, messageReference, decryptionResultForReply)
     }
 
@@ -1119,15 +1119,15 @@ open class MessageList :
         MessageActions.actionEditDraft(this, messageReference)
     }
 
-    override fun onReply(messageReference: MessageReference, decryptionResultForReply: Parcelable) {
+    override fun onReply(messageReference: MessageReference, decryptionResultForReply: Parcelable?) {
         MessageActions.actionReply(this, messageReference, false, decryptionResultForReply)
     }
 
-    override fun onReplyAll(messageReference: MessageReference, decryptionResultForReply: Parcelable) {
+    override fun onReplyAll(messageReference: MessageReference, decryptionResultForReply: Parcelable?) {
         MessageActions.actionReply(this, messageReference, true, decryptionResultForReply)
     }
 
-    override fun onCompose(account: Account) {
+    override fun onCompose(account: Account?) {
         MessageActions.actionCompose(this, account)
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.java
@@ -32,6 +32,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.view.ActionMode;
 import androidx.fragment.app.DialogFragment;
@@ -1998,8 +1999,8 @@ public class MessageListFragment extends Fragment implements OnItemClickListener
         void showThread(Account account, long rootId);
         void openMessage(MessageReference messageReference);
         void setMessageListTitle(String title);
-        void onCompose(Account account);
-        boolean startSearch(Account account, Long folderId);
+        void onCompose(@Nullable Account account);
+        boolean startSearch(@Nullable Account account, @Nullable Long folderId);
         void remoteSearchStarted();
         void goBack();
         void updateMenu();

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -16,6 +16,8 @@ import android.os.Bundle;
 import android.os.Handler;
 import android.os.Parcelable;
 import android.os.SystemClock;
+
+import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
@@ -751,12 +753,12 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     }
 
     public interface MessageViewFragmentListener {
-        void onForward(MessageReference messageReference, Parcelable decryptionResultForReply);
-        void onForwardAsAttachment(MessageReference messageReference, Parcelable decryptionResultForReply);
+        void onForward(MessageReference messageReference, @Nullable Parcelable decryptionResultForReply);
+        void onForwardAsAttachment(MessageReference messageReference, @Nullable Parcelable decryptionResultForReply);
         void onEditAsNewMessage(MessageReference messageReference);
         void disableDeleteAction();
-        void onReplyAll(MessageReference messageReference, Parcelable decryptionResultForReply);
-        void onReply(MessageReference messageReference, Parcelable decryptionResultForReply);
+        void onReplyAll(MessageReference messageReference, @Nullable Parcelable decryptionResultForReply);
+        void onReply(MessageReference messageReference, @Nullable Parcelable decryptionResultForReply);
         void setProgress(boolean b);
         void showNextMessageOrReturn();
         void updateMenu();


### PR DESCRIPTION
Fix crash when forwarding or replying to a non-encrypted message.

Partial stack trace from the Google Play Console:

```
java.lang.NullPointerException: 
  at com.fsck.k9.activity.MessageList.onReply (Unknown Source:7)
  at com.fsck.k9.ui.messageview.MessageViewFragment.onReply (MessageViewFragment.java:354)
  at com.fsck.k9.ui.messageview.MessageViewFragment$2.onMenuItemClick (MessageViewFragment.java:192)
  at androidx.appcompat.widget.PopupMenu$1.onMenuItemSelected (PopupMenu.java:113)
```

Fixes #5035