### PR TITLE
Add 'search everywhere' menu item

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -876,6 +876,9 @@ open class MessageList :
         } else if (id == R.id.search_remote) {
             messageListFragment!!.onRemoteSearch()
             return true
+        } else if (id == R.id.search_everywhere) {
+            searchEverywhere()
+            return true
         } else if (id == R.id.mark_all_as_read) {
             messageListFragment!!.confirmMarkAllAsRead()
             return true
@@ -952,6 +955,14 @@ open class MessageList :
                 super.onOptionsItemSelected(item)
             }
         }
+    }
+
+    private fun searchEverywhere() {
+        val searchIntent = Intent(this, Search::class.java).apply {
+            action = Intent.ACTION_SEARCH
+            putExtra(SearchManager.QUERY, intent.getStringExtra(SearchManager.QUERY))
+        }
+        onNewIntent(searchIntent)
     }
 
     override fun onCreateOptionsMenu(menu: Menu): Boolean {
@@ -1078,9 +1089,10 @@ open class MessageList :
 
         // Set visibility of menu items related to the message list
 
-        // Hide both search menu items by default and enable one when appropriate
+        // Hide search menu items by default and enable one when appropriate
         menu.findItem(R.id.search).isVisible = false
         menu.findItem(R.id.search_remote).isVisible = false
+        menu.findItem(R.id.search_everywhere).isVisible = false
 
         if (displayMode == DisplayMode.MESSAGE_VIEW || messageListFragment == null ||
             !messageListFragment!!.isInitialized
@@ -1112,6 +1124,11 @@ open class MessageList :
                 menu.findItem(R.id.search_remote).isVisible = true
             } else if (!messageListFragment!!.isManualSearch) {
                 menu.findItem(R.id.search).isVisible = true
+            }
+
+            val messageListFragment = messageListFragment!!
+            if (messageListFragment.isManualSearch && !messageListFragment.localSearch.searchAllAccounts()) {
+                menu.findItem(R.id.search_everywhere).isVisible = true
             }
         }
     }

--- a/app/ui/legacy/src/main/res/menu/message_list_option.xml
+++ b/app/ui/legacy/src/main/res/menu/message_list_option.xml
@@ -226,4 +226,10 @@
         app:showAsAction="never"
         android:title="@string/message_view_theme_action_dark"/>
 
+    <!-- MessageList -->
+    <item
+        android:id="@+id/search_everywhere"
+        app:showAsAction="never"
+        android:title="@string/search_everywhere_action"/>
+
 </menu>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -136,6 +136,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="add_account_action">Add account</string>
     <string name="compose_action">Compose</string>
     <string name="search_action">Search</string>
+    <string name="search_everywhere_action">Search everywhere</string>
     <string name="search_results">Search results</string>
     <string name="preferences_action">Settings</string>
     <string name="folders_action">Manage folders</string>


### PR DESCRIPTION
When starting a search in a regular folder only messages in that folder are searched. 'Search everywhere' will re-run that search in all accounts and all folders.

Closes #4514