### PR TITLE
Don't crash when trying to load an account that has been removed

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsViewModel.kt
@@ -4,31 +4,34 @@ import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.asLiveData
+import androidx.lifecycle.viewModelScope
 import com.fsck.k9.Account
 import com.fsck.k9.mailstore.FolderRepository
 import com.fsck.k9.mailstore.FolderType
 import com.fsck.k9.mailstore.RemoteFolder
 import com.fsck.k9.mailstore.SpecialFolderSelectionStrategy
 import com.fsck.k9.preferences.AccountManager
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 class AccountSettingsViewModel(
     private val accountManager: AccountManager,
     private val folderRepository: FolderRepository,
-    private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy
+    private val specialFolderSelectionStrategy: SpecialFolderSelectionStrategy,
+    private val backgroundDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : ViewModel() {
     val accounts = accountManager.getAccountsFlow().asLiveData()
-    private val accountLiveData = MutableLiveData<Account>()
+    private var accountUuid: String? = null
+    private val accountLiveData = MutableLiveData<Account?>()
     private val foldersLiveData = MutableLiveData<RemoteFolderInfo>()
 
-    fun getAccount(accountUuid: String): LiveData<Account> {
-        if (accountLiveData.value == null) {
-
-            GlobalScope.launch(Dispatchers.Main) {
-                val account = withContext(Dispatchers.IO) {
+    fun getAccount(accountUuid: String): LiveData<Account?> {
+        if (this.accountUuid != accountUuid) {
+            this.accountUuid = accountUuid
+            viewModelScope.launch {
+                val account = withContext(backgroundDispatcher) {
                     loadAccount(accountUuid)
                 }
                 accountLiveData.value = account
@@ -43,13 +46,16 @@ class AccountSettingsViewModel(
      * doesn't support asynchronous preference loading.
      */
     fun getAccountBlocking(accountUuid: String): Account {
-        return accountLiveData.value ?: loadAccount(accountUuid).also {
-            accountLiveData.value = it
-        }
+        return accountLiveData.value
+            ?: loadAccount(accountUuid).also { account ->
+                this.accountUuid = accountUuid
+                accountLiveData.value = account
+            }
+            ?: error("Account $accountUuid not found")
     }
 
-    private fun loadAccount(accountUuid: String): Account {
-        return accountManager.getAccount(accountUuid) ?: error("Account $accountUuid not found")
+    private fun loadAccount(accountUuid: String): Account? {
+        return accountManager.getAccount(accountUuid)
     }
 
     fun getFolders(account: Account): LiveData<RemoteFolderInfo> {
@@ -61,8 +67,8 @@ class AccountSettingsViewModel(
     }
 
     private fun loadFolders(account: Account) {
-        GlobalScope.launch(Dispatchers.Main) {
-            val remoteFolderInfo = withContext(Dispatchers.IO) {
+        viewModelScope.launch {
+            val remoteFolderInfo = withContext(backgroundDispatcher) {
                 val folders = folderRepository.getRemoteFolders(account)
                 val automaticSpecialFolders = getAutomaticSpecialFolders(folders)
                 RemoteFolderInfo(folders, automaticSpecialFolders)


### PR DESCRIPTION
I wasn't able to reproduce the crash in #5711. But this change should avoid it.

Fixes #5711