### PR TITLE
Protect password for mail accounts in UI

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupIncoming.java
@@ -200,6 +200,8 @@ public class AccountSetupIncoming extends K9Activity implements OnClickListener 
                 mPasswordView.setText(settings.password);
             }
 
+            mPasswordLayoutView.setEndIconVisible(!editSettings);
+
             if (settings.clientCertificateAlias != null) {
                 mClientCertificateSpinner.setAlias(settings.clientCertificateAlias);
             }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupOutgoing.java
@@ -148,6 +148,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
             mAccount = Preferences.getPreferences(this).getAccount(accountUuid);
         }
 
+        boolean editSettings = Intent.ACTION_EDIT.equals(getIntent().getAction());
+
         try {
             ServerSettings settings = mAccount.getOutgoingServerSettings();
 
@@ -188,6 +190,8 @@ public class AccountSetupOutgoing extends K9Activity implements OnClickListener,
             if (settings.password != null) {
                 mPasswordView.setText(settings.password);
             }
+
+            mPasswordLayoutView.setEndIconVisible(!editSettings);
 
             if (settings.clientCertificateAlias != null) {
                 mClientCertificateSpinner.setAlias(settings.clientCertificateAlias);


### PR DESCRIPTION
Only show the password reveal icon if you are creating an account for the first time.

A weak security measure, effective only against a casual snooper, but better than nothing.

It can be sometimes convenient for a user to see the password. Additional authentication, from https://developer.android.com/training/sign-in/biometric-auth , could be added to enable this.

Therefore, this PR can be merged as-is (restoring the security level available in 5.600), or can wait for the work to add an additional authentication prompt.