### PR TITLE
Refactor LocalStore.createFolders()

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/CreateFolderInfo.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/CreateFolderInfo.kt
@@ -1,0 +1,10 @@
+package com.fsck.k9.mailstore
+
+import com.fsck.k9.mail.FolderType
+
+data class CreateFolderInfo(
+    val serverId: String,
+    val name: String,
+    val type: FolderType,
+    val settings: FolderSettings
+)

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderSettings.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderSettings.kt
@@ -1,0 +1,13 @@
+package com.fsck.k9.mailstore
+
+import com.fsck.k9.mail.FolderClass
+
+data class FolderSettings(
+    val visibleLimit: Int,
+    val displayClass: FolderClass,
+    val syncClass: FolderClass,
+    val notifyClass: FolderClass,
+    val pushClass: FolderClass,
+    val inTopGroup: Boolean,
+    val integrate: Boolean,
+)

--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderSettingsProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderSettingsProvider.kt
@@ -1,0 +1,44 @@
+package com.fsck.k9.mailstore
+
+import com.fsck.k9.Account
+import com.fsck.k9.Preferences
+import com.fsck.k9.mail.FolderClass
+
+/**
+ * Provides imported folder settings if available, otherwise default values.
+ */
+class FolderSettingsProvider(val preferences: Preferences, val account: Account) {
+    fun getFolderSettings(folderServerId: String): FolderSettings {
+        val storage = preferences.storage
+        val prefix = "${account.uuid}.$folderServerId"
+
+        return FolderSettings(
+            visibleLimit = account.displayCount,
+            displayClass = storage.getString("$prefix.displayMode", null).toFolderClass(FolderClass.NO_CLASS),
+            syncClass = storage.getString("$prefix.syncMode", null).toFolderClass(FolderClass.INHERITED),
+            notifyClass = storage.getString("$prefix.notifyMode", null).toFolderClass(FolderClass.INHERITED),
+            pushClass = storage.getString("$prefix.pushMode", null).toFolderClass(FolderClass.SECOND_CLASS),
+            inTopGroup = storage.getBoolean("$prefix.inTopGroup", false),
+            integrate = storage.getBoolean("$prefix.integrate", false),
+        ).also {
+            removeImportedFolderSettings(prefix)
+        }
+    }
+
+    private fun removeImportedFolderSettings(prefix: String) {
+        val editor = preferences.createStorageEditor()
+
+        editor.remove("$prefix.displayMode")
+        editor.remove("$prefix.syncMode")
+        editor.remove("$prefix.notifyMode")
+        editor.remove("$prefix.pushMode")
+        editor.remove("$prefix.inTopGroup")
+        editor.remove("$prefix.integrate")
+
+        editor.commit()
+    }
+
+    private fun String?.toFolderClass(defaultValue: FolderClass): FolderClass {
+        return if (this == null) defaultValue else FolderClass.valueOf(this)
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/K9BackendStorageFactory.kt
@@ -12,6 +12,7 @@ class K9BackendStorageFactory(
     fun createBackendStorage(account: Account): K9BackendStorage {
         val folderRepository = folderRepositoryManager.getFolderRepository(account)
         val localStore = localStoreProvider.getInstance(account)
+        val folderSettingsProvider = FolderSettingsProvider(preferences, account)
         val specialFolderUpdater = SpecialFolderUpdater(
             preferences,
             folderRepository,
@@ -21,6 +22,6 @@ class K9BackendStorageFactory(
         val specialFolderListener = SpecialFolderBackendFoldersRefreshListener(specialFolderUpdater)
         val autoExpandFolderListener = AutoExpandFolderBackendFoldersRefreshListener(preferences, account, folderRepository)
         val listeners = listOf(specialFolderListener, autoExpandFolderListener)
-        return K9BackendStorage(account, localStore, listeners)
+        return K9BackendStorage(localStore, folderSettingsProvider, listeners)
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -37,7 +37,6 @@ import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.internet.MimeMultipart;
 import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mail.internet.SizeAware;
-import com.fsck.k9.mail.message.MessageHeaderCollector;
 import com.fsck.k9.mail.message.MessageHeaderParser;
 import com.fsck.k9.mailstore.LockableDatabase.DbCallback;
 import com.fsck.k9.mailstore.LockableDatabase.WrappedException;
@@ -47,8 +46,6 @@ import com.fsck.k9.message.extractors.MessageFulltextCreator;
 import com.fsck.k9.message.extractors.MessagePreviewCreator;
 import com.fsck.k9.message.extractors.PreviewResult;
 import com.fsck.k9.message.extractors.PreviewResult.PreviewType;
-import com.fsck.k9.preferences.Storage;
-import com.fsck.k9.preferences.StorageEditor;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.util.MimeUtil;
@@ -276,52 +273,6 @@ public class LocalFolder {
         });
     }
 
-    PreferencesHolder getPreferencesHolder() {
-        PreferencesHolder preferencesHolder = new PreferencesHolder();
-
-        Storage storage = localStore.getPreferences().getStorage();
-        String prefId = getPrefId(serverId);
-
-        String displayModeString = storage.getString(prefId + ".displayMode", null);
-        if (displayModeString != null) {
-            preferencesHolder.displayClass = FolderClass.valueOf(displayModeString);
-        }
-
-        String notifyModeString = storage.getString(prefId + ".notifyMode", null);
-        if (notifyModeString != null) {
-            preferencesHolder.notifyClass = FolderClass.valueOf(notifyModeString);
-        }
-
-        String syncModeString = storage.getString(prefId + ".syncMode", null);
-        if (syncModeString != null) {
-            preferencesHolder.syncClass = FolderClass.valueOf(syncModeString);
-        }
-
-        String pushModeString = storage.getString(prefId + ".pushMode", null);
-        if (pushModeString != null) {
-            preferencesHolder.pushClass = FolderClass.valueOf(pushModeString);
-        }
-
-        if (storage.contains(prefId + ".inTopGroup")) {
-            preferencesHolder.inTopGroup = storage.getBoolean(prefId + ".inTopGroup", isInTopGroup);
-        }
-
-        if (storage.contains(prefId + ".integrate")) {
-            preferencesHolder.integrate = storage.getBoolean(prefId + ".integrate", isIntegrate);
-        }
-
-        return preferencesHolder;
-    }
-
-    class PreferencesHolder {
-        FolderClass displayClass = LocalFolder.this.displayClass;
-        FolderClass syncClass = LocalFolder.this.syncClass;
-        FolderClass notifyClass = LocalFolder.this.notifyClass;
-        FolderClass pushClass = LocalFolder.this.pushClass;
-        boolean inTopGroup = isInTopGroup;
-        boolean integrate = isIntegrate;
-    }
-
     public int getMessageCount() throws MessagingException {
         try {
             return this.localStore.getDatabase().execute(false, new DbCallback<Integer>() {
@@ -510,29 +461,6 @@ public class LocalFolder {
 
     public boolean isLocalOnly() {
         return localOnly;
-    }
-
-    private String getPrefId(String name) {
-        if (prefId == null) {
-            prefId = getAccount().getUuid() + "." + name;
-        }
-
-        return prefId;
-    }
-
-    void deleteSavedSettings() {
-        String id = getPrefId(serverId);
-
-        StorageEditor editor = localStore.getPreferences().createStorageEditor();
-
-        editor.remove(id + ".displayMode");
-        editor.remove(id + ".syncMode");
-        editor.remove(id + ".pushMode");
-        editor.remove(id + ".notifyMode");
-        editor.remove(id + ".inTopGroup");
-        editor.remove(id + ".integrate");
-
-        editor.commit();
     }
 
     public void fetch(final List<LocalMessage> messages, final FetchProfile fp, final MessageRetrievalListener<LocalMessage> listener)

--- a/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendFolderTest.kt
@@ -116,7 +116,7 @@ class K9BackendFolderTest : K9RobolectricTest() {
 
     fun createBackendFolder(): BackendFolder {
         val localStore: LocalStore = localStoreProvider.getInstance(account)
-        val backendStorage = K9BackendStorage(account, localStore, emptyList())
+        val backendStorage = K9BackendStorage(localStore, createFolderSettingsProvider(), emptyList())
         backendStorage.updateFolders {
             createFolders(listOf(FolderInfo(FOLDER_SERVER_ID, FOLDER_NAME, FOLDER_TYPE)))
         }

--- a/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendStorageTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/mailstore/K9BackendStorageTest.kt
@@ -5,7 +5,11 @@ import com.fsck.k9.Account
 import com.fsck.k9.K9RobolectricTest
 import com.fsck.k9.Preferences
 import com.fsck.k9.backend.api.BackendStorage
+import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.provider.EmailProvider
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
 import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -73,7 +77,23 @@ class K9BackendStorageTest : K9RobolectricTest() {
     }
 
     private fun createBackendStorage(): BackendStorage {
-        val localStore: LocalStore = localStoreProvider.getInstance(account)
-        return K9BackendStorage(account, localStore, emptyList())
+        val localStore = localStoreProvider.getInstance(account)
+        val folderSettingsProvider = createFolderSettingsProvider()
+        return K9BackendStorage(localStore, folderSettingsProvider, emptyList())
+    }
+}
+
+internal fun createFolderSettingsProvider(): FolderSettingsProvider {
+    return mock {
+        on { getFolderSettings(any()) } doReturn
+            FolderSettings(
+                visibleLimit = 25,
+                displayClass = FolderClass.NO_CLASS,
+                syncClass = FolderClass.INHERITED,
+                notifyClass = FolderClass.INHERITED,
+                pushClass = FolderClass.SECOND_CLASS,
+                inTopGroup = false,
+                integrate = false,
+            )
     }
 }


### PR DESCRIPTION
The code to retrieve imported folder settings has been extracted to `FolderSettingsProvider`. As a result the implementation of `LocalStore.createFolders()` could be simplified quite a bit.