### PR TITLE
Use TextInputLayout to match other setup screens

### DIFF
--- a/app/ui/legacy/src/main/res/layout/account_setup_names.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_names.xml
@@ -21,22 +21,30 @@
                 android:layout_gravity="center_horizontal|center_vertical"
                 android:orientation="vertical">
 
-            <EditText
-                    android:id="@+id/account_description"
-                    android:singleLine="true"
-                    android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
-                    android:hint="@string/account_setup_names_account_name_label"
-                    android:contentDescription="@string/account_setup_names_account_name_label"/>
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
 
-            <EditText
-                    android:id="@+id/account_name"
-                    android:singleLine="true"
-                    android:inputType="textPersonName"
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/account_description"
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_width="fill_parent"
+                    android:hint="@string/account_setup_names_account_name_label"
+                    android:singleLine="true"/>
+            </com.google.android.material.textfield.TextInputLayout>
+
+            <com.google.android.material.textfield.TextInputLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content">
+
+                <com.google.android.material.textfield.TextInputEditText
+                    android:id="@+id/account_name"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
                     android:hint="@string/account_setup_names_user_name_label"
-                    android:contentDescription="@string/account_setup_names_user_name_label"/>
+                    android:singleLine="true"
+                    android:inputType="textPersonName"/>
+            </com.google.android.material.textfield.TextInputLayout>
 
             <View
                     android:layout_height="0dip"


### PR DESCRIPTION
The final setup screen, for entering names, was using a standard edit text which meant the hint couldn't be read once you entered something. I've updated it to use TextInputLayout like all the other setup screens (e.g. account_setup_basics.xml)

![image](https://user-images.githubusercontent.com/8265864/122903848-e7fa4280-d3a3-11eb-804a-d7cf9bcf6594.png)
