### PR TITLE
Remove "Notification opens unread messages" option

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -152,7 +152,6 @@ public class Account implements BaseAccount {
     private Expunge expungePolicy = Expunge.EXPUNGE_IMMEDIATELY;
     private int maxPushFolders;
     private int idleRefreshMinutes;
-    private boolean goToUnreadMessageSearch;
     private final Map<NetworkType, Boolean> compressionMap = new ConcurrentHashMap<>();
     private Searchable searchableFolders;
     private boolean subscribedFoldersOnly;
@@ -793,14 +792,6 @@ public class Account implements BaseAccount {
 
     public synchronized void setIdleRefreshMinutes(int idleRefreshMinutes) {
         this.idleRefreshMinutes = idleRefreshMinutes;
-    }
-
-    public synchronized boolean isGoToUnreadMessageSearch() {
-        return goToUnreadMessageSearch;
-    }
-
-    public synchronized void setGoToUnreadMessageSearch(boolean goToUnreadMessageSearch) {
-        this.goToUnreadMessageSearch = goToUnreadMessageSearch;
     }
 
     public synchronized boolean isSubscribedFoldersOnly() {

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -104,7 +104,6 @@ class AccountPreferenceSerializer(
             isSyncRemoteDeletions = storage.getBoolean("$accountUuid.syncRemoteDeletions", true)
 
             maxPushFolders = storage.getInt("$accountUuid.maxPushFolders", 10)
-            isGoToUnreadMessageSearch = storage.getBoolean("$accountUuid.goToUnreadMessageSearch", false)
             isSubscribedFoldersOnly = storage.getBoolean("$accountUuid.subscribedFoldersOnly", false)
             maximumPolledMessageAge = storage.getInt("$accountUuid.maximumPolledMessageAge", -1)
             maximumAutoDownloadMessageSize = storage.getInt("$accountUuid.maximumAutoDownloadMessageSize", 32768)
@@ -293,7 +292,6 @@ class AccountPreferenceSerializer(
             editor.putInt("$accountUuid.maxPushFolders", maxPushFolders)
             editor.putString("$accountUuid.searchableFolders", searchableFolders.name)
             editor.putInt("$accountUuid.chipColor", chipColor)
-            editor.putBoolean("$accountUuid.goToUnreadMessageSearch", isGoToUnreadMessageSearch)
             editor.putBoolean("$accountUuid.subscribedFoldersOnly", isSubscribedFoldersOnly)
             editor.putInt("$accountUuid.maximumPolledMessageAge", maximumPolledMessageAge)
             editor.putInt("$accountUuid.maximumAutoDownloadMessageSize", maximumAutoDownloadMessageSize)
@@ -411,7 +409,6 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.chipColor")
         editor.remove("$accountUuid.led")
         editor.remove("$accountUuid.ledColor")
-        editor.remove("$accountUuid.goToUnreadMessageSearch")
         editor.remove("$accountUuid.subscribedFoldersOnly")
         editor.remove("$accountUuid.maximumPolledMessageAge")
         editor.remove("$accountUuid.maximumAutoDownloadMessageSize")
@@ -566,7 +563,6 @@ class AccountPreferenceSerializer(
             importedAutoExpandFolder = null
             legacyInboxFolder = null
             maxPushFolders = 10
-            isGoToUnreadMessageSearch = false
             isSubscribedFoldersOnly = false
             maximumPolledMessageAge = -1
             maximumAutoDownloadMessageSize = 32768

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -99,9 +99,6 @@ public class AccountSettingsDescriptions {
         s.put("folderTargetMode", Settings.versions(
                 new V(1, new EnumSetting<>(FolderMode.class, FolderMode.NOT_SECOND_CLASS))
         ));
-        s.put("goToUnreadMessageSearch", Settings.versions(
-                new V(1, new BooleanSetting(false))
-        ));
         s.put("idleRefreshMinutes", Settings.versions(
                 new V(1, new IntegerResourceSetting(24, R.array.idle_refresh_period_values))
         ));

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 70;
+    public static final int VERSION = 71;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
+++ b/app/core/src/main/java/com/fsck/k9/search/AccountSearchConditions.kt
@@ -2,7 +2,6 @@ package com.fsck.k9.search
 
 import com.fsck.k9.Account
 import com.fsck.k9.Account.FolderMode
-import com.fsck.k9.BaseAccount
 import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.search.SearchSpecification.Attribute
 import com.fsck.k9.search.SearchSpecification.SearchCondition
@@ -108,24 +107,5 @@ class AccountSearchConditions {
         if (folderId != null) {
             search.and(SearchField.FOLDER, folderId.toString(), Attribute.NOT_EQUALS)
         }
-    }
-
-    fun createUnreadSearch(account: BaseAccount, searchTitle: String): LocalSearch {
-        val search: LocalSearch
-        if (account is SearchAccount) {
-            search = account.relatedSearch.clone()
-            search.name = searchTitle
-        } else {
-            search = LocalSearch(searchTitle)
-            search.addAccountUuid(account.uuid)
-
-            val realAccount = account as Account
-            excludeSpecialFolders(realAccount, search)
-            limitToDisplayableFolders(realAccount, search)
-        }
-
-        search.and(SearchField.READ, "1", Attribute.NOT_EQUALS)
-
-        return search
     }
 }

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
@@ -16,7 +16,6 @@ import com.fsck.k9.activity.compose.MessageActions;
 import com.fsck.k9.activity.setup.AccountSetupIncoming;
 import com.fsck.k9.activity.setup.AccountSetupOutgoing;
 import com.fsck.k9.controller.MessageReference;
-import com.fsck.k9.jmap.R;
 import com.fsck.k9.search.AccountSearchConditions;
 import com.fsck.k9.search.LocalSearch;
 import com.fsck.k9.ui.messagelist.DefaultFolderProvider;
@@ -34,7 +33,6 @@ import com.fsck.k9.ui.messagelist.DefaultFolderProvider;
  */
 class K9NotificationActionCreator implements NotificationActionCreator {
     private final Context context;
-    private final AccountSearchConditions accountSearchConditions = DI.get(AccountSearchConditions.class);
     private final DefaultFolderProvider defaultFolderProvider = DI.get(DefaultFolderProvider.class);
 
 
@@ -58,17 +56,13 @@ class K9NotificationActionCreator implements NotificationActionCreator {
     public PendingIntent createViewMessagesPendingIntent(Account account, List<MessageReference> messageReferences,
             int notificationId) {
 
-        Intent intent;
-        if (account.isGoToUnreadMessageSearch()) {
-            intent = createUnreadIntent(account);
-        } else {
-            Long folderServerId = getFolderIdOfAllMessages(messageReferences);
+        Long folderServerId = getFolderIdOfAllMessages(messageReferences);
 
-            if (folderServerId == null) {
-                intent = createMessageListIntent(account);
-            } else {
-                intent = createMessageListIntent(account, folderServerId);
-            }
+        Intent intent;
+        if (folderServerId == null) {
+            intent = createMessageListIntent(account);
+        } else {
+            intent = createMessageListIntent(account, folderServerId);
         }
 
         return PendingIntent.getActivity(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
@@ -202,12 +196,6 @@ class K9NotificationActionCreator implements NotificationActionCreator {
         Intent intent = NotificationActionService.createMarkMessageAsSpamIntent(context, messageReference);
 
         return PendingIntent.getService(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-    }
-
-    private Intent createUnreadIntent(final Account account) {
-        String searchTitle = context.getString(R.string.search_title, account.getDescription(), context.getString(R.string.unread_modifier));
-        LocalSearch search = accountSearchConditions.createUnreadSearch(account, searchTitle);
-        return MessageList.intentDisplaySearch(context, search, true, false, false);
     }
 
     private Intent createMessageListIntent(Account account) {

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.java
@@ -10,7 +10,6 @@ import android.content.Intent;
 import com.fsck.k9.Account;
 import com.fsck.k9.DI;
 import com.fsck.k9.K9;
-import com.fsck.k9.R;
 import com.fsck.k9.activity.MessageList;
 import com.fsck.k9.controller.MessageReference;
 import com.fsck.k9.ui.notification.DeleteConfirmationActivity;
@@ -34,7 +33,6 @@ import com.fsck.k9.ui.messagelist.DefaultFolderProvider;
  */
 class K9NotificationActionCreator implements NotificationActionCreator {
     private final Context context;
-    private final AccountSearchConditions accountSearchConditions = DI.get(AccountSearchConditions.class);
     private final DefaultFolderProvider defaultFolderProvider = DI.get(DefaultFolderProvider.class);
 
 
@@ -58,17 +56,13 @@ class K9NotificationActionCreator implements NotificationActionCreator {
     public PendingIntent createViewMessagesPendingIntent(Account account, List<MessageReference> messageReferences,
             int notificationId) {
 
-        Intent intent;
-        if (account.isGoToUnreadMessageSearch()) {
-            intent = createUnreadIntent(account);
-        } else {
-            Long folderServerId = getFolderIdOfAllMessages(messageReferences);
+        Long folderServerId = getFolderIdOfAllMessages(messageReferences);
 
-            if (folderServerId == null) {
-                intent = createMessageListIntent(account);
-            } else {
-                intent = createMessageListIntent(account, folderServerId);
-            }
+        Intent intent;
+        if (folderServerId == null) {
+            intent = createMessageListIntent(account);
+        } else {
+            intent = createMessageListIntent(account, folderServerId);
         }
 
         return PendingIntent.getActivity(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
@@ -202,12 +196,6 @@ class K9NotificationActionCreator implements NotificationActionCreator {
         Intent intent = NotificationActionService.createMarkMessageAsSpamIntent(context, messageReference);
 
         return PendingIntent.getService(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT);
-    }
-
-    private Intent createUnreadIntent(final Account account) {
-        String searchTitle = context.getString(R.string.search_title, account.getDescription(), context.getString(R.string.unread_modifier));
-        LocalSearch search = accountSearchConditions.createUnreadSearch(account, searchTitle);
-        return MessageList.intentDisplaySearch(context, search, true, false, false);
     }
 
     private Intent createMessageListIntent(Account account) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -31,7 +31,6 @@ class AccountSettingsDataStore(
             "account_vibrate" -> account.notificationSetting.isVibrateEnabled
             "account_led" -> account.notificationSetting.isLedEnabled
             "account_notify_sync" -> account.isNotifySync
-            "notification_opens_unread" -> account.isGoToUnreadMessageSearch
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject
             "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts
@@ -64,7 +63,6 @@ class AccountSettingsDataStore(
             "account_vibrate" -> account.notificationSetting.isVibrateEnabled = value
             "account_led" -> account.notificationSetting.setLed(value)
             "account_notify_sync" -> account.isNotifySync = value
-            "notification_opens_unread" -> account.isGoToUnreadMessageSearch = value
             "remote_search_enabled" -> account.isAllowRemoteSearch = value
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly = value
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject = value

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -512,8 +512,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_notify_self_summary">Show a notification for messages I sent</string>
     <string name="account_notify_contacts_mail_only_label">Contacts only</string>
     <string name="account_notify_contacts_mail_only_summary">Show notifications only for messages from known contacts</string>
-    <string name="account_settings_notification_opens_unread_label">Notification opens unread messages</string>
-    <string name="account_settings_notification_opens_unread_summary">Searches for unread messages when Notification is opened</string>
     <string name="account_settings_mark_message_as_read_on_view_label">Mark as read when opened</string>
     <string name="account_settings_mark_message_as_read_on_view_summary">Mark a message as read when it is opened for viewing</string>
     <string name="account_settings_mark_message_as_read_on_delete_label">Mark as read when deleted</string>

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -386,12 +386,6 @@
             android:summary="@string/account_settings_notify_sync_summary"
             android:title="@string/account_settings_notify_sync_label" />
 
-        <CheckBoxPreference
-            android:defaultValue="true"
-            android:key="notification_opens_unread"
-            android:summary="@string/account_settings_notification_opens_unread_summary"
-            android:title="@string/account_settings_notification_opens_unread_label" />
-
         <com.fsck.k9.ui.settings.account.NotificationsPreference
             android:key="open_notification_settings"
             android:summary="@string/account_settings_notification_open_system_notifications_summary"


### PR DESCRIPTION
It's possible for this feature to open a message list with no visual indication that it's a filtered list. That's a support nightmare.

If we bring this back it'll be as "notification opens list of new messages".