### PR TITLE
Fix display in 'import settings' screen

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/import/SettingsImportViewModel.kt
@@ -233,7 +233,10 @@ class SettingsImportViewModel(
                     .mapIndexed { index, account -> index to account.uuid }
                     .toMap(mutableMapOf())
 
-                val items = mutableListOf<SettingsListItem>(SettingsListItem.GeneralSettings())
+                val items = mutableListOf<SettingsListItem>()
+                if (contents.globalSettings) {
+                    items.add(SettingsListItem.GeneralSettings())
+                }
                 contents.accounts.mapIndexedTo(items) { index, accountDescription ->
                     SettingsListItem.Account(index, accountDescription.name)
                 }


### PR DESCRIPTION
Only show 'general settings' as an option when the settings file actually contains general settings :see_no_evil: 

<img src="https://user-images.githubusercontent.com/218061/107154879-8f3a8800-6975-11eb-8032-596d03f89876.png" alt="k9mail_import_general_settings" width=300> <img src="https://user-images.githubusercontent.com/218061/107154880-8fd31e80-6975-11eb-848d-7f6f15644c7f.png" alt="k9mail_import_no_general_settings" width=300>