### PR TITLE
Add support for In-Reply-To parameter in mailto: URIs

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1484,10 +1484,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         String inReplyTo = mailTo.getInReplyTo();
-        if (inReplyTo != null && !inReplyTo.isEmpty()) {
-            // See https://tools.ietf.org/html/rfc5322 section 3.6.4 msg-id format:
-            // msg-id          =   [CFWS] "<" id-left "@" id-right ">" [CFWS]
-            repliedToMessageId = "<" + inReplyTo + ">";
+        if (inReplyTo != null) {
+            repliedToMessageId = inReplyTo;
         }
 
         String body = mailTo.getBody();

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1483,6 +1483,13 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             subjectView.setText(subject);
         }
 
+        String inReplyTo = mailTo.getInReplyTo();
+        if (inReplyTo != null && !inReplyTo.isEmpty()) {
+            // See https://tools.ietf.org/html/rfc5322 section 3.6.4 msg-id format:
+            // msg-id          =   [CFWS] "<" id-left "@" id-right ">" [CFWS]
+            repliedToMessageId = "<" + inReplyTo + ">";
+        }
+
         String body = mailTo.getBody();
         if (body != null && !body.isEmpty()) {
             messageContentView.setText(CrLfConverter.toLf(body));

--- a/mail/common/src/main/java/com/fsck/k9/helper/MailTo.java
+++ b/mail/common/src/main/java/com/fsck/k9/helper/MailTo.java
@@ -77,11 +77,7 @@ public final class MailTo {
         if (inReplyTo != null) {
             try {
                 List<String> inReplyToMessageIds = MessageIdParser.parseList(inReplyTo);
-                if (inReplyToMessageIds != null && !inReplyToMessageIds.isEmpty()) {
-                    String firstMessageId = inReplyToMessageIds.get(0);
-                    if (firstMessageId != null && !firstMessageId.isEmpty())
-                        inReplyToMessageId = firstMessageId;
-                }
+                inReplyToMessageId = inReplyToMessageIds.get(0);
             } catch (MimeHeaderParserException e) {
                 Timber.w(e, "Ignoring invalid in-reply-to value within the mailto: link.");
             }

--- a/mail/common/src/main/java/com/fsck/k9/helper/MailTo.java
+++ b/mail/common/src/main/java/com/fsck/k9/helper/MailTo.java
@@ -4,6 +4,9 @@ package com.fsck.k9.helper;
 import android.net.Uri;
 
 import com.fsck.k9.mail.Address;
+import com.fsck.k9.mail.internet.MessageIdParser;
+import com.fsck.k9.mail.internet.MimeHeaderParserException;
+import timber.log.Timber;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,8 +70,22 @@ public final class MailTo {
         Address[] bccAddresses = toAddressArray(bccList);
 
         String subject = getFirstParameterValue(params, SUBJECT);
-        String inReplyToMessageId = getFirstParameterValue(params, IN_REPLY_TO);
         String body = getFirstParameterValue(params, BODY);
+        String inReplyTo = getFirstParameterValue(params, IN_REPLY_TO);
+
+        String inReplyToMessageId = null;
+        if (inReplyTo != null) {
+            try {
+                List<String> inReplyToMessageIds = MessageIdParser.parseList(inReplyTo);
+                if (inReplyToMessageIds != null && !inReplyToMessageIds.isEmpty()) {
+                    String firstMessageId = inReplyToMessageIds.get(0);
+                    if (firstMessageId != null && !firstMessageId.isEmpty())
+                        inReplyToMessageId = firstMessageId;
+                }
+            } catch (MimeHeaderParserException e) {
+                Timber.w(e, "Ignoring invalid in-reply-to value within the mailto: link.");
+            }
+        }
 
         return new MailTo(toAddresses, ccAddresses, bccAddresses, inReplyToMessageId, subject, body);
     }

--- a/mail/common/src/main/java/com/fsck/k9/helper/MailTo.java
+++ b/mail/common/src/main/java/com/fsck/k9/helper/MailTo.java
@@ -12,6 +12,7 @@ import java.util.List;
 public final class MailTo {
     private static final String MAILTO_SCHEME = "mailto";
     private static final String TO = "to";
+    private static final String IN_REPLY_TO = "in-reply-to";
     private static final String BODY = "body";
     private static final String CC = "cc";
     private static final String BCC = "bcc";
@@ -23,6 +24,7 @@ public final class MailTo {
     private final Address[] toAddresses;
     private final Address[] ccAddresses;
     private final Address[] bccAddresses;
+    private final String inReplyToMessageId;
     private final String subject;
     private final String body;
 
@@ -65,9 +67,10 @@ public final class MailTo {
         Address[] bccAddresses = toAddressArray(bccList);
 
         String subject = getFirstParameterValue(params, SUBJECT);
+        String inReplyToMessageId = getFirstParameterValue(params, IN_REPLY_TO);
         String body = getFirstParameterValue(params, BODY);
 
-        return new MailTo(toAddresses, ccAddresses, bccAddresses, subject, body);
+        return new MailTo(toAddresses, ccAddresses, bccAddresses, inReplyToMessageId, subject, body);
     }
 
     private static String getFirstParameterValue(CaseInsensitiveParamWrapper params, String paramName) {
@@ -95,10 +98,12 @@ public final class MailTo {
         return stringBuilder.toString();
     }
 
-    private MailTo(Address[] toAddresses, Address[] ccAddresses, Address[] bccAddresses, String subject, String body) {
+    private MailTo(Address[] toAddresses, Address[] ccAddresses, Address[] bccAddresses, String inReplyToMessageId,
+            String subject, String body) {
         this.toAddresses = toAddresses;
         this.ccAddresses = ccAddresses;
         this.bccAddresses = bccAddresses;
+        this.inReplyToMessageId = inReplyToMessageId;
         this.subject = subject;
         this.body = body;
     }
@@ -123,6 +128,7 @@ public final class MailTo {
         return body;
     }
 
+    public String getInReplyTo() { return inReplyToMessageId; }
 
     static class CaseInsensitiveParamWrapper {
         private final Uri uri;

--- a/mail/common/src/test/java/com/fsck/k9/helper/MailToTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/helper/MailToTest.java
@@ -7,6 +7,7 @@ import com.fsck.k9.helper.MailTo.CaseInsensitiveParamWrapper;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 
+import com.fsck.k9.mail.internet.MimeHeaderParserException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -187,4 +188,52 @@ public class MailToTest {
 
         assertThat(Collections.<String>emptyList(), is(result));
     }
+
+    @Test
+    public void testGetInReplyTo_singleMessageId() {
+        Uri uri = Uri.parse("mailto:?in-reply-to=<7C72B202-73F3@somewhere>");
+
+        MailTo mailToHelper = MailTo.parse(uri);
+
+        assertEquals(mailToHelper.getInReplyTo(), "<7C72B202-73F3@somewhere>");
+    }
+
+    @Test
+    public void testGetInReplyTo_multipleMessageIds() {
+        Uri uri = Uri.parse("mailto:?in-reply-to=<7C72B202-73F3@somewhere>;<8A39-1A87CB40C114@somewhereelse>");
+
+        MailTo mailToHelper = MailTo.parse(uri);
+
+        assertEquals(mailToHelper.getInReplyTo(), null);
+    }
+
+
+    @Test
+    public void testGetInReplyTo_RFC6068Example() {
+        Uri uri = Uri.parse("mailto:list@example.org?In-Reply-To=%3C3469A91.D10AF4C@example.com%3E");
+
+        MailTo mailToHelper = MailTo.parse(uri);
+
+        assertEquals(mailToHelper.getInReplyTo(), "<3469A91.D10AF4C@example.com>");
+    }
+
+    @Test
+    public void testGetInReplyTo_invalid() {
+        Uri uri = Uri.parse("mailto:?in-reply-to=7C72B202-73F3somewhere");
+
+        MailTo mailToHelper = MailTo.parse(uri);
+
+        assertEquals(mailToHelper.getInReplyTo(), null);
+    }
+
+    @Test
+    public void testGetInReplyTo_empty() {
+        Uri uri = Uri.parse("mailto:?in-reply-to=");
+
+        MailTo mailToHelper = MailTo.parse(uri);
+
+        assertEquals(mailToHelper.getInReplyTo(), null);
+
+    }
+
 }

--- a/mail/common/src/test/java/com/fsck/k9/helper/MailToTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/helper/MailToTest.java
@@ -7,7 +7,6 @@ import com.fsck.k9.helper.MailTo.CaseInsensitiveParamWrapper;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.K9LibRobolectricTestRunner;
 
-import com.fsck.k9.mail.internet.MimeHeaderParserException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -191,20 +190,20 @@ public class MailToTest {
 
     @Test
     public void testGetInReplyTo_singleMessageId() {
-        Uri uri = Uri.parse("mailto:?in-reply-to=<7C72B202-73F3@somewhere>");
+        Uri uri = Uri.parse("mailto:?in-reply-to=%3C7C72B202-73F3@somewhere%3E");
 
         MailTo mailToHelper = MailTo.parse(uri);
 
-        assertEquals(mailToHelper.getInReplyTo(), "<7C72B202-73F3@somewhere>");
+        assertEquals("<7C72B202-73F3@somewhere>", mailToHelper.getInReplyTo());
     }
 
     @Test
     public void testGetInReplyTo_multipleMessageIds() {
-        Uri uri = Uri.parse("mailto:?in-reply-to=<7C72B202-73F3@somewhere>;<8A39-1A87CB40C114@somewhereelse>");
+        Uri uri = Uri.parse("mailto:?in-reply-to=%3C7C72B202-73F3@somewhere%3E%3C8A39-1A87CB40C114@somewhereelse%3E");
 
         MailTo mailToHelper = MailTo.parse(uri);
 
-        assertEquals(mailToHelper.getInReplyTo(), null);
+        assertEquals("<7C72B202-73F3@somewhere>", mailToHelper.getInReplyTo());
     }
 
 
@@ -214,7 +213,7 @@ public class MailToTest {
 
         MailTo mailToHelper = MailTo.parse(uri);
 
-        assertEquals(mailToHelper.getInReplyTo(), "<3469A91.D10AF4C@example.com>");
+        assertEquals("<3469A91.D10AF4C@example.com>", mailToHelper.getInReplyTo());
     }
 
     @Test
@@ -223,7 +222,7 @@ public class MailToTest {
 
         MailTo mailToHelper = MailTo.parse(uri);
 
-        assertEquals(mailToHelper.getInReplyTo(), null);
+        assertEquals(null, mailToHelper.getInReplyTo());
     }
 
     @Test
@@ -232,7 +231,7 @@ public class MailToTest {
 
         MailTo mailToHelper = MailTo.parse(uri);
 
-        assertEquals(mailToHelper.getInReplyTo(), null);
+        assertEquals(null, mailToHelper.getInReplyTo());
 
     }
 


### PR DESCRIPTION
According to the RFC In-Reply-To header could contain
multiple addresses with flexible format. K-9 creently
supports only a single In-Reply-To, so I assumed a
single In-Reply-To for mailto: links, to keep it simple.

Fixes https://github.com/k9mail/k-9/issues/5193
Initial disucssion at: https://forum.k9mail.app/t/in-reply-to-header-not-set/766