### PR TITLE
#1551 get rid of EOLConvertingOutputStream

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
+++ b/app/core/src/main/java/com/fsck/k9/message/PgpMessageBuilder.java
@@ -25,7 +25,7 @@ import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.BoundaryGenerator;
 import com.fsck.k9.mail.Message.RecipientType;
 import com.fsck.k9.mail.MessagingException;
-import com.fsck.k9.mail.filter.EOLConvertingOutputStream;
+//import com.fsck.k9.mail.filter.EOLConvertingOutputStream;
 import com.fsck.k9.mail.internet.BinaryTempFileBody;
 import com.fsck.k9.mail.internet.Headers;
 import com.fsck.k9.mail.internet.MessageIdGenerator;
@@ -296,7 +296,7 @@ public class PgpMessageBuilder extends MessageBuilder {
                 outputStream = pgpResultTempBody.getOutputStream();
                 // OpenKeychain/BouncyCastle at this point use the system newline for formatting, which is LF on android.
                 // we need this to be CRLF, so we convert the data after receiving.
-                outputStream = new EOLConvertingOutputStream(outputStream);
+//                outputStream = new EOLConvertingOutputStream(outputStream);
             } catch (IOException e) {
                 throw new MessagingException("could not allocate temp file for storage!", e);
             }

--- a/mail/common/src/main/java/com/fsck/k9/mail/Message.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Message.java
@@ -11,7 +11,6 @@ import java.util.Set;
 import androidx.annotation.NonNull;
 
 import com.fsck.k9.mail.filter.CountingOutputStream;
-import com.fsck.k9.mail.filter.EOLConvertingOutputStream;
 import timber.log.Timber;
 
 
@@ -162,9 +161,8 @@ public abstract class Message implements Part, Body {
         try {
 
             CountingOutputStream out = new CountingOutputStream();
-            EOLConvertingOutputStream eolOut = new EOLConvertingOutputStream(out);
-            writeTo(eolOut);
-            eolOut.flush();
+            writeTo(out);
+            out.flush();
             return out.getCount();
         } catch (IOException e) {
             Timber.e(e, "Failed to calculate a message size");

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
@@ -10,7 +10,6 @@ import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.MessageRetrievalListener
 import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.mail.Part
-import com.fsck.k9.mail.filter.EOLConvertingOutputStream
 import com.fsck.k9.mail.internet.MimeBodyPart
 import com.fsck.k9.mail.internet.MimeHeader
 import com.fsck.k9.mail.internet.MimeMessageHelper
@@ -1007,11 +1006,11 @@ class ImapFolder internal constructor(
                     handleUntaggedResponse(response)
 
                     if (response.isContinuationRequested) {
-                        val eolOut = EOLConvertingOutputStream(connection!!.outputStream)
-                        message.writeTo(eolOut)
-                        eolOut.write('\r'.toInt())
-                        eolOut.write('\n'.toInt())
-                        eolOut.flush()
+                        val out = connection!!.outputStream
+                        message.writeTo(out)
+                        out.write('\r'.toInt())
+                        out.write('\n'.toInt())
+                        out.flush()
                     }
                 } while (response.tag == null)
 

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.java
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.java
@@ -39,7 +39,6 @@ import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mail.Transport;
 import com.fsck.k9.mail.filter.Base64;
-import com.fsck.k9.mail.filter.EOLConvertingOutputStream;
 import com.fsck.k9.mail.filter.LineWrapOutputStream;
 import com.fsck.k9.mail.filter.PeekableInputStream;
 import com.fsck.k9.mail.filter.SmtpDataStuffing;
@@ -426,11 +425,10 @@ public class SmtpTransport extends Transport {
                 executeCommand("DATA");
             }
 
-            EOLConvertingOutputStream msgOut = new EOLConvertingOutputStream(
-                    new LineWrapOutputStream(new SmtpDataStuffing(outputStream), 1000));
+            LineWrapOutputStream out = new LineWrapOutputStream(new SmtpDataStuffing(outputStream), 1000);
 
-            message.writeTo(msgOut);
-            msgOut.endWithCrLfAndFlush();
+            message.writeTo(out);
+            out.flush();
 
             entireMessageSent = true; // After the "\r\n." is attempted, we may have sent the message
             executeCommand(".");

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.java
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransport.java
@@ -428,6 +428,8 @@ public class SmtpTransport extends Transport {
             LineWrapOutputStream out = new LineWrapOutputStream(new SmtpDataStuffing(outputStream), 1000);
 
             message.writeTo(out);
+            out.write('\r');
+            out.write('\n');
             out.flush();
 
             entireMessageSent = true; // After the "\r\n." is attempted, we may have sent the message

--- a/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -7,7 +7,6 @@ import com.fsck.k9.mail.K9MailLib;
 import com.fsck.k9.mail.Message;
 import com.fsck.k9.mail.MessageRetrievalListener;
 import com.fsck.k9.mail.MessagingException;
-import com.fsck.k9.mail.filter.EOLConvertingOutputStream;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
@@ -621,10 +620,9 @@ public class WebDavFolder {
                 out = new ByteArrayOutputStream((int) size);
 
                 open();
-                EOLConvertingOutputStream msgOut = new EOLConvertingOutputStream(
-                        new BufferedOutputStream(out, 1024));
-                message.writeTo(msgOut);
-                msgOut.flush();
+                BufferedOutputStream bufferedOut = new BufferedOutputStream(out, 1024);
+                message.writeTo(bufferedOut);
+                bufferedOut.flush();
 
                 bodyEntity = new StringEntity(out.toString(), "UTF-8");
                 bodyEntity.setContentType("message/rfc822");

--- a/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
+++ b/mail/protocols/webdav/src/main/java/com/fsck/k9/mail/store/webdav/WebDavFolder.java
@@ -602,14 +602,7 @@ public class WebDavFolder {
     public List<WebDavMessage> appendWebDavMessages(List<Message> messages) throws MessagingException {
         List<WebDavMessage> retMessages = new ArrayList<>(messages.size());
 
-        WebDavHttpClient httpclient = store.getHttpClient();
-
         for (Message message : messages) {
-            HttpGeneric httpmethod;
-            HttpResponse response;
-            StringEntity bodyEntity;
-            int statusCode;
-
             try {
                 ByteArrayOutputStream out;
 
@@ -624,7 +617,7 @@ public class WebDavFolder {
                 message.writeTo(bufferedOut);
                 bufferedOut.flush();
 
-                bodyEntity = new StringEntity(out.toString(), "UTF-8");
+                final StringEntity bodyEntity = new StringEntity(out.toString(), "UTF-8");
                 bodyEntity.setContentType("message/rfc822");
 
                 String messageURL = mFolderUrl;


### PR DESCRIPTION
Hi,

I try to handle issue #1551 and remove the EOLConvertingOutputStream.
Now I'm not sure in the PgpMessageBuilder. There is the comment:

> OpenKeychain/BouncyCastle at this point use the system newline for formatting, which is LF on android. we need this to be CRLF, so we convert the data after receiving.

Is this still relevant? All unit tests are ok.

When that is resolved, I can solve this issue.