### PR TITLE
Fixed localized strings if app language and system language are different

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/LocaleHelper.kt
+++ b/app/core/src/main/java/com/fsck/k9/LocaleHelper.kt
@@ -1,0 +1,41 @@
+package com.fsck.k9
+
+import android.content.res.Resources
+import java.util.Locale
+
+class LocaleHelper {
+    companion object {
+        private lateinit var currentLanguage: String
+
+        @JvmStatic
+        fun initializeLocale(resources: Resources) {
+            currentLanguage = K9.k9Language
+            setLanguage(resources)
+        }
+
+        private fun setLanguage(resources: Resources) {
+            val locale = actualLocale()
+
+            val config = resources.configuration
+            config.locale = locale
+            resources.updateConfiguration(config, resources.displayMetrics)
+        }
+
+        @JvmStatic
+        fun actualLocale(): Locale {
+            val locale = if (K9.k9Language == null || K9.k9Language.isEmpty()) {
+                Resources.getSystem().configuration.locale
+            } else if (K9.k9Language.length == 5 && K9.k9Language[2] == '_') {
+                // language is in the form: en_US
+                Locale(K9.k9Language.substring(0, 2), K9.k9Language.substring(3))
+            } else {
+                Locale(K9.k9Language)
+            }
+            return locale
+        }
+
+        fun languageHasChanged(): Boolean {
+            return currentLanguage != K9.k9Language
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/message/quote/HtmlQuoteCreator.java
+++ b/app/core/src/main/java/com/fsck/k9/message/quote/HtmlQuoteCreator.java
@@ -4,8 +4,6 @@ package com.fsck.k9.message.quote;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import android.content.res.Resources;
-
 import com.fsck.k9.CoreResourceProvider;
 import com.fsck.k9.DI;
 import timber.log.Timber;
@@ -44,7 +42,7 @@ public class HtmlQuoteCreator {
      * @param quoteStyle Style of quoting.
      * @return Modified insertable message.
      */
-    public static InsertableHtmlContent quoteOriginalHtmlMessage(Resources resources, Message originalMessage,
+    public static InsertableHtmlContent quoteOriginalHtmlMessage(Message originalMessage,
             String messageBody, QuoteStyle quoteStyle) {
         CoreResourceProvider resourceProvider = DI.get(CoreResourceProvider.class);
         InsertableHtmlContent insertable = findInsertionPoints(messageBody);

--- a/app/core/src/main/java/com/fsck/k9/message/quote/QuoteDateFormatter.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/quote/QuoteDateFormatter.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.message.quote
 
 import com.fsck.k9.K9
+import com.fsck.k9.LocaleHelper.Companion.actualLocale
 import java.text.DateFormat
 import java.util.Date
 import java.util.TimeZone
@@ -20,7 +21,7 @@ class QuoteDateFormatter {
     }
 
     private fun createDateFormat(): DateFormat {
-        return DateFormat.getDateTimeInstance(DATE_STYLE, TIME_STYLE).apply {
+        return DateFormat.getDateTimeInstance(DATE_STYLE, TIME_STYLE, actualLocale()).apply {
             if (K9.isHideTimeZone) {
                 timeZone = TimeZone.getTimeZone("UTC")
             }

--- a/app/core/src/test/java/com/fsck/k9/message/quote/QuoteDateFormatterTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/message/quote/QuoteDateFormatterTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 class QuoteDateFormatterTest {
     private lateinit var originalLocale: Locale
     private var originalTimeZone: TimeZone? = null
+    private lateinit var originalK9language: String
     private val quoteDateFormatter = QuoteDateFormatter()
 
     @Before
@@ -20,12 +21,15 @@ class QuoteDateFormatterTest {
         originalLocale = Locale.getDefault()
         originalTimeZone = TimeZone.getDefault()
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+02:00"))
+        originalK9language = K9.k9Language
+        K9.k9Language = Locale.US.language
     }
 
     @After
     fun tearDown() {
         Locale.setDefault(originalLocale)
         TimeZone.setDefault(originalTimeZone)
+        K9.k9Language = originalK9language
     }
 
     @Test
@@ -42,6 +46,7 @@ class QuoteDateFormatterTest {
     fun hideTimeZoneEnabled_GermanyLocale() {
         K9.isHideTimeZone = true
         Locale.setDefault(Locale.GERMANY)
+        K9.k9Language = Locale.GERMANY.language
 
         val formattedDate = quoteDateFormatter.format("2020-09-19T20:00:00+00:00".toDate())
 
@@ -62,6 +67,7 @@ class QuoteDateFormatterTest {
     fun hideTimeZoneDisabled_GermanyLocale() {
         K9.isHideTimeZone = false
         Locale.setDefault(Locale.GERMANY)
+        K9.k9Language = Locale.GERMANY.language
 
         val formattedDate = quoteDateFormatter.format("2020-09-19T20:00:00+00:00".toDate())
 

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
@@ -2,44 +2,52 @@ package com.fsck.k9.resources
 
 import android.content.Context
 import com.fsck.k9.CoreResourceProvider
+import com.fsck.k9.LocaleHelper
 import com.fsck.k9.jmap.R
 
 class K9CoreResourceProvider(private val context: Context) : CoreResourceProvider {
-    override fun defaultSignature(): String = context.getString(R.string.default_signature)
-    override fun defaultIdentityDescription(): String = context.getString(R.string.default_identity_description)
+    override fun defaultSignature(): String = resolve(R.string.default_signature)
+    override fun defaultIdentityDescription(): String = resolve(R.string.default_identity_description)
 
-    override fun internalStorageProviderName(): String =
-        context.getString(R.string.local_storage_provider_internal_label)
+    override fun internalStorageProviderName(): String = resolve(R.string.local_storage_provider_internal_label)
 
-    override fun externalStorageProviderName(): String =
-        context.getString(R.string.local_storage_provider_external_label)
+    override fun externalStorageProviderName(): String = resolve(R.string.local_storage_provider_external_label)
 
-    override fun contactDisplayNamePrefix(): String = context.getString(R.string.message_to_label)
-    override fun contactUnknownSender(): String = context.getString(R.string.unknown_sender)
-    override fun contactUnknownRecipient(): String = context.getString(R.string.unknown_recipient)
+    override fun contactDisplayNamePrefix(): String = resolve(R.string.message_to_label)
+    override fun contactUnknownSender(): String = resolve(R.string.unknown_sender)
+    override fun contactUnknownRecipient(): String = resolve(R.string.unknown_recipient)
 
-    override fun messageHeaderFrom(): String = context.getString(R.string.message_compose_quote_header_from)
-    override fun messageHeaderTo(): String = context.getString(R.string.message_compose_quote_header_to)
-    override fun messageHeaderCc(): String = context.getString(R.string.message_compose_quote_header_cc)
-    override fun messageHeaderDate(): String = context.getString(R.string.message_compose_quote_header_send_date)
-    override fun messageHeaderSubject(): String = context.getString(R.string.message_compose_quote_header_subject)
-    override fun messageHeaderSeparator(): String = context.getString(R.string.message_compose_quote_header_separator)
+    override fun messageHeaderFrom(): String = resolve(R.string.message_compose_quote_header_from)
+    override fun messageHeaderTo(): String = resolve(R.string.message_compose_quote_header_to)
+    override fun messageHeaderCc(): String = resolve(R.string.message_compose_quote_header_cc)
+    override fun messageHeaderDate(): String = resolve(R.string.message_compose_quote_header_send_date)
+    override fun messageHeaderSubject(): String = resolve(R.string.message_compose_quote_header_subject)
+    override fun messageHeaderSeparator(): String = resolve(R.string.message_compose_quote_header_separator)
 
-    override fun noSubject(): String = context.getString(R.string.general_no_subject)
+    override fun noSubject(): String = resolve(R.string.general_no_subject)
 
-    override fun userAgent(): String = context.getString(R.string.message_header_mua)
-    override fun encryptedSubject(): String = context.getString(R.string.encrypted_subject)
+    override fun userAgent(): String = resolve(R.string.message_header_mua)
+    override fun encryptedSubject(): String = resolve(R.string.encrypted_subject)
 
-    override fun replyHeader(sender: String): String =
-        context.getString(R.string.message_compose_reply_header_fmt, sender)
+    override fun replyHeader(sender: String): String = resolve(R.string.message_compose_reply_header_fmt, sender)
 
     override fun replyHeader(sender: String, sentDate: String): String =
-        context.getString(R.string.message_compose_reply_header_fmt_with_date, sentDate, sender)
+        resolve(R.string.message_compose_reply_header_fmt_with_date, sentDate, sender)
 
-    override fun searchAllMessagesTitle(): String = context.getString(R.string.search_all_messages_title)
-    override fun searchAllMessagesDetail(): String = context.getString(R.string.search_all_messages_detail)
-    override fun searchUnifiedInboxTitle(): String = context.getString(R.string.integrated_inbox_title)
-    override fun searchUnifiedInboxDetail(): String = context.getString(R.string.integrated_inbox_detail)
+    override fun searchAllMessagesTitle(): String = resolve(R.string.search_all_messages_title)
+    override fun searchAllMessagesDetail(): String = resolve(R.string.search_all_messages_detail)
+    override fun searchUnifiedInboxTitle(): String = resolve(R.string.integrated_inbox_title)
+    override fun searchUnifiedInboxDetail(): String = resolve(R.string.integrated_inbox_detail)
 
-    override fun outboxFolderName(): String = context.getString(R.string.special_mailbox_name_outbox)
+    override fun outboxFolderName(): String = resolve(R.string.special_mailbox_name_outbox)
+
+    private fun resolve(id: Int): String {
+        LocaleHelper.initializeLocale(context.resources)
+        return context.getString(id)
+    }
+
+    private fun resolve(id: Int, vararg args: String): String {
+        LocaleHelper.initializeLocale(context.resources)
+        return context.getString(id, *args)
+    }
 }

--- a/app/k9mail/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
@@ -2,44 +2,52 @@ package com.fsck.k9.resources
 
 import android.content.Context
 import com.fsck.k9.CoreResourceProvider
+import com.fsck.k9.LocaleHelper
 import com.fsck.k9.R
 
 class K9CoreResourceProvider(private val context: Context) : CoreResourceProvider {
-    override fun defaultSignature(): String = context.getString(R.string.default_signature)
-    override fun defaultIdentityDescription(): String = context.getString(R.string.default_identity_description)
+    override fun defaultSignature(): String = resolve(R.string.default_signature)
+    override fun defaultIdentityDescription(): String = resolve(R.string.default_identity_description)
 
-    override fun internalStorageProviderName(): String =
-        context.getString(R.string.local_storage_provider_internal_label)
+    override fun internalStorageProviderName(): String = resolve(R.string.local_storage_provider_internal_label)
 
-    override fun externalStorageProviderName(): String =
-        context.getString(R.string.local_storage_provider_external_label)
+    override fun externalStorageProviderName(): String = resolve(R.string.local_storage_provider_external_label)
 
-    override fun contactDisplayNamePrefix(): String = context.getString(R.string.message_to_label)
-    override fun contactUnknownSender(): String = context.getString(R.string.unknown_sender)
-    override fun contactUnknownRecipient(): String = context.getString(R.string.unknown_recipient)
+    override fun contactDisplayNamePrefix(): String = resolve(R.string.message_to_label)
+    override fun contactUnknownSender(): String = resolve(R.string.unknown_sender)
+    override fun contactUnknownRecipient(): String = resolve(R.string.unknown_recipient)
 
-    override fun messageHeaderFrom(): String = context.getString(R.string.message_compose_quote_header_from)
-    override fun messageHeaderTo(): String = context.getString(R.string.message_compose_quote_header_to)
-    override fun messageHeaderCc(): String = context.getString(R.string.message_compose_quote_header_cc)
-    override fun messageHeaderDate(): String = context.getString(R.string.message_compose_quote_header_send_date)
-    override fun messageHeaderSubject(): String = context.getString(R.string.message_compose_quote_header_subject)
-    override fun messageHeaderSeparator(): String = context.getString(R.string.message_compose_quote_header_separator)
+    override fun messageHeaderFrom(): String = resolve(R.string.message_compose_quote_header_from)
+    override fun messageHeaderTo(): String = resolve(R.string.message_compose_quote_header_to)
+    override fun messageHeaderCc(): String = resolve(R.string.message_compose_quote_header_cc)
+    override fun messageHeaderDate(): String = resolve(R.string.message_compose_quote_header_send_date)
+    override fun messageHeaderSubject(): String = resolve(R.string.message_compose_quote_header_subject)
+    override fun messageHeaderSeparator(): String = resolve(R.string.message_compose_quote_header_separator)
 
-    override fun noSubject(): String = context.getString(R.string.general_no_subject)
+    override fun noSubject(): String = resolve(R.string.general_no_subject)
 
-    override fun userAgent(): String = context.getString(R.string.message_header_mua)
-    override fun encryptedSubject(): String = context.getString(R.string.encrypted_subject)
+    override fun userAgent(): String = resolve(R.string.message_header_mua)
+    override fun encryptedSubject(): String = resolve(R.string.encrypted_subject)
 
-    override fun replyHeader(sender: String): String =
-        context.getString(R.string.message_compose_reply_header_fmt, sender)
+    override fun replyHeader(sender: String): String = resolve(R.string.message_compose_reply_header_fmt, sender)
 
     override fun replyHeader(sender: String, sentDate: String): String =
-        context.getString(R.string.message_compose_reply_header_fmt_with_date, sentDate, sender)
+        resolve(R.string.message_compose_reply_header_fmt_with_date, sentDate, sender)
 
-    override fun searchAllMessagesTitle(): String = context.getString(R.string.search_all_messages_title)
-    override fun searchAllMessagesDetail(): String = context.getString(R.string.search_all_messages_detail)
-    override fun searchUnifiedInboxTitle(): String = context.getString(R.string.integrated_inbox_title)
-    override fun searchUnifiedInboxDetail(): String = context.getString(R.string.integrated_inbox_detail)
+    override fun searchAllMessagesTitle(): String = resolve(R.string.search_all_messages_title)
+    override fun searchAllMessagesDetail(): String = resolve(R.string.search_all_messages_detail)
+    override fun searchUnifiedInboxTitle(): String = resolve(R.string.integrated_inbox_title)
+    override fun searchUnifiedInboxDetail(): String = resolve(R.string.integrated_inbox_detail)
 
-    override fun outboxFolderName(): String = context.getString(R.string.special_mailbox_name_outbox)
+    override fun outboxFolderName(): String = resolve(R.string.special_mailbox_name_outbox)
+
+    private fun resolve(id: Int): String {
+        LocaleHelper.initializeLocale(context.resources)
+        return context.getString(id)
+    }
+
+    private fun resolve(id: Int, vararg args: String): String {
+        LocaleHelper.initializeLocale(context.resources)
+        return context.getString(id, *args)
+    }
 }

--- a/app/k9mail/src/main/res/layout/message_list_widget_layout.xml
+++ b/app/k9mail/src/main/res/layout/message_list_widget_layout.xml
@@ -1,5 +1,4 @@
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -23,7 +22,7 @@
             android:paddingTop="12dp"
             android:textSize="20sp"
             android:textColor="@color/message_list_widget_header_text"
-            tools:text="Unified Inbox" />
+            android:text="@string/integrated_inbox_title" />
 
         <ImageButton
             android:id="@+id/new_message"

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/K9Activity.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/K9Activity.kt
@@ -1,13 +1,11 @@
 package com.fsck.k9.ui.base
 
-import android.content.res.Resources
 import android.os.Bundle
-import android.text.TextUtils
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.Toolbar
-import com.fsck.k9.K9
-import java.util.Locale
+import com.fsck.k9.LocaleHelper.Companion.initializeLocale
+import com.fsck.k9.LocaleHelper.Companion.languageHasChanged
 import org.koin.android.ext.android.inject
 
 abstract class K9Activity(private val themeType: ThemeType) : AppCompatActivity() {
@@ -15,11 +13,10 @@ abstract class K9Activity(private val themeType: ThemeType) : AppCompatActivity(
 
     protected val themeManager: ThemeManager by inject()
 
-    private lateinit var currentLanguage: String
     private lateinit var currentTheme: Theme
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        initializeLanguage()
+        initializeLocale(resources)
         initializeTheme()
         super.onCreate(savedInstanceState)
     }
@@ -27,13 +24,6 @@ abstract class K9Activity(private val themeType: ThemeType) : AppCompatActivity(
     override fun onResume() {
         languageChangeCheck()
         super.onResume()
-    }
-
-    private fun initializeLanguage() {
-        K9.k9Language.let { language ->
-            currentLanguage = language
-            setLanguage(language)
-        }
     }
 
     private fun initializeTheme() {
@@ -46,24 +36,9 @@ abstract class K9Activity(private val themeType: ThemeType) : AppCompatActivity(
     }
 
     private fun languageChangeCheck() {
-        if (currentLanguage != K9.k9Language) {
+        if (languageHasChanged()) {
             recreate()
         }
-    }
-
-    private fun setLanguage(language: String) {
-        val locale = if (TextUtils.isEmpty(language)) {
-            Resources.getSystem().configuration.locale
-        } else if (language.length == 5 && language[2] == '_') {
-            // language is in the form: en_US
-            Locale(language.substring(0, 2), language.substring(3))
-        } else {
-            Locale(language)
-        }
-
-        val config = resources.configuration
-        config.locale = locale
-        resources.updateConfiguration(config, resources.displayMetrics)
     }
 
     protected fun setLayout(@LayoutRes layoutResId: Int) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -119,6 +119,8 @@ import org.openintents.openpgp.OpenPgpApiManager;
 import org.openintents.openpgp.util.OpenPgpApi;
 import timber.log.Timber;
 
+import static com.fsck.k9.LocaleHelper.initializeLocale;
+
 
 @SuppressWarnings("deprecation") // TODO get rid of activity dialogs and indeterminate progress bars
 public class MessageCompose extends K9Activity implements OnClickListener,
@@ -259,6 +261,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         contentContainer.setLayoutInflater(themedLayoutInflater);
 
         View contentView = contentContainer.inflate();
+        // For some reason language is reset, see issue #4407 -> init again
+        initializeLocale(getResources());
 
         // background color needs to be forced
         //TODO: Change themes to use appropriate background colors that don't need overriding.

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -121,6 +121,8 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setLayout(R.layout.account_setup_incoming);
+        // For some reason we need to set the title, see issue #4407
+        setTitle(R.string.account_setup_incoming_title);
 
         mUsernameView = findViewById(R.id.account_username);
         mPasswordView = findViewById(R.id.account_password);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -29,6 +29,7 @@ import com.fsck.k9.Account.Expunge
 import com.fsck.k9.Account.SortType
 import com.fsck.k9.Clock
 import com.fsck.k9.K9
+import com.fsck.k9.LocaleHelper.Companion.initializeLocale
 import com.fsck.k9.Preferences
 import com.fsck.k9.activity.FolderInfoHolder
 import com.fsck.k9.activity.misc.ContactPicture
@@ -149,6 +150,8 @@ class MessageListFragment :
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        // For some reason language is reset, see issue #4407 -> init again
+        initializeLocale(resources)
 
         restoreInstanceState(savedInstanceState)
         decodeArguments()

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessagePresenter.java
@@ -113,8 +113,7 @@ public class QuotedMessagePresenter {
             }
 
             // Add the HTML reply header to the top of the content.
-            quotedHtmlContent = HtmlQuoteCreator.quoteOriginalHtmlMessage(
-                    resources, messageViewInfo.message, content, quoteStyle);
+            quotedHtmlContent = HtmlQuoteCreator.quoteOriginalHtmlMessage(messageViewInfo.message, content, quoteStyle);
 
             // Load the message with the reply header. TODO replace with MessageViewInfo data
             view.setQuotedHtml(quotedHtmlContent.getQuotedContent(),

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageContainerView.java
@@ -45,6 +45,7 @@ import com.fsck.k9.view.MessageWebView.OnPageFinishedListener;
 import com.fsck.k9.view.WebViewConfigProvider;
 
 import static android.app.DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED;
+import static com.fsck.k9.LocaleHelper.initializeLocale;
 
 
 public class MessageContainerView extends LinearLayout implements OnCreateContextMenuListener {
@@ -90,6 +91,7 @@ public class MessageContainerView extends LinearLayout implements OnCreateContex
     @Override
     public void onFinishInflate() {
         super.onFinishInflate();
+        initializeLocale(getResources());
 
         mMessageContentView = findViewById(R.id.message_content);
         if (!isInEditMode()) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.java
@@ -251,11 +251,6 @@ public class MessageViewFragment extends Fragment implements ConfirmationDialogF
         }
     }
 
-    private void showUnableToDecodeError() {
-        Context context = getActivity().getApplicationContext();
-        Toast.makeText(context, R.string.message_view_toast_unable_to_display_message, Toast.LENGTH_SHORT).show();
-    }
-
     private void showMessage(MessageViewInfo messageViewInfo) {
         hideKeyboard();
 


### PR DESCRIPTION
Resolves #4407

I could reproduce the following findings on current main (commit 1a68adc8) and Android 10 with the following steps after setting app language to another language than system language and closing the app (steps 1 to 3 in description of issue #4407).

Finding 5.1: "Load up to 10 more" at bottom screen
1. Launch app
2. Open side menu on the left using sandwich icon in the upper left
3. Switch to a folder other than unified inbox
4. Open a mail
5. Go back (using arrow in the upper left or Android's back button)
6. Scroll down, button text is "Load up to X more"

Finding 5.2: I could reproduce only wrong name of unified inbox
1. Launch app
2. Title is "Unified Inbox"
3. Open side menu on the left using sandwich icon in the upper left
4. Menu item is "Unified Inbox"

Finding 5.3 and 5.4: "Compose" title when composing a new mail
1. Launch app
2. Compose new mail using the pencil icon in the upper right
3. Title is "Compose"
4. Go back (using arrow in the upper left or Android's back button)
5. Compose another mail -> title is correct

Finding 5.5: Incoming server settings
1. Launch app
2. Open a mail from unified inbox
3. Go back (using arrow in the upper left or Android's back button)
4. Open side menu on the left using sandwich icon in the upper left
5. Tab settings
6. Tab an existing account
7. Tab "Fetching mail"
8. Tab "Incoming server" -> title is in English

Finding 5.6 and 5.7: Reply and forward header
1. Launch app
2. Open a mail in unified inbox
3. Tab on response arrow on the right
4. Menu is in English (reply, reply all, forward, ...)
5. Choose "reply" or "forward"
6. Reply/forward header is in English