### PR TITLE
Make sure "memory key" in MemorizingMessagingListener doesn't change

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MemorizingMessagingListener.java
@@ -102,7 +102,7 @@ class MemorizingMessagingListener extends SimpleMessagingListener {
     }
 
     private static String getMemoryKey(Account account, long folderId) {
-        return account.getDescription() + ":" + folderId;
+        return account.getUuid() + ":" + folderId;
     }
 
     private enum MemorizingState { STARTED, FINISHED, FAILED }


### PR DESCRIPTION
Previously, renaming an account could lead to old sync state being retained. I noticed this when the progress bar beneath the toolbar was shown even though no sync was in progress.