### PR TITLE
Use minimum priority for 'Synchronize (Push)' notification

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/PushNotificationManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/PushNotificationManager.kt
@@ -58,6 +58,7 @@ internal class PushNotificationManager(
         val contentIntent = PendingIntent.getActivity(context, 1, intent, flag)
 
         return NotificationCompat.Builder(context, notificationChannelManager.pushChannelId)
+            .setPriority(NotificationCompat.PRIORITY_MIN)
             .setSmallIcon(resourceProvider.iconPushNotification)
             .setContentTitle(resourceProvider.pushNotificationText(notificationState))
             .setContentText(resourceProvider.pushNotificationInfoText())


### PR DESCRIPTION
This way the "@" notification shouldn't be displayed in the status bar on Android versions prior to 8.0.

Closes #5521