### PR TITLE
Refresh the folder list when checking the account

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2356,6 +2356,8 @@ public class MessagingController {
 
         sendPendingMessages(account, listener);
 
+        refreshFolderListIfStale(account);
+
         try {
             Account.FolderMode aDisplayMode = account.getFolderDisplayMode();
             Account.FolderMode aSyncMode = account.getFolderSyncMode();


### PR DESCRIPTION
We already check if the folder list needs refreshing when synchronizing an individual folder. But if the folder list was never retrieved from the server we don't know about any remote folders, so the code to trigger refreshing the folder list will never be run.

With this change the folder list check is also triggered when synchronizing an account. This can be manually triggered from the navigation drawer even when the folder list only contains local folders.

Fixes #5106