### PR TITLE
Avoid leaking CountingOutputStream.

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/ProgressBodyFactory.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/ProgressBodyFactory.java
@@ -21,10 +21,8 @@ class ProgressBodyFactory extends DefaultBodyFactory {
 
     @Override
     protected void copyData(InputStream inputStream, OutputStream outputStream) throws IOException {
-        final CountingOutputStream countingOutputStream = new CountingOutputStream(outputStream);
-
         Timer timer = new Timer();
-        try {
+        try (CountingOutputStream countingOutputStream = new CountingOutputStream(outputStream)) {
             timer.scheduleAtFixedRate(new TimerTask() {
                 @Override
                 public void run() {

--- a/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -785,20 +785,15 @@ public class LocalFolder {
     }
 
     private long decodeAndCountBytes(InputStream rawInputStream, String encoding, long fallbackValue) {
-        InputStream decodingInputStream = localStore.getDecodingInputStream(rawInputStream, encoding);
-        try {
-            CountingOutputStream countingOutputStream = new CountingOutputStream();
-            try {
-                IOUtils.copy(decodingInputStream, countingOutputStream);
+        try (InputStream decodingInputStream = localStore.getDecodingInputStream(rawInputStream, encoding)) {
 
+            try (CountingOutputStream countingOutputStream = new CountingOutputStream()) {
+                IOUtils.copy(decodingInputStream, countingOutputStream);
                 return countingOutputStream.getCount();
-            } catch (IOException e) {
-                return fallbackValue;
             }
-        } finally {
-            try {
-                decodingInputStream.close();
-            } catch (IOException e) { /* ignore */ }
+
+        } catch (IOException e) {
+            return fallbackValue;
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
+++ b/app/core/src/main/java/com/fsck/k9/provider/RawMessageProvider.java
@@ -99,8 +99,7 @@ public class RawMessageProvider extends ContentProvider {
 
     private long computeMessageSize(LocalMessage message) {
         // TODO: Store message size in database when saving message so this can be a simple lookup instead.
-        try {
-            CountingOutputStream countingOutputStream = new CountingOutputStream();
+        try (CountingOutputStream countingOutputStream = new CountingOutputStream()) {
             message.writeTo(countingOutputStream);
             return countingOutputStream.getCount();
         } catch (IOException | MessagingException e) {

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/SaveMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/SaveMessageOperations.kt
@@ -305,9 +305,10 @@ internal class SaveMessageOperations(
     private fun decodeAndCountBytes(rawInputStream: InputStream, encoding: String, fallbackValue: Long): Long {
         return try {
             getDecodingInputStream(rawInputStream, encoding).use { decodingInputStream ->
-                val countingOutputStream = CountingOutputStream()
-                IOUtils.copy(decodingInputStream, countingOutputStream)
-                countingOutputStream.count
+                CountingOutputStream().use { countingOutputStream ->
+                    IOUtils.copy(decodingInputStream, countingOutputStream)
+                    countingOutputStream.count
+                }
             }
         } catch (e: IOException) {
             fallbackValue

--- a/mail/common/src/main/java/com/fsck/k9/mail/Message.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Message.java
@@ -159,16 +159,12 @@ public abstract class Message implements Part, Body {
     public abstract void setEncoding(String encoding) throws MessagingException;
 
     public long calculateSize() {
-        try {
-
-            CountingOutputStream out = new CountingOutputStream();
+        try (CountingOutputStream out = new CountingOutputStream()) {
             EOLConvertingOutputStream eolOut = new EOLConvertingOutputStream(out);
             writeTo(eolOut);
             eolOut.flush();
             return out.getCount();
-        } catch (IOException e) {
-            Timber.e(e, "Failed to calculate a message size");
-        } catch (MessagingException e) {
+        } catch (IOException | MessagingException e) {
             Timber.e(e, "Failed to calculate a message size");
         }
         return 0;

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/TextBody.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/TextBody.java
@@ -113,23 +113,18 @@ public class TextBody implements Body, SizeAware {
     }
 
     private long getLengthWhenQuotedPrintableEncoded(byte[] bytes) throws IOException {
-        CountingOutputStream countingOutputStream = new CountingOutputStream();
-        writeSignSafeQuotedPrintable(countingOutputStream, bytes);
-        return countingOutputStream.getCount();
+        try (CountingOutputStream countingOutputStream = new CountingOutputStream()) {
+            writeSignSafeQuotedPrintable(countingOutputStream, bytes);
+            return countingOutputStream.getCount();
+        }
     }
 
     private void writeSignSafeQuotedPrintable(OutputStream out, byte[] bytes) throws IOException {
-        SignSafeOutputStream signSafeOutputStream = new SignSafeOutputStream(out);
-        try {
-            QuotedPrintableOutputStream signSafeQuotedPrintableOutputStream =
-                    new QuotedPrintableOutputStream(signSafeOutputStream, false);
-            try {
+        try (SignSafeOutputStream signSafeOutputStream = new SignSafeOutputStream(out)) {
+            try (QuotedPrintableOutputStream signSafeQuotedPrintableOutputStream = new QuotedPrintableOutputStream(
+                    signSafeOutputStream, false)) {
                 signSafeQuotedPrintableOutputStream.write(bytes);
-            } finally {
-                signSafeQuotedPrintableOutputStream.close();
             }
-        } finally {
-            signSafeOutputStream.close();
         }
     }
 


### PR DESCRIPTION
- Ensure `CountingOutputStream` is closed in `ProgressBodyFactory#copyData`.