### PR TITLE
[Push] Re-establish connections on network change

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/AccountPushController.kt
@@ -49,6 +49,11 @@ internal class AccountPushController(
         stopBackendPusher()
     }
 
+    fun reconnect() {
+        Timber.v("AccountPushController(%s).reconnect()", account.uuid)
+        backendPusher?.reconnect()
+    }
+
     private fun startBackendPusher() {
         val backend = backendManager.getBackend(account)
         backendPusher = backend.createPusher(backendPusherCallback).also { backendPusher ->

--- a/app/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/push/PushController.kt
@@ -45,7 +45,10 @@ class PushController internal constructor(
     private val pushers = mutableMapOf<String, AccountPushController>()
 
     private val autoSyncListener = AutoSyncListener(::onAutoSyncChanged)
-    private val connectivityChangeListener = ConnectivityChangeListener(::onConnectivityChanged)
+    private val connectivityChangeListener = object : ConnectivityChangeListener {
+        override fun onConnectivityChanged() = this@PushController.onConnectivityChanged()
+        override fun onConnectivityLost() = this@PushController.onConnectivityChanged()
+    }
 
     /**
      * Initialize [PushController].

--- a/app/core/src/main/java/com/fsck/k9/network/ConnectivityManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/network/ConnectivityManager.kt
@@ -11,8 +11,9 @@ interface ConnectivityManager {
     fun removeListener(listener: ConnectivityChangeListener)
 }
 
-fun interface ConnectivityChangeListener {
+interface ConnectivityChangeListener {
     fun onConnectivityChanged()
+    fun onConnectivityLost()
 }
 
 internal fun ConnectivityManager(systemConnectivityManager: SystemConnectivityManager): ConnectivityManager {

--- a/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi21.kt
+++ b/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi21.kt
@@ -33,7 +33,11 @@ internal class ConnectivityManagerApi21(
                 if (networkType != lastNetworkType || isConnected != wasConnected) {
                     lastNetworkType = networkType
                     wasConnected = isConnected
-                    notifyListeners()
+                    if (isConnected) {
+                        notifyOnConnectivityChanged()
+                    } else {
+                        notifyOnConnectivityLost()
+                    }
                 }
             }
         }

--- a/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi23.kt
+++ b/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi23.kt
@@ -36,7 +36,11 @@ internal class ConnectivityManagerApi23(
                 if (activeNetwork != lastActiveNetwork || isConnected != wasConnected) {
                     lastActiveNetwork = activeNetwork
                     wasConnected = isConnected
-                    notifyListeners()
+                    if (isConnected) {
+                        notifyOnConnectivityChanged()
+                    } else {
+                        notifyOnConnectivityLost()
+                    }
                 }
             }
         }

--- a/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi24.kt
+++ b/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerApi24.kt
@@ -20,7 +20,7 @@ internal class ConnectivityManagerApi24(
             Timber.v("Network available: $network")
             synchronized(this@ConnectivityManagerApi24) {
                 isNetworkAvailable = true
-                notifyListeners()
+                notifyOnConnectivityChanged()
             }
         }
 
@@ -28,7 +28,7 @@ internal class ConnectivityManagerApi24(
             Timber.v("Network lost: $network")
             synchronized(this@ConnectivityManagerApi24) {
                 isNetworkAvailable = false
-                notifyListeners()
+                notifyOnConnectivityLost()
             }
         }
     }

--- a/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerBase.kt
+++ b/app/core/src/main/java/com/fsck/k9/network/ConnectivityManagerBase.kt
@@ -16,9 +16,16 @@ internal abstract class ConnectivityManagerBase : ConnectivityManager {
     }
 
     @Synchronized
-    protected fun notifyListeners() {
+    protected fun notifyOnConnectivityChanged() {
         for (listener in listeners) {
             listener.onConnectivityChanged()
+        }
+    }
+
+    @Synchronized
+    protected fun notifyOnConnectivityLost() {
+        for (listener in listeners) {
+            listener.onConnectivityLost()
         }
     }
 }

--- a/backend/api/src/main/java/com/fsck/k9/backend/api/BackendPusher.kt
+++ b/backend/api/src/main/java/com/fsck/k9/backend/api/BackendPusher.kt
@@ -4,4 +4,5 @@ interface BackendPusher {
     fun start()
     fun updateFolders(folderServerIds: Collection<String>)
     fun stop()
+    fun reconnect()
 }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
@@ -151,6 +151,26 @@ internal class ImapBackendPusher(
         }
     }
 
+    override fun reconnect() {
+        Timber.v("ImapBackendPusher.reconnect()")
+
+        synchronized(lock) {
+            for (pushFolder in pushFolders.values) {
+                pushFolder.stop()
+            }
+            pushFolders.clear()
+
+            for (retryTimer in pushFolderSleeping.values) {
+                retryTimer.cancel()
+            }
+            pushFolderSleeping.clear()
+        }
+
+        imapStore.closeAllConnections()
+
+        updateFolders()
+    }
+
     private fun createImapFolderPusher(folderServerId: String): ImapFolderPusher {
         return ImapFolderPusher(
             imapStore,


### PR DESCRIPTION
When the default network changes Android usually kills connections established over the old network after a little while. K-9 Mail treats this as a regular network error and sleeps for 5 minutes before trying to re-establish the Push connection(s). Closing old connections and opening new ones when a network change is detected avoids this error.