### PR TITLE
Perform provider URI decoding inside 'ProvidersXmlDiscovery'

### DIFF
--- a/app/autodiscovery/providersxml/src/main/java/com/fsck/k9/autodiscovery/providersxml/KoinModule.kt
+++ b/app/autodiscovery/providersxml/src/main/java/com/fsck/k9/autodiscovery/providersxml/KoinModule.kt
@@ -4,5 +4,5 @@ import org.koin.dsl.module
 
 val autodiscoveryProvidersXmlModule = module {
     factory { ProvidersXmlProvider(context = get()) }
-    factory { ProvidersXmlDiscovery(backendManager = get(), xmlProvider = get()) }
+    factory { ProvidersXmlDiscovery(xmlProvider = get()) }
 }

--- a/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
+++ b/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
@@ -713,14 +713,4 @@
         <incoming uri="imap+ssl+://mail.ecloud.global" username="$email" />
         <outgoing uri="smtp+tls+://mail.ecloud.global" username="$email" />
     </provider>
-    
-    <!-- Developers' vanity providers -->
-    <provider id="fsck.com" label="Jesse's personal mail" domain="fsck.com" >
-        <incoming uri="imap+ssl+://fsck.com"  username="$user" />
-        <outgoing uri="smtp+tls+://mail.bestpractical.com:2525" />
-    </provider>
-    <provider id="bestpractical.com" label="Best Practical Solutions" domain="bestpractical.com" >
-        <incoming uri="imap+ssl+://imap.bestpractical.com"  username="$user" />
-        <outgoing uri="smtp+tls+://smtp.bestpractical.com:2525" />
-    </provider>
 </providers>

--- a/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
+++ b/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
@@ -3,26 +3,14 @@ package com.fsck.k9.autodiscovery.providersxml
 import androidx.test.core.app.ApplicationProvider
 import com.fsck.k9.RobolectricTest
 import com.fsck.k9.autodiscovery.api.DiscoveryTarget
-import com.fsck.k9.backend.BackendManager
-import com.fsck.k9.backend.imap.ImapStoreUriDecoder
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ConnectionSecurity
-import com.fsck.k9.mail.transport.smtp.SmtpTransportUriDecoder
 import com.google.common.truth.Truth.assertThat
-import com.nhaarman.mockitokotlin2.doAnswer
-import com.nhaarman.mockitokotlin2.mock
 import org.junit.Test
-import org.mockito.ArgumentMatchers.anyString
 
 class ProvidersXmlDiscoveryTest : RobolectricTest() {
-    private val backendManager = mock<BackendManager> {
-        on { decodeStoreUri(anyString()) } doAnswer { mock -> ImapStoreUriDecoder.decode(mock.getArgument(0)) }
-        on { decodeTransportUri(anyString()) } doAnswer { mock ->
-            SmtpTransportUriDecoder.decodeSmtpUri(mock.getArgument(0))
-        }
-    }
     private val xmlProvider = ProvidersXmlProvider(ApplicationProvider.getApplicationContext())
-    private val providersXmlDiscovery = ProvidersXmlDiscovery(backendManager, xmlProvider)
+    private val providersXmlDiscovery = ProvidersXmlDiscovery(xmlProvider)
 
     @Test
     fun discover_withGmailDomain_shouldReturnCorrectSettings() {


### PR DESCRIPTION
The URIs in `providers.xml` are only on the surface similar to our internal store/transport URIs. This change decouples them, so we can later get rid of the store/transport URI mechanism.