### PR TITLE
Fix setup back navigation

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -186,6 +186,7 @@ public class Account implements BaseAccount {
     private boolean uploadSentMessages;
     private long lastSyncTime;
     private long lastFolderListRefreshTime;
+    private boolean isFinishedSetup = false;
 
     private boolean changedVisibleLimits = false;
 
@@ -289,13 +290,6 @@ public class Account implements BaseAccount {
     public synchronized void setName(String name) {
         Identity newIdentity = identities.get(0).withName(name);
         identities.set(0, newIdentity);
-    }
-
-    /**
-     * an account is only setup when it has a name (as it's the last required step of the setup)
-     */
-    public synchronized boolean isFinishedSetup() {
-        return getName() != null && !getName().isEmpty();
     }
 
     public synchronized boolean getSignatureUse() {
@@ -1153,4 +1147,11 @@ public class Account implements BaseAccount {
         changedVisibleLimits = false;
     }
 
+    public synchronized boolean isFinishedSetup() {
+        return isFinishedSetup;
+    }
+
+    public void markSetupFinished() {
+        isFinishedSetup = true;
+    }
 }

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -291,6 +291,13 @@ public class Account implements BaseAccount {
         identities.set(0, newIdentity);
     }
 
+    /**
+     * an account is only setup when it has a name (as it's the last required step of the setup)
+     */
+    public synchronized boolean isFinishedSetup() {
+        return getName() != null && !getName().isEmpty();
+    }
+
     public synchronized boolean getSignatureUse() {
         return identities.get(0).getSignatureUse();
     }

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -175,7 +175,7 @@ class AccountPreferenceSerializer(
             isAlwaysShowCcBcc = storage.getBoolean("$accountUuid.alwaysShowCcBcc", false)
             lastSyncTime = storage.getLong("$accountUuid.lastSyncTime", 0L)
             lastFolderListRefreshTime = storage.getLong("$accountUuid.lastFolderListRefreshTime", 0L)
-            val isFinishedSetup = storage.getBoolean("$accountUuid.isFinishedSetup", false)
+            val isFinishedSetup = storage.getBoolean("$accountUuid.isFinishedSetup", true)
             if (isFinishedSetup) markSetupFinished()
 
             // Use email address as account description if necessary

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -175,6 +175,8 @@ class AccountPreferenceSerializer(
             isAlwaysShowCcBcc = storage.getBoolean("$accountUuid.alwaysShowCcBcc", false)
             lastSyncTime = storage.getLong("$accountUuid.lastSyncTime", 0L)
             lastFolderListRefreshTime = storage.getLong("$accountUuid.lastFolderListRefreshTime", 0L)
+            val isFinishedSetup = storage.getBoolean("$accountUuid.isFinishedSetup", false)
+            if (isFinishedSetup) markSetupFinished()
 
             // Use email address as account description if necessary
             if (description == null) {
@@ -336,6 +338,7 @@ class AccountPreferenceSerializer(
             editor.putInt("$accountUuid.ledColor", notificationSetting.ledColor)
             editor.putLong("$accountUuid.lastSyncTime", lastSyncTime)
             editor.putLong("$accountUuid.lastFolderListRefreshTime", lastFolderListRefreshTime)
+            editor.putBoolean("$accountUuid.isFinishedSetup", isFinishedSetup)
 
             for (type in NetworkType.values()) {
                 val useCompression = compressionMap[type]
@@ -460,6 +463,7 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.autoExpandFolderId")
         editor.remove("$accountUuid.lastSyncTime")
         editor.remove("$accountUuid.lastFolderListRefreshTime")
+        editor.remove("$accountUuid.isFinishedSetup")
 
         for (type in NetworkType.values()) {
             editor.remove("$accountUuid.useCompression." + type.name)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.kt
@@ -91,7 +91,6 @@ class AccountSetupAccountType : K9Activity() {
 
     private fun returnAccountTypeSelectionResult() {
         AccountSetupIncoming.actionIncomingSettings(this, account, makeDefault)
-        finish()
     }
 
     companion object {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.text.Editable;
-import android.text.InputType;
 import android.text.TextWatcher;
 import android.view.View;
 import android.view.View.OnClickListener;
@@ -312,7 +311,6 @@ public class AccountSetupBasics extends K9Activity
                 Preferences.getPreferences(this).saveAccount(mAccount);
                 Core.setServicesEnabled(this);
                 AccountSetupNames.actionSetNames(this, mAccount);
-                finish();
             }
         }
     }
@@ -351,8 +349,6 @@ public class AccountSetupBasics extends K9Activity
         mAccount.setTransportUri(transportUri);
 
         AccountSetupAccountType.actionSelectAccountType(this, mAccount, false);
-
-        finish();
     }
 
     public void onClick(View v) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -551,9 +551,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                      */
                 }
 
-
                 AccountSetupOutgoing.actionOutgoingSettings(this, mAccount, mMakeDefault);
-                finish();
             }
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
@@ -89,6 +89,7 @@ public class AccountSetupNames extends K9Activity implements OnClickListener {
             mAccount.setDescription(mDescription.getText().toString());
         }
         mAccount.setName(mName.getText().toString());
+        mAccount.markSetupFinished();
         Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
         finishAffinity();
         MessageList.launch(this, mAccount);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
@@ -90,8 +90,8 @@ public class AccountSetupNames extends K9Activity implements OnClickListener {
         }
         mAccount.setName(mName.getText().toString());
         Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
+        finishAffinity();
         MessageList.launch(this, mAccount);
-        finish();
     }
 
     public void onClick(View v) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
@@ -120,7 +120,6 @@ public class AccountSetupOptions extends K9Activity implements OnClickListener {
         }
         Core.setServicesEnabled(this);
         AccountSetupNames.actionSetNames(this, mAccount);
-        finish();
     }
 
     public void onClick(View v) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -465,7 +465,6 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
                 finish();
             } else {
                 AccountSetupOptions.actionOptions(this, mAccount, mMakeDefault);
-                finish();
             }
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
@@ -52,10 +52,11 @@ class SettingsListFragment : Fragment() {
 
     private fun populateSettingsList() {
         viewModel.accounts.observeNotNull(this) { accounts ->
-            if (accounts.isEmpty()) {
+            val accountsFinishedSetup = accounts.filter { it.isFinishedSetup }
+            if (accountsFinishedSetup.isEmpty()) {
                 launchOnboarding()
             } else {
-                populateSettingsList(accounts)
+                populateSettingsList(accountsFinishedSetup)
             }
         }
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/SettingsListFragment.kt
@@ -121,7 +121,7 @@ class SettingsListFragment : Fragment() {
 
     private fun launchOnboarding() {
         findNavController().navigate(R.id.action_settingsListScreen_to_onboardingScreen)
-        requireActivity().finish()
+        requireActivity().finishAffinity()
     }
 
     private fun buildSettingsList(block: SettingsListBuilder.() -> Unit): List<GenericItem> {


### PR DESCRIPTION
Previously pressing back during setup would exit the app from any setup screen when you would expect it to navigate to the previous step in the setup. Then reopening the app would launch the message list with an account that wasn't complete which led to problems/crashes.

This change allows for back navigation during setup. And when launching k9 it removes any accounts that have not finished setup so that we don't use the app with broken accounts.
Fixes #3971, #4797, #5044

I realize deleting incomplete accounts this way isn't the tidiest solution but should be good enough until wider work can be done around the setup flow.

