### PR TITLE
Add oauth2 support for gmail and outlook

### DIFF
--- a/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
+++ b/app/autodiscovery/providersxml/src/test/java/com/fsck/k9/autodiscovery/providersxml/ProvidersXmlDiscoveryTest.kt
@@ -20,13 +20,13 @@ class ProvidersXmlDiscoveryTest : RobolectricTest() {
         with(connectionSettings!!.incoming.first()) {
             assertThat(host).isEqualTo("imap.gmail.com")
             assertThat(security).isEqualTo(ConnectionSecurity.SSL_TLS_REQUIRED)
-            assertThat(authType).isEqualTo(AuthType.PLAIN)
+            assertThat(authType).isEqualTo(AuthType.XOAUTH2)
             assertThat(username).isEqualTo("user@gmail.com")
         }
         with(connectionSettings.outgoing.first()) {
             assertThat(host).isEqualTo("smtp.gmail.com")
             assertThat(security).isEqualTo(ConnectionSecurity.SSL_TLS_REQUIRED)
-            assertThat(authType).isEqualTo(AuthType.PLAIN)
+            assertThat(authType).isEqualTo(AuthType.XOAUTH2)
             assertThat(username).isEqualTo("user@gmail.com")
         }
     }

--- a/app/k9mail/src/main/java/com/fsck/k9/Dependencies.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/Dependencies.kt
@@ -4,6 +4,7 @@ import com.fsck.k9.backends.backendsModule
 import com.fsck.k9.controller.ControllerExtension
 import com.fsck.k9.crypto.EncryptionExtractor
 import com.fsck.k9.crypto.openpgp.OpenPgpEncryptionExtractor
+import com.fsck.k9.mail.oauth.oauth2Module
 import com.fsck.k9.notification.notificationModule
 import com.fsck.k9.preferences.K9StoragePersister
 import com.fsck.k9.preferences.StoragePersister
@@ -38,5 +39,6 @@ val appModules = listOf(
     notificationModule,
     resourcesModule,
     backendsModule,
-    storageModule
+    storageModule,
+    oauth2Module
 )

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/ImapBackendFactory.kt
@@ -27,7 +27,9 @@ class ImapBackendFactory(
     private val powerManager: PowerManager,
     private val idleRefreshManager: IdleRefreshManager,
     private val backendStorageFactory: K9BackendStorageFactory,
-    private val trustedSocketFactory: TrustedSocketFactory
+    private val trustedSocketFactory: TrustedSocketFactory,
+    private val oAuth2TokenProvider: OAuth2TokenProvider
+
 ) : BackendFactory {
     override fun createBackend(account: Account): Backend {
         val accountName = account.displayName
@@ -48,7 +50,7 @@ class ImapBackendFactory(
     }
 
     private fun createImapStore(account: Account): ImapStore {
-        val oAuth2TokenProvider: OAuth2TokenProvider? = null
+        val oAuth2TokenProvider: OAuth2TokenProvider? = oAuth2TokenProvider
         val config = createImapStoreConfig(account)
         return ImapStore.create(
             account.incomingServerSettings,
@@ -72,7 +74,7 @@ class ImapBackendFactory(
 
     private fun createSmtpTransport(account: Account): SmtpTransport {
         val serverSettings = account.outgoingServerSettings
-        val oauth2TokenProvider: OAuth2TokenProvider? = null
+        val oauth2TokenProvider: OAuth2TokenProvider? = oAuth2TokenProvider
         return SmtpTransport(serverSettings, trustedSocketFactory, oauth2TokenProvider)
     }
 

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/KoinModule.kt
@@ -23,7 +23,8 @@ val backendsModule = module {
             powerManager = get(),
             idleRefreshManager = get(),
             backendStorageFactory = get(),
-            trustedSocketFactory = get()
+            trustedSocketFactory = get(),
+            oAuth2TokenProvider = get()
         )
     }
     single<SystemAlarmManager> { AndroidAlarmManager(context = get(), alarmManager = get()) }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -19,11 +19,9 @@ import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
 import android.widget.Spinner;
-import android.widget.TextView;
 import android.widget.Toast;
 
 import com.fsck.k9.Account;
-import com.fsck.k9.Account.FolderMode;
 import com.fsck.k9.DI;
 import com.fsck.k9.LocalKeyStoreManager;
 import com.fsck.k9.Preferences;
@@ -410,17 +408,16 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
      * Shows/hides password field and client certificate spinner
      */
     private void updateViewFromAuthType() {
-        AuthType authType = getSelectedAuthType();
-        boolean isAuthTypeExternal = (AuthType.EXTERNAL == authType);
-
-        if (isAuthTypeExternal) {
-
-            // hide password fields, show client certificate fields
-            mPasswordLayoutView.setVisibility(View.GONE);
-        } else {
-
-            // show password fields, hide client certificate fields
-            mPasswordLayoutView.setVisibility(View.VISIBLE);
+        switch (getSelectedAuthType()) {
+            case EXTERNAL:
+            case XOAUTH2:
+                // hide password fields, show client certificate fields
+                mPasswordLayoutView.setVisibility(View.GONE);
+                break;
+            default:
+                // show password fields, hide client certificate fields
+                mPasswordLayoutView.setVisibility(View.VISIBLE);
+                break;
         }
     }
 
@@ -431,8 +428,9 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
     private void updateViewFromSecurity() {
         ConnectionSecurity security = getSelectedSecurity();
         boolean isUsingTLS = ((ConnectionSecurity.SSL_TLS_REQUIRED  == security) || (ConnectionSecurity.STARTTLS_REQUIRED == security));
+        boolean isUsingXoauth2 = getSelectedAuthType() == AuthType.XOAUTH2;
 
-        if (isUsingTLS) {
+        if (isUsingTLS && !isUsingXoauth2) {
             mAllowClientCertificateView.setVisibility(View.VISIBLE);
         } else {
             mAllowClientCertificateView.setVisibility(View.GONE);
@@ -503,9 +501,12 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 && hasConnectionSecurity
                 && hasValidCertificateAlias;
 
+        boolean hasValidXOAuth2Settings = hasValidUserName
+                && AuthType.XOAUTH2 == authType;
+
         mNextButton.setEnabled(Utility.domainFieldValid(mServerView)
                 && Utility.requiredFieldValid(mPortView)
-                && (hasValidPasswordSettings || hasValidExternalAuthSettings));
+                && (hasValidPasswordSettings || hasValidExternalAuthSettings || hasValidXOAuth2Settings));
         Utility.setCompoundDrawablesAlpha(mNextButton, mNextButton.isEnabled() ? 255 : 128);
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -341,15 +341,14 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
      * Shows/hides password field
      */
     private void updateViewFromAuthType() {
-        AuthType authType = getSelectedAuthType();
-        boolean isAuthTypeExternal = (AuthType.EXTERNAL == authType);
-
-        if (isAuthTypeExternal) {
-            // hide password fields
-            mPasswordLayoutView.setVisibility(View.GONE);
-        } else {
-            // show password fields
-            mPasswordLayoutView.setVisibility(View.VISIBLE);
+        switch (getSelectedAuthType()) {
+            case EXTERNAL:
+            case XOAUTH2:
+                // hide password fields
+                mPasswordLayoutView.setVisibility(View.GONE);
+            default:
+                // show password fields
+                mPasswordLayoutView.setVisibility(View.VISIBLE);
         }
     }
 
@@ -358,8 +357,9 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
      */
     private void updateViewFromSecurity(ConnectionSecurity security) {
         boolean isUsingTLS = ((ConnectionSecurity.SSL_TLS_REQUIRED  == security) || (ConnectionSecurity.STARTTLS_REQUIRED == security));
+        boolean isUsingXoauth2 = getSelectedAuthType() == AuthType.XOAUTH2;
 
-        if (isUsingTLS) {
+        if (isUsingTLS && !isUsingXoauth2) {
             mAllowClientCertificateView.setVisibility(View.VISIBLE);
         } else {
             mAllowClientCertificateView.setVisibility(View.GONE);
@@ -430,11 +430,14 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
                 && hasConnectionSecurity
                 && hasValidCertificateAlias;
 
+        boolean hasValidXOAuth2Settings = hasValidUserName
+                && AuthType.XOAUTH2 == authType;
+
         mNextButton
                 .setEnabled(Utility.domainFieldValid(mServerView)
                         && Utility.requiredFieldValid(mPortView)
                         && (!mRequireLoginView.isChecked()
-                                || hasValidPasswordSettings || hasValidExternalAuthSettings));
+                                || hasValidPasswordSettings || hasValidExternalAuthSettings || hasValidXOAuth2Settings));
         Utility.setCompoundDrawablesAlpha(mNextButton, mNextButton.isEnabled() ? 255 : 128);
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AuthTypeAdapter.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AuthTypeAdapter.java
@@ -12,7 +12,7 @@ class AuthTypeAdapter extends ArrayAdapter<AuthTypeHolder> {
     }
 
     public static AuthTypeAdapter get(Context context) {
-        AuthType[] authTypes = new AuthType[]{AuthType.PLAIN, AuthType.CRAM_MD5, AuthType.EXTERNAL};
+        AuthType[] authTypes = new AuthType[]{AuthType.PLAIN, AuthType.CRAM_MD5, AuthType.EXTERNAL, AuthType.XOAUTH2};
         AuthTypeHolder[] holders = new AuthTypeHolder[authTypes.length];
         for (int i = 0; i < authTypes.length; i++) {
             holders[i] = new AuthTypeHolder(authTypes[i], context.getResources());

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AuthTypeHolder.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AuthTypeHolder.java
@@ -41,7 +41,8 @@ class AuthTypeHolder {
                 return R.string.account_setup_auth_type_encrypted_password;
             case EXTERNAL:
                 return R.string.account_setup_auth_type_tls_client_certificate;
-
+            case XOAUTH2:
+                return R.string.account_setup_auth_type_xoauth2;
             case AUTOMATIC:
             case LOGIN:
             default:

--- a/app/ui/legacy/src/main/res/layout/account_setup_basics.xml
+++ b/app/ui/legacy/src/main/res/layout/account_setup_basics.xml
@@ -36,6 +36,7 @@
             </com.google.android.material.textfield.TextInputLayout>
 
             <com.google.android.material.textfield.TextInputLayout
+                android:id="@+id/account_password_input_layout"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 app:passwordToggleEnabled="true">

--- a/app/ui/legacy/src/main/res/layout/oauth_webview.xml
+++ b/app/ui/legacy/src/main/res/layout/oauth_webview.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+      <WebView
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:id="@+id/web_view"/>
+
+</LinearLayout>
+

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -378,6 +378,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_setup_auth_type_insecure_password">Password, transmitted insecurely</string>
     <string name="account_setup_auth_type_encrypted_password">Encrypted password</string>
     <string name="account_setup_auth_type_tls_client_certificate">Client certificate</string>
+    <string name="account_setup_auth_type_xoauth2">XOauth2 (Gmail, Outlook)</string>
 
     <string name="account_setup_incoming_title">Incoming server settings</string>
     <string name="account_setup_incoming_username_label">Username</string>

--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,7 @@ buildscript {
                 'okhttp': '4.9.1',
                 'minidns': '1.0.0',
                 'glide': '4.12.0',
+                'retrofit': '2.7.2',
 
                 'androidxTestRunner': '1.3.0',
                 'junit': '4.13.2',

--- a/mail/common/build.gradle
+++ b/mail/common/build.gradle
@@ -12,6 +12,11 @@ dependencies {
     implementation "commons-io:commons-io:${versions.commonsIo}"
     implementation "androidx.annotation:annotation:${versions.androidxAnnotation}"
     implementation "com.jakewharton.timber:timber:${versions.timber}"
+    implementation "org.koin:koin-android:${versions.koin}"
+    implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.kotlinCoroutines}"
+
+    implementation "com.squareup.retrofit2:retrofit:${versions.retrofit}"
+    implementation "com.squareup.retrofit2:converter-gson:${versions.retrofit}"
 
     testImplementation project(":mail:testing")
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
@@ -34,6 +39,13 @@ android {
     buildTypes {
         debug {
             testCoverageEnabled rootProject.testCoverage
+            buildConfigField "String", "GOOGLE_CLIENT_ID", "\"*********add debug credentials here***************.apps.googleusercontent.com\""
+            buildConfigField "String", "GOOGLE_CLIENT_ID_PACKAGE_NAME", "\"com.fsck.k9.debug\""
+        }
+
+        release {
+            buildConfigField "String", "GOOGLE_CLIENT_ID", "\"*********add release credentials here***************.apps.googleusercontent.com\""
+            buildConfigField "String", "GOOGLE_CLIENT_ID_PACKAGE_NAME", "\"com.fsck.k9\""
         }
     }
 

--- a/mail/common/src/main/java/com/fsck/k9/mail/AuthenticationFailedException.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/AuthenticationFailedException.kt
@@ -6,4 +6,9 @@ class AuthenticationFailedException @JvmOverloads constructor(
     val messageFromServer: String? = null
 ) : MessagingException(message, throwable) {
     val isMessageFromServerAvailable = messageFromServer != null
+
+    companion object {
+        const val OAUTH2_ERROR_INVALID_REFRESH_TOKEN = "oauth2-invalid refresh token"
+        const val OAUTH2_ERROR_UNKNOWN = "oauth2-unknown"
+    }
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/AuthorizationException.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/AuthorizationException.java
@@ -1,5 +1,6 @@
 package com.fsck.k9.mail.oauth;
 
+
 public class AuthorizationException extends Exception {
     public AuthorizationException(String detailMessage, Throwable throwable) {
         super(detailMessage, throwable);

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/K9OAuth2TokenProvider.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/K9OAuth2TokenProvider.kt
@@ -1,0 +1,46 @@
+package com.fsck.k9.mail.oauth
+
+import com.fsck.k9.mail.AuthenticationFailedException
+import com.fsck.k9.mail.oauth.authorizationserver.AuthorizationServer
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2CodeGrantFlowManager
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2NeedUserPromptException
+
+class K9OAuth2TokenProvider(
+    private val tokensStore: OAuth2TokensStore,
+    private val oAuth2CodeGrantFlowManager: OAuth2CodeGrantFlowManager
+) : OAuth2TokenProvider {
+
+    @Throws(AuthenticationFailedException::class, OAuth2NeedUserPromptException::class)
+    override fun getToken(email: String, timeoutMillis: Long): String {
+        if (tokensStore.getAccessToken(email) == null) {
+            val refreshToken = tokensStore.getRefreshToken(email)
+            if (refreshToken != null) {
+                try {
+                    refreshToken(email, refreshToken)
+                } catch (e: Exception) {
+                    throw AuthenticationFailedException(e.message!!)
+                }
+            } else {
+                oAuth2CodeGrantFlowManager.showAuthDialog(email)
+                throw OAuth2NeedUserPromptException()
+            }
+        }
+        return tokensStore.getAccessToken(email)!!
+    }
+
+    override fun invalidateToken(email: String) {
+        tokensStore.invalidateAccessToken(email)
+    }
+
+    @Throws(AuthenticationFailedException::class)
+    private fun refreshToken(email: String, refreshToken: String) {
+        val server = getAuthorizationServer(email)
+        server?.refreshToken(email, refreshToken)?.let { newToken ->
+            tokensStore.saveAccessToken(email, newToken)
+        }
+    }
+
+    private fun getAuthorizationServer(email: String): AuthorizationServer? {
+        return OAuth2Provider.getProvider(email)?.authorizationServer
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/KoinModule.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/KoinModule.kt
@@ -1,0 +1,10 @@
+package com.fsck.k9.mail.oauth
+
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2CodeGrantFlowManager
+import org.koin.dsl.module
+
+val oauth2Module = module {
+    single<OAuth2TokenProvider> { K9OAuth2TokenProvider(get(), get()) }
+    single { OAuth2CodeGrantFlowManager(get()) }
+    single { OAuth2TokensStore(get()) }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2Provider.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2Provider.kt
@@ -1,0 +1,50 @@
+package com.fsck.k9.mail.oauth
+
+import com.fsck.k9.mail.oauth.authorizationserver.AuthorizationServer
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2CodeGrantFlowManager
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2WebViewClient
+import com.fsck.k9.mail.oauth.gmail.GmailAuthorizationServer
+import com.fsck.k9.mail.oauth.gmail.GmailWebViewClient
+import com.fsck.k9.mail.oauth.outlook.OutlookAuthorizationServer
+import com.fsck.k9.mail.oauth.outlook.OutlookWebViewClient
+
+enum class OAuth2Provider(
+    val authorizationServer: AuthorizationServer,
+    val isInDomain: (String) -> Boolean,
+    val webViewClient: (String, OAuth2CodeGrantFlowManager) -> OAuth2WebViewClient
+) {
+    GMAIL(
+        GmailAuthorizationServer(),
+        {
+            it in listOf("gmail.com", "android.com", "google.com", "googlemail.com")
+        },
+        { email: String, codeGrantFlowManager: OAuth2CodeGrantFlowManager ->
+            GmailWebViewClient(email, codeGrantFlowManager)
+        }
+    ),
+    OUTLOOK(
+        OutlookAuthorizationServer(),
+        {
+            val domainWoExt = it.split('.')[0]
+            domainWoExt in listOf("hotmail", "live", "msn", "outlook")
+        },
+        { email: String, codeGrantFlowManager: OAuth2CodeGrantFlowManager ->
+            OutlookWebViewClient(email, codeGrantFlowManager)
+        }
+    );
+
+    companion object {
+        private fun getTypeFromDomain(domain: String): OAuth2Provider? {
+            return values().firstOrNull { it.isInDomain(domain) }
+        }
+
+        fun getProvider(email: String): OAuth2Provider? {
+            val domain = email.split("@".toRegex()).toTypedArray()[1]
+            return getTypeFromDomain(domain)
+        }
+
+        fun isXOAuth2(domain: String): Boolean {
+            return values().any { it.isInDomain(domain) }
+        }
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2TokenProvider.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2TokenProvider.java
@@ -1,11 +1,8 @@
 package com.fsck.k9.mail.oauth;
 
 
-import java.util.List;
-
-import android.app.Activity;
-
 import com.fsck.k9.mail.AuthenticationFailedException;
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2NeedUserPromptException;
 
 
 public interface OAuth2TokenProvider {
@@ -14,47 +11,20 @@ public interface OAuth2TokenProvider {
      */
     int OAUTH2_TIMEOUT = 30000;
 
-    
-    /**
-     * @return Accounts suitable for OAuth 2.0 token provision.
-     */
-    List<String> getAccounts();
-
-    /**
-     * Request API authorization. This is a foreground action that may produce a dialog to interact with.
-     *
-     * @param username
-     *         Username
-     * @param activity
-     *         The responsible activity
-     * @param callback
-     *         A callback to process the asynchronous response
-     */
-    void authorizeApi(String username, Activity activity, OAuth2TokenProviderAuthCallback callback);
-
     /**
      * Fetch a token. No guarantees are provided for validity.
      */
-    String getToken(String username, long timeoutMillis) throws AuthenticationFailedException;
+    String getToken(String email, long timeoutMillis)
+            throws AuthenticationFailedException, OAuth2NeedUserPromptException;
 
     /**
-     * Invalidate the token for this username.
+     * Invalidate the token for this email.
      *
      * <p>
-     * Note that the token should always be invalidated on credential failure. However invalidating a token every
-     * single time is not recommended.
+     * Note that the token should always be invalidated on credential failure. However invalidating a token every single
+     * time is not recommended.
      * <p>
      * Invalidating a token and then failure with a new token should be treated as a permanent failure.
      */
-    void invalidateToken(String username);
-
-
-    /**
-     * Provides an asynchronous response to an
-     * {@link OAuth2TokenProvider#authorizeApi(String, Activity, OAuth2TokenProviderAuthCallback)} request.
-     */
-    interface OAuth2TokenProviderAuthCallback {
-        void success();
-        void failure(AuthorizationException e);
-    }
+    void invalidateToken(String email);
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2TokensStore.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/OAuth2TokensStore.kt
@@ -1,0 +1,45 @@
+package com.fsck.k9.mail.oauth
+
+import android.content.Context
+import android.content.SharedPreferences
+import java.util.HashMap
+
+/**
+ * Store access and refresh token.
+ * Access token are in RAM. Refresh token are saved in sharedPreferences.
+ */
+class OAuth2TokensStore(context: Context) {
+
+    private val sharedPreferences: SharedPreferences =
+        context.getSharedPreferences(REFRESH_TOKEN_SP, Context.MODE_PRIVATE)
+
+    private val accessTokens: HashMap<String, String> = HashMap()
+
+    fun saveAccessToken(email: String, token: String) {
+        accessTokens[email] = token
+    }
+
+    fun getAccessToken(email: String): String? {
+        return accessTokens[email]
+    }
+
+    fun invalidateAccessToken(email: String) {
+        accessTokens.remove(email)
+    }
+
+    fun saveRefreshToken(email: String, token: String) {
+        sharedPreferences.edit().putString(email, token).apply()
+    }
+
+    fun getRefreshToken(email: String): String? {
+        return sharedPreferences.getString(email, null)
+    }
+
+    fun invalidateRefreshToken(email: String) {
+        sharedPreferences.edit().remove(email).apply()
+    }
+
+    companion object {
+        private const val REFRESH_TOKEN_SP = "refresh_token"
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/XOAuth2ChallengeParser.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/XOAuth2ChallengeParser.java
@@ -9,8 +9,7 @@ import timber.log.Timber;
 
 
 /**
- * Parses Google's Error/Challenge responses
- * See: https://developers.google.com/gmail/xoauth2_protocol#error_response
+ * Parses Google's Error/Challenge responses See: https://developers.google.com/gmail/xoauth2_protocol#error_response
  */
 public class XOAuth2ChallengeParser {
     public static final String BAD_RESPONSE = "400";

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/AuthorizationServer.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/AuthorizationServer.kt
@@ -1,0 +1,34 @@
+package com.fsck.k9.mail.oauth.authorizationserver
+
+import com.fsck.k9.mail.AuthenticationFailedException
+
+/**
+ * Oauth2 rely on authorization server:
+ * An authorization code grant flow procedure in a webview (it is the authorization server which provide pages).
+ * The exchange code serve to get access code and refresh token from authentication server.
+ * The refresh token serve to renew the access token.
+ * This interface regroup method needed for user authorization code grant flow procedure and for refreshing token.
+ * @see http://www.bubblecode.net/en/2016/01/22/understanding-oauth2/
+ */
+interface AuthorizationServer {
+
+    /**
+     * Get the url for authentication code grant flow procedure.
+     */
+    fun getAuthorizationUrl(email: String): String
+
+    /**
+     * At the end of the user authentication flow procedure, we got a code.
+     * This request permit to get the tokens from this code.
+     * @param code the code obtain at the end of user authentication flow procedure.
+     */
+    @Throws(AuthenticationFailedException::class)
+    fun exchangeCode(email: String, code: String): OAuth2Tokens?
+
+    /**
+     * Get new access token with refresh token
+     * @param refreshToken refresh token got before
+     */
+    @Throws(AuthenticationFailedException::class)
+    fun refreshToken(email: String, refreshToken: String): String?
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/OAuth2Tokens.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/OAuth2Tokens.kt
@@ -1,0 +1,9 @@
+package com.fsck.k9.mail.oauth.authorizationserver
+
+/**
+ * OAuth2 tokens: access and refresh.
+ * Access token: serve to access data on the resource server.
+ * Refresh token: serve to renew the access token.
+ * @see http://www.bubblecode.net/en/2016/01/22/understanding-oauth2/
+ */
+data class OAuth2Tokens(val accessToken: String, val refreshToken: String)

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/codegrantflow/OAuth2CodeGrantFlowManager.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/codegrantflow/OAuth2CodeGrantFlowManager.kt
@@ -1,0 +1,37 @@
+package com.fsck.k9.mail.oauth.authorizationserver.codegrantflow
+
+import com.fsck.k9.mail.AuthenticationFailedException
+import com.fsck.k9.mail.oauth.OAuth2Provider
+import com.fsck.k9.mail.oauth.OAuth2TokensStore
+
+/**
+ * Manage the user authentication code grant flow procedure.
+ */
+class OAuth2CodeGrantFlowManager(private val tokensStore: OAuth2TokensStore) {
+
+    var promptRequestHandler: OAuth2PromptRequestHandler? = null
+
+    @Throws(AuthenticationFailedException::class)
+    fun showAuthDialog(email: String) {
+        OAuth2Provider.getProvider(email)?.let { provider ->
+            promptRequestHandler?.handleRedirectUrl(
+                provider.webViewClient(email, this),
+                provider.authorizationServer.getAuthorizationUrl(email)
+            )
+        }
+    }
+
+    @Throws(AuthenticationFailedException::class)
+    fun exchangeCode(email: String, code: String) {
+        OAuth2Provider.getProvider(email)?.let {
+            it.authorizationServer.exchangeCode(email, code)?.let { tokens ->
+                tokensStore.saveAccessToken(email, tokens.accessToken)
+                tokensStore.saveRefreshToken(email, tokens.refreshToken)
+            }
+        }
+    }
+
+    fun invalidateRefreshToken(email: String) {
+        tokensStore.invalidateRefreshToken(email)
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/codegrantflow/OAuth2NeedUserPromptException.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/codegrantflow/OAuth2NeedUserPromptException.kt
@@ -1,0 +1,5 @@
+package com.fsck.k9.mail.oauth.authorizationserver.codegrantflow
+
+import com.fsck.k9.mail.MessagingException
+
+class OAuth2NeedUserPromptException : MessagingException("Need user's prompt for xoauth2")

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/codegrantflow/OAuth2PromptRequestHandler.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/codegrantflow/OAuth2PromptRequestHandler.kt
@@ -1,0 +1,13 @@
+package com.fsck.k9.mail.oauth.authorizationserver.codegrantflow
+
+import android.webkit.WebViewClient
+
+interface OAuth2PromptRequestHandler {
+    fun handleRedirectUrl(webViewClient: WebViewClient, url: String)
+
+    fun onObtainCodeSuccessful()
+
+    fun onObtainAccessTokenSuccessful()
+
+    fun onError(errorMessage: String)
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/codegrantflow/OAuth2WebViewClient.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/authorizationserver/codegrantflow/OAuth2WebViewClient.kt
@@ -1,0 +1,68 @@
+package com.fsck.k9.mail.oauth.authorizationserver.codegrantflow
+
+import android.annotation.TargetApi
+import android.net.Uri
+import android.os.Build
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import com.fsck.k9.mail.AuthenticationFailedException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import timber.log.Timber
+
+/**
+ * Bass class for standard authorization code flow like Google's or Microsoft's
+ */
+abstract class OAuth2WebViewClient(
+    private val email: String,
+    private val codeGrantFlowManager: OAuth2CodeGrantFlowManager
+) : WebViewClient() {
+    protected abstract fun arrivedAtRedirectUri(uri: Uri?): Boolean
+
+    override fun shouldOverrideUrlLoading(view: WebView, url: String): Boolean {
+        return handleUrl(url)
+    }
+
+    @TargetApi(Build.VERSION_CODES.N)
+    override fun shouldOverrideUrlLoading(view: WebView, request: WebResourceRequest): Boolean {
+        return handleUrl(request.url.toString())
+    }
+
+    private fun handleUrl(url: String): Boolean {
+        Timber.d(url)
+        val uri = Uri.parse(url)
+        if (arrivedAtRedirectUri(uri)) {
+            val error = uri.getQueryParameter("error")
+            if (error != null) {
+                Timber.e("got oauth error: $error")
+                codeGrantFlowManager.promptRequestHandler?.onError(error)
+                return true
+            }
+
+            uri.getQueryParameter("code")?.let { oauthCode ->
+                codeGrantFlowManager.promptRequestHandler?.onObtainCodeSuccessful()
+                GlobalScope.launch {
+                    withContext(Dispatchers.IO) {
+                        try {
+                            codeGrantFlowManager.exchangeCode(email, oauthCode)
+                            withContext(Dispatchers.Main) {
+                                codeGrantFlowManager.promptRequestHandler?.onObtainAccessTokenSuccessful()
+                            }
+                        } catch (e: AuthenticationFailedException) {
+                            withContext(Dispatchers.Main) {
+                                codeGrantFlowManager.promptRequestHandler?.onError("Error when exchanging code")
+                            }
+                        }
+                    }
+                }
+            } ?: run {
+                codeGrantFlowManager.promptRequestHandler?.onError("No auth code")
+            }
+            return true
+        }
+        return false
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/gmail/GmailAuthorizationServer.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/gmail/GmailAuthorizationServer.kt
@@ -1,0 +1,156 @@
+package com.fsck.k9.mail.oauth.gmail
+
+import com.fsck.k9.mail.AuthenticationFailedException
+import com.fsck.k9.mail.AuthenticationFailedException.Companion.OAUTH2_ERROR_INVALID_REFRESH_TOKEN
+import com.fsck.k9.mail.AuthenticationFailedException.Companion.OAUTH2_ERROR_UNKNOWN
+import com.fsck.k9.mail.common.BuildConfig
+import com.fsck.k9.mail.oauth.authorizationserver.AuthorizationServer
+import com.fsck.k9.mail.oauth.authorizationserver.OAuth2Tokens
+import com.google.gson.Gson
+import com.google.gson.annotations.SerializedName
+import java.io.IOException
+import retrofit2.Call
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+import timber.log.Timber
+
+class GmailAuthorizationServer : AuthorizationServer {
+
+    private val service: GoogleRestApi
+
+    init {
+        val retrofit = Retrofit.Builder()
+            .baseUrl(GOOGLE_API_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+        service = retrofit.create(GoogleRestApi::class.java)
+    }
+
+    override fun exchangeCode(email: String, code: String): OAuth2Tokens? {
+        val call: Call<ExchangeResponse>? =
+            service.exchangeCode(code, BuildConfig.GOOGLE_CLIENT_ID, "authorization_code", REDIRECT_URI)
+        val exchangeResponse: ExchangeResponse?
+        val response: Response<ExchangeResponse>?
+        try {
+            response = call?.execute()
+            exchangeResponse = response?.body()
+        } catch (e: Exception) {
+            throw AuthenticationFailedException(e.message!!)
+        }
+
+        return when {
+            exchangeResponse == null -> null
+            exchangeResponse.accessToken.isNullOrEmpty() -> null
+            else -> OAuth2Tokens(exchangeResponse.accessToken!!, exchangeResponse.refreshToken!!)
+        }
+    }
+
+    override fun refreshToken(email: String, refreshToken: String): String? {
+        val call: Call<RefreshResponse>? =
+            service.refreshToken(BuildConfig.GOOGLE_CLIENT_ID, refreshToken, "refresh_token")
+        val response: Response<RefreshResponse>?
+        val refreshResponse: RefreshResponse?
+        try {
+            response = call?.execute()
+            refreshResponse = response?.body()
+        } catch (e: IOException) {
+            throw AuthenticationFailedException(e.message!!)
+        }
+
+        refreshResponse?.let {
+            return it.accessToken
+        } ?: run {
+            response?.let {
+                try {
+                    val errorBody = response.errorBody()?.string()
+                    val oAuth2Error =
+                        Gson().fromJson(errorBody, OAuth2Error::class.java)
+                    when (oAuth2Error.error) {
+                        "invalid_grant" -> throw AuthenticationFailedException(OAUTH2_ERROR_INVALID_REFRESH_TOKEN)
+                        else -> throw AuthenticationFailedException(OAUTH2_ERROR_UNKNOWN)
+                    }
+                } catch (e: IOException) {
+                    throw AuthenticationFailedException(OAUTH2_ERROR_UNKNOWN)
+                }
+            } ?: run {
+                throw AuthenticationFailedException(OAUTH2_ERROR_UNKNOWN)
+            }
+        }
+    }
+
+    override fun getAuthorizationUrl(email: String): String {
+        if (BuildConfig.GOOGLE_CLIENT_ID == "null") {
+            throw IllegalStateException("GOOGLE_CLIENT_ID is empty")
+        }
+        Timber.d("AUTHORIZATION_URL" + AUTHORIZATION_URL)
+        return "$AUTHORIZATION_URL&login_hint=$email"
+    }
+
+    private class OAuth2Error {
+        var error: String? = null
+
+        @SerializedName("error_description")
+        var errorDescription: String? = null
+    }
+
+    private class ExchangeResponse {
+        @SerializedName("access_token")
+        var accessToken: String? = null
+
+        @SerializedName("id_token")
+        var idToken: String? = null
+
+        @SerializedName("refresh_token")
+        var refreshToken: String? = null
+
+        @SerializedName("expires_in")
+        var expiresIn = 0
+
+        @SerializedName("token_type")
+        var tokenType: String? = null
+    }
+
+    private class RefreshResponse {
+        @SerializedName("access_token")
+        var accessToken: String? = null
+
+        @SerializedName("expires_in")
+        var expiresIn = 0
+
+        @SerializedName("token_type")
+        var tokenType: String? = null
+    }
+
+    private interface GoogleRestApi {
+        @FormUrlEncoded
+        @POST("oauth2/v4/token")
+        fun refreshToken(
+            @Field("client_id") clientId: String,
+            @Field("refresh_token") refreshToken: String,
+            @Field("grant_type") grantType: String
+        ): Call<RefreshResponse>?
+
+        @FormUrlEncoded
+        @POST("oauth2/v4/token")
+        fun exchangeCode(
+            @Field("code") code: String,
+            @Field("client_id") clientId: String,
+            @Field("grant_type") grantType: String,
+            @Field("redirect_uri") redirectUri: String
+        ): Call<ExchangeResponse>?
+    }
+
+    companion object {
+        private const val GOOGLE_API_BASE_URL = "https://www.googleapis.com/"
+        private const val REDIRECT_URI = BuildConfig.GOOGLE_CLIENT_ID_PACKAGE_NAME + ":/oauth2redirect"
+        private const val AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth?" +
+            "scope=https://mail.google.com/&" +
+            "response_type=code&" +
+            "redirect_uri=" + REDIRECT_URI + "&" +
+            "client_id=" + BuildConfig.GOOGLE_CLIENT_ID
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/gmail/GmailWebViewClient.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/gmail/GmailWebViewClient.kt
@@ -1,0 +1,13 @@
+package com.fsck.k9.mail.oauth.gmail
+
+import android.net.Uri
+import com.fsck.k9.mail.common.BuildConfig
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2CodeGrantFlowManager
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2WebViewClient
+
+class GmailWebViewClient(email: String, codeGrantFlowManager: OAuth2CodeGrantFlowManager) :
+    OAuth2WebViewClient(email, codeGrantFlowManager) {
+    override fun arrivedAtRedirectUri(uri: Uri?): Boolean {
+        return BuildConfig.GOOGLE_CLIENT_ID_PACKAGE_NAME == uri!!.scheme
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/outlook/OutlookAuthorizationServer.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/outlook/OutlookAuthorizationServer.kt
@@ -1,0 +1,123 @@
+package com.fsck.k9.mail.oauth.outlook
+
+import com.fsck.k9.mail.AuthenticationFailedException
+import com.fsck.k9.mail.oauth.authorizationserver.AuthorizationServer
+import com.fsck.k9.mail.oauth.authorizationserver.OAuth2Tokens
+import com.google.gson.annotations.SerializedName
+import java.io.IOException
+import retrofit2.Call
+import retrofit2.Response
+import retrofit2.Retrofit
+import retrofit2.converter.gson.GsonConverterFactory
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
+import retrofit2.http.POST
+
+class OutlookAuthorizationServer : AuthorizationServer {
+
+    private val service: OutlookService
+
+    init {
+        val retrofit = Retrofit.Builder()
+            .baseUrl(OUTLOOK_BASE_URL)
+            .addConverterFactory(GsonConverterFactory.create())
+            .build()
+        service = retrofit.create(OutlookService::class.java)
+    }
+
+    override fun getAuthorizationUrl(email: String): String {
+        return "$AUTHORIZATION_URL&login_hint=$email"
+    }
+
+    override fun exchangeCode(email: String, code: String): OAuth2Tokens? {
+        val call =
+            service.exchangeCode(code, CLIENT_ID, "authorization_code", REDIRECT_URI)
+        val exchangeResponse: ExchangeResponse?
+        val response: Response<ExchangeResponse>?
+        try {
+            response = call?.execute()
+            exchangeResponse = response?.body()
+        } catch (e: Exception) {
+            throw AuthenticationFailedException(e.message!!)
+        }
+        return when {
+            exchangeResponse == null -> null
+            exchangeResponse.accessToken.isNullOrEmpty() -> null
+            else -> OAuth2Tokens(exchangeResponse.accessToken!!, exchangeResponse.refreshToken!!)
+        }
+    }
+
+    override fun refreshToken(email: String, refreshToken: String): String? {
+        val call =
+            service.refreshToken(CLIENT_ID, refreshToken, "refresh_token", "https://login.live.com/oauth20_desktop.srf")
+        val response: RefreshResponse?
+        response = try {
+            call?.execute()?.body()
+        } catch (e: IOException) {
+            throw AuthenticationFailedException(e.message!!)
+        }
+        if (response == null) {
+            throw AuthenticationFailedException("Error when getting refresh token")
+        }
+        return response.accessToken
+    }
+
+    private interface OutlookService {
+        @FormUrlEncoded
+        @POST("oauth20_token.srf")
+        fun refreshToken(
+            @Field("client_id") clientId: String,
+            @Field("refresh_token") refreshToken: String,
+            @Field("grant_type") grantType: String,
+            @Field("redirect_uri") redirectUri: String
+        ): Call<RefreshResponse>?
+
+        @FormUrlEncoded
+        @POST("oauth20_token.srf")
+        fun exchangeCode(
+            @Field("code") code: String,
+            @Field("client_id") clientId: String,
+            @Field("grant_type") grantType: String,
+            @Field("redirect_uri") redirectUri: String
+        ): Call<ExchangeResponse>?
+    }
+
+    private class ExchangeResponse {
+        @SerializedName("access_token")
+        var accessToken: String? = null
+
+        @SerializedName("id_token")
+        var idToken: String? = null
+
+        @SerializedName("refresh_token")
+        var refreshToken: String? = null
+
+        @SerializedName("expires_in")
+        var expiresIn = 0
+
+        @SerializedName("token_type")
+        var tokenType: String? = null
+    }
+
+    private class RefreshResponse {
+        @SerializedName("access_token")
+        var accessToken: String? = null
+
+        @SerializedName("expires_in")
+        var expiresIn = 0
+
+        @SerializedName("token_type")
+        var tokenType: String? = null
+    }
+
+    companion object {
+        private const val OUTLOOK_BASE_URL = "https://login.live.com/"
+        const val CLIENT_ID = "309d8028-bdcb-4c7a-8d3e-990247a02474"
+        private const val REDIRECT_URI = "msal$CLIENT_ID://auth"
+        private const val AUTHORIZATION_URL = "https://login.live.com/oauth20_authorize.srf?" +
+            "client_id=" + CLIENT_ID + "&" +
+            "scope=wl.imap wl.offline_access&" +
+            "response_type=code&" +
+            "redirect_uri=" + REDIRECT_URI
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/oauth/outlook/OutlookWebViewClient.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/oauth/outlook/OutlookWebViewClient.kt
@@ -1,0 +1,12 @@
+package com.fsck.k9.mail.oauth.outlook
+
+import android.net.Uri
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2CodeGrantFlowManager
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2WebViewClient
+
+class OutlookWebViewClient(email: String, codeGrantFlowManager: OAuth2CodeGrantFlowManager) :
+    OAuth2WebViewClient(email, codeGrantFlowManager) {
+    override fun arrivedAtRedirectUri(uri: Uri?): Boolean {
+        return "msal" + OutlookAuthorizationServer.CLIENT_ID == uri?.scheme
+    }
+}

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.java
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapConnectionTest.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.net.UnknownHostException;
 import java.util.List;
 
-import android.app.Activity;
 import android.net.ConnectivityManager;
 
 import com.fsck.k9.mail.AuthType;
@@ -1071,16 +1070,6 @@ public class RealImapConnectionTest {
             public void invalidateToken(String username) {
                 assertEquals(USERNAME, username);
                 invalidationCount++;
-            }
-
-            @Override
-            public List<String> getAccounts() {
-                throw new UnsupportedOperationException();
-            }
-
-            @Override
-            public void authorizeApi(String username, Activity activity, OAuth2TokenProviderAuthCallback callback) {
-                throw new UnsupportedOperationException();
             }
         };
     }

--- a/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
+++ b/mail/protocols/smtp/src/test/java/com/fsck/k9/mail/transport/smtp/SmtpTransportTest.java
@@ -15,6 +15,7 @@ import com.fsck.k9.mail.helpers.TestMessageBuilder;
 import com.fsck.k9.mail.helpers.TestTrustedSocketFactory;
 import com.fsck.k9.mail.internet.MimeMessage;
 import com.fsck.k9.mail.oauth.OAuth2TokenProvider;
+import com.fsck.k9.mail.oauth.authorizationserver.codegrantflow.OAuth2NeedUserPromptException;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
 import com.fsck.k9.mail.transport.mockServer.MockSmtpServer;
 import org.junit.Before;
@@ -45,7 +46,7 @@ public class SmtpTransportTest {
 
 
     @Before
-    public void before() throws AuthenticationFailedException {
+    public void before() throws AuthenticationFailedException, OAuth2NeedUserPromptException {
         socketFactory = TestTrustedSocketFactory.newInstance();
         oAuth2TokenProvider = mock(OAuth2TokenProvider.class);
         when(oAuth2TokenProvider.getToken(eq(USERNAME), anyLong()))


### PR DESCRIPTION
This is an updated PR to fix the merge conflicts of the [previous xoauth2 PR](https://github.com/k9mail/k-9/pull/4832)

Relates to #655 

Note that Gmail support requires updating the google client id (and potentially package name) in `common/build.gradle`.
Use the google console to create OAuth 2.0 Client IDs: https://console.cloud.google.com/apis/credentials

Also worth considering this adds a dependency on retrofit which isn't used by k9 anywhere else.

