### PR TITLE
Add setting to suppress notifications for chat messages

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -119,6 +119,7 @@ public class Account implements BaseAccount {
     private FolderMode folderNotifyNewMailMode;
     private boolean notifySelfNewMail;
     private boolean notifyContactsMailOnly;
+    private boolean ignoreChatMessages;
     private String legacyInboxFolder;
     private String importedDraftsFolder;
     private String importedSentFolder;
@@ -678,6 +679,14 @@ public class Account implements BaseAccount {
 
     public synchronized void setNotifyContactsMailOnly(boolean notifyContactsMailOnly) {
         this.notifyContactsMailOnly = notifyContactsMailOnly;
+    }
+
+    public synchronized boolean isIgnoreChatMessages() {
+        return ignoreChatMessages;
+    }
+
+    public synchronized void setIgnoreChatMessages(boolean ignoreChatMessages) {
+        this.ignoreChatMessages = ignoreChatMessages;
     }
 
     public synchronized Expunge getExpungePolicy() {

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -51,6 +51,7 @@ class AccountPreferenceSerializer(
             folderNotifyNewMailMode = getEnumStringPref<FolderMode>(storage, "$accountUuid.folderNotifyNewMailMode", FolderMode.ALL)
             isNotifySelfNewMail = storage.getBoolean("$accountUuid.notifySelfNewMail", true)
             isNotifyContactsMailOnly = storage.getBoolean("$accountUuid.notifyContactsMailOnly", false)
+            isIgnoreChatMessages = storage.getBoolean("$accountUuid.ignoreChatMessages", false)
             isNotifySync = storage.getBoolean("$accountUuid.notifyMailCheck", false)
             deletePolicy = DeletePolicy.fromInt(storage.getInt("$accountUuid.deletePolicy", DeletePolicy.NEVER.setting))
             legacyInboxFolder = storage.getString("$accountUuid.inboxFolderName", null)
@@ -256,6 +257,7 @@ class AccountPreferenceSerializer(
             editor.putString("$accountUuid.folderNotifyNewMailMode", folderNotifyNewMailMode.name)
             editor.putBoolean("$accountUuid.notifySelfNewMail", isNotifySelfNewMail)
             editor.putBoolean("$accountUuid.notifyContactsMailOnly", isNotifyContactsMailOnly)
+            editor.putBoolean("$accountUuid.ignoreChatMessages", isIgnoreChatMessages)
             editor.putBoolean("$accountUuid.notifyMailCheck", isNotifySync)
             editor.putInt("$accountUuid.deletePolicy", deletePolicy.setting)
             editor.putString("$accountUuid.inboxFolderName", legacyInboxFolder)
@@ -379,6 +381,7 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.lastAutomaticCheckTime")
         editor.remove("$accountUuid.notifyNewMail")
         editor.remove("$accountUuid.notifySelfNewMail")
+        editor.remove("$accountUuid.ignoreChatMessages")
         editor.remove("$accountUuid.deletePolicy")
         editor.remove("$accountUuid.draftsFolderName")
         editor.remove("$accountUuid.sentFolderName")
@@ -551,6 +554,7 @@ class AccountPreferenceSerializer(
             isNotifySync = false
             isNotifySelfNewMail = true
             isNotifyContactsMailOnly = false
+            isIgnoreChatMessages = false
             folderDisplayMode = FolderMode.NOT_SECOND_CLASS
             folderSyncMode = FolderMode.FIRST_CLASS
             folderPushMode = FolderMode.NONE

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -261,6 +261,9 @@ public class AccountSettingsDescriptions {
         s.put("trashFolderSelection", Settings.versions(
                 new V(54, new EnumSetting<>(SpecialFolderSelection.class, SpecialFolderSelection.AUTOMATIC))
         ));
+        s.put("ignoreChatMessages", Settings.versions(
+                new V(76, new BooleanSetting(false))
+        ));
         // note that there is no setting for openPgpProvider, because this will have to be set up together
         // with the actual provider after import anyways.
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 75;
+    public static final int VERSION = 76;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationStrategy.kt
@@ -4,6 +4,8 @@ import com.fsck.k9.Account
 import com.fsck.k9.K9
 import com.fsck.k9.helper.Contacts
 import com.fsck.k9.mail.Flag
+import com.fsck.k9.mail.K9MailLib
+import com.fsck.k9.mail.Message
 import com.fsck.k9.mailstore.LocalFolder
 import com.fsck.k9.mailstore.LocalFolder.isModeMismatch
 import com.fsck.k9.mailstore.LocalMessage
@@ -80,6 +82,11 @@ class K9NotificationStrategy(private val contacts: Contacts) : NotificationStrat
             return false
         }
 
+        if (account.isIgnoreChatMessages && message.isChatMessage) {
+            Timber.v("No notification: Notifications for chat messages are disabled")
+            return false
+        }
+
         if (!account.isNotifySelfNewMail && account.isAnIdentity(message.from)) {
             Timber.v("No notification: Notifications for messages from yourself are disabled")
             return false
@@ -92,4 +99,7 @@ class K9NotificationStrategy(private val contacts: Contacts) : NotificationStrat
 
         return true
     }
+
+    private val Message.isChatMessage: Boolean
+        get() = getHeader(K9MailLib.CHAT_HEADER).isNotEmpty()
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -37,6 +37,7 @@ class AccountSettingsDataStore(
             "remote_search_enabled" -> account.isAllowRemoteSearch
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual
             "upload_sent_messages" -> account.isUploadSentMessages
+            "ignore_chat_messages" -> account.isIgnoreChatMessages
             else -> defValue
         }
     }
@@ -69,6 +70,7 @@ class AccountSettingsDataStore(
             "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts = value
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual = value
             "upload_sent_messages" -> account.isUploadSentMessages = value
+            "ignore_chat_messages" -> account.isIgnoreChatMessages = value
             else -> return
         }
 

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -517,6 +517,8 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_notify_self_summary">Show a notification for messages I sent</string>
     <string name="account_notify_contacts_mail_only_label">Contacts only</string>
     <string name="account_notify_contacts_mail_only_summary">Show notifications only for messages from known contacts</string>
+    <string name="account_settings_ignore_chat_messages_label">Ignore chat messages</string>
+    <string name="account_settings_ignore_chat_messages_summary">Don\'t show notifications for messages belonging to an email chat</string>
     <string name="account_settings_mark_message_as_read_on_view_label">Mark as read when opened</string>
     <string name="account_settings_mark_message_as_read_on_view_summary">Mark a message as read when it is opened for viewing</string>
     <string name="account_settings_mark_message_as_read_on_delete_label">Mark as read when deleted</string>

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -327,6 +327,13 @@
             android:summary="@string/account_notify_contacts_mail_only_summary"
             android:title="@string/account_notify_contacts_mail_only_label" />
 
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:dependency="account_notify"
+            android:key="ignore_chat_messages"
+            android:summary="@string/account_settings_ignore_chat_messages_summary"
+            android:title="@string/account_settings_ignore_chat_messages_label" />
+
         <com.takisoft.preferencex.RingtonePreference
             android:defaultValue="content://settings/system/notification_sound"
             android:dependency="account_notify"

--- a/mail/common/src/main/java/com/fsck/k9/mail/K9MailLib.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/K9MailLib.java
@@ -9,6 +9,7 @@ public class K9MailLib {
 
     public static final int PUSH_WAKE_LOCK_TIMEOUT = 60000;
     public static final String IDENTITY_HEADER = "X-K9mail-Identity";
+    public static final String CHAT_HEADER = "Chat-Version";
 
     /**
      * Should K-9 log the conversation it has over the wire with

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapFolder.kt
@@ -540,7 +540,8 @@ internal class RealImapFolder(
             fetchFields.add("RFC822.SIZE")
             fetchFields.add(
                 "BODY.PEEK[HEADER.FIELDS (date subject from content-type to cc " +
-                    "reply-to message-id references in-reply-to " + K9MailLib.IDENTITY_HEADER + ")]"
+                    "reply-to message-id references in-reply-to " +
+                    K9MailLib.IDENTITY_HEADER + " " + K9MailLib.CHAT_HEADER + ")]"
             )
         }
 

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/RealImapFolderTest.kt
@@ -692,7 +692,8 @@ class RealImapFolderTest {
 
         verify(imapConnection).sendCommand(
             "UID FETCH 1 (UID INTERNALDATE RFC822.SIZE BODY.PEEK[HEADER.FIELDS " +
-                "(date subject from content-type to cc reply-to message-id references in-reply-to X-K9mail-Identity)])",
+                "(date subject from content-type to cc reply-to message-id references in-reply-to " +
+                "X-K9mail-Identity Chat-Version)])",
             false
         )
     }


### PR DESCRIPTION
Messages containing a 'Chat-Version' header field will not generate notifications when this setting is enabled.

<img src="https://user-images.githubusercontent.com/218061/129485946-70abfb68-5c65-4120-857c-4cb1f3e73199.png" alt="k9mail__account_settings__ignore_chat_messages" width=300>

Closes #3471