### PR TITLE
Replace Account.setRingNotified() mechanism

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -158,9 +158,6 @@ public class Account implements BaseAccount {
     private boolean subscribedFoldersOnly;
     private int maximumPolledMessageAge;
     private int maximumAutoDownloadMessageSize;
-    // Tracks if we have sent a notification for this account for
-    // current set of fetched messages
-    private boolean ringNotified;
     private MessageFormat messageFormat;
     private boolean messageFormatAuto;
     private boolean messageReadReceipt;
@@ -315,15 +312,6 @@ public class Account implements BaseAccount {
 
     public synchronized void setAlwaysBcc(String alwaysBcc) {
         this.alwaysBcc = alwaysBcc;
-    }
-
-    /* Have we sent a new mail notification on this account */
-    public boolean isRingNotified() {
-        return ringNotified;
-    }
-
-    public void setRingNotified(boolean ringNotified) {
-        this.ringNotified = ringNotified;
     }
 
     public String getLocalStorageProviderId() {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -594,19 +594,17 @@ public class MessagingController {
      */
     public void synchronizeMailbox(Account account, long folderId, MessagingListener listener) {
         putBackground("synchronizeMailbox", listener, () ->
-                synchronizeMailboxSynchronous(account, folderId, listener)
+                synchronizeMailboxSynchronous(account, folderId, listener, new NotificationState())
         );
     }
 
     public void synchronizeMailboxBlocking(Account account, String folderServerId) {
         long folderId = getFolderId(account, folderServerId);
 
-        account.setRingNotified(false);
-
         final CountDownLatch latch = new CountDownLatch(1);
         putBackground("synchronizeMailbox", null, () -> {
             try {
-                synchronizeMailboxSynchronous(account, folderId, null);
+                synchronizeMailboxSynchronous(account, folderId, null, new NotificationState());
             } finally {
                 latch.countDown();
             }
@@ -626,11 +624,12 @@ public class MessagingController {
      * TODO Break this method up into smaller chunks.
      */
     @VisibleForTesting
-    void synchronizeMailboxSynchronous(Account account, long folderId, MessagingListener listener) {
+    void synchronizeMailboxSynchronous(Account account, long folderId, MessagingListener listener,
+            NotificationState notificationState) {
         refreshFolderListIfStale(account);
 
         Backend backend = getBackend(account);
-        syncFolder(account, folderId, listener, backend);
+        syncFolder(account, folderId, listener, backend, notificationState);
     }
 
     private void refreshFolderListIfStale(Account account) {
@@ -645,7 +644,8 @@ public class MessagingController {
         }
     }
 
-    private void syncFolder(Account account, long folderId, MessagingListener listener, Backend backend) {
+    private void syncFolder(Account account, long folderId, MessagingListener listener, Backend backend,
+            NotificationState notificationState) {
         ServerSettings serverSettings = account.getIncomingServerSettings();
         if (serverSettings.isMissingCredentials()) {
             handleAuthenticationFailure(account, true);
@@ -681,7 +681,8 @@ public class MessagingController {
 
         String folderServerId = localFolder.getServerId();
         SyncConfig syncConfig = createSyncConfig(account);
-        ControllerSyncListener syncListener = new ControllerSyncListener(account, listener, suppressNotifications);
+        ControllerSyncListener syncListener =
+                new ControllerSyncListener(account, listener, suppressNotifications, notificationState);
 
         backend.sync(folderServerId, syncConfig, syncListener);
 
@@ -2376,7 +2377,7 @@ public class MessagingController {
 
         Timber.i("Synchronizing account %s", account.getDescription());
 
-        account.setRingNotified(false);
+        NotificationState notificationState = new NotificationState();
 
         sendPendingMessages(account, listener);
 
@@ -2416,7 +2417,7 @@ public class MessagingController {
 
                     continue;
                 }
-                synchronizeFolder(account, folder, ignoreLastCheckedTime, listener);
+                synchronizeFolder(account, folder, ignoreLastCheckedTime, listener, notificationState);
             }
         } catch (MessagingException e) {
             Timber.e(e, "Unable to synchronize account %s", account.getName());
@@ -2426,7 +2427,6 @@ public class MessagingController {
                         public void run() {
                             Timber.v("Clearing notification flag for %s", account.getDescription());
 
-                            account.setRingNotified(false);
                             if (getUnreadMessageCount(account) == 0) {
                                 notificationController.clearNewMailNotifications(account);
                             }
@@ -2439,14 +2439,14 @@ public class MessagingController {
     }
 
     private void synchronizeFolder(Account account, LocalFolder folder, boolean ignoreLastCheckedTime,
-            MessagingListener listener) {
+            MessagingListener listener, NotificationState notificationState) {
         putBackground("sync" + folder.getServerId(), null, () -> {
-            synchronizeFolderInBackground(account, folder, ignoreLastCheckedTime, listener);
+            synchronizeFolderInBackground(account, folder, ignoreLastCheckedTime, listener, notificationState);
         });
     }
 
     private void synchronizeFolderInBackground(Account account, LocalFolder folder, boolean ignoreLastCheckedTime,
-            MessagingListener listener) {
+            MessagingListener listener, NotificationState notificationState) {
         Timber.v("Folder %s was last synced @ %tc", folder.getServerId(), folder.getLastChecked());
 
         if (!ignoreLastCheckedTime) {
@@ -2469,7 +2469,7 @@ public class MessagingController {
         try {
             showFetchingMailNotificationIfNecessary(account, folder);
             try {
-                synchronizeMailboxSynchronous(account, folder.getDatabaseId(), listener);
+                synchronizeMailboxSynchronous(account, folder.getDatabaseId(), listener, notificationState);
             } finally {
                 clearFetchingMailNotificationIfNecessary(account);
             }
@@ -2658,13 +2658,16 @@ public class MessagingController {
         private final LocalStore localStore;
         private final int previousUnreadMessageCount;
         private final boolean suppressNotifications;
+        private final NotificationState notificationState;
         boolean syncFailed = false;
 
 
-        ControllerSyncListener(Account account, MessagingListener listener, boolean suppressNotifications) {
+        ControllerSyncListener(Account account, MessagingListener listener, boolean suppressNotifications,
+                NotificationState notificationState) {
             this.account = account;
             this.listener = listener;
             this.suppressNotifications = suppressNotifications;
+            this.notificationState = notificationState;
             this.localStore = getLocalStoreOrThrow(account);
 
             previousUnreadMessageCount = getUnreadMessageCount(account);
@@ -2725,7 +2728,9 @@ public class MessagingController {
                     notificationStrategy.shouldNotifyForMessage(account, localFolder, message, isOldMessage)) {
                 Timber.v("Creating notification for message %s:%s", localFolder.getName(), message.getUid());
                 // Notify with the localMessage so that we don't have to recalculate the content preview.
-                notificationController.addNewMailNotification(account, message, previousUnreadMessageCount);
+                boolean silent = notificationState.wasNotified();
+                notificationController.addNewMailNotification(account, message, previousUnreadMessageCount, silent);
+                notificationState.setWasNotified(true);
             }
 
             if (!message.isSet(Flag.SEEN)) {

--- a/app/core/src/main/java/com/fsck/k9/controller/NotificationState.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/NotificationState.kt
@@ -1,0 +1,6 @@
+package com.fsck.k9.controller
+
+class NotificationState {
+    @get:JvmName("wasNotified")
+    var wasNotified: Boolean = false
+}

--- a/app/core/src/main/java/com/fsck/k9/notification/MessageSummaryNotifications.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/MessageSummaryNotifications.kt
@@ -45,12 +45,6 @@ internal open class MessageSummaryNotifications(
 
         lockScreenNotification.configureLockScreenNotification(builder, notificationData)
 
-        var ringAndVibrate = false
-        if (!silent && !account.isRingNotified) {
-            account.isRingNotified = true
-            ringAndVibrate = true
-        }
-
         val notificationSetting = account.notificationSetting
         notificationHelper.configureNotification(
             builder = builder,
@@ -58,7 +52,7 @@ internal open class MessageSummaryNotifications(
             vibrationPattern = if (notificationSetting.isVibrateEnabled) notificationSetting.vibration else null,
             ledColor = if (notificationSetting.isLedEnabled) notificationSetting.ledColor else null,
             ledSpeed = NotificationHelper.NOTIFICATION_LED_BLINK_SLOW,
-            ringAndVibrate = ringAndVibrate
+            ringAndVibrate = !silent
         )
 
         return builder.build()

--- a/app/core/src/main/java/com/fsck/k9/notification/NewMailNotifications.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NewMailNotifications.kt
@@ -19,7 +19,7 @@ internal open class NewMailNotifications(
     private val notifications = SparseArray<NotificationData>()
     private val lock = Any()
 
-    fun addNewMailNotification(account: Account, message: LocalMessage, unreadMessageCount: Int) {
+    fun addNewMailNotification(account: Account, message: LocalMessage, unreadMessageCount: Int, silent: Boolean) {
         val content = contentCreator.createFromMessage(account, message)
 
         synchronized(lock) {
@@ -32,7 +32,7 @@ internal open class NewMailNotifications(
             }
 
             createSingleMessageNotification(account, result.notificationHolder)
-            createSummaryNotification(account, notificationData, false)
+            createSummaryNotification(account, notificationData, silent)
         }
     }
 
@@ -99,7 +99,7 @@ internal open class NewMailNotifications(
         if (notificationData.newMessagesCount == 0) {
             clearNewMailNotifications(account)
         } else {
-            createSummaryNotification(account, notificationData, true)
+            createSummaryNotification(account, notificationData, silent = true)
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationController.kt
@@ -52,8 +52,13 @@ class NotificationController internal constructor(
         syncNotifications.clearFetchingMailNotification(account)
     }
 
-    fun addNewMailNotification(account: Account, message: LocalMessage, previousUnreadMessageCount: Int) {
-        newMailNotifications.addNewMailNotification(account, message, previousUnreadMessageCount)
+    fun addNewMailNotification(
+        account: Account,
+        message: LocalMessage,
+        previousUnreadMessageCount: Int,
+        silent: Boolean
+    ) {
+        newMailNotifications.addNewMailNotification(account, message, previousUnreadMessageCount, silent)
     }
 
     fun removeNewMailNotification(account: Account, messageReference: MessageReference) {

--- a/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.kt
@@ -49,7 +49,7 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         addToSingleMessageNotifications(holder, singleMessageNotification)
         addToSummaryNotifications(summaryNotification)
 
-        newMailNotifications.addNewMailNotification(account, message, 42)
+        newMailNotifications.addNewMailNotification(account, message, 42, silent = false)
 
         val singleMessageNotificationId = NotificationIds.getSingleMessageNotificationId(account, notificationIndex)
         verify(notificationManager).notify(singleMessageNotificationId, singleMessageNotification)
@@ -70,7 +70,7 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         addToSingleMessageNotifications(holder, singleMessageNotification)
         addToSummaryNotifications(summaryNotification)
 
-        newMailNotifications.addNewMailNotification(account, message, 42)
+        newMailNotifications.addNewMailNotification(account, message, 42, silent = false)
 
         val singleMessageNotificationId = NotificationIds.getSingleMessageNotificationId(account, notificationIndex)
         verify(notificationManager).notify(singleMessageNotificationId, singleMessageNotification)
@@ -91,7 +91,7 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         val singleMessageNotification = createNotification()
         addToSummaryNotifications(singleMessageNotification)
 
-        newMailNotifications.addNewMailNotification(account, message, 42)
+        newMailNotifications.addNewMailNotification(account, message, 42, silent = false)
 
         val singleMessageNotificationId = NotificationIds.getSingleMessageNotificationId(account, notificationIndex)
         val summaryNotificationId = NotificationIds.getNewMailSummaryNotificationId(account)
@@ -120,8 +120,8 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         addToSingleMessageNotifications(holderTwo, singleMessageNotificationTwo)
         addToSummaryNotifications(summaryNotification)
 
-        newMailNotifications.addNewMailNotification(account, messageOne, 42)
-        newMailNotifications.addNewMailNotification(account, messageTwo, 42)
+        newMailNotifications.addNewMailNotification(account, messageOne, 42, silent = false)
+        newMailNotifications.addNewMailNotification(account, messageTwo, 42, silent = false)
 
         val singleMessageNotificationIdOne = NotificationIds.getSingleMessageNotificationId(account, notificationIndexOne)
         verify(notificationManager).notify(singleMessageNotificationIdOne, singleMessageNotificationOne)
@@ -152,7 +152,7 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         whenAddingContentReturn(content, AddNotificationResult.newNotification(holder))
         val summaryNotification = createNotification()
         addToSummaryNotifications(summaryNotification)
-        newMailNotifications.addNewMailNotification(account, message, 23)
+        newMailNotifications.addNewMailNotification(account, message, 23, silent = false)
         whenRemovingContentReturn(messageReference, RemoveNotificationResult.unknownNotification())
 
         newMailNotifications.removeNewMailNotification(account, messageReference)
@@ -173,7 +173,7 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         whenAddingContentReturn(content, AddNotificationResult.newNotification(holder))
         val summaryNotification = createNotification()
         addToSummaryNotifications(summaryNotification)
-        newMailNotifications.addNewMailNotification(account, message, 23)
+        newMailNotifications.addNewMailNotification(account, message, 23, silent = false)
         whenRemovingContentReturn(messageReference, RemoveNotificationResult.cancelNotification(notificationId))
 
         newMailNotifications.removeNewMailNotification(account, messageReference)
@@ -195,7 +195,7 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         whenAddingContentReturn(content, AddNotificationResult.newNotification(holder))
         val summaryNotification = createNotification()
         addToSummaryNotifications(summaryNotification)
-        newMailNotifications.addNewMailNotification(account, message, 23)
+        newMailNotifications.addNewMailNotification(account, message, 23, silent = false)
         whenRemovingContentReturn(messageReference, RemoveNotificationResult.cancelNotification(notificationId))
         whenever(newMailNotifications.notificationData.newMessagesCount).thenReturn(0)
         setActiveNotificationIds()
@@ -225,7 +225,7 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         val singleMessageNotificationTwo = createNotification()
         addToSingleMessageNotifications(holderOne, singleMessageNotificationOne)
         addToSingleMessageNotifications(holderTwo, singleMessageNotificationTwo)
-        newMailNotifications.addNewMailNotification(account, message, 23)
+        newMailNotifications.addNewMailNotification(account, message, 23, silent = false)
         whenRemovingContentReturn(messageReference, RemoveNotificationResult.createNotification(holderTwo))
 
         newMailNotifications.removeNewMailNotification(account, messageReference)
@@ -253,7 +253,7 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         addToNotificationContentCreator(message, content)
         setActiveNotificationIds(notificationId)
         whenAddingContentReturn(content, AddNotificationResult.newNotification(holder))
-        newMailNotifications.addNewMailNotification(account, message, 3)
+        newMailNotifications.addNewMailNotification(account, message, 3, silent = false)
 
         newMailNotifications.clearNewMailNotifications(account)
 


### PR DESCRIPTION
`MessagingController` now uses `NotificationState` to make sure there's only one audible notification during a single sync operation.

Closes #5493