### PR TITLE
Added menu to 'edit identity' screen

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
@@ -1,6 +1,8 @@
 package com.fsck.k9.activity
 
 import android.os.Bundle
+import android.view.Menu
+import android.view.MenuItem
 import androidx.core.view.isVisible
 import com.fsck.k9.Account
 import com.fsck.k9.Identity
@@ -17,6 +19,7 @@ class EditIdentity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setLayout(R.layout.edit_identity)
+        supportActionBar!!.setDisplayHomeAsUpEnabled(true)
 
         identityIndex = intent.getIntExtra(EXTRA_IDENTITY_INDEX, -1)
         val accountUuid = intent.getStringExtra(EXTRA_ACCOUNT)
@@ -77,14 +80,26 @@ class EditIdentity : K9Activity() {
         finish()
     }
 
-    override fun onBackPressed() {
-        saveIdentity()
-        super.onBackPressed()
-    }
-
     public override fun onSaveInstanceState(outState: Bundle) {
         super.onSaveInstanceState(outState)
         outState.putParcelable(EXTRA_IDENTITY, identity)
+    }
+
+    override fun onCreateOptionsMenu(menu: Menu?): Boolean {
+        menuInflater.inflate(R.menu.edit_identity_menu, menu)
+        return true
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            finish()
+            return true
+        } else if (item.itemId == R.id.edit_identity_save) {
+            saveIdentity()
+            finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
     }
 
     companion object {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/ManageIdentities.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/ManageIdentities.java
@@ -2,6 +2,7 @@ package com.fsck.k9.activity;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Bundle;
 import android.view.ContextMenu;
 import android.view.ContextMenu.ContextMenuInfo;
 import android.view.Menu;
@@ -25,6 +26,12 @@ public class ManageIdentities extends ChooseIdentity {
         Intent intent = new Intent(activity, ManageIdentities.class);
         intent.putExtra(ChooseIdentity.EXTRA_ACCOUNT, accountUuid);
         activity.startActivity(intent);
+    }
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
 
     @Override
@@ -60,6 +67,8 @@ public class ManageIdentities extends ChooseIdentity {
             Intent intent = new Intent(ManageIdentities.this, EditIdentity.class);
             intent.putExtra(EditIdentity.EXTRA_ACCOUNT, mAccount.getUuid());
             startActivityForResult(intent, ACTIVITY_EDIT_IDENTITY);
+        } else if (item.getItemId() == android.R.id.home) {
+            finish();
         } else {
             return super.onOptionsItemSelected(item);
         }

--- a/app/ui/legacy/src/main/res/menu/edit_identity_menu.xml
+++ b/app/ui/legacy/src/main/res/menu/edit_identity_menu.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+      xmlns:app="http://schemas.android.com/apk/res-auto">
+    <item
+        android:id="@+id/edit_identity_save"
+        android:title="@string/edit_identity_save"
+        app:showAsAction="always" />
+</menu>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -706,6 +706,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="manage_identities_context_menu_title">Manage identity</string>
 
     <string name="edit_identity_title">Edit identity</string>
+    <string name="edit_identity_save">Save</string>
     <string name="new_identity_action">New identity</string>
 
     <string name="account_settings_always_bcc_label">Bcc all messages to</string>


### PR DESCRIPTION
Whenever I use the "Edit identity" screen, I am confused that there is no "save" button. This simple PR adds an OK button to the ActionBar. I also added the up arrow buttons.