### PR TITLE
Show unread count in account list

### DIFF
--- a/app/ui/base/src/main/res/drawable/empty.xml
+++ b/app/ui/base/src/main/res/drawable/empty.xml
@@ -1,2 +1,0 @@
-<!-- for use as badge background where we only want the number and no shape -->
-<shape/>

--- a/app/ui/base/src/main/res/drawable/empty.xml
+++ b/app/ui/base/src/main/res/drawable/empty.xml
@@ -1,0 +1,2 @@
+<!-- for use as badge background where we only want the number and no shape -->
+<shape/>

--- a/app/ui/legacy/build.gradle
+++ b/app/ui/legacy/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     implementation "de.cketti.library.changelog:ckchangelog-core:2.0.0-beta01"
     implementation "com.splitwise:tokenautocomplete:4.0.0-beta01"
     implementation "de.cketti.safecontentresolver:safe-content-resolver-v21:1.0.0"
-    implementation 'com.mikepenz:materialdrawer:8.4.0'
+    implementation 'com.mikepenz:materialdrawer:8.4.1'
     implementation 'com.mikepenz:materialdrawer-iconics:8.3.3'
     implementation 'com.mikepenz:fontawesome-typeface:5.9.0.0-kotlin@aar'
     implementation 'com.github.ByteHamster:SearchPreference:v2.0.0'

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -165,8 +165,8 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
         val oldSelectedBackgroundColor = selectedBackgroundColor
 
         var newActiveProfile: IProfile? = null
-        val accountItems = displayAccounts.map { accountAndUnread ->
-            val account = accountAndUnread.account
+        val accountItems = displayAccounts.map { displayAccount ->
+            val account = displayAccount.account
             val drawerId = (account.accountNumber + 1 shl DRAWER_ACCOUNT_SHIFT).toLong()
 
             val drawerColors = getDrawerColorsForAccount(account)
@@ -182,7 +182,7 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
                 descriptionTextColor = selectedTextColor
                 selectedColorInt = drawerColors.selectedColor
                 icon = ImageHolder(createAccountImageUri(account))
-                accountAndUnread.unreadCount.takeIf { it > 0 }?.let { unreadCount ->
+                displayAccount.unreadCount.takeIf { it > 0 }?.let { unreadCount ->
                     badgeText = unreadCount.toString()
                     badgeStyle = BadgeStyle().apply {
                         textColorStateList = selectedTextColor

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountsViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountsViewModel.kt
@@ -1,8 +1,86 @@
 package com.fsck.k9.ui.account
 
+import android.content.ContentResolver
+import android.database.ContentObserver
+import android.os.Handler
+import android.os.Looper
+import androidx.lifecycle.LiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.asLiveData
+import com.fsck.k9.Account
+import com.fsck.k9.AccountsChangeListener
 import com.fsck.k9.Preferences
+import com.fsck.k9.controller.UnreadMessageCountProvider
+import com.fsck.k9.provider.EmailProvider
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 
-class AccountsViewModel(preferences: Preferences) : ViewModel() {
-    val accountsLiveData = AccountsLiveData(preferences)
+@OptIn(ExperimentalCoroutinesApi::class)
+class AccountsViewModel(
+    val preferences: Preferences,
+    val unreadMessageCountProvider: UnreadMessageCountProvider,
+    private val contentResolver: ContentResolver
+) :
+    ViewModel() {
+
+    private val accountsFlow: Flow<List<Account>> =
+        callbackFlow {
+            send(preferences.accounts)
+
+            val accountsChangeListener = AccountsChangeListener {
+                launch {
+                    send(preferences.accounts)
+                }
+            }
+            preferences.addOnAccountsChangeListener(accountsChangeListener)
+            awaitClose {
+                preferences.removeOnAccountsChangeListener(accountsChangeListener)
+            }
+        }.flowOn(Dispatchers.IO)
+
+    private val displayAccountFlow: Flow<List<DisplayAccount>> = accountsFlow
+        .flatMapLatest { accounts ->
+
+            val unreadCountFlows: List<Flow<Int>> = accounts.map { account ->
+                getUnreadCountFlow(account)
+            }
+
+            combine(unreadCountFlows) { unreadCounts ->
+                unreadCounts.mapIndexed { index, unreadCount ->
+                    DisplayAccount(account = accounts[index], unreadCount)
+                }
+            }
+        }
+
+    private fun getUnreadCountFlow(account: Account): Flow<Int> {
+        return callbackFlow {
+
+            val notificationUri = EmailProvider.getNotificationUri(account.uuid)
+
+            send(unreadMessageCountProvider.getUnreadMessageCount(account))
+
+            val contentObserver = object : ContentObserver(Handler(Looper.getMainLooper())) {
+                override fun onChange(selfChange: Boolean) {
+                    launch {
+                        send(unreadMessageCountProvider.getUnreadMessageCount(account))
+                    }
+                }
+            }
+
+            contentResolver.registerContentObserver(notificationUri, false, contentObserver)
+
+            awaitClose {
+                contentResolver.unregisterContentObserver(contentObserver)
+            }
+        }.flowOn(Dispatchers.IO)
+    }
+
+    val displayAccountsLiveData: LiveData<List<DisplayAccount>> = displayAccountFlow.asLiveData()
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountsViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/AccountsViewModel.kt
@@ -24,12 +24,10 @@ import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class AccountsViewModel(
-    val preferences: Preferences,
-    val unreadMessageCountProvider: UnreadMessageCountProvider,
+    private val preferences: Preferences,
+    private val unreadMessageCountProvider: UnreadMessageCountProvider,
     private val contentResolver: ContentResolver
-) :
-    ViewModel() {
-
+) : ViewModel() {
     private val accountsFlow: Flow<List<Account>> =
         callbackFlow {
             send(preferences.accounts)
@@ -40,6 +38,7 @@ class AccountsViewModel(
                 }
             }
             preferences.addOnAccountsChangeListener(accountsChangeListener)
+
             awaitClose {
                 preferences.removeOnAccountsChangeListener(accountsChangeListener)
             }
@@ -47,7 +46,6 @@ class AccountsViewModel(
 
     private val displayAccountFlow: Flow<List<DisplayAccount>> = accountsFlow
         .flatMapLatest { accounts ->
-
             val unreadCountFlows: List<Flow<Int>> = accounts.map { account ->
                 getUnreadCountFlow(account)
             }
@@ -61,7 +59,6 @@ class AccountsViewModel(
 
     private fun getUnreadCountFlow(account: Account): Flow<Int> {
         return callbackFlow {
-
             val notificationUri = EmailProvider.getNotificationUri(account.uuid)
 
             send(unreadMessageCountProvider.getUnreadMessageCount(account))
@@ -73,7 +70,6 @@ class AccountsViewModel(
                     }
                 }
             }
-
             contentResolver.registerContentObserver(notificationUri, false, contentObserver)
 
             awaitClose {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/DisplayAccount.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/DisplayAccount.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.ui.account
+
+import com.fsck.k9.Account
+
+data class DisplayAccount(val account: Account, val unreadCount: Int)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/account/KoinModule.kt
@@ -4,7 +4,7 @@ import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val accountUiModule = module {
-    viewModel { AccountsViewModel(preferences = get()) }
+    viewModel { AccountsViewModel(preferences = get(), unreadMessageCountProvider = get(), contentResolver = get()) }
     factory { AccountImageLoader(accountFallbackImageProvider = get()) }
     factory { AccountFallbackImageProvider(context = get()) }
     factory { AccountImageModelLoaderFactory(contactPhotoLoader = get(), accountFallbackImageProvider = get()) }


### PR DESCRIPTION
Attempt to fix #4515 

There are a couple of issues with this PR:

The unread count is retrieved on the UI thread (needs to be decoupled)
There is a cosmetic issue where the account that's selected in the drawer, has its unread count text overwritten onto the avatar.
I'm not quite convinced that using the accountsLiveData as the source of changes of the unread count is always going to pick up changes to the unread count. It worked when I tested it.

I will go ahead and try to fix these, if @cketti is happy with the general approach.

Fixes #4515 