### PR TITLE
Remove message list update mechanism that no longer works

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/cache/EmailProviderCache.java
+++ b/app/core/src/main/java/com/fsck/k9/cache/EmailProviderCache.java
@@ -5,9 +5,7 @@ import java.util.List;
 import java.util.Map;
 
 import android.content.Context;
-import android.content.Intent;
 import android.net.Uri;
-import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.provider.EmailProvider;
@@ -16,8 +14,6 @@ import com.fsck.k9.provider.EmailProvider;
  * Cache to bridge the time needed to write (user-initiated) changes to the database.
  */
 public class EmailProviderCache {
-    public static final String ACTION_CACHE_UPDATED = "EmailProviderCache.ACTION_CACHE_UPDATED";
-
     private static Context sContext;
     private static Map<String, EmailProviderCache> sInstances =
             new HashMap<>();
@@ -152,20 +148,7 @@ public class EmailProviderCache {
         }
     }
 
-    /**
-     * Notify all concerned parties that the message list has changed.
-     *
-     * <p><strong>Note:</strong>
-     * Notifying the content resolver of the change will cause the {@code CursorLoader} in
-     * {@code MessageListFragment} to reload the cursor. But especially with flag changes this will
-     * block because of the DB write operation to update the flags. So additionally we use
-     * {@link LocalBroadcastManager} to send a {@link #ACTION_CACHE_UPDATED} broadcast. This way
-     * {@code MessageListFragment} can update the view without reloading the cursor.
-     * </p>
-     */
     private void notifyChange() {
-        LocalBroadcastManager.getInstance(sContext).sendBroadcast(new Intent(ACTION_CACHE_UPDATED));
-
         Uri uri = Uri.withAppendedPath(EmailProvider.CONTENT_URI, "account/" + mAccountUuid +
                 "/messages");
         sContext.getContentResolver().notifyChange(uri, null);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/KoinModule.kt
@@ -1,10 +1,7 @@
 package com.fsck.k9.fragment
 
-import android.content.Context
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import org.koin.dsl.module
 
 val fragmentModule = module {
     single { SortTypeToastProvider() }
-    factory { LocalBroadcastManager.getInstance(get<Context>()) }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -1,10 +1,8 @@
 package com.fsck.k9.fragment
 
 import android.app.Activity
-import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
-import android.content.IntentFilter
 import android.os.Bundle
 import android.os.Parcelable
 import android.view.LayoutInflater
@@ -22,7 +20,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.view.ActionMode
 import androidx.core.os.bundleOf
 import androidx.fragment.app.Fragment
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.fsck.k9.Account
 import com.fsck.k9.Account.Expunge
@@ -32,7 +29,6 @@ import com.fsck.k9.K9
 import com.fsck.k9.Preferences
 import com.fsck.k9.activity.FolderInfoHolder
 import com.fsck.k9.activity.misc.ContactPicture
-import com.fsck.k9.cache.EmailProviderCache
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.controller.SimpleMessagingListener
@@ -73,7 +69,6 @@ class MessageListFragment :
     private val folderNameFormatter: FolderNameFormatter by lazy { folderNameFormatterFactory.create(requireContext()) }
     private val messagingController: MessagingController by inject()
     private val preferences: Preferences by inject()
-    private val localBroadcastManager: LocalBroadcastManager by inject()
 
     private val handler = MessageListHandler(this)
     private val activityListener = MessageListActivityListener()
@@ -129,13 +124,6 @@ class MessageListFragment :
      */
     var isInitialized = false
         private set
-
-    private val cacheIntentFilter = IntentFilter(EmailProviderCache.ACTION_CACHE_UPDATED)
-    private val cacheBroadcastReceiver = object : BroadcastReceiver() {
-        override fun onReceive(context: Context, intent: Intent) {
-            adapter.notifyDataSetChanged()
-        }
-    }
 
     override fun onAttach(context: Context) {
         super.onAttach(context)
@@ -471,7 +459,6 @@ class MessageListFragment :
             hasConnectivity = Utility.hasConnectivity(requireActivity().application)
         }
 
-        localBroadcastManager.registerReceiver(cacheBroadcastReceiver, cacheIntentFilter)
         messagingController.addListener(activityListener)
 
         for (account in localSearch.getAccounts(preferences)) {
@@ -484,7 +471,6 @@ class MessageListFragment :
     override fun onPause() {
         super.onPause()
 
-        localBroadcastManager.unregisterReceiver(cacheBroadcastReceiver)
         messagingController.removeListener(activityListener)
     }
 


### PR DESCRIPTION
The adapter in `MessageListFragment` used a complicated mechanism that allowed for changing the displayed list by changing the cache and not reading the data from the database again. With the latest change to the adapter this no longer works. And so the associated "notification" mechanism can be removed.
