### PR TITLE
Fix attachment box layout in compose screen

### DIFF
--- a/app/ui/legacy/src/main/res/layout/message_compose_attachment.xml
+++ b/app/ui/legacy/src/main/res/layout/message_compose_attachment.xml
@@ -104,6 +104,7 @@
             app:srcCompat="?attr/iconActionCancel"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toEndOf="@+id/progressBar"
             app:layout_constraintTop_toBottomOf="@+id/attachment_preview" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
Before:
![k9mail__compose_attachment_before](https://user-images.githubusercontent.com/218061/122264063-699b2d80-ced7-11eb-93ac-e03c82189544.png)

After:
![k9mail__compose_attachment_after](https://user-images.githubusercontent.com/218061/122264083-6e5fe180-ced7-11eb-9c30-c0dc91ea2461.png)
