### PR TITLE
Don't crash when loading images without internet permission

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.java
@@ -47,8 +47,8 @@ public class MessageWebView extends WebView {
          */
         try {
             getSettings().setBlockNetworkLoads(shouldBlockNetworkData);
-        } catch(SecurityException e) {
-            Timber.e(e, "SecurityException in blockNetworkData(final boolean shouldBlockNetworkData)");
+        } catch (SecurityException e) {
+            Timber.e(e, "Failed to unblock network loads. Missing INTERNET permission?");
         }
     }
 


### PR DESCRIPTION
This PR fixes the issue #5525. When the internet permission is not granted, the app crashes when trying to load pictures of a email. This issue mainly concerns the GrapheneOS users.