### PR TITLE
Reset account settings during setup progression

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.kt
@@ -6,13 +6,15 @@ import android.os.Bundle
 import android.view.View
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
+import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.helper.EmailHelper.getDomainFromEmailAddress
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mailstore.SpecialLocalFoldersCreator
 import com.fsck.k9.preferences.Protocols
 import com.fsck.k9.setup.ServerNameSuggester
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.K9Activity
-import java.net.URI
 import org.koin.android.ext.android.inject
 
 /**
@@ -24,9 +26,11 @@ class AccountSetupAccountType : K9Activity() {
     private val preferences: Preferences by inject()
     private val serverNameSuggester: ServerNameSuggester by inject()
     private val localFoldersCreator: SpecialLocalFoldersCreator by inject()
+    private val backendManager: BackendManager by inject()
 
     private lateinit var account: Account
     private var makeDefault = false
+    private lateinit var initialAccountSettings: InitialAccountSettings
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -42,47 +46,60 @@ class AccountSetupAccountType : K9Activity() {
         val accountUuid = intent.getStringExtra(EXTRA_ACCOUNT) ?: error("No account UUID provided")
         account = preferences.getAccount(accountUuid) ?: error("No account with given UUID found")
         makeDefault = intent.getBooleanExtra(EXTRA_MAKE_DEFAULT, false)
+        initialAccountSettings = intent.getParcelableExtra(EXTRA_DEFAULT_SETTINGS) as InitialAccountSettings
     }
 
     private fun setupPop3Account() {
-        setupAccount(Protocols.POP3, "pop3+ssl+")
+        setupAccount(Protocols.POP3)
     }
 
     private fun setupImapAccount() {
-        setupAccount(Protocols.IMAP, "imap+ssl+")
+        setupAccount(Protocols.IMAP)
     }
 
-    private fun setupAccount(serverType: String, schemePrefix: String) {
-        setupStoreAndSmtpTransport(serverType, schemePrefix)
+    private fun setupAccount(serverType: String) {
+        setupStoreAndSmtpTransport(serverType)
         createSpecialLocalFolders()
         returnAccountTypeSelectionResult()
     }
 
-    private fun setupStoreAndSmtpTransport(serverType: String, schemePrefix: String) {
+    private fun setupStoreAndSmtpTransport(serverType: String) {
         val domainPart = getDomainFromEmailAddress(account.email) ?: error("Couldn't get domain from email address")
 
-        setupStoreUri(serverType, domainPart, schemePrefix)
+        setupStoreUri(serverType, domainPart)
         setupTransportUri(domainPart)
     }
 
-    private fun setupStoreUri(serverType: String, domainPart: String, schemePrefix: String) {
+    private fun setupStoreUri(serverType: String, domainPart: String) {
         val suggestedStoreServerName = serverNameSuggester.suggestServerName(serverType, domainPart)
-        val storeUriForDecode = URI(account.storeUri)
-        val storeUri = URI(
-            schemePrefix, storeUriForDecode.userInfo, suggestedStoreServerName,
-            storeUriForDecode.port, null, null, null
+        val storeServer = ServerSettings(
+            serverType,
+            suggestedStoreServerName,
+            -1,
+            ConnectionSecurity.SSL_TLS_REQUIRED,
+            initialAccountSettings.authenticationType,
+            initialAccountSettings.email,
+            initialAccountSettings.password,
+            initialAccountSettings.clientCertificateAlias
         )
-        account.storeUri = storeUri.toString()
+        val storeUri = backendManager.createStoreUri(storeServer)
+        account.storeUri = storeUri
     }
 
     private fun setupTransportUri(domainPart: String) {
         val suggestedTransportServerName = serverNameSuggester.suggestServerName(Protocols.SMTP, domainPart)
-        val transportUriForDecode = URI(account.transportUri)
-        val transportUri = URI(
-            "smtp+tls+", transportUriForDecode.userInfo, suggestedTransportServerName,
-            transportUriForDecode.port, null, null, null
+        val transportServer = ServerSettings(
+            Protocols.SMTP,
+            suggestedTransportServerName,
+            -1,
+            ConnectionSecurity.STARTTLS_REQUIRED,
+            initialAccountSettings.authenticationType,
+            initialAccountSettings.email,
+            initialAccountSettings.password,
+            initialAccountSettings.clientCertificateAlias
         )
-        account.transportUri = transportUri.toString()
+        val transportUri = backendManager.createTransportUri(transportServer)
+        account.transportUri = transportUri
     }
 
     private fun createSpecialLocalFolders() {
@@ -96,12 +113,14 @@ class AccountSetupAccountType : K9Activity() {
     companion object {
         private const val EXTRA_ACCOUNT = "account"
         private const val EXTRA_MAKE_DEFAULT = "makeDefault"
+        private const val EXTRA_DEFAULT_SETTINGS = "defaultAccountSettings"
 
         @JvmStatic
-        fun actionSelectAccountType(context: Context, account: Account, makeDefault: Boolean) {
+        fun actionSelectAccountType(context: Context, account: Account, makeDefault: Boolean, initialAccountSettings: InitialAccountSettings) {
             val intent = Intent(context, AccountSetupAccountType::class.java).apply {
                 putExtra(EXTRA_ACCOUNT, account.uuid)
                 putExtra(EXTRA_MAKE_DEFAULT, makeDefault)
+                putExtra(EXTRA_DEFAULT_SETTINGS, initialAccountSettings)
             }
             context.startActivity(intent)
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.kt
@@ -46,7 +46,8 @@ class AccountSetupAccountType : K9Activity() {
         val accountUuid = intent.getStringExtra(EXTRA_ACCOUNT) ?: error("No account UUID provided")
         account = preferences.getAccount(accountUuid) ?: error("No account with given UUID found")
         makeDefault = intent.getBooleanExtra(EXTRA_MAKE_DEFAULT, false)
-        initialAccountSettings = intent.getParcelableExtra(EXTRA_DEFAULT_SETTINGS) as InitialAccountSettings
+        initialAccountSettings = intent.getParcelableExtra(EXTRA_INITIAL_ACCOUNT_SETTINGS)
+            ?: error("Initial account settings are missing")
     }
 
     private fun setupPop3Account() {
@@ -113,14 +114,19 @@ class AccountSetupAccountType : K9Activity() {
     companion object {
         private const val EXTRA_ACCOUNT = "account"
         private const val EXTRA_MAKE_DEFAULT = "makeDefault"
-        private const val EXTRA_DEFAULT_SETTINGS = "defaultAccountSettings"
+        private const val EXTRA_INITIAL_ACCOUNT_SETTINGS = "initialAccountSettings"
 
         @JvmStatic
-        fun actionSelectAccountType(context: Context, account: Account, makeDefault: Boolean, initialAccountSettings: InitialAccountSettings) {
+        fun actionSelectAccountType(
+            context: Context,
+            account: Account,
+            makeDefault: Boolean,
+            initialAccountSettings: InitialAccountSettings
+        ) {
             val intent = Intent(context, AccountSetupAccountType::class.java).apply {
                 putExtra(EXTRA_ACCOUNT, account.uuid)
                 putExtra(EXTRA_MAKE_DEFAULT, makeDefault)
-                putExtra(EXTRA_DEFAULT_SETTINGS, initialAccountSettings)
+                putExtra(EXTRA_INITIAL_ACCOUNT_SETTINGS, initialAccountSettings)
             }
             context.startActivity(intent)
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -333,7 +333,8 @@ public class AccountSetupBasics extends K9Activity
         mAccount.setName(getOwnerName());
         mAccount.setEmail(email);
 
-        InitialAccountSettings initialAccountSettings = new InitialAccountSettings(authenticationType, email, password, clientCertificateAlias);
+        InitialAccountSettings initialAccountSettings = new InitialAccountSettings(authenticationType, email, password,
+                clientCertificateAlias);
 
         AccountSetupAccountType.actionSelectAccountType(this, mAccount, false, initialAccountSettings);
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -26,13 +26,10 @@ import com.fsck.k9.autodiscovery.api.DiscoveryResults;
 import com.fsck.k9.autodiscovery.api.DiscoveryTarget;
 import com.fsck.k9.autodiscovery.providersxml.ProvidersXmlDiscovery;
 import com.fsck.k9.backend.BackendManager;
-import com.fsck.k9.helper.EmailHelper;
 import com.fsck.k9.helper.Utility;
 import com.fsck.k9.mail.AuthType;
-import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mailstore.SpecialLocalFoldersCreator;
-import com.fsck.k9.preferences.Protocols;
 import com.fsck.k9.ui.R;
 import com.fsck.k9.ui.ConnectionSettings;
 import com.fsck.k9.view.ClientCertificateSpinner;
@@ -317,7 +314,6 @@ public class AccountSetupBasics extends K9Activity
 
     private void onManualSetup() {
         String email = mEmailView.getText().toString();
-        String domain = EmailHelper.getDomainFromEmailAddress(email);
 
         String password = null;
         String clientCertificateAlias = null;
@@ -337,18 +333,9 @@ public class AccountSetupBasics extends K9Activity
         mAccount.setName(getOwnerName());
         mAccount.setEmail(email);
 
-        // set default uris
-        // NOTE: they will be changed again in AccountSetupAccountType!
-        ServerSettings storeServer = new ServerSettings(Protocols.IMAP, "mail." + domain, -1,
-                ConnectionSecurity.SSL_TLS_REQUIRED, authenticationType, email, password, clientCertificateAlias);
-        ServerSettings transportServer = new ServerSettings(Protocols.SMTP, "mail." + domain, -1,
-                ConnectionSecurity.SSL_TLS_REQUIRED, authenticationType, email, password, clientCertificateAlias);
-        String storeUri = backendManager.createStoreUri(storeServer);
-        String transportUri = backendManager.createTransportUri(transportServer);
-        mAccount.setStoreUri(storeUri);
-        mAccount.setTransportUri(transportUri);
+        InitialAccountSettings initialAccountSettings = new InitialAccountSettings(authenticationType, email, password, clientCertificateAlias);
 
-        AccountSetupAccountType.actionSelectAccountType(this, mAccount, false);
+        AccountSetupAccountType.actionSelectAccountType(this, mAccount, false, initialAccountSettings);
     }
 
     public void onClick(View v) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/InitialAccountSettings.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/InitialAccountSettings.kt
@@ -1,0 +1,13 @@
+package com.fsck.k9.activity.setup
+
+import android.os.Parcelable
+import com.fsck.k9.mail.AuthType
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class InitialAccountSettings(
+    val authenticationType: AuthType,
+    val email: String,
+    val password: String?,
+    val clientCertificateAlias: String?
+) : Parcelable


### PR DESCRIPTION
Fixes #5088 (Port isn't changed when switching account types)
As per my comment on that issue I've made it so that all settings are reset when you navigate to the incoming/outgoing screen. 
Doesn't change what the default settings are when first navigating to those screens just resets back to those same defaults each time you go to the incoming/outgoing screens.