### PR TITLE
Make FoldableLinearLayout.SavedState public

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/FoldableLinearLayout.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/FoldableLinearLayout.java
@@ -121,9 +121,9 @@ public class FoldableLinearLayout extends LinearLayout {
         }
     }
 
-    static class SavedState extends BaseSavedState {
+    public static class SavedState extends BaseSavedState {
 
-        static final Parcelable.Creator<SavedState> CREATOR =
+        public static final Parcelable.Creator<SavedState> CREATOR =
                 new Parcelable.Creator<FoldableLinearLayout.SavedState>() {
 
             @Override


### PR DESCRIPTION
Without this change the class can't be found when restoring the instance state after process death.

Fixes #5077