### PR TITLE
Don't limit line length when converting from HTML to plain text

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/message/html/HtmlToPlainText.kt
+++ b/app/core/src/main/java/com/fsck/k9/message/html/HtmlToPlainText.kt
@@ -22,7 +22,6 @@ object HtmlToPlainText {
 }
 
 private class FormattingVisitor : NodeVisitor {
-    private var width = 0
     private val output = StringBuilder()
     private var collectLinkText = false
     private var linkText = StringBuilder()
@@ -73,36 +72,11 @@ private class FormattingVisitor : NodeVisitor {
     }
 
     private fun append(text: String) {
-        if (text.startsWith("\n")) {
-            width = 0
-        }
-
         if (text == " " && (output.isEmpty() || output.last() in listOf(' ', '\n'))) {
             return
         }
 
-        if (text.length + width > MAX_WIDTH) {
-            val words = text.split(Regex("\\s+"))
-            for (i in words.indices) {
-                var word = words[i]
-
-                val last = i == words.size - 1
-                if (!last) {
-                    word = "$word "
-                }
-
-                if (word.length + width > MAX_WIDTH) {
-                    output.append("\n").append(word)
-                    width = word.length
-                } else {
-                    output.append(word)
-                    width += word.length
-                }
-            }
-        } else {
-            output.append(text)
-            width += text.length
-        }
+        output.append(text)
     }
 
     private fun startNewLine() {
@@ -133,9 +107,5 @@ private class FormattingVisitor : NodeVisitor {
         }
 
         return output.substring(0, lastIndex + 1)
-    }
-
-    companion object {
-        private const val MAX_WIDTH = 76
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
+++ b/app/core/src/test/java/com/fsck/k9/message/html/HtmlConverterTest.java
@@ -306,4 +306,24 @@ public class HtmlConverterTest {
 
         assertEquals("https://domain.example/path/", result);
     }
+
+    @Test
+    public void htmlToText_withLineBreaksInHtml() {
+        String input = "One\nTwo\r\nThree";
+
+        String result = HtmlConverter.htmlToText(input);
+
+        assertEquals("One Two Three", result);
+    }
+
+    @Test
+    public void htmlToText_withLongTextLine_shouldNotAddLineBreaksToOutput() {
+        String input = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam sit amet finibus felis, " +
+                "viverra ullamcorper justo. Suspendisse potenti. Etiam erat sem, interdum a condimentum quis, " +
+                "fringilla quis orci.";
+
+        String result = HtmlConverter.htmlToText(input);
+
+        assertEquals(input, result);
+    }
 }


### PR DESCRIPTION
The class to convert HTML to plain text contained code to limit the line length to 76 characters. As far as I can tell this "feature" isn't used anywhere. But it's causing issues when editing drafts.

Fixes #5702