### PR TITLE
Upgrade to targetSkdVersion 30

### DIFF
--- a/app/ui/legacy/src/main/AndroidManifest.xml
+++ b/app/ui/legacy/src/main/AndroidManifest.xml
@@ -1,2 +1,43 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.fsck.k9.ui" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.fsck.k9.ui">
+
+    <queries>
+        <intent>
+            <!-- Used to check whether to display the "Add from Contacts" menu item in the compose screen -->
+            <action android:name="android.intent.action.PICK" />
+            <data
+                android:mimeType="*/*"
+                android:scheme="content"
+                android:host="com.android.contacts" />
+        </intent>
+
+        <intent>
+            <!-- Used by AttachmentController to find the best Intent to view an attachment -->
+            <action android:name="android.intent.action.VIEW" />
+            <data
+                android:mimeType="*/*"
+                android:scheme="content" />
+        </intent>
+
+        <intent>
+            <!-- Used by the OpenPGP API -->
+            <action android:name="org.openintents.openpgp.IOpenPgpService2" />
+        </intent>
+
+        <intent>
+            <!-- Used by OpenPgpAppSelectDialog -->
+            <action android:name="android.intent.action.VIEW" />
+            <data
+                android:mimeType="*/*"
+                android:scheme="market"
+                android:host="details" />
+        </intent>
+
+        <intent>
+            <!-- Used by OpenPgpAppSelectDialog -->
+            <action android:name="org.openintents.openpgp.IOpenPgpService" />
+        </intent>
+    </queries>
+
+</manifest>

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptKeyTransferActivity.kt
@@ -62,8 +62,8 @@ class AutocryptKeyTransferActivity : K9Activity() {
         presenter.initFromIntent(accountUuid)
     }
 
-    override fun onOptionsItemSelected(item: MenuItem?): Boolean {
-        if (item?.itemId == android.R.id.home) {
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
             presenter.onClickHome()
             return true
         } else {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupMessageLiveEvent.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/endtoend/AutocryptSetupMessageLiveEvent.kt
@@ -34,7 +34,7 @@ class AutocryptSetupMessageLiveEvent(val messageCreator: AutocryptTransferMessag
         val result = openPgpApi.executeApi(intent, null as InputStream?, baos)
 
         val keyData = baos.toByteArray()
-        val pi: PendingIntent = result.getParcelableExtra(OpenPgpApi.RESULT_INTENT)
+        val pi: PendingIntent = result.getParcelableExtra(OpenPgpApi.RESULT_INTENT) ?: error("Missing result intent")
 
         val setupMessage = messageCreator.createAutocryptTransferMessage(keyData, address)
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,11 +3,11 @@ import org.jetbrains.kotlin.gradle.dsl.KotlinCompile
 buildscript {
     ext {
         buildConfig = [
-                'compileSdk': 29,
-                'targetSdk': 29,
+                'compileSdk': 30,
+                'targetSdk': 30,
                 'minSdk': 21,
-                'buildTools': '29.0.3',
-                'robolectricSdk': 29
+                'buildTools': '30.0.3',
+                'robolectricSdk': 30
         ]
 
         versions = [


### PR DESCRIPTION
Increase `compileSdkVersion` and `targetSdkVersion` to 30. 

Add the necessary `<queries>` element to the manifest necessary due to the [package visibility](https://developer.android.com/training/package-visibility) changes in Android 11.