### PR TITLE
Fix Push keeping the device awake

### DIFF
--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/ImapConnection.kt
@@ -44,7 +44,4 @@ internal interface ImapConnection {
 
     @Throws(SocketException::class)
     fun setSocketReadTimeout(timeout: Int)
-
-    @Throws(IOException::class)
-    fun isDataAvailable(): Boolean
 }

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.java
@@ -911,11 +911,6 @@ class RealImapConnection implements ImapConnection {
     }
 
     @Override
-    public boolean isDataAvailable() throws IOException {
-        return inputStream.available() > 0;
-    }
-
-    @Override
     public int getConnectionGeneration() {
         return connectionGeneration;
     }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderIdlerTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderIdlerTest.kt
@@ -121,7 +121,6 @@ class RealImapFolderIdlerTest {
         wakeLock.waitForRelease()
         imapConnection.enqueueUntaggedServerResponse("1 EXISTS")
         imapConnection.waitForCommand("DONE")
-        assertThat(wakeLock.isHeld).isTrue()
         imapConnection.enqueueTaggedServerResponse("OK")
 
         latch.awaitWithTimeout()

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapConnection.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestImapConnection.kt
@@ -94,8 +94,6 @@ internal open class TestImapConnection(val timeout: Long, override val connectio
         currentSocketReadTimeout = timeout
     }
 
-    override fun isDataAvailable(): Boolean = false
-
     fun waitForCommand(command: String) {
         do {
             val receivedCommand = receivedCommands.poll(timeout, TimeUnit.SECONDS) ?: throw AssertionError("Timeout")


### PR DESCRIPTION
`ImapConnection.isDataAvailable()` didn't reliably work on all devices (returned `true` when no complete IMAP response was available). This lead to situations where a wakelock was being held the whole time the IDLE command was active. At the same time no alarm was set to refresh the IDLE connection. So most of the time the blocking read would time out.

Fixes #5397