### PR TITLE
Unified inbox: Show starred and unread message counts

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -55,7 +55,8 @@ import com.mikepenz.materialdrawer.util.getDrawerItem
 import com.mikepenz.materialdrawer.util.removeAllItems
 import com.mikepenz.materialdrawer.widget.AccountHeaderView
 import com.mikepenz.materialdrawer.widget.MaterialDrawerSliderView
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.component.KoinComponent
@@ -97,6 +98,7 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
     private var unifiedInboxSelected: Boolean = false
     private var unifiedInboxDrawerItem: PrimaryDrawerItem? = null
     private val unifiedInboxMessageCounts = MutableLiveData<MessageCounts>()
+    private val coroutineScope: CoroutineScope = CoroutineScope(Dispatchers.Default)
 
     private val textColor: Int
     private var selectedTextColor: ColorStateList? = null
@@ -171,7 +173,7 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
 
     private fun unifiedInboxRefresh() {
         if (K9.isShowUnifiedInbox) {
-            GlobalScope.launch {
+            coroutineScope.launch {
                 unifiedInboxRefreshInner()
             }
         }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -170,8 +170,11 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
     }
 
     private fun unifiedInboxRefresh() {
-        GlobalScope.launch {
-            unifiedInboxMessageCounts.postValue(messageCountsProvider.getMessageCounts(SearchAccount.createUnifiedInboxAccount()))
+        if (K9.isShowUnifiedInbox) {
+            GlobalScope.launch {
+                unifiedInboxMessageCounts.postValue(
+                    messageCountsProvider.getMessageCounts(SearchAccount.createUnifiedInboxAccount()))
+            }
         }
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -172,11 +172,16 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
     private fun unifiedInboxRefresh() {
         if (K9.isShowUnifiedInbox) {
             GlobalScope.launch {
-                unifiedInboxMessageCounts.postValue(
-                    messageCountsProvider.getMessageCounts(SearchAccount.createUnifiedInboxAccount())
-                )
+                unifiedInboxRefreshInner()
             }
         }
+    }
+
+    @Synchronized
+    private fun unifiedInboxRefreshInner() {
+        unifiedInboxMessageCounts.postValue(
+            messageCountsProvider.getMessageCounts(SearchAccount.createUnifiedInboxAccount())
+        )
     }
 
     private fun initializeImageLoader() {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -173,7 +173,8 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
         if (K9.isShowUnifiedInbox) {
             GlobalScope.launch {
                 unifiedInboxMessageCounts.postValue(
-                    messageCountsProvider.getMessageCounts(SearchAccount.createUnifiedInboxAccount()))
+                    messageCountsProvider.getMessageCounts(SearchAccount.createUnifiedInboxAccount())
+                )
             }
         }
     }


### PR DESCRIPTION
Navigation drawer Unified Inbox was showing neither the unread message count (#5443), nor the starred message count (#5519).

This PR resolves that.

Signed-off-by: Andrew Fiddian-Green <software@whitebear.ch>

![image](https://user-images.githubusercontent.com/893994/131245347-5bd15968-5e48-4164-9ac2-f3a0df9e7580.png)

