### PR TITLE
Fixed localized quotes if app language and system language are different

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/LocaleHelper.kt
+++ b/app/core/src/main/java/com/fsck/k9/LocaleHelper.kt
@@ -1,0 +1,41 @@
+package com.fsck.k9
+
+import android.content.res.Resources
+import java.util.Locale
+
+class LocaleHelper {
+    companion object {
+        private lateinit var currentLanguage: String
+
+        @JvmStatic
+        fun initializeLocale(resources: Resources) {
+            currentLanguage = K9.k9Language
+            setLanguage(resources)
+        }
+
+        private fun setLanguage(resources: Resources) {
+            val locale = actualLocale()
+
+            val config = resources.configuration
+            config.setLocale(locale)
+            resources.updateConfiguration(config, resources.displayMetrics)
+        }
+
+        @JvmStatic
+        fun actualLocale(): Locale {
+            val locale = if (K9.k9Language == null || K9.k9Language.isEmpty()) {
+                Resources.getSystem().configuration.locale
+            } else if (K9.k9Language.length == 5 && K9.k9Language[2] == '_') {
+                // language is in the form: en_US
+                Locale(K9.k9Language.substring(0, 2), K9.k9Language.substring(3))
+            } else {
+                Locale(K9.k9Language)
+            }
+            return locale
+        }
+
+        fun languageHasChanged(): Boolean {
+            return currentLanguage != K9.k9Language
+        }
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/message/quote/QuoteDateFormatter.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/quote/QuoteDateFormatter.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.message.quote
 
 import com.fsck.k9.K9
+import com.fsck.k9.LocaleHelper.Companion.actualLocale
 import java.text.DateFormat
 import java.util.Date
 import java.util.TimeZone
@@ -20,7 +21,7 @@ class QuoteDateFormatter {
     }
 
     private fun createDateFormat(): DateFormat {
-        return DateFormat.getDateTimeInstance(DATE_STYLE, TIME_STYLE).apply {
+        return DateFormat.getDateTimeInstance(DATE_STYLE, TIME_STYLE, actualLocale()).apply {
             if (K9.isHideTimeZone) {
                 timeZone = TimeZone.getTimeZone("UTC")
             }

--- a/app/core/src/test/java/com/fsck/k9/message/quote/QuoteDateFormatterTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/message/quote/QuoteDateFormatterTest.kt
@@ -13,6 +13,7 @@ import org.junit.Test
 class QuoteDateFormatterTest {
     private lateinit var originalLocale: Locale
     private var originalTimeZone: TimeZone? = null
+    private lateinit var originalK9language: String
     private val quoteDateFormatter = QuoteDateFormatter()
 
     @Before
@@ -20,12 +21,15 @@ class QuoteDateFormatterTest {
         originalLocale = Locale.getDefault()
         originalTimeZone = TimeZone.getDefault()
         TimeZone.setDefault(TimeZone.getTimeZone("GMT+02:00"))
+        originalK9language = K9.k9Language
+        K9.k9Language = Locale.US.language
     }
 
     @After
     fun tearDown() {
         Locale.setDefault(originalLocale)
         TimeZone.setDefault(originalTimeZone)
+        K9.k9Language = originalK9language
     }
 
     @Test
@@ -42,6 +46,7 @@ class QuoteDateFormatterTest {
     fun hideTimeZoneEnabled_GermanyLocale() {
         K9.isHideTimeZone = true
         Locale.setDefault(Locale.GERMANY)
+        K9.k9Language = Locale.GERMANY.language
 
         val formattedDate = quoteDateFormatter.format("2020-09-19T20:00:00+00:00".toDate())
 
@@ -62,6 +67,7 @@ class QuoteDateFormatterTest {
     fun hideTimeZoneDisabled_GermanyLocale() {
         K9.isHideTimeZone = false
         Locale.setDefault(Locale.GERMANY)
+        K9.k9Language = Locale.GERMANY.language
 
         val formattedDate = quoteDateFormatter.format("2020-09-19T20:00:00+00:00".toDate())
 

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
@@ -2,44 +2,52 @@ package com.fsck.k9.resources
 
 import android.content.Context
 import com.fsck.k9.CoreResourceProvider
+import com.fsck.k9.LocaleHelper
 import com.fsck.k9.jmap.R
 
 class K9CoreResourceProvider(private val context: Context) : CoreResourceProvider {
-    override fun defaultSignature(): String = context.getString(R.string.default_signature)
-    override fun defaultIdentityDescription(): String = context.getString(R.string.default_identity_description)
+    override fun defaultSignature(): String = resolve(R.string.default_signature)
+    override fun defaultIdentityDescription(): String = resolve(R.string.default_identity_description)
 
-    override fun internalStorageProviderName(): String =
-        context.getString(R.string.local_storage_provider_internal_label)
+    override fun internalStorageProviderName(): String = resolve(R.string.local_storage_provider_internal_label)
 
-    override fun externalStorageProviderName(): String =
-        context.getString(R.string.local_storage_provider_external_label)
+    override fun externalStorageProviderName(): String = resolve(R.string.local_storage_provider_external_label)
 
-    override fun contactDisplayNamePrefix(): String = context.getString(R.string.message_to_label)
-    override fun contactUnknownSender(): String = context.getString(R.string.unknown_sender)
-    override fun contactUnknownRecipient(): String = context.getString(R.string.unknown_recipient)
+    override fun contactDisplayNamePrefix(): String = resolve(R.string.message_to_label)
+    override fun contactUnknownSender(): String = resolve(R.string.unknown_sender)
+    override fun contactUnknownRecipient(): String = resolve(R.string.unknown_recipient)
 
-    override fun messageHeaderFrom(): String = context.getString(R.string.message_compose_quote_header_from)
-    override fun messageHeaderTo(): String = context.getString(R.string.message_compose_quote_header_to)
-    override fun messageHeaderCc(): String = context.getString(R.string.message_compose_quote_header_cc)
-    override fun messageHeaderDate(): String = context.getString(R.string.message_compose_quote_header_send_date)
-    override fun messageHeaderSubject(): String = context.getString(R.string.message_compose_quote_header_subject)
-    override fun messageHeaderSeparator(): String = context.getString(R.string.message_compose_quote_header_separator)
+    override fun messageHeaderFrom(): String = resolve(R.string.message_compose_quote_header_from)
+    override fun messageHeaderTo(): String = resolve(R.string.message_compose_quote_header_to)
+    override fun messageHeaderCc(): String = resolve(R.string.message_compose_quote_header_cc)
+    override fun messageHeaderDate(): String = resolve(R.string.message_compose_quote_header_send_date)
+    override fun messageHeaderSubject(): String = resolve(R.string.message_compose_quote_header_subject)
+    override fun messageHeaderSeparator(): String = resolve(R.string.message_compose_quote_header_separator)
 
-    override fun noSubject(): String = context.getString(R.string.general_no_subject)
+    override fun noSubject(): String = resolve(R.string.general_no_subject)
 
-    override fun userAgent(): String = context.getString(R.string.message_header_mua)
-    override fun encryptedSubject(): String = context.getString(R.string.encrypted_subject)
+    override fun userAgent(): String = resolve(R.string.message_header_mua)
+    override fun encryptedSubject(): String = resolve(R.string.encrypted_subject)
 
-    override fun replyHeader(sender: String): String =
-        context.getString(R.string.message_compose_reply_header_fmt, sender)
+    override fun replyHeader(sender: String): String = resolve(R.string.message_compose_reply_header_fmt, sender)
 
     override fun replyHeader(sender: String, sentDate: String): String =
-        context.getString(R.string.message_compose_reply_header_fmt_with_date, sentDate, sender)
+        resolve(R.string.message_compose_reply_header_fmt_with_date, sentDate, sender)
 
-    override fun searchAllMessagesTitle(): String = context.getString(R.string.search_all_messages_title)
-    override fun searchAllMessagesDetail(): String = context.getString(R.string.search_all_messages_detail)
-    override fun searchUnifiedInboxTitle(): String = context.getString(R.string.integrated_inbox_title)
-    override fun searchUnifiedInboxDetail(): String = context.getString(R.string.integrated_inbox_detail)
+    override fun searchAllMessagesTitle(): String = resolve(R.string.search_all_messages_title)
+    override fun searchAllMessagesDetail(): String = resolve(R.string.search_all_messages_detail)
+    override fun searchUnifiedInboxTitle(): String = resolve(R.string.integrated_inbox_title)
+    override fun searchUnifiedInboxDetail(): String = resolve(R.string.integrated_inbox_detail)
 
-    override fun outboxFolderName(): String = context.getString(R.string.special_mailbox_name_outbox)
+    override fun outboxFolderName(): String = resolve(R.string.special_mailbox_name_outbox)
+
+    private fun resolve(id: Int): String {
+        LocaleHelper.initializeLocale(context.resources)
+        return context.getString(id)
+    }
+
+    private fun resolve(id: Int, vararg args: String): String {
+        LocaleHelper.initializeLocale(context.resources)
+        return context.getString(id, *args)
+    }
 }

--- a/app/k9mail/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/resources/K9CoreResourceProvider.kt
@@ -2,44 +2,52 @@ package com.fsck.k9.resources
 
 import android.content.Context
 import com.fsck.k9.CoreResourceProvider
+import com.fsck.k9.LocaleHelper
 import com.fsck.k9.R
 
 class K9CoreResourceProvider(private val context: Context) : CoreResourceProvider {
-    override fun defaultSignature(): String = context.getString(R.string.default_signature)
-    override fun defaultIdentityDescription(): String = context.getString(R.string.default_identity_description)
+    override fun defaultSignature(): String = resolve(R.string.default_signature)
+    override fun defaultIdentityDescription(): String = resolve(R.string.default_identity_description)
 
-    override fun internalStorageProviderName(): String =
-        context.getString(R.string.local_storage_provider_internal_label)
+    override fun internalStorageProviderName(): String = resolve(R.string.local_storage_provider_internal_label)
 
-    override fun externalStorageProviderName(): String =
-        context.getString(R.string.local_storage_provider_external_label)
+    override fun externalStorageProviderName(): String = resolve(R.string.local_storage_provider_external_label)
 
-    override fun contactDisplayNamePrefix(): String = context.getString(R.string.message_to_label)
-    override fun contactUnknownSender(): String = context.getString(R.string.unknown_sender)
-    override fun contactUnknownRecipient(): String = context.getString(R.string.unknown_recipient)
+    override fun contactDisplayNamePrefix(): String = resolve(R.string.message_to_label)
+    override fun contactUnknownSender(): String = resolve(R.string.unknown_sender)
+    override fun contactUnknownRecipient(): String = resolve(R.string.unknown_recipient)
 
-    override fun messageHeaderFrom(): String = context.getString(R.string.message_compose_quote_header_from)
-    override fun messageHeaderTo(): String = context.getString(R.string.message_compose_quote_header_to)
-    override fun messageHeaderCc(): String = context.getString(R.string.message_compose_quote_header_cc)
-    override fun messageHeaderDate(): String = context.getString(R.string.message_compose_quote_header_send_date)
-    override fun messageHeaderSubject(): String = context.getString(R.string.message_compose_quote_header_subject)
-    override fun messageHeaderSeparator(): String = context.getString(R.string.message_compose_quote_header_separator)
+    override fun messageHeaderFrom(): String = resolve(R.string.message_compose_quote_header_from)
+    override fun messageHeaderTo(): String = resolve(R.string.message_compose_quote_header_to)
+    override fun messageHeaderCc(): String = resolve(R.string.message_compose_quote_header_cc)
+    override fun messageHeaderDate(): String = resolve(R.string.message_compose_quote_header_send_date)
+    override fun messageHeaderSubject(): String = resolve(R.string.message_compose_quote_header_subject)
+    override fun messageHeaderSeparator(): String = resolve(R.string.message_compose_quote_header_separator)
 
-    override fun noSubject(): String = context.getString(R.string.general_no_subject)
+    override fun noSubject(): String = resolve(R.string.general_no_subject)
 
-    override fun userAgent(): String = context.getString(R.string.message_header_mua)
-    override fun encryptedSubject(): String = context.getString(R.string.encrypted_subject)
+    override fun userAgent(): String = resolve(R.string.message_header_mua)
+    override fun encryptedSubject(): String = resolve(R.string.encrypted_subject)
 
-    override fun replyHeader(sender: String): String =
-        context.getString(R.string.message_compose_reply_header_fmt, sender)
+    override fun replyHeader(sender: String): String = resolve(R.string.message_compose_reply_header_fmt, sender)
 
     override fun replyHeader(sender: String, sentDate: String): String =
-        context.getString(R.string.message_compose_reply_header_fmt_with_date, sentDate, sender)
+        resolve(R.string.message_compose_reply_header_fmt_with_date, sentDate, sender)
 
-    override fun searchAllMessagesTitle(): String = context.getString(R.string.search_all_messages_title)
-    override fun searchAllMessagesDetail(): String = context.getString(R.string.search_all_messages_detail)
-    override fun searchUnifiedInboxTitle(): String = context.getString(R.string.integrated_inbox_title)
-    override fun searchUnifiedInboxDetail(): String = context.getString(R.string.integrated_inbox_detail)
+    override fun searchAllMessagesTitle(): String = resolve(R.string.search_all_messages_title)
+    override fun searchAllMessagesDetail(): String = resolve(R.string.search_all_messages_detail)
+    override fun searchUnifiedInboxTitle(): String = resolve(R.string.integrated_inbox_title)
+    override fun searchUnifiedInboxDetail(): String = resolve(R.string.integrated_inbox_detail)
 
-    override fun outboxFolderName(): String = context.getString(R.string.special_mailbox_name_outbox)
+    override fun outboxFolderName(): String = resolve(R.string.special_mailbox_name_outbox)
+
+    private fun resolve(id: Int): String {
+        LocaleHelper.initializeLocale(context.resources)
+        return context.getString(id)
+    }
+
+    private fun resolve(id: Int, vararg args: String): String {
+        LocaleHelper.initializeLocale(context.resources)
+        return context.getString(id, *args)
+    }
 }


### PR DESCRIPTION
Resolves part of #4407 (finding 5.6 / 5.7: Quotation of answers or forwarded messages)

How to reproduce:
1. Set system language to English and app language to any other language than English, close app
2. Launch app
3. Open a mail in unified inbox
4. Tab on response arrow on the right
6. Choose (translated) "reply" or "forward"
7. Reply/forward header before quoted text is in English
