### PR TITLE
Re-apply the locale override to the configuration if necessary

### DIFF
--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/AppLanguageManager.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/AppLanguageManager.kt
@@ -45,6 +45,12 @@ class AppLanguageManager(
         setLocale(appLanguage)
     }
 
+    fun applyOverrideLocale() {
+        currentOverrideLocale?.let { overrideLocale ->
+            Locale.setDefault(overrideLocale)
+        }
+    }
+
     private fun setLocale(appLanguage: String) {
         val overrideLocale = getOverrideLocaleForLanguage(appLanguage)
         currentOverrideLocale = overrideLocale


### PR DESCRIPTION
Creating a `WebView` instance causes the `Resources` configuration to be reset. With this change we'll re-apply our locale override when necessary.

Fixes #4407