### PR TITLE
Long names in folder list #5290

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -11,7 +11,6 @@ import android.os.Bundle
 import android.text.TextUtils
 import android.util.TypedValue
 import android.widget.ImageView
-import androidx.annotation.LayoutRes
 import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
@@ -341,7 +340,7 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
                 identifier = drawerId
                 tag = folder
                 nameText = getFolderDisplayName(folder)
-                //TODO: set elipsize=middle after https://github.com/mikepenz/MaterialDrawer/issues/2724 is fixed
+                // TODO: set elipsize=middle after https://github.com/mikepenz/MaterialDrawer/issues/2724 is fixed
                 displayFolder.unreadCount.takeIf { it > 0 }?.let {
                     badgeText = it.toString()
                     badgeStyle = folderBadgeStyle

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.ui
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.res.ColorStateList
 import android.content.res.Resources
@@ -7,8 +8,11 @@ import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import android.os.Bundle
+import android.text.TextUtils
 import android.util.TypedValue
 import android.widget.ImageView
+import androidx.annotation.LayoutRes
+import androidx.appcompat.widget.AppCompatTextView
 import androidx.core.view.GravityCompat
 import androidx.drawerlayout.widget.DrawerLayout
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
@@ -282,6 +286,25 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
         }
     }
 
+    /**
+     * Custom layout for PrimaryDrawerItem allowing 2 lines
+     * and elipsize="middle" to keep the start+end of deep subfolder trees
+     * on screen.
+     *
+     * Can be replaced after
+     * https://github.com/mikepenz/MaterialDrawer/issues/2724
+     */
+    private class PrimaryFolderDrawerItem : PrimaryDrawerItem() {
+
+        @SuppressLint("MissingSuperCall") // Lint false positive, super IS called
+        override fun bindView(holder: ViewHolder, payloads: List<Any>) {
+            super.bindView(holder, payloads)
+            holder.itemView.findViewById<AppCompatTextView>(R.id.material_drawer_name)?.let { text ->
+                text.ellipsize = TextUtils.TruncateAt.MIDDLE
+            }
+        }
+    }
+
     private fun setUserFolders(folders: List<DisplayFolder>?) {
         clearUserFolders()
 
@@ -313,11 +336,12 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
             val folder = displayFolder.folder
             val drawerId = folder.id shl DRAWER_FOLDER_SHIFT
 
-            val drawerItem = PrimaryDrawerItem().apply {
+            val drawerItem = PrimaryFolderDrawerItem().apply {
                 iconRes = folderIconProvider.getFolderIcon(folder.type)
                 identifier = drawerId
                 tag = folder
                 nameText = getFolderDisplayName(folder)
+                //TODO: set elipsize=middle after https://github.com/mikepenz/MaterialDrawer/issues/2724 is fixed
                 displayFolder.unreadCount.takeIf { it > 0 }?.let {
                     badgeText = it.toString()
                     badgeStyle = folderBadgeStyle

--- a/app/ui/legacy/src/main/res/layout/folder_list_item.xml
+++ b/app/ui/legacy/src/main/res/layout/folder_list_item.xml
@@ -30,7 +30,6 @@
         android:paddingBottom="12dp"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="?android:attr/textColorPrimary"
-        android:ellipsize="middle"
         tools:text="Parent Folder/Sub Folder/Sub Folder/Folder name" />
 
 </LinearLayout>

--- a/app/ui/legacy/src/main/res/layout/folder_list_item.xml
+++ b/app/ui/legacy/src/main/res/layout/folder_list_item.xml
@@ -17,7 +17,7 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_marginStart="16dp"
-        android:layout_marginEnd="16dp"
+        android:layout_marginEnd="32dp"
         tools:src="@drawable/ic_drafts_folder" />
 
     <TextView

--- a/app/ui/legacy/src/main/res/layout/folder_list_item.xml
+++ b/app/ui/legacy/src/main/res/layout/folder_list_item.xml
@@ -17,7 +17,7 @@
         android:layout_width="24dp"
         android:layout_height="24dp"
         android:layout_marginStart="16dp"
-        android:layout_marginEnd="32dp"
+        android:layout_marginEnd="16dp"
         tools:src="@drawable/ic_drafts_folder" />
 
     <TextView
@@ -30,6 +30,7 @@
         android:paddingBottom="12dp"
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:textColor="?android:attr/textColorPrimary"
-        tools:text="Folder name" />
+        android:ellipsize="middle"
+        tools:text="Parent Folder/Sub Folder/Sub Folder/Folder name" />
 
 </LinearLayout>


### PR DESCRIPTION
* added middle elipsis for single line folder names in nav drawer
* less margin in folder_list_item (manage folder/select destination folder)