### PR TITLE
Fix MessageCompose activity enabled status

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Core.kt
+++ b/app/core/src/main/java/com/fsck/k9/Core.kt
@@ -46,7 +46,7 @@ object Core : EarlyInit {
     @JvmStatic
     fun setServicesEnabled(context: Context) {
         val appContext = context.applicationContext
-        val acctLength = Preferences.getPreferences(appContext).availableAccounts.size
+        val acctLength = Preferences.getPreferences(appContext).accounts.size
         val enable = acctLength > 0
 
         setServicesEnabled(appContext, enable)


### PR DESCRIPTION
Fixes #5140

Applied the proposed change mentioned in issue #5140.
getavailableAccounts -> getaccounts
