### PR TITLE
Display account name in toolbar

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1174,13 +1174,14 @@ open class MessageList :
         finish()
     }
 
-    fun setActionBarTitle(title: String) {
+    fun setActionBarTitle(title: String, subtitle: String? = null) {
         actionBar.title = title
+        actionBar.subtitle = subtitle
     }
 
-    override fun setMessageListTitle(title: String) {
+    override fun setMessageListTitle(title: String, subtitle: String?) {
         if (displayMode != DisplayMode.MESSAGE_VIEW) {
-            setActionBarTitle(title)
+            setActionBarTitle(title, subtitle)
         }
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -331,7 +331,15 @@ class MessageListFragment :
             else -> ""
         }
 
-        fragmentListener.setMessageListTitle(title)
+        val subtitle = account.let { account ->
+            if (account == null || isUnifiedInbox || preferences.accounts.size == 1) {
+                null
+            } else {
+                account.description
+            }
+        }
+
+        fragmentListener.setMessageListTitle(title, subtitle)
     }
 
     fun progress(progress: Boolean) {
@@ -1876,7 +1884,7 @@ class MessageListFragment :
         fun setMessageListProgress(level: Int)
         fun showThread(account: Account, threadRootId: Long)
         fun openMessage(messageReference: MessageReference)
-        fun setMessageListTitle(title: String)
+        fun setMessageListTitle(title: String, subtitle: String?)
         fun onCompose(account: Account?)
         fun startSearch(account: Account?, folderId: Long?): Boolean
         fun remoteSearchStarted()


### PR DESCRIPTION
If there's only one account set up, we skip displaying the account name. Same for views that don't belong to a single account (Unified Inbox, global search results).

<img src="https://user-images.githubusercontent.com/218061/127478689-fe35cf9c-58c5-4871-b7c3-ba5228f828b9.png" alt="k9mail_account_name_in_toolbar" width=300>


Fixes #4496