### PR TITLE
Add AccountRemovedListener

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/AccountRemovedListener.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountRemovedListener.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9
+
+fun interface AccountRemovedListener {
+    fun onAccountRemoved(account: Account)
+}

--- a/app/core/src/main/java/com/fsck/k9/Preferences.kt
+++ b/app/core/src/main/java/com/fsck/k9/Preferences.kt
@@ -5,6 +5,7 @@ import androidx.annotation.GuardedBy
 import androidx.annotation.RestrictTo
 import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.mailstore.LocalStoreProvider
+import com.fsck.k9.preferences.AccountManager
 import com.fsck.k9.preferences.Storage
 import com.fsck.k9.preferences.StorageEditor
 import com.fsck.k9.preferences.StoragePersister
@@ -19,7 +20,7 @@ class Preferences internal constructor(
     private val storagePersister: StoragePersister,
     private val localStoreProvider: LocalStoreProvider,
     private val accountPreferenceSerializer: AccountPreferenceSerializer
-) {
+) : AccountManager {
     private val accountLock = Any()
 
     @GuardedBy("accountLock")
@@ -260,7 +261,7 @@ class Preferences internal constructor(
         }
     }
 
-    fun addAccountRemovedListener(listener: AccountRemovedListener) {
+    override fun addAccountRemovedListener(listener: AccountRemovedListener) {
         accountRemovedListeners.add(listener)
     }
 

--- a/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import com.fsck.k9.Preferences
 import com.fsck.k9.backend.BackendManager
 import com.fsck.k9.mailstore.LocalStoreProvider
-import com.fsck.k9.mailstore.MessageStoreProvider
+import com.fsck.k9.mailstore.MessageStoreManager
 import com.fsck.k9.notification.NotificationController
 import com.fsck.k9.notification.NotificationStrategy
 import org.koin.core.qualifier.named
@@ -20,7 +20,7 @@ val controllerModule = module {
             get<UnreadMessageCountProvider>(),
             get<BackendManager>(),
             get<Preferences>(),
-            get<MessageStoreProvider>(),
+            get<MessageStoreManager>(),
             get(named("controllerExtensions"))
         )
     }

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -69,7 +69,7 @@ import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.mailstore.LocalStoreProvider;
 import com.fsck.k9.mailstore.MessageStore;
-import com.fsck.k9.mailstore.MessageStoreProvider;
+import com.fsck.k9.mailstore.MessageStoreManager;
 import com.fsck.k9.mailstore.OutboxState;
 import com.fsck.k9.mailstore.OutboxStateRepository;
 import com.fsck.k9.mailstore.SendState;
@@ -115,7 +115,7 @@ public class MessagingController {
     private final LocalStoreProvider localStoreProvider;
     private final BackendManager backendManager;
     private final Preferences preferences;
-    private final MessageStoreProvider messageStoreProvider;
+    private final MessageStoreManager messageStoreManager;
 
     private final Thread controllerThread;
 
@@ -139,7 +139,7 @@ public class MessagingController {
     MessagingController(Context context, NotificationController notificationController,
             NotificationStrategy notificationStrategy, LocalStoreProvider localStoreProvider,
             UnreadMessageCountProvider unreadMessageCountProvider, BackendManager backendManager,
-            Preferences preferences, MessageStoreProvider messageStoreProvider,
+            Preferences preferences, MessageStoreManager messageStoreManager,
             List<ControllerExtension> controllerExtensions) {
         this.context = context;
         this.notificationController = notificationController;
@@ -148,7 +148,7 @@ public class MessagingController {
         this.unreadMessageCountProvider = unreadMessageCountProvider;
         this.backendManager = backendManager;
         this.preferences = preferences;
-        this.messageStoreProvider = messageStoreProvider;
+        this.messageStoreManager = messageStoreManager;
 
         controllerThread = new Thread(new Runnable() {
             @Override
@@ -1629,7 +1629,7 @@ public class MessagingController {
             String sentFolderServerId = sentFolder.getServerId();
             Timber.i("Moving sent message to folder '%s' (%d)", sentFolderServerId, sentFolderId);
 
-            MessageStore messageStore = messageStoreProvider.getMessageStore(account);
+            MessageStore messageStore = messageStoreManager.getMessageStore(account);
             long destinationMessageId = messageStore.moveMessage(message.getDatabaseId(), sentFolderId);
 
             Timber.i("Moved sent message to folder '%s' (%d)", sentFolderServerId, sentFolderId);
@@ -1835,7 +1835,7 @@ public class MessagingController {
                         }
                     }
                 } else {
-                    MessageStore messageStore = messageStoreProvider.getMessageStore(account);
+                    MessageStore messageStore = messageStoreManager.getMessageStore(account);
 
                     List<Long> messageIds = new ArrayList<>();
                     Map<Long, String> messageIdToUidMapping = new HashMap<>();
@@ -2052,7 +2052,7 @@ public class MessagingController {
                 Timber.d("Deleting messages in normal folder, moving");
                 localTrashFolder = localStore.getFolder(trashFolderId);
 
-                MessageStore messageStore = messageStoreProvider.getMessageStore(account);
+                MessageStore messageStore = messageStoreManager.getMessageStore(account);
 
                 List<Long> messageIds = new ArrayList<>();
                 Map<Long, String> messageIdToUidMapping = new HashMap<>();

--- a/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -10,6 +10,6 @@ val mailStoreModule = module {
     single { SpecialFolderSelectionStrategy() }
     single { K9BackendStorageFactory(get(), get(), get(), get()) }
     factory { SpecialLocalFoldersCreator(preferences = get(), localStoreProvider = get()) }
-    single { MessageStoreManager(messageStoreFactory = get()) }
+    single { MessageStoreManager(preferences = get(), messageStoreFactory = get()) }
     single { MessageRepository(preferences = get(), localStoreProvider = get()) }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -10,6 +10,6 @@ val mailStoreModule = module {
     single { SpecialFolderSelectionStrategy() }
     single { K9BackendStorageFactory(get(), get(), get(), get()) }
     factory { SpecialLocalFoldersCreator(preferences = get(), localStoreProvider = get()) }
-    single { MessageStoreProvider(messageStoreFactory = get()) }
+    single { MessageStoreManager(messageStoreFactory = get()) }
     single { MessageRepository(preferences = get(), localStoreProvider = get()) }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/KoinModule.kt
@@ -10,6 +10,6 @@ val mailStoreModule = module {
     single { SpecialFolderSelectionStrategy() }
     single { K9BackendStorageFactory(get(), get(), get(), get()) }
     factory { SpecialLocalFoldersCreator(preferences = get(), localStoreProvider = get()) }
-    single { MessageStoreManager(preferences = get(), messageStoreFactory = get()) }
+    single { MessageStoreManager(accountManager = get(), messageStoreFactory = get()) }
     single { MessageRepository(preferences = get(), localStoreProvider = get()) }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStoreManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStoreManager.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.mailstore
 import com.fsck.k9.Account
 import java.util.concurrent.ConcurrentHashMap
 
-class MessageStoreProvider(private val messageStoreFactory: MessageStoreFactory) {
+class MessageStoreManager(private val messageStoreFactory: MessageStoreFactory) {
     private val messageStores = ConcurrentHashMap<String, MessageStore>()
 
     fun getMessageStore(account: Account): MessageStore {

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStoreManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStoreManager.kt
@@ -1,14 +1,14 @@
 package com.fsck.k9.mailstore
 
 import com.fsck.k9.Account
-import com.fsck.k9.Preferences
+import com.fsck.k9.preferences.AccountManager
 import java.util.concurrent.ConcurrentHashMap
 
-class MessageStoreManager(preferences: Preferences, private val messageStoreFactory: MessageStoreFactory) {
+class MessageStoreManager(accountManager: AccountManager, private val messageStoreFactory: MessageStoreFactory) {
     private val messageStores = ConcurrentHashMap<String, MessageStore>()
 
     init {
-        preferences.addAccountRemovedListener { account ->
+        accountManager.addAccountRemovedListener { account ->
             removeMessageStore(account.uuid)
         }
     }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStoreManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStoreManager.kt
@@ -1,12 +1,23 @@
 package com.fsck.k9.mailstore
 
 import com.fsck.k9.Account
+import com.fsck.k9.Preferences
 import java.util.concurrent.ConcurrentHashMap
 
-class MessageStoreManager(private val messageStoreFactory: MessageStoreFactory) {
+class MessageStoreManager(preferences: Preferences, private val messageStoreFactory: MessageStoreFactory) {
     private val messageStores = ConcurrentHashMap<String, MessageStore>()
+
+    init {
+        preferences.addAccountRemovedListener { account ->
+            removeMessageStore(account.uuid)
+        }
+    }
 
     fun getMessageStore(account: Account): MessageStore {
         return messageStores.getOrPut(account.uuid) { messageStoreFactory.create(account) }
+    }
+
+    private fun removeMessageStore(accountUuid: String) {
+        messageStores.remove(accountUuid)
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountManager.kt
@@ -1,0 +1,7 @@
+package com.fsck.k9.preferences
+
+import com.fsck.k9.AccountRemovedListener
+
+interface AccountManager {
+    fun addAccountRemovedListener(listener: AccountRemovedListener)
+}

--- a/app/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.preferences
 
+import com.fsck.k9.Preferences
 import org.koin.dsl.module
 
 val preferencesModule = module {
@@ -12,4 +13,5 @@ val preferencesModule = module {
         )
     }
     factory { FolderSettingsProvider(folderRepositoryManager = get()) }
+    factory<AccountManager> { get<Preferences>() }
 }

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -24,7 +24,7 @@ import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
 import com.fsck.k9.mailstore.LocalStoreProvider;
-import com.fsck.k9.mailstore.MessageStoreProvider;
+import com.fsck.k9.mailstore.MessageStoreManager;
 import com.fsck.k9.mailstore.OutboxState;
 import com.fsck.k9.mailstore.OutboxStateRepository;
 import com.fsck.k9.mailstore.SendState;
@@ -78,7 +78,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
     @Mock
     private LocalStoreProvider localStoreProvider;
     @Mock
-    private MessageStoreProvider messageStoreProvider;
+    private MessageStoreManager messageStoreManager;
     @Mock
     private SimpleMessagingListener listener;
     @Mock
@@ -136,7 +136,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
         preferences = Preferences.getPreferences(appContext);
 
         controller = new MessagingController(appContext, notificationController, notificationStrategy,
-                localStoreProvider, unreadMessageCountProvider, backendManager, preferences, messageStoreProvider,
+                localStoreProvider, unreadMessageCountProvider, backendManager, preferences, messageStoreManager,
                 Collections.<ControllerExtension>emptyList());
 
         configureAccount();

--- a/app/core/src/test/java/com/fsck/k9/mailstore/MessageStoreManagerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/MessageStoreManagerTest.kt
@@ -1,0 +1,50 @@
+package com.fsck.k9.mailstore
+
+import com.fsck.k9.Account
+import com.fsck.k9.AccountRemovedListener
+import com.fsck.k9.preferences.AccountManager
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.KStubbing
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doNothing
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import org.junit.Test
+
+class MessageStoreManagerTest {
+    private val account = Account("00000000-0000-4000-0000-000000000000")
+    private val messageStore1 = mock<MessageStore>(name = "messageStore1")
+    private val messageStore2 = mock<MessageStore>(name = "messageStore2")
+    private val messageStoreFactory = mock<MessageStoreFactory> {
+        on { create(account) } doReturn messageStore1 doReturn messageStore2
+    }
+
+    @Test
+    fun `MessageStore instance is reused`() {
+        val accountManager = mock<AccountManager>()
+        val messageStoreManager = MessageStoreManager(accountManager, messageStoreFactory)
+
+        assertThat(messageStoreManager.getMessageStore(account)).isSameInstanceAs(messageStore1)
+        assertThat(messageStoreManager.getMessageStore(account)).isSameInstanceAs(messageStore1)
+    }
+
+    @Test
+    fun `MessageStore instance is removed when account is removed`() {
+        val listenerCaptor = argumentCaptor<AccountRemovedListener>()
+        val accountManager = mock<AccountManager> {
+            doNothingOn { addAccountRemovedListener(listenerCaptor.capture()) }
+        }
+        val messageStoreManager = MessageStoreManager(accountManager, messageStoreFactory)
+
+        assertThat(messageStoreManager.getMessageStore(account)).isSameInstanceAs(messageStore1)
+
+        listenerCaptor.firstValue.onAccountRemoved(account)
+
+        assertThat(messageStoreManager.getMessageStore(account)).isSameInstanceAs(messageStore2)
+    }
+
+    private fun <T> KStubbing<T>.doNothingOn(block: T.() -> Any) {
+        doNothing().whenever(mock).block()
+    }
+}


### PR DESCRIPTION
Use the new functionality in `MessageStoreManager` (previously `MessageStoreProvider`) to remove a cached `MessageStore` instance when an account is removed.