### PR TITLE
Inline attachments are included in forwarded messages

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/MessageBuilder.java
+++ b/app/core/src/main/java/com/fsck/k9/message/MessageBuilder.java
@@ -3,6 +3,7 @@ package com.fsck.k9.message;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import android.app.Activity;
 import android.app.PendingIntent;
@@ -56,6 +57,7 @@ public abstract class MessageBuilder {
     private SimpleMessageFormat messageFormat;
     private String text;
     private List<Attachment> attachments;
+    private Map<String, Attachment> inlineAttachments;
     private String signature;
     private QuoteStyle quoteStyle;
     private QuotedTextMode quotedTextMode;
@@ -169,7 +171,16 @@ public abstract class MessageBuilder {
             // Let the receiver select either the text or the HTML part.
             bodyPlain = buildText(isDraft, SimpleMessageFormat.TEXT);
             composedMimeMessage.addBodyPart(MimeBodyPart.create(bodyPlain, "text/plain"));
-            composedMimeMessage.addBodyPart(MimeBodyPart.create(body, "text/html"));
+            MimeBodyPart htmlPart = MimeBodyPart.create(body, "text/html");
+            if (inlineAttachments != null && inlineAttachments.size() > 0) {
+                MimeMultipart htmlPartWithInlineImages = new MimeMultipart("multipart/related",
+                        boundaryGenerator.generateBoundary());
+                htmlPartWithInlineImages.addBodyPart(htmlPart);
+                addInlineAttachmentsToMessage(htmlPartWithInlineImages);
+                composedMimeMessage.addBodyPart(MimeBodyPart.create(htmlPartWithInlineImages));
+            } else {
+                composedMimeMessage.addBodyPart(htmlPart);
+            }
 
             if (hasAttachments) {
                 // If we're HTML and have attachments, we have a MimeMultipart container to hold the
@@ -236,7 +247,25 @@ public abstract class MessageBuilder {
             MimeBodyPart bp = MimeBodyPart.create(body);
 
             addContentType(bp, attachment.getContentType(), attachment.getName());
-            addContentDisposition(bp, attachment.getName(), attachment.getSize());
+            addContentDisposition(bp, "attachment", attachment.getName(), attachment.getSize());
+
+            mp.addBodyPart(bp);
+        }
+    }
+
+    private void addInlineAttachmentsToMessage(final MimeMultipart mp) throws MessagingException {
+        for (String cid : inlineAttachments.keySet()) {
+            Attachment attachment = inlineAttachments.get(cid);
+            if (attachment.getState() != Attachment.LoadingState.COMPLETE) {
+                continue;
+            }
+
+            Body body = new TempFileBody(attachment.getFileName());
+            MimeBodyPart bp = MimeBodyPart.create(body);
+
+            addContentType(bp, attachment.getContentType(), attachment.getName());
+            addContentDisposition(bp, "inline", attachment.getName(), attachment.getSize());
+            bp.addHeader(MimeHeader.HEADER_CONTENT_ID, cid);
 
             mp.addBodyPart(bp);
         }
@@ -251,8 +280,8 @@ public abstract class MessageBuilder {
         }
     }
 
-    private void addContentDisposition(MimeBodyPart bodyPart, String fileName, Long size) {
-        String value = Headers.contentDisposition("attachment", fileName, size);
+    private void addContentDisposition(MimeBodyPart bodyPart, String disposition, String fileName, Long size) {
+        String value = Headers.contentDisposition(disposition, fileName, size);
         bodyPart.addHeader(MimeHeader.HEADER_CONTENT_DISPOSITION, value);
     }
 
@@ -398,6 +427,11 @@ public abstract class MessageBuilder {
 
     public MessageBuilder setAttachments(List<Attachment> attachments) {
         this.attachments = attachments;
+        return this;
+    }
+
+    public MessageBuilder setInlineAttachments(Map<String, Attachment> attachments) {
+        this.inlineAttachments = attachments;
         return this;
     }
 

--- a/app/ui/legacy/build.gradle
+++ b/app/ui/legacy/build.gradle
@@ -57,6 +57,7 @@ dependencies {
     testImplementation project(':app:storage')
     testImplementation project(':app:testing')
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
+    testImplementation "androidx.test:core:${versions.androidxTestCore}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
     testImplementation "org.mockito:mockito-core:${versions.mockito}"

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -713,6 +713,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
                 .setMessageFormat(currentMessageFormat)
                 .setText(CrLfConverter.toCrLf(messageContentView.getText()))
                 .setAttachments(attachmentPresenter.getAttachments())
+                .setInlineAttachments(attachmentPresenter.getInlineAttachments())
                 .setSignature(CrLfConverter.toCrLf(signatureView.getText()))
                 .setSignatureBeforeQuotedText(account.isSignatureBeforeQuotedText())
                 .setIdentityChanged(identityChanged)
@@ -1369,7 +1370,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         if (!relatedMessageProcessed) {
-            attachmentPresenter.loadNonInlineAttachments(messageViewInfo);
+            attachmentPresenter.loadAllAvailableAttachments(messageViewInfo);
         }
 
         // Decode the identity header when loading a draft.

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/AttachmentPresenter.java
@@ -4,6 +4,7 @@ package com.fsck.k9.activity.compose;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 import android.app.Activity;
 import android.content.ClipData;
@@ -19,6 +20,7 @@ import com.fsck.k9.activity.compose.ComposeCryptoStatus.AttachErrorState;
 import com.fsck.k9.activity.loader.AttachmentContentLoader;
 import com.fsck.k9.activity.loader.AttachmentInfoLoader;
 import com.fsck.k9.activity.misc.Attachment;
+import com.fsck.k9.activity.misc.InlineAttachment;
 import com.fsck.k9.controller.MessageReference;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mailstore.AttachmentViewInfo;
@@ -46,7 +48,8 @@ public class AttachmentPresenter {
     private final AttachmentsChangedListener listener;
 
     // persistent state
-    private LinkedHashMap<Uri, Attachment> attachments;
+    private final LinkedHashMap<Uri, Attachment> attachments;
+    private final LinkedHashMap<Uri, InlineAttachment> inlineAttachments;
     private int nextLoaderId = 0;
     private WaitingAction actionToPerformAfterWaiting = WaitingAction.NONE;
 
@@ -59,6 +62,7 @@ public class AttachmentPresenter {
         this.listener = listener;
 
         attachments = new LinkedHashMap<>();
+        inlineAttachments = new LinkedHashMap<>();
     }
 
     public void onSaveInstanceState(Bundle outState) {
@@ -122,6 +126,14 @@ public class AttachmentPresenter {
         return new ArrayList<>(attachments.values());
     }
 
+    public Map<String, com.fsck.k9.message.Attachment> getInlineAttachments() {
+        Map<String, com.fsck.k9.message.Attachment> result = new LinkedHashMap<>();
+        for (InlineAttachment attachment : inlineAttachments.values()) {
+            result.put(attachment.getContentId(), attachment.getAttachment());
+        }
+        return result;
+    }
+
     public void onClickAddAttachment(RecipientPresenter recipientPresenter) {
         ComposeCryptoStatus currentCachedCryptoStatus = recipientPresenter.getCurrentCachedCryptoStatus();
         if (currentCachedCryptoStatus == null) {
@@ -159,6 +171,24 @@ public class AttachmentPresenter {
         addAttachment(uri, contentType, false, false);
     }
 
+    private void addInlineAttachment(AttachmentViewInfo attachmentViewInfo) {
+        if (inlineAttachments.containsKey(attachmentViewInfo.internalUri)) {
+            throw new IllegalStateException("Received the same attachmentViewInfo twice!");
+        }
+
+        int loaderId = getNextFreeLoaderId();
+        Attachment attachment = Attachment.createAttachment(
+                attachmentViewInfo.internalUri, loaderId, attachmentViewInfo.mimeType, true, true);
+        attachment = attachment.deriveWithMetadataLoaded(
+                attachmentViewInfo.mimeType, attachmentViewInfo.displayName, attachmentViewInfo.size);
+
+        inlineAttachments.put(attachment.uri, new InlineAttachment(attachmentViewInfo.part.getContentId(), attachment));
+
+        Bundle bundle = new Bundle();
+        bundle.putParcelable(LOADER_ARG_ATTACHMENT, attachment.uri);
+        loaderManager.initLoader(attachment.loaderId, bundle, mInlineAttachmentContentLoaderCallback);
+    }
+
     private void addInternalAttachment(Uri uri, String contentType, boolean allowMessageType) {
         addAttachment(uri, contentType, allowMessageType, true);
     }
@@ -174,25 +204,26 @@ public class AttachmentPresenter {
         addAttachmentAndStartLoader(attachment);
     }
 
-    public boolean loadNonInlineAttachments(MessageViewInfo messageViewInfo) {
+    public boolean loadAllAvailableAttachments(MessageViewInfo messageViewInfo) {
         boolean allPartsAvailable = true;
 
         for (AttachmentViewInfo attachmentViewInfo : messageViewInfo.attachments) {
-            if (attachmentViewInfo.inlineAttachment) {
-                continue;
-            }
-            if (!attachmentViewInfo.isContentAvailable()) {
+            if (attachmentViewInfo.isContentAvailable()) {
+                if (attachmentViewInfo.inlineAttachment) {
+                    addInlineAttachment(attachmentViewInfo);
+                } else {
+                    addInternalAttachment(attachmentViewInfo);
+                }
+            } else {
                 allPartsAvailable = false;
-                continue;
             }
-            addInternalAttachment(attachmentViewInfo);
         }
 
         return allPartsAvailable;
     }
 
     public void processMessageToForward(MessageViewInfo messageViewInfo) {
-        boolean isMissingParts = !loadNonInlineAttachments(messageViewInfo);
+        boolean isMissingParts = !loadAllAvailableAttachments(messageViewInfo);
         if (isMissingParts) {
             attachmentMvpView.showMissingAttachmentsPartialMessageWarning();
         }
@@ -302,6 +333,35 @@ public class AttachmentPresenter {
                     } else {
                         attachments.remove(attachment.uri);
                         attachmentMvpView.removeAttachmentView(attachment);
+                    }
+
+                    postPerformStalledAction();
+                }
+
+                @Override
+                public void onLoaderReset(Loader<Attachment> loader) {
+                    // nothing to do
+                }
+            };
+
+    private LoaderManager.LoaderCallbacks<Attachment> mInlineAttachmentContentLoaderCallback =
+            new LoaderManager.LoaderCallbacks<Attachment>() {
+                @Override
+                public Loader<Attachment> onCreateLoader(int id, Bundle args) {
+                    Uri uri = args.getParcelable(LOADER_ARG_ATTACHMENT);
+                    return new AttachmentContentLoader(context, inlineAttachments.get(uri).getAttachment());
+                }
+
+                @Override
+                public void onLoadFinished(Loader<Attachment> loader, Attachment attachment) {
+                    int loaderId = loader.getId();
+                    loaderManager.destroyLoader(loaderId);
+
+                    if (attachment.state == Attachment.LoadingState.COMPLETE) {
+                        inlineAttachments.put(attachment.uri, new InlineAttachment(
+                                inlineAttachments.get(attachment.uri).getContentId(), attachment));
+                    } else {
+                        inlineAttachments.remove(attachment.uri);
                     }
 
                     postPerformStalledAction();

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/misc/InlineAttachment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/misc/InlineAttachment.kt
@@ -1,0 +1,3 @@
+package com.fsck.k9.activity.misc
+
+data class InlineAttachment(val contentId: String, val attachment: Attachment)

--- a/app/ui/legacy/src/test/java/com/fsck/k9/activity/compose/AttachmentPresenterTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/activity/compose/AttachmentPresenterTest.kt
@@ -1,0 +1,159 @@
+package com.fsck.k9.activity.compose
+
+import android.net.Uri
+import androidx.loader.app.LoaderManager
+import androidx.loader.app.LoaderManager.LoaderCallbacks
+import androidx.test.core.app.ApplicationProvider
+import com.fsck.k9.K9RobolectricTest
+import com.fsck.k9.activity.compose.AttachmentPresenter.AttachmentMvpView
+import com.fsck.k9.activity.compose.AttachmentPresenter.AttachmentsChangedListener
+import com.fsck.k9.activity.misc.Attachment
+import com.fsck.k9.mail.internet.MimeHeader
+import com.fsck.k9.mail.internet.MimeMessage
+import com.fsck.k9.mail.internet.MimeMessageHelper
+import com.fsck.k9.mail.internet.TextBody
+import com.fsck.k9.mailstore.AttachmentResolver
+import com.fsck.k9.mailstore.AttachmentViewInfo
+import com.fsck.k9.mailstore.LocalBodyPart
+import com.fsck.k9.mailstore.MessageViewInfo
+import com.google.common.truth.Truth.assertThat
+import java.util.function.Supplier
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.Mockito.doAnswer
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+private val attachmentMvpView = mock<AttachmentMvpView>()
+private val loaderManager = mock<LoaderManager>()
+private val listener = mock<AttachmentsChangedListener>()
+private val attachmentResolver = mock<AttachmentResolver>()
+
+private const val ACCOUNT_UUID = "uuid"
+private const val SUBJECT = "subject"
+private const val TEXT = "text"
+private const val EXTRA_TEXT = "extra text"
+private const val ATTACHMENT_NAME = "1x1.png"
+private const val MESSAGE_ID = 1L
+private const val PATH_TO_FILE = "path/to/file.png"
+private const val MIME_TYPE = "image/png"
+private val URI = Uri.Builder().scheme("content://").build()
+
+class AttachmentPresenterTest : K9RobolectricTest() {
+    lateinit var attachmentPresenter: AttachmentPresenter
+
+    @Before
+    fun setUp() {
+        attachmentPresenter = AttachmentPresenter(
+            ApplicationProvider.getApplicationContext(), attachmentMvpView, loaderManager, listener
+        )
+    }
+
+    @Test
+    fun loadNonInlineAttachments_normalAttachment() {
+        val size = 42L
+        val message = MimeMessage()
+        MimeMessageHelper.setBody(message, TextBody(TEXT))
+        val attachmentViewInfo = AttachmentViewInfo(
+            MIME_TYPE, ATTACHMENT_NAME, size, URI, false,
+            LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, size), true
+        )
+        val messageViewInfo = MessageViewInfo(
+            message, false, message, SUBJECT, false, TEXT, listOf(attachmentViewInfo), null, attachmentResolver,
+            EXTRA_TEXT, ArrayList()
+        )
+
+        mockLoaderManager({ attachmentPresenter.attachments.get(0) as Attachment })
+
+        val result = attachmentPresenter.loadAllAvailableAttachments(messageViewInfo)
+
+        assertThat(result).isTrue()
+        assertThat(attachmentPresenter.attachments).hasSize(1)
+        assertThat(attachmentPresenter.inlineAttachments).isEmpty()
+        val attachment = attachmentPresenter.attachments.get(0)
+        assertThat(attachment?.name).isEqualTo(ATTACHMENT_NAME)
+        assertThat(attachment?.size).isEqualTo(size)
+        assertThat(attachment?.state).isEqualTo(com.fsck.k9.message.Attachment.LoadingState.COMPLETE)
+        assertThat(attachment?.fileName).isEqualTo(PATH_TO_FILE)
+    }
+
+    @Test
+    fun loadNonInlineAttachments_normalAttachmentNotAvailable() {
+        val size = 42L
+        val message = MimeMessage()
+        MimeMessageHelper.setBody(message, TextBody(TEXT))
+        val attachmentViewInfo = AttachmentViewInfo(
+            MIME_TYPE, ATTACHMENT_NAME, size, URI, false,
+            LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, size), false
+        )
+        val messageViewInfo = MessageViewInfo(
+            message, false, message, SUBJECT, false, TEXT, listOf(attachmentViewInfo), null, attachmentResolver,
+            EXTRA_TEXT, ArrayList()
+        )
+
+        val result = attachmentPresenter.loadAllAvailableAttachments(messageViewInfo)
+
+        assertThat(result).isFalse()
+        assertThat(attachmentPresenter.attachments).isEmpty()
+        assertThat(attachmentPresenter.inlineAttachments).isEmpty()
+    }
+
+    @Test
+    fun loadNonInlineAttachments_inlineAttachment() {
+        val size = 42L
+        val contentId = "xyz"
+        val message = MimeMessage()
+        MimeMessageHelper.setBody(message, TextBody(TEXT))
+        val localBodyPart = LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, size)
+        localBodyPart.addHeader(MimeHeader.HEADER_CONTENT_ID, contentId)
+        val attachmentViewInfo = AttachmentViewInfo(MIME_TYPE, ATTACHMENT_NAME, size, URI, true, localBodyPart, true)
+        val messageViewInfo = MessageViewInfo(
+            message, false, message, SUBJECT, false, TEXT, listOf(attachmentViewInfo), null, attachmentResolver,
+            EXTRA_TEXT, ArrayList()
+        )
+
+        mockLoaderManager({ attachmentPresenter.inlineAttachments.get(contentId) as Attachment })
+
+        val result = attachmentPresenter.loadAllAvailableAttachments(messageViewInfo)
+
+        assertThat(result).isTrue()
+        assertThat(attachmentPresenter.attachments).isEmpty()
+        assertThat(attachmentPresenter.inlineAttachments).hasSize(1)
+        val attachment = attachmentPresenter.inlineAttachments.get(contentId)
+        assertThat(attachment?.name).isEqualTo(ATTACHMENT_NAME)
+        assertThat(attachment?.size).isEqualTo(size)
+        assertThat(attachment?.state).isEqualTo(com.fsck.k9.message.Attachment.LoadingState.COMPLETE)
+        assertThat(attachment?.fileName).isEqualTo(PATH_TO_FILE)
+    }
+
+    @Test
+    fun loadNonInlineAttachments_inlineAttachmentNotAvailable() {
+        val size = 42L
+        val contentId = "xyz"
+        val message = MimeMessage()
+        MimeMessageHelper.setBody(message, TextBody(TEXT))
+        val localBodyPart = LocalBodyPart(ACCOUNT_UUID, mock(), MESSAGE_ID, size)
+        localBodyPart.addHeader(MimeHeader.HEADER_CONTENT_ID, contentId)
+        val attachmentViewInfo = AttachmentViewInfo(MIME_TYPE, ATTACHMENT_NAME, size, URI, true, localBodyPart, false)
+        val messageViewInfo = MessageViewInfo(
+            message, false, message, SUBJECT, false, TEXT, listOf(attachmentViewInfo), null, attachmentResolver,
+            EXTRA_TEXT, ArrayList()
+        )
+
+        val result = attachmentPresenter.loadAllAvailableAttachments(messageViewInfo)
+
+        assertThat(result).isFalse()
+        assertThat(attachmentPresenter.attachments).isEmpty()
+        assertThat(attachmentPresenter.inlineAttachments).isEmpty()
+    }
+
+    private fun mockLoaderManager(attachmentSupplier: Supplier<Attachment>) {
+        doAnswer {
+            val loaderCallbacks = it.getArgument<LoaderCallbacks<Attachment>>(2)
+            loaderCallbacks.onLoadFinished(mock(), attachmentSupplier.get().deriveWithLoadComplete(PATH_TO_FILE))
+            null
+        }.whenever(loaderManager).initLoader(anyInt(), any(), any<LoaderCallbacks<Attachment>>())
+    }
+}


### PR DESCRIPTION
Resolves #2490

I can reproduce the issue by forwarding the following mail:

```
To: x@example.com
From: y@example.com
Subject: inline attachment
Message-ID: <XXX>
Date: XXX
User-Agent: XXX
MIME-Version: 1.0
Content-Type: multipart/alternative;
 boundary="------------6DA55383243B64A886F2E3C6"
Content-Language: en-US

This is a multi-part message in MIME format.
--------------6DA55383243B64A886F2E3C6
Content-Type: text/plain; charset=utf-8; format=flowed
Content-Transfer-Encoding: 7bit

text with image 1x1 test


--------------6DA55383243B64A886F2E3C6
Content-Type: multipart/related;
 boundary="------------84EA168083F5E842FCF139D3"


--------------84EA168083F5E842FCF139D3
Content-Type: text/html; charset=utf-8
Content-Transfer-Encoding: 7bit

<html>
  <head>

    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
  </head>
  <body>
    <p>text with image <img moz-do-not-send="false"
        src="cid:part1.09AEA62C.20716EEE" alt="1x1" width="1"
        height="1"> test<br>
    </p>
  </body>
</html>

--------------84EA168083F5E842FCF139D3
Content-Type: image/png;
 name="1x1.png"
Content-Transfer-Encoding: base64
Content-ID: <part1.09AEA62C.20716EEE>
Content-Disposition: inline;
 filename="1x1.png"

iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQI12P4//8/AAX+Av7c
zFnnAAAAAElFTkSuQmCC
--------------84EA168083F5E842FCF139D3--

--------------6DA55383243B64A886F2E3C6--

```