### PR TITLE
Fold identity header value so we're not generating invalid messages

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/IdentityHeaderParser.java
+++ b/app/core/src/main/java/com/fsck/k9/message/IdentityHeaderParser.java
@@ -29,10 +29,12 @@ public class IdentityHeaderParser {
             return identity;
         }
 
+        String encodedString = unfoldHeaderValue(identityString);
+
         // Check to see if this is a "next gen" identity.
-        if (identityString.charAt(0) == IdentityField.IDENTITY_VERSION_1.charAt(0) && identityString.length() > 2) {
+        if (encodedString.charAt(0) == IdentityField.IDENTITY_VERSION_1.charAt(0) && encodedString.length() > 2) {
             Uri.Builder builder = new Uri.Builder();
-            builder.encodedQuery(identityString.substring(1));  // Need to cut off the ! at the beginning.
+            builder.encodedQuery(encodedString.substring(1));  // Need to cut off the ! at the beginning.
             Uri uri = builder.build();
             for (IdentityField key : IdentityField.values()) {
                 String value = uri.getQueryParameter(key.value());
@@ -56,9 +58,9 @@ public class IdentityHeaderParser {
         } else {
             // Legacy identity
 
-            Timber.d("Got a saved legacy identity: %s", identityString);
+            Timber.d("Got a saved legacy identity: %s", encodedString);
 
-            StringTokenizer tokenizer = new StringTokenizer(identityString, ":", false);
+            StringTokenizer tokenizer = new StringTokenizer(encodedString, ":", false);
 
             // First item is the body length. We use this to separate the composed reply from the quoted text.
             if (tokenizer.hasMoreTokens()) {
@@ -84,5 +86,9 @@ public class IdentityHeaderParser {
         }
 
         return identity;
+    }
+
+    private static String unfoldHeaderValue(String identityString) {
+        return identityString.replaceAll("\r?\n ", "");
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/message/IdentityHeaderBuilderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/message/IdentityHeaderBuilderTest.kt
@@ -1,0 +1,56 @@
+package com.fsck.k9.message
+
+import com.fsck.k9.Account.QuoteStyle
+import com.fsck.k9.Identity
+import com.fsck.k9.RobolectricTest
+import com.fsck.k9.mail.internet.MimeHeaderChecker
+import com.fsck.k9.mail.internet.TextBody
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+private const val IDENTITY_HEADER = "X-K9mail-Identity"
+
+class IdentityHeaderBuilderTest : RobolectricTest() {
+    @Test
+    fun `valid unstructured header field value`() {
+        val signature = "a".repeat(1000)
+
+        val identityHeader = IdentityHeaderBuilder()
+            .setCursorPosition(0)
+            .setIdentity(createIdentity(signatureUse = true))
+            .setIdentityChanged(false)
+            .setMessageFormat(SimpleMessageFormat.TEXT)
+            .setMessageReference(null)
+            .setQuotedHtmlContent(null)
+            .setQuoteStyle(QuoteStyle.PREFIX)
+            .setQuoteTextMode(QuotedTextMode.NONE)
+            .setSignature(signature)
+            .setSignatureChanged(true)
+            .setBody(TextBody("irrelevant"))
+            .setBodyPlain(null)
+            .build()
+
+        assertThat(identityHeader.length).isGreaterThan(1000)
+        assertIsValidHeader(identityHeader)
+    }
+
+    private fun assertIsValidHeader(identityHeader: String) {
+        try {
+            MimeHeaderChecker.checkHeader(IDENTITY_HEADER, identityHeader)
+        } catch (e: Exception) {
+            println("$IDENTITY_HEADER: $identityHeader")
+            throw e
+        }
+    }
+
+    private fun createIdentity(
+        description: String? = null,
+        name: String? = null,
+        email: String? = null,
+        signature: String? = null,
+        signatureUse: Boolean = false,
+        replyTo: String? = null
+    ): Identity {
+        return Identity(description, name, email, signature, signatureUse, replyTo)
+    }
+}

--- a/app/core/src/test/java/com/fsck/k9/message/IdentityHeaderParserTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/message/IdentityHeaderParserTest.kt
@@ -1,0 +1,33 @@
+package com.fsck.k9.message
+
+import com.fsck.k9.RobolectricTest
+import com.fsck.k9.helper.toCrLf
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class IdentityHeaderParserTest : RobolectricTest() {
+    @Test
+    fun `folded header value`() {
+        val input = """
+            |!l=10&o=0&qs=PREFIX&f=TEXT&s=aaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+            | aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa&p=0&q=NONE
+        """.trimMargin().toCrLf()
+
+        val result = IdentityHeaderParser.parse(input)
+
+        assertThat(result).containsEntry(IdentityField.SIGNATURE, "a".repeat(1000))
+    }
+}


### PR DESCRIPTION
Saving a draft will create a message containing K-9 Mail's "identity header". If the signature was edited, the identity header will contain the text of the modified signature. If that text is very long, the header may exceed the maximum line length of the internet message format (998 characters + CR LF). In that case `MimeHeaderChecker` will crash the app to prevent us from creating invalid messages and to help us find and fix such bugs. Mission accomplished :tada:

This change will make sure the identity header value is properly folded, i.e. lines in the email are no longer than 72 characters. 

Fixes #5436