### PR TITLE
Fix mail checks

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -192,16 +192,6 @@ public class Account implements BaseAccount {
     private boolean changedVisibleLimits = false;
 
     /**
-     * Indicates whether this account is enabled, i.e. ready for use, or not.
-     *
-     * <p>
-     * Right now newly imported accounts are disabled if the settings file didn't contain a
-     * password for the incoming and/or outgoing server.
-     * </p>
-     */
-    private boolean isEnabled;
-
-    /**
      * Database ID of the folder that was last selected for a copy or move operation.
      *
      * Note: For now this value isn't persisted. So it will be reset when K-9 Mail is restarted.
@@ -1082,14 +1072,6 @@ public class Account implements BaseAccount {
         String localStorageProviderId = getLocalStorageProviderId();
         boolean storageProviderIsInternalMemory = localStorageProviderId == null;
         return storageProviderIsInternalMemory || StorageManager.getInstance(context).isReady(localStorageProviderId);
-    }
-
-    public synchronized boolean isEnabled() {
-        return isEnabled;
-    }
-
-    public synchronized void setEnabled(boolean enabled) {
-        isEnabled = enabled;
     }
 
     public synchronized boolean isMarkMessageAsReadOnView() {

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -173,7 +173,6 @@ class AccountPreferenceSerializer(
             remoteSearchNumResults = storage.getInt("$accountUuid.remoteSearchNumResults", DEFAULT_REMOTE_SEARCH_NUM_RESULTS)
             isUploadSentMessages = storage.getBoolean("$accountUuid.uploadSentMessages", true)
 
-            isEnabled = storage.getBoolean("$accountUuid.enabled", true)
             isMarkMessageAsReadOnView = storage.getBoolean("$accountUuid.markMessageAsReadOnView", true)
             isMarkMessageAsReadOnDelete = storage.getBoolean("$accountUuid.markMessageAsReadOnDelete", true)
             isAlwaysShowCcBcc = storage.getBoolean("$accountUuid.alwaysShowCcBcc", false)
@@ -328,7 +327,6 @@ class AccountPreferenceSerializer(
             editor.putBoolean("$accountUuid.remoteSearchFullText", isRemoteSearchFullText)
             editor.putInt("$accountUuid.remoteSearchNumResults", remoteSearchNumResults)
             editor.putBoolean("$accountUuid.uploadSentMessages", isUploadSentMessages)
-            editor.putBoolean("$accountUuid.enabled", isEnabled)
             editor.putBoolean("$accountUuid.markMessageAsReadOnView", isMarkMessageAsReadOnView)
             editor.putBoolean("$accountUuid.markMessageAsReadOnDelete", isMarkMessageAsReadOnDelete)
             editor.putBoolean("$accountUuid.alwaysShowCcBcc", isAlwaysShowCcBcc)
@@ -604,7 +602,6 @@ class AccountPreferenceSerializer(
             isRemoteSearchFullText = false
             remoteSearchNumResults = DEFAULT_REMOTE_SEARCH_NUM_RESULTS
             isUploadSentMessages = true
-            isEnabled = true
             isMarkMessageAsReadOnView = true
             isMarkMessageAsReadOnDelete = true
             isAlwaysShowCcBcc = false

--- a/app/core/src/main/java/com/fsck/k9/Preferences.java
+++ b/app/core/src/main/java/com/fsck/k9/Preferences.java
@@ -149,7 +149,7 @@ public class Preferences {
         List<Account> allAccounts = getAccounts();
         Collection<Account> result = new ArrayList<>(allAccounts.size());
         for (Account account : allAccounts) {
-            if (account.isEnabled() && account.isAvailable(context)) {
+            if (account.isAvailable(context)) {
                 result.add(account);
             }
         }

--- a/app/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
+++ b/app/core/src/test/java/com/fsck/k9/preferences/SettingsImporterTest.java
@@ -16,7 +16,6 @@ import org.junit.Test;
 import org.robolectric.RuntimeEnvironment;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 
@@ -171,9 +170,6 @@ public class SettingsImporterTest extends K9RobolectricTest {
         assertEquals(validUUID, results.importedAccounts.get(0).imported.uuid);
         assertTrue(results.importedAccounts.get(0).incomingPasswordNeeded);
         assertTrue(results.importedAccounts.get(0).outgoingPasswordNeeded);
-
-        assertFalse(Preferences.getPreferences(RuntimeEnvironment.application)
-                .getAccount(validUUID).isEnabled());
     }
 
     @Test

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -1684,6 +1684,10 @@ class MessageListFragment :
             }
         }
 
+        override fun checkMailFinished(context: Context?, account: Account?) {
+            handler.progress(false)
+        }
+
         private fun updateForMe(account: Account?, folderId: Long): Boolean {
             if (account == null || account.uuid !in accountUuids) return false
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/import/AccountActivator.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/import/AccountActivator.kt
@@ -39,8 +39,6 @@ class AccountActivator(
             account.outgoingServerSettings = account.outgoingServerSettings.newPassword(outgoingServerPassword)
         }
 
-        account.isEnabled = true
-
         preferences.saveAccount(account)
     }
 }


### PR DESCRIPTION
After importing accounts we only mark them as "enabled" when the user supplies the server passwords right away. We allow deferring that action, but then never mark the account as enabled. During mail checks accounts not marked as enabled are skipped. Manually checking individual folders did work, though.

This change gets rid of the "enabled" mechanism. It was used to prevent users from viewing the account before entering the server passwords. With the new UI this approach is no longer possible.

Fixes #5139