### PR TITLE
Try to create email tokens in recipient input field when it loses focus

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/RecipientSelectView.java
@@ -204,6 +204,10 @@ public class RecipientSelectView extends TokenCompleteTextView<Recipient> implem
 
     @Override
     public void onFocusChanged(boolean hasFocus, int direction, Rect previous) {
+        if (!hasFocus) {
+            performCompletion();
+        }
+
         super.onFocusChanged(hasFocus, direction, previous);
         if (hasFocus) {
             displayKeyboard();


### PR DESCRIPTION
Try to convert input text to tokens when changing focus away from recipient views in the "compose" screen. This seems to match the behavior in 5.600. It also works around a number of issues the `TokenAutoComplete` library has when text is collapsed to one line.

Fixes #5004