### PR TITLE
Fix back button behavior in MessageList

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -184,6 +184,7 @@
 
         <activity
             android:name=".activity.MessageList"
+            android:launchMode="singleTop"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN"/>

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListRemoteViewFactory.java
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/list/MessageListRemoteViewFactory.java
@@ -135,6 +135,7 @@ public class MessageListRemoteViewFactory implements RemoteViewsService.RemoteVi
         }
 
         Intent intent = new Intent();
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
         intent.setData(item.uri);
         remoteView.setOnClickFillInIntent(R.id.mail_list_item, intent);
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -215,6 +215,12 @@ open class MessageList :
             return
         }
 
+        if (intent.action == Intent.ACTION_MAIN && intent.hasCategory(Intent.CATEGORY_LAUNCHER)) {
+            // There's nothing to do if the default launcher Intent was used.
+            // This only brings the existing screen to the foreground.
+            return
+        }
+
         setIntent(intent)
 
         if (firstBackStackId >= 0) {


### PR DESCRIPTION
When opening the message view screen from a notification we want the back button to go to the message list screen.
When opening the message view screen from the message list widget we want the back button to return to the message list widget on the home screen. So we finish the Activity.

Fixes #5819