### PR TITLE
Fix swipeRefreshLayout being hidden before refresh is finished

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -88,10 +88,15 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
 
             val progressViewStart = view.measuredHeight
             val progressViewEnd = progressViewStart + (PROGRESS_VIEW_END_OFFSET * densityMultiplier).toInt()
-            swipeRefreshLayout.setProgressViewOffset(true, progressViewStart, progressViewEnd)
 
-            val slingshotDistance = (PROGRESS_VIEW_SLINGSHOT_DISTANCE * densityMultiplier).toInt()
-            swipeRefreshLayout.setSlingshotDistance(slingshotDistance)
+            val progressViewStartOld = swipeRefreshLayout.progressViewStartOffset
+            val progressViewEndOld = swipeRefreshLayout.progressViewEndOffset
+            if (progressViewStart != progressViewStartOld || progressViewEnd != progressViewEndOld) {
+                swipeRefreshLayout.setProgressViewOffset(true, progressViewStart, progressViewEnd)
+
+                val slingshotDistance = (PROGRESS_VIEW_SLINGSHOT_DISTANCE * densityMultiplier).toInt()
+                swipeRefreshLayout.setSlingshotDistance(slingshotDistance)
+            }
         }
 
         addFooterItems()


### PR DESCRIPTION
Setting `progressViewOffset` hides the circle thing, and was called whenever a folder was completed. The code now checks if there is something to do, so that the circle stays until refreshing is completed.