### PR TITLE
Don't allow an IDLE refresh interval of 1 minute

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 73;
+    public static final int VERSION = 74;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/core/src/main/res/values/arrays_account_settings_values.xml
+++ b/app/core/src/main/res/values/arrays_account_settings_values.xml
@@ -157,7 +157,6 @@
     </string-array>
 
     <string-array name="idle_refresh_period_values" translatable="false">
-        <item>1</item>
         <item>2</item>
         <item>3</item>
         <item>6</item>

--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -21,7 +21,7 @@ import timber.log.Timber;
 
 
 public class K9StoragePersister implements StoragePersister {
-    private static final int DB_VERSION = 14;
+    private static final int DB_VERSION = 15;
     private static final String DB_NAME = "preferences_storage";
 
     private final Context context;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo15.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo15.kt
@@ -1,0 +1,36 @@
+package com.fsck.k9.preferences.migrations
+
+import android.database.sqlite.SQLiteDatabase
+
+private const val DEFAULT_IDLE_REFRESH_MINUTES = 24
+private const val MINIMUM_IDLE_REFRESH_MINUTES = 2
+
+/**
+ * Rewrite 'idleRefreshMinutes' to make sure the minimum value is 2 minutes.
+ */
+class StorageMigrationTo15(
+    private val db: SQLiteDatabase,
+    private val migrationsHelper: StorageMigrationsHelper
+) {
+    fun rewriteIdleRefreshInterval() {
+        val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")
+        if (accountUuidsListValue == null || accountUuidsListValue.isEmpty()) {
+            return
+        }
+
+        val accountUuids = accountUuidsListValue.split(",")
+        for (accountUuid in accountUuids) {
+            rewriteIdleRefreshInterval(accountUuid)
+        }
+    }
+
+    private fun rewriteIdleRefreshInterval(accountUuid: String) {
+        val idleRefreshMinutes = migrationsHelper.readValue(db, "$accountUuid.idleRefreshMinutes")?.toIntOrNull()
+            ?: DEFAULT_IDLE_REFRESH_MINUTES
+
+        val newIdleRefreshMinutes = idleRefreshMinutes.coerceAtLeast(MINIMUM_IDLE_REFRESH_MINUTES)
+        if (newIdleRefreshMinutes != idleRefreshMinutes) {
+            migrationsHelper.writeValue(db, "$accountUuid.idleRefreshMinutes", newIdleRefreshMinutes.toString())
+        }
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
@@ -20,5 +20,6 @@ internal object StorageMigrations {
         if (oldVersion < 12) StorageMigrationTo12(db, migrationsHelper).removeStoreAndTransportUri()
         if (oldVersion < 13) StorageMigrationTo13(db, migrationsHelper).renameHideSpecialAccounts()
         if (oldVersion < 14) StorageMigrationTo14(db, migrationsHelper).disablePushFoldersForNonImapAccounts()
+        if (oldVersion < 15) StorageMigrationTo15(db, migrationsHelper).rewriteIdleRefreshInterval()
     }
 }

--- a/app/ui/legacy/src/main/res/values/arrays_account_settings_strings.xml
+++ b/app/ui/legacy/src/main/res/values/arrays_account_settings_strings.xml
@@ -134,7 +134,6 @@
     </string-array>
 
     <string-array name="idle_refresh_period_entries">
-        <item>@string/idle_refresh_period_1min</item>
         <item>@string/idle_refresh_period_2min</item>
         <item>@string/idle_refresh_period_3min</item>
         <item>@string/idle_refresh_period_6min</item>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -462,7 +462,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_setup_options_enable_push_label">Enable push mail for this account</string>
     <string name="account_setup_options_enable_push_summary">If your server supports it, new messages will appear instantly. This option can dramatically improve or hurt performance.</string>
     <string name="idle_refresh_period_label">Refresh IDLE connection</string>
-    <string name="idle_refresh_period_1min">Every minute</string>
     <string name="idle_refresh_period_2min">Every 2 minutes</string>
     <string name="idle_refresh_period_3min">Every 3 minutes</string>
     <string name="idle_refresh_period_6min">Every 6 minutes</string>


### PR DESCRIPTION
`BackendIdleRefreshManager` doesn't support a value of 1 minute. Such a low timeout is a bad idea anyway.