### PR TITLE
Optionally suppress notifications for mails matching a pattern

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -45,6 +45,7 @@ class AccountPreferenceSerializer(
             }
             latestOldMessageSeenTime = storage.getLong("$accountUuid.latestOldMessageSeenTime", 0)
             isNotifyNewMail = storage.getBoolean("$accountUuid.notifyNewMail", false)
+            notificationSuppressions = storage.getString("$accountUuid.notificationSuppressions", "")
 
             folderNotifyNewMailMode = getEnumStringPref<FolderMode>(storage, "$accountUuid.folderNotifyNewMailMode", FolderMode.ALL)
             isNotifySelfNewMail = storage.getBoolean("$accountUuid.notifySelfNewMail", true)
@@ -253,6 +254,7 @@ class AccountPreferenceSerializer(
             editor.putInt("$accountUuid.displayCount", displayCount)
             editor.putLong("$accountUuid.latestOldMessageSeenTime", latestOldMessageSeenTime)
             editor.putBoolean("$accountUuid.notifyNewMail", isNotifyNewMail)
+            editor.putString("$accountUuid.notificationSuppressions", notificationSuppressions)
             editor.putString("$accountUuid.folderNotifyNewMailMode", folderNotifyNewMailMode.name)
             editor.putBoolean("$accountUuid.notifySelfNewMail", isNotifySelfNewMail)
             editor.putBoolean("$accountUuid.notifyContactsMailOnly", isNotifyContactsMailOnly)
@@ -562,6 +564,7 @@ class AccountPreferenceSerializer(
             displayCount = K9.DEFAULT_VISIBLE_LIMIT
             accountNumber = UNASSIGNED_ACCOUNT_NUMBER
             isNotifyNewMail = true
+            notificationSuppressions = ""
             folderNotifyNewMailMode = FolderMode.ALL
             isNotifySync = false
             isNotifySelfNewMail = true

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -60,6 +60,9 @@ class K9NotificationStrategy(val contacts: Contacts) : NotificationStrategy {
             }
         }
 
+        if (account.isNotificationSuppressed(message))
+            return false
+
         // Don't notify if the sender address matches one of our identities and the user chose not
         // to be notified for such messages.
         return if (account.isAnIdentity(message.from) && !account.isNotifySelfNewMail) {

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -90,6 +90,11 @@ class K9NotificationStrategy(private val contacts: Contacts) : NotificationStrat
             return false
         }
 
+        if (account.isNotificationSuppressed(message)) {
+            Timber.v("No notification: Message matches suppression pattern")
+            return false
+        }
+
         return true
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -146,6 +146,7 @@ class AccountSettingsDataStore(
             "account_vibrate_times" -> account.notificationSetting.vibrateTimes.toString()
             "account_remote_search_num_results" -> account.remoteSearchNumResults.toString()
             "account_ringtone" -> account.notificationSetting.ringtone
+            "notification_suppressions" -> account.notificationSuppressions
             else -> defValue
         }
     }
@@ -198,6 +199,7 @@ class AccountSettingsDataStore(
                 isRingEnabled = true
                 ringtone = value
             }
+            "notification_suppressions" -> account.notificationSuppressions = value
             else -> return
         }
 

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -511,6 +511,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_mark_message_as_read_on_view_summary">Mark a message as read when it is opened for viewing</string>
     <string name="account_settings_mark_message_as_read_on_delete_label">Mark as read when deleted</string>
     <string name="account_settings_mark_message_as_read_on_delete_summary">Mark a message as read when it is deleted</string>
+    <string name="account_settings_notifications_suppressions_label">Suppression patterns</string>
+    <string name="account_settings_notifications_suppressions_summary">Suppress notifications for mails matching these regular expressions</string>
     <string name="account_settings_notification_open_system_notifications_label">Notification settings</string>
     <string name="account_settings_notification_open_system_notifications_summary">Open system notification settings</string>
 

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -396,6 +396,12 @@
             android:summary="@string/account_settings_notification_opens_unread_summary"
             android:title="@string/account_settings_notification_opens_unread_label" />
 
+        <EditTextPreference
+            android:key="notification_suppressions"
+            android:singleLine="false"
+            android:summary="@string/account_settings_notifications_suppressions_summary"
+            android:title="@string/account_settings_notifications_suppressions_label" />
+
         <com.fsck.k9.ui.settings.account.NotificationsPreference
             android:key="open_notification_settings"
             android:summary="@string/account_settings_notification_open_system_notifications_summary"


### PR DESCRIPTION
I do get a lot of emails. I mean, a _lot_. And to get out of notification hell, I typically disable notifications altogether. However, K-9 is pretty neat in that it is open source, and I gave it a shot to suppress notifications based on regular patterns for the headers.

This is my current attempt, and it seems to do the job for me.

My open questions are:

- Is the code in an okay enough shape?
- Is this feature useful enough for K-9 to ship it as part of the official builds?
- Should this option be hidden behind an "Advanced" button in the notification settings?
- Is it okay to use regular expressions here?
- Are there any ideas how to improve this (e.g. make it prettier, or easier to configure)?