### PR TITLE
Summary notification opens Unified Inbox

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
@@ -172,6 +172,11 @@ interface MessageStore {
     fun <T> getDisplayFolders(displayMode: FolderMode, outboxFolderId: Long?, mapper: FolderMapper<T>): List<T>
 
     /**
+     * Check if all given folders are included in the Unified Inbox.
+     */
+    fun areAllIncludedInUnifiedInbox(folderIds: Collection<Long>): Boolean
+
+    /**
      * Find a folder with the given server ID and return its store ID.
      */
     fun getFolderId(folderServerId: String): Long?

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/KoinModule.kt
@@ -3,7 +3,9 @@ package com.fsck.k9.notification
 import org.koin.dsl.module
 
 val notificationModule = module {
-    single<NotificationActionCreator> { K9NotificationActionCreator(context = get(), defaultFolderProvider = get()) }
+    single<NotificationActionCreator> {
+        K9NotificationActionCreator(context = get(), defaultFolderProvider = get(), messageStoreManager = get())
+    }
     single<NotificationResourceProvider> { K9NotificationResourceProvider(get()) }
     single<NotificationStrategy> { K9NotificationStrategy(get()) }
 }

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/CheckFolderOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/CheckFolderOperations.kt
@@ -1,0 +1,33 @@
+package com.fsck.k9.storage.messages
+
+import com.fsck.k9.mailstore.LockableDatabase
+
+internal class CheckFolderOperations(private val lockableDatabase: LockableDatabase) {
+    fun areAllIncludedInUnifiedInbox(folderIds: Collection<Long>): Boolean {
+        return lockableDatabase.execute(false) { database ->
+            var allIncludedInUnifiedInbox = true
+
+            performChunkedOperation(
+                arguments = folderIds,
+                argumentTransformation = Long::toString
+            ) { selectionSet, selectionArguments ->
+                if (allIncludedInUnifiedInbox) {
+                    database.rawQuery(
+                        "SELECT COUNT(id) FROM folders WHERE integrate = 1 AND id $selectionSet", selectionArguments
+                    ).use { cursor ->
+                        if (cursor.moveToFirst()) {
+                            val count = cursor.getInt(0)
+                            if (count != selectionArguments.size) {
+                                allIncludedInUnifiedInbox = false
+                            }
+                        } else {
+                            allIncludedInUnifiedInbox = false
+                        }
+                    }
+                }
+            }
+
+            allIncludedInUnifiedInbox
+        }
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -37,6 +37,7 @@ class K9MessageStore(
     private val deleteMessageOperations = DeleteMessageOperations(database, attachmentFileManager)
     private val createFolderOperations = CreateFolderOperations(database)
     private val retrieveFolderOperations = RetrieveFolderOperations(database)
+    private val checkFolderOperations = CheckFolderOperations(database)
     private val updateFolderOperations = UpdateFolderOperations(database)
     private val deleteFolderOperations = DeleteFolderOperations(database, attachmentFileManager)
     private val keyValueStoreOperations = KeyValueStoreOperations(database)
@@ -128,6 +129,10 @@ class K9MessageStore(
         mapper: FolderMapper<T>
     ): List<T> {
         return retrieveFolderOperations.getDisplayFolders(displayMode, outboxFolderId, mapper)
+    }
+
+    override fun areAllIncludedInUnifiedInbox(folderIds: Collection<Long>): Boolean {
+        return checkFolderOperations.areAllIncludedInUnifiedInbox(folderIds)
     }
 
     override fun getFolderId(folderServerId: String): Long? {

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/CheckFolderOperationsTest.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/CheckFolderOperationsTest.kt
@@ -1,0 +1,63 @@
+package com.fsck.k9.storage.messages
+
+import com.fsck.k9.storage.RobolectricTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class CheckFolderOperationsTest : RobolectricTest() {
+    private val sqliteDatabase = createDatabase()
+    private val lockableDatabase = createLockableDatabaseMock(sqliteDatabase)
+    private val checkFolderOperations = CheckFolderOperations(lockableDatabase)
+
+    @Test
+    fun `single folder not included in Unified Inbox`() {
+        val folderIds = listOf(sqliteDatabase.createFolder(integrate = false))
+
+        val result = checkFolderOperations.areAllIncludedInUnifiedInbox(folderIds)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `single folder included in Unified Inbox`() {
+        val folderIds = listOf(sqliteDatabase.createFolder(integrate = true))
+
+        val result = checkFolderOperations.areAllIncludedInUnifiedInbox(folderIds)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `not all folders included in Unified Inbox`() {
+        val folderIds = listOf(
+            sqliteDatabase.createFolder(integrate = true),
+            sqliteDatabase.createFolder(integrate = false)
+        )
+
+        val result = checkFolderOperations.areAllIncludedInUnifiedInbox(folderIds)
+
+        assertThat(result).isFalse()
+    }
+
+    @Test
+    fun `1000 folders included in Unified Inbox`() {
+        val folderIds = List(1000) {
+            sqliteDatabase.createFolder(integrate = true)
+        }
+
+        val result = checkFolderOperations.areAllIncludedInUnifiedInbox(folderIds)
+
+        assertThat(result).isTrue()
+    }
+
+    @Test
+    fun `999 of 1000 folders included in Unified Inbox`() {
+        val folderIds = List(999) {
+            sqliteDatabase.createFolder(integrate = true)
+        } + sqliteDatabase.createFolder(integrate = false)
+
+        val result = checkFolderOperations.areAllIncludedInUnifiedInbox(folderIds)
+
+        assertThat(result).isFalse()
+    }
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1672,6 +1672,21 @@ open class MessageList :
             }
         }
 
+        fun createUnifiedInboxIntent(context: Context, account: Account): Intent {
+            return Intent(context, MessageList::class.java).apply {
+                val search = SearchAccount.createUnifiedInboxAccount().relatedSearch
+
+                // TODO: Use 'account' parameter
+
+                putExtra(EXTRA_SEARCH, ParcelableUtil.marshall(search))
+                putExtra(EXTRA_NO_THREADING, false)
+
+                addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP)
+                addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP)
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            }
+        }
+
         @JvmStatic
         fun shortcutIntent(context: Context?, specialFolder: String?): Intent {
             return Intent(context, MessageList::class.java).apply {


### PR DESCRIPTION
When tapping the summary notification and all messages belong to a folder that is included in the Unified Inbox, open the Unified Inbox (provided it is enabled).

Implements the first part of #5565