### PR TITLE
Remember notification timestamp

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/NewMailNotificationManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NewMailNotificationManager.kt
@@ -23,12 +23,13 @@ internal class NewMailNotificationManager(
 
         synchronized(lock) {
             val notificationData = getOrCreateNotificationData(account)
-            val result = notificationData.addNotificationContent(content)
+            val result = notificationData.addNotificationContent(content, timestamp = now())
 
             val singleNotificationData = createSingleNotificationData(
                 account = account,
                 notificationId = result.notificationHolder.notificationId,
                 content = result.notificationHolder.content,
+                timestamp = result.notificationHolder.timestamp,
                 addLockScreenNotification = notificationData.isSingleMessageNotification
             )
 
@@ -69,6 +70,7 @@ internal class NewMailNotificationManager(
                     account = account,
                     notificationId = result.notificationHolder.notificationId,
                     content = result.notificationHolder.content,
+                    timestamp = result.notificationHolder.timestamp,
                     addLockScreenNotification = notificationData.isSingleMessageNotification
                 )
                 listOf(singleNotificationData)
@@ -101,19 +103,20 @@ internal class NewMailNotificationManager(
         account: Account,
         notificationId: Int,
         content: NotificationContent,
+        timestamp: Long,
         addLockScreenNotification: Boolean
     ): SingleNotificationData {
         return singleMessageNotificationDataCreator.createSingleNotificationData(
             account,
             notificationId,
             content,
-            timestamp = now(),
+            timestamp,
             addLockScreenNotification
         )
     }
 
     private fun createSummaryNotificationData(data: NotificationData, silent: Boolean): SummaryNotificationData {
-        return summaryNotificationDataCreator.createSummaryNotificationData(data, timestamp = now(), silent)
+        return summaryNotificationDataCreator.createSummaryNotificationData(data, silent)
     }
 
     private fun getOrCreateNotificationData(account: Account): NotificationData {

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationHolder.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationHolder.kt
@@ -2,5 +2,11 @@ package com.fsck.k9.notification
 
 internal class NotificationHolder(
     val notificationId: Int,
+    val timestamp: Long,
+    val content: NotificationContent
+)
+
+internal class InactiveNotificationHolder(
+    val timestamp: Long,
     val content: NotificationContent
 )

--- a/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationDataCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationDataCreator.kt
@@ -6,11 +6,8 @@ import com.fsck.k9.K9
 internal class SummaryNotificationDataCreator(
     private val singleMessageNotificationDataCreator: SingleMessageNotificationDataCreator
 ) {
-    fun createSummaryNotificationData(
-        data: NotificationData,
-        timestamp: Long,
-        silent: Boolean
-    ): SummaryNotificationData {
+    fun createSummaryNotificationData(data: NotificationData, silent: Boolean): SummaryNotificationData {
+        val timestamp = data.holderForLatestNotification.timestamp
         val shouldBeSilent = silent || K9.isQuietTime
         return if (data.isSingleMessageNotification) {
             createSummarySingleNotificationData(data, timestamp, shouldBeSilent)

--- a/app/core/src/test/java/com/fsck/k9/notification/AddNotificationResultTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/AddNotificationResultTest.kt
@@ -9,6 +9,7 @@ private const val NOTIFICATION_ID = 23
 class AddNotificationResultTest {
     private val notificationHolder = NotificationHolder(
         notificationId = NOTIFICATION_ID,
+        timestamp = 0L,
         content = NotificationContent(
             messageReference = MessageReference("irrelevant", 1, "irrelevant"),
             sender = "irrelevant",

--- a/app/core/src/test/java/com/fsck/k9/notification/BaseNotificationDataCreatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/BaseNotificationDataCreatorTest.kt
@@ -181,7 +181,8 @@ class BaseNotificationDataCreatorTest {
                     preview = "irrelevant",
                     summary = "irrelevant",
                     subject = "irrelevant"
-                )
+                ),
+                timestamp = 0L
             )
         }
         return notificationData

--- a/app/core/src/test/java/com/fsck/k9/notification/NotificationDataTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NotificationDataTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.mock
 private const val ACCOUNT_UUID = "1-2-3"
 private const val ACCOUNT_NUMBER = 23
 private const val FOLDER_ID = 42L
+private const val TIMESTAMP = 0L
 
 class NotificationDataTest : RobolectricTest() {
     private val account = createFakeAccount()
@@ -21,7 +22,7 @@ class NotificationDataTest : RobolectricTest() {
     fun testAddNotificationContent() {
         val content = createNotificationContent("1")
 
-        val result = notificationData.addNotificationContent(content)
+        val result = notificationData.addNotificationContent(content, TIMESTAMP)
 
         assertThat(result.shouldCancelNotification).isFalse()
 
@@ -34,16 +35,16 @@ class NotificationDataTest : RobolectricTest() {
 
     @Test
     fun testAddNotificationContentWithReplacingNotification() {
-        notificationData.addNotificationContent(createNotificationContent("1"))
-        notificationData.addNotificationContent(createNotificationContent("2"))
-        notificationData.addNotificationContent(createNotificationContent("3"))
-        notificationData.addNotificationContent(createNotificationContent("4"))
-        notificationData.addNotificationContent(createNotificationContent("5"))
-        notificationData.addNotificationContent(createNotificationContent("6"))
-        notificationData.addNotificationContent(createNotificationContent("7"))
-        notificationData.addNotificationContent(createNotificationContent("8"))
+        notificationData.addNotificationContent(createNotificationContent("1"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("2"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("3"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("4"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("5"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("6"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("7"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("8"), TIMESTAMP)
 
-        val result = notificationData.addNotificationContent(createNotificationContent("9"))
+        val result = notificationData.addNotificationContent(createNotificationContent("9"), TIMESTAMP)
 
         assertThat(result.shouldCancelNotification).isTrue()
         assertThat(result.notificationId).isEqualTo(NotificationIds.getSingleMessageNotificationId(account, 0))
@@ -52,7 +53,7 @@ class NotificationDataTest : RobolectricTest() {
     @Test
     fun testRemoveNotificationForMessage() {
         val content = createNotificationContent("1")
-        notificationData.addNotificationContent(content)
+        notificationData.addNotificationContent(content, TIMESTAMP)
 
         val result = notificationData.removeNotificationForMessage(content.messageReference)
 
@@ -63,18 +64,18 @@ class NotificationDataTest : RobolectricTest() {
 
     @Test
     fun testRemoveNotificationForMessageWithRecreatingNotification() {
-        notificationData.addNotificationContent(createNotificationContent("1"))
+        notificationData.addNotificationContent(createNotificationContent("1"), TIMESTAMP)
         val content = createNotificationContent("2")
-        notificationData.addNotificationContent(content)
-        notificationData.addNotificationContent(createNotificationContent("3"))
-        notificationData.addNotificationContent(createNotificationContent("4"))
-        notificationData.addNotificationContent(createNotificationContent("5"))
-        notificationData.addNotificationContent(createNotificationContent("6"))
-        notificationData.addNotificationContent(createNotificationContent("7"))
-        notificationData.addNotificationContent(createNotificationContent("8"))
-        notificationData.addNotificationContent(createNotificationContent("9"))
+        notificationData.addNotificationContent(content, TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("3"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("4"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("5"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("6"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("7"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("8"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("9"), TIMESTAMP)
         val latestContent = createNotificationContent("10")
-        notificationData.addNotificationContent(latestContent)
+        notificationData.addNotificationContent(latestContent, TIMESTAMP)
 
         val result = notificationData.removeNotificationForMessage(latestContent.messageReference)
 
@@ -91,7 +92,7 @@ class NotificationDataTest : RobolectricTest() {
     fun testRemoveDoesNotLeakNotificationIds() {
         for (i in 1..NotificationData.MAX_NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS + 1) {
             val content = createNotificationContent(i.toString())
-            notificationData.addNotificationContent(content)
+            notificationData.addNotificationContent(content, TIMESTAMP)
             notificationData.removeNotificationForMessage(content.messageReference)
         }
     }
@@ -101,11 +102,11 @@ class NotificationDataTest : RobolectricTest() {
         assertThat(notificationData.newMessagesCount).isEqualTo(0)
 
         val contentOne = createNotificationContent("1")
-        notificationData.addNotificationContent(contentOne)
+        notificationData.addNotificationContent(contentOne, TIMESTAMP)
         assertThat(notificationData.newMessagesCount).isEqualTo(1)
 
         val contentTwo = createNotificationContent("2")
-        notificationData.addNotificationContent(contentTwo)
+        notificationData.addNotificationContent(contentTwo, TIMESTAMP)
         assertThat(notificationData.newMessagesCount).isEqualTo(2)
     }
 
@@ -113,17 +114,17 @@ class NotificationDataTest : RobolectricTest() {
     fun testIsSingleMessageNotification() {
         assertThat(notificationData.isSingleMessageNotification).isFalse()
 
-        notificationData.addNotificationContent(createNotificationContent("1"))
+        notificationData.addNotificationContent(createNotificationContent("1"), TIMESTAMP)
         assertThat(notificationData.isSingleMessageNotification).isTrue()
 
-        notificationData.addNotificationContent(createNotificationContent("2"))
+        notificationData.addNotificationContent(createNotificationContent("2"), TIMESTAMP)
         assertThat(notificationData.isSingleMessageNotification).isFalse()
     }
 
     @Test
     fun testGetHolderForLatestNotification() {
         val content = createNotificationContent("1")
-        val addResult = notificationData.addNotificationContent(content)
+        val addResult = notificationData.addNotificationContent(content, TIMESTAMP)
 
         val holder = notificationData.holderForLatestNotification
 
@@ -132,17 +133,17 @@ class NotificationDataTest : RobolectricTest() {
 
     @Test
     fun testGetContentForSummaryNotification() {
-        notificationData.addNotificationContent(createNotificationContent("1"))
+        notificationData.addNotificationContent(createNotificationContent("1"), TIMESTAMP)
         val content4 = createNotificationContent("2")
-        notificationData.addNotificationContent(content4)
+        notificationData.addNotificationContent(content4, TIMESTAMP)
         val content3 = createNotificationContent("3")
-        notificationData.addNotificationContent(content3)
+        notificationData.addNotificationContent(content3, TIMESTAMP)
         val content2 = createNotificationContent("4")
-        notificationData.addNotificationContent(content2)
+        notificationData.addNotificationContent(content2, TIMESTAMP)
         val content1 = createNotificationContent("5")
-        notificationData.addNotificationContent(content1)
+        notificationData.addNotificationContent(content1, TIMESTAMP)
         val content0 = createNotificationContent("6")
-        notificationData.addNotificationContent(content0)
+        notificationData.addNotificationContent(content0, TIMESTAMP)
 
         val contents = notificationData.getContentForSummaryNotification()
 
@@ -156,8 +157,8 @@ class NotificationDataTest : RobolectricTest() {
 
     @Test
     fun testGetActiveNotificationIds() {
-        notificationData.addNotificationContent(createNotificationContent("1"))
-        notificationData.addNotificationContent(createNotificationContent("2"))
+        notificationData.addNotificationContent(createNotificationContent("1"), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent("2"), TIMESTAMP)
 
         val notificationIds = notificationData.getActiveNotificationIds()
 
@@ -182,15 +183,15 @@ class NotificationDataTest : RobolectricTest() {
         val messageReference6 = createMessageReference("7")
         val messageReference7 = createMessageReference("8")
         val messageReference8 = createMessageReference("9")
-        notificationData.addNotificationContent(createNotificationContent(messageReference8))
-        notificationData.addNotificationContent(createNotificationContent(messageReference7))
-        notificationData.addNotificationContent(createNotificationContent(messageReference6))
-        notificationData.addNotificationContent(createNotificationContent(messageReference5))
-        notificationData.addNotificationContent(createNotificationContent(messageReference4))
-        notificationData.addNotificationContent(createNotificationContent(messageReference3))
-        notificationData.addNotificationContent(createNotificationContent(messageReference2))
-        notificationData.addNotificationContent(createNotificationContent(messageReference1))
-        notificationData.addNotificationContent(createNotificationContent(messageReference0))
+        notificationData.addNotificationContent(createNotificationContent(messageReference8), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference7), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference6), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference5), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference4), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference3), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference2), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference1), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference0), TIMESTAMP)
 
         val messageReferences = notificationData.getAllMessageReferences()
 
@@ -220,15 +221,15 @@ class NotificationDataTest : RobolectricTest() {
         val messageReference6 = createMessageReference("7")
         val messageReference7 = createMessageReference("8")
         val messageReference8 = createMessageReference("9")
-        notificationData.addNotificationContent(createNotificationContent(messageReference8))
-        notificationData.addNotificationContent(createNotificationContent(messageReference7))
-        notificationData.addNotificationContent(createNotificationContent(messageReference6))
-        notificationData.addNotificationContent(createNotificationContent(messageReference5))
-        notificationData.addNotificationContent(createNotificationContent(messageReference4))
-        notificationData.addNotificationContent(createNotificationContent(messageReference3))
-        notificationData.addNotificationContent(createNotificationContent(messageReference2))
-        notificationData.addNotificationContent(createNotificationContent(messageReference1))
-        notificationData.addNotificationContent(createNotificationContent(messageReference0))
+        notificationData.addNotificationContent(createNotificationContent(messageReference8), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference7), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference6), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference5), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference4), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference3), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference2), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference1), TIMESTAMP)
+        notificationData.addNotificationContent(createNotificationContent(messageReference0), TIMESTAMP)
 
         assertThat(notificationData.hasSummaryOverflowMessages()).isTrue()
         assertThat(notificationData.getSummaryOverflowMessagesCount()).isEqualTo(4)

--- a/app/core/src/test/java/com/fsck/k9/notification/RemoveNotificationResultTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/RemoveNotificationResultTest.kt
@@ -12,6 +12,7 @@ private const val NOTIFICATION_ID = 23
 class RemoveNotificationResultTest {
     private val notificationHolder = NotificationHolder(
         notificationId = NOTIFICATION_ID,
+        timestamp = 0L,
         content = NotificationContent(
             messageReference = MessageReference("irrelevant", 1, "irrelevant"),
             sender = "irrelevant",

--- a/app/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationDataCreatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationDataCreatorTest.kt
@@ -268,7 +268,7 @@ class SingleMessageNotificationDataCreatorTest {
 
     private fun createNotificationData(content: NotificationContent): NotificationData {
         return NotificationData(account).apply {
-            addNotificationContent(content)
+            addNotificationContent(content, timestamp = 0L)
         }
     }
 }

--- a/app/core/src/test/java/com/fsck/k9/notification/SummaryNotificationDataCreatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/SummaryNotificationDataCreatorTest.kt
@@ -13,6 +13,8 @@ import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 
+private val TIMESTAMP = 0L
+
 class SummaryNotificationDataCreatorTest {
     private val account = createAccount()
     private val notificationDataCreator = SummaryNotificationDataCreator(SingleMessageNotificationDataCreator())
@@ -40,7 +42,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = false
         )
 
@@ -54,7 +55,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = false
         )
 
@@ -69,7 +69,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = false
         )
 
@@ -84,7 +83,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = false
         )
 
@@ -99,7 +97,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = false
         )
 
@@ -113,7 +110,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = true
         )
 
@@ -122,7 +118,7 @@ class SummaryNotificationDataCreatorTest {
             NotificationIds.getNewMailSummaryNotificationId(account)
         )
         assertThat(summaryNotificationData.isSilent).isTrue()
-        assertThat(summaryNotificationData.timestamp).isEqualTo(9000)
+        assertThat(summaryNotificationData.timestamp).isEqualTo(TIMESTAMP)
     }
 
     @Test
@@ -131,7 +127,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = true
         )
 
@@ -148,7 +143,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = true
         )
 
@@ -165,7 +159,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = true
         )
 
@@ -182,7 +175,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = true
         )
 
@@ -198,7 +190,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = true
         )
 
@@ -214,7 +205,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = true
         )
 
@@ -229,7 +219,6 @@ class SummaryNotificationDataCreatorTest {
 
         val result = notificationDataCreator.createSummaryNotificationData(
             notificationData,
-            timestamp = 9000,
             silent = true
         )
 
@@ -272,7 +261,7 @@ class SummaryNotificationDataCreatorTest {
     ): NotificationData {
         return NotificationData(account).apply {
             for (content in contentList) {
-                addNotificationContent(content)
+                addNotificationContent(content, TIMESTAMP)
             }
         }
     }


### PR DESCRIPTION
When recreating a notification, use its original timestamp, not the current time.