### PR TITLE
Use SummaryProvider instead of summary attribute with format strings

### DIFF
--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -39,7 +39,7 @@
             android:entries="@array/show_pictures_entries"
             android:entryValues="@array/show_pictures_values"
             android:key="show_pictures_enum"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_show_pictures_label" />
 
         <CheckBoxPreference
@@ -59,7 +59,7 @@
             android:entries="@array/display_count_entries"
             android:entryValues="@array/display_count_values"
             android:key="account_display_count"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_mail_display_count_label" />
 
         <ListPreference
@@ -67,7 +67,7 @@
             android:entries="@array/message_age_entries"
             android:entryValues="@array/message_age_values"
             android:key="account_message_age"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_message_age_label" />
 
         <ListPreference
@@ -75,7 +75,7 @@
             android:entries="@array/autodownload_message_size_entries"
             android:entryValues="@array/autodownload_message_size_values"
             android:key="account_autodownload_size"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_autodownload_message_size_label" />
 
         <ListPreference
@@ -83,7 +83,7 @@
             android:entries="@array/check_frequency_entries"
             android:entryValues="@array/check_frequency_values"
             android:key="account_check_frequency"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_mail_check_frequency_label" />
 
         <ListPreference
@@ -91,7 +91,7 @@
             android:entries="@array/folder_sync_mode_entries"
             android:entryValues="@array/folder_sync_mode_values"
             android:key="folder_sync_mode"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_folder_sync_mode_label" />
 
         <!-- Temporarily disabled. See GH-4253
@@ -100,7 +100,7 @@
             android:entries="@array/folder_push_mode_entries"
             android:entryValues="@array/folder_push_mode_values"
             android:key="folder_push_mode"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_folder_push_mode_label" />
         -->
 
@@ -120,7 +120,7 @@
             android:entries="@array/delete_policy_entries"
             android:entryValues="@array/delete_policy_values"
             android:key="delete_policy"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_setup_incoming_delete_policy_label" />
 
         <ListPreference
@@ -128,7 +128,7 @@
             android:entries="@array/expunge_policy_entries"
             android:entryValues="@array/expunge_policy_values"
             android:key="expunge_policy"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_setup_expunge_policy_label" />
 
         <Preference
@@ -149,14 +149,14 @@
                 android:entries="@array/push_limit_entries"
                 android:entryValues="@array/push_limit_values"
                 android:key="max_push_folders"
-                android:summary="%s"
+                app:useSimpleSummaryProvider="true"
                 android:title="@string/account_setup_push_limit_label" />
 
             <ListPreference
                 android:entries="@array/idle_refresh_period_entries"
                 android:entryValues="@array/idle_refresh_period_values"
                 android:key="idle_refresh_period"
-                android:summary="%s"
+                app:useSimpleSummaryProvider="true"
                 android:title="@string/idle_refresh_period_label" />
 
         </PreferenceScreen>
@@ -183,7 +183,7 @@
             android:entries="@array/message_format_entries"
             android:entryValues="@array/message_format_values"
             android:key="message_format"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_message_format_label" />
 
         <CheckBoxPreference
@@ -199,7 +199,7 @@
             android:entries="@array/quote_style_entries"
             android:entryValues="@array/quote_style_values"
             android:key="quote_style"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_quote_style_label" />
 
         <CheckBoxPreference
@@ -247,7 +247,7 @@
 
         <com.fsck.k9.ui.settings.account.FolderListPreference
             android:key="account_setup_auto_expand_folder"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_setup_auto_expand_folder" />
 
         <ListPreference
@@ -255,7 +255,7 @@
             android:entries="@array/folder_display_mode_entries"
             android:entryValues="@array/folder_display_mode_values"
             android:key="folder_display_mode"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_folder_display_mode_label" />
 
         <ListPreference
@@ -263,7 +263,7 @@
             android:entries="@array/folder_target_mode_entries"
             android:entryValues="@array/folder_target_mode_values"
             android:key="folder_target_mode"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_folder_target_mode_label" />
 
         <ListPreference
@@ -271,32 +271,32 @@
             android:entries="@array/searchable_entries"
             android:entryValues="@array/searchable_values"
             android:key="searchable_folders"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_searchable_label" />
 
         <com.fsck.k9.ui.settings.account.FolderListPreference
             android:key="archive_folder"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/archive_folder_label" />
 
         <com.fsck.k9.ui.settings.account.FolderListPreference
             android:key="drafts_folder"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/drafts_folder_label" />
 
         <com.fsck.k9.ui.settings.account.FolderListPreference
             android:key="sent_folder"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/sent_folder_label" />
 
         <com.fsck.k9.ui.settings.account.FolderListPreference
             android:key="spam_folder"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/spam_folder_label" />
 
         <com.fsck.k9.ui.settings.account.FolderListPreference
             android:key="trash_folder"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/trash_folder_label" />
 
     </PreferenceScreen>
@@ -318,7 +318,7 @@
             android:entries="@array/folder_notify_new_mail_mode_entries"
             android:entryValues="@array/folder_notify_new_mail_mode_values"
             android:key="folder_notify_new_mail_mode"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_folder_notify_new_mail_mode_label" />
 
         <CheckBoxPreference
@@ -358,7 +358,7 @@
             android:entryValues="@array/vibrate_pattern_values"
             android:key="account_vibrate_pattern"
             android:layout="?android:attr/preferenceLayoutChild"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_vibrate_pattern_label" />
 
         <ListPreference
@@ -368,7 +368,7 @@
             android:entryValues="@array/vibrate_times_label"
             android:key="account_vibrate_times"
             android:layout="?android:attr/preferenceLayoutChild"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_vibrate_times" />
 
         <CheckBoxPreference
@@ -419,7 +419,7 @@
             android:entries="@array/remote_search_num_results_entries"
             android:entryValues="@array/remote_search_num_results_values"
             android:key="account_remote_search_num_results"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:title="@string/account_settings_remote_search_num_label" />
 
     </PreferenceScreen>

--- a/app/ui/legacy/src/main/res/xml/folder_settings_preferences.xml
+++ b/app/ui/legacy/src/main/res/xml/folder_settings_preferences.xml
@@ -14,7 +14,8 @@
      limitations under the License.
 -->
 
-<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android">
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <PreferenceCategory
         android:key="folder_settings">
@@ -27,7 +28,7 @@
         <ListPreference
             android:key="folder_settings_folder_display_mode"
             android:title="@string/folder_settings_folder_display_mode_label"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:entries="@array/folder_settings_folder_display_mode_entries"
             android:entryValues="@array/folder_settings_folder_display_mode_values"
             android:dialogTitle="@string/folder_settings_folder_display_mode_label" />
@@ -35,7 +36,7 @@
         <ListPreference
             android:key="folder_settings_folder_sync_mode"
             android:title="@string/folder_settings_folder_sync_mode_label"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:entries="@array/folder_settings_folder_sync_mode_entries"
             android:entryValues="@array/folder_settings_folder_sync_mode_values"
             android:dialogTitle="@string/folder_settings_folder_sync_mode_label" />
@@ -44,7 +45,7 @@
         <ListPreference
             android:key="folder_settings_folder_push_mode"
             android:title="@string/folder_settings_folder_push_mode_label"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:entries="@array/folder_settings_folder_push_mode_entries"
             android:entryValues="@array/folder_settings_folder_push_mode_values"
             android:dialogTitle="@string/folder_settings_folder_push_mode_label" />
@@ -53,7 +54,7 @@
         <ListPreference
             android:key="folder_settings_folder_notify_mode"
             android:title="@string/folder_settings_folder_notify_mode_label"
-            android:summary="%s"
+            app:useSimpleSummaryProvider="true"
             android:entries="@array/folder_settings_folder_notify_mode_entries"
             android:entryValues="@array/folder_settings_folder_notify_mode_values"
             android:dialogTitle="@string/folder_settings_folder_notify_mode_label" />

--- a/app/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/general_settings.xml
@@ -22,8 +22,7 @@
                 android:entries="@array/language_entries"
                 android:entryValues="@array/language_values"
                 android:key="language"
-                android:summary="%s"
-                search:summary=""
+                app:useSimpleSummaryProvider="true"
                 android:title="@string/settings_language_label" />
 
             <ListPreference
@@ -31,8 +30,7 @@
                 android:entries="@array/theme_entries"
                 android:entryValues="@array/theme_values"
                 android:key="theme"
-                android:summary="%s"
-                search:summary=""
+                app:useSimpleSummaryProvider="true"
                 android:title="@string/settings_theme_label" />
 
             <CheckBoxPreference
@@ -48,8 +46,7 @@
                 android:entries="@array/message_theme_entries"
                 android:entryValues="@array/message_theme_values"
                 android:key="messageViewTheme"
-                android:summary="%s"
-                search:summary=""
+                app:useSimpleSummaryProvider="true"
                 android:title="@string/settings_message_theme_label" />
 
             <ListPreference
@@ -57,8 +54,7 @@
                 android:entries="@array/message_theme_entries"
                 android:entryValues="@array/message_theme_values"
                 android:key="message_compose_theme"
-                android:summary="%s"
-                search:summary=""
+                app:useSimpleSummaryProvider="true"
                 android:title="@string/settings_compose_theme_label" />
 
             <PreferenceScreen
@@ -73,7 +69,7 @@
                     <ListPreference
                         android:key="account_name_font"
                         android:title="@string/font_size_account_name"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_account_name" />
@@ -81,7 +77,7 @@
                     <ListPreference
                         android:key="account_description_font"
                         android:title="@string/font_size_account_description"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_account_description" />
@@ -95,7 +91,7 @@
                     <ListPreference
                         android:key="folder_name_font"
                         android:title="@string/font_size_folder_name"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_folder_name" />
@@ -103,7 +99,7 @@
                     <ListPreference
                         android:key="folder_status_font"
                         android:title="@string/font_size_folder_status"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_folder_status" />
@@ -117,7 +113,7 @@
                     <ListPreference
                         android:key="message_list_subject_font"
                         android:title="@string/font_size_message_list_subject"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_list_subject" />
@@ -125,7 +121,7 @@
                     <ListPreference
                         android:key="message_list_sender_font"
                         android:title="@string/font_size_message_list_sender"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_list_sender" />
@@ -133,7 +129,7 @@
                     <ListPreference
                         android:key="message_list_date_font"
                         android:title="@string/font_size_message_list_date"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_list_date" />
@@ -141,7 +137,7 @@
                     <ListPreference
                         android:key="message_list_preview_font"
                         android:title="@string/font_size_message_list_preview"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_list_preview" />
@@ -155,7 +151,7 @@
                     <ListPreference
                         android:key="message_view_sender_font"
                         android:title="@string/font_size_message_view_sender"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_view_sender" />
@@ -163,7 +159,7 @@
                     <ListPreference
                         android:key="message_view_to_font"
                         android:title="@string/font_size_message_view_to"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_view_to" />
@@ -171,7 +167,7 @@
                     <ListPreference
                         android:key="message_view_cc_font"
                         android:title="@string/font_size_message_view_cc"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_view_cc" />
@@ -179,7 +175,7 @@
                     <ListPreference
                         android:key="message_view_bcc_font"
                         android:title="@string/font_size_message_view_bcc"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_view_bcc" />
@@ -187,7 +183,7 @@
                     <ListPreference
                         android:key="message_view_subject_font"
                         android:title="@string/font_size_message_view_subject"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_view_subject" />
@@ -195,7 +191,7 @@
                     <ListPreference
                         android:key="message_view_date_font"
                         android:title="@string/font_size_message_view_date"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_view_date" />
@@ -203,7 +199,7 @@
                     <ListPreference
                         android:key="message_view_additional_headers_font"
                         android:title="@string/font_size_message_view_additional_headers"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_view_additional_headers" />
@@ -224,7 +220,7 @@
                     <ListPreference
                         android:key="message_compose_input_font"
                         android:title="@string/font_size_message_compose_input"
-                        android:summary="%s"
+                        app:useSimpleSummaryProvider="true"
                         android:entries="@array/font_entries"
                         android:entryValues="@array/font_values"
                         android:dialogTitle="@string/font_size_message_compose_input" />
@@ -259,8 +255,7 @@
                 android:entries="@array/preview_lines_entries"
                 android:entryValues="@array/preview_lines_values"
                 android:key="messagelist_preview_lines"
-                android:summary="%s"
-                search:summary=""
+                app:useSimpleSummaryProvider="true"
                 android:title="@string/global_settings_preview_lines_label" />
 
             <CheckBoxPreference
@@ -321,8 +316,7 @@
                 android:entries="@array/splitview_mode_entries"
                 android:entryValues="@array/splitview_mode_values"
                 android:key="splitview_mode"
-                android:summary="%s"
-                search:summary=""
+                app:useSimpleSummaryProvider="true"
                 android:title="@string/global_settings_splitview_mode_label" />
 
         </PreferenceCategory>
@@ -424,8 +418,7 @@
             android:entries="@array/notification_quick_delete_entries"
             android:entryValues="@array/notification_quick_delete_values"
             android:key="notification_quick_delete"
-            android:summary="%s"
-            search:summary=""
+            app:useSimpleSummaryProvider="true"
             android:title="@string/global_settings_notification_quick_delete_title" />
 
         <ListPreference
@@ -433,8 +426,7 @@
             android:entries="@array/lock_screen_notification_visibility_entries"
             android:entryValues="@array/lock_screen_notification_visibility_values"
             android:key="lock_screen_notification_visibility"
-            android:summary="%s"
-            search:summary=""
+            app:useSimpleSummaryProvider="true"
             android:title="@string/global_settings_lock_screen_notification_visibility_title" />
 
     </PreferenceScreen>
@@ -450,8 +442,7 @@
             android:entries="@array/background_ops_entries"
             android:entryValues="@array/background_ops_values"
             android:key="background_ops"
-            android:summary="%s"
-            search:summary=""
+            app:useSimpleSummaryProvider="true"
             android:title="@string/background_ops_label" />
 
     </PreferenceScreen>
@@ -466,8 +457,7 @@
             android:entries="@array/notification_hide_subject_entries"
             android:entryValues="@array/notification_hide_subject_values"
             android:key="notification_hide_subject"
-            android:summary="%s"
-            search:summary=""
+            app:useSimpleSummaryProvider="true"
             android:title="@string/global_settings_notification_hide_subject_title" />
 
         <CheckBoxPreference


### PR DESCRIPTION
This will get rid of logcat messages like this one:

> ListPreference: Setting a summary with a String formatting marker is no longer supported. You should use a SummaryProvider instead.
