### PR TITLE
Fixed localized titles if app language and system language are different

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseAccount.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseAccount.java
@@ -1,12 +1,21 @@
 package com.fsck.k9.activity;
 
 import android.content.Intent;
+import android.os.Bundle;
 
 import com.fsck.k9.BaseAccount;
+import com.fsck.k9.ui.R;
+
 
 public class ChooseAccount extends AccountList {
 
     public static final String EXTRA_ACCOUNT_UUID = "com.fsck.k9.ChooseAccount_account_uuid";
+
+    @Override
+    public void onCreate(Bundle icicle) {
+        super.onCreate(icicle);
+        setTitle(R.string.choose_account_title);
+    }
 
     @Override
     protected void onAccountSelected(BaseAccount account) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
@@ -30,6 +30,7 @@ public class ChooseIdentity extends K9ListActivity {
 
         requestWindowFeature(Window.FEATURE_INDETERMINATE_PROGRESS);
         setLayout(R.layout.list_content_simple);
+        setTitle(R.string.choose_identity_title);
 
         getListView().setTextFilterEnabled(true);
         getListView().setItemsCanFocus(false);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
@@ -30,6 +30,7 @@ class EditIdentity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setLayout(R.layout.edit_identity)
+        setTitle(R.string.edit_identity_title)
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
 
         identityIndex = intent.getIntExtra(EXTRA_IDENTITY_INDEX, -1)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/LauncherShortcuts.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/LauncherShortcuts.java
@@ -13,6 +13,7 @@ public class LauncherShortcuts extends AccountList {
     @Override
     public void onCreate(Bundle icicle) {
         super.onCreate(icicle);
+        setTitle(R.string.shortcuts_title);
 
         // finish() immediately if we aren't supposed to be here
         if (!Intent.ACTION_CREATE_SHORTCUT.equals(getIntent().getAction())) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/ManageIdentities.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/ManageIdentities.java
@@ -31,6 +31,7 @@ public class ManageIdentities extends ChooseIdentity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
+        setTitle(R.string.manage_identities_title);
         getSupportActionBar().setDisplayHomeAsUpEnabled(true);
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/UpgradeDatabases.java
@@ -127,6 +127,7 @@ public class UpgradeDatabases extends K9Activity {
      */
     private void initializeLayout() {
         setLayout(R.layout.upgrade_databases);
+        setTitle(R.string.upgrade_databases_title);
 
         mUpgradeText = findViewById(R.id.databaseUpgradeText);
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupAccountType.kt
@@ -33,6 +33,7 @@ class AccountSetupAccountType : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setLayout(R.layout.account_setup_account_type)
+        setTitle(R.string.account_setup_account_type_title)
 
         decodeArguments()
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -75,6 +75,7 @@ public class AccountSetupBasics extends K9Activity
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setLayout(R.layout.account_setup_basics);
+        setTitle(R.string.account_setup_basics_title);
         mEmailView = findViewById(R.id.account_email);
         mPasswordView = findViewById(R.id.account_password);
         mClientCertificateCheckBox = findViewById(R.id.account_client_certificate);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupComposition.java
@@ -46,6 +46,7 @@ public class AccountSetupComposition extends K9Activity {
         mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
 
         setLayout(R.layout.account_setup_composition);
+        setTitle(R.string.account_settings_composition_title);
 
         /*
          * If we're being reloaded we override the original account with the one

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -121,9 +121,7 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setLayout(R.layout.account_setup_incoming);
-        // For some reason we need to set the title, see issue #4407
         setTitle(R.string.account_setup_incoming_title);
-
 
         mUsernameView = findViewById(R.id.account_username);
         mPasswordView = findViewById(R.id.account_password);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -121,6 +121,9 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setLayout(R.layout.account_setup_incoming);
+        // For some reason we need to set the title, see issue #4407
+        setTitle(R.string.account_setup_incoming_title);
+
 
         mUsernameView = findViewById(R.id.account_username);
         mPasswordView = findViewById(R.id.account_password);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupNames.java
@@ -42,6 +42,8 @@ public class AccountSetupNames extends K9Activity implements OnClickListener {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setLayout(R.layout.account_setup_names);
+        setTitle(R.string.account_setup_names_title);
+
         mDescription = findViewById(R.id.account_description);
         mName = findViewById(R.id.account_name);
         mDoneButton = findViewById(R.id.done);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOptions.java
@@ -43,6 +43,7 @@ public class AccountSetupOptions extends K9Activity implements OnClickListener {
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setLayout(R.layout.account_setup_options);
+        setTitle(R.string.account_setup_options_title);
 
         mCheckFrequencyView = findViewById(R.id.account_check_frequency);
         mDisplayCountView = findViewById(R.id.account_display_count);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -96,6 +96,7 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setLayout(R.layout.account_setup_outgoing);
+        setTitle(R.string.account_setup_outgoing_title);
 
         String accountUuid = getIntent().getStringExtra(EXTRA_ACCOUNT);
         mAccount = Preferences.getPreferences(this).getAccount(accountUuid);

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -51,6 +51,7 @@ class ChooseFolderActivity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setLayout(R.layout.folder_list)
+        setTitle(R.string.choose_folder_title)
 
         if (!decodeArguments(savedInstanceState)) {
             finish()

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferActivity.kt
@@ -38,6 +38,7 @@ class AutocryptKeyTransferActivity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setLayout(R.layout.crypto_key_transfer)
+        setTitle(R.string.ac_transfer_title)
 
         val accountUuid = intent.getStringExtra(EXTRA_ACCOUNT)
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersActivity.kt
@@ -18,6 +18,7 @@ class ManageFoldersActivity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setLayout(R.layout.activity_manage_folders)
+        setTitle(R.string.folders_action)
 
         val accountUuid = intent.getStringExtra(EXTRA_ACCOUNT) ?: error("Missing Intent extra '$EXTRA_ACCOUNT'")
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagesource/MessageSourceActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagesource/MessageSourceActivity.kt
@@ -16,6 +16,7 @@ class MessageSourceActivity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setLayout(R.layout.message_view_headers_activity)
+        setTitle(R.string.show_headers_action)
         supportActionBar!!.setDisplayHomeAsUpEnabled(true)
 
         if (savedInstanceState == null) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/onboarding/OnboardingActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/onboarding/OnboardingActivity.kt
@@ -16,6 +16,7 @@ class OnboardingActivity : K9Activity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setLayout(R.layout.activity_onboarding)
+        setTitle(R.string.account_setup_basics_title)
 
         initializeActionBar()
     }


### PR DESCRIPTION
Resolves part of #4407 (wrong titles)

How to reproduce:
Finding 5.5: Incoming server settings
1. Set system language to English and app language to any other language than English, close app
2. Launch app
3. Open a mail from unified inbox
4. Go back (using arrow in the upper left or Android's back button)
5. Open side menu on the left using sandwich icon in the upper left
6. Tab (translated) "Settings"
7. Tab an existing account
8. Tab (translated) "Fetching mail"
9. Tab (translated) "Incoming server" -> title is in English



Add account settings
1. Set system language to English and app language to any other language than English, close app
2. Launch app
3. Open a mail from unified inbox
4. Go back (using arrow in the upper left or Android's back button)
5. Open side menu on the left using sandwich icon in the upper left
6. Tab (translated) "Settings"
7. Tab (translated) "Add account" -> title is in English
