### PR TITLE
Remove unused K9JobManager.schedulePusherRefresh()

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -609,11 +609,8 @@ public class Account implements BaseAccount {
         return folderPushMode;
     }
 
-    public synchronized boolean setFolderPushMode(FolderMode pushMode) {
-        FolderMode oldPushMode = folderPushMode;
-
+    public synchronized void setFolderPushMode(FolderMode pushMode) {
         folderPushMode = pushMode;
-        return pushMode != oldPushMode;
     }
 
     public synchronized boolean isNotifySync() {

--- a/app/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
@@ -20,10 +20,6 @@ class K9JobManager(
         mailSyncWorkerManager.scheduleMailSync(account)
     }
 
-    fun schedulePusherRefresh() {
-        // Push is temporarily disabled. See GH-4253
-    }
-
     private fun scheduleMailSync() {
         cancelAllMailSyncJobs()
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -534,10 +534,6 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
 
         if (resultCode == RESULT_OK) {
             if (Intent.ACTION_EDIT.equals(getIntent().getAction())) {
-                boolean isPushCapable = messagingController.isPushCapable(mAccount);
-                if (isPushCapable && mAccount.getFolderPushMode() != FolderMode.NONE) {
-                    jobManager.schedulePusherRefresh();
-                }
                 Preferences.getPreferences(getApplicationContext()).saveAccount(mAccount);
                 finish();
             } else {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -165,11 +165,7 @@ class AccountSettingsDataStore(
                     reschedulePoll()
                 }
             }
-            "folder_push_mode" -> {
-                if (account.setFolderPushMode(Account.FolderMode.valueOf(value))) {
-                    restartPushers()
-                }
-            }
+            "folder_push_mode" -> account.folderPushMode = Account.FolderMode.valueOf(value)
             "delete_policy" -> account.deletePolicy = Account.DeletePolicy.valueOf(value)
             "expunge_policy" -> account.expungePolicy = Account.Expunge.valueOf(value)
             "max_push_folders" -> account.maxPushFolders = value.toInt()
@@ -212,10 +208,6 @@ class AccountSettingsDataStore(
 
     private fun reschedulePoll() {
         jobManager.scheduleMailSync(account)
-    }
-
-    private fun restartPushers() {
-        jobManager.schedulePusherRefresh()
     }
 
     private fun extractFolderId(preferenceValue: String): Long? {


### PR DESCRIPTION
Code interested in changes to the 'push folders' setting now uses the `AccountsChangeListener` mechanism instead.