### PR TITLE
Don't set notification priority to high for starred messages

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationContent.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationContent.kt
@@ -7,6 +7,5 @@ internal class NotificationContent(
     val sender: String,
     val subject: String,
     val preview: CharSequence,
-    val summary: CharSequence,
-    val isStarred: Boolean
+    val summary: CharSequence
 )

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationContentCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationContentCreator.kt
@@ -6,7 +6,6 @@ import com.fsck.k9.Account
 import com.fsck.k9.K9
 import com.fsck.k9.helper.Contacts
 import com.fsck.k9.helper.MessageHelper
-import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.Message
 import com.fsck.k9.mailstore.LocalMessage
 import com.fsck.k9.message.extractors.PreviewResult.PreviewType
@@ -23,8 +22,7 @@ internal class NotificationContentCreator(
             sender = getMessageSenderForDisplay(sender),
             subject = getMessageSubject(message),
             preview = getMessagePreview(message),
-            summary = buildMessageSummary(sender, getMessageSubject(message)),
-            isStarred = message.isSet(Flag.FLAGGED)
+            summary = buildMessageSummary(sender, getMessageSubject(message))
         )
     }
 

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationData.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationData.kt
@@ -80,10 +80,6 @@ internal class NotificationData(val account: Account) {
         return NotificationHolder(notificationId, content)
     }
 
-    fun containsStarredMessages(): Boolean {
-        return activeNotifications.any { it.content.isStarred } || additionalNotifications.any { it.isStarred }
-    }
-
     fun hasSummaryOverflowMessages(): Boolean {
         return activeNotifications.size > MAX_NUMBER_OF_MESSAGES_FOR_SUMMARY_NOTIFICATION
     }

--- a/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationCreator.kt
@@ -28,10 +28,6 @@ internal open class SummaryNotificationCreator(
             }
         }
 
-        if (notificationData.containsStarredMessages()) {
-            builder.priority = NotificationCompat.PRIORITY_HIGH
-        }
-
         val notificationId = getNewMailSummaryNotificationId(account)
         val deletePendingIntent = actionCreator.createDismissAllMessagesPendingIntent(account, notificationId)
         builder.setDeleteIntent(deletePendingIntent)

--- a/app/core/src/test/java/com/fsck/k9/notification/AddNotificationResultTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/AddNotificationResultTest.kt
@@ -14,8 +14,7 @@ class AddNotificationResultTest {
             sender = "irrelevant",
             subject = "irrelevant",
             preview = "irrelevant",
-            summary = "irrelevant",
-            isStarred = false
+            summary = "irrelevant"
         )
     )
 

--- a/app/core/src/test/java/com/fsck/k9/notification/LockScreenNotificationCreatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/LockScreenNotificationCreatorTest.kt
@@ -169,7 +169,13 @@ class LockScreenNotificationCreatorTest : RobolectricTest() {
     }
 
     private fun createNotificationContent(sender: String): NotificationContent {
-        val messageReference = MessageReference("irrelevant", 1, "irrelevant")
-        return NotificationContent(messageReference, sender, "irrelevant", "irrelevant", "irrelevant", false)
+        val messageReference = MessageReference(accountUuid = "irrelevant", folderId = 1, uid = "irrelevant")
+        return NotificationContent(
+            messageReference = messageReference,
+            sender = sender,
+            subject = "irrelevant",
+            preview = "irrelevant",
+            summary = "irrelevant"
+        )
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationControllerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationControllerTest.kt
@@ -245,8 +245,14 @@ class NewMailNotificationControllerTest : K9RobolectricTest() {
     private fun createLocalMessage(): LocalMessage = mock()
 
     private fun createNotificationContent(): NotificationContent {
-        val messageReference = MessageReference("irrelevant", 1, "irrelevant")
-        return NotificationContent(messageReference, "irrelevant", "irrelevant", "irrelevant", "irrelevant", false)
+        val messageReference = MessageReference(accountUuid = "irrelevant", folderId = 1, uid = "irrelevant")
+        return NotificationContent(
+            messageReference = messageReference,
+            sender = "irrelevant",
+            subject = "irrelevant",
+            preview = "irrelevant",
+            summary = "irrelevant"
+        )
     }
 
     private fun createNotificationHolder(content: NotificationContent, index: Int): NotificationHolder {

--- a/app/core/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NotificationContentCreatorTest.kt
@@ -5,7 +5,6 @@ import com.fsck.k9.Account
 import com.fsck.k9.RobolectricTest
 import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.mail.Address
-import com.fsck.k9.mail.Flag
 import com.fsck.k9.mail.Message.RecipientType
 import com.fsck.k9.mailstore.LocalMessage
 import com.fsck.k9.message.extractors.PreviewResult.PreviewType
@@ -42,7 +41,6 @@ class NotificationContentCreatorTest : RobolectricTest() {
         assertThat(content.subject).isEqualTo(SUBJECT)
         assertThat(content.preview.toString()).isEqualTo("$SUBJECT\n$PREVIEW")
         assertThat(content.summary.toString()).isEqualTo("$SENDER_NAME $SUBJECT")
-        assertThat(content.isStarred).isFalse()
     }
 
     @Test
@@ -119,17 +117,6 @@ class NotificationContentCreatorTest : RobolectricTest() {
 
         assertThat(content.sender).isEqualTo("To:Bob")
         assertThat(content.summary.toString()).isEqualTo("To:Bob $SUBJECT")
-    }
-
-    @Test
-    fun createFromMessage_withStarredMessage() {
-        stubbing(message) {
-            on { isSet(Flag.FLAGGED) } doReturn true
-        }
-
-        val content = contentCreator.createFromMessage(account, message)
-
-        assertThat(content.isStarred).isTrue()
     }
 
     @Test

--- a/app/core/src/test/java/com/fsck/k9/notification/NotificationDataTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NotificationDataTest.kt
@@ -110,32 +110,6 @@ class NotificationDataTest : RobolectricTest() {
     }
 
     @Test
-    fun testContainsStarredMessages() {
-        assertThat(notificationData.containsStarredMessages()).isFalse()
-
-        notificationData.addNotificationContent(createNotificationContentForStarredMessage())
-
-        assertThat(notificationData.containsStarredMessages()).isTrue()
-    }
-
-    @Test
-    fun testContainsStarredMessagesWithAdditionalMessages() {
-        notificationData.addNotificationContent(createNotificationContent("1"))
-        notificationData.addNotificationContent(createNotificationContent("2"))
-        notificationData.addNotificationContent(createNotificationContent("3"))
-        notificationData.addNotificationContent(createNotificationContent("4"))
-        notificationData.addNotificationContent(createNotificationContent("5"))
-        notificationData.addNotificationContent(createNotificationContent("6"))
-        notificationData.addNotificationContent(createNotificationContent("7"))
-        notificationData.addNotificationContent(createNotificationContent("8"))
-        assertThat(notificationData.containsStarredMessages()).isFalse()
-
-        notificationData.addNotificationContent(createNotificationContentForStarredMessage())
-
-        assertThat(notificationData.containsStarredMessages()).isTrue()
-    }
-
-    @Test
     fun testIsSingleMessageNotification() {
         assertThat(notificationData.isSingleMessageNotification).isFalse()
 
@@ -276,11 +250,12 @@ class NotificationDataTest : RobolectricTest() {
     }
 
     private fun createNotificationContent(messageReference: MessageReference): NotificationContent {
-        return NotificationContent(messageReference, "", "", "", "", false)
-    }
-
-    private fun createNotificationContentForStarredMessage(): NotificationContent {
-        val messageReference = createMessageReference("42")
-        return NotificationContent(messageReference, "", "", "", "", true)
+        return NotificationContent(
+            messageReference = messageReference,
+            sender = "irrelevant",
+            subject = "irrelevant",
+            preview = "irrelevant",
+            summary = "irrelevant"
+        )
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/notification/RemoveNotificationResultTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/RemoveNotificationResultTest.kt
@@ -17,8 +17,7 @@ class RemoveNotificationResultTest {
             sender = "irrelevant",
             subject = "irrelevant",
             preview = "irrelevant",
-            summary = "irrelevant",
-            isStarred = false
+            summary = "irrelevant"
         )
     )
 

--- a/app/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationCreatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationCreatorTest.kt
@@ -9,7 +9,6 @@ import com.fsck.k9.K9
 import com.fsck.k9.K9.NotificationQuickDelete
 import com.fsck.k9.RobolectricTest
 import com.fsck.k9.controller.MessageReference
-import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.testing.MockHelper.mockBuilder
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -158,11 +157,6 @@ class SingleMessageNotificationCreatorTest : RobolectricTest() {
         whenever(account.spamFolderId).thenReturn(11L)
     }
 
-    private fun disableOptionalSummaryActions() {
-        disableDeleteAction()
-        disableArchiveAction()
-    }
-
     private fun createNotificationBuilder(notification: Notification): NotificationCompat.Builder {
         return mockBuilder {
             on { build() } doReturn notification
@@ -183,14 +177,14 @@ class SingleMessageNotificationCreatorTest : RobolectricTest() {
         }
     }
 
-    private fun createMessagingController(): MessagingController {
-        return mock {
-            on { isMoveCapable(account) } doReturn true
-        }
-    }
-
     private fun createNotificationContent(messageReference: MessageReference): NotificationContent {
-        return NotificationContent(messageReference, "irrelevant", "irrelevant", "irrelevant", "irrelevant", false)
+        return NotificationContent(
+            messageReference = messageReference,
+            sender = "irrelevant",
+            subject = "irrelevant",
+            preview = "irrelevant",
+            summary = "irrelevant"
+        )
     }
 
     private fun createNotificationHolder(notificationId: Int, content: NotificationContent): NotificationHolder {
@@ -203,17 +197,6 @@ class SingleMessageNotificationCreatorTest : RobolectricTest() {
 
     private fun createFakePendingIntent(requestCode: Int): PendingIntent {
         return PendingIntent.getActivity(ApplicationProvider.getApplicationContext(), requestCode, null, 0)
-    }
-
-    private fun createMessageReferenceList(): ArrayList<MessageReference> {
-        return arrayListOf(createMessageReference(1), createMessageReference(2))
-    }
-
-    private fun createNotificationData(messageReferences: ArrayList<MessageReference>): NotificationData {
-        return mock {
-            on { account } doReturn account
-            on { getAllMessageReferences() } doReturn messageReferences
-        }
     }
 
     private fun verifyExtendWasOnlyCalledOnce() {

--- a/app/core/src/test/java/com/fsck/k9/notification/SummaryNotificationCreatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/SummaryNotificationCreatorTest.kt
@@ -73,7 +73,6 @@ class SummaryNotificationCreatorTest : RobolectricTest() {
         K9.notificationQuickDeleteBehaviour = NotificationQuickDelete.ALWAYS
         stubbing(notificationData) {
             on { isSingleMessageNotification } doReturn false
-            on { containsStarredMessages() } doReturn true
         }
 
         val result = notificationCreator.buildSummaryNotification(account, notificationData, false)
@@ -86,7 +85,6 @@ class SummaryNotificationCreatorTest : RobolectricTest() {
         verify(builder).setSubText(ACCOUNT_NAME)
         verify(builder).setGroup("newMailNotifications-$ACCOUNT_NUMBER")
         verify(builder).setGroupSummary(true)
-        verify(builder).priority = NotificationCompat.PRIORITY_HIGH
         verify(builder).setStyle(notificationCreator.inboxStyle)
         verify(notificationCreator.inboxStyle).setBigContentTitle("$NEW_MESSAGE_COUNT new messages")
         verify(notificationCreator.inboxStyle).setSummaryText(ACCOUNT_NAME)
@@ -153,8 +151,8 @@ class SummaryNotificationCreatorTest : RobolectricTest() {
 
     private fun createFakeNotificationData(account: Account): NotificationData {
         val messageReference = MessageReference("irrelevant", 1, "irrelevant")
-        val content = NotificationContent(messageReference, SENDER, SUBJECT, PREVIEW, SUMMARY, false)
-        val content2 = NotificationContent(messageReference, SENDER_2, SUBJECT_2, PREVIEW_2, SUMMARY_2, true)
+        val content = NotificationContent(messageReference, SENDER, SUBJECT, PREVIEW, SUMMARY)
+        val content2 = NotificationContent(messageReference, SENDER_2, SUBJECT_2, PREVIEW_2, SUMMARY_2)
         return mock {
             on { newMessagesCount } doReturn NEW_MESSAGE_COUNT
             on { this.account } doReturn account


### PR DESCRIPTION
This is an obscure feature I doubt was used much. It only worked on Android versions prior to 8.0 anyway.
