### PR TITLE
Fix ServerSettings.isMissingCredentials

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/ServerSettings.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/ServerSettings.kt
@@ -18,7 +18,7 @@ data class ServerSettings @JvmOverloads constructor(
 ) {
     val isMissingCredentials: Boolean = when (authenticationType) {
         AuthType.EXTERNAL -> clientCertificateAlias == null
-        else -> password == null
+        else -> username.isNotBlank() && password == null
     }
 
     init {


### PR DESCRIPTION
We support SMTP without authentication and in that case set the username to the empty string :cry: 

See https://forum.k9mail.app/t/tls-client-certificate-auth-for-smtp-stopped-working-with-v5-805/2951

Fixes #5613