### PR TITLE
Don't start another instance of AccountSettingsActivity when removing an account

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSelectionSpinner.kt
@@ -7,12 +7,12 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
-import android.widget.Spinner
+import androidx.appcompat.widget.AppCompatSpinner
 import com.fsck.k9.Account
 import com.fsck.k9.ui.R
 import kotlinx.android.synthetic.main.account_list_item.view.*
 
-class AccountSelectionSpinner : Spinner {
+class AccountSelectionSpinner : AppCompatSpinner {
     var selection: Account
         get() = selectedItem as Account
         set(account) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsActivity.kt
@@ -59,7 +59,7 @@ class AccountSettingsActivity : K9Activity(), OnPreferenceStartScreenCallback {
     }
 
     private fun onAccountSelected(selectedAccountUuid: String) {
-        if (selectedAccountUuid != accountUuid) {
+        if (selectedAccountUuid != accountUuid && !isFinishing) {
             start(this, selectedAccountUuid)
             finish()
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -328,8 +328,8 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     }
 
     override fun doPositiveClick(dialogId: Int) {
-        accountRemover.removeAccountAsync(accountUuid)
         closeAccountSettings()
+        accountRemover.removeAccountAsync(accountUuid)
     }
 
     override fun doNegativeClick(dialogId: Int) = Unit


### PR DESCRIPTION
Removing an account will trigger an update of `AccountSelectionSpinner` which will then detect the currently selected item is no longer available. It'll mark the first item as selected which in turn will trigger a call to `onAccountSelected()`. That will start `AccountSettingsActivity` with the newly selected account.
We now check whether `finish()` has already been called (because deleting the account will do that) and not start another instance of `AccountSettingsActivity` in that case.
