### PR TITLE
Re-enable "advanced" IMAP IDLE settings screen

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
@@ -51,7 +51,9 @@ internal class AccountPushController(
 
     private fun startBackendPusher() {
         val backend = backendManager.getBackend(account)
-        backendPusher = backend.createPusher(backendPusherCallback)
+        backendPusher = backend.createPusher(backendPusherCallback).also { backendPusher ->
+            backendPusher.start()
+        }
     }
 
     private fun stopBackendPusher() {

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/backends/KoinModule.kt
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/backends/KoinModule.kt
@@ -21,6 +21,7 @@ val backendsModule = module {
     single {
         ImapBackendFactory(
             context = get(),
+            accountManager = get(),
             powerManager = get(),
             idleRefreshManager = get(),
             backendStorageFactory = get(),

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/KoinModule.kt
@@ -19,6 +19,7 @@ val backendsModule = module {
     single {
         ImapBackendFactory(
             context = get(),
+            accountManager = get(),
             powerManager = get(),
             idleRefreshManager = get(),
             backendStorageFactory = get(),

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -134,7 +134,6 @@
             android:summary="@string/account_settings_incoming_summary"
             android:title="@string/account_settings_incoming_label" />
 
-        <!-- Temporarily disabled. See GH-4253
         <PreferenceScreen
             android:key="push_advanced"
             android:title="@string/account_settings_push_advanced_title">
@@ -154,7 +153,6 @@
                 android:title="@string/idle_refresh_period_label" />
 
         </PreferenceScreen>
-        -->
 
     </PreferenceScreen>
 

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/BackendPusher.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/BackendPusher.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.backend.api
 
 interface BackendPusher {
+    fun start()
     fun updateFolders(folderServerIds: Collection<String>)
     fun stop()
 }

--- a/backend/imap/build.gradle
+++ b/backend/imap/build.gradle
@@ -10,6 +10,7 @@ dependencies {
     api project(":mail:protocols:imap")
     api project(":mail:protocols:smtp")
 
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
 
     testImplementation project(":mail:testing")

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackend.kt
@@ -21,6 +21,7 @@ class ImapBackend(
     private val imapStore: ImapStore,
     private val powerManager: PowerManager,
     private val idleRefreshManager: IdleRefreshManager,
+    private val pushConfigProvider: ImapPushConfigProvider,
     private val smtpTransport: SmtpTransport
 ) : Backend {
     private val imapSync = ImapSync(accountName, backendStorage, imapStore)
@@ -157,6 +158,6 @@ class ImapBackend(
     }
 
     override fun createPusher(callback: BackendPusherCallback): BackendPusher {
-        return ImapBackendPusher(imapStore, powerManager, idleRefreshManager, callback, accountName)
+        return ImapBackendPusher(imapStore, powerManager, idleRefreshManager, pushConfigProvider, callback, accountName)
     }
 }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
@@ -10,6 +10,12 @@ import com.fsck.k9.mail.store.imap.IdleRefreshTimeoutProvider
 import com.fsck.k9.mail.store.imap.IdleRefreshTimer
 import com.fsck.k9.mail.store.imap.ImapStore
 import java.io.IOException
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
 import timber.log.Timber
 
 private const val IO_ERROR_TIMEOUT = 5 * 60 * 1000L
@@ -22,16 +28,71 @@ internal class ImapBackendPusher(
     private val imapStore: ImapStore,
     private val powerManager: PowerManager,
     private val idleRefreshManager: IdleRefreshManager,
+    private val pushConfigProvider: ImapPushConfigProvider,
     private val callback: BackendPusherCallback,
-    private val accountName: String
+    private val accountName: String,
+    backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : BackendPusher, ImapPusherCallback {
+    private val coroutineScope = CoroutineScope(backgroundDispatcher)
     private val lock = Any()
     private val pushFolders = mutableMapOf<String, ImapFolderPusher>()
     private var currentFolderServerIds: Collection<String> = emptySet()
     private val pushFolderSleeping = mutableMapOf<String, IdleRefreshTimer>()
 
+    private val idleRefreshTimeoutProvider = object : IdleRefreshTimeoutProvider {
+        override val idleRefreshTimeoutMs
+            get() = currentIdleRefreshMs
+    }
+
+    @Volatile
+    private var currentMaxPushFolders = 0
+
+    @Volatile
+    private var currentIdleRefreshMs = 15 * 60 * 1000L
+
+    override fun start() {
+        coroutineScope.launch {
+            pushConfigProvider.maxPushFoldersFlow.collect { maxPushFolders ->
+                currentMaxPushFolders = maxPushFolders
+                updateFolders()
+            }
+        }
+
+        coroutineScope.launch {
+            pushConfigProvider.idleRefreshMinutesFlow.collect { idleRefreshMinutes ->
+                currentIdleRefreshMs = idleRefreshMinutes * 60 * 1000L
+                refreshFolderTimers()
+            }
+        }
+    }
+
+    private fun refreshFolderTimers() {
+        synchronized(lock) {
+            for (pushFolder in pushFolders.values) {
+                pushFolder.refresh()
+            }
+        }
+    }
+
     override fun updateFolders(folderServerIds: Collection<String>) {
+        updateFolders(folderServerIds, currentMaxPushFolders)
+    }
+
+    private fun updateFolders() {
+        val currentFolderServerIds = synchronized(lock) { currentFolderServerIds }
+        updateFolders(currentFolderServerIds, currentMaxPushFolders)
+    }
+
+    private fun updateFolders(folderServerIds: Collection<String>, maxPushFolders: Int) {
         Timber.v("ImapBackendPusher.updateFolders(): %s", folderServerIds)
+
+        val pushFolderServerIds = if (folderServerIds.size > maxPushFolders) {
+            folderServerIds.take(maxPushFolders).also { pushFolderServerIds ->
+                Timber.v("..limiting Push to %d folders: %s", maxPushFolders, pushFolderServerIds)
+            }
+        } else {
+            folderServerIds
+        }
 
         val stopFolderPushers: List<ImapFolderPusher>
         val startFolderPushers: List<ImapFolderPusher>
@@ -40,7 +101,7 @@ internal class ImapBackendPusher(
 
             val oldRunningFolderServerIds = pushFolders.keys
             val oldFolderServerIds = oldRunningFolderServerIds + pushFolderSleeping.keys
-            val removeFolderServerIds = oldFolderServerIds - folderServerIds
+            val removeFolderServerIds = oldFolderServerIds - pushFolderServerIds
             stopFolderPushers = removeFolderServerIds
                 .asSequence()
                 .onEach { folderServerId -> cancelRetryTimer(folderServerId) }
@@ -48,7 +109,7 @@ internal class ImapBackendPusher(
                 .filterNotNull()
                 .toList()
 
-            val startFolderServerIds = folderServerIds - oldRunningFolderServerIds
+            val startFolderServerIds = pushFolderServerIds - oldRunningFolderServerIds
             startFolderPushers = startFolderServerIds
                 .asSequence()
                 .filterNot { folderServerId -> isWaitingForRetry(folderServerId) }
@@ -73,6 +134,8 @@ internal class ImapBackendPusher(
     override fun stop() {
         Timber.v("ImapBackendPusher.stop()")
 
+        coroutineScope.cancel()
+
         synchronized(lock) {
             for (pushFolder in pushFolders.values) {
                 pushFolder.stop()
@@ -89,10 +152,6 @@ internal class ImapBackendPusher(
     }
 
     private fun createImapFolderPusher(folderServerId: String): ImapFolderPusher {
-        val idleRefreshTimeoutProvider = object : IdleRefreshTimeoutProvider {
-            // TODO: use value from account settings
-            override val idleRefreshTimeoutMs = 15 * 60 * 1000L
-        }
         return ImapFolderPusher(
             imapStore,
             powerManager,
@@ -149,7 +208,7 @@ internal class ImapBackendPusher(
 
     private fun startRetryTimer(folderServerId: String, timeout: Long) {
         Timber.v("ImapBackendPusher for folder %s sleeping for %d ms", folderServerId, timeout)
-        pushFolderSleeping[folderServerId] = idleRefreshManager.startTimer(timeout, ::refresh)
+        pushFolderSleeping[folderServerId] = idleRefreshManager.startTimer(timeout, ::restartFolderPushers)
     }
 
     private fun cancelRetryTimer(folderServerId: String) {
@@ -161,10 +220,9 @@ internal class ImapBackendPusher(
         return pushFolderSleeping[folderServerId]?.isWaiting == true
     }
 
-    private fun refresh() {
+    private fun restartFolderPushers() {
         Timber.v("Refreshing ImapBackendPusher (at least one retry timer has expired)")
 
-        val currentFolderServerIds = synchronized(lock) { currentFolderServerIds }
-        updateFolders(currentFolderServerIds)
+        updateFolders()
     }
 }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
@@ -6,6 +6,7 @@ import com.fsck.k9.mail.AuthenticationFailedException
 import com.fsck.k9.mail.MessagingException
 import com.fsck.k9.mail.power.PowerManager
 import com.fsck.k9.mail.store.imap.IdleRefreshManager
+import com.fsck.k9.mail.store.imap.IdleRefreshTimeoutProvider
 import com.fsck.k9.mail.store.imap.IdleRefreshTimer
 import com.fsck.k9.mail.store.imap.ImapStore
 import java.io.IOException
@@ -88,8 +89,10 @@ internal class ImapBackendPusher(
     }
 
     private fun createImapFolderPusher(folderServerId: String): ImapFolderPusher {
-        // TODO: use value from account settings
-        val idleRefreshTimeoutMs = 15 * 60 * 1000L
+        val idleRefreshTimeoutProvider = object : IdleRefreshTimeoutProvider {
+            // TODO: use value from account settings
+            override val idleRefreshTimeoutMs = 15 * 60 * 1000L
+        }
         return ImapFolderPusher(
             imapStore,
             powerManager,
@@ -97,7 +100,7 @@ internal class ImapBackendPusher(
             this,
             accountName,
             folderServerId,
-            idleRefreshTimeoutMs
+            idleRefreshTimeoutProvider
         )
     }
 

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapFolderPusher.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapFolderPusher.kt
@@ -2,6 +2,7 @@ package com.fsck.k9.backend.imap
 
 import com.fsck.k9.mail.power.PowerManager
 import com.fsck.k9.mail.store.imap.IdleRefreshManager
+import com.fsck.k9.mail.store.imap.IdleRefreshTimeoutProvider
 import com.fsck.k9.mail.store.imap.IdleResult
 import com.fsck.k9.mail.store.imap.ImapFolderIdler
 import com.fsck.k9.mail.store.imap.ImapStore
@@ -18,7 +19,7 @@ class ImapFolderPusher(
     private val callback: ImapPusherCallback,
     private val accountName: String,
     private val folderServerId: String,
-    private val idleRefreshTimeoutMs: Long
+    private val idleRefreshTimeoutProvider: IdleRefreshTimeoutProvider
 ) {
     @Volatile
     private var folderIdler: ImapFolderIdler? = null
@@ -56,7 +57,7 @@ class ImapFolderPusher(
             wakeLock,
             imapStore,
             folderServerId,
-            idleRefreshTimeoutMs
+            idleRefreshTimeoutProvider
         ).also {
             folderIdler = it
         }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapFolderPusher.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapFolderPusher.kt
@@ -39,6 +39,12 @@ class ImapFolderPusher(
         }
     }
 
+    fun refresh() {
+        Timber.v("Refreshing ImapFolderPusher for %s / %s", accountName, folderServerId)
+
+        folderIdler?.refresh()
+    }
+
     fun stop() {
         Timber.v("Stopping ImapFolderPusher for %s / %s", accountName, folderServerId)
 

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapPushConfigProvider.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapPushConfigProvider.kt
@@ -1,0 +1,8 @@
+package com.fsck.k9.backend.imap
+
+import kotlinx.coroutines.flow.Flow
+
+interface ImapPushConfigProvider {
+    val maxPushFoldersFlow: Flow<Int>
+    val idleRefreshMinutesFlow: Flow<Int>
+}

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/IdleRefreshTimeoutProvider.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/IdleRefreshTimeoutProvider.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.mail.store.imap
+
+interface IdleRefreshTimeoutProvider {
+    val idleRefreshTimeoutMs: Long
+}

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderIdler.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderIdler.kt
@@ -20,7 +20,7 @@ interface ImapFolderIdler {
             wakeLock: WakeLock,
             imapStore: ImapStore,
             folderServerId: String,
-            idleRefreshTimeoutMs: Long
+            idleRefreshTimeoutProvider: IdleRefreshTimeoutProvider
         ): ImapFolderIdler {
             return RealImapFolderIdler(
                 idleRefreshManager,
@@ -28,7 +28,7 @@ interface ImapFolderIdler {
                 imapStore,
                 connectionProvider,
                 folderServerId,
-                idleRefreshTimeoutMs
+                idleRefreshTimeoutProvider
             )
         }
     }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderIdler.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapFolderIdler.kt
@@ -4,7 +4,7 @@ import com.fsck.k9.mail.power.WakeLock
 
 interface ImapFolderIdler {
     fun idle(): IdleResult
-
+    fun refresh()
     fun stop()
 
     companion object {

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolderIdler.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolderIdler.kt
@@ -12,7 +12,7 @@ internal class RealImapFolderIdler(
     private val imapStore: ImapStore,
     private val connectionProvider: ImapConnectionProvider,
     private val folderServerId: String,
-    private val idleRefreshTimeoutMs: Long
+    private val idleRefreshTimeoutProvider: IdleRefreshTimeoutProvider
 ) : ImapFolderIdler {
     private val logTag = "ImapFolderIdler[$folderServerId]"
 
@@ -89,7 +89,7 @@ internal class RealImapFolderIdler(
                 val expectSleeping = !connection.isDataAvailable() && !stopIdle
 
                 idleRefreshTimer = if (expectSleeping) {
-                    idleRefreshManager.startTimer(idleRefreshTimeoutMs) { idleRefresh() }
+                    idleRefreshManager.startTimer(idleRefreshTimeoutProvider.idleRefreshTimeoutMs) { idleRefresh() }
                 } else {
                     null
                 }
@@ -149,7 +149,7 @@ internal class RealImapFolderIdler(
     }
 
     private fun ImapConnection.setSocketIdleReadTimeout() {
-        setSocketReadTimeout((idleRefreshTimeoutMs + SOCKET_EXTRA_TIMEOUT_MS).toInt())
+        setSocketReadTimeout((idleRefreshTimeoutProvider.idleRefreshTimeoutMs + SOCKET_EXTRA_TIMEOUT_MS).toInt())
     }
 
     private val ImapResponse.isRelevant: Boolean

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolderIdler.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolderIdler.kt
@@ -44,10 +44,19 @@ internal class RealImapFolderIdler(
     }
 
     @Synchronized
+    override fun refresh() {
+        Timber.v("%s.refresh()", logTag)
+        endIdle()
+    }
+
+    @Synchronized
     override fun stop() {
         Timber.v("%s.stop()", logTag)
         stopIdle = true
+        endIdle()
+    }
 
+    private fun endIdle() {
         if (idleSent && !doneSent) {
             idleRefreshTimer?.cancel()
             sendDone()

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderIdlerTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderIdlerTest.kt
@@ -21,13 +21,16 @@ class RealImapFolderIdlerTest {
     private val imapConnection = TestImapConnection(timeout = TEST_TIMEOUT_SECONDS)
     private val imapFolder = TestImapFolder(FOLDER_SERVER_ID, imapConnection)
     private val imapStore = TestImapStore(imapFolder)
+    private val idleRefreshTimeoutProvider = object : IdleRefreshTimeoutProvider {
+        override val idleRefreshTimeoutMs = IDLE_TIMEOUT_MS
+    }
     private val idler = RealImapFolderIdler(
         idleRefreshManager,
         wakeLock,
         imapStore,
         imapStore,
         FOLDER_SERVER_ID,
-        IDLE_TIMEOUT_MS
+        idleRefreshTimeoutProvider
     )
 
     @Test


### PR DESCRIPTION
This re-adds support for the following settings:
- "Max folders to check with push"
- "Refresh IDLE connection" (configure refresh timeout)

Closes #4258