### PR TITLE
Ignore extraneous spaces when filtering the folder list

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
@@ -146,6 +146,7 @@ class ManageFoldersFragment : Fragment() {
         val locale = Locale.getDefault()
         val displayName = item.displayName.toLowerCase(locale)
         return constraint.splitToSequence(" ")
+            .filter { it.isNotEmpty() }
             .map { it.toLowerCase(locale) }
             .any { it in displayName }
     }


### PR DESCRIPTION
Filter strings with e.g. a trailing space were split into the search term and the empty string. But the empty string can be found in every folder name, so all folders were displayed. This change drops all search terms that are the empty string.

Fixes #5524