### PR TITLE
Load account images off the main thread

### DIFF
--- a/app/ui/legacy/build.gradle
+++ b/app/ui/legacy/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation "de.cketti.library.changelog:ckchangelog-core:2.0.0-beta01"
     implementation "com.splitwise:tokenautocomplete:4.0.0-beta01"
     implementation "de.cketti.safecontentresolver:safe-content-resolver-v21:1.0.0"
-    implementation 'com.mikepenz:materialdrawer:8.3.3'
+    implementation 'com.mikepenz:materialdrawer:8.4.0'
     implementation 'com.mikepenz:materialdrawer-iconics:8.3.3'
     implementation 'com.mikepenz:fontawesome-typeface:5.9.0.0-kotlin@aar'
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'

--- a/app/ui/legacy/src/main/java/com/fsck/k9/contacts/ContactPictureGlideModule.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/contacts/ContactPictureGlideModule.java
@@ -8,17 +8,28 @@ import com.bumptech.glide.Registry;
 import com.bumptech.glide.annotation.GlideModule;
 import com.bumptech.glide.module.LibraryGlideModule;
 import com.fsck.k9.DI;
-
+import com.fsck.k9.ui.account.AccountImage;
+import com.fsck.k9.ui.account.AccountImageModelLoaderFactory;
 import org.jetbrains.annotations.NotNull;
 
 @GlideModule
 public class ContactPictureGlideModule extends LibraryGlideModule {
     @Override
-    public void registerComponents(@NotNull Context context, @NotNull Glide glide, Registry registry) {
+    public void registerComponents(@NotNull Context context, @NotNull Glide glide, @NotNull Registry registry) {
+        registerContactImage(glide, registry);
+        registerAccountImage(registry);
+    }
+
+    private void registerContactImage(@NotNull Glide glide, @NotNull Registry registry) {
         registry.append(ContactImage.class, ContactImage.class, new ContactImageModelLoaderFactory());
 
         ContactImageBitmapDecoderFactory factory = DI.get(ContactImageBitmapDecoderFactory.class);
         ContactImageBitmapDecoder contactImageBitmapDecoder = factory.create(glide.getBitmapPool());
         registry.append(ContactImage.class, Bitmap.class, contactImageBitmapDecoder);
+    }
+
+    private void registerAccountImage(@NotNull Registry registry) {
+        AccountImageModelLoaderFactory factory = DI.get(AccountImageModelLoaderFactory.class);
+        registry.append(AccountImage.class, Bitmap.class, factory);
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountFallbackImageProvider.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountFallbackImageProvider.kt
@@ -1,0 +1,25 @@
+package com.fsck.k9.ui.account
+
+import android.content.Context
+import android.graphics.drawable.Drawable
+import com.fsck.k9.ui.R
+import com.mikepenz.iconics.IconicsDrawable
+import com.mikepenz.iconics.typeface.library.fontawesome.FontAwesome
+import com.mikepenz.iconics.utils.backgroundColorInt
+import com.mikepenz.iconics.utils.colorRes
+import com.mikepenz.iconics.utils.paddingDp
+import com.mikepenz.iconics.utils.sizeDp
+
+/**
+ * Provides a [Drawable] for the account using the account's color as background color.
+ */
+class AccountFallbackImageProvider(private val context: Context) {
+    fun getDrawable(color: Int): Drawable {
+        return IconicsDrawable(context, FontAwesome.Icon.faw_user_alt).apply {
+            colorRes = R.color.material_drawer_profile_icon
+            backgroundColorInt = color
+            sizeDp = 56
+            paddingDp = 12
+        }
+    }
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountImageLoader.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountImageLoader.kt
@@ -1,0 +1,23 @@
+package com.fsck.k9.ui.account
+
+import android.widget.ImageView
+import com.bumptech.glide.Glide
+import com.bumptech.glide.load.engine.DiskCacheStrategy
+
+/**
+ * Load the account image into an [ImageView].
+ */
+class AccountImageLoader(private val accountFallbackImageProvider: AccountFallbackImageProvider) {
+    fun setAccountImage(imageView: ImageView, email: String, color: Int) {
+        Glide.with(imageView.context)
+            .load(AccountImage(email, color))
+            .placeholder(accountFallbackImageProvider.getDrawable(color))
+            .diskCacheStrategy(DiskCacheStrategy.NONE)
+            .dontAnimate()
+            .into(imageView)
+    }
+
+    fun cancel(imageView: ImageView) {
+        Glide.with(imageView.context).clear(imageView)
+    }
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountImageModelLoader.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountImageModelLoader.kt
@@ -1,0 +1,91 @@
+package com.fsck.k9.ui.account
+
+import android.graphics.Bitmap
+import androidx.core.graphics.drawable.toBitmap
+import com.bumptech.glide.Priority
+import com.bumptech.glide.load.DataSource
+import com.bumptech.glide.load.Key
+import com.bumptech.glide.load.Options
+import com.bumptech.glide.load.data.DataFetcher
+import com.bumptech.glide.load.model.ModelLoader
+import com.bumptech.glide.load.model.ModelLoaderFactory
+import com.bumptech.glide.load.model.MultiModelLoaderFactory
+import com.fsck.k9.contacts.ContactPhotoLoader
+import java.security.MessageDigest
+
+/**
+ * A custom [ModelLoader] so we can use [AccountImageDataFetcher] to load the account image.
+ */
+internal class AccountImageModelLoader(
+    private val contactPhotoLoader: ContactPhotoLoader,
+    private val accountFallbackImageProvider: AccountFallbackImageProvider,
+) : ModelLoader<AccountImage, Bitmap> {
+    override fun buildLoadData(
+        accountImage: AccountImage,
+        width: Int,
+        height: Int,
+        options: Options
+    ): ModelLoader.LoadData<Bitmap> {
+        val dataFetcher = AccountImageDataFetcher(
+            contactPhotoLoader,
+            accountFallbackImageProvider,
+            accountImage
+        )
+        return ModelLoader.LoadData(accountImage, dataFetcher)
+    }
+
+    override fun handles(model: AccountImage) = true
+}
+
+data class AccountImage(val email: String, val color: Int) : Key {
+    override fun updateDiskCacheKey(messageDigest: MessageDigest) {
+        messageDigest.update(toString().toByteArray(Key.CHARSET))
+    }
+}
+
+/**
+ * Load an account image.
+ *
+ * Uses [ContactPhotoLoader] to try to load the user's contact photo (using the account's email address). If there's no
+ * such contact or it doesn't have a picture use the fallback image provided by [AccountFallbackImageProvider].
+ *
+ * We're not using Glide's own fallback mechanism because negative responses aren't cached and the next time the
+ * account image is requested another attempt will be made to load the contact photo.
+ */
+internal class AccountImageDataFetcher(
+    private val contactPhotoLoader: ContactPhotoLoader,
+    private val accountFallbackImageProvider: AccountFallbackImageProvider,
+    private val accountImage: AccountImage
+) : DataFetcher<Bitmap> {
+    override fun loadData(priority: Priority, callback: DataFetcher.DataCallback<in Bitmap>) {
+        val bitmap = loadAccountImage() ?: createFallbackBitmap()
+        callback.onDataReady(bitmap)
+    }
+
+    private fun loadAccountImage(): Bitmap? {
+        return contactPhotoLoader.loadContactPhoto(accountImage.email)
+    }
+
+    private fun createFallbackBitmap(): Bitmap {
+        return accountFallbackImageProvider.getDrawable(accountImage.color).toBitmap()
+    }
+
+    override fun getDataClass() = Bitmap::class.java
+
+    override fun getDataSource() = DataSource.LOCAL
+
+    override fun cleanup() = Unit
+
+    override fun cancel() = Unit
+}
+
+internal class AccountImageModelLoaderFactory(
+    private val contactPhotoLoader: ContactPhotoLoader,
+    private val accountFallbackImageProvider: AccountFallbackImageProvider
+) : ModelLoaderFactory<AccountImage, Bitmap> {
+    override fun build(multiFactory: MultiModelLoaderFactory): ModelLoader<AccountImage, Bitmap> {
+        return AccountImageModelLoader(contactPhotoLoader, accountFallbackImageProvider)
+    }
+
+    override fun teardown() = Unit
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/KoinModule.kt
@@ -5,4 +5,7 @@ import org.koin.dsl.module
 
 val accountUiModule = module {
     viewModel { AccountsViewModel(preferences = get()) }
+    factory { AccountImageLoader(accountFallbackImageProvider = get()) }
+    factory { AccountFallbackImageProvider(context = get()) }
+    factory { AccountImageModelLoaderFactory(contactPhotoLoader = get(), accountFallbackImageProvider = get()) }
 }


### PR DESCRIPTION
Right now account images in the drawer are fetched from the contacts provider on the main thread. This can lead to a noticeable delay.