### PR TITLE
Make persistent push notification low priority

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/PushNotificationManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/PushNotificationManager.kt
@@ -64,6 +64,7 @@ internal class PushNotificationManager(
             .setContentIntent(contentIntent)
             .setOngoing(true)
             .setNotificationSilent()
+            .setPriority(NotificationCompat.PRIORITY_MIN)
             .setBadgeIconType(NotificationCompat.BADGE_ICON_NONE)
             .setLocalOnly(true)
             .setShowWhen(false)


### PR DESCRIPTION
This should fix #5521 -- please see the description of the issue and of this fix there.

I've built and tested this fix on an Android 7.1 AVD, and it appears to work as intended; the notification icon isn't shown in the status bar, and when the notification shade is pulled down the notification is placed at the bottom of the list in a slightly dimmed colour. This should make the persistent notification much less obtrusive on Android versions lower than Oreo.

![Screenshot from 2021-08-04 18-56-57](https://user-images.githubusercontent.com/567041/128266521-577232c4-a791-463e-901d-d6c5b056f3c4.png)
