### PR TITLE
Ensure boundary parameter is quoted in Content-Type header value

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/BoundaryGenerator.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/BoundaryGenerator.java
@@ -32,7 +32,7 @@ public class BoundaryGenerator {
 
     public String generateBoundary() {
         StringBuilder builder = new StringBuilder(4 + BOUNDARY_CHARACTER_COUNT);
-        builder.append("----");
+        builder.append("----==");
         
         for (int i = 0; i < BOUNDARY_CHARACTER_COUNT; i++) {
             builder.append(BASE36_MAP[random.nextInt(36)]);

--- a/mail/common/src/test/java/com/fsck/k9/mail/BoundaryGeneratorTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/BoundaryGeneratorTest.java
@@ -19,7 +19,7 @@ public class BoundaryGeneratorTest {
 
         String result = boundaryGenerator.generateBoundary();
 
-        assertEquals("----000000000000000000000000000000", result);
+        assertEquals("----==000000000000000000000000000000", result);
     }
 
     @Test
@@ -30,7 +30,7 @@ public class BoundaryGeneratorTest {
 
         String result = boundaryGenerator.generateBoundary();
 
-        assertEquals("----0123456789ABCDEFGHIJKLMNOPQRSZ", result);
+        assertEquals("----==0123456789ABCDEFGHIJKLMNOPQRSZ", result);
     }
 
     private Random createRandom(int... values) {


### PR DESCRIPTION
The easiest way to accomplish this is to include "=" characters in the boundary string.

Before:
```
Content-Type: multipart/alternative;
 boundary=----AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
```

After:
```
Content-Type: multipart/alternative;
 boundary="----==AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
```

Aside from header field ordering, this is the only noticeable change between messages created by K-9 Mail 5.600 and those created by K-9 Mail 5.800. 

Waiting for feedback to see if this fixes the issue some users are experiencing. See https://forum.k9mail.app/t/5-8-showing-as-sent-but-not-always-arriving-at-destination/2481