### PR TITLE
Add show/hide toggle to password field in setup

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -175,16 +175,6 @@ public class AccountSetupBasics extends K9Activity
         }
     }
 
-    private void showPassword(boolean show) {
-        int cursorPosition = mPasswordView.getSelectionStart();
-        if (show) {
-            mPasswordView.setInputType(InputType.TYPE_TEXT_VARIATION_PASSWORD);
-        } else {
-            mPasswordView.setInputType(InputType.TYPE_CLASS_TEXT | InputType.TYPE_TEXT_VARIATION_PASSWORD);
-        }
-        mPasswordView.setSelection(cursorPosition);
-    }
-
     private void validateFields() {
         boolean clientCertificateChecked = mClientCertificateCheckBox.isChecked();
         String clientCertificateAlias = mClientCertificateSpinner.getAlias();

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -13,7 +13,6 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
-import android.widget.EditText;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Core;
@@ -39,6 +38,7 @@ import com.fsck.k9.ui.R;
 import com.fsck.k9.ui.ConnectionSettings;
 import com.fsck.k9.view.ClientCertificateSpinner;
 import com.fsck.k9.view.ClientCertificateSpinner.OnClientCertificateChangedListener;
+import com.google.android.material.textfield.TextInputEditText;
 import timber.log.Timber;
 
 /**
@@ -59,8 +59,8 @@ public class AccountSetupBasics extends K9Activity
     private final AccountCreator accountCreator = DI.get(AccountCreator.class);
     private final SpecialLocalFoldersCreator localFoldersCreator = DI.get(SpecialLocalFoldersCreator.class);
 
-    private EditText mEmailView;
-    private EditText mPasswordView;
+    private TextInputEditText mEmailView;
+    private TextInputEditText mPasswordView;
     private CheckBox mClientCertificateCheckBox;
     private ClientCertificateSpinner mClientCertificateSpinner;
     private Button mNextButton;
@@ -69,7 +69,6 @@ public class AccountSetupBasics extends K9Activity
 
     private EmailAddressValidator mEmailValidator = new EmailAddressValidator();
     private boolean mCheckedIncoming = false;
-    private CheckBox mShowPasswordCheckBox;
 
     public static void actionNewAccount(Context context) {
         Intent i = new Intent(context, AccountSetupBasics.class);
@@ -86,7 +85,6 @@ public class AccountSetupBasics extends K9Activity
         mClientCertificateSpinner = findViewById(R.id.account_client_certificate_spinner);
         mNextButton = findViewById(R.id.next);
         mManualSetupButton = findViewById(R.id.manual_setup);
-        mShowPasswordCheckBox = findViewById(R.id.show_password);
         mNextButton.setOnClickListener(this);
         mManualSetupButton.setOnClickListener(this);
     }
@@ -96,13 +94,6 @@ public class AccountSetupBasics extends K9Activity
         mPasswordView.addTextChangedListener(this);
         mClientCertificateCheckBox.setOnCheckedChangeListener(this);
         mClientCertificateSpinner.setOnClientCertificateChangedListener(this);
-        mShowPasswordCheckBox.setOnCheckedChangeListener(new OnCheckedChangeListener() {
-            @Override
-            public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
-                showPassword(isChecked);
-            }
-        });
-
     }
 
     @Override
@@ -126,8 +117,6 @@ public class AccountSetupBasics extends K9Activity
         mCheckedIncoming = savedInstanceState.getBoolean(STATE_KEY_CHECKED_INCOMING);
 
         updateViewVisibility(mClientCertificateCheckBox.isChecked());
-
-        showPassword(mShowPasswordCheckBox.isChecked());
     }
 
     @Override
@@ -178,12 +167,10 @@ public class AccountSetupBasics extends K9Activity
         if (usingCertificates) {
             // hide password fields, show client certificate spinner
             mPasswordView.setVisibility(View.GONE);
-            mShowPasswordCheckBox.setVisibility(View.GONE);
             mClientCertificateSpinner.setVisibility(View.VISIBLE);
         } else {
             // show password fields, hide client certificate spinner
             mPasswordView.setVisibility(View.VISIBLE);
-            mShowPasswordCheckBox.setVisibility(View.VISIBLE);
             mClientCertificateSpinner.setVisibility(View.GONE);
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -17,7 +17,6 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
-import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -51,6 +50,8 @@ import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 import timber.log.Timber;
 
 public class AccountSetupIncoming extends K9Activity implements OnClickListener {
@@ -65,23 +66,23 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     private final AccountCreator accountCreator = DI.get(AccountCreator.class);
 
     private String mStoreType;
-    private EditText mUsernameView;
-    private EditText mPasswordView;
+    private TextInputEditText mUsernameView;
+    private TextInputEditText mPasswordView;
     private ClientCertificateSpinner mClientCertificateSpinner;
     private TextView mClientCertificateLabelView;
-    private TextView mPasswordLabelView;
-    private EditText mServerView;
-    private EditText mPortView;
+    private TextInputLayout mPasswordLayoutView;
+    private TextInputEditText mServerView;
+    private TextInputEditText mPortView;
     private String mCurrentPortViewSetting;
     private Spinner mSecurityTypeView;
     private int mCurrentSecurityTypeViewPosition;
     private Spinner mAuthTypeView;
     private int mCurrentAuthTypeViewPosition;
     private CheckBox mImapAutoDetectNamespaceView;
-    private EditText mImapPathPrefixView;
-    private EditText mWebdavPathPrefixView;
-    private EditText mWebdavAuthPathView;
-    private EditText mWebdavMailboxPathView;
+    private TextInputEditText mImapPathPrefixView;
+    private TextInputEditText mWebdavPathPrefixView;
+    private TextInputEditText mWebdavAuthPathView;
+    private TextInputEditText mWebdavMailboxPathView;
     private Button mNextButton;
     private Account mAccount;
     private boolean mMakeDefault;
@@ -123,8 +124,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
         mPasswordView = findViewById(R.id.account_password);
         mClientCertificateSpinner = findViewById(R.id.account_client_certificate_spinner);
         mClientCertificateLabelView = findViewById(R.id.account_client_certificate_label);
-        mPasswordLabelView = findViewById(R.id.account_password_label);
-        TextView serverLabelView = findViewById(R.id.account_server_label);
+        mPasswordLayoutView = findViewById(R.id.account_password_layout);
         mServerView = findViewById(R.id.account_server);
         mPortView = findViewById(R.id.account_port);
         mSecurityTypeView = findViewById(R.id.account_security_type);
@@ -139,6 +139,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
         mCompressionWifi = findViewById(R.id.compression_wifi);
         mCompressionOther = findViewById(R.id.compression_other);
         mSubscribedFoldersOnly = findViewById(R.id.subscribed_folders_only);
+        TextInputLayout serverLayoutView = findViewById(R.id.account_server_layout);
 
         mNextButton.setOnClickListener(this);
 
@@ -203,7 +204,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
 
             mStoreType = settings.type;
             if (settings.type.equals(Protocols.POP3)) {
-                serverLabelView.setText(R.string.account_setup_incoming_pop_server_label);
+                serverLayoutView.setHint(getString(R.string.account_setup_incoming_pop_server_label));
                 findViewById(R.id.imap_path_prefix_section).setVisibility(View.GONE);
                 findViewById(R.id.webdav_advanced_header).setVisibility(View.GONE);
                 findViewById(R.id.webdav_mailbox_alias_section).setVisibility(View.GONE);
@@ -213,7 +214,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 findViewById(R.id.compression_label).setVisibility(View.GONE);
                 mSubscribedFoldersOnly.setVisibility(View.GONE);
             } else if (settings.type.equals(Protocols.IMAP)) {
-                serverLabelView.setText(R.string.account_setup_incoming_imap_server_label);
+                serverLayoutView.setHint(getString(R.string.account_setup_incoming_imap_server_label));
 
                 ImapStoreSettings imapSettings = (ImapStoreSettings) settings;
 
@@ -231,7 +232,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                     findViewById(R.id.imap_folder_setup_section).setVisibility(View.GONE);
                 }
             } else if (settings.type.equals(Protocols.WEBDAV)) {
-                serverLabelView.setText(R.string.account_setup_incoming_webdav_server_label);
+                serverLayoutView.setHint(getString(R.string.account_setup_incoming_webdav_server_label));
                 mConnectionSecurityChoices = new ConnectionSecurity[] {
                         ConnectionSecurity.NONE,
                         ConnectionSecurity.SSL_TLS_REQUIRED };
@@ -410,15 +411,13 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
         if (isAuthTypeExternal) {
 
             // hide password fields, show client certificate fields
-            mPasswordView.setVisibility(View.GONE);
-            mPasswordLabelView.setVisibility(View.GONE);
+            mPasswordLayoutView.setVisibility(View.GONE);
             mClientCertificateLabelView.setVisibility(View.VISIBLE);
             mClientCertificateSpinner.setVisibility(View.VISIBLE);
         } else {
 
             // show password fields, hide client certificate fields
-            mPasswordView.setVisibility(View.VISIBLE);
-            mPasswordLabelView.setVisibility(View.VISIBLE);
+            mPasswordLayoutView.setVisibility(View.VISIBLE);
             mClientCertificateLabelView.setVisibility(View.GONE);
             mClientCertificateSpinner.setVisibility(View.GONE);
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -20,7 +20,6 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
-import android.widget.EditText;
 import android.widget.Spinner;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -42,6 +41,8 @@ import com.fsck.k9.mail.MailServerDirection;
 import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.view.ClientCertificateSpinner;
 import com.fsck.k9.view.ClientCertificateSpinner.OnClientCertificateChangedListener;
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 import timber.log.Timber;
 
 public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
@@ -56,13 +57,13 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     private final BackendManager backendManager = DI.get(BackendManager.class);
     private final AccountCreator accountCreator = DI.get(AccountCreator.class);
 
-    private EditText mUsernameView;
-    private EditText mPasswordView;
+    private TextInputEditText mUsernameView;
+    private TextInputEditText mPasswordView;
+    private TextInputLayout mPasswordLayoutView;
     private ClientCertificateSpinner mClientCertificateSpinner;
     private TextView mClientCertificateLabelView;
-    private TextView mPasswordLabelView;
-    private EditText mServerView;
-    private EditText mPortView;
+    private TextInputEditText mServerView;
+    private TextInputEditText mPortView;
     private String mCurrentPortViewSetting;
     private CheckBox mRequireLoginView;
     private ViewGroup mRequireLoginSettingsView;
@@ -119,7 +120,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         mPasswordView = findViewById(R.id.account_password);
         mClientCertificateSpinner = findViewById(R.id.account_client_certificate_spinner);
         mClientCertificateLabelView = findViewById(R.id.account_client_certificate_label);
-        mPasswordLabelView = findViewById(R.id.account_password_label);
+        mPasswordLayoutView = findViewById(R.id.account_password_layout);
         mServerView = findViewById(R.id.account_server);
         mPortView = findViewById(R.id.account_port);
         mRequireLoginView = findViewById(R.id.account_require_login);
@@ -354,15 +355,13 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
         if (isAuthTypeExternal) {
 
             // hide password fields, show client certificate fields
-            mPasswordView.setVisibility(View.GONE);
-            mPasswordLabelView.setVisibility(View.GONE);
+            mPasswordLayoutView.setVisibility(View.GONE);
             mClientCertificateLabelView.setVisibility(View.VISIBLE);
             mClientCertificateSpinner.setVisibility(View.VISIBLE);
         } else {
 
             // show password fields, hide client certificate fields
-            mPasswordView.setVisibility(View.VISIBLE);
-            mPasswordLabelView.setVisibility(View.VISIBLE);
+            mPasswordLayoutView.setVisibility(View.VISIBLE);
             mClientCertificateLabelView.setVisibility(View.GONE);
             mClientCertificateSpinner.setVisibility(View.GONE);
         }

--- a/app/ui/legacy/src/main/res/layout/account_setup_basics.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_basics.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:custom="http://schemas.android.com/apk/res-auto"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
-    android:layout_height="fill_parent"
-    android:layout_width="fill_parent" >
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
 
     <include layout="@layout/toolbar" />
 
@@ -16,37 +16,42 @@
         android:scrollbarStyle="outsideInset" >
 
         <LinearLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal|center_vertical"
             android:orientation="vertical" >
 
-            <EditText
-                android:id="@+id/account_email"
-                android:hint="@string/account_setup_basics_email_hint"
-                android:singleLine="true"
-                android:inputType="textEmailAddress"
-                android:layout_height="wrap_content"
-                android:layout_width="fill_parent" />
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-            <EditText
-                android:id="@+id/account_password"
-                android:inputType="textPassword"
-                android:hint="@string/account_setup_basics_password_hint"
-                android:singleLine="true"
-                android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
-                android:nextFocusDown="@+id/next" />
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/account_email"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/account_setup_basics_email_hint"
+                    android:singleLine="true"
+                    android:inputType="textEmailAddress"/>
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <CheckBox
-                android:id="@+id/show_password"
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
-                android:text="@string/account_setup_basics_show_password" />
+                app:passwordToggleEnabled="true">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/account_password"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:hint="@string/account_setup_basics_password_hint"
+                    android:singleLine="true"
+                    android:inputType="textPassword"
+                    android:nextFocusDown="@+id/next"/>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <com.fsck.k9.view.ClientCertificateSpinner
                 android:id="@+id/account_client_certificate_spinner"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:visibility="gone" />
 
@@ -55,18 +60,18 @@
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:layout_marginTop="16dp"
-                custom:foldedLabel="@string/client_certificate_advanced_options"
-                custom:unFoldedLabel="@string/client_certificate_advanced_options" >
+                app:foldedLabel="@string/client_certificate_advanced_options"
+                app:unFoldedLabel="@string/client_certificate_advanced_options" >
 
                 <CheckBox
                     android:id="@+id/account_client_certificate"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:text="@string/account_setup_basics_client_certificate" />
             </com.fsck.k9.view.FoldableLinearLayout>
 
             <View
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="0dip"
                 android:layout_weight="1" />
         </LinearLayout>

--- a/app/ui/legacy/src/main/res/layout/account_setup_incoming.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_incoming.xml
@@ -1,14 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:orientation="vertical"
-        android:layout_height="fill_parent"
-        android:layout_width="fill_parent">
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
 
     <include layout="@layout/toolbar"/>
 
     <ScrollView
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="0dp"
             android:layout_weight="1"
             android:padding="6dip"
@@ -19,29 +20,29 @@
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:orientation="vertical">
-            <!-- This text may be changed in code if the server is IMAP, etc. -->
-            <TextView
-                    android:id="@+id/account_server_label"
-                    android:text="@string/account_setup_incoming_pop_server_label"
-                    android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:contentDescription="@string/account_setup_incoming_password_label"/>
 
-            <EditText
-                    android:id="@+id/account_server"
-                    android:singleLine="true"
-                    android:inputType="textUri"
+            <!-- The hint text may be changed in code if the server is IMAP, etc. -->
+            <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/account_server_layout"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"/>
+                    android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing">
+
+                <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/account_server"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textUri"
+                        android:hint="@string/account_setup_incoming_pop_server_label"
+                        android:singleLine="true" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
                     android:text="@string/account_setup_incoming_security_label"
                     android:layout_height="wrap_content"
                     android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"/>
+                    style="@style/InputLabel"
+                    android:layout_marginTop="6dp"/>
 
             <Spinner
                     android:id="@+id/account_security_type"
@@ -49,84 +50,87 @@
                     android:layout_width="fill_parent"
                     android:contentDescription="@string/account_setup_incoming_security_label"/>
 
-            <TextView
-                    android:text="@string/account_setup_incoming_port_label"
+            <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"/>
+                    android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing">
 
-            <EditText
-                    android:id="@+id/account_port"
-                    android:singleLine="true"
-                    android:inputType="number"
-                    android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:contentDescription="@string/account_setup_incoming_port_label"/>
+                <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/account_port"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="number"
+                        android:hint="@string/account_setup_incoming_port_label"
+                        android:singleLine="true" />
+            </com.google.android.material.textfield.TextInputLayout>
 
-            <TextView
-                    android:text="@string/account_setup_incoming_username_label"
+            <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"/>
+                    android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing">
 
-            <EditText
-                    android:id="@+id/account_username"
-                    android:singleLine="true"
-                    android:inputType="textEmailAddress"
-                    android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:contentDescription="@string/account_setup_incoming_username_label"/>
+                <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/account_username"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textEmailAddress"
+                        android:hint="@string/account_setup_incoming_username_label"
+                        android:singleLine="true" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
                     android:id="@+id/account_auth_type_label"
                     android:text="@string/account_setup_incoming_auth_type_label"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"/>
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="6dp"
+                    style="@style/InputLabel"/>
 
             <Spinner
                     android:id="@+id/account_auth_type"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:contentDescription="@string/account_setup_incoming_auth_type_label"/>
 
-            <TextView
-                    android:id="@+id/account_password_label"
-                    android:text="@string/account_setup_incoming_password_label"
+            <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/account_password_layout"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"/>
+                    android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing"
+                    app:passwordToggleEnabled="true">
 
-            <EditText
-                    android:id="@+id/account_password"
-                    android:inputType="textPassword"
-                    android:singleLine="true"
-                    android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"/>
+                <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/account_password"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/account_setup_incoming_password_label"
+                        android:singleLine="true"
+                        android:inputType="textPassword"
+                        android:nextFocusDown="@+id/next"/>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
                     android:id="@+id/account_client_certificate_label"
                     android:text="@string/account_setup_incoming_client_certificate_label"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:visibility="gone"/>
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="6dp"
+                    style="@style/InputLabel"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
 
             <com.fsck.k9.view.ClientCertificateSpinner
                     android:id="@+id/account_client_certificate_spinner"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:visibility="gone"/>
+                    android:layout_width="match_parent"
+                    android:visibility="gone"
+                    tools:visibility="visible"/>
 
             <LinearLayout
                     android:id="@+id/imap_path_prefix_section"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
+                    android:layout_marginTop="6dp"
                     android:orientation="vertical">
 
                 <CheckBox
@@ -135,23 +139,21 @@
                         android:layout_width="wrap_content"
                         android:text="@string/account_setup_incoming_autodetect_namespace_label"/>
 
-                <TextView
-                        android:text="@string/account_setup_incoming_imap_path_prefix_label"
-                        android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
-                        android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="?android:attr/textColorPrimary"/>
+                <com.google.android.material.textfield.TextInputLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
 
-                <EditText
-                        android:id="@+id/imap_path_prefix"
-                        android:singleLine="true"
-                        android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
-                        android:contentDescription="@string/account_setup_incoming_imap_path_prefix_label"/>
+                    <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/imap_path_prefix"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/account_setup_incoming_imap_path_prefix_label"
+                            android:singleLine="true" />
+                </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
 
             <LinearLayout
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:id="@+id/imap_folder_setup_section"
                     android:orientation="vertical">
@@ -166,14 +168,14 @@
 
             <LinearLayout
                     android:id="@+id/webdav_advanced_header"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
                 <TextView
                         android:text="@string/advanced"
                         android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
+                        android:layout_width="match_parent"
                         android:textAppearance="?android:attr/textAppearanceSmall"
                         android:textColor="?android:attr/textColorPrimary"
                         android:textStyle="bold"
@@ -186,20 +188,17 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                <TextView
-                        android:text="@string/account_setup_incoming_webdav_mailbox_path_label"
-                        android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
-                        android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="?android:attr/textColorPrimary"/>
+                <com.google.android.material.textfield.TextInputLayout
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content">
 
-                <EditText
-                        android:id="@+id/webdav_mailbox_path"
-                        android:hint="@string/account_setup_incoming_webdav_mailbox_path_hint"
-                        android:singleLine="true"
-                        android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
-                        android:contentDescription="@string/account_setup_incoming_webdav_mailbox_path_label"/>
+                    <com.google.android.material.textfield.TextInputEditText
+                            android:id="@+id/webdav_mailbox_path"
+                            android:layout_width="match_parent"
+                            android:layout_height="wrap_content"
+                            android:hint="@string/account_setup_incoming_webdav_mailbox_path_label"
+                            android:singleLine="true" />
+                </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
 
             <LinearLayout
@@ -208,20 +207,18 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                <TextView
-                        android:text="@string/account_setup_incoming_webdav_path_prefix_label"
-                        android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
-                        android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="?android:attr/textColorPrimary"/>
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing">
 
-                <EditText
+                    <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/webdav_path_prefix"
-                        android:hint="@string/account_setup_incoming_webdav_path_prefix_hint"
-                        android:singleLine="true"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
-                        android:contentDescription="@string/account_setup_incoming_webdav_path_prefix_label"/>
+                        android:hint="@string/account_setup_incoming_webdav_path_prefix_label"
+                        android:singleLine="true" />
+                </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
 
             <LinearLayout
@@ -230,33 +227,31 @@
                     android:layout_height="wrap_content"
                     android:orientation="vertical">
 
-                <TextView
-                        android:text="@string/account_setup_incoming_webdav_auth_path_label"
-                        android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
-                        android:textAppearance="?android:attr/textAppearanceSmall"
-                        android:textColor="?android:attr/textColorPrimary"/>
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing">
 
-                <EditText
+                    <com.google.android.material.textfield.TextInputEditText
                         android:id="@+id/webdav_auth_path"
-                        android:hint="@string/account_setup_incoming_webdav_auth_path_hint"
-                        android:singleLine="true"
+                        android:layout_width="match_parent"
                         android:layout_height="wrap_content"
-                        android:layout_width="fill_parent"
-                        android:contentDescription="@string/account_setup_incoming_webdav_auth_path_label"/>
+                        android:hint="@string/account_setup_incoming_webdav_auth_path_label"
+                        android:singleLine="true" />
+                </com.google.android.material.textfield.TextInputLayout>
             </LinearLayout>
 
             <TextView
                     android:id="@+id/compression_label"
                     android:text="@string/account_setup_incoming_compression_label"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"/>
+                    android:layout_width="match_parent"
+                    android:layout_marginTop="6dp"
+                    style="@style/InputLabel"/>
 
             <LinearLayout
                     android:id="@+id/compression_section"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:orientation="horizontal">
 
@@ -285,7 +280,7 @@
             </LinearLayout>
 
             <View
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:layout_height="0dip"
                     android:layout_weight="1"/>
         </LinearLayout>

--- a/app/ui/legacy/src/main/res/layout/account_setup_outgoing.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_outgoing.xml
@@ -1,14 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical"
-    android:layout_height="fill_parent"
-    android:layout_width="fill_parent">
+    android:layout_height="match_parent"
+    android:layout_width="match_parent">
 
     <include layout="@layout/toolbar"/>
 
     <ScrollView
-        android:layout_width="fill_parent"
+        android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
         android:padding="6dip"
@@ -16,87 +18,87 @@
         android:scrollbarStyle="outsideInset">
 
         <LinearLayout
-            android:layout_width="fill_parent"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:orientation="vertical">
 
-            <TextView
-                android:text="@string/account_setup_outgoing_smtp_server_label"
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
-                android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="?android:attr/textColorPrimary" />
+                android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing">
 
-            <EditText
-                android:id="@+id/account_server"
-                android:singleLine="true"
-                android:inputType="textUri"
-                android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
-                android:contentDescription="@string/account_setup_outgoing_smtp_server_label" />
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/account_server"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="textUri"
+                    android:hint="@string/account_setup_outgoing_smtp_server_label"
+                    android:singleLine="true" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <TextView
                 android:text="@string/account_setup_outgoing_security_label"
                 android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
-                android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="?android:attr/textColorPrimary" />
+                android:layout_width="match_parent"
+                android:layout_marginTop="6dp"
+                style="@style/InputLabel" />
 
             <Spinner
                 android:id="@+id/account_security_type"
                 android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:contentDescription="@string/account_setup_outgoing_security_label" />
 
-            <TextView
-                android:text="@string/account_setup_outgoing_port_label"
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
-                android:textAppearance="?android:attr/textAppearanceSmall"
-                android:textColor="?android:attr/textColorPrimary" />
+                android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing">
 
-            <EditText
-                android:id="@+id/account_port"
-                android:singleLine="true"
-                android:inputType="number"
-                android:layout_height="wrap_content"
-                android:layout_width="fill_parent"
-                android:contentDescription="@string/account_setup_outgoing_port_label" />
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/account_port"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:inputType="number"
+                    android:hint="@string/account_setup_incoming_port_label"
+                    android:singleLine="true" />
+            </com.google.android.material.textfield.TextInputLayout>
 
             <CheckBox
                 android:id="@+id/account_require_login"
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:text="@string/account_setup_outgoing_require_login_label" />
+                android:layout_marginTop="6dp"
+                android:text="@string/account_setup_outgoing_require_login_label"
+                tools:checked="true" />
 
             <LinearLayout
                 android:id="@+id/account_require_login_settings"
-                android:layout_width="fill_parent"
-                android:layout_height="fill_parent"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
                 android:orientation="vertical"
-                android:visibility="gone">
+                android:visibility="gone"
+                tools:visibility="visible">
 
-                <TextView
-                    android:text="@string/account_setup_outgoing_username_label"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary" />
+                    android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing">
 
-                <EditText
-                    android:id="@+id/account_username"
-                    android:singleLine="true"
-                    android:inputType="textEmailAddress"
-                    android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:contentDescription="@string/account_setup_outgoing_username_label" />
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/account_username"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:inputType="textEmailAddress"
+                        android:hint="@string/account_setup_outgoing_username_label"
+                        android:singleLine="true" />
+                </com.google.android.material.textfield.TextInputLayout>
 
                 <TextView
                     android:text="@string/account_setup_outgoing_authentication_label"
                     android:layout_height="wrap_content"
                     android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary" />
+                    android:layout_marginTop="6dp"
+                    style="@style/InputLabel" />
 
                 <Spinner
                     android:id="@+id/account_auth_type"
@@ -104,27 +106,28 @@
                     android:layout_width="fill_parent"
                     android:contentDescription="@string/account_setup_outgoing_authentication_label" />
 
-                <TextView
-                    android:id="@+id/account_password_label"
-                    android:text="@string/account_setup_outgoing_password_label"
+                <com.google.android.material.textfield.TextInputLayout
+                    android:id="@+id/account_password_layout"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary" />
+                    android:layout_marginTop="@dimen/account_setup_margin_between_items_incoming_and_outgoing"
+                    app:passwordToggleEnabled="true">
 
-                <EditText
-                    android:id="@+id/account_password"
-                    android:singleLine="true"
-                    android:inputType="textPassword"
-                    android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:contentDescription="@string/account_setup_outgoing_password_label" />
+                    <com.google.android.material.textfield.TextInputEditText
+                        android:id="@+id/account_password"
+                        android:layout_width="match_parent"
+                        android:layout_height="wrap_content"
+                        android:hint="@string/account_setup_outgoing_password_label"
+                        android:singleLine="true"
+                        android:inputType="textPassword"
+                        android:nextFocusDown="@+id/next"/>
+                </com.google.android.material.textfield.TextInputLayout>
 
                 <TextView
                     android:id="@+id/account_client_certificate_label"
                     android:text="@string/account_setup_incoming_client_certificate_label"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:textAppearance="?android:attr/textAppearanceSmall"
                     android:textColor="?android:attr/textColorPrimary"
                     android:visibility="gone" />
@@ -132,12 +135,12 @@
                 <com.fsck.k9.view.ClientCertificateSpinner
                     android:id="@+id/account_client_certificate_spinner"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
+                    android:layout_width="match_parent"
                     android:visibility="gone" />
             </LinearLayout>
 
             <View
-                android:layout_width="fill_parent"
+                android:layout_width="match_parent"
                 android:layout_height="0dip"
                 android:layout_weight="1" />
         </LinearLayout>

--- a/app/ui/legacy/src/main/res/values/dimensions.xml
+++ b/app/ui/legacy/src/main/res/values/dimensions.xml
@@ -3,4 +3,8 @@
     <dimen name="button_minWidth">100sp</dimen>
     <dimen name="widget_padding">8dp</dimen>
     <dimen name="highlight_radius">48dp</dimen>
+
+    <dimen name="input_label_vertical_spacing">8dp</dimen>
+    <dimen name="input_label_horizontal_spacing">4dp</dimen>
+    <dimen name="account_setup_margin_between_items_incoming_and_outgoing">12dp</dimen>
 </resources>

--- a/app/ui/legacy/src/main/res/values/styles.xml
+++ b/app/ui/legacy/src/main/res/values/styles.xml
@@ -39,5 +39,13 @@
         <item name="android:button">?attr/messageStar</item>
     </style>
 
+    <style name="InputLabel" parent="TextAppearance.AppCompat.Caption">
+        <item name="android:paddingBottom">@dimen/input_label_vertical_spacing</item>
+        <item name="android:paddingLeft">@dimen/input_label_horizontal_spacing</item>
+        <item name="android:paddingRight">@dimen/input_label_horizontal_spacing</item>
+        <item name="android:textColor">?android:attr/textColorHint</item>
+    </style>
+
+
 </resources>
 


### PR DESCRIPTION
In the setup flow I've changed the EditText's for usernames and passwords etc to TextInputEditText's. This allowed use of the password show/hide icon in an android native way. Also updated the rest of the setup screens to match the TextInputEditText UI.

The password toggle has been requested in #3672 (I think it's also what #4234 wants but honestly the description confused me) 

Here's what it looks like. Old on the left -> new on the right

![setup](https://user-images.githubusercontent.com/8265864/102731678-5af71200-439d-11eb-8354-011bf7911dbb.png)

![incoming](https://user-images.githubusercontent.com/8265864/102731684-5df20280-439d-11eb-9b8f-6a0fa773311b.png)

![outgoing](https://user-images.githubusercontent.com/8265864/102731687-60545c80-439d-11eb-8f23-a0eaab9f9c2c.png)

Closes #3672