### PR TITLE
Don't connect to server when incoming/outgoing server passwords are missing

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -64,6 +64,7 @@ import com.fsck.k9.mail.MessageDownloadState;
 import com.fsck.k9.mail.MessageRetrievalListener;
 import com.fsck.k9.mail.MessagingException;
 import com.fsck.k9.mail.Part;
+import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
@@ -390,6 +391,12 @@ public class MessagingController {
 
     public void refreshFolderListSynchronous(Account account) {
         try {
+            ServerSettings serverSettings = account.getIncomingServerSettings();
+            if (serverSettings.password == null) {
+                handleAuthenticationFailure(account, true);
+                return;
+            }
+
             Backend backend = getBackend(account);
             backend.refreshFolderList();
 
@@ -643,6 +650,12 @@ public class MessagingController {
     }
 
     private void syncFolder(Account account, long folderId, MessagingListener listener, Backend backend) {
+        ServerSettings serverSettings = account.getIncomingServerSettings();
+        if (serverSettings.password == null) {
+            handleAuthenticationFailure(account, true);
+            return;
+        }
+
         Exception commandException = null;
         try {
             processPendingCommandsSynchronous(account);
@@ -1498,6 +1511,12 @@ public class MessagingController {
         Exception lastFailure = null;
         boolean wasPermanentFailure = false;
         try {
+            ServerSettings serverSettings = account.getOutgoingServerSettings();
+            if (serverSettings.password == null) {
+                handleAuthenticationFailure(account, false);
+                return;
+            }
+
             LocalStore localStore = localStoreProvider.getInstance(account);
             OutboxStateRepository outboxStateRepository = localStore.getOutboxStateRepository();
             LocalFolder localFolder = localStore.getFolder(account.getOutboxFolderId());

--- a/app/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/MailSyncWorker.kt
@@ -39,6 +39,11 @@ class MailSyncWorker(
             return Result.success()
         }
 
+        if (account.incomingServerSettings.password == null) {
+            Timber.d("Password for this account is missing. Skipping mail sync.")
+            return Result.success()
+        }
+
         val success = messagingController.performPeriodicMailSync(account)
 
         return if (success) Result.success() else Result.retry()

--- a/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/app/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -14,11 +14,14 @@ import com.fsck.k9.K9RobolectricTest;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.backend.BackendManager;
 import com.fsck.k9.backend.api.Backend;
+import com.fsck.k9.mail.AuthType;
 import com.fsck.k9.mail.AuthenticationFailedException;
 import com.fsck.k9.mail.CertificateValidationException;
+import com.fsck.k9.mail.ConnectionSecurity;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.MessageRetrievalListener;
 import com.fsck.k9.mail.MessagingException;
+import com.fsck.k9.mail.ServerSettings;
 import com.fsck.k9.mailstore.LocalFolder;
 import com.fsck.k9.mailstore.LocalMessage;
 import com.fsck.k9.mailstore.LocalStore;
@@ -31,6 +34,7 @@ import com.fsck.k9.mailstore.SendState;
 import com.fsck.k9.mailstore.UnavailableStorageException;
 import com.fsck.k9.notification.NotificationController;
 import com.fsck.k9.notification.NotificationStrategy;
+import com.fsck.k9.preferences.Protocols;
 import com.fsck.k9.search.LocalSearch;
 import com.fsck.k9.search.SearchAccount;
 import org.jetbrains.annotations.NotNull;
@@ -441,6 +445,10 @@ public class MessagingControllerTest extends K9RobolectricTest {
         account = preferences.newAccount();
         accountUuid = account.getUuid();
 
+        account.setIncomingServerSettings(new ServerSettings(Protocols.IMAP, "host", 993,
+                ConnectionSecurity.SSL_TLS_REQUIRED, AuthType.PLAIN, "username", "password", null));
+        account.setOutgoingServerSettings(new ServerSettings(Protocols.SMTP, "host", 465,
+                ConnectionSecurity.SSL_TLS_REQUIRED, AuthType.PLAIN, "username", "password", null));
         account.setMaximumAutoDownloadMessageSize(MAXIMUM_SMALL_MESSAGE_SIZE);
         account.setEmail("user@host.com");
     }


### PR DESCRIPTION
If a user imports an account but doesn't provide server passwords, don't attempt to connect to the incoming or outgoing server of that account.

Fixes #5576