### PR TITLE
Don't show sensitive information in status/error notifications on the lock screen

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/AuthenticationErrorNotificationController.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.notification
 
+import android.app.Notification
 import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -26,7 +27,7 @@ internal open class AuthenticationErrorNotificationController(
             .setContentText(text)
             .setContentIntent(editServerSettingsPendingIntent)
             .setStyle(NotificationCompat.BigTextStyle().bigText(text))
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setPublicVersion(createLockScreenNotification(account))
             .setCategory(NotificationCompat.CATEGORY_ERROR)
 
         notificationHelper.configureNotification(
@@ -52,6 +53,15 @@ internal open class AuthenticationErrorNotificationController(
         } else {
             actionCreator.getEditOutgoingServerSettingsIntent(account)
         }
+    }
+
+    private fun createLockScreenNotification(account: Account): Notification {
+        return notificationHelper
+            .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
+            .setSmallIcon(resourceProvider.iconWarning)
+            .setWhen(System.currentTimeMillis())
+            .setContentTitle(resourceProvider.authenticationErrorTitle())
+            .build()
     }
 
     private val notificationManager: NotificationManagerCompat

--- a/app/core/src/main/java/com/fsck/k9/notification/CertificateErrorNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CertificateErrorNotificationController.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.notification
 
+import android.app.Notification
 import android.app.PendingIntent
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
@@ -26,7 +27,7 @@ internal open class CertificateErrorNotificationController(
             .setContentText(text)
             .setContentIntent(editServerSettingsPendingIntent)
             .setStyle(NotificationCompat.BigTextStyle().bigText(text))
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setPublicVersion(createLockScreenNotification(account))
             .setCategory(NotificationCompat.CATEGORY_ERROR)
 
         notificationHelper.configureNotification(
@@ -52,6 +53,15 @@ internal open class CertificateErrorNotificationController(
         } else {
             actionCreator.getEditOutgoingServerSettingsIntent(account)
         }
+    }
+
+    private fun createLockScreenNotification(account: Account): Notification {
+        return notificationHelper
+            .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
+            .setSmallIcon(resourceProvider.iconWarning)
+            .setWhen(System.currentTimeMillis())
+            .setContentTitle(resourceProvider.certificateErrorTitle())
+            .build()
     }
 
     private val notificationManager: NotificationManagerCompat

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationResourceProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationResourceProvider.kt
@@ -24,6 +24,7 @@ interface NotificationResourceProvider {
     fun authenticationErrorTitle(): String
     fun authenticationErrorBody(accountName: String): String
 
+    fun certificateErrorTitle(): String
     fun certificateErrorTitle(accountName: String): String
     fun certificateErrorBody(): String
 

--- a/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.notification
 
+import android.app.Notification
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.fsck.k9.Account
@@ -29,7 +30,7 @@ internal class SendFailedNotificationController(
             .setContentText(text)
             .setContentIntent(folderListPendingIntent)
             .setStyle(NotificationCompat.BigTextStyle().bigText(text))
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setPublicVersion(createLockScreenNotification(account))
             .setCategory(NotificationCompat.CATEGORY_ERROR)
 
         notificationHelper.configureNotification(
@@ -47,6 +48,15 @@ internal class SendFailedNotificationController(
     fun clearSendFailedNotification(account: Account) {
         val notificationId = NotificationIds.getSendFailedNotificationId(account)
         notificationManager.cancel(notificationId)
+    }
+
+    private fun createLockScreenNotification(account: Account): Notification {
+        return notificationHelper
+            .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
+            .setSmallIcon(resourceProvider.iconWarning)
+            .setWhen(System.currentTimeMillis())
+            .setContentTitle(resourceProvider.sendFailedTitle())
+            .build()
     }
 
     private val notificationManager: NotificationManagerCompat

--- a/app/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.notification
 
+import android.app.Notification
 import androidx.core.app.NotificationCompat
 import androidx.core.app.NotificationManagerCompat
 import com.fsck.k9.Account
@@ -32,7 +33,7 @@ internal class SyncNotificationController(
             .setContentTitle(title)
             .setContentText(accountName)
             .setContentIntent(showMessageListPendingIntent)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setPublicVersion(createSendingLockScreenNotification(account))
 
         if (NOTIFICATION_LED_WHILE_SYNCING) {
             notificationHelper.configureNotification(
@@ -77,7 +78,7 @@ internal class SyncNotificationController(
             .setContentTitle(title)
             .setContentText(text)
             .setContentIntent(showMessageListPendingIntent)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setPublicVersion(createFetchingMailLockScreenNotification(account))
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
 
         if (NOTIFICATION_LED_WHILE_SYNCING) {
@@ -106,7 +107,7 @@ internal class SyncNotificationController(
             .setOngoing(true)
             .setContentTitle(title)
             .setContentText(text)
-            .setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+            .setPublicVersion(createFetchingMailLockScreenNotification(account))
             .setCategory(NotificationCompat.CATEGORY_SERVICE)
 
         if (NOTIFICATION_LED_WHILE_SYNCING) {
@@ -126,6 +127,24 @@ internal class SyncNotificationController(
     fun clearFetchingMailNotification(account: Account) {
         val notificationId = NotificationIds.getFetchingMailNotificationId(account)
         notificationManager.cancel(notificationId)
+    }
+
+    private fun createSendingLockScreenNotification(account: Account): Notification {
+        return notificationHelper
+            .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
+            .setSmallIcon(resourceProvider.iconSendingMail)
+            .setWhen(System.currentTimeMillis())
+            .setContentTitle(resourceProvider.sendingMailTitle())
+            .build()
+    }
+
+    private fun createFetchingMailLockScreenNotification(account: Account): Notification {
+        return notificationHelper
+            .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
+            .setSmallIcon(resourceProvider.iconCheckingMail)
+            .setWhen(System.currentTimeMillis())
+            .setContentTitle(resourceProvider.checkingMailTitle())
+            .build()
     }
 
     private val notificationManager: NotificationManagerCompat

--- a/app/core/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationControllerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/AuthenticationErrorNotificationControllerTest.kt
@@ -13,6 +13,7 @@ import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
 
 private const val INCOMING = true
 private const val OUTGOING = false
@@ -22,9 +23,15 @@ private const val ACCOUNT_NAME = "TestAccount"
 class AuthenticationErrorNotificationControllerTest : RobolectricTest() {
     private val resourceProvider = TestNotificationResourceProvider()
     private val notification = mock<Notification>()
+    private val lockScreenNotification = mock<Notification>()
     private val notificationManager = mock<NotificationManagerCompat>()
     private val builder = createFakeNotificationBuilder(notification)
-    private val notificationHelper = createFakeNotificationHelper(notificationManager, builder)
+    private val lockScreenNotificationBuilder = createFakeNotificationBuilder(lockScreenNotification)
+    private val notificationHelper = createFakeNotificationHelper(
+        notificationManager,
+        builder,
+        lockScreenNotificationBuilder
+    )
     private val account = createFakeAccount()
     private val controller = TestAuthenticationErrorNotificationController()
     private val contentIntent = mock<PendingIntent>()
@@ -73,7 +80,10 @@ class AuthenticationErrorNotificationControllerTest : RobolectricTest() {
         verify(builder).setContentTitle("Authentication failed")
         verify(builder).setContentText("Authentication failed for $ACCOUNT_NAME. Update your server settings.")
         verify(builder).setContentIntent(contentIntent)
-        verify(builder).setVisibility(NotificationCompat.VISIBILITY_PUBLIC)
+        verify(builder).setPublicVersion(lockScreenNotification)
+        verify(lockScreenNotificationBuilder).setContentTitle("Authentication failed")
+        verify(lockScreenNotificationBuilder, never()).setContentText(any())
+        verify(lockScreenNotificationBuilder, never()).setTicker(any())
     }
 
     private fun createFakeNotificationBuilder(notification: Notification): NotificationCompat.Builder {
@@ -84,12 +94,13 @@ class AuthenticationErrorNotificationControllerTest : RobolectricTest() {
 
     private fun createFakeNotificationHelper(
         notificationManager: NotificationManagerCompat,
-        builder: NotificationCompat.Builder
+        notificationBuilder: NotificationCompat.Builder,
+        lockScreenNotificationBuilder: NotificationCompat.Builder
     ): NotificationHelper {
         return mock {
             on { getContext() } doReturn ApplicationProvider.getApplicationContext()
             on { getNotificationManager() } doReturn notificationManager
-            on { createNotificationBuilder(any(), any()) } doReturn builder
+            on { createNotificationBuilder(any(), any()) }.doReturn(notificationBuilder, lockScreenNotificationBuilder)
         }
     }
 

--- a/app/core/src/test/java/com/fsck/k9/notification/TestNotificationResourceProvider.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/TestNotificationResourceProvider.kt
@@ -26,6 +26,8 @@ class TestNotificationResourceProvider : NotificationResourceProvider {
     override fun authenticationErrorBody(accountName: String): String =
         "Authentication failed for $accountName. Update your server settings."
 
+    override fun certificateErrorTitle(): String = "Certificate error"
+
     override fun certificateErrorTitle(accountName: String): String = "Certificate error for $accountName"
 
     override fun certificateErrorBody(): String = "Check your server settings"

--- a/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
+++ b/app/k9mail-jmap/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
@@ -36,6 +36,8 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override fun authenticationErrorBody(accountName: String): String =
         context.getString(R.string.notification_authentication_error_text, accountName)
 
+    override fun certificateErrorTitle(): String = context.getString(R.string.notification_certificate_error_public)
+
     override fun certificateErrorTitle(accountName: String): String =
         context.getString(R.string.notification_certificate_error_title, accountName)
 

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationResourceProvider.kt
@@ -36,6 +36,8 @@ class K9NotificationResourceProvider(private val context: Context) : Notificatio
     override fun authenticationErrorBody(accountName: String): String =
         context.getString(R.string.notification_authentication_error_text, accountName)
 
+    override fun certificateErrorTitle(): String = context.getString(R.string.notification_certificate_error_public)
+
     override fun certificateErrorTitle(accountName: String): String =
         context.getString(R.string.notification_certificate_error_title, accountName)
 

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -195,6 +195,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="notification_action_archive">Archive</string>
     <string name="notification_action_archive_all">Archive All</string>
     <string name="notification_action_spam">Spam</string>
+    <string name="notification_certificate_error_public">Certificate error</string>
     <string name="notification_certificate_error_title">Certificate error for <xliff:g id="account">%s</xliff:g></string>
     <string name="notification_certificate_error_text">Check your server settings</string>
 


### PR DESCRIPTION
Fixes #2823