### PR TITLE
Re-implement copy message functionality in MessageStore

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -9,14 +9,10 @@ import androidx.annotation.NonNull;
 
 import androidx.annotation.Nullable;
 import com.fsck.k9.Account;
-import com.fsck.k9.DI;
 import com.fsck.k9.K9;
 import com.fsck.k9.controller.MessageReference;
-import com.fsck.k9.crypto.EncryptionExtractor;
-import com.fsck.k9.crypto.EncryptionResult;
 import com.fsck.k9.helper.FileHelper;
 import com.fsck.k9.helper.Utility;
-import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Body;
 import com.fsck.k9.mail.BodyPart;
 import com.fsck.k9.mail.BoundaryGenerator;
@@ -25,7 +21,6 @@ import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.FolderClass;
 import com.fsck.k9.mail.FolderType;
 import com.fsck.k9.mail.Message;
-import com.fsck.k9.mail.Message.RecipientType;
 import com.fsck.k9.mail.MessageRetrievalListener;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Multipart;
@@ -33,19 +28,13 @@ import com.fsck.k9.mail.Part;
 import com.fsck.k9.mail.filter.CountingOutputStream;
 import com.fsck.k9.mail.internet.BinaryTempFileBody;
 import com.fsck.k9.mail.internet.MimeHeader;
-import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.internet.MimeMultipart;
 import com.fsck.k9.mail.internet.MimeUtility;
 import com.fsck.k9.mail.internet.SizeAware;
 import com.fsck.k9.mail.message.MessageHeaderParser;
 import com.fsck.k9.mailstore.LockableDatabase.DbCallback;
 import com.fsck.k9.mailstore.LockableDatabase.WrappedException;
-import com.fsck.k9.message.extractors.AttachmentCounter;
 import com.fsck.k9.message.extractors.AttachmentInfoExtractor;
-import com.fsck.k9.message.extractors.MessageFulltextCreator;
-import com.fsck.k9.message.extractors.MessagePreviewCreator;
-import com.fsck.k9.message.extractors.PreviewResult;
-import com.fsck.k9.message.extractors.PreviewResult.PreviewType;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.util.MimeUtil;
@@ -65,8 +54,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
-import java.util.Stack;
-import java.util.UUID;
 
 import timber.log.Timber;
 
@@ -78,7 +65,6 @@ public class LocalFolder {
 
     private final LocalStore localStore;
     private final AttachmentInfoExtractor attachmentInfoExtractor;
-    private final EncryptionExtractor encryptionExtractor = DI.get(EncryptionExtractor.class);
 
 
     private String status = null;
@@ -88,7 +74,6 @@ public class LocalFolder {
     private String name;
     private long databaseId = -1L;
     private int visibleLimit = -1;
-    private String prefId = null;
 
     private FolderClass displayClass = FolderClass.NO_CLASS;
     private FolderClass syncClass = FolderClass.INHERITED;
@@ -791,10 +776,6 @@ public class LocalFolder {
         return messages;
     }
 
-    public Map<String, String> copyMessages(List<LocalMessage> msgs, LocalFolder folder) throws MessagingException {
-        return folder.appendMessages(msgs, true);
-    }
-
     public void destroyMessages(final List<LocalMessage> messages) {
         try {
             this.localStore.getDatabase().execute(true, new DbCallback<Void>() {
@@ -813,260 +794,6 @@ public class LocalFolder {
         } catch (MessagingException e) {
             throw new WrappedException(e);
         }
-    }
-
-    private ThreadInfo getThreadInfo(SQLiteDatabase db, String messageId, boolean onlyEmpty) {
-        if (messageId == null) {
-            return null;
-        }
-
-        String sql = "SELECT t.id, t.message_id, t.root, t.parent " +
-                "FROM messages m " +
-                "LEFT JOIN threads t ON (t.message_id = m.id) " +
-                "WHERE m.folder_id = ? AND m.message_id = ? " +
-                ((onlyEmpty) ? "AND m.empty = 1 " : "") +
-                "ORDER BY m.id LIMIT 1";
-        String[] selectionArgs = { Long.toString(databaseId), messageId };
-        Cursor cursor = db.rawQuery(sql, selectionArgs);
-
-        if (cursor != null) {
-            try {
-                if (cursor.getCount() > 0) {
-                    cursor.moveToFirst();
-                    long threadId = cursor.getLong(0);
-                    long msgId = cursor.getLong(1);
-                    long rootId = (cursor.isNull(2)) ? -1 : cursor.getLong(2);
-                    long parentId = (cursor.isNull(3)) ? -1 : cursor.getLong(3);
-
-                    return new ThreadInfo(threadId, msgId, messageId, rootId, parentId);
-                }
-            } finally {
-                cursor.close();
-            }
-        }
-
-        return null;
-    }
-
-    /**
-     * The method differs slightly from the contract; If an incoming message already has a uid
-     * assigned and it matches the uid of an existing message then this message will replace
-     * the old message. This functionality is used in saving of drafts and re-synchronization
-     * of updated server messages.
-     *
-     * NOTE that although this method is located in the LocalStore class, it is not guaranteed
-     * that the messages supplied as parameters are actually {@link LocalMessage} instances (in
-     * fact, in most cases, they are not). Therefore, if you want to make local changes only to a
-     * message, retrieve the appropriate local message instance first (if it already exists).
-     * @return uidMap of srcUids -> destUids
-     */
-    private Map<String, String> appendMessages(final List<? extends Message> messages, final boolean copy)
-            throws MessagingException {
-        open();
-        try {
-            final Map<String, String> uidMap = new HashMap<>();
-            this.localStore.getDatabase().execute(true, new DbCallback<Void>() {
-                @Override
-                public Void doDbWork(final SQLiteDatabase db) throws WrappedException, UnavailableStorageException {
-                    try {
-                        for (Message message : messages) {
-                            saveMessage(db, message, copy, uidMap);
-                        }
-                    } catch (MessagingException e) {
-                        throw new WrappedException(e);
-                    }
-                    return null;
-                }
-            });
-
-            this.localStore.notifyChange();
-
-            return uidMap;
-        } catch (WrappedException e) {
-            throw (MessagingException) e.getCause();
-        }
-    }
-
-    private void saveMessage(SQLiteDatabase db, Message message, boolean copy, Map<String, String> uidMap)
-            throws MessagingException {
-        if (!(message instanceof MimeMessage)) {
-            throw new Error("LocalStore can only store Messages that extend MimeMessage");
-        }
-
-        long oldMessageId = -1;
-        String uid = message.getUid();
-        boolean shouldCreateNewMessage = uid == null || copy;
-        if (shouldCreateNewMessage) {
-            String randomLocalUid = K9.LOCAL_UID_PREFIX + UUID.randomUUID().toString();
-
-            if (copy) {
-                // Save mapping: source UID -> target UID
-                uidMap.put(uid, randomLocalUid);
-            } else {
-                // Modify the Message instance to reference the new UID
-                message.setUid(randomLocalUid);
-            }
-
-            // The message will be saved with the newly generated UID
-            uid = randomLocalUid;
-        } else {
-            LocalMessage oldMessage = getMessage(uid);
-
-            if (oldMessage != null) {
-                oldMessageId = oldMessage.getDatabaseId();
-
-                long oldRootMessagePartId = oldMessage.getMessagePartId();
-                deleteMessagePartsAndDataFromDisk(oldRootMessagePartId);
-            }
-        }
-
-        long rootId = -1;
-        long parentId = -1;
-        long msgId;
-
-        if (oldMessageId == -1) {
-            // This is a new message. Do the message threading.
-            ThreadInfo threadInfo = doMessageThreading(db, message);
-            oldMessageId = threadInfo.msgId;
-            rootId = threadInfo.rootId;
-            parentId = threadInfo.parentId;
-        }
-
-        try {
-            String encryptionType;
-            PreviewResult previewResult;
-            int attachmentCount;
-            String fulltext;
-            ContentValues extraContentValues;
-
-            EncryptionResult encryptionResult = encryptionExtractor.extractEncryption(message);
-            if (encryptionResult != null) {
-                encryptionType = encryptionResult.getEncryptionType();
-                previewResult = encryptionResult.getPreviewResult();
-                attachmentCount = encryptionResult.getAttachmentCount();
-                fulltext = encryptionResult.getTextForSearchIndex();
-                extraContentValues = encryptionResult.getExtraContentValues();
-            } else {
-                MessagePreviewCreator previewCreator = localStore.getMessagePreviewCreator();
-                MessageFulltextCreator fulltextCreator = localStore.getMessageFulltextCreator();
-                AttachmentCounter attachmentCounter = localStore.getAttachmentCounter();
-
-                encryptionType = null;
-                previewResult = previewCreator.createPreview(message);
-                attachmentCount = attachmentCounter.getAttachmentCount(message);
-                fulltext = fulltextCreator.createFulltext(message);
-                extraContentValues = null;
-            }
-
-            PreviewType previewType = previewResult.getPreviewType();
-            DatabasePreviewType databasePreviewType = DatabasePreviewType.fromPreviewType(previewType);
-
-            long rootMessagePartId = saveMessageParts(db, message);
-
-            ContentValues cv = new ContentValues();
-            cv.put("message_part_id", rootMessagePartId);
-            cv.put("uid", uid);
-            cv.put("subject", message.getSubject());
-            cv.put("sender_list", Address.pack(message.getFrom()));
-            cv.put("date", message.getSentDate() == null
-                    ? System.currentTimeMillis() : message.getSentDate().getTime());
-            cv.put("flags", LocalStore.serializeFlags(message.getFlags()));
-            cv.put("deleted", message.isSet(Flag.DELETED) ? 1 : 0);
-            cv.put("read", message.isSet(Flag.SEEN) ? 1 : 0);
-            cv.put("flagged", message.isSet(Flag.FLAGGED) ? 1 : 0);
-            cv.put("answered", message.isSet(Flag.ANSWERED) ? 1 : 0);
-            cv.put("forwarded", message.isSet(Flag.FORWARDED) ? 1 : 0);
-            cv.put("folder_id", databaseId);
-            cv.put("to_list", Address.pack(message.getRecipients(RecipientType.TO)));
-            cv.put("cc_list", Address.pack(message.getRecipients(RecipientType.CC)));
-            cv.put("bcc_list", Address.pack(message.getRecipients(RecipientType.BCC)));
-            cv.put("reply_to_list", Address.pack(message.getReplyTo()));
-            cv.put("attachment_count", attachmentCount);
-            cv.put("internal_date", message.getInternalDate() == null
-                    ? System.currentTimeMillis() : message.getInternalDate().getTime());
-            cv.put("mime_type", message.getMimeType());
-            cv.put("empty", 0);
-            cv.put("encryption_type", encryptionType);
-
-            cv.put("preview_type", databasePreviewType.getDatabaseValue());
-            if (previewResult.isPreviewTextAvailable()) {
-                cv.put("preview", previewResult.getPreviewText());
-            } else {
-                cv.putNull("preview");
-            }
-
-            String messageId = message.getMessageId();
-            if (messageId != null) {
-                cv.put("message_id", messageId);
-            }
-
-            if (extraContentValues != null) {
-                cv.putAll(extraContentValues);
-            }
-
-            if (oldMessageId == -1) {
-                msgId = db.insert("messages", "uid", cv);
-
-                // Create entry in 'threads' table
-                cv.clear();
-                cv.put("message_id", msgId);
-
-                if (rootId != -1) {
-                    cv.put("root", rootId);
-                }
-                if (parentId != -1) {
-                    cv.put("parent", parentId);
-                }
-
-                db.insert("threads", null, cv);
-            } else {
-                msgId = oldMessageId;
-                db.update("messages", cv, "id = ?", new String[] { Long.toString(oldMessageId) });
-            }
-
-            if (fulltext != null) {
-                cv.clear();
-                cv.put("docid", msgId);
-                cv.put("fulltext", fulltext);
-                db.replace("messages_fulltext", null, cv);
-            }
-        } catch (Exception e) {
-            throw new MessagingException("Error appending message: " + message.getSubject(), e);
-        }
-    }
-
-    private long saveMessageParts(SQLiteDatabase db, Message message) throws IOException, MessagingException {
-        long rootMessagePartId = saveMessagePart(db, new PartContainer(-1, message), -1, 0);
-
-        Stack<PartContainer> partsToSave = new Stack<>();
-        addChildrenToStack(partsToSave, message, rootMessagePartId);
-
-        int order = 1;
-        while (!partsToSave.isEmpty()) {
-            PartContainer partContainer = partsToSave.pop();
-            long messagePartId = saveMessagePart(db, partContainer, rootMessagePartId, order);
-            order++;
-
-            addChildrenToStack(partsToSave, partContainer.part, messagePartId);
-        }
-
-        return rootMessagePartId;
-    }
-
-    private long saveMessagePart(SQLiteDatabase db, PartContainer partContainer, long rootMessagePartId, int order)
-            throws IOException, MessagingException {
-
-        Part part = partContainer.part;
-
-        ContentValues cv = new ContentValues();
-        if (rootMessagePartId != -1) {
-            cv.put("root", rootMessagePartId);
-        }
-        cv.put("parent", partContainer.parent);
-        cv.put("seq", order);
-        cv.put("server_extra", part.getServerExtra());
-
-        return updateOrInsertMessagePart(db, cv, part, INVALID_MESSAGE_PART_ID);
     }
 
     private void moveTemporaryFile(File tempFile, String messagePartId) throws IOException {
@@ -1243,30 +970,6 @@ public class LocalFolder {
         }
 
         return MimeUtil.ENC_7BIT;
-    }
-
-    private void addChildrenToStack(Stack<PartContainer> stack, Part part, long parentMessageId) {
-        Body body = part.getBody();
-        if (body instanceof Multipart) {
-            Multipart multipart = (Multipart) body;
-            for (int i = multipart.getCount() - 1; i >= 0; i--) {
-                BodyPart childPart = multipart.getBodyPart(i);
-                stack.push(new PartContainer(parentMessageId, childPart));
-            }
-        } else if (body instanceof Message) {
-            Message innerMessage = (Message) body;
-            stack.push(new PartContainer(parentMessageId, innerMessage));
-        }
-    }
-
-    private static class PartContainer {
-        public final long parent;
-        public final Part part;
-
-        PartContainer(long parent, Part part) {
-            this.parent = parent;
-            this.part = part;
-        }
     }
 
     public void addPartToMessage(final LocalMessage message, final Part part) throws MessagingException {
@@ -1636,108 +1339,6 @@ public class LocalFolder {
     public void setInTopGroup(boolean inTopGroup) throws MessagingException {
         isInTopGroup = inTopGroup;
         updateFolderColumn("top_group", isInTopGroup ? 1 : 0);
-    }
-
-    public ThreadInfo doMessageThreading(SQLiteDatabase db, Message message) {
-        long rootId = -1;
-        long parentId = -1;
-
-        String messageId = message.getMessageId();
-
-        // If there's already an empty message in the database, update that
-        ThreadInfo msgThreadInfo = getThreadInfo(db, messageId, true);
-
-        // Get the message IDs from the "References" header line
-        String[] referencesArray = message.getHeader("References");
-        List<String> messageIds = null;
-        if (referencesArray.length > 0) {
-            messageIds = Utility.extractMessageIds(referencesArray[0]);
-        }
-
-        // Append the first message ID from the "In-Reply-To" header line
-        String[] inReplyToArray = message.getHeader("In-Reply-To");
-        String inReplyTo;
-        if (inReplyToArray.length > 0) {
-            inReplyTo = Utility.extractMessageId(inReplyToArray[0]);
-            if (inReplyTo != null) {
-                if (messageIds == null) {
-                    messageIds = new ArrayList<>(1);
-                    messageIds.add(inReplyTo);
-                } else if (!messageIds.contains(inReplyTo)) {
-                    messageIds.add(inReplyTo);
-                }
-            }
-        }
-
-        if (messageIds == null) {
-            // This is not a reply, nothing to do for us.
-            return (msgThreadInfo != null) ?
-                    msgThreadInfo : new ThreadInfo(-1, -1, messageId, -1, -1);
-        }
-
-        for (String reference : messageIds) {
-            ThreadInfo threadInfo = getThreadInfo(db, reference, false);
-
-            if (threadInfo == null) {
-                // Create placeholder message in 'messages' table
-                ContentValues cv = new ContentValues();
-                cv.put("message_id", reference);
-                cv.put("folder_id", databaseId);
-                cv.put("empty", 1);
-
-                long newMsgId = db.insert("messages", null, cv);
-
-                // Create entry in 'threads' table
-                cv.clear();
-                cv.put("message_id", newMsgId);
-                if (rootId != -1) {
-                    cv.put("root", rootId);
-                }
-                if (parentId != -1) {
-                    cv.put("parent", parentId);
-                }
-
-                parentId = db.insert("threads", null, cv);
-                if (rootId == -1) {
-                    rootId = parentId;
-                }
-            } else {
-                if (rootId != -1 && threadInfo.rootId == -1 && rootId != threadInfo.threadId) {
-                    // We found an existing root container that is not
-                    // the root of our current path (References).
-                    // Connect it to the current parent.
-
-                    // Let all children know who's the new root
-                    ContentValues cv = new ContentValues();
-                    cv.put("root", rootId);
-                    db.update("threads", cv, "root = ?",
-                            new String[] { Long.toString(threadInfo.threadId) });
-
-                    // Connect the message to the current parent
-                    cv.put("parent", parentId);
-                    db.update("threads", cv, "id = ?",
-                            new String[] { Long.toString(threadInfo.threadId) });
-                } else {
-                    rootId = (threadInfo.rootId == -1) ?
-                            threadInfo.threadId : threadInfo.rootId;
-                }
-                parentId = threadInfo.threadId;
-            }
-        }
-
-        //TODO: set in-reply-to "link" even if one already exists
-
-        long threadId;
-        long msgId;
-        if (msgThreadInfo != null) {
-            threadId = msgThreadInfo.threadId;
-            msgId = msgThreadInfo.msgId;
-        } else {
-            threadId = -1;
-            msgId = -1;
-        }
-
-        return new ThreadInfo(threadId, msgId, messageId, rootId, parentId);
     }
 
     public List<String> extractNewMessages(final List<String> messageServerIds)

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
@@ -28,6 +28,26 @@ interface MessageStore {
     fun saveLocalMessage(folderId: Long, messageData: SaveMessageData, existingMessageId: Long? = null): Long
 
     /**
+     * Copy a message to another folder.
+     *
+     * @return The message's database ID in the destination folder.
+     */
+    fun copyMessage(messageId: Long, destinationFolderId: Long): Long
+
+    /**
+     * Copy messages to another folder.
+     *
+     * @return A mapping of the original message database ID to the new message database ID.
+     */
+    fun copyMessages(messageIds: Collection<Long>, destinationFolderId: Long): Map<Long, Long> {
+        return messageIds
+            .map { messageId ->
+                messageId to copyMessage(messageId, destinationFolderId)
+            }
+            .toMap()
+    }
+
+    /**
      * Move a message to another folder.
      *
      * @return The message's database ID in the destination folder. This will most likely be different from the

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentFileManager.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentFileManager.kt
@@ -7,7 +7,7 @@ import com.fsck.k9.mailstore.StorageManager.InternalStorageProvider
 import java.io.File
 import timber.log.Timber
 
-class AttachmentFileManager(
+internal class AttachmentFileManager(
     private val storageManager: StorageManager,
     private val accountUuid: String
 ) {
@@ -23,7 +23,13 @@ class AttachmentFileManager(
         FileHelper.renameOrMoveByCopying(temporaryFile, destinationFile)
     }
 
-    private fun getAttachmentFile(messagePartId: Long): File {
+    fun copyFile(sourceMessagePartId: Long, destinationMessagePartId: Long) {
+        val sourceFile = getAttachmentFile(sourceMessagePartId)
+        val destinationFile = getAttachmentFile(destinationMessagePartId)
+        sourceFile.copyTo(destinationFile)
+    }
+
+    fun getAttachmentFile(messagePartId: Long): File {
         val attachmentDirectory = storageManager.getAttachmentDirectory(accountUuid, InternalStorageProvider.ID)
         return File(attachmentDirectory, messagePartId.toString())
     }

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/CopyMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/CopyMessageOperations.kt
@@ -1,0 +1,315 @@
+package com.fsck.k9.storage.messages
+
+import android.content.ContentValues
+import android.database.Cursor
+import android.database.sqlite.SQLiteDatabase
+import androidx.core.database.getBlobOrNull
+import androidx.core.database.getLongOrNull
+import androidx.core.database.getStringOrNull
+import com.fsck.k9.K9
+import com.fsck.k9.mailstore.LockableDatabase
+import java.util.UUID
+
+internal class CopyMessageOperations(
+    private val lockableDatabase: LockableDatabase,
+    private val attachmentFileManager: AttachmentFileManager,
+    private val threadMessageOperations: ThreadMessageOperations
+) {
+    fun copyMessage(messageId: Long, destinationFolderId: Long): Long {
+        return lockableDatabase.execute(true) { database ->
+            val newMessageId = copyMessage(database, messageId, destinationFolderId)
+
+            copyFulltextEntry(database, newMessageId, messageId)
+
+            newMessageId
+        }
+    }
+
+    private fun copyMessage(
+        database: SQLiteDatabase,
+        messageId: Long,
+        destinationFolderId: Long
+    ): Long {
+        val rootMessagePart = copyMessageParts(database, messageId)
+
+        val threadInfo = threadMessageOperations.doMessageThreading(
+            database,
+            folderId = destinationFolderId,
+            threadHeaders = threadMessageOperations.getMessageThreadHeaders(database, messageId)
+        )
+
+        return if (threadInfo?.messageId != null) {
+            updateMessageRow(
+                database,
+                sourceMessageId = messageId,
+                destinationMessageId = threadInfo.messageId,
+                destinationFolderId,
+                rootMessagePart
+            )
+        } else {
+            val newMessageId = insertMessageRow(
+                database,
+                sourceMessageId = messageId,
+                destinationFolderId = destinationFolderId,
+                rootMessagePartId = rootMessagePart
+            )
+
+            if (threadInfo?.threadId == null) {
+                threadMessageOperations.createThreadEntry(
+                    database,
+                    newMessageId,
+                    threadInfo?.rootId,
+                    threadInfo?.parentId
+                )
+            }
+
+            newMessageId
+        }
+    }
+
+    private fun copyMessageParts(database: SQLiteDatabase, messageId: Long): Long {
+        return database.rawQuery(
+            """
+            SELECT                 
+                message_parts.id,
+                message_parts.type,
+                message_parts.root,
+                message_parts.parent,
+                message_parts.seq,
+                message_parts.mime_type,
+                message_parts.decoded_body_size,
+                message_parts.display_name,
+                message_parts.header,
+                message_parts.encoding,
+                message_parts.charset,
+                message_parts.data_location,
+                message_parts.data,
+                message_parts.preamble,
+                message_parts.epilogue,
+                message_parts.boundary,
+                message_parts.content_id,
+                message_parts.server_extra 
+            FROM messages 
+            JOIN message_parts ON (message_parts.root = messages.message_part_id) 
+            WHERE messages.id = ? 
+            ORDER BY message_parts.seq
+            """.trimIndent(),
+            arrayOf(messageId.toString())
+        ).use { cursor ->
+            if (!cursor.moveToNext()) error("No message part found for message with ID $messageId")
+
+            val rootMessagePart = cursor.readMessagePart()
+
+            val rootMessagePartId = writeMessagePart(
+                database = database,
+                databaseMessagePart = rootMessagePart,
+                newRootId = null,
+                newParentId = -1
+            )
+
+            val messagePartIdMapping = mutableMapOf<Long, Long>()
+            messagePartIdMapping[rootMessagePart.id] = rootMessagePartId
+
+            while (cursor.moveToNext()) {
+                val messagePart = cursor.readMessagePart()
+
+                messagePartIdMapping[messagePart.id] = writeMessagePart(
+                    database = database,
+                    databaseMessagePart = messagePart,
+                    newRootId = rootMessagePartId,
+                    newParentId = messagePartIdMapping[messagePart.parent] ?: error("parent ID not found")
+                )
+            }
+
+            rootMessagePartId
+        }
+    }
+
+    private fun writeMessagePart(
+        database: SQLiteDatabase,
+        databaseMessagePart: DatabaseMessagePart,
+        newRootId: Long?,
+        newParentId: Long
+    ): Long {
+        val values = ContentValues().apply {
+            put("type", databaseMessagePart.type)
+            put("root", newRootId)
+            put("parent", newParentId)
+            put("seq", databaseMessagePart.seq)
+            put("mime_type", databaseMessagePart.mimeType)
+            put("decoded_body_size", databaseMessagePart.decodedBodySize)
+            put("display_name", databaseMessagePart.displayName)
+            put("header", databaseMessagePart.header)
+            put("encoding", databaseMessagePart.encoding)
+            put("charset", databaseMessagePart.charset)
+            put("data_location", databaseMessagePart.dataLocation)
+            put("data", databaseMessagePart.data)
+            put("preamble", databaseMessagePart.preamble)
+            put("epilogue", databaseMessagePart.epilogue)
+            put("boundary", databaseMessagePart.boundary)
+            put("content_id", databaseMessagePart.contentId)
+            put("server_extra", databaseMessagePart.serverExtra)
+        }
+
+        val messagePartId = database.insert("message_parts", null, values)
+
+        if (databaseMessagePart.dataLocation == DataLocation.ON_DISK) {
+            attachmentFileManager.copyFile(databaseMessagePart.id, messagePartId)
+        }
+
+        return messagePartId
+    }
+
+    private fun updateMessageRow(
+        database: SQLiteDatabase,
+        sourceMessageId: Long,
+        destinationMessageId: Long,
+        destinationFolderId: Long,
+        rootMessagePartId: Long
+    ): Long {
+        val values = readMessageToContentValues(database, sourceMessageId, destinationFolderId, rootMessagePartId)
+
+        database.update("messages", values, "id = ?", arrayOf(destinationMessageId.toString()))
+        return destinationMessageId
+    }
+
+    private fun insertMessageRow(
+        database: SQLiteDatabase,
+        sourceMessageId: Long,
+        destinationFolderId: Long,
+        rootMessagePartId: Long
+    ): Long {
+        val values = readMessageToContentValues(database, sourceMessageId, destinationFolderId, rootMessagePartId)
+
+        return database.insert("messages", null, values)
+    }
+
+    private fun readMessageToContentValues(
+        database: SQLiteDatabase,
+        sourceMessageId: Long,
+        destinationFolderId: Long,
+        rootMessagePartId: Long
+    ): ContentValues {
+        val values = readMessageToContentValues(database, sourceMessageId)
+
+        return values.apply {
+            put("folder_id", destinationFolderId)
+            put("uid", K9.LOCAL_UID_PREFIX + UUID.randomUUID().toString())
+            put("message_part_id", rootMessagePartId)
+        }
+    }
+
+    private fun copyFulltextEntry(database: SQLiteDatabase, newMessageId: Long, messageId: Long) {
+        database.execSQL(
+            """
+            INSERT OR REPLACE INTO messages_fulltext (docid, fulltext)
+              SELECT ?, fulltext FROM messages_fulltext WHERE docid = ?
+            """.trimIndent(),
+            arrayOf(newMessageId.toString(), messageId.toString())
+        )
+    }
+
+    private fun readMessageToContentValues(database: SQLiteDatabase, messageId: Long): ContentValues {
+        return database.query(
+            "messages",
+            arrayOf(
+                "deleted",
+                "subject",
+                "date",
+                "flags",
+                "sender_list",
+                "to_list",
+                "cc_list",
+                "bcc_list",
+                "reply_to_list",
+                "attachment_count",
+                "internal_date",
+                "message_id",
+                "preview_type",
+                "preview",
+                "mime_type",
+                "normalized_subject_hash",
+                "empty",
+                "read",
+                "flagged",
+                "answered",
+                "forwarded",
+                "encryption_type"
+            ),
+            "id = ?",
+            arrayOf(messageId.toString()),
+            null, null, null
+        ).use { cursor ->
+            if (!cursor.moveToNext()) error("Message with ID $messageId not found")
+
+            ContentValues().apply {
+                put("deleted", cursor.getInt(0))
+                put("subject", cursor.getStringOrNull(1))
+                put("date", cursor.getLong(2))
+                put("flags", cursor.getStringOrNull(3))
+                put("sender_list", cursor.getStringOrNull(4))
+                put("to_list", cursor.getStringOrNull(5))
+                put("cc_list", cursor.getStringOrNull(6))
+                put("bcc_list", cursor.getStringOrNull(7))
+                put("reply_to_list", cursor.getStringOrNull(8))
+                put("attachment_count", cursor.getInt(9))
+                put("internal_date", cursor.getLong(10))
+                put("message_id", cursor.getStringOrNull(11))
+                put("preview_type", cursor.getStringOrNull(12))
+                put("preview", cursor.getStringOrNull(13))
+                put("mime_type", cursor.getStringOrNull(14))
+                put("normalized_subject_hash", cursor.getLong(15))
+                put("empty", cursor.getInt(16))
+                put("read", cursor.getInt(17))
+                put("flagged", cursor.getInt(18))
+                put("answered", cursor.getInt(19))
+                put("forwarded", cursor.getInt(20))
+                put("encryption_type", cursor.getStringOrNull(21))
+            }
+        }
+    }
+
+    private fun Cursor.readMessagePart(): DatabaseMessagePart {
+        return DatabaseMessagePart(
+            id = getLong(0),
+            type = getInt(1),
+            root = getLong(2),
+            parent = getLong(3),
+            seq = getInt(4),
+            mimeType = getString(5),
+            decodedBodySize = getLongOrNull(6),
+            displayName = getStringOrNull(7),
+            header = getBlobOrNull(8),
+            encoding = getStringOrNull(9),
+            charset = getStringOrNull(10),
+            dataLocation = getInt(11),
+            data = getBlobOrNull(12),
+            preamble = getBlobOrNull(13),
+            epilogue = getBlobOrNull(14),
+            boundary = getStringOrNull(15),
+            contentId = getStringOrNull(16),
+            serverExtra = getStringOrNull(17)
+        )
+    }
+}
+
+private class DatabaseMessagePart(
+    val id: Long,
+    val type: Int,
+    val root: Long,
+    val parent: Long,
+    val seq: Int,
+    val mimeType: String?,
+    val decodedBodySize: Long?,
+    val displayName: String?,
+    val header: ByteArray?,
+    val encoding: String?,
+    val charset: String?,
+    val dataLocation: Int,
+    val data: ByteArray?,
+    val preamble: ByteArray?,
+    val epilogue: ByteArray?,
+    val boundary: String?,
+    val contentId: String?,
+    val serverExtra: String?
+)

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -33,6 +33,7 @@ class K9MessageStore(
         basicPartInfoExtractor,
         threadMessageOperations
     )
+    private val copyMessageOperations = CopyMessageOperations(database, attachmentFileManager, threadMessageOperations)
     private val moveMessageOperations = MoveMessageOperations(database, threadMessageOperations)
     private val flagMessageOperations = FlagMessageOperations(database)
     private val retrieveMessageOperations = RetrieveMessageOperations(database)
@@ -50,6 +51,12 @@ class K9MessageStore(
 
     override fun saveLocalMessage(folderId: Long, messageData: SaveMessageData, existingMessageId: Long?): Long {
         return saveMessageOperations.saveLocalMessage(folderId, messageData, existingMessageId)
+    }
+
+    override fun copyMessage(messageId: Long, destinationFolderId: Long): Long {
+        return copyMessageOperations.copyMessage(messageId, destinationFolderId).also {
+            localStore.notifyChange()
+        }
     }
 
     override fun moveMessage(messageId: Long, destinationFolderId: Long): Long {

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/ThreadMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/ThreadMessageOperations.kt
@@ -18,7 +18,7 @@ internal class ThreadMessageOperations {
         return doMessageThreading(database, destinationFolderId, threadHeaders)
     }
 
-    private fun getMessageThreadHeaders(database: SQLiteDatabase, messageId: Long): ThreadHeaders {
+    fun getMessageThreadHeaders(database: SQLiteDatabase, messageId: Long): ThreadHeaders {
         return database.rawQuery(
             """
             SELECT messages.message_id, message_parts.header 

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/CopyMessageOperationsTest.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/CopyMessageOperationsTest.kt
@@ -1,0 +1,248 @@
+package com.fsck.k9.storage.messages
+
+import com.fsck.k9.mail.crlf
+import com.fsck.k9.mailstore.StorageManager
+import com.fsck.k9.storage.RobolectricTest
+import com.google.common.truth.Truth.assertThat
+import okio.buffer
+import okio.sink
+import okio.source
+import org.junit.After
+import org.junit.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+
+private const val ACCOUNT_UUID = "00000000-0000-4000-0000-000000000000"
+
+class CopyMessageOperationsTest : RobolectricTest() {
+    private val messagePartDirectory = createRandomTempDirectory()
+    private val sqliteDatabase = createDatabase()
+    private val storageManager = mock<StorageManager> {
+        on { getAttachmentDirectory(eq(ACCOUNT_UUID), anyOrNull()) } doReturn messagePartDirectory
+    }
+    private val lockableDatabase = createLockableDatabaseMock(sqliteDatabase)
+    private val attachmentFileManager = AttachmentFileManager(storageManager, ACCOUNT_UUID)
+    private val threadMessageOperations = ThreadMessageOperations()
+    private val copyMessageOperations = CopyMessageOperations(
+        lockableDatabase,
+        attachmentFileManager,
+        threadMessageOperations
+    )
+
+    @After
+    fun tearDown() {
+        messagePartDirectory.deleteRecursively()
+    }
+
+    @Test
+    fun `copy message that is part of a thread`() {
+        val sourceMessagePartId1 = sqliteDatabase.createMessagePart(
+            seq = 0,
+            dataLocation = DataLocation.CHILD_PART_CONTAINS_DATA,
+            mimeType = "multipart/mixed",
+            boundary = "--boundary",
+            header = "Message-ID: <msg0002@domain.example>\nIn-Reply-To: <msg0001@domain.example>\n".crlf()
+        )
+        val sourceMessagePartId2 = sqliteDatabase.createMessagePart(
+            seq = 1,
+            root = sourceMessagePartId1,
+            parent = sourceMessagePartId1,
+            mimeType = "text/plain",
+            dataLocation = DataLocation.IN_DATABASE,
+            data = "Text part".toByteArray()
+        )
+        val sourceMessagePartId3 = sqliteDatabase.createMessagePart(
+            seq = 2,
+            root = sourceMessagePartId1,
+            parent = sourceMessagePartId1,
+            mimeType = "application/octet-stream",
+            dataLocation = DataLocation.ON_DISK
+        )
+        attachmentFileManager.getAttachmentFile(sourceMessagePartId3).sink().buffer().use { sink ->
+            sink.writeUtf8("Part contents")
+        }
+
+        val messageId1 = sqliteDatabase.createMessage(
+            folderId = 1,
+            empty = true,
+            messageIdHeader = "<msg0001@domain.example>"
+        )
+        val messageId2 = sqliteDatabase.createMessage(
+            folderId = 1,
+            empty = false,
+            messageIdHeader = "<msg0002@domain.example>",
+            messagePartId = sourceMessagePartId1
+        )
+        val messageId3 = sqliteDatabase.createMessage(
+            folderId = 1,
+            empty = false,
+            messageIdHeader = "<msg0003@domain.example>"
+        )
+        val threadId1 = sqliteDatabase.createThread(messageId1)
+        val threadId2 = sqliteDatabase.createThread(messageId2, root = threadId1, parent = threadId1)
+        val threadId3 = sqliteDatabase.createThread(messageId3, root = threadId1, parent = threadId2)
+
+        val destinationMessageId = copyMessageOperations.copyMessage(messageId = messageId2, destinationFolderId = 2)
+
+        assertThat(destinationMessageId).isNotIn(setOf(messageId1, messageId2, messageId3))
+
+        val threads = sqliteDatabase.readThreads()
+        assertThat(threads).hasSize(3 + 2)
+
+        val destinationMessageThread = threads.first { it.messageId == destinationMessageId }
+        assertThat(destinationMessageThread.id).isNotIn(setOf(threadId1, threadId2, threadId3))
+        assertThat(destinationMessageThread.parent).isEqualTo(destinationMessageThread.root)
+
+        val destinationRootThread = threads.first { it.id == destinationMessageThread.root }
+        assertThat(destinationRootThread.messageId).isNotIn(setOf(messageId1, messageId2, messageId3))
+        assertThat(destinationRootThread.root).isEqualTo(destinationRootThread.id)
+        assertThat(destinationRootThread.parent).isNull()
+
+        val messages = sqliteDatabase.readMessages()
+        val destinationRootThreadMessage = messages.first { it.id == destinationRootThread.messageId }
+        assertThat(destinationRootThreadMessage.empty).isEqualTo(1)
+        assertThat(destinationRootThreadMessage.folderId).isEqualTo(2)
+        assertThat(destinationRootThreadMessage.messageId).isEqualTo("<msg0001@domain.example>")
+
+        val destinationMessage = messages.first { it.id == destinationMessageThread.messageId }
+        val sourceMessage = messages.first { it.id == messageId2 }
+        assertThat(destinationMessage).isEqualTo(
+            sourceMessage.copy(
+                id = destinationMessageId,
+                uid = destinationMessage.uid,
+                folderId = 2,
+                messagePartId = destinationMessage.messagePartId
+            )
+        )
+
+        val messageParts = sqliteDatabase.readMessageParts()
+        assertThat(messageParts).hasSize(3 + 3)
+
+        val sourceMessagePart1 = messageParts.first { it.id == sourceMessagePartId1 }
+        val sourceMessagePart2 = messageParts.first { it.id == sourceMessagePartId2 }
+        val sourceMessagePart3 = messageParts.first { it.id == sourceMessagePartId3 }
+        val destinationMessagePart1 = messageParts.first { it.id == destinationMessage.messagePartId }
+        val destinationMessagePart2 = messageParts.first { it.root == destinationMessage.messagePartId && it.seq == 1 }
+        val destinationMessagePart3 = messageParts.first { it.root == destinationMessage.messagePartId && it.seq == 2 }
+        assertThat(destinationMessagePart1).isNotIn(setOf(sourceMessagePart1, sourceMessagePart2, sourceMessagePart3))
+        assertThat(destinationMessagePart1).isEqualTo(
+            sourceMessagePart1.copy(
+                id = destinationMessagePart1.id,
+                root = destinationMessagePart1.id,
+                parent = -1
+            )
+        )
+        assertThat(destinationMessagePart2).isNotIn(setOf(sourceMessagePart1, sourceMessagePart2, sourceMessagePart3))
+        assertThat(destinationMessagePart2).isEqualTo(
+            sourceMessagePart2.copy(
+                id = destinationMessagePart2.id,
+                root = destinationMessagePart1.id,
+                parent = destinationMessagePart1.id
+            )
+        )
+        assertThat(destinationMessagePart3).isNotIn(setOf(sourceMessagePart1, sourceMessagePart2, sourceMessagePart3))
+        assertThat(destinationMessagePart3).isEqualTo(
+            sourceMessagePart3.copy(
+                id = destinationMessagePart3.id,
+                root = destinationMessagePart1.id,
+                parent = destinationMessagePart1.id
+            )
+        )
+
+        val files = messagePartDirectory.list()?.toList() ?: emptyList()
+        assertThat(files).hasSize(2)
+
+        attachmentFileManager.getAttachmentFile(destinationMessagePart3.id!!).source().buffer().use { source ->
+            assertThat(source.readUtf8()).isEqualTo("Part contents")
+        }
+    }
+
+    @Test
+    fun `copy message into an existing thread`() {
+        val sourceMessagePartId = sqliteDatabase.createMessagePart(
+            header = "Message-ID: <msg0002@domain.example>\nIn-Reply-To: <msg0001@domain.example>\n".crlf(),
+            mimeType = "text/plain",
+            dataLocation = DataLocation.IN_DATABASE,
+            data = "Text part".toByteArray()
+        )
+        attachmentFileManager.getAttachmentFile(sourceMessagePartId).sink().buffer().use { sink ->
+            sink.writeUtf8("Part contents")
+        }
+
+        val sourceMessageId = sqliteDatabase.createMessage(
+            folderId = 1,
+            empty = false,
+            messageIdHeader = "<msg0002@domain.example>",
+            messagePartId = sourceMessagePartId
+        )
+        val destinationMessageId = sqliteDatabase.createMessage(
+            folderId = 2,
+            empty = true,
+            messageIdHeader = "<msg0002@domain.example>"
+        )
+        val otherDestinationMessageId = sqliteDatabase.createMessage(
+            folderId = 2,
+            empty = false,
+            messageIdHeader = "<msg0003@domain.example>"
+        )
+        val destinationThreadId = sqliteDatabase.createThread(destinationMessageId)
+        val otherDestinationThreadId = sqliteDatabase.createThread(
+            otherDestinationMessageId,
+            root = destinationThreadId,
+            parent = destinationThreadId
+        )
+
+        val resultMessageId = copyMessageOperations.copyMessage(messageId = sourceMessageId, destinationFolderId = 2)
+
+        assertThat(resultMessageId).isEqualTo(destinationMessageId)
+
+        val threads = sqliteDatabase.readThreads()
+        assertThat(threads).hasSize(2 + 1)
+
+        val destinationThread = threads.first { it.messageId == destinationMessageId }
+        assertThat(destinationThread.id).isEqualTo(destinationThreadId)
+        assertThat(destinationThread.parent).isEqualTo(destinationThread.root)
+
+        val destinationRootThread = threads.first { it.id == destinationThread.root }
+        assertThat(destinationRootThread.root).isEqualTo(destinationRootThread.id)
+        assertThat(destinationRootThread.parent).isNull()
+
+        val otherDestinationThread = threads.first { it.id == otherDestinationThreadId }
+        assertThat(otherDestinationThread.root).isEqualTo(destinationRootThread.id)
+        assertThat(otherDestinationThread.parent).isEqualTo(destinationThread.id)
+
+        val messages = sqliteDatabase.readMessages()
+        assertThat(messages).hasSize(3 + 1)
+
+        val destinationRootThreadMessage = messages.first { it.id == destinationRootThread.messageId }
+        assertThat(destinationRootThreadMessage.empty).isEqualTo(1)
+        assertThat(destinationRootThreadMessage.folderId).isEqualTo(2)
+        assertThat(destinationRootThreadMessage.messageId).isEqualTo("<msg0001@domain.example>")
+
+        val destinationMessage = messages.first { it.id == destinationMessageId }
+        val sourceMessage = messages.first { it.id == sourceMessageId }
+        assertThat(destinationMessage).isEqualTo(
+            sourceMessage.copy(
+                id = destinationMessageId,
+                uid = destinationMessage.uid,
+                folderId = 2,
+                messagePartId = destinationMessage.messagePartId
+            )
+        )
+
+        val messageParts = sqliteDatabase.readMessageParts()
+        assertThat(messageParts).hasSize(1 + 1)
+
+        val sourceMessagePart = messageParts.first { it.id == sourceMessagePartId }
+        val destinationMessagePart = messageParts.first { it.id == destinationMessage.messagePartId }
+        assertThat(destinationMessagePart).isEqualTo(
+            sourceMessagePart.copy(
+                id = destinationMessagePart.id,
+                root = destinationMessagePart.id,
+                parent = -1
+            )
+        )
+    }
+}

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/MessagePartDatabaseHelpers.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/MessagePartDatabaseHelpers.kt
@@ -10,8 +10,8 @@ import com.fsck.k9.helper.map
 
 fun SQLiteDatabase.createMessagePart(
     type: Int = MessagePartType.UNKNOWN,
-    root: Int? = null,
-    parent: Int = -1,
+    root: Long? = null,
+    parent: Long = -1,
     seq: Int = 0,
     mimeType: String? = null,
     decodedBodySize: Int? = null,
@@ -77,7 +77,7 @@ fun SQLiteDatabase.readMessageParts(): List<MessagePartEntry> {
     }
 }
 
-class MessagePartEntry(
+data class MessagePartEntry(
     val id: Long?,
     val type: Int?,
     val root: Long?,
@@ -96,7 +96,85 @@ class MessagePartEntry(
     val boundary: String?,
     val contentId: String?,
     val serverExtra: String?
-)
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MessagePartEntry
+
+        if (id != other.id) return false
+        if (type != other.type) return false
+        if (root != other.root) return false
+        if (parent != other.parent) return false
+        if (seq != other.seq) return false
+        if (mimeType != other.mimeType) return false
+        if (decodedBodySize != other.decodedBodySize) return false
+        if (displayName != other.displayName) return false
+        if (header != null) {
+            if (other.header == null) return false
+            if (!header.contentEquals(other.header)) return false
+        } else if (other.header != null) return false
+        if (encoding != other.encoding) return false
+        if (charset != other.charset) return false
+        if (dataLocation != other.dataLocation) return false
+        if (data != null) {
+            if (other.data == null) return false
+            if (!data.contentEquals(other.data)) return false
+        } else if (other.data != null) return false
+        if (preamble != other.preamble) return false
+        if (epilogue != other.epilogue) return false
+        if (boundary != other.boundary) return false
+        if (contentId != other.contentId) return false
+        if (serverExtra != other.serverExtra) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id?.hashCode() ?: 0
+        result = 31 * result + (type ?: 0)
+        result = 31 * result + (root?.hashCode() ?: 0)
+        result = 31 * result + (parent?.hashCode() ?: 0)
+        result = 31 * result + (seq ?: 0)
+        result = 31 * result + (mimeType?.hashCode() ?: 0)
+        result = 31 * result + (decodedBodySize ?: 0)
+        result = 31 * result + (displayName?.hashCode() ?: 0)
+        result = 31 * result + (header?.contentHashCode() ?: 0)
+        result = 31 * result + (encoding?.hashCode() ?: 0)
+        result = 31 * result + (charset?.hashCode() ?: 0)
+        result = 31 * result + (dataLocation ?: 0)
+        result = 31 * result + (data?.contentHashCode() ?: 0)
+        result = 31 * result + (preamble?.hashCode() ?: 0)
+        result = 31 * result + (epilogue?.hashCode() ?: 0)
+        result = 31 * result + (boundary?.hashCode() ?: 0)
+        result = 31 * result + (contentId?.hashCode() ?: 0)
+        result = 31 * result + (serverExtra?.hashCode() ?: 0)
+        return result
+    }
+
+    override fun toString(): String {
+        return "MessagePartEntry(" +
+            "id=$id, " +
+            "type=$type, " +
+            "root=$root, " +
+            "parent=$parent, " +
+            "seq=$seq, " +
+            "mimeType=$mimeType, " +
+            "decodedBodySize=$decodedBodySize, " +
+            "displayName=$displayName, " +
+            "header=${header?.decodeToString()}, " +
+            "encoding=$encoding, " +
+            "charset=$charset, " +
+            "dataLocation=$dataLocation, " +
+            "data=${data?.decodeToString()}, " +
+            "preamble=$preamble, " +
+            "epilogue=$epilogue, " +
+            "boundary=$boundary, " +
+            "contentId=$contentId, " +
+            "serverExtra=$serverExtra)"
+    }
+}
 
 private fun Cursor.getBlobOrNull(columnName: String): ByteArray? {
     val columnIndex = getColumnIndex(columnName)


### PR DESCRIPTION
Instead of loading a message into memory and then saving it to the new folder the new code copies the database entries and data files.

This allows us to finally get rid of `LocalFolder.appendMessages()`.