### PR TITLE
Remove notification when a message is removed from a folder

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2775,6 +2775,11 @@ public class MessagingController {
             for (MessagingListener messagingListener : getListeners(listener)) {
                 messagingListener.synchronizeMailboxRemovedMessage(account, folderServerId, messageServerId);
             }
+
+            String accountUuid = account.getUuid();
+            long folderId = getFolderIdOrThrow(account, folderServerId);
+            MessageReference messageReference = new MessageReference(accountUuid, folderId, messageServerId, null);
+            notificationController.removeNewMailNotification(account, messageReference);
         }
 
         @Override


### PR DESCRIPTION
When moving or deleting a message without marking it read we didn't remove the notification for that message.

Fixes #5545