### PR TITLE
Make sure activity title always uses the appropriate locale

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/search/LocalSearch.java
+++ b/app/core/src/main/java/com/fsck/k9/search/LocalSearch.java
@@ -24,7 +24,6 @@ import android.os.Parcelable;
 public class LocalSearch implements SearchSpecification {
 
     private String id;
-    private String mName;
     private boolean mPredefined;
     private boolean mManualSearch = false;
 
@@ -44,25 +43,14 @@ public class LocalSearch implements SearchSpecification {
     public LocalSearch() {}
 
     /**
-     *
-     * @param name
-     */
-    public LocalSearch(String name) {
-        this.mName = name;
-    }
-
-    /**
      * Use this constructor when you know what you're doing. Normally it's only used
      * when restoring these search objects from the database.
      *
-     * @param name Name of the search
      * @param searchConditions SearchConditions, may contains flags and folders
      * @param accounts Relative Account's uuid's
      * @param predefined Is this a predefined search or a user created one?
      */
-    protected LocalSearch(String name, ConditionsTreeNode searchConditions,
-            String accounts, boolean predefined) {
-        this(name);
+    protected LocalSearch(ConditionsTreeNode searchConditions, String accounts, boolean predefined) {
         mConditions = searchConditions;
         mPredefined = predefined;
         mLeafSet = new HashSet<>();
@@ -84,7 +72,7 @@ public class LocalSearch implements SearchSpecification {
     public LocalSearch clone() {
         ConditionsTreeNode conditions = (mConditions == null) ? null : mConditions.cloneTree();
 
-        LocalSearch copy = new LocalSearch(mName, conditions, null, mPredefined);
+        LocalSearch copy = new LocalSearch(conditions, null, mPredefined);
         copy.mManualSearch = mManualSearch;
         copy.mAccountUuids = new HashSet<>(mAccountUuids);
 
@@ -94,16 +82,6 @@ public class LocalSearch implements SearchSpecification {
     ///////////////////////////////////////////////////////////////
     // Public manipulation methods
     ///////////////////////////////////////////////////////////////
-    /**
-     * Sets the name of the saved search. If one existed it will
-     * be overwritten.
-     *
-     * @param name Name to be set.
-     */
-    public void setName(String name) {
-        this.mName = name;
-    }
-
     /**
      * Set the ID of the search. This is used to identify a unified inbox
      * search
@@ -285,16 +263,6 @@ public class LocalSearch implements SearchSpecification {
     }
 
     /**
-     * Returns the name of the saved search.
-     *
-     * @return Name of the search.
-     */
-    @Override
-    public String getName() {
-        return (mName == null) ? "" : mName;
-    }
-
-    /**
      * Returns the ID of the search
      *
      * @return The ID of the search
@@ -361,7 +329,6 @@ public class LocalSearch implements SearchSpecification {
     @Override
     public void writeToParcel(Parcel dest, int flags) {
         dest.writeString(id);
-        dest.writeString(mName);
         dest.writeByte((byte) (mPredefined ? 1 : 0));
         dest.writeByte((byte) (mManualSearch ? 1 : 0));
         dest.writeStringList(new ArrayList<>(mAccountUuids));
@@ -384,7 +351,6 @@ public class LocalSearch implements SearchSpecification {
 
     public LocalSearch(Parcel in) {
         id = in.readString();
-        mName = in.readString();
         mPredefined = (in.readByte() == 1);
         mManualSearch = (in.readByte() == 1);
         mAccountUuids.addAll(in.createStringArrayList());

--- a/app/core/src/main/java/com/fsck/k9/search/SearchAccount.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SearchAccount.java
@@ -19,11 +19,11 @@ public class SearchAccount implements BaseAccount {
     // create the unified inbox meta account ( all accounts is default when none specified )
     public static SearchAccount createUnifiedInboxAccount() {
         CoreResourceProvider resourceProvider = DI.get(CoreResourceProvider.class);
-        String name = resourceProvider.searchUnifiedInboxTitle();
-        LocalSearch tmpSearch = new LocalSearch(name);
+        LocalSearch tmpSearch = new LocalSearch();
         tmpSearch.setId(UNIFIED_INBOX);
         tmpSearch.and(SearchField.INTEGRATE, "1", Attribute.EQUALS);
-        return new SearchAccount(UNIFIED_INBOX, tmpSearch, name, resourceProvider.searchUnifiedInboxDetail());
+        return new SearchAccount(UNIFIED_INBOX, tmpSearch, resourceProvider.searchUnifiedInboxTitle(),
+                resourceProvider.searchUnifiedInboxDetail());
     }
 
     private String mId;

--- a/app/core/src/main/java/com/fsck/k9/search/SearchSpecification.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SearchSpecification.java
@@ -12,12 +12,6 @@ public interface SearchSpecification extends Parcelable {
     String[] getAccountUuids();
 
     /**
-     * Returns the search's name if it was named.
-     * @return Name of the search.
-     */
-    String getName();
-
-    /**
      * Returns the root node of the condition tree accompanying
      * the search.
      *

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -385,7 +385,7 @@ open class MessageList :
             // Query was received from Search Dialog
             val query = queryString.trim()
 
-            val search = LocalSearch(getString(R.string.search_results)).apply {
+            val search = LocalSearch().apply {
                 isManualSearch = true
                 or(SearchCondition(SearchField.SENDER, SearchSpecification.Attribute.CONTAINS, query))
                 or(SearchCondition(SearchField.SUBJECT, SearchSpecification.Attribute.CONTAINS, query))

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -38,6 +38,7 @@ import com.fsck.k9.helper.Utility
 import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.search.LocalSearch
+import com.fsck.k9.search.SearchAccount
 import com.fsck.k9.search.getAccounts
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.choosefolder.ChooseFolderActivity
@@ -88,7 +89,7 @@ class MessageListFragment :
     private var currentFolder: FolderInfoHolder? = null
     private var remoteSearchFuture: Future<*>? = null
     private var extraSearchResults: List<String>? = null
-    private var title: String? = null
+    private var threadTitle: String? = null
     private var allAccounts = false
     private var sortType = SortType.SORT_DATE
     private var sortAscending = true
@@ -174,8 +175,6 @@ class MessageListFragment :
         showingThreadedList = arguments.getBoolean(ARG_THREADED_LIST, false)
         isThreadDisplay = arguments.getBoolean(ARG_IS_THREAD_DISPLAY, false)
         localSearch = arguments.getParcelable(ARG_SEARCH)!!
-
-        title = localSearch.name
 
         allAccounts = localSearch.searchAllAccounts()
         val searchAccounts = localSearch.getAccounts(preferences)
@@ -326,7 +325,10 @@ class MessageListFragment :
             fragmentListener.setMessageListTitle(currentFolder!!.displayName)
         } else {
             // query result display.  This may be for a search folder as opposed to a user-initiated search.
-            val title = this.title
+            var title = this.threadTitle
+            if (SearchAccount.UNIFIED_INBOX == localSearch.id) {
+                title = resources.getString(R.string.integrated_inbox_title)
+            }
             if (title != null) {
                 // This was a search folder; the search folder has overridden our title.
                 fragmentListener.setMessageListTitle(title)
@@ -1418,7 +1420,7 @@ class MessageListFragment :
         if (isThreadDisplay) {
             if (messageListItems.isNotEmpty()) {
                 val strippedSubject = messageListItems.first().subject?.let { Utility.stripSubject(it) }
-                title = if (strippedSubject.isNullOrEmpty()) {
+                threadTitle = if (strippedSubject.isNullOrEmpty()) {
                     getString(R.string.general_no_subject)
                 } else {
                     strippedSubject

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -119,6 +119,9 @@ class MessageListFragment :
     var isRemoteSearch = false
         private set
 
+    private val isUnifiedInbox: Boolean
+        get() = localSearch.id == SearchAccount.UNIFIED_INBOX
+
     /**
      * `true` after [.onCreate] was executed. Used in [.updateTitle] to
      * make sure we don't access member variables before initialization is complete.
@@ -320,23 +323,15 @@ class MessageListFragment :
     }
 
     private fun setWindowTitle() {
-        // regular folder content display
-        if (!isManualSearch && isSingleFolderMode) {
-            fragmentListener.setMessageListTitle(currentFolder!!.displayName)
-        } else {
-            // query result display.  This may be for a search folder as opposed to a user-initiated search.
-            var title = this.threadTitle
-            if (SearchAccount.UNIFIED_INBOX == localSearch.id) {
-                title = resources.getString(R.string.integrated_inbox_title)
-            }
-            if (title != null) {
-                // This was a search folder; the search folder has overridden our title.
-                fragmentListener.setMessageListTitle(title)
-            } else {
-                // This is a search result; set it to the default search result line.
-                fragmentListener.setMessageListTitle(getString(R.string.search_results))
-            }
+        val title = when {
+            isUnifiedInbox -> getString(R.string.integrated_inbox_title)
+            isManualSearch -> getString(R.string.search_results)
+            isThreadDisplay -> threadTitle ?: ""
+            isSingleFolderMode -> currentFolder!!.displayName
+            else -> ""
         }
+
+        fragmentListener.setMessageListTitle(title)
     }
 
     fun progress(progress: Boolean) {


### PR DESCRIPTION
When the user switched the app language the app held on to the original localized name of the Unified Inbox. 

This is a rebased version of PR #5319 by @plan3d.

See issue #4407