### PR TITLE
Honor expunge policy when deleting messages

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/DraftOperations.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.controller
 
 import com.fsck.k9.Account
+import com.fsck.k9.Account.Expunge
 import com.fsck.k9.K9
 import com.fsck.k9.backend.api.Backend
 import com.fsck.k9.controller.MessagingControllerCommands.PendingAppend
@@ -114,7 +115,7 @@ internal class DraftOperations(
             uploadMessage(backend, account, localFolder, localMessage)
         }
 
-        deleteMessage(backend, localFolder, command.deleteMessageId)
+        deleteMessage(backend, account, localFolder, command.deleteMessageId)
     }
 
     private fun uploadMessage(
@@ -151,7 +152,7 @@ internal class DraftOperations(
         }
     }
 
-    private fun deleteMessage(backend: Backend, localFolder: LocalFolder, messageId: Long) {
+    private fun deleteMessage(backend: Backend, account: Account, localFolder: LocalFolder, messageId: Long) {
         val messageServerId = localFolder.getMessageUidById(messageId) ?: run {
             Timber.i("Couldn't find local copy of message [ID: %d] to be deleted. Skipping delete.", messageId)
             return
@@ -160,6 +161,10 @@ internal class DraftOperations(
         val messageServerIds = listOf(messageServerId)
         val folderServerId = localFolder.serverId
         backend.deleteMessages(folderServerId, messageServerIds)
+
+        if (backend.supportsExpunge && account.expungePolicy == Expunge.EXPUNGE_IMMEDIATELY) {
+            backend.expungeMessages(folderServerId, messageServerIds)
+        }
 
         messagingController.destroyPlaceholderMessages(localFolder, messageServerIds)
     }

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1009,6 +1009,10 @@ public class MessagingController {
         String folderServerId = getFolderServerId(account, folderId);
         backend.deleteMessages(folderServerId, uids);
 
+        if (backend.getSupportsExpunge() && account.getExpungePolicy() == Expunge.EXPUNGE_IMMEDIATELY) {
+            backend.expungeMessages(folderServerId, uids);
+        }
+
         LocalStore localStore = localStoreProvider.getInstance(account);
         LocalFolder localFolder = localStore.getFolder(folderId);
         localFolder.open();


### PR DESCRIPTION
Previously, we didn't expunge messages when the expunge policy was set to 'immediately' (default) and no Trash folder was configured.

Fixes #5345