### PR TITLE
Add e.foundation to providers list

### DIFF
--- a/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
+++ b/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
@@ -707,6 +707,12 @@
         <incoming uri="imap+ssl+://mail.fairnatics.net" username="$email" />
         <outgoing uri="smtp+tls+://mail.fairnatics.net:25" username="$email" />
     </provider>
+
+    <!-- eFoundation -->
+    <provider id="e.foundation" label="/e/" domain="e.email">
+        <incoming uri="imap+ssl+://mail.ecloud.global" username="$email" />
+        <outgoing uri="smtp+tls+://mail.ecloud.global" username="$email" />
+    </provider>
     
     <!-- Developers' vanity providers -->
     <provider id="fsck.com" label="Jesse's personal mail" domain="fsck.com" >


### PR DESCRIPTION
Adds support for domain e.email in the providers list to allow auto setup.

Uses details from https://e.foundation/email-configuration/

Not sure if this is the sort of change that you'd accept but after reading up on the project I figured the best way to find out was to try, and to try with something small. Don't hesitate to tell me if there is something I should be doing different.
Is there any requirement on popularity or anything to add to this auto setup list?