### PR TITLE
Consider default email address in auto-complete suggestions

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/RecipientLoader.java
@@ -64,7 +64,8 @@ public class RecipientLoader extends AsyncTaskLoader<List<Recipient>> {
 
     private static final String SORT_ORDER = "" +
             ContactsContract.CommonDataKinds.Email.TIMES_CONTACTED + " DESC, " +
-            ContactsContract.Contacts.SORT_KEY_PRIMARY;
+            ContactsContract.Contacts.SORT_KEY_PRIMARY + "," +
+            ContactsContract.CommonDataKinds.Email.IS_SUPER_PRIMARY + " DESC";
 
     private static final String[] PROJECTION_NICKNAME = {
             ContactsContract.Data.CONTACT_ID,


### PR DESCRIPTION
Display default email address before other email addresses of a contact (if number of times contacted is the same).

Before and after (with work address being marked as default):

<img src="https://user-images.githubusercontent.com/218061/99267619-76ae4c00-2824-11eb-9fa1-f1d830d03360.png" alt="k9mail__message_compose__auto_complete_before" width=300> <img src="https://user-images.githubusercontent.com/218061/99267626-7910a600-2824-11eb-9492-73e23c31840a.png" alt="k9mail__message_compose__auto_complete_after" width=300>

Closes #5054