### PR TITLE
update imap & smtp URI for ease of maintenance 

### DIFF
--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapStoreUriCreator.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapStoreUriCreator.java
@@ -84,6 +84,7 @@ public class ImapStoreUriCreator {
             } else {
                 path = "/1|";
             }
+            // query is assumed to have at least one entry, and we have to do the encoding ourselves, due to limitations in URI
             return new URI(scheme, userInfo, server.host, server.port, path, null, null).toString() + "?" + query;
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Can't create ImapStore URI", e);

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapStoreUriCreator.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapStoreUriCreator.java
@@ -84,7 +84,7 @@ public class ImapStoreUriCreator {
             } else {
                 path = "/1|";
             }
-            return new URI(scheme, userInfo, server.host, server.port, path, query, null).toString();
+            return new URI(scheme, userInfo, server.host, server.port, path, null, null).toString() + "?" + query;
         } catch (URISyntaxException e) {
             throw new IllegalArgumentException("Can't create ImapStore URI", e);
         }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapStoreUriDecoder.java
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapStoreUriDecoder.java
@@ -142,7 +142,7 @@ public class ImapStoreUriDecoder {
                 }
             }
         }
-        String query = imapUri.getQuery();
+        String query = imapUri.getRawQuery();
         Map<String,String> queryParams = splitQuery(query);
         if (queryParams.containsKey("prefix")) {
             if (queryParams.get("prefix").toLowerCase().equals("auto")) {

--- a/backend/imap/src/test/java/com/fsck/k9/backend/imap/ImapStoreUriTest.java
+++ b/backend/imap/src/test/java/com/fsck/k9/backend/imap/ImapStoreUriTest.java
@@ -178,7 +178,7 @@ public class ImapStoreUriTest {
 
     @Test
     public void testDecodeStoreUriImapHybridPrefix() {
-        String uri = "imap://PLAIN:user:pass@server:143/0%7CcustomPathPrefix?prefix=/customPathPrefix&auth-type=plain";
+        String uri = "imap://PLAIN:user:pass@server:143/0%7CcustomPathPrefix?prefix=%2FcustomPathPrefix&auth-type=plain";
 
         ServerSettings settings = ImapStoreUriDecoder.decode(uri);
 
@@ -241,6 +241,19 @@ public class ImapStoreUriTest {
     }
 
     @Test
+    public void testDecodeStoreUriImapFunkyPrefixl() {
+        String uri = "imap+ssl+://PLAIN:user:pass@server:993?prefix=%2FThis%22Is%3F%3DNot%26+%23Healthy%2B&tls-cert=emailCert&auth-type=plain";
+
+        ServerSettings settings = ImapStoreUriDecoder.decode(uri);
+
+        assertEquals("This\"Is?=Not& #Healthy+", settings.getExtra().get("pathPrefix"));
+
+
+    }
+
+
+
+    @Test
     public void testCreateStoreUriImapPrefix() {
         Map<String, String> extra = new HashMap<>();
         extra.put("autoDetectNamespace", "false");
@@ -250,7 +263,7 @@ public class ImapStoreUriTest {
 
         String uri = ImapStoreUriCreator.create(settings);
 
-        assertEquals("imap://PLAIN:user:pass@server:143/0%7CcustomPathPrefix?prefix=/customPathPrefix&auth-type=plain", uri);
+        assertEquals("imap://PLAIN:user:pass@server:143/0%7CcustomPathPrefix?prefix=%2FcustomPathPrefix&auth-type=plain", uri);
     }
 
     @Test
@@ -263,7 +276,21 @@ public class ImapStoreUriTest {
 
         String uri = ImapStoreUriCreator.create(settings);
 
-        assertEquals("imap+ssl+://EXTERNAL:user:emailCert@server:993/0%7C?prefix=/&tls-cert=emailCert&auth-type=external", uri);
+        assertEquals("imap+ssl+://EXTERNAL:user:emailCert@server:993/0%7C?prefix=%2F&tls-cert=emailCert&auth-type=external", uri);
+    }
+
+
+    @Test
+    public void testCreateStoreUriImapFunkyPrefixl() {
+        Map<String, String> extra = new HashMap<>();
+        extra.put("autoDetectNamespace", "false");
+        extra.put("pathPrefix", "This\"Is?=Not& #Healthy+");
+        ServerSettings settings = new ServerSettings("imap", "server", 993,
+                ConnectionSecurity.SSL_TLS_REQUIRED, AuthType.PLAIN, "user", "pass", "emailCert", extra);
+
+        String uri = ImapStoreUriCreator.create(settings);
+
+        assertEquals("imap+ssl+://PLAIN:user:pass@server:993/0%7CThis%22Is%3F=Not&%20%23Healthy+?prefix=%2FThis%22Is%3F%3DNot%26+%23Healthy%2B&tls-cert=emailCert&auth-type=plain", uri);
     }
 
     @Test
@@ -276,7 +303,7 @@ public class ImapStoreUriTest {
 
         String uri = ImapStoreUriCreator.create(settings);
 
-        assertEquals("imap://PLAIN:user:pass@server:143/0%7C?prefix=/&auth-type=plain", uri);
+        assertEquals("imap://PLAIN:user:pass@server:143/0%7C?prefix=%2F&auth-type=plain", uri);
     }
 
     @Test

--- a/mail/common/src/main/java/com/fsck/k9/mail/helper/UrlEncodingHelper.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/helper/UrlEncodingHelper.java
@@ -19,7 +19,7 @@ public final class UrlEncodingHelper {
         String[] params = query.split("&");
         for(String param: params) {
             String[] parts = param.split("=");
-            queryParams.put(parts[0], parts[1]);
+            queryParams.put(parts[0], decodeUtf8(parts[1]));
         }
         return queryParams;
     }
@@ -29,7 +29,8 @@ public final class UrlEncodingHelper {
         for (String param: params.keySet()) {
             query.append(param);
             query.append('=');
-            query.append(params.get(param));
+            //query.append(params.get(param));
+            query.append(encodeUtf8(params.get(param)));
             query.append('&');
         }
         query.deleteCharAt(query.length()-1);

--- a/mail/common/src/main/java/com/fsck/k9/mail/helper/UrlEncodingHelper.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/helper/UrlEncodingHelper.java
@@ -4,11 +4,39 @@ package com.fsck.k9.mail.helper;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
 
 
 public final class UrlEncodingHelper {
     private UrlEncodingHelper() {
     }
+    public static Map<String, String> splitQuery(String query) {
+        Map<String, String> queryParams = new HashMap<>();
+        if (query == null) {
+            return queryParams;
+        }
+        String[] params = query.split("&");
+        for(String param: params) {
+            String[] parts = param.split("=");
+            queryParams.put(parts[0], parts[1]);
+        }
+        return queryParams;
+    }
+
+    public static String buildQuery(Map<String, String> params) {
+        StringBuffer query = new StringBuffer("");
+        for (String param: params.keySet()) {
+            query.append(param);
+            query.append('=');
+            query.append(params.get(param));
+            query.append('&');
+        }
+        query.deleteCharAt(query.length()-1);
+        return query.toString();
+    }
+
+
 
     public static String decodeUtf8(String s) {
         try {

--- a/mail/common/src/main/java/com/fsck/k9/mail/helper/UrlEncodingHelper.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/helper/UrlEncodingHelper.java
@@ -11,6 +11,7 @@ import java.util.Map;
 public final class UrlEncodingHelper {
     private UrlEncodingHelper() {
     }
+
     public static Map<String, String> splitQuery(String query) {
         Map<String, String> queryParams = new HashMap<>();
         if (query == null) {
@@ -25,19 +26,19 @@ public final class UrlEncodingHelper {
     }
 
     public static String buildQuery(Map<String, String> params) {
+        if (params.size() == 0) {
+            return null;
+        }
         StringBuffer query = new StringBuffer("");
         for (String param: params.keySet()) {
             query.append(param);
             query.append('=');
-            //query.append(params.get(param));
             query.append(encodeUtf8(params.get(param)));
             query.append('&');
         }
         query.deleteCharAt(query.length()-1);
         return query.toString();
     }
-
-
 
     public static String decodeUtf8(String s) {
         try {

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriCreator.java
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriCreator.java
@@ -39,7 +39,9 @@ public class SmtpTransportUriCreator {
         if (! clientCertificateAliasEnc.equals("") ) {
             params.put("tls-cert",clientCertificateAliasEnc);
         }
-        params.put("auth-type",server.authenticationType.name().toLowerCase());
+        if (server.authenticationType != null) {
+            params.put("auth-type", server.authenticationType.name().toLowerCase());
+        }
         String query = buildQuery(params);
 
 
@@ -69,6 +71,11 @@ public class SmtpTransportUriCreator {
             }
         } else {
             userInfo = userEnc + ":" + passwordEnc;
+            if (userInfo.equals(":")) {
+                userInfo = null;
+            } else if ((passwordEnc == null) || (passwordEnc.equals(""))) {
+                userInfo = userEnc;
+            }
         }
         try {
             return new URI(scheme, userInfo, server.host, server.port, null, query,

--- a/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriDecoder.java
+++ b/mail/protocols/smtp/src/main/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriDecoder.java
@@ -5,10 +5,12 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLDecoder;
+import java.util.Map;
 
 import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.ServerSettings;
+import static com.fsck.k9.mail.helper.UrlEncodingHelper.splitQuery;
 
 
 public class SmtpTransportUriDecoder {
@@ -94,6 +96,15 @@ public class SmtpTransportUriDecoder {
                     password = decodeUtf8(userInfoParts[1]);
                 }
             }
+        }
+
+        String query = smtpUri.getQuery();
+        Map<String,String> queryParams = splitQuery(query);
+        if (queryParams.containsKey("auth-type")) {
+            authType = AuthType.valueOf(queryParams.get("auth-type").toUpperCase());
+        }
+        if (queryParams.containsKey("tls-cert")) {
+            clientCertificateAlias = queryParams.get("tls-cert");
         }
 
         return new ServerSettings("smtp", host, port, connectionSecurity,

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriCreatorTest.java
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriCreatorTest.java
@@ -62,6 +62,31 @@ public class SmtpTransportUriCreatorTest {
     }
 
     @Test
+    public void createTransportUri_noAuthUri() {
+        ServerSettings serverSettings = new ServerSettings(
+                "smtp", "server", 123456,
+                ConnectionSecurity.STARTTLS_REQUIRED, null,
+                null, null, "clientCert");
+
+        String result = SmtpTransportUriCreator.createSmtpUri(serverSettings);
+
+        assertEquals("smtp+tls+://server:123456?tls-cert=clientCert", result);
+    }
+
+
+    @Test
+    public void createTransportUri_noQueryUri() {
+        ServerSettings serverSettings = new ServerSettings(
+                "smtp", "server", 123456,
+                ConnectionSecurity.NONE, null,
+                "user", null, null);
+
+        String result = SmtpTransportUriCreator.createSmtpUri(serverSettings);
+
+        assertEquals("smtp://user@server:123456", result);
+    }
+
+    @Test
     public void createTransportUri_canEncodeSmtpUri() {
         ServerSettings serverSettings = new ServerSettings(
                 "smtp", "server", 123456,

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriCreatorTest.java
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriCreatorTest.java
@@ -46,7 +46,7 @@ public class SmtpTransportUriCreatorTest {
 
         String result = SmtpTransportUriCreator.createSmtpUri(serverSettings);
 
-        assertEquals("smtp+ssl+://user:clientCert:EXTERNAL@server:123456", result);
+        assertEquals("smtp+ssl+://user:clientCert:EXTERNAL@server:123456?tls-cert=clientCert&auth-type=external", result);
     }
 
     @Test
@@ -58,7 +58,7 @@ public class SmtpTransportUriCreatorTest {
 
         String result = SmtpTransportUriCreator.createSmtpUri(serverSettings);
 
-        assertEquals("smtp+tls+://user:password:PLAIN@server:123456", result);
+        assertEquals("smtp+tls+://user:password:PLAIN@server:123456?tls-cert=clientCert&auth-type=plain", result);
     }
 
     @Test
@@ -66,10 +66,10 @@ public class SmtpTransportUriCreatorTest {
         ServerSettings serverSettings = new ServerSettings(
                 "smtp", "server", 123456,
                 ConnectionSecurity.NONE, AuthType.CRAM_MD5,
-                "user", "password", "clientCert");
+                "user", "password", null);
 
         String result = SmtpTransportUriCreator.createSmtpUri(serverSettings);
 
-        assertEquals("smtp://user:password:CRAM_MD5@server:123456", result);
+        assertEquals("smtp://user:password:CRAM_MD5@server:123456?auth-type=cram_md5", result);
     }
 }

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriDecoderTest.java
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriDecoderTest.java
@@ -7,6 +7,7 @@ import com.fsck.k9.mail.ServerSettings;
 import org.junit.Test;
 
 import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 
 public class SmtpTransportUriDecoderTest {
@@ -140,6 +141,33 @@ public class SmtpTransportUriDecoderTest {
 
         assertEquals(25, result.port);
     }
+
+    @Test
+    public void decodeTransportUri_decodeCleanishURI() {
+        String storeUri = "smtp+tls+://:@server:25/?auth-type=PLAIN&tls-cert=clientCert";
+
+        ServerSettings result = SmtpTransportUriDecoder.decodeSmtpUri(storeUri);
+
+        assertEquals("clientCert", result.clientCertificateAlias);
+        assertEquals(AuthType.PLAIN, result.authenticationType);
+        assertNull(result.password);
+
+        assertEquals(25, result.port);
+    }
+    @Test
+    public void decodeTransportUri_decodeAlmostEmptyURI() {
+        String storeUri = "smtp+tls+://server";
+
+        ServerSettings result = SmtpTransportUriDecoder.decodeSmtpUri(storeUri);
+
+        assertNull(result.clientCertificateAlias);
+        assertNull(result.authenticationType);
+        assertNull(result.password);
+
+        assertEquals(587, result.port);
+    }
+
+
 
     @Test
     public void decodeTransportUri_canHybridParamsWinURI() {

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriDecoderTest.java
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportUriDecoderTest.java
@@ -115,4 +115,43 @@ public class SmtpTransportUriDecoderTest {
 
         SmtpTransportUriDecoder.decodeSmtpUri(storeUri);
     }
+
+    @Test
+    public void decodeTransportUri_canDecodeCleanishURI() {
+        String storeUri = "smtp+ssl+://user@server/?auth-type=external&tls-cert=clientCert";
+
+        ServerSettings result = SmtpTransportUriDecoder.decodeSmtpUri(storeUri);
+
+        assertEquals("clientCert", result.clientCertificateAlias);
+        assertEquals(AuthType.EXTERNAL, result.authenticationType);
+        assertEquals(465, result.port);
+
+    }
+
+    @Test
+    public void decodeTransportUri_canDecodeHybridURI() {
+        String storeUri = "smtp+tls+://user:password:PLAIN@server:25/?auth-type=PLAIN&tls-cert=clientCert";
+
+        ServerSettings result = SmtpTransportUriDecoder.decodeSmtpUri(storeUri);
+
+        assertEquals("clientCert", result.clientCertificateAlias);
+        assertEquals(AuthType.PLAIN, result.authenticationType);
+        assertEquals("password", result.password);
+
+        assertEquals(25, result.port);
+    }
+
+    @Test
+    public void decodeTransportUri_canHybridParamsWinURI() {
+        String storeUri = "smtp+tls+://user:never:EXTERNAL@server?auth-type=PLAIN&tls-cert=clientCert";
+
+        ServerSettings result = SmtpTransportUriDecoder.decodeSmtpUri(storeUri);
+
+        assertEquals("clientCert", result.clientCertificateAlias);
+        assertEquals(AuthType.PLAIN, result.authenticationType);
+        assertEquals(587, result.port);
+    }
+
+
+
 }


### PR DESCRIPTION
This change cleans up the imapURI a bit.  If we call the current state "legacy", then legacy looks a bit like this:

legacy:     imap[+(ssl|tls)+]://auth:user:(password|certAlias)@host[:port]/[(0|1)\|][prefix]

If we were to imagine a cleaned up version that didn't totally break the
current scheme, we'd move most options to query parameters, which are
named (hence ordering doesn't matter) and it is easier to mantain
forwards and backwards compatability.

This also "split" tls-cert from auth external, so they can be set
independenty in the future.  It also merged "autoPrefix" with "prefix"
so they cannot be set independently.

cleanish:   imap[+(ssl|tls)+]://user[:password]@host[:port]/?prefix=(auto|\/INBOX)&auth-type=(external|plain|oauth2|)&tls-cert=certAlias

What we can do, and be 100% backwards compatable today, is encode the
values both as query parameters and in the "legacy" form.  This is
called hybrid, and it doesn't break old decoders since they ignore
query, and all the information in query is redundant.  It looks like
this:

hybrid:     imap[+(ssl|tls)+]://[auth:]user[:(password|certAlias)]@host[:port]/[(0|1)\|][prefix]?prefix=(auto|\/prefix)&auth-type=(external|plain|xoauth2|)&tls-cert=certAlias

What I have implemented in this patch is encoding the hybrid uri format.
The uri decoder has been updated to read in legacy, hybrid, and cleanish formats.

If you like this approach, I will update smtp (and pop3, if that's still sticking around) along the same lines, as well as adding a few more test cases.   Then I will address any other feedback about the code quality.  java is not my native tongue. 
