### PR TITLE
Fix crash when starting MessageCompose without an account UUID

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -281,7 +281,9 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 relatedMessageReference.getAccountUuid() :
                 intent.getStringExtra(EXTRA_ACCOUNT);
 
-        account = preferences.getAccount(accountUuid);
+        if (accountUuid != null) {
+            account = preferences.getAccount(accountUuid);
+        }
 
         if (account == null) {
             account = preferences.getDefaultAccount();


### PR DESCRIPTION
Fixes #5261