### PR TITLE
Rename "hideSpecialAccounts" to "showUnifiedInbox"

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -227,7 +227,7 @@ object K9 : EarlyInit {
     var isUseVolumeKeysForListNavigation = false
 
     @JvmStatic
-    var isHideSpecialAccounts = false
+    var isShowUnifiedInbox = true
 
     @JvmStatic
     var isAutoFitWidth: Boolean = false
@@ -338,7 +338,7 @@ object K9 : EarlyInit {
         isShowAnimations = storage.getBoolean("animations", true)
         isUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false)
         isUseVolumeKeysForListNavigation = storage.getBoolean("useVolumeKeysForListNavigation", false)
-        isHideSpecialAccounts = storage.getBoolean("hideSpecialAccounts", false)
+        isShowUnifiedInbox = !storage.getBoolean("hideSpecialAccounts", false)
         isMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false)
         isShowMessageListStars = storage.getBoolean("messageListStars", true)
         messageListPreviewLines = storage.getInt("messageListPreviewLines", 2)
@@ -424,7 +424,7 @@ object K9 : EarlyInit {
         editor.putString("quietTimeEnds", quietTimeEnds)
 
         editor.putBoolean("messageListSenderAboveSubject", isMessageListSenderAboveSubject)
-        editor.putBoolean("hideSpecialAccounts", isHideSpecialAccounts)
+        editor.putBoolean("hideSpecialAccounts", !isShowUnifiedInbox)
         editor.putBoolean("messageListStars", isShowMessageListStars)
         editor.putInt("messageListPreviewLines", messageListPreviewLines)
         editor.putBoolean("showCorrespondentNames", isShowCorrespondentNames)

--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -338,7 +338,7 @@ object K9 : EarlyInit {
         isShowAnimations = storage.getBoolean("animations", true)
         isUseVolumeKeysForNavigation = storage.getBoolean("useVolumeKeysForNavigation", false)
         isUseVolumeKeysForListNavigation = storage.getBoolean("useVolumeKeysForListNavigation", false)
-        isShowUnifiedInbox = !storage.getBoolean("hideSpecialAccounts", false)
+        isShowUnifiedInbox = storage.getBoolean("showUnifiedInbox", true)
         isMessageListSenderAboveSubject = storage.getBoolean("messageListSenderAboveSubject", false)
         isShowMessageListStars = storage.getBoolean("messageListStars", true)
         messageListPreviewLines = storage.getInt("messageListPreviewLines", 2)
@@ -424,7 +424,7 @@ object K9 : EarlyInit {
         editor.putString("quietTimeEnds", quietTimeEnds)
 
         editor.putBoolean("messageListSenderAboveSubject", isMessageListSenderAboveSubject)
-        editor.putBoolean("hideSpecialAccounts", !isShowUnifiedInbox)
+        editor.putBoolean("showUnifiedInbox", isShowUnifiedInbox)
         editor.putBoolean("messageListStars", isShowMessageListStars)
         editor.putInt("messageListPreviewLines", messageListPreviewLines)
         editor.putBoolean("showCorrespondentNames", isShowCorrespondentNames)

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -129,7 +129,8 @@ public class GeneralSettingsDescriptions {
                 new V(1, new FontSizeSetting(FontSizes.FONT_DEFAULT))
         ));
         s.put("hideSpecialAccounts", Settings.versions(
-                new V(1, new BooleanSetting(false))
+                new V(1, new BooleanSetting(false)),
+                new V(69, null)
         ));
         s.put("keyguardPrivacy", Settings.versions(
                 new V(1, new BooleanSetting(false)),
@@ -170,6 +171,9 @@ public class GeneralSettingsDescriptions {
         ));
         s.put("showCorrespondentNames", Settings.versions(
                 new V(1, new BooleanSetting(true))
+        ));
+        s.put("showUnifiedInbox", Settings.versions(
+                new V(69, new BooleanSetting(true))
         ));
         s.put("sortTypeEnum", Settings.versions(
                 new V(10, new EnumSetting<>(SortType.class, Account.DEFAULT_SORT_TYPE))
@@ -284,6 +288,7 @@ public class GeneralSettingsDescriptions {
         u.put(24, new SettingsUpgraderV24());
         u.put(31, new SettingsUpgraderV31());
         u.put(58, new SettingsUpgraderV58());
+        u.put(69, new SettingsUpgraderV69());
 
         UPGRADERS = Collections.unmodifiableMap(u);
     }
@@ -415,6 +420,25 @@ public class GeneralSettingsDescriptions {
             }
 
             return null;
+        }
+    }
+
+    /**
+     * Upgrades the settings from version 68 to 69.
+     *
+     * <p>
+     * Renames {@code hideSpecialAccounts} to {@code showUnifiedInbox}.
+     * </p>
+     */
+    private static class SettingsUpgraderV69 implements SettingsUpgrader {
+
+        @Override
+        public Set<String> upgrade(Map<String, Object> settings) {
+            Boolean hideSpecialAccounts = (Boolean) settings.get("hideSpecialAccounts");
+            boolean showUnifiedInbox = hideSpecialAccounts == null || !hideSpecialAccounts;
+            settings.put("showUnifiedInbox", showUnifiedInbox);
+
+            return new HashSet<>(Collections.singleton("hideSpecialAccounts"));
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 68;
+    public static final int VERSION = 69;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -21,7 +21,7 @@ import timber.log.Timber;
 
 
 public class K9StoragePersister implements StoragePersister {
-    private static final int DB_VERSION = 12;
+    private static final int DB_VERSION = 13;
     private static final String DB_NAME = "preferences_storage";
 
     private final Context context;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo13.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo13.kt
@@ -1,0 +1,18 @@
+package com.fsck.k9.preferences.migrations
+
+import android.database.sqlite.SQLiteDatabase
+
+/**
+ * Rename `hideSpecialAccounts` to `showUnifiedInbox` (and invert value).
+ */
+class StorageMigrationTo13(
+    private val db: SQLiteDatabase,
+    private val migrationsHelper: StorageMigrationsHelper
+) {
+    fun renameHideSpecialAccounts() {
+        val hideSpecialAccounts = migrationsHelper.readValue(db, "hideSpecialAccounts")?.toBoolean() ?: false
+        val showUnifiedInbox = !hideSpecialAccounts
+        migrationsHelper.insertValue(db, "showUnifiedInbox", showUnifiedInbox.toString())
+        migrationsHelper.writeValue(db, "hideSpecialAccounts", null)
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
@@ -18,5 +18,6 @@ internal object StorageMigrations {
         if (oldVersion < 10) StorageMigrationTo10(db, migrationsHelper).removeSavedFolderSettings()
         if (oldVersion < 11) StorageMigrationTo11(db, migrationsHelper).upgradeMessageViewContentFontSize()
         if (oldVersion < 12) StorageMigrationTo12(db, migrationsHelper).removeStoreAndTransportUri()
+        if (oldVersion < 13) StorageMigrationTo13(db, migrationsHelper).renameHideSpecialAccounts()
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/AccountList.java
@@ -70,7 +70,7 @@ public abstract class AccountList extends K9ListActivity implements OnItemClickL
     public void populateListView(List<Account> realAccounts) {
         List<BaseAccount> accounts = new ArrayList<>();
 
-        if (displaySpecialAccounts() && !K9.isHideSpecialAccounts()) {
+        if (displaySpecialAccounts() && K9.isShowUnifiedInbox()) {
             BaseAccount unifiedInboxAccount = SearchAccount.createUnifiedInboxAccount();
             accounts.add(unifiedInboxAccount);
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -394,15 +394,15 @@ open class MessageList :
                 search!!.addAccountUuid(accountUuid)
                 search!!.addAllowedFolder(folderId)
             } else {
-                if (K9.isHideSpecialAccounts) {
+                if (K9.isShowUnifiedInbox) {
+                    account = null
+                    search = SearchAccount.createUnifiedInboxAccount().relatedSearch
+                } else {
                     account = preferences.defaultAccount
                     search = LocalSearch()
                     search!!.addAccountUuid(account!!.uuid)
                     val folderId = defaultFolderProvider.getDefaultFolder(account!!)
                     search!!.addAllowedFolder(folderId)
-                } else {
-                    account = null
-                    search = SearchAccount.createUnifiedInboxAccount().relatedSearch
                 }
             }
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityAppearance.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityAppearance.kt
@@ -5,7 +5,7 @@ import com.fsck.k9.K9
 data class MessageListActivityAppearance(
     val appTheme: K9.AppTheme,
     val k9Language: String,
-    val isHideSpecialAccounts: Boolean,
+    val isShowUnifiedInbox: Boolean,
     val isShowMessageListStars: Boolean,
     val isShowCorrespondentNames: Boolean,
     val isMessageListSenderAboveSubject: Boolean,
@@ -36,7 +36,7 @@ data class MessageListActivityAppearance(
         fun create() = MessageListActivityAppearance(
             appTheme = K9.appTheme,
             k9Language = K9.k9Language,
-            isHideSpecialAccounts = K9.isHideSpecialAccounts,
+            isShowUnifiedInbox = K9.isShowUnifiedInbox,
             isShowMessageListStars = K9.isShowMessageListStars,
             isShowCorrespondentNames = K9.isShowCorrespondentNames,
             isMessageListSenderAboveSubject = K9.isMessageListSenderAboveSubject,

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -106,7 +106,7 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
             .withActivity(parent)
             .withHeaderBackground(R.drawable.drawer_header_background)
 
-        if (!K9.isHideSpecialAccounts) {
+        if (K9.isShowUnifiedInbox) {
             headerBuilder.addProfiles(
                 ProfileDrawerItem()
                     .withNameShown(true)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -22,7 +22,7 @@ class GeneralSettingsDataStore(
         return when (key) {
             "fixed_message_view_theme" -> K9.isFixedMessageViewTheme
             "animations" -> K9.isShowAnimations
-            "show_unified_inbox" -> !K9.isHideSpecialAccounts
+            "show_unified_inbox" -> K9.isShowUnifiedInbox
             "messagelist_stars" -> K9.isShowMessageListStars
             "messagelist_show_correspondent_names" -> K9.isShowCorrespondentNames
             "messagelist_sender_above_subject" -> K9.isMessageListSenderAboveSubject
@@ -50,7 +50,7 @@ class GeneralSettingsDataStore(
         when (key) {
             "fixed_message_view_theme" -> K9.isFixedMessageViewTheme = value
             "animations" -> K9.isShowAnimations = value
-            "show_unified_inbox" -> K9.isHideSpecialAccounts = !value
+            "show_unified_inbox" -> K9.isShowUnifiedInbox = value
             "messagelist_stars" -> K9.isShowMessageListStars = value
             "messagelist_show_correspondent_names" -> K9.isShowCorrespondentNames = value
             "messagelist_sender_above_subject" -> K9.isMessageListSenderAboveSubject = value

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -22,7 +22,7 @@ class GeneralSettingsDataStore(
         return when (key) {
             "fixed_message_view_theme" -> K9.isFixedMessageViewTheme
             "animations" -> K9.isShowAnimations
-            "hide_special_accounts" -> K9.isHideSpecialAccounts
+            "show_unified_inbox" -> !K9.isHideSpecialAccounts
             "messagelist_stars" -> K9.isShowMessageListStars
             "messagelist_show_correspondent_names" -> K9.isShowCorrespondentNames
             "messagelist_sender_above_subject" -> K9.isMessageListSenderAboveSubject
@@ -50,7 +50,7 @@ class GeneralSettingsDataStore(
         when (key) {
             "fixed_message_view_theme" -> K9.isFixedMessageViewTheme = value
             "animations" -> K9.isShowAnimations = value
-            "hide_special_accounts" -> K9.isHideSpecialAccounts = value
+            "show_unified_inbox" -> K9.isHideSpecialAccounts = !value
             "messagelist_stars" -> K9.isShowMessageListStars = value
             "messagelist_show_correspondent_names" -> K9.isShowCorrespondentNames = value
             "messagelist_sender_above_subject" -> K9.isMessageListSenderAboveSubject = value

--- a/app/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bg/strings.xml
@@ -653,7 +653,6 @@ K-9 Mail е мощен, безплатен имейл клиент за Андр
   <string name="volume_navigation_title">Навигация с клавиш за звука</string>
   <string name="volume_navigation_message">В преглед на съобщението</string>
   <string name="volume_navigation_list">В списъка със съобщения</string>
-  <string name="hide_special_accounts_title">Скрий обща входяща кутия</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Не прочетени</string>
   <string name="search_all_messages_title">Всички съобщения</string>

--- a/app/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ca/strings.xml
@@ -684,7 +684,6 @@ Si us plau, envieu informes d\'errors, contribuïu-hi amb noves millores i feu p
   <string name="volume_navigation_title">Navegació amb botons de volum</string>
   <string name="volume_navigation_message">Vista del missatge</string>
   <string name="volume_navigation_list">A la vista de llistes</string>
-  <string name="hide_special_accounts_title">Amaga la bústia unificada</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- No llegit</string>
   <string name="search_all_messages_title">Tots els missatges</string>

--- a/app/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cs/strings.xml
@@ -667,7 +667,6 @@ Hlášení o chyb, úpravy pro nové funkce a dotazy zadávejte prostřednictví
   <string name="volume_navigation_title">Navigace tlačítky hlasitosti</string>
   <string name="volume_navigation_message">Zobrazení zpráv</string>
   <string name="volume_navigation_list">Různá zobrazení seznamů</string>
-  <string name="hide_special_accounts_title">Skrýt sjednocenou příchozí poštu</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Nepřečtené</string>
   <string name="search_all_messages_title">Všechny zprávy</string>

--- a/app/ui/legacy/src/main/res/values-cy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cy/strings.xml
@@ -687,7 +687,6 @@ Plîs rho wybod am unrhyw wallau, syniadau am nodweddion newydd, neu ofyn cwesti
   <string name="volume_navigation_title">Pori gyda\'r botymau sain</string>
   <string name="volume_navigation_message">Wrth edrych ar neges</string>
   <string name="volume_navigation_list">Wrth edrych ar restr</string>
-  <string name="hide_special_accounts_title">Cuddio Mewnflwch Unedig</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- Heb eu darllen</string>
   <string name="search_all_messages_title">Pob neges</string>

--- a/app/ui/legacy/src/main/res/values-da/strings.xml
+++ b/app/ui/legacy/src/main/res/values-da/strings.xml
@@ -660,7 +660,6 @@ Rapporter venligst fejl, forslag til nye funktioner eller stil spørgsmål på:
   <string name="volume_navigation_title">Volume-knap navigation</string>
   <string name="volume_navigation_message">Mail-visning</string>
   <string name="volume_navigation_list">Diverse listevisninger</string>
-  <string name="hide_special_accounts_title">Skjul Fælles indbakke</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Ulæste</string>
   <string name="search_all_messages_title">Alle mails</string>

--- a/app/ui/legacy/src/main/res/values-de/strings.xml
+++ b/app/ui/legacy/src/main/res/values-de/strings.xml
@@ -688,7 +688,6 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   <string name="volume_navigation_title">Lauter/Leiser-Navigation</string>
   <string name="volume_navigation_message">Nachrichtenansicht</string>
   <string name="volume_navigation_list">Diverse Listenansichten</string>
-  <string name="hide_special_accounts_title">Gemeinsamen Posteingang ausblenden</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Ungelesen</string>
   <string name="search_all_messages_title">Alle Nachrichten</string>

--- a/app/ui/legacy/src/main/res/values-el/strings.xml
+++ b/app/ui/legacy/src/main/res/values-el/strings.xml
@@ -661,7 +661,6 @@
   <string name="volume_navigation_title">Πλοήγηση με πλήκτρο έντασης</string>
   <string name="volume_navigation_message">Προβολή μηνύματος</string>
   <string name="volume_navigation_list">Διάφορες προβολές λίστας</string>
-  <string name="hide_special_accounts_title">Απόκρυψη Ενοποιημένων Εισερχομένων</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Μη αναγνωσμένα</string>
   <string name="search_all_messages_title">Όλα τα μηνύματα</string>

--- a/app/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eo/strings.xml
@@ -682,7 +682,6 @@ Bonvolu raporti erarojn, kontribui novajn eblojn kaj peti pri novaj funkcioj per
   <string name="volume_navigation_title">Navigado per sonfortecaj butonoj</string>
   <string name="volume_navigation_message">En vido de mesaĝoj</string>
   <string name="volume_navigation_list">En vidoj de listoj</string>
-  <string name="hide_special_accounts_title">Kaŝi unuigitan ricevujon</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- nelegita</string>
   <string name="search_all_messages_title">Ĉiuj mesaĝoj</string>

--- a/app/ui/legacy/src/main/res/values-es/strings.xml
+++ b/app/ui/legacy/src/main/res/values-es/strings.xml
@@ -677,7 +677,6 @@ Por favor informe de fallos, aporte nueva funcionalidad o envíe sus preguntas a
   <string name="volume_navigation_title">Navegación con teclas de volumen</string>
   <string name="volume_navigation_message">Vista de mensaje</string>
   <string name="volume_navigation_list">Listas de mensajes</string>
-  <string name="hide_special_accounts_title">Ocultar bandeja unificada</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - No leído</string>
   <string name="search_all_messages_title">Todos los mensajes</string>

--- a/app/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eu/strings.xml
@@ -655,7 +655,6 @@ Mesedez akatsen berri emateko, ezaugarri berriak gehitzeko eta galderak egiteko
   <string name="volume_navigation_title">Bolumen teklekin nabigatu</string>
   <string name="volume_navigation_message">Mezu barruko ikuspegiak</string>
   <string name="volume_navigation_list">Zerrenda barruko ikuspegiak</string>
-  <string name="hide_special_accounts_title">Ezkutatu sarrerako ontzi bateratua</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Irakurri gabe</string>
   <string name="search_all_messages_title">Mezu guztiak</string>

--- a/app/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fa/strings.xml
@@ -677,7 +677,6 @@
   <string name="volume_navigation_title">جابه‌جایی با کلیدهای تنظیم صدا</string>
   <string name="volume_navigation_message">در نماهای پیام</string>
   <string name="volume_navigation_list">در نماهای لیستی</string>
-  <string name="hide_special_accounts_title">پنهان‌کردن صندوق ورودی یکپارچه</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- نخوانده</string>
   <string name="search_all_messages_title">همهٔ پیام‌ها</string>

--- a/app/ui/legacy/src/main/res/values-fi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fi/strings.xml
@@ -685,7 +685,6 @@ Ilmoita virheistä, ota osaa sovelluskehitykseen ja esitä kysymyksiä osoittees
   <string name="volume_navigation_title">Navigointi äänenvoimakkuusnäppäimillä</string>
   <string name="volume_navigation_message">Viestinäkymä</string>
   <string name="volume_navigation_list">Erilaisia listanäkymiä</string>
-  <string name="hide_special_accounts_title">Piilota yhdistetyt saapuneet</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Lukemattomat</string>
   <string name="search_all_messages_title">Kaikki viestit</string>

--- a/app/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fr/strings.xml
@@ -685,7 +685,6 @@ jusqu’à <xliff:g id="messages_to_load">%d</xliff:g> de plus</string>
   <string name="volume_navigation_title">Navigation à l’aide de la touche de volume</string>
   <string name="volume_navigation_message">Dans les vues des courriels</string>
   <string name="volume_navigation_list">Dans les vues en liste</string>
-  <string name="hide_special_accounts_title">Cacher la boîte de réception unifiée</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Non lu</string>
   <string name="search_all_messages_title">Tous les courriels</string>

--- a/app/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hr/strings.xml
@@ -649,7 +649,6 @@
   <string name="volume_navigation_title">Navigacija tipkama glasnoće</string>
   <string name="volume_navigation_message">U pregledu poruka</string>
   <string name="volume_navigation_list">U pregledu popisa</string>
-  <string name="hide_special_accounts_title">Sakrij objedinjenu dolaznu poštu</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- Nepročitano</string>
   <string name="search_all_messages_title">Sve poruke</string>

--- a/app/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hu/strings.xml
@@ -676,7 +676,6 @@ Hibajelentések beküldésével hozzájárulhatunk új funkciókhoz és kérdés
   <string name="volume_navigation_title">Hangerő gomb navigáció</string>
   <string name="volume_navigation_message">Üzenetnézetekben</string>
   <string name="volume_navigation_list">Listanézetekben</string>
-  <string name="hide_special_accounts_title">Egységes beérkezett üzenetek elrejtése</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">– Olvasatlan</string>
   <string name="search_all_messages_title">Összes üzenet</string>

--- a/app/ui/legacy/src/main/res/values-in/strings.xml
+++ b/app/ui/legacy/src/main/res/values-in/strings.xml
@@ -676,7 +676,6 @@ Kirimkan laporan bug, kontribusikan fitur baru dan ajukan pertanyaan di
   <string name="volume_navigation_title">Navigasi tombol volume</string>
   <string name="volume_navigation_message">Dalam tampilan pesan</string>
   <string name="volume_navigation_list">Dalam tampilan daftar</string>
-  <string name="hide_special_accounts_title">Sembunyikan Kotak Masuk Terpadu</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- Belum dibaca</string>
   <string name="search_all_messages_title">Semua pesan</string>

--- a/app/ui/legacy/src/main/res/values-is/strings.xml
+++ b/app/ui/legacy/src/main/res/values-is/strings.xml
@@ -678,7 +678,6 @@ Sendu inn villuskýrslur, leggðu fram nýja eiginleika og spurðu spurninga á
   <string name="volume_navigation_title">Flakk með hljóðstyrkshnöppum</string>
   <string name="volume_navigation_message">Í skilaboðasýnum</string>
   <string name="volume_navigation_list">Í listasýnum</string>
-  <string name="hide_special_accounts_title">Fela sameinað innhólf</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- Ólesið</string>
   <string name="search_all_messages_title">Öll skilaboð</string>

--- a/app/ui/legacy/src/main/res/values-it/strings.xml
+++ b/app/ui/legacy/src/main/res/values-it/strings.xml
@@ -688,7 +688,6 @@ Invia segnalazioni di bug, contribuisci con nuove funzionalità e poni domande s
   <string name="volume_navigation_title">Navigazione con tasti volume</string>
   <string name="volume_navigation_message">In visualizzazione messaggi</string>
   <string name="volume_navigation_list">In visualizzazione elenco</string>
-  <string name="hide_special_accounts_title">Nascondi Posta in arrivo combinata</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- Non letto</string>
   <string name="search_all_messages_title">Tutti i messaggi</string>

--- a/app/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ja/strings.xml
@@ -676,7 +676,6 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
   <string name="volume_navigation_title">ボリュームキー操作</string>
   <string name="volume_navigation_message">メッセージ表示</string>
   <string name="volume_navigation_list">一覧表示</string>
-  <string name="hide_special_accounts_title">統合フォルダを非表示</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - 未読</string>
   <string name="search_all_messages_title">全メッセージ</string>

--- a/app/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lv/strings.xml
@@ -680,7 +680,6 @@ pat <xliff:g id="messages_to_load">%d</xliff:g> vairāk</string>
   <string name="volume_navigation_title">Skaļuma pogas navigācija</string>
   <string name="volume_navigation_message">Vēstuļu skatā</string>
   <string name="volume_navigation_list">Saraksta skatā</string>
-  <string name="hide_special_accounts_title">Paslēpt apvienoto pastkasti</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- nelasīts</string>
   <string name="search_all_messages_title">Visas vēstules</string>

--- a/app/ui/legacy/src/main/res/values-nb/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nb/strings.xml
@@ -677,7 +677,6 @@ til <xliff:g id="messages_to_load">%d</xliff:g> flere</string>
   <string name="volume_navigation_title">Navigering med lydstyrkeknapp</string>
   <string name="volume_navigation_message">I meldingsvisninger</string>
   <string name="volume_navigation_list">I listevisninger</string>
-  <string name="hide_special_accounts_title">Gjem samlet innboks</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- Uleste</string>
   <string name="search_all_messages_title">Alle meldinger</string>

--- a/app/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nl/strings.xml
@@ -682,7 +682,6 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   <string name="volume_navigation_title">Volume op/neer navigatie</string>
   <string name="volume_navigation_message">Bericht beeld</string>
   <string name="volume_navigation_list">Variabele lijst weergave</string>
-  <string name="hide_special_accounts_title">Gecombineerde postvak-in verbergen</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Ongelezen</string>
   <string name="search_all_messages_title">Alle berichten</string>

--- a/app/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pl/strings.xml
@@ -681,7 +681,6 @@ Wysłane z urządzenia Android za pomocą K-9 Mail. Proszę wybaczyć moją zwi�
   <string name="volume_navigation_title">Nawigacja przyciskiem głośności</string>
   <string name="volume_navigation_message">Wygląd wiadomości</string>
   <string name="volume_navigation_list">Różne widoki list</string>
-  <string name="hide_special_accounts_title">Ukryj zunifikowaną skrzynkę odbiorczą</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Nieprzeczytane</string>
   <string name="search_all_messages_title">Wszystkie wiadomości</string>

--- a/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -686,7 +686,6 @@ Por favor encaminhe relatórios de bugs, contribua com novos recursos e tire dú
   <string name="volume_navigation_title">Navegação com a tecla de volume</string>
   <string name="volume_navigation_message">Nas visualizações das mensagens</string>
   <string name="volume_navigation_list">Nas visualizações das listas</string>
-  <string name="hide_special_accounts_title">Ocultar a caixa de entrada unificada</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Não lido</string>
   <string name="search_all_messages_title">Todas as mensagens</string>

--- a/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -678,7 +678,6 @@ Por favor envie relatórios de falhas, contribua com novas funcionalidades e col
   <string name="volume_navigation_title">Navegação com as teclas de volume</string>
   <string name="volume_navigation_message">Na vista de mensagens</string>
   <string name="volume_navigation_list">Nas vistas em lista</string>
-  <string name="hide_special_accounts_title">Esconder Caixa de Entrada Unificada</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- Não lidos</string>
   <string name="search_all_messages_title">Todas as mensagens</string>

--- a/app/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ro/strings.xml
@@ -681,7 +681,6 @@ Uneori datorită faptului că cineva încearcă să te atace pe tine sau serveru
   <string name="volume_navigation_title">Navigare prin butonu de volum</string>
   <string name="volume_navigation_message">Vizualizări în mesaj</string>
   <string name="volume_navigation_list">Vizualizări în listă</string>
-  <string name="hide_special_accounts_title">Ascunde Căsuță poștală unificată</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Necitite</string>
   <string name="search_all_messages_title">Toate mesajele</string>

--- a/app/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ru/strings.xml
@@ -679,7 +679,6 @@ K-9 Mail — почтовый клиент для Android.
   <string name="volume_navigation_title">Прокрутка кнопками Vol+/-</string>
   <string name="volume_navigation_message">В сообщении</string>
   <string name="volume_navigation_list">В списке</string>
-  <string name="hide_special_accounts_title">Скрыть единый почтовый ящик</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">– не прочитано</string>
   <string name="search_all_messages_title">Вся почта</string>

--- a/app/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sl/strings.xml
@@ -691,7 +691,6 @@ dodatnih <xliff:g id="messages_to_load">%d</xliff:g> sporočil</string>
   <string name="volume_navigation_title">Dovoli upravljanje programa s tipko za glasnost</string>
   <string name="volume_navigation_message">V pogledu sporočil</string>
   <string name="volume_navigation_list">V pogledu seznamov</string>
-  <string name="hide_special_accounts_title">Skrij skupno mapo prejetih sporočil</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- Neprebrano</string>
   <string name="search_all_messages_title">Vsa sporočila</string>

--- a/app/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sq/strings.xml
@@ -688,7 +688,6 @@ Ju lutemi, parashtrim njoftimesh për të meta, kontribute për veçori të reaj
   <string name="volume_navigation_title">Lëvizje me buton volumi</string>
   <string name="volume_navigation_message">Në skenë mesazhi</string>
   <string name="volume_navigation_list">Në skenë liste</string>
-  <string name="hide_special_accounts_title">Fshihi Të marrat e Unifikuar</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier">- Të palexuar</string>
   <string name="search_all_messages_title">Krejt mesazhet</string>

--- a/app/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sr/strings.xml
@@ -689,7 +689,6 @@
   <string name="volume_navigation_title">Навигација тастерима за јачину звука</string>
   <string name="volume_navigation_message">у приказу порука</string>
   <string name="volume_navigation_list">у приказу спискова</string>
-  <string name="hide_special_accounts_title">Сакриј обједињено сандуче</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - непрочитане</string>
   <string name="search_all_messages_title">Све поруке</string>

--- a/app/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sv/strings.xml
@@ -678,7 +678,6 @@ Skicka gärna in felrapporter, bidra med nya funktioner och ställ frågor på
   <string name="volume_navigation_title">Navigering med volymknapp</string>
   <string name="volume_navigation_message">I meddelandelistor</string>
   <string name="volume_navigation_list">I listvyer</string>
-  <string name="hide_special_accounts_title">Dölj samlad inkorg</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Olästa</string>
   <string name="search_all_messages_title">Alla meddelanden</string>

--- a/app/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-tr/strings.xml
@@ -677,7 +677,6 @@ Microsoft Exchange ile konuşurken bazı tuhaflıklar yaşadığını not ediniz
   <string name="volume_navigation_title">Ses Düğmesi ile dolaşma</string>
   <string name="volume_navigation_message">İleti görünümlerinde</string>
   <string name="volume_navigation_list">liste görünümlerinde</string>
-  <string name="hide_special_accounts_title">Birleşik Gelen Kutusunu Gizle</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Okunmadı</string>
   <string name="search_all_messages_title">Bütün mesajlar</string>

--- a/app/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-uk/strings.xml
@@ -666,7 +666,6 @@ K-9 Mail — це вільний клієнт електронної пошти 
   <string name="volume_navigation_title">Навігація кнопками зміни гучності</string>
   <string name="volume_navigation_message">при перегляді повідомлень</string>
   <string name="volume_navigation_list">у списках</string>
-  <string name="hide_special_accounts_title">Приховати \"Об\'єднані Вхідні\"</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - Непрочитані</string>
   <string name="search_all_messages_title">Всі повідомлення</string>

--- a/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -682,7 +682,6 @@ K-9 Mail 是 Android 上一款功能强大的自由 email 客户端。
   <string name="volume_navigation_title">音量键导航</string>
   <string name="volume_navigation_message">信息视图</string>
   <string name="volume_navigation_list">不同的列表视图</string>
-  <string name="hide_special_accounts_title">隐藏统一收件箱</string>
   <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
   <string name="unread_modifier"> - 未读</string>
   <string name="search_all_messages_title">所有邮件</string>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -829,7 +829,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="volume_navigation_message">In message views</string>
     <string name="volume_navigation_list">In list views</string>
 
-    <string name="hide_special_accounts_title">Hide Unified Inbox</string>
+    <string name="show_unified_inbox_title">Show Unified Inbox</string>
 
     <string name="search_title"><xliff:g id="search_name">%s</xliff:g> <xliff:g id="modifier">%s</xliff:g></string>
     <string name="unread_modifier"> - Unread</string>

--- a/app/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/general_settings.xml
@@ -245,9 +245,8 @@
             android:title="@string/accountlist_preferences">
 
             <CheckBoxPreference
-                android:disableDependentsState="true"
-                android:key="hide_special_accounts"
-                android:title="@string/hide_special_accounts_title" />
+                android:key="show_unified_inbox"
+                android:title="@string/show_unified_inbox_title" />
 
         </PreferenceCategory>
 


### PR DESCRIPTION
This extracts the name change (`K9.isHideSpecialAccounts` to `K9.isShowUnifiedInbox`) from PR #5122 and takes it all the way.

- The entry under `General settings > Display` is renamed from "Hide Unified Inbox" to "Show Unified Inbox".
- The storage key is changed from `hideSpecialAccounts` to `showUnifiedInbox`.
- When exporting this value we now also use the key `showUnifiedInbox`.
- Upgrading from old app versions and importing old settings files performs the appropriate data migration.