### PR TITLE
Add AccountManager.getAccountFlow()

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/FolderRepository.kt
@@ -2,7 +2,6 @@ package com.fsck.k9.mailstore
 
 import com.fsck.k9.Account
 import com.fsck.k9.Account.FolderMode
-import com.fsck.k9.AccountsChangeListener
 import com.fsck.k9.mail.FolderClass
 import com.fsck.k9.preferences.AccountManager
 import kotlinx.coroutines.CoroutineDispatcher
@@ -16,6 +15,7 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import com.fsck.k9.mail.FolderType as RemoteFolderType
 
@@ -229,22 +229,7 @@ class FolderRepository(
     }
 
     private fun Account.getFolderPushModeFlow(): Flow<FolderMode> {
-        val account = this@getFolderPushModeFlow
-        return callbackFlow {
-            send(account.folderPushMode)
-
-            val listener = AccountsChangeListener {
-                launch {
-                    send(account.folderPushMode)
-                }
-            }
-            accountManager.addOnAccountsChangeListener(listener)
-
-            awaitClose {
-                accountManager.removeOnAccountsChangeListener(listener)
-            }
-        }.distinctUntilChanged()
-            .flowOn(ioDispatcher)
+        return accountManager.getAccountFlow(uuid).map { it.folderPushMode }
     }
 
     private val RemoteFolderDetails.effectivePushClass: FolderClass

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountManager.kt
@@ -3,9 +3,11 @@ package com.fsck.k9.preferences
 import com.fsck.k9.Account
 import com.fsck.k9.AccountRemovedListener
 import com.fsck.k9.AccountsChangeListener
+import kotlinx.coroutines.flow.Flow
 
 interface AccountManager {
     fun getAccount(accountUuid: String): Account?
+    fun getAccountFlow(accountUuid: String): Flow<Account>
     fun addAccountRemovedListener(listener: AccountRemovedListener)
     fun moveAccount(account: Account, newPosition: Int)
     fun addOnAccountsChangeListener(accountsChangeListener: AccountsChangeListener)


### PR DESCRIPTION
Instead of adding a custom callbackFlow() for each account property we're interested in, we can now use `AccountManager.getAccountFlow(accountUuid).map { it.relevantProperty }`.
