### PR TITLE
Show scrollbar in manage folders and choose folder lists

### DIFF
--- a/app/ui/legacy/src/main/res/layout/folder_list.xml
+++ b/app/ui/legacy/src/main/res/layout/folder_list.xml
@@ -13,6 +13,7 @@
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1"
+        android:scrollbars="vertical"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:listitem="@layout/folder_list_item" />
 

--- a/app/ui/legacy/src/main/res/layout/fragment_manage_folders.xml
+++ b/app/ui/legacy/src/main/res/layout/fragment_manage_folders.xml
@@ -5,5 +5,6 @@
     android:id="@+id/folderList"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:scrollbars="vertical"
     app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
     tools:listitem="@layout/folder_list_item" />


### PR DESCRIPTION

Fixes #5438. The scrollbar will show while scrolling and fade when idle.

I noticed the scrollbar was not showing in `ManageFoldersFragment` either, so I added it there too.

---

<img src="https://user-images.githubusercontent.com/47775302/129386767-7a7e4ab9-0d42-42c7-ab2f-3be3af146579.png" width="400">



