### PR TITLE
Fix code to pick initial account color

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/account/AccountCreator.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/account/AccountCreator.kt
@@ -60,10 +60,10 @@ class AccountCreator(private val preferences: Preferences, private val resources
             return accountColors.random()
         }
 
-        return availableColors.shuffled().minOf { color ->
+        return availableColors.shuffled().minByOrNull { color ->
             val index = DEFAULT_COLORS.indexOf(color)
             if (index != -1) index else DEFAULT_COLORS.size
-        }
+        } ?: error("availableColors must not be empty")
     }
 
     companion object {


### PR DESCRIPTION
I accidentally broke this when updating to Kotlin 1.5.30. See 6084321bdee575e00a30aa03ea5f4e4810785d4c