### PR TITLE
Don't reuse AccountsLiveData instance

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
@@ -15,7 +15,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val settingsUiModule = module {
-    single { AccountsLiveData(get()) }
+    factory { AccountsLiveData(get()) }
     viewModel { SettingsViewModel(accountManager = get(), accounts = get()) }
 
     factory { GeneralSettingsDataStore(jobManager = get(), themeManager = get(), appLanguageManager = get()) }


### PR DESCRIPTION
When the last account is deleted while `AccountsLiveData` is active, it will hold on to an empty list. Then, when an account is added again and `AccountsLiveData` becomes active again, the empty list is emitted before the list containing the new account is emitted. This lead to the onboarding screen being shown when it shouldn't have. Not holding on to old `AccountsLiveData` instances will get rid of this problem.

Fixes #5197