### PR TITLE
Add Mailo.com as a provider

### DIFF
--- a/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
+++ b/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
@@ -284,6 +284,16 @@
         <outgoing uri="smtp+ssl+://smtp.virginmedia.com" username="$email" />
     </provider>
     
+    <!-- France -->
+    <provider id="mailo.com" label="mailo.com" domain="mailo.com*">
+        <incoming uri="imap+tls+://mail.mailo.com" username="$email" />
+        <outgoing uri="smtp+tls+://mail.mailo.com" username="$email" />
+    </provider>
+    <provider id="net-c.fr" label="net-c.fr" domain="net-c.fr*">
+        <incoming uri="imap+tls+://mail.mailo.com" username="$email" />
+        <outgoing uri="smtp+tls+://mail.mailo.com" username="$email" />
+    </provider>
+
     <!-- Germany -->
     <provider id="mailbox.org" label="mailbox.org" domain="mailbox.org">
         <incoming uri="imap+tls+://imap.mailbox.org" username="$email" />

--- a/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
+++ b/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
@@ -285,11 +285,11 @@
     </provider>
     
     <!-- France -->
-    <provider id="mailo.com" label="mailo.com" domain="mailo.com*">
+    <provider id="mailo.com" label="mailo.com" domain="mailo.com">
         <incoming uri="imap+tls+://mail.mailo.com" username="$email" />
         <outgoing uri="smtp+tls+://mail.mailo.com" username="$email" />
     </provider>
-    <provider id="net-c.fr" label="net-c.fr" domain="net-c.fr*">
+    <provider id="net-c.fr" label="net-c.fr" domain="net-c.fr">
         <incoming uri="imap+tls+://mail.mailo.com" username="$email" />
         <outgoing uri="smtp+tls+://mail.mailo.com" username="$email" />
     </provider>

--- a/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
+++ b/app/autodiscovery/providersxml/src/main/res/xml/providers.xml
@@ -286,12 +286,12 @@
     
     <!-- France -->
     <provider id="mailo.com" label="mailo.com" domain="mailo.com">
-        <incoming uri="imap+tls+://mail.mailo.com" username="$email" />
-        <outgoing uri="smtp+tls+://mail.mailo.com" username="$email" />
+        <incoming uri="imap+ssl+://mail.mailo.com" username="$email" />
+        <outgoing uri="smtp+ssl+://mail.mailo.com" username="$email" />
     </provider>
     <provider id="net-c.fr" label="net-c.fr" domain="net-c.fr">
-        <incoming uri="imap+tls+://mail.mailo.com" username="$email" />
-        <outgoing uri="smtp+tls+://mail.mailo.com" username="$email" />
+        <incoming uri="imap+ssl+://mail.mailo.com" username="$email" />
+        <outgoing uri="smtp+ssl+://mail.mailo.com" username="$email" />
     </provider>
 
     <!-- Germany -->


### PR DESCRIPTION
Updated `app/autodiscovery/providersxml/src/main/res/xml/providers.xml` to add two of the sub-domains for Mailo.com.