### PR TITLE
Close drawer when switching to an account with an auto-expand folder

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -618,13 +618,17 @@ open class MessageList :
         ManageFoldersActivity.launch(this, account!!)
     }
 
-    fun openRealAccount(account: Account) {
+    fun openRealAccount(account: Account): Boolean {
+        val shouldCloseDrawer = account.autoExpandFolderId != null
+
         val folderId = defaultFolderProvider.getDefaultFolder(account)
 
         val search = LocalSearch()
         search.addAllowedFolder(folderId)
         search.addAccountUuid(account.uuid)
         actionDisplaySearch(this, search, noThreading = false, newTask = false)
+
+        return shouldCloseDrawer
     }
 
     private fun performSearch(search: LocalSearch) {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -155,9 +155,10 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
         headerView.onAccountHeaderListener = { _, profile, _ ->
             val account = (profile as ProfileDrawerItem).tag as Account
             openedAccountUuid = account.uuid
-            parent.openRealAccount(account)
+            val eventHandled = !parent.openRealAccount(account)
             updateUserAccountsAndFolders(account)
-            true
+
+            eventHandled
         }
     }
 


### PR DESCRIPTION
Previously, when selecting an account the drawer would stay open and display the folder list of the newly selected account. Now, it only stays open if the auto-expand folder is set to *None*. If an auto-expand folder is configured the message list for that folder is displayed and the drawer is closed.