### PR TITLE
update providers to add 2 of the domains offered by Mailo

### DIFF
--- a/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
+++ b/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
@@ -284,6 +284,16 @@
         <outgoing uri="smtp+ssl+://smtp.virginmedia.com" username="$email" />
     </provider>
     
+    <!-- France -->
+    <provider id="mailo.com" label="mailo.com" domain="mailo.com*">
+        <incoming uri="imap+tls+://mail.mailo.com" username="$email" />
+        <outgoing uri="smtp+tls+://mail.mailo.com" username="$email" />
+    </provider>
+    <provider id="net-c.fr" label="net-c.fr" domain="net-c.fr*">
+        <incoming uri="imap+tls+://mail.mailo.com" username="$email" />
+        <outgoing uri="smtp+tls+://mail.mailo.com" username="$email" />
+    </provider>
+
     <!-- Germany -->
     <provider id="mailbox.org" label="mailbox.org" domain="mailbox.org">
         <incoming uri="imap+tls+://imap.mailbox.org" username="$email" />


### PR DESCRIPTION
Updated `app/autodiscovery/providersxml/src/main/res/xml/providers.xml` to add details for Mailo.com.