### PR TITLE
Downgrade Apache Commons IO to version 2.6

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ buildscript {
                 'moshi': '1.12.0',
                 'timber': '5.0.1',
                 'koin': '3.1.3',
-                'commonsIo': '2.11.0',
+                'commonsIo': '2.6',
                 'mime4j': '0.8.6',
                 'okhttp': '4.9.2',
                 'minidns': '1.0.0',


### PR DESCRIPTION
I wasn't able to get newer versions to work on API 21 devices, even with [core library desugaring](https://developer.android.com/studio/write/java8-support#library-desugaring) enabled.
