### PR TITLE
Fixed localized unified inbox title if app language was changed

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -38,6 +38,7 @@ import com.fsck.k9.helper.Utility
 import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.search.LocalSearch
+import com.fsck.k9.search.SearchAccount
 import com.fsck.k9.search.getAccounts
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.choosefolder.ChooseFolderActivity
@@ -175,7 +176,11 @@ class MessageListFragment :
         isThreadDisplay = arguments.getBoolean(ARG_IS_THREAD_DISPLAY, false)
         localSearch = arguments.getParcelable(ARG_SEARCH)!!
 
-        title = localSearch.name
+        if (SearchAccount.UNIFIED_INBOX == localSearch.id) {
+            title = resources.getString(R.string.integrated_inbox_title)
+        } else {
+            title = localSearch.name
+        }
 
         allAccounts = localSearch.searchAllAccounts()
         val searchAccounts = localSearch.getAccounts(preferences)


### PR DESCRIPTION
Resolves part of #4407 (wrong title of unified inbox)

How to reproduce:
1. Set system language and app language to English, close app
2. Launch app
2. Change app language to any language other than English (open side menu, click "Settings", "General settings", "Display", "Language")
3. Go back until "Unified Inbox" -> title is in English