### PR TITLE
Remove "hide subject in notifications" setting

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -156,9 +156,6 @@ object K9 : EarlyInit {
     var isConfirmMarkAllRead = true
 
     @JvmStatic
-    var notificationHideSubject = NotificationHideSubject.NEVER
-
-    @JvmStatic
     var notificationQuickDeleteBehaviour = NotificationQuickDelete.ALWAYS
 
     @JvmStatic
@@ -345,7 +342,6 @@ object K9 : EarlyInit {
         val sortAscendingSetting = storage.getBoolean("sortAscending", Account.DEFAULT_SORT_ASCENDING)
         sortAscending[sortType] = sortAscendingSetting
 
-        notificationHideSubject = storage.getEnum("notificationHideSubject", NotificationHideSubject.NEVER)
         notificationQuickDeleteBehaviour = storage.getEnum("notificationQuickDelete", NotificationQuickDelete.ALWAYS)
 
         lockScreenNotificationVisibility = storage.getEnum(
@@ -426,7 +422,6 @@ object K9 : EarlyInit {
         editor.putEnum("sortTypeEnum", sortType)
         editor.putBoolean("sortAscending", sortAscending[sortType] ?: false)
 
-        editor.putString("notificationHideSubject", notificationHideSubject.toString())
         editor.putString("notificationQuickDelete", notificationQuickDeleteBehaviour.toString())
         editor.putString("lockScreenNotificationVisibility", lockScreenNotificationVisibility.toString())
 
@@ -520,15 +515,6 @@ object K9 : EarlyInit {
 
     enum class BACKGROUND_OPS {
         ALWAYS, NEVER, WHEN_CHECKED_AUTO_SYNC
-    }
-
-    /**
-     * Controls when to hide the subject in the notification area.
-     */
-    enum class NotificationHideSubject {
-        ALWAYS,
-        WHEN_LOCKED,
-        NEVER
     }
 
     /**

--- a/app/core/src/main/java/com/fsck/k9/notification/MessageSummaryNotifications.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/MessageSummaryNotifications.kt
@@ -1,12 +1,9 @@
 package com.fsck.k9.notification
 
-import android.app.KeyguardManager
 import android.app.Notification
-import android.content.Context
 import androidx.core.app.NotificationCompat
 import com.fsck.k9.Account
 import com.fsck.k9.K9
-import com.fsck.k9.K9.NotificationHideSubject
 import com.fsck.k9.K9.NotificationQuickDelete
 import com.fsck.k9.notification.NotificationGroupKeys.getGroupKey
 import com.fsck.k9.notification.NotificationIds.getNewMailSummaryNotificationId
@@ -23,9 +20,6 @@ internal open class MessageSummaryNotifications(
         val unreadMessageCount = notificationData.unreadMessageCount
 
         val builder = when {
-            isPrivacyModeActive -> {
-                createSimpleSummaryNotification(account, unreadMessageCount)
-            }
             notificationData.isSingleMessageNotification -> {
                 val holder = notificationData.holderForLatestNotification
                 createSingleMessageNotification(account, holder)
@@ -56,21 +50,6 @@ internal open class MessageSummaryNotifications(
         )
 
         return builder.build()
-    }
-
-    private fun createSimpleSummaryNotification(account: Account, unreadMessageCount: Int): NotificationCompat.Builder {
-        val accountName = notificationHelper.getAccountName(account)
-        val newMailText = resourceProvider.newMailTitle()
-        val unreadMessageCountText = resourceProvider.newMailUnreadMessageCount(unreadMessageCount, accountName)
-        val notificationId = getNewMailSummaryNotificationId(account)
-        val contentIntent = actionCreator.createViewFolderListPendingIntent(account, notificationId)
-
-        return createAndInitializeNotificationBuilder(account)
-            .setNumber(unreadMessageCount)
-            .setTicker(newMailText)
-            .setContentTitle(unreadMessageCountText)
-            .setContentText(newMailText)
-            .setContentIntent(contentIntent)
     }
 
     private fun createSingleMessageNotification(
@@ -224,15 +203,6 @@ internal open class MessageSummaryNotifications(
     private fun isArchiveActionAvailableForWear(account: Account): Boolean {
         return account.archiveFolderId != null
     }
-
-    private val isPrivacyModeActive: Boolean
-        get() {
-            val keyguardService = context.getSystemService(Context.KEYGUARD_SERVICE) as KeyguardManager
-            val privacyModeAlwaysEnabled = K9.notificationHideSubject === NotificationHideSubject.ALWAYS
-            val privacyModeEnabledWhenLocked = K9.notificationHideSubject === NotificationHideSubject.WHEN_LOCKED
-            val screenLocked = keyguardService.inKeyguardRestrictedInputMode()
-            return privacyModeAlwaysEnabled || privacyModeEnabledWhenLocked && screenLocked
-        }
 
     protected open fun createInboxStyle(builder: NotificationCompat.Builder?): NotificationCompat.InboxStyle {
         return NotificationCompat.InboxStyle(builder)

--- a/app/core/src/main/java/com/fsck/k9/notification/NewMailNotifications.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NewMailNotifications.kt
@@ -3,7 +3,6 @@ package com.fsck.k9.notification
 import android.util.SparseArray
 import androidx.core.app.NotificationManagerCompat
 import com.fsck.k9.Account
-import com.fsck.k9.K9
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.mailstore.LocalMessage
 
@@ -110,17 +109,10 @@ internal open class NewMailNotifications(
     }
 
     private fun createSingleMessageNotification(account: Account, holder: NotificationHolder) {
-        if (isPrivacyModeEnabled) {
-            return
-        }
-
         val notification = singleMessageNotifications.buildSingleMessageNotification(account, holder)
         val notificationId = holder.notificationId
         notificationManager.notify(notificationId, notification)
     }
-
-    private val isPrivacyModeEnabled: Boolean
-        get() = K9.notificationHideSubject !== K9.NotificationHideSubject.NEVER
 
     private val notificationManager: NotificationManagerCompat
         get() = notificationHelper.getNotificationManager()

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -16,7 +16,6 @@ import com.fsck.k9.Account.SortType;
 import com.fsck.k9.DI;
 import com.fsck.k9.FontSizes;
 import com.fsck.k9.K9;
-import com.fsck.k9.K9.NotificationHideSubject;
 import com.fsck.k9.K9.NotificationQuickDelete;
 import com.fsck.k9.K9.SplitViewMode;
 import com.fsck.k9.K9.AppTheme;
@@ -132,10 +131,6 @@ public class GeneralSettingsDescriptions {
                 new V(1, new BooleanSetting(false)),
                 new V(69, null)
         ));
-        s.put("keyguardPrivacy", Settings.versions(
-                new V(1, new BooleanSetting(false)),
-                new V(12, null)
-        ));
         s.put("language", Settings.versions(
                 new V(1, new LanguageSetting())
         ));
@@ -194,9 +189,6 @@ public class GeneralSettingsDescriptions {
         ));
         s.put("useVolumeKeysForNavigation", Settings.versions(
                 new V(1, new BooleanSetting(false))
-        ));
-        s.put("notificationHideSubject", Settings.versions(
-                new V(12, new EnumSetting<>(NotificationHideSubject.class, NotificationHideSubject.NEVER))
         ));
         s.put("useBackgroundAsUnreadIndicator", Settings.versions(
                 new V(19, new BooleanSetting(true)),
@@ -290,7 +282,6 @@ public class GeneralSettingsDescriptions {
         SETTINGS = Collections.unmodifiableMap(s);
 
         Map<Integer, SettingsUpgrader> u = new HashMap<>();
-        u.put(12, new SettingsUpgraderV12());
         u.put(24, new SettingsUpgraderV24());
         u.put(31, new SettingsUpgraderV31());
         u.put(58, new SettingsUpgraderV58());
@@ -320,27 +311,6 @@ public class GeneralSettingsDescriptions {
             }
         }
         return result;
-    }
-
-    /**
-     * Upgrades the settings from version 11 to 12
-     *
-     * Map the 'keyguardPrivacy' value to the new NotificationHideSubject enum.
-     */
-    private static class SettingsUpgraderV12 implements SettingsUpgrader {
-
-        @Override
-        public Set<String> upgrade(Map<String, Object> settings) {
-            Boolean keyguardPrivacy = (Boolean) settings.get("keyguardPrivacy");
-            if (keyguardPrivacy != null && keyguardPrivacy) {
-                // current setting: only show subject when unlocked
-                settings.put("notificationHideSubject", NotificationHideSubject.WHEN_LOCKED);
-            } else {
-                // always show subject [old default]
-                settings.put("notificationHideSubject", NotificationHideSubject.NEVER);
-            }
-            return new HashSet<>(Collections.singletonList("keyguardPrivacy"));
-        }
     }
 
     /**

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 76;
+    public static final int VERSION = 77;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/core/src/main/res/values/arrays_general_settings_values.xml
+++ b/app/core/src/main/res/values/arrays_general_settings_values.xml
@@ -171,12 +171,6 @@
         <item>6</item>
     </string-array>
 
-    <string-array name="notification_hide_subject_values" translatable="false">
-        <item name="1">NEVER</item>
-        <item name="2">WHEN_LOCKED</item>
-        <item name="3">ALWAYS</item>
-    </string-array>
-
     <string-array name="notification_quick_delete_values" translatable="false">
         <item name="1">NEVER</item>
         <item name="2">FOR_SINGLE_MSG</item>

--- a/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationsTest.kt
@@ -3,8 +3,6 @@ package com.fsck.k9.notification
 import android.app.Notification
 import androidx.core.app.NotificationManagerCompat
 import com.fsck.k9.Account
-import com.fsck.k9.K9
-import com.fsck.k9.K9.NotificationHideSubject
 import com.fsck.k9.K9RobolectricTest
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.mailstore.LocalMessage
@@ -14,7 +12,6 @@ import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -80,26 +77,6 @@ class NewMailNotificationsTest : K9RobolectricTest() {
     }
 
     @Test
-    fun testAddNewMailNotificationWithPrivacyModeEnabled() {
-        enablePrivacyMode()
-        val notificationIndex = 0
-        val message = createLocalMessage()
-        val content = createNotificationContent()
-        val holder = createNotificationHolder(content, notificationIndex)
-        addToNotificationContentCreator(message, content)
-        whenAddingContentReturn(content, AddNotificationResult.newNotification(holder))
-        val singleMessageNotification = createNotification()
-        addToSummaryNotifications(singleMessageNotification)
-
-        newMailNotifications.addNewMailNotification(account, message, 42, silent = false)
-
-        val singleMessageNotificationId = NotificationIds.getSingleMessageNotificationId(account, notificationIndex)
-        val summaryNotificationId = NotificationIds.getNewMailSummaryNotificationId(account)
-        verify(notificationManager, never()).notify(eq(singleMessageNotificationId), any())
-        verify(notificationManager).notify(summaryNotificationId, singleMessageNotification)
-    }
-
-    @Test
     fun testAddNewMailNotificationTwice() {
         val notificationIndexOne = 0
         val notificationIndexTwo = 1
@@ -142,7 +119,6 @@ class NewMailNotificationsTest : K9RobolectricTest() {
 
     @Test
     fun testRemoveNewMailNotificationWithUnknownMessageReference() {
-        enablePrivacyMode()
         val messageReference = createMessageReference(1)
         val notificationIndex = 0
         val message = createLocalMessage()
@@ -162,7 +138,6 @@ class NewMailNotificationsTest : K9RobolectricTest() {
 
     @Test
     fun testRemoveNewMailNotification() {
-        enablePrivacyMode()
         val messageReference = createMessageReference(1)
         val notificationIndex = 0
         val notificationId = NotificationIds.getSingleMessageNotificationId(account, notificationIndex)
@@ -338,10 +313,6 @@ class NewMailNotificationsTest : K9RobolectricTest() {
         stubbing(newMailNotifications.notificationData) {
             on { getActiveNotificationIds() } doReturn notificationIds
         }
-    }
-
-    private fun enablePrivacyMode() {
-        K9.notificationHideSubject = NotificationHideSubject.ALWAYS
     }
 
     internal class TestNewMailNotifications(

--- a/app/core/src/test/java/com/fsck/k9/notification/SummaryNotificationsTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/SummaryNotificationsTest.kt
@@ -5,7 +5,6 @@ import androidx.core.app.NotificationCompat
 import androidx.test.core.app.ApplicationProvider
 import com.fsck.k9.Account
 import com.fsck.k9.K9
-import com.fsck.k9.K9.NotificationHideSubject
 import com.fsck.k9.K9.NotificationQuickDelete
 import com.fsck.k9.RobolectricTest
 import com.fsck.k9.controller.MessageReference
@@ -47,25 +46,7 @@ class SummaryNotificationsTest : RobolectricTest() {
     private val notifications = createSummaryNotifications(builder, lockScreenNotification)
 
     @Test
-    fun buildSummaryNotification_withPrivacyModeActive() {
-        K9.notificationHideSubject = NotificationHideSubject.ALWAYS
-
-        val result = notifications.buildSummaryNotification(account, notificationData, false)
-
-        verify(builder).setSmallIcon(resourceProvider.iconNewMail)
-        verify(builder).color = ACCOUNT_COLOR
-        verify(builder).setAutoCancel(true)
-        verify(builder).setNumber(UNREAD_MESSAGE_COUNT)
-        verify(builder).setTicker("New mail")
-        verify(builder).setContentText("New mail")
-        verify(builder).setContentTitle("$UNREAD_MESSAGE_COUNT Unread ($ACCOUNT_NAME)")
-        verify(lockScreenNotification).configureLockScreenNotification(builder, notificationData)
-        assertThat(result).isEqualTo(notification)
-    }
-
-    @Test
     fun buildSummaryNotification_withSingleMessageNotification() {
-        K9.notificationHideSubject = NotificationHideSubject.NEVER
         K9.notificationQuickDeleteBehaviour = NotificationQuickDelete.ALWAYS
         stubbing(notificationData) {
             on { isSingleMessageNotification } doReturn true
@@ -90,7 +71,6 @@ class SummaryNotificationsTest : RobolectricTest() {
 
     @Test
     fun buildSummaryNotification_withMultiMessageNotification() {
-        K9.notificationHideSubject = NotificationHideSubject.NEVER
         K9.notificationQuickDeleteBehaviour = NotificationQuickDelete.ALWAYS
         stubbing(notificationData) {
             on { isSingleMessageNotification } doReturn false
@@ -121,7 +101,6 @@ class SummaryNotificationsTest : RobolectricTest() {
 
     @Test
     fun buildSummaryNotification_withAdditionalMessages() {
-        K9.notificationHideSubject = NotificationHideSubject.NEVER
         K9.notificationQuickDeleteBehaviour = NotificationQuickDelete.ALWAYS
         stubbing(notificationData) {
             on { isSingleMessageNotification } doReturn false
@@ -136,7 +115,6 @@ class SummaryNotificationsTest : RobolectricTest() {
 
     @Test
     fun buildSummaryNotification_withoutDeleteAllAction() {
-        K9.notificationHideSubject = NotificationHideSubject.NEVER
         K9.notificationQuickDeleteBehaviour = NotificationQuickDelete.NEVER
         stubbing(notificationData) {
             on { isSingleMessageNotification } doReturn false
@@ -150,7 +128,6 @@ class SummaryNotificationsTest : RobolectricTest() {
     @Test
     @Throws(Exception::class)
     fun buildSummaryNotification_withoutDeleteAction() {
-        K9.notificationHideSubject = NotificationHideSubject.NEVER
         K9.notificationQuickDeleteBehaviour = NotificationQuickDelete.NEVER
         stubbing(notificationData) {
             on { isSingleMessageNotification } doReturn true

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo6.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo6.kt
@@ -10,21 +10,8 @@ class StorageMigrationTo6(
     private val migrationsHelper: StorageMigrationsHelper
 ) {
     fun performLegacyMigrations() {
-        rewriteKeyguardPrivacy()
         rewriteTheme()
         migrateOpenPgpGlobalToAccountSettings()
-    }
-
-    private fun rewriteKeyguardPrivacy() {
-        val notificationHideSubject = migrationsHelper.readValue(db, "notificationHideSubject")
-        if (notificationHideSubject == null) {
-            val keyguardPrivacy = migrationsHelper.readValue(db, "keyguardPrivacy")
-            if (keyguardPrivacy?.toBoolean() == true) {
-                migrationsHelper.writeValue(db, "notificationHideSubject", "WHEN_LOCKED")
-            } else {
-                migrationsHelper.writeValue(db, "notificationHideSubject", "NEVER")
-            }
-        }
     }
 
     private fun rewriteTheme() {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -103,7 +103,6 @@ class GeneralSettingsDataStore(
             "notification_quick_delete" -> K9.notificationQuickDeleteBehaviour.name
             "lock_screen_notification_visibility" -> K9.lockScreenNotificationVisibility.name
             "background_ops" -> K9.backgroundOps.name
-            "notification_hide_subject" -> K9.notificationHideSubject.name
             "quiet_time_starts" -> K9.quietTimeStarts
             "quiet_time_ends" -> K9.quietTimeEnds
             "account_name_font" -> K9.fontSizes.accountName.toString()
@@ -143,7 +142,6 @@ class GeneralSettingsDataStore(
                 K9.lockScreenNotificationVisibility = K9.LockScreenNotificationVisibility.valueOf(value)
             }
             "background_ops" -> setBackgroundOps(value)
-            "notification_hide_subject" -> K9.notificationHideSubject = K9.NotificationHideSubject.valueOf(value)
             "quiet_time_starts" -> K9.quietTimeStarts = value
             "quiet_time_ends" -> K9.quietTimeEnds = value
             "account_name_font" -> K9.fontSizes.accountName = value.toInt()

--- a/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
+++ b/app/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
@@ -119,12 +119,6 @@
         <item>6</item>
     </string-array>
 
-    <string-array name="notification_hide_subject_entries">
-        <item name="1">@string/global_settings_notification_hide_subject_never</item>
-        <item name="2">@string/global_settings_notification_hide_subject_when_locked</item>
-        <item name="3">@string/global_settings_notification_hide_subject_always</item>
-    </string-array>
-
     <string-array name="notification_quick_delete_entries">
         <item name="1">@string/global_settings_notification_quick_delete_never</item>
         <item name="2">@string/global_settings_notification_quick_delete_when_single_msg</item>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -328,10 +328,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="global_settings_privacy_hide_useragent_detail">Remove K-9 User-Agent from mail headers</string>
     <string name="global_settings_privacy_hide_timezone">Hide timezone</string>
     <string name="global_settings_privacy_hide_timezone_detail">Use UTC instead of local timezone in mail headers and reply header</string>
-    <string name="global_settings_notification_hide_subject_title">Hide subject in notifications</string>
-    <string name="global_settings_notification_hide_subject_never">Never</string>
-    <string name="global_settings_notification_hide_subject_when_locked">When device is locked</string>
-    <string name="global_settings_notification_hide_subject_always">Always</string>
 
     <string name="global_settings_notification_quick_delete_title">Show \'Delete\' button</string>
     <string name="global_settings_notification_quick_delete_never">Never</string>

--- a/app/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/general_settings.xml
@@ -457,13 +457,6 @@
         android:title="@string/privacy_preferences"
         search:ignore="true">
 
-        <ListPreference
-            android:entries="@array/notification_hide_subject_entries"
-            android:entryValues="@array/notification_hide_subject_values"
-            android:key="notification_hide_subject"
-            app:useSimpleSummaryProvider="true"
-            android:title="@string/global_settings_notification_hide_subject_title" />
-
         <CheckBoxPreference
             android:key="privacy_hide_useragent"
             android:summary="@string/global_settings_privacy_hide_useragent_detail"


### PR DESCRIPTION
This feature didn't work properly. And the "lock screen notifications" setting offers very similar functionality.

Related to #3707.