### PR TITLE
Remove ImapFolder caching

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
@@ -31,19 +31,13 @@ class ImapFolder internal constructor(
     val serverId: String,
     private val folderNameCodec: FolderNameCodec
 ) {
-    @Volatile
     private var uidNext = -1L
-
-    @Volatile
     private var connection: ImapConnection? = null
-
-    @Volatile
     private var exists = false
     private var inSearch = false
     private var canCreateKeywords = false
     private var uidValidity: Long? = null
 
-    @Volatile
     var messageCount = -1
         private set
 

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolder.kt
@@ -4,7 +4,6 @@ import com.fsck.k9.mail.Body
 import com.fsck.k9.mail.BodyFactory
 import com.fsck.k9.mail.FetchProfile
 import com.fsck.k9.mail.Flag
-import com.fsck.k9.mail.FolderType
 import com.fsck.k9.mail.K9MailLib
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mail.MessageRetrievalListener
@@ -23,7 +22,6 @@ import java.util.Date
 import java.util.HashMap
 import java.util.LinkedHashSet
 import java.util.Locale
-import java.util.concurrent.ConcurrentHashMap
 import kotlin.math.max
 import kotlin.math.min
 import timber.log.Timber
@@ -38,7 +36,6 @@ class ImapFolder internal constructor(
 
     @Volatile
     private var connection: ImapConnection? = null
-    private var msgSeqUidMap: MutableMap<Long, String> = ConcurrentHashMap()
 
     @Volatile
     private var exists = false
@@ -49,8 +46,6 @@ class ImapFolder internal constructor(
     @Volatile
     var messageCount = -1
         private set
-
-    var type = FolderType.REGULAR
 
     var mode = 0
         private set
@@ -122,8 +117,6 @@ class ImapFolder internal constructor(
         }
 
         try {
-            msgSeqUidMap.clear()
-
             val openCommand = if (mode == OPEN_MODE_RW) "SELECT" else "EXAMINE"
             val encodedFolderName = folderNameCodec.encode(prefixedName)
             val escapedFolderName = ImapUtility.encodeString(encodedFolderName)
@@ -596,17 +589,6 @@ class ImapFolder internal constructor(
                     if (response.tag == null && ImapResponseParser.equalsIgnoreCase(response[1], "FETCH")) {
                         val fetchList = response.getKeyedValue("FETCH") as ImapList
                         val uid = fetchList.getKeyedString("UID")
-                        val msgSeq = response.getLong(0)
-                        if (uid != null) {
-                            try {
-                                msgSeqUidMap[msgSeq] = uid
-                                if (K9MailLib.isDebug()) {
-                                    Timber.v("Stored uid '%s' for msgSeq %d into map", uid, msgSeq)
-                                }
-                            } catch (e: Exception) {
-                                Timber.e("Unable to store uid '%s' for msgSeq %d", uid, msgSeq)
-                            }
-                        }
 
                         val message = messageMap[uid]
                         if (message == null) {

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapStore.java
@@ -53,14 +53,6 @@ public class ImapStore {
     private final Deque<ImapConnection> connections = new LinkedList<>();
     private FolderNameCodec folderNameCodec;
 
-    /**
-     * Cache of ImapFolder objects. ImapFolders are attached to a given folder on the server
-     * and as long as their associated connection remains open they are reusable between
-     * requests. This cache lets us make sure we always reuse, if possible, for a given
-     * folder name.
-     */
-    private final Map<String, ImapFolder> folderCache = new HashMap<>();
-
 
     public ImapStore(ServerSettings serverSettings, ImapStoreConfig config,
             TrustedSocketFactory trustedSocketFactory, ConnectivityManager connectivityManager,
@@ -90,16 +82,7 @@ public class ImapStore {
     }
 
     public ImapFolder getFolder(String name) {
-        ImapFolder folder;
-        synchronized (folderCache) {
-            folder = folderCache.get(name);
-            if (folder == null) {
-                folder = new ImapFolder(this, name);
-                folderCache.put(name, folder);
-            }
-        }
-
-        return folder;
+        return new ImapFolder(this, name);
     }
 
     String getCombinedPrefix() {

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/ImapStoreTest.java
@@ -61,16 +61,6 @@ public class ImapStoreTest {
     }
 
     @Test
-    public void getFolder_calledTwice_shouldReturnFirstInstance() throws Exception {
-        String folderName = "Trash";
-        ImapFolder imapFolder = imapStore.getFolder(folderName);
-
-        ImapFolder result = imapStore.getFolder(folderName);
-
-        assertEquals(imapFolder, result);
-    }
-
-    @Test
     public void checkSettings_shouldCreateImapConnectionAndCallOpen() throws Exception {
         ImapConnection imapConnection = mock(ImapConnection.class);
         imapStore.enqueueImapConnection(imapConnection);


### PR DESCRIPTION
The cache was causing problems when a folder was accessed from two threads at the same time. Also, there was no invalidation mechanism that removed folders that had been removed from the server.

The easy fix is to get rid of this cache. There's no state in `ImapFolder` that survives closing the folder anyway.

Fixes #4412