### PR TITLE
Don't start PushService if there are no Push-enabled accounts

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
@@ -118,11 +118,12 @@ class PushController internal constructor(
         val backgroundSyncDisabledViaSystem = autoSyncManager.isAutoSyncDisabled
         val backgroundSyncDisabledInApp = K9.backgroundOps == K9.BACKGROUND_OPS.NEVER
         val networkNotAvailable = !connectivityManager.isNetworkAvailable()
+        val realPushAccounts = getPushAccounts()
 
         val pushAccounts = if (backgroundSyncDisabledViaSystem || backgroundSyncDisabledInApp || networkNotAvailable) {
             emptyList()
         } else {
-            getPushAccounts()
+            realPushAccounts
         }
         val pushAccountUuids = pushAccounts.map { it.uuid }
 
@@ -155,6 +156,9 @@ class PushController internal constructor(
         }
 
         when {
+            realPushAccounts.isEmpty() -> {
+                stopServices()
+            }
             backgroundSyncDisabledViaSystem -> {
                 setPushNotificationState(WAIT_BACKGROUND_SYNC)
                 startServices()


### PR DESCRIPTION
Starting the app in airplane mode would start the service and display "Sleeping until network is available" in the notification. The service would then be stopped when connectivity returned and there was no Push-enabled account.