### PR TITLE
Add release dates to changelog xml

### DIFF
--- a/app/ui/legacy/src/main/res/raw/changelog_master.xml
+++ b/app/ui/legacy/src/main/res/raw/changelog_master.xml
@@ -13,31 +13,31 @@
         <change>Fixed bug when going back to previous steps when setting up an account</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.726" versioncode="27026">
+    <release version="5.726" versioncode="27026" date="2021-01-06">
         <change>Updated password input fields to be able to reveal passwords</change>
         <change>Added support for going back to previous steps when setting up an account</change>
         <change>Fixed a couple of crashes</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.725" versioncode="27025">
+    <release version="5.725" versioncode="27025" date="2020-11-18">
         <change>Prefer email addresses marked as default in email auto-completion popup</change>
         <change>Internal changes</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.724" versioncode="27024">
+    <release version="5.724" versioncode="27024" date="2020-11-01">
         <change>Fixed crash when trying to forward or reply to a message</change>
         <change>Fixed crash when trying to compose a message from a search view</change>
         <change>Fixed crash when message list couldn't be loaded</change>
         <change>Fixed crash when setting up an account didn't work right away, e.g. wrong password was entered</change>
     </release>
-    <release version="5.723" versioncode="27023">
+    <release version="5.723" versioncode="27023" date="2020-10-31">
         <change>Fixed bug that prevented some messages from being moved</change>
         <change>Fixed message list display bug when multiple roles were assigned to the same folder</change>
         <change>Number of messages in Outbox folder are now displayed in the side drawer</change>
         <change>Tweaked message list appearance of Outbox</change>
         <change>Message list footer is now hidden while list is loading</change>
     </release>
-    <release version="5.722" versioncode="27022">
+    <release version="5.722" versioncode="27022" date="2020-10-20">
         <change>Fixed bug where updating drafts wouldn't upload the change to the server</change>
         <change>Fixed bug where URLs were duplicated when saving drafts</change>
         <change>Improved HTTP URL detection when URL is wrapped in parentheses</change>
@@ -47,18 +47,18 @@
         <change>Display message headers in original order</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.721" versioncode="27021">
+    <release version="5.721" versioncode="27021" date="2020-10-07">
         <change>Fixed bug that lead to the message body not being displayed when it contained a signature ending with a URL</change>
         <change>Added 'copy link text to clipboard' option when long-pressing links</change>
         <change>Treat all whitespace as separator when detecting URLs</change>
     </release>
-    <release version="5.720" versioncode="27020">
+    <release version="5.720" versioncode="27020" date="2020-10-06">
         <change>Fixed bug in preview text extraction that could stop synchronization</change>
         <change>When displaying text/plain parts the signature is de-emphasized</change>
         <change>Sharing a message now includes subject, date, sender, and recipients</change>
         <change>No longer use ISO-8859-1 encoding for headers</change>
     </release>
-    <release version="5.719" versioncode="27019">
+    <release version="5.719" versioncode="27019" date="2020-10-04">
         <change>Show image previews for attachments with application/octet-stream MIME type</change>
         <change>Improved display of certain HTML messages</change>
         <change>When auto-completing email addresses show starred contacts first</change>
@@ -71,7 +71,7 @@
         <change>Many internal changes</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.718" versioncode="27018">
+    <release version="5.718" versioncode="27018" date="2020-08-18">
         <change>Hide empty footer view in message list</change>
         <change>Don't show standard message actions for messages in the Outbox</change>
         <change>Tweaked UX of recipient chips</change>
@@ -80,7 +80,7 @@
         <change>Many internal changes</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.717" versioncode="27017">
+    <release version="5.717" versioncode="27017" date="2020-06-19">
         <change>Fixed display of text/plain parts containing text in a right-to-left language</change>
         <change>Don't retry remote commands that failed with an error</change>
         <change>Don't use default signature when setting up a new account</change>
@@ -89,33 +89,33 @@
         <change>Fixed various bugs with POP3 accounts</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.716" versioncode="27016">
+    <release version="5.716" versioncode="27016" date="2020-06-04">
         <change>Fixed bug that hid folders in the drawer behind the sticky footer</change>
         <change>Fixed crash when server contains a folder named 'Outbox'</change>
         <change>Avoid crash when adding an attachment fails</change>
         <change>Removed support for using Shift JIS charsets when sending a message</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.715" versioncode="27015">
+    <release version="5.715" versioncode="27015" date="2020-05-27">
         <change>Added swipe to refresh to side drawer</change>
         <change>Display day of the week in the message list for messages younger than 7 days</change>
         <change>Fixed bug that could lead to duplicated folders</change>
         <change>Fixed bug that didn't allow to turn off encryption when replying to an encrypted email</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.714" versioncode="27014">
+    <release version="5.714" versioncode="27014" date="2020-05-13">
         <change>IMAP: Fixed refreshing the folder list</change>
         <change>Keep drawer open after selecting an account</change>
         <change>Increased the size of the progress bar shown when refreshing a folder</change>
         <change>Some smaller bug fixes</change>
     </release>
-    <release version="5.713" versioncode="27013">
+    <release version="5.713" versioncode="27013" date="2020-05-08">
         <change>Fixed bug where reply/reply all/forward would open an empty new message screen</change>
     </release>
-    <release version="5.712" versioncode="27012">
+    <release version="5.712" versioncode="27012" date="2020-05-08">
         <change>Fixed crash on startup with Android 7 and older</change>
     </release>
-    <release version="5.711" versioncode="27011">
+    <release version="5.711" versioncode="27011" date="2020-05-08">
         <change>Fixed some bugs with periodic mail sync (mail was usually checked too often)</change>
         <change>Fixed a couple of bugs where unnecessary data was kept in the local database</change>
         <change>Fixed bug where a special folder wasn't removed locally when removed from the server</change>
@@ -123,21 +123,21 @@
         <change>Lots of internal changes</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.710" versioncode="27010">
+    <release version="5.710" versioncode="27010" date="2020-04-24">
         <change>Fixed duplicate message bug after moving a message</change>
         <change>Removed keyboard shortcuts for menu items; on some devices they conflicted with system shortcuts</change>
         <change>Don't show fullscreen keyboard in landscape mode</change>
         <change>Fixed bug where line breaks were ignored when loading draft messages</change>
         <change>POP3: Fixed moving deleted messages to the Trash folder</change>
     </release>
-    <release version="5.709" versioncode="27009">
+    <release version="5.709" versioncode="27009" date="2020-04-18">
         <change>Display larger preview for image attachments</change>
         <change>Fixed import and export of folder settings</change>
         <change>IMAP: Properly handle UIDVALIDITY changes</change>
         <change>Various smaller bug fixes</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.708" versioncode="27008">
+    <release version="5.708" versioncode="27008" date="2020-03-19">
         <change>Long-press on message in message list now selects the message</change>
         <change>Click on contact picture in message list now selects the message</change>
         <change>Fixed bug that disabled auto-completion when composing messages</change>
@@ -145,12 +145,12 @@
         <change>Removed 'Gestures' setting</change>
         <change>Renamed "send again" to "edit as new message"</change>
     </release>
-    <release version="5.707" versioncode="27007">
+    <release version="5.707" versioncode="27007" date="2020-03-06">
         <change>Fixed a bug in the new 'back button opens default folder' code</change>
         <change>Fixed a crash on Android 5.x devices with old WebView versions</change>
         <change>Fixed theme issues in some settings screens</change>
     </release>
-    <release version="5.706" versioncode="27006">
+    <release version="5.706" versioncode="27006" date="2020-03-03">
         <change>Unified Inbox is now opened by default (if enabled)</change>
         <change>Back button now opens default folder before exiting the app</change>
         <change>Fixed bug where the input area for the message body wasn't growing properly</change>
@@ -163,7 +163,7 @@
         <change>Removed automatic display of "What's New" dialog because of display issues</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.705" versioncode="27005">
+    <release version="5.705" versioncode="27005" date="2020-02-06">
         <change>Fixed bug that prevented contact pictures from being displayed</change>
         <change>Display progress bar when syncing a folder</change>
         <change>Fixed deleting messages when there's no Trash folder (IMAP)</change>
@@ -173,20 +173,20 @@
         <change>Updated translations</change>
         <change>A lot of internal changes and improvements</change>
     </release>
-    <release version="5.704" versioncode="27004">
+    <release version="5.704" versioncode="27004" date="2020-01-09">
         <change>Changed background color of the app icon</change>
         <change>Added setting to mark a message as read when it is deleted (enabled by default)</change>
         <change>Fixed crash when trying to reply to encrypted messages</change>
         <change>Fixed configuration of special folders that lead to Inbox not being checked for new messages automatically</change>
     </release>
-    <release version="5.703" versioncode="27003">
+    <release version="5.703" versioncode="27003" date="2019-12-22">
         <change>Fixed issue where going back to the app would open the default folder</change>
         <change>Fixed crash when trying to create a new identity</change>
         <change>Various smaller bug fixes</change>
         <change>'Choose folder' now displays folders in the same order as the side drawer</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.702" versioncode="27002">
+    <release version="5.702" versioncode="27002" date="2019-12-13">
         <change>The back button now closes the side drawer instead of exiting the app immediately</change>
         <change>Fixed "Download complete message" for POP3 accounts</change>
         <change>Fixed bug that could lead to some messages not being synchronized with an IMAP server</change>
@@ -194,14 +194,14 @@
         <change>Fixed crash when changing theme</change>
         <change>'Manage folders' now displays folders in the same order as the side drawer</change>
     </release>
-    <release version="5.701" versioncode="27001">
+    <release version="5.701" versioncode="27001" date="2019-12-02">
         <change>Use account color as accent color in drawer</change>
         <change>Removed setting 'Start in Unified Inbox'</change>
         <change>Fixed bug that displayed folders when the Unified Inbox was selected</change>
         <change>Fixed bug where work was accidentally done in the main thread</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.700" versioncode="27000">
+    <release version="5.700" versioncode="27000" date="2019-11-24">
         <change>Major redesign of the user interface</change>
         <change>Temporarily disabled Push (IMAP IDLE) until we can make it work reliable; your accounts will be polled every 15 minutes instead</change>
         <change>Deprecated support for the WebDAV protocol; new accounts can no longer be added</change>
@@ -213,21 +213,21 @@
         <change>Removed the 'remote control' interface third-party apps could use to change some settings in K-9 Mail</change>
         <change>Fixed a lot of bugs and probably introduced some new ones. Please report bugs.</change>
     </release>
-    <release version="5.600" versioncode="26000">
+    <release version="5.600" versioncode="26000" date="2018-09-02">
         <change>Allow some outdated HTML attributes so emails from popular internet services are displayed as intended</change>
         <change>Fixed bug when moving or copying message (IMAP)</change>
     </release>
-    <release version="5.503" versioncode="25030">
+    <release version="5.503" versioncode="25030" date="2018-04-02">
         <change>Fixed bug with some soft keyboards when auto-completing recipients</change>
         <change>Fixed crash when decrypting messages</change>
     </release>
-    <release version="5.502" versioncode="25020">
+    <release version="5.502" versioncode="25020" date="2018-03-11">
         <change>Updated translations</change>
     </release>
-    <release version="5.501" versioncode="25010">
+    <release version="5.501" versioncode="25010" date="2018-02-25">
         <change>Fixed bug that lead to important files being stripped from the APK</change>
     </release>
-    <release version="5.500" versioncode="25000">
+    <release version="5.500" versioncode="25000" date="2018-02-24">
         <change>Further improvements to encryption user experience</change>
         <change>Added ability to forward a message as attachment</change>
         <change>Improved the way we display text/plain messages</change>
@@ -241,39 +241,39 @@
         <change>Updated translations</change>
         <change>More bug fixes</change>
     </release>
-    <release version="5.403" versioncode="23630">
+    <release version="5.403" versioncode="23630" date="2018-01-06">
         <change>Fixed bug that caused 'Quiet Time' to behave erratically</change>
     </release>
-    <release version="5.402" versioncode="23620">
+    <release version="5.402" versioncode="23620" date="2018-01-04">
         <change>Fixed display issues with certain messages</change>
     </release>
-    <release version="5.401" versioncode="23610">
+    <release version="5.401" versioncode="23610" date="2018-01-03">
         <change>Fixed bug that lead to some messages showing as empty</change>
     </release>
-    <release version="5.400" versioncode="23600">
+    <release version="5.400" versioncode="23600" date="2017-12-27">
         <change>Avoid crash on Android 8.1</change>
         <change>Updated translations</change>
         <change>Added Albanian translation</change>
     </release>
-    <release version="5.304" versioncode="23540">
+    <release version="5.304" versioncode="23540" date="2017-11-10">
         <change>Fixed bug that could cause OpenPGP signature verification to fail when it shouldn't</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.303" versioncode="23530">
+    <release version="5.303" versioncode="23530" date="2017-11-03">
         <change>Fixed bug that could lead to attachments not being displayed</change>
         <change>Fixed bug where HTML messages weren't displayed correctly</change>
         <change>Fixed crash when encountering invalid email addresses</change>
     </release>
-    <release version="5.302" versioncode="23520">
+    <release version="5.302" versioncode="23520" date="2017-10-28">
         <change>Fixed display errors of plain text messages</change>
         <change>Added translations: Indonesian, Breton</change>
     </release>
-    <release version="5.301" versioncode="23510">
+    <release version="5.301" versioncode="23510" date="2017-10-14">
         <change>Improved OpenPGP support</change>
         <change>Various bug fixes</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.300" versioncode="23500">
+    <release version="5.300" versioncode="23500" date="2017-09-10">
         <change>New app icon</change>
         <change>New widget: Message List</change>
         <change>New OpenPGP flow, adhering to Autocrypt specification</change>
@@ -283,20 +283,19 @@
         <change>Many bugfixes and optimizations</change>
         <change>Added translations: Esperanto, Gaelic (Scottish), Icelandic, Welsh</change>
     </release>
-
-    <release version="5.208" versioncode="23271">
+    <release version="5.208" versioncode="23271" date="2017-08-28">
         <change>Fixed bug where automatic synchronization wouldn't restart after the device exited doze mode</change>
     </release>
-    <release version="5.207" versioncode="23270">
+    <release version="5.207" versioncode="23270" date="2017-04-13">
         <change>Improved speed of local message search</change>
     </release>
-    <release version="5.206" versioncode="23260">
+    <release version="5.206" versioncode="23260" date="2017-03-15">
         <change>Fixed crash when starting the app from the unread widget</change>
     </release>
-    <release version="5.205" versioncode="23250">
+    <release version="5.205" versioncode="23250" date="2017-02-24">
         <change>Fixed bug where the message body wasn't displayed when no crypto provider was configured</change>
     </release>
-    <release version="5.204" versioncode="23240">
+    <release version="5.204" versioncode="23240" date="2017-02-24">
         <change>Fixed bug where not all data was removed for deleted messages</change>
         <change>Improved support for messages that didn't display correctly</change>
         <change>Fixed bug with notification actions sometimes not working</change>
@@ -304,7 +303,7 @@
         <change>Updated translations</change>
         <change>Many more bug fixes</change>
     </release>
-    <release version="5.203" versioncode="23230">
+    <release version="5.203" versioncode="23230" date="2017-01-17">
         <change>Fixed bug with pinch to zoom gesture</change>
         <change>Added setting for disabling 'mark all as read' confirmation dialog</change>
         <change>Update full text search index when removing messages</change>
@@ -314,7 +313,7 @@
         <change>Don't save drafts when message could be sent encrypted</change>
         <change>More bug fixes</change>
     </release>
-    <release version="5.202" versioncode="23220">
+    <release version="5.202" versioncode="23220" date="2017-01-05">
         <change>Fixed bug where BCC header line was accidentally included in sent messages</change>
         <change>Fixed problem with getting the list of IMAP folders</change>
         <change>Always show subject in message header when split mode is active</change>
@@ -322,19 +321,19 @@
         <change>Fixed button to expand CC/BCC recipients in dark theme</change>
         <change>Fixed various crashes</change>
     </release>
-    <release version="5.201" versioncode="23210">
+    <release version="5.201" versioncode="23210" date="2016-12-31">
         <change>Fixed crash during database upgrade</change>
         <change>Fixed various minor bugs</change>
     </release>
-    <release version="5.200" versioncode="23200">
+    <release version="5.200" versioncode="23200" date="2016-12-26">
         <change>Fixed bug with status display of signed messages</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.200-RC2" versioncode="23191">
+    <release version="5.200-RC2" versioncode="23191" date="2016-12-11">
         <change>Fixed crash when opening attached messages</change>
         <change>Don't crash when message list contains messages for which we couldn't extract a preview</change>
     </release>
-    <release version="5.200-RC1" versioncode="23190" >
+    <release version="5.200-RC1" versioncode="23190" date="2016-12-09">
         <change>Added support for PGP/MIME</change>
         <change>Added support for bundled notifications on Android 7+ and Android Wear</change>
         <change>New option: only notify for messages from contacts</change>
@@ -348,7 +347,7 @@
         <change>Added translations: Bulgarian, Persian (Farsi), Croatian, Portuguese, Romanian, Slovenian, Serbian</change>
         <change>Lots of smaller bug fixes and features</change>
     </release>
-    <release version="5.115" versioncode="23114" >
+    <release version="5.115" versioncode="23114" date="2016-11-18">
         <change>More user interface tweaks for encryption-related functionality</change>
         <change>Message signing without encryption is now an expert feature that is disabled by default</change>
         <change>Added support for directional pad to move to next/previous message</change>
@@ -356,7 +355,7 @@
         <change>Fixed notification grouping on Android Wear and Android 7.0</change>
         <change>Fixed notification actions on Android 7.0</change>
     </release>
-    <release version="5.114" versioncode="23113" >
+    <release version="5.114" versioncode="23113" date="2016-10-13">
         <change>User interface tweaks for encryption-related functionality</change>
         <change>Fixed crash caused by new message notifications</change>
         <change>Fixed bug with downloading attachments</change>
@@ -364,10 +363,10 @@
         <change>Fixed bug where message list was displayed twice</change>
         <change>Updated translations</change>
     </release>
-    <release version="5.113" versioncode="23112" >
+    <release version="5.113" versioncode="23112" date="2016-10-06">
         <change>Fixed dark theme</change>
     </release>
-    <release version="5.112" versioncode="23111" >
+    <release version="5.112" versioncode="23111" date="2016-10-05">
         <change>Fixed crash when selecting folder to move message</change>
         <change>Fixed bug where wrong message format was used when replying</change>
         <change>Fixed position of context menus on Android 7.0</change>
@@ -377,7 +376,7 @@
         <change>Added support for linkifying URLs with new TLDs</change>
         <change>Added server settings for more providers</change>
     </release>
-    <release version="5.111" versioncode="23110" >
+    <release version="5.111" versioncode="23110" date="2016-08-27">
         <change>Fixed replying to and forwarding of encrypted messages</change>
         <change>Ask for confirmation on "mark all as read"</change>
         <change>Suggest server name based on server type</change>
@@ -387,13 +386,13 @@
         <change>Removed broken support for sending messages as 8-bit via SMTP</change>
         <change>Lots of internal changes and minor bug fixes</change>
     </release>
-    <release version="5.110" versioncode="23100" >
+    <release version="5.110" versioncode="23100" date="2016-07-06">
         <change>New option: only notify for messages from contacts</change>
         <change>Added auto-configuration support for more providers</change>
         <change>Improved PGP/MIME experience</change>
         <change>Lots of internal improvements</change>
     </release>
-    <release version="5.109" versioncode="23090" >
+    <release version="5.109" versioncode="23090" date="2016-05-21">
         <change>Added support for List-Post header</change>
         <change>Added support for sub-folders (WebDAV)</change>
         <change>Display notification on authentication failures</change>
@@ -404,7 +403,7 @@
         <change>Fixed 'reply to all'</change>
         <change>More bug fixes</change>
     </release>
-    <release version="5.108" versioncode="23080" >
+    <release version="5.108" versioncode="23080" date="2016-03-22">
         <change>Added rudimentary support for reading and composing PGP/MIME messages</change>
         <change>Added support for stacked single message notifications on Android Wear</change>
         <change>Added setting to disable notifications during quiet time</change>
@@ -423,39 +422,39 @@
         <change>Updated translations</change>
         <change>More bug fixes</change>
     </release>
-    <release version="5.107" versioncode="23070" >
+    <release version="5.107" versioncode="23070" date="2015-06-09">
         <change>Fixed an issue caused by the latest Android System WebView update</change>
     </release>
-    <release version="5.106" versioncode="23060">
+    <release version="5.106" versioncode="23060" date="2015-05-02">
         <change>Fixed a bug where messages where not always displayed on Android 5.x</change>
     </release>
-    <release version="5.105" versioncode="23050">
+    <release version="5.105" versioncode="23050" date="2015-03-14">
         <change>Reverted all changes introduced with v5.104 except for the bugfixes related to Android 5.1</change>
     </release>
-    <release version="5.104" versioncode="23040">
+    <release version="5.104" versioncode="23040" date="2015-03-13">
         <change>Fixed crash when selecting multiple messages on Android 5.1</change>
         <change>Fixed settings export</change>
         <change>Fixed some layout bugs</change>
         <change>Added Serbian translation</change>
         <change>Updated several translations</change>
     </release>
-    <release version="5.103" versioncode="23030">
+    <release version="5.103" versioncode="23030" date="2014-12-06">
         <change>Added ability to customize lock screen notifications (Android 5.0+ only)</change>
         <change>Fixed a bug where a certificate error was wrongly reported</change>
         <change>Updated translation</change>
     </release>
-    <release version="5.102" versioncode="23020">
+    <release version="5.102" versioncode="23020" date="2014-11-28">
         <change>Improved 'open' functionality for attachments</change>
         <change>Removed APG legacy interface</change>
         <change>Fixed bug in Russian translation</change>
     </release>
-    <release version="5.101" versioncode="23010">
+    <release version="5.101" versioncode="23010" date="2014-10-10">
         <change>Fixed build problems that caused v5.100 to request the permissions READ_CALL_LOG and WRITE_CALL_LOG</change>
     </release>
-    <release version="5.100" versioncode="23000">
+    <release version="5.100" versioncode="23000" date="2014-10-08">
         <change>Removed SSL/TLS session caching because it was causing problems</change>
     </release>
-    <release version="4.905" versioncode="21008">
+    <release version="4.905" versioncode="21008" date="2014-09-10">
         <change>Dropped support for Android versions older than 4.0.3</change>
         <change>Added ability to use client certificates for authentication</change>
         <change>Enabled support for TLSv1.1 and TLSv1.2</change>
@@ -470,25 +469,25 @@
         <change>Various bug fixes</change>
         <change>Added translations: Latvian, Estonian, Norwegian Bokmål, Galician (Spain)</change>
     </release>
-    <release version="4.904" versioncode="21007" >
+    <release version="4.904" versioncode="21007" date="2014-04-18">
         <change>Added support for OpenPGP API v3</change>
         <change>Fixed problems with IMAP login</change>
         <change>Updated translations</change>
         <change>Fixed multiple bugs</change>
     </release>
-    <release version="4.903" versioncode="21006" >
+    <release version="4.903" versioncode="21006" date="2014-03-06">
         <change>Offer encrypted connection by default when manually setting up an account</change>
         <change>Simplified options for authentication and security</change>
         <change>Removed auto-configuration settings for all providers that didn't support encrypted connections</change>
         <change>Improved compatibility with IMAP (proxy) servers</change>
         <change>More small fixes and improvements</change>
     </release>
-    <release version="4.902" versioncode="21005" >
+    <release version="4.902" versioncode="21005" date="2014-02-23">
         <change>Avoid adding the same recipient twice when using "reply to all"</change>
         <change>Fixed a bug with bitcoin URIs</change>
         <change>Added mailbox.org to the list of providers</change>
     </release>
-    <release version="4.901" versioncode="21004" >
+    <release version="4.901" versioncode="21004" date="2014-02-14">
         <change>Added a slider to allow picking a font size for the message body (40% to 250%) in settings</change>
         <change>Added support for KitKat's Storage Access Framework that allows you to attach multiple files at once</change>
         <change>Added support for apps that don't know how to properly use Android's 'share' functionality</change>
@@ -499,7 +498,7 @@
         <change>More bug fixes</change>
         <change>Updated Japanese translation</change>
     </release>
-    <release version="4.900" versioncode="21003" >
+    <release version="4.900" versioncode="21003" date="2014-01-22">
         <change>Fix issue 6064: Inline images don't display on KitKat</change>
         <change>Update list of German Internet providers</change>
         <change>Add provider Outlook.sk and Azet.sk to provider list</change>
@@ -520,7 +519,7 @@
         <change>With the new webview scrollview combo we've got loadinoverviewmode seems to behave better.</change>
         <change>Fix file selection for import Using FLAG_ACTIVITY_NO_HISTORY will cause the file selection to fail when KitKat's "Open from" activity opens a third-party activity.</change>
     </release>
-    <release version="4.701" versioncode="19002" >
+    <release version="4.701" versioncode="19002" date="2013-11-06">
         <change>Overhauled how we do message view scrolling to fix a KitKat issue. Thanks to Joe Steele!</change>
         <change>Hardened TLS cipher suites and versions</change>
         <change>K-9 no longer adds blank lines to composed messages if there is no quoted text</change>
@@ -529,14 +528,14 @@
         <change>Worked around a bug in KitKat that stopped settings import from working</change>
         <change>Updated German, Greek, Japanese, Korean, Lithuanian, Portugese, Russian and Slovak translations</change>
     </release>
-    <release version="4.700" versioncode="19001" >
+    <release version="4.700" versioncode="19001" date="2013-10-11">
         <change>Code cleanups</change>
         <change>Fixed a bug that could have caused message drafts to be sent before they were ready</change>
         <change>Updates to German, Japanese, Russian, Slovak translations</change>
         <change>Fix some small bugs in contact picture generation</change>
         <change>Fetch attachments while MessageCompose activity is running</change>
     </release>
-    <release version="4.512" versioncode="18012" >
+    <release version="4.512" versioncode="18012" date="2013-09-16">
         <change>Updated auto-configuration settings to use IMAP for outlook.com</change>
         <change>Updated auto-configuration settings for gmx.de</change>
         <change>Notifications no longer show "null" when sending mail</change>
@@ -545,21 +544,21 @@
         <change>Dramatically improved SMTP 8BITMIME compliance</change>
         <change>Updated Czech, French, German, Russian and Slovak translation</change>
     </release>
-    <release version="4.511" versioncode="18011" >
+    <release version="4.511" versioncode="18011" date="2013-08-31">
         <change>Remove remote/local store references when deleting accounts</change>
         <change>Add visual indicator that a menu item opens a submenu</change>
         <change>Make actions shown in message view menu configurable</change>
         <change>Remove icons from the "Refile" submenu, as we don't show icons in any other submenu.</change>
         <change>Add icon for the copy action</change>
     </release>
-    <release version="4.510" versioncode="18010" >
+    <release version="4.510" versioncode="18010" date="2013-08-27">
         <change>Fix erroneous SSL certificate warnings when connecting to a server that speaks STARTTLS</change>
         <change>Updates to Russian and Slovakian translations</change>
         <change>Major performance updates when opening folder lists</change>
         <change>Fix a crashing bug related to random number generation on some 3rd party roms</change>
         <change>Fixed a bug that prevented starring messages in the message list</change>
     </release>
-    <release version="4.509" versioncode="18009" >
+    <release version="4.509" versioncode="18009" date="2013-08-23">
         <change>Updates to Catalan, Czech, Dutch, Finnish, French, German, Korean, Spanish and Swedish translations</change>
         <change>Several performance improvements and crash fixes</change>
         <change>tweak message list item "read item" background color so you can see the item divider a bit better</change>
@@ -579,29 +578,29 @@
         <change>Restore super-dense message list layout when the user has selected 0 lines of message preview and no contact pictures</change>
         <change>Rename "SSL" to "SSL/TLS" and "TLS" to "STARTTLS" to better explain what's really going on</change>
     </release>
-    <release version="4.508" versioncode="18008" >
+    <release version="4.508" versioncode="18008" date="2013-07-18">
         <change>Move 'share' menu item back, at least for the moment</change>
     </release>
-    <release version="4.507" versioncode="18007" >
+    <release version="4.507" versioncode="18007" date="2013-07-18">
         <change>Add some Russian ISPs for autoconfiguration</change>
         <change>Polish and Slovak translation updates</change>
         <change>Performance improvements</change>
         <change>Build system improvements</change>
         <change>Move 'share' menu item up a level in the menu to ease discoverability</change>
     </release>
-    <release version="4.506" versioncode="18006" >
+    <release version="4.506" versioncode="18006" date="2013-07-11">
         <change>Performance improvements</change>
         <change>Added autoconfiguration for Fastmail.FM</change>
         <change>New Slovak translation</change>
         <change>Updated Italian and Russian translations</change>
         <change>Don't save signature to identity header if identity doesn't use a signature</change>
     </release>
-    <release version="4.505" versioncode="18005" >
+    <release version="4.505" versioncode="18005" date="2013-07-08">
         <change>Major performance improvements in folder lists</change>
         <change>Catalan, Chinese and Russian translation updates</change>
         <change>Several bugfixes</change>
     </release>
-    <release version="4.503" versioncode="18003" >
+    <release version="4.503" versioncode="18003" date="2013-07-05">
         <change>Added additional shortcuts to the Folder list</change>
         <change>Tweaks to checkboxes and color chip display</change>
         <change>Added an "empty trash" option to the Account context menu</change>
@@ -612,19 +611,16 @@
         <change>Updated Russian, French, Greek, and Brazilian Portuguese translation</change>
         <change>More bug fixes</change>
     </release>
-
-    <release version="4.502" versioncode="18002" >
+    <release version="4.502" versioncode="18002" date="2013-05-23">
         <change>Fixed bug that prevented moving to previous and next message in some situations</change>
         <change>Updated Japanese, Czech, and Brazilian Portuguese translation</change>
         <change>Fixed a couple of bugs</change>
     </release>
-
-    <release version="4.501" versioncode="18001" >
+    <release version="4.501" versioncode="18001" date="2013-05-10">
         <change>Added setting to automatically shrink messages to fit the screen width</change>
         <change>Updated Greek translation</change>
     </release>
-
-    <release version="4.331" versioncode="17032" >
+    <release version="4.331" versioncode="17032" date="2013-05-07">
         <change>Checking mail from the Unified Inbox is now supported</change>
         <change>Added "mark all as read" to the menu of the message list</change>
         <change>Added sort by sender</change>
@@ -636,15 +632,13 @@
         <change>Updated German translation</change>
         <change>Many bug fixes</change>
     </release>
-
-    <release version="4.330" versioncode="17031" >
+    <release version="4.330" versioncode="17031" date="2013-03-19">
         <change>Changed appearance of the unread widget</change>
         <change>Fixed crash when opening the app from notifications</change>
         <change>Updated Finnish, Catalan translations</change>
         <change>Multiple bug fixes</change>
     </release>
-
-    <release version="4.329" versioncode="17030" >
+    <release version="4.329" versioncode="17030" date="2013-03-14">
         <change>Changed the notification icon (Android 2.3+ only)</change>
         <change>Restored showing the unread count on top of notification icons (Android 2.x only)</change>
         <change>Show preview text of the latest message in a thread</change>
@@ -660,12 +654,10 @@
         <change>Updated Korean, Danish, Finnish translations</change>
         <change>More bug fixes</change>
     </release>
-
-    <release version="4.328" versioncode="17029" >
+    <release version="4.328" versioncode="17029" date="2013-02-20">
         <change>Fixed the changelog :)</change>
     </release>
-
-    <release version="4.327" versioncode="17028" >
+    <release version="4.327" versioncode="17028" date="2013-02-20">
         <change>Fix dialog message when deleting multiple messages from a notification</change>
         <change>Message view / list: fix NPE when list is empty</change>
         <change>If there is no message when resuming, K-9 should return to a MessageList.</change>
@@ -674,7 +666,7 @@
         <change>Updated French translation</change>
         <change>Updated Czech localization</change>
     </release>
-    <release version="4.326" versioncode="17027" >
+    <release version="4.326" versioncode="17027" date="2013-02-16">
         <change>Korean translation update</change>
         <change>Message header area overhauled</change>
         <change>Holo theme improvements</change>
@@ -692,23 +684,20 @@
         <change>Move message view theme setting from message view menu to global prefs by default.</change>
         <change>Move "show all headers" into the menu (and out of the UI)</change>
     </release>
-    <release version="4.325" versioncode="17026" >
+    <release version="4.325" versioncode="17026" date="2013-02-07">
         <change>Bug fixes (threading, checkboxes)</change>
         <change>German translation update</change>
-
     </release>
-    <release version="4.324" versioncode="17025" >
+    <release version="4.324" versioncode="17025" date="2013-02-06">
         <change>Bug fixes</change>
         <change>Improved animations when showing the message list</change>
-
     </release>
-    <release version="4.323" versioncode="17024" >
+    <release version="4.323" versioncode="17024" date="2013-02-05">
         <change>Bug fixes</change>
         <change>Updates to Finnish and French translations</change>
         <change>Put back prev/next buttons in non-split message views</change>
     </release>
-
-    <release version="4.322" versioncode="17023" >
+    <release version="4.322" versioncode="17023" date="2013-02-04">
         <change>Added a setting to enable split-screen mode (display message list next to message content)</change>
         <change>Show a thread as unread/starred if at least one message is unread/starred</change>
         <change>Modified the preview lines setting to allow disabling message preview in message list</change>
@@ -719,8 +708,7 @@
         <change>Fixed a bug that caused the app to load too many messages when you clicked "Load more messages"</change>
         <change>Updated Finnish, French, German, Dutch translations</change>
     </release>
-
-    <release version="4.321" versioncode="17022" >
+    <release version="4.321" versioncode="17022" date="2013-01-16">
         <change>Fixed some bugs related to message threading</change>
         <change>Improved search for folders in the folder list</change>
         <change>Added support for wrapping long folder names in the folder list</change>
@@ -735,14 +723,12 @@
         <change>Close thread view when last message has been moved/deleted</change>
         <change>Performance improvements</change>
     </release>
-
-    <release version="4.320" versioncode="17021" >
+    <release version="4.320" versioncode="17021" date="2013-01-11">
         <change>Added 'Account settings' back to the account context menu</change>
         <change>Added 'Refresh' and 'Settings' back to the folder context menu</change>
         <change>Minor bug fixes</change>
     </release>
-
-    <release version="4.319" versioncode="17020" >
+    <release version="4.319" versioncode="17020" date="2013-01-08">
         <change>Added Jelly Bean-style notifications</change>
     </release>
 


### PR DESCRIPTION
- Release dates (format: YYYY-MM-DD) are in accordance with UTC timezone.
- Removed extra spaces and lines in release xml.

Fixes #5099
