### PR TITLE
Make ConnectivityManager notify when the active network changes

### DIFF
--- a/app/core/src/main/AndroidManifest.xml
+++ b/app/core/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.fsck.k9.core">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.READ_SYNC_SETTINGS" />
 
     <application>

--- a/app/core/src/main/java/com/fsck/k9/network/ConnectivityManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/network/ConnectivityManager.kt
@@ -1,91 +1,24 @@
 package com.fsck.k9.network
 
-import android.annotation.SuppressLint
-import android.net.ConnectivityManager.NetworkCallback
-import android.net.Network
-import android.net.NetworkCapabilities
-import android.net.NetworkRequest
 import android.os.Build
 import android.net.ConnectivityManager as SystemConnectivityManager
 
-@SuppressLint("MissingPermission")
-class ConnectivityManager(private val systemConnectivityManager: SystemConnectivityManager) {
-    private var isRunning = false
-    private val listeners = mutableSetOf<ConnectivityChangeListener>()
-    private var isNetworkAvailable: Boolean? = null
-
-    private val networkCallback = object : NetworkCallback() {
-        override fun onAvailable(network: Network) {
-            synchronized(this@ConnectivityManager) {
-                isNetworkAvailable = true
-                notifyListeners()
-            }
-        }
-
-        override fun onLost(network: Network) {
-            synchronized(this@ConnectivityManager) {
-                isNetworkAvailable = false
-                notifyListeners()
-            }
-        }
-    }
-
-    @Synchronized
-    fun start() {
-        if (!isRunning) {
-            isRunning = true
-
-            val networkRequest = NetworkRequest.Builder().build()
-            systemConnectivityManager.registerNetworkCallback(networkRequest, networkCallback)
-        }
-    }
-
-    @Synchronized
-    fun stop() {
-        if (isRunning) {
-            isRunning = false
-
-            systemConnectivityManager.unregisterNetworkCallback(networkCallback)
-        }
-    }
-
-    @Synchronized
-    fun addListener(listener: ConnectivityChangeListener) {
-        listeners.add(listener)
-    }
-
-    @Synchronized
-    fun removeListener(listener: ConnectivityChangeListener) {
-        listeners.remove(listener)
-    }
-
-    @Synchronized
-    fun notifyListeners() {
-        for (listener in listeners) {
-            listener.onConnectivityChanged()
-        }
-    }
-
-    fun isNetworkAvailable(): Boolean {
-        return synchronized(this) { isNetworkAvailable } ?: isNetworkConnected()
-    }
-
-    @Suppress("DEPRECATION")
-    private fun isNetworkConnected(): Boolean {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-            val activeNetwork = systemConnectivityManager.activeNetwork
-            if (activeNetwork != null) {
-                val networkCapabilities = systemConnectivityManager.getNetworkCapabilities(activeNetwork)
-                networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) ?: false
-            } else {
-                false
-            }
-        } else {
-            systemConnectivityManager.activeNetworkInfo?.isConnected == true
-        }
-    }
+interface ConnectivityManager {
+    fun start()
+    fun stop()
+    fun isNetworkAvailable(): Boolean
+    fun addListener(listener: ConnectivityChangeListener)
+    fun removeListener(listener: ConnectivityChangeListener)
 }
 
 fun interface ConnectivityChangeListener {
     fun onConnectivityChanged()
+}
+
+internal fun ConnectivityManager(systemConnectivityManager: SystemConnectivityManager): ConnectivityManager {
+    return if (Build.VERSION.SDK_INT >= 23) {
+        ConnectivityManagerApi23(systemConnectivityManager)
+    } else {
+        ConnectivityManagerApi21(systemConnectivityManager)
+    }
 }

--- a/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi21.kt
+++ b/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi21.kt
@@ -1,0 +1,62 @@
+package com.fsck.k9.network
+
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkRequest
+import timber.log.Timber
+import android.net.ConnectivityManager as SystemConnectivityManager
+
+@Suppress("DEPRECATION")
+internal class ConnectivityManagerApi21(
+    private val systemConnectivityManager: SystemConnectivityManager
+) : ConnectivityManagerBase() {
+    private var isRunning = false
+    private var lastNetworkType: Int? = null
+    private var wasConnected: Boolean? = null
+
+    private val networkCallback = object : NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            Timber.v("Network available: $network")
+            notifyIfConnectivityHasChanged()
+        }
+
+        override fun onLost(network: Network) {
+            Timber.v("Network lost: $network")
+            notifyIfConnectivityHasChanged()
+        }
+
+        private fun notifyIfConnectivityHasChanged() {
+            val networkType = systemConnectivityManager.activeNetworkInfo?.type
+            val isConnected = isNetworkAvailable()
+
+            synchronized(this@ConnectivityManagerApi21) {
+                if (networkType != lastNetworkType || isConnected != wasConnected) {
+                    lastNetworkType = networkType
+                    wasConnected = isConnected
+                    notifyListeners()
+                }
+            }
+        }
+    }
+
+    @Synchronized
+    override fun start() {
+        if (!isRunning) {
+            isRunning = true
+
+            val networkRequest = NetworkRequest.Builder().build()
+            systemConnectivityManager.registerNetworkCallback(networkRequest, networkCallback)
+        }
+    }
+
+    @Synchronized
+    override fun stop() {
+        if (isRunning) {
+            isRunning = false
+
+            systemConnectivityManager.unregisterNetworkCallback(networkCallback)
+        }
+    }
+
+    override fun isNetworkAvailable(): Boolean = systemConnectivityManager.activeNetworkInfo?.isConnected == true
+}

--- a/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi23.kt
+++ b/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi23.kt
@@ -1,0 +1,69 @@
+package com.fsck.k9.network
+
+import android.net.ConnectivityManager.NetworkCallback
+import android.net.Network
+import android.net.NetworkCapabilities
+import android.net.NetworkRequest
+import android.os.Build
+import androidx.annotation.RequiresApi
+import timber.log.Timber
+import android.net.ConnectivityManager as SystemConnectivityManager
+
+@RequiresApi(Build.VERSION_CODES.M)
+internal class ConnectivityManagerApi23(
+    private val systemConnectivityManager: SystemConnectivityManager
+) : ConnectivityManagerBase() {
+    private var isRunning = false
+    private var lastActiveNetwork: Network? = null
+    private var wasConnected: Boolean? = null
+
+    private val networkCallback = object : NetworkCallback() {
+        override fun onAvailable(network: Network) {
+            Timber.v("Network available: $network")
+            notifyIfActiveNetworkOrConnectivityHasChanged()
+        }
+
+        override fun onLost(network: Network) {
+            Timber.v("Network lost: $network")
+            notifyIfActiveNetworkOrConnectivityHasChanged()
+        }
+
+        private fun notifyIfActiveNetworkOrConnectivityHasChanged() {
+            val activeNetwork = systemConnectivityManager.activeNetwork
+            val isConnected = isNetworkAvailable()
+
+            synchronized(this@ConnectivityManagerApi23) {
+                if (activeNetwork != lastActiveNetwork || isConnected != wasConnected) {
+                    lastActiveNetwork = activeNetwork
+                    wasConnected = isConnected
+                    notifyListeners()
+                }
+            }
+        }
+    }
+
+    @Synchronized
+    override fun start() {
+        if (!isRunning) {
+            isRunning = true
+
+            val networkRequest = NetworkRequest.Builder().build()
+            systemConnectivityManager.registerNetworkCallback(networkRequest, networkCallback)
+        }
+    }
+
+    @Synchronized
+    override fun stop() {
+        if (isRunning) {
+            isRunning = false
+
+            systemConnectivityManager.unregisterNetworkCallback(networkCallback)
+        }
+    }
+
+    override fun isNetworkAvailable(): Boolean {
+        val activeNetwork = systemConnectivityManager.activeNetwork ?: return false
+        val networkCapabilities = systemConnectivityManager.getNetworkCapabilities(activeNetwork)
+        return networkCapabilities?.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET) == true
+    }
+}

--- a/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerBase.kt
+++ b/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerBase.kt
@@ -1,0 +1,24 @@
+package com.fsck.k9.network
+
+import java.util.concurrent.CopyOnWriteArraySet
+
+internal abstract class ConnectivityManagerBase : ConnectivityManager {
+    private val listeners = CopyOnWriteArraySet<ConnectivityChangeListener>()
+
+    @Synchronized
+    override fun addListener(listener: ConnectivityChangeListener) {
+        listeners.add(listener)
+    }
+
+    @Synchronized
+    override fun removeListener(listener: ConnectivityChangeListener) {
+        listeners.remove(listener)
+    }
+
+    @Synchronized
+    protected fun notifyListeners() {
+        for (listener in listeners) {
+            listener.onConnectivityChanged()
+        }
+    }
+}


### PR DESCRIPTION
Also fix how `isNetworkAvailable()` works. We now always query the active network (if there is one).

Fixes #5366