### PR TITLE
Make sure downloaded images are accessible via the system's file picker

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -9,6 +9,8 @@ import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Environment;
 import android.os.Message;
 import android.text.TextUtils;
 import android.util.AttributeSet;
@@ -337,6 +339,10 @@ public class MessageContainerView extends LinearLayout implements OnCreateContex
 
     private void downloadImage(Uri uri) {
         DownloadManager.Request request = new DownloadManager.Request(uri);
+        if (Build.VERSION.SDK_INT >= 29) {
+            String filename = uri.getLastPathSegment();
+            request.setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename);
+        }
         request.setNotificationVisibility(VISIBILITY_VISIBLE_NOTIFY_COMPLETED);
 
         DownloadManager downloadManager = (DownloadManager) getContext().getSystemService(Context.DOWNLOAD_SERVICE);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.Locale;
 
 import android.app.Activity;
-import android.app.DownloadManager;
 import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
@@ -93,7 +92,6 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
     private MessageReference mMessageReference;
     private LocalMessage mMessage;
     private MessagingController mController;
-    private DownloadManager downloadManager;
     private Handler handler = new Handler();
     private MessageLoaderHelper messageLoaderHelper;
     private MessageCryptoPresenter messageCryptoPresenter;
@@ -140,7 +138,6 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
 
         Context context = getActivity().getApplicationContext();
         mController = MessagingController.getInstance(context);
-        downloadManager = (DownloadManager) context.getSystemService(Context.DOWNLOAD_SERVICE);
         messageCryptoPresenter = new MessageCryptoPresenter(messageCryptoMvpView);
         messageLoaderHelper = messageLoaderHelperFactory.createForMessageView(
                 context, getLoaderManager(), getParentFragmentManager(), messageLoaderCallbacks);


### PR DESCRIPTION
Starting with API 29 files downloaded with DownloadManager are not automatically written to a location that is accessible via the system's file picker. Manually specifying the 'Downloads' directory does work and doesn't require the WRITE_EXTERNAL_STORAGE permission (on API 29+).

Related: #4995