### PR TITLE
When switching accounts don't update accounts and folders in drawer twice

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -168,7 +168,6 @@ class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : K
             val account = (profile as ProfileDrawerItem).tag as Account
             openedAccountUuid = account.uuid
             val eventHandled = !parent.openRealAccount(account)
-            updateUserAccountsAndFolders(account)
             updateButtonBarVisibility(false)
 
             eventHandled


### PR DESCRIPTION
`MessageList.onNewIntent()` will call `K9Drawer.updateUserAccountsAndFolders()`