### PR TITLE
Show full error message in notification

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/CertificateErrorNotifications.java
+++ b/app/core/src/main/java/com/fsck/k9/notification/CertificateErrorNotifications.java
@@ -3,6 +3,7 @@ package com.fsck.k9.notification;
 
 import android.app.PendingIntent;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationCompat.BigTextStyle;
 import androidx.core.app.NotificationManagerCompat;
 
 import com.fsck.k9.Account;
@@ -40,6 +41,7 @@ class CertificateErrorNotifications {
                 .setContentTitle(title)
                 .setContentText(text)
                 .setContentIntent(editServerSettingsPendingIntent)
+                .setStyle(new BigTextStyle().bigText(text))
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setCategory(NotificationCompat.CATEGORY_ERROR);
 

--- a/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotifications.java
+++ b/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotifications.java
@@ -3,6 +3,7 @@ package com.fsck.k9.notification;
 
 import android.app.PendingIntent;
 import androidx.core.app.NotificationCompat;
+import androidx.core.app.NotificationCompat.BigTextStyle;
 import androidx.core.app.NotificationManagerCompat;
 
 import com.fsck.k9.Account;
@@ -42,6 +43,7 @@ class SendFailedNotifications {
                 .setContentTitle(title)
                 .setContentText(text)
                 .setContentIntent(folderListPendingIntent)
+                .setStyle(new BigTextStyle().bigText(text))
                 .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
                 .setCategory(NotificationCompat.CATEGORY_ERROR);
 


### PR DESCRIPTION
Update the sending message failed notifications so the full text can be read in an expanded notification. Changes match what's already in `AuthenticationErrorNotifications`


Partially fixes the following issue (although doesn't address the on tap behavior) #5378

Old on left, new on right (I added my own exception for the purpose of testing)
![device-2021-07-17-1525491](https://user-images.githubusercontent.com/8265864/126024444-0e34bc24-e5a0-48da-9bb1-e36b124ef41d.png)