### PR TITLE
decouple client certificates from authentication

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -8,6 +8,7 @@ import android.text.Editable;
 import android.text.TextWatcher;
 import android.view.View;
 import android.view.View.OnClickListener;
+import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
@@ -60,6 +61,7 @@ public class AccountSetupBasics extends K9Activity
     private Button mNextButton;
     private Button mManualSetupButton;
     private Account mAccount;
+    private ViewGroup mAllowClientCertificateView;
 
     private EmailAddressValidator mEmailValidator = new EmailAddressValidator();
     private boolean mCheckedIncoming = false;
@@ -77,6 +79,8 @@ public class AccountSetupBasics extends K9Activity
         mPasswordView = findViewById(R.id.account_password);
         mClientCertificateCheckBox = findViewById(R.id.account_client_certificate);
         mClientCertificateSpinner = findViewById(R.id.account_client_certificate_spinner);
+        mAllowClientCertificateView = findViewById(R.id.account_allow_client_certificate);
+
         mNextButton = findViewById(R.id.next);
         mManualSetupButton = findViewById(R.id.manual_setup);
         mNextButton.setOnClickListener(this);
@@ -151,21 +155,19 @@ public class AccountSetupBasics extends K9Activity
         updateViewVisibility(isChecked);
         validateFields();
 
-        // Have the user select (or confirm) the client certificate
-        if (isChecked) {
+        // Have the user select the client certificate if not already selected
+        if ((isChecked) && (mClientCertificateSpinner.getAlias() == null)) {
             mClientCertificateSpinner.chooseCertificate();
         }
     }
 
     private void updateViewVisibility(boolean usingCertificates) {
         if (usingCertificates) {
-            // hide password fields, show client certificate spinner
-            mPasswordView.setVisibility(View.GONE);
-            mClientCertificateSpinner.setVisibility(View.VISIBLE);
+            // show client certificate spinner
+            mAllowClientCertificateView.setVisibility(View.VISIBLE);
         } else {
-            // show password fields, hide client certificate spinner
-            mPasswordView.setVisibility(View.VISIBLE);
-            mClientCertificateSpinner.setVisibility(View.GONE);
+            // hide client certificate spinner
+            mAllowClientCertificateView.setVisibility(View.GONE);
         }
     }
 
@@ -314,12 +316,15 @@ public class AccountSetupBasics extends K9Activity
         String password = null;
         String clientCertificateAlias = null;
         AuthType authenticationType;
+
+        authenticationType = AuthType.PLAIN;
+        password = mPasswordView.getText().toString();
         if (mClientCertificateCheckBox.isChecked()) {
-            authenticationType = AuthType.EXTERNAL;
             clientCertificateAlias = mClientCertificateSpinner.getAlias();
-        } else {
-            authenticationType = AuthType.PLAIN;
-            password = mPasswordView.getText().toString();
+            if (mPasswordView.getText().toString().equals("")) {
+                authenticationType = AuthType.EXTERNAL;
+                password = null;
+            }
         }
 
         if (mAccount == null) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/ClientCertificateSpinner.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/ClientCertificateSpinner.java
@@ -75,6 +75,7 @@ public class ClientCertificateSpinner extends LinearLayout {
             @Override
             public void run() {
                 updateView();
+                mDeleteButton.setVisibility((mAlias==null)?View.GONE: View.VISIBLE);
                 if (mListener != null) {
                     mListener.onClientCertificateChanged(mAlias);
                 }
@@ -93,6 +94,7 @@ public class ClientCertificateSpinner extends LinearLayout {
 
     private void onDelete() {
         setAlias(null);
+        mDeleteButton.setVisibility(View.GONE);
     }
 
     public void chooseCertificate() {

--- a/app/ui/legacy/src/main/res/layout/account_setup_basics.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_basics.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
     android:orientation="vertical"
     android:layout_height="match_parent"
     android:layout_width="match_parent">
@@ -48,12 +49,26 @@
                     android:inputType="textPassword"
                     android:nextFocusDown="@+id/next"/>
             </com.google.android.material.textfield.TextInputLayout>
+        <LinearLayout
+            android:id="@+id/account_allow_client_certificate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
+
+            <TextView
+                android:text="@string/account_setup_incoming_client_certificate_label"
+                android:layout_height="wrap_content"
+                android:layout_width="match_parent"
+                style="@style/InputLabel"
+                android:layout_marginTop="6dp"/>
 
             <com.fsck.k9.view.ClientCertificateSpinner
                 android:id="@+id/account_client_certificate_spinner"
                 android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:visibility="gone" />
+                android:layout_height="wrap_content" />
+        </LinearLayout>
 
             <com.fsck.k9.view.FoldableLinearLayout
                 android:id="@+id/foldable_advanced_options"

--- a/app/ui/legacy/src/main/res/layout/account_setup_incoming.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_incoming.xml
@@ -108,23 +108,27 @@
                         android:inputType="textPassword"
                         android:nextFocusDown="@+id/next"/>
             </com.google.android.material.textfield.TextInputLayout>
-
+        <LinearLayout
+            android:id="@+id/account_allow_client_certificate"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:visibility="gone"
+            tools:visibility="visible">
             <TextView
-                    android:id="@+id/account_client_certificate_label"
                     android:text="@string/account_setup_incoming_client_certificate_label"
                     android:layout_height="wrap_content"
                     android:layout_width="match_parent"
                     android:layout_marginTop="6dp"
-                    style="@style/InputLabel"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
+                    style="@style/InputLabel"/>
 
             <com.fsck.k9.view.ClientCertificateSpinner
                     android:id="@+id/account_client_certificate_spinner"
+                    android:paddingLeft="6dp"
                     android:layout_height="wrap_content"
-                    android:layout_width="match_parent"
-                    android:visibility="gone"
-                    tools:visibility="visible"/>
+                    android:layout_width="match_parent"/>
+        </LinearLayout>
+
 
             <LinearLayout
                     android:id="@+id/imap_path_prefix_section"

--- a/app/ui/legacy/src/main/res/layout/account_setup_outgoing.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_outgoing.xml
@@ -123,20 +123,28 @@
                         android:nextFocusDown="@+id/next"/>
                 </com.google.android.material.textfield.TextInputLayout>
 
+            </LinearLayout>
+
+            <LinearLayout
+                android:id="@+id/account_allow_client_certificate"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="vertical"
+                android:visibility="gone"
+                tools:visibility="visible">
+
                 <TextView
-                    android:id="@+id/account_client_certificate_label"
                     android:text="@string/account_setup_incoming_client_certificate_label"
                     android:layout_height="wrap_content"
                     android:layout_width="match_parent"
-                    android:textAppearance="?android:attr/textAppearanceSmall"
-                    android:textColor="?android:attr/textColorPrimary"
-                    android:visibility="gone" />
+                    style="@style/InputLabel"
+                    android:layout_marginTop="6dp"/>
 
                 <com.fsck.k9.view.ClientCertificateSpinner
                     android:id="@+id/account_client_certificate_spinner"
+                    android:paddingLeft="6dp"
                     android:layout_height="wrap_content"
-                    android:layout_width="match_parent"
-                    android:visibility="gone" />
+                    android:layout_width="match_parent" />
             </LinearLayout>
 
             <View

--- a/app/ui/legacy/src/main/res/layout/client_certificate_spinner.xml
+++ b/app/ui/legacy/src/main/res/layout/client_certificate_spinner.xml
@@ -9,6 +9,7 @@
         android:layout_width="0dip"
         android:layout_height="wrap_content"
         android:layout_weight="1"
+        android:padding="6dp"
         android:text="@string/client_certificate_spinner_empty"
         android:freezesText="true" />
 
@@ -19,6 +20,7 @@
         android:background="?selectableItemBackground"
         android:contentDescription="@string/client_certificate_spinner_delete"
         android:padding="8dp"
+        android:visibility="gone"
         app:srcCompat="?attr/iconActionCancel" />
 
 </merge>


### PR DESCRIPTION
This allows the usage of client certificates to be independent of
authentication.  It is possible that the usage of client certificates
eliminate the need for any authentication, or that they provide
other benifits.

This patch restructures the incoming and outgoing server setup pages
so that client certificates can be set as long as the connection uses
TLS/SSL.  If the user chooses client certificates for authentication
it will prompt for certificate only if there isn't one already set.

Mixing password and client certificates works, and this builds upon
other work that allows these settings to coexist in the imap/smtpURI.

This also give the certificate spinner a little more polish.
  - label looks like other labels
  - some indentation
  - the cancel button only appears if there is something to cancel

Happy to get feedback.  I reviewed the other attempts at this, and the only thing 
that this lacks is the ability to use auth external without tls/ssl, which I could 
implement, but I don't think there's a valid use case for that.

This PR requires a new decoder/encoder that can full persist these serversettings, as 
the old uri format isn't up for the job.  I'm happy to help coding a the new encoder/decoder
as well as a preference migrations routine if that help is desired.
