### PR TITLE
Add "new messages" view

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2407,7 +2407,7 @@ public class MessagingController {
                             clearFetchingMailNotification(account);
 
                             if (getUnreadMessageCount(account) == 0) {
-                                notificationController.clearNewMailNotifications(account);
+                                notificationController.clearNewMailNotifications(account, false);
                             }
                         }
                     }
@@ -2493,7 +2493,7 @@ public class MessagingController {
     }
 
     public void deleteAccount(Account account) {
-        notificationController.clearNewMailNotifications(account);
+        notificationController.clearNewMailNotifications(account, false);
         memorizingMessagingListener.removeAccount(account);
     }
 
@@ -2549,8 +2549,14 @@ public class MessagingController {
         }
     }
 
+    public void removeNotificationsForAccount(Account account) {
+        put("removeNotificationsForAccount", null, () -> {
+            notificationController.clearNewMailNotifications(account, false);
+        });
+    }
+
     public void cancelNotificationsForAccount(Account account) {
-        notificationController.clearNewMailNotifications(account);
+        notificationController.clearNewMailNotifications(account, true);
     }
 
     public void cancelNotificationForMessage(Account account, MessageReference messageReference) {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -1365,6 +1365,15 @@ public class MessagingController {
         messageStore.setNewMessageState(folderId, messageServerId, false);
     }
 
+    public void clearNewMessages(Account account) {
+        put("clearNewMessages", null, () -> clearNewMessagesBlocking(account));
+    }
+
+    private void clearNewMessagesBlocking(Account account) {
+        MessageStore messageStore = messageStoreManager.getMessageStore(account);
+        messageStore.clearNewMessageState();
+    }
+
     public void loadAttachment(final Account account, final LocalMessage message, final Part part,
             final MessagingListener listener) {
 

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
@@ -84,6 +84,11 @@ interface MessageStore {
     fun setNewMessageState(folderId: Long, messageServerId: String, newMessage: Boolean)
 
     /**
+     * Clear the new message state for all messages.
+     */
+    fun clearNewMessageState()
+
+    /**
      * Retrieve the server ID for a given message.
      */
     fun getMessageServerId(messageId: Long): String

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
@@ -79,6 +79,11 @@ interface MessageStore {
     fun setMessageFlag(folderId: Long, messageServerId: String, flag: Flag, set: Boolean)
 
     /**
+     * Set whether a message should be considered as new.
+     */
+    fun setNewMessageState(folderId: Long, messageServerId: String, newMessage: Boolean)
+
+    /**
      * Retrieve the server ID for a given message.
      */
     fun getMessageServerId(messageId: Long): String

--- a/app/core/src/main/java/com/fsck/k9/mailstore/NotifierMessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/NotifierMessageStore.kt
@@ -43,6 +43,11 @@ class NotifierMessageStore(
         notifyChange()
     }
 
+    override fun setNewMessageState(folderId: Long, messageServerId: String, newMessage: Boolean) {
+        messageStore.setNewMessageState(folderId, messageServerId, newMessage)
+        notifyChange()
+    }
+
     override fun destroyMessages(folderId: Long, messageServerIds: Collection<String>) {
         messageStore.destroyMessages(folderId, messageServerIds)
         notifyChange()

--- a/app/core/src/main/java/com/fsck/k9/mailstore/NotifierMessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/NotifierMessageStore.kt
@@ -48,6 +48,11 @@ class NotifierMessageStore(
         notifyChange()
     }
 
+    override fun clearNewMessageState() {
+        messageStore.clearNewMessageState()
+        notifyChange()
+    }
+
     override fun destroyMessages(folderId: Long, messageServerIds: Collection<String>) {
         messageStore.destroyMessages(folderId, messageServerIds)
         notifyChange()

--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -108,6 +108,7 @@ val coreNotificationModule = module {
         NotificationRepository(
             notificationStoreProvider = get(),
             localStoreProvider = get(),
+            messageStoreManager = get(),
             notificationContentCreator = get()
         )
     }

--- a/app/core/src/main/java/com/fsck/k9/notification/NewMailNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NewMailNotificationController.kt
@@ -38,8 +38,8 @@ internal class NewMailNotificationController(
         }
     }
 
-    fun clearNewMailNotifications(account: Account) {
-        val cancelNotificationIds = newMailNotificationManager.clearNewMailNotifications(account)
+    fun clearNewMailNotifications(account: Account, clearNewMessageState: Boolean) {
+        val cancelNotificationIds = newMailNotificationManager.clearNewMailNotifications(account, clearNewMessageState)
 
         cancelNotifications(cancelNotificationIds)
     }

--- a/app/core/src/main/java/com/fsck/k9/notification/NewMailNotificationManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NewMailNotificationManager.kt
@@ -100,8 +100,8 @@ internal class NewMailNotificationManager(
         )
     }
 
-    fun clearNewMailNotifications(account: Account): List<Int> {
-        notificationRepository.clearNotifications(account)
+    fun clearNewMailNotifications(account: Account, clearNewMessageState: Boolean): List<Int> {
+        notificationRepository.clearNotifications(account, clearNewMessageState)
         return NotificationIds.getAllMessageNotificationIds(account)
     }
 

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationController.kt
@@ -68,7 +68,7 @@ class NotificationController internal constructor(
         newMailNotificationController.removeNewMailNotification(account, messageReference)
     }
 
-    fun clearNewMailNotifications(account: Account) {
-        newMailNotificationController.clearNewMailNotifications(account)
+    fun clearNewMailNotifications(account: Account, clearNewMessageState: Boolean) {
+        newMailNotificationController.clearNewMailNotifications(account, clearNewMessageState)
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationRepository.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationRepository.kt
@@ -51,9 +51,12 @@ internal class NotificationRepository(
     }
 
     @Synchronized
-    fun clearNotifications(account: Account) {
-        return notificationDataStore.clearNotifications(account).also {
-            clearNotificationStore(account)
+    fun clearNotifications(account: Account, clearNewMessageState: Boolean) {
+        notificationDataStore.clearNotifications(account)
+        clearNotificationStore(account)
+
+        if (clearNewMessageState) {
+            clearNewMessageState(account)
         }
     }
 
@@ -88,6 +91,11 @@ internal class NotificationRepository(
                 else -> Unit
             }
         }
+    }
+
+    private fun clearNewMessageState(account: Account) {
+        val messageStore = messageStoreManager.getMessageStore(account)
+        messageStore.clearNewMessageState()
     }
 
     private fun clearNotificationStore(account: Account) {

--- a/app/core/src/main/java/com/fsck/k9/search/SearchAccount.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SearchAccount.java
@@ -14,6 +14,7 @@ import com.fsck.k9.search.SearchSpecification.SearchField;
  */
 public class SearchAccount implements BaseAccount {
     public static final String UNIFIED_INBOX = "unified_inbox";
+    public static final String NEW_MESSAGES = "new_messages";
 
 
     // create the unified inbox meta account ( all accounts is default when none specified )

--- a/app/core/src/main/java/com/fsck/k9/search/SearchSpecification.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SearchSpecification.java
@@ -68,6 +68,7 @@ public interface SearchSpecification extends Parcelable {
         THREAD_ID,
         ID,
         INTEGRATE,
+        NEW_MESSAGE,
         READ,
         FLAGGED,
         DISPLAY_CLASS,

--- a/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
+++ b/app/core/src/main/java/com/fsck/k9/search/SqlQueryBuilder.java
@@ -150,6 +150,10 @@ public class SqlQueryBuilder {
                 columnName = "integrate";
                 break;
             }
+            case NEW_MESSAGE: {
+                columnName = "new_message";
+                break;
+            }
             case READ: {
                 columnName = "read";
                 break;
@@ -247,6 +251,7 @@ public class SqlQueryBuilder {
             case FOLDER:
             case ID:
             case INTEGRATE:
+            case NEW_MESSAGE:
             case THREAD_ID:
             case READ:
             case FLAGGED: {

--- a/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationManagerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NewMailNotificationManagerTest.kt
@@ -6,6 +6,7 @@ import com.fsck.k9.controller.MessageReference
 import com.fsck.k9.mailstore.LocalMessage
 import com.fsck.k9.mailstore.LocalStore
 import com.fsck.k9.mailstore.LocalStoreProvider
+import com.fsck.k9.mailstore.MessageStoreManager
 import com.fsck.k9.mailstore.NotificationMessage
 import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertNotNull
@@ -429,14 +430,18 @@ class NewMailNotificationManagerTest {
     }
 
     private fun createNotificationRepository(): NotificationRepository {
-        val notificationStoreProvider = object : NotificationStoreProvider {
-            override fun getNotificationStore(account: Account): NotificationStore {
-                return object : NotificationStore {
-                    override fun persistNotificationChanges(operations: List<NotificationStoreOperation>) = Unit
-                    override fun clearNotifications() = Unit
-                }
-            }
+        val notificationStoreProvider = mock<NotificationStoreProvider> {
+            on { getNotificationStore(account) } doReturn mock()
         }
-        return NotificationRepository(notificationStoreProvider, localStoreProvider, notificationContentCreator)
+        val messageStoreManager = mock<MessageStoreManager> {
+            on { getMessageStore(account) } doReturn mock()
+        }
+
+        return NotificationRepository(
+            notificationStoreProvider,
+            localStoreProvider,
+            messageStoreManager,
+            notificationContentCreator
+        )
     }
 }

--- a/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/notification/K9NotificationActionCreator.kt
@@ -56,7 +56,7 @@ internal class K9NotificationActionCreator(
         } else if (folderIds.size == 1) {
             createMessageListIntent(account, folderIds.first())
         } else {
-            createMessageListIntent(account)
+            createNewMessagesIntent(account)
         }
 
         return PendingIntent.getActivity(context, notificationId, intent, PendingIntent.FLAG_UPDATE_CURRENT)
@@ -232,6 +232,10 @@ internal class K9NotificationActionCreator(
 
     private fun createUnifiedInboxIntent(account: Account): Intent {
         return MessageList.createUnifiedInboxIntent(context, account)
+    }
+
+    private fun createNewMessagesIntent(account: Account): Intent {
+        return MessageList.createNewMessagesIntent(context, account)
     }
 
     private fun extractFolderIds(messageReferences: List<MessageReference>): Set<Long> {

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -72,6 +72,10 @@ class K9MessageStore(
         updateMessageOperations.setNewMessageState(folderId, messageServerId, newMessage)
     }
 
+    override fun clearNewMessageState() {
+        updateMessageOperations.clearNewMessageState()
+    }
+
     override fun getMessageServerId(messageId: Long): String {
         return retrieveMessageOperations.getMessageServerId(messageId)
     }

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -33,6 +33,7 @@ class K9MessageStore(
     private val copyMessageOperations = CopyMessageOperations(database, attachmentFileManager, threadMessageOperations)
     private val moveMessageOperations = MoveMessageOperations(database, threadMessageOperations)
     private val flagMessageOperations = FlagMessageOperations(database)
+    private val updateMessageOperations = UpdateMessageOperations(database)
     private val retrieveMessageOperations = RetrieveMessageOperations(database)
     private val deleteMessageOperations = DeleteMessageOperations(database, attachmentFileManager)
     private val createFolderOperations = CreateFolderOperations(database)
@@ -65,6 +66,10 @@ class K9MessageStore(
 
     override fun setMessageFlag(folderId: Long, messageServerId: String, flag: Flag, set: Boolean) {
         flagMessageOperations.setMessageFlag(folderId, messageServerId, flag, set)
+    }
+
+    override fun setNewMessageState(folderId: Long, messageServerId: String, newMessage: Boolean) {
+        updateMessageOperations.setNewMessageState(folderId, messageServerId, newMessage)
     }
 
     override fun getMessageServerId(messageId: Long): String {

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/UpdateMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/UpdateMessageOperations.kt
@@ -1,0 +1,22 @@
+package com.fsck.k9.storage.messages
+
+import android.content.ContentValues
+import com.fsck.k9.mailstore.LockableDatabase
+
+internal class UpdateMessageOperations(private val lockableDatabase: LockableDatabase) {
+
+    fun setNewMessageState(folderId: Long, messageServerId: String, newMessage: Boolean) {
+        lockableDatabase.execute(false) { database ->
+            val values = ContentValues().apply {
+                put("new_message", if (newMessage) 1 else 0)
+            }
+
+            database.update(
+                "messages",
+                values,
+                "folder_id = ? AND uid = ?",
+                arrayOf(folderId.toString(), messageServerId)
+            )
+        }
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/UpdateMessageOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/UpdateMessageOperations.kt
@@ -19,4 +19,10 @@ internal class UpdateMessageOperations(private val lockableDatabase: LockableDat
             )
         }
     }
+
+    fun clearNewMessageState() {
+        lockableDatabase.execute(false) { database ->
+            database.execSQL("UPDATE messages SET new_message = 0")
+        }
+    }
 }

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo82.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo82.kt
@@ -1,0 +1,27 @@
+package com.fsck.k9.storage.migrations
+
+import android.database.sqlite.SQLiteDatabase
+
+/**
+ * Add 'new_message' column to 'messages' table.
+ */
+internal class MigrationTo82(private val db: SQLiteDatabase) {
+    fun addNewMessageColumn() {
+        db.execSQL("ALTER TABLE messages ADD new_message INTEGER DEFAULT 0")
+
+        db.execSQL("DROP INDEX IF EXISTS new_messages")
+        db.execSQL("CREATE INDEX IF NOT EXISTS new_messages ON messages(new_message)")
+
+        db.execSQL(
+            "CREATE TRIGGER new_message_reset " +
+                "AFTER UPDATE OF read ON messages " +
+                "FOR EACH ROW WHEN NEW.read = 1 AND NEW.new_message = 1 " +
+                "BEGIN " +
+                "UPDATE messages SET new_message = 0 WHERE ROWID = NEW.ROWID; " +
+                "END"
+        )
+
+        // Mark messages with existing notifications as "new"
+        db.execSQL("UPDATE messages SET new_message = 1 WHERE id in (SELECT message_id FROM notifications)")
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
@@ -27,5 +27,6 @@ object Migrations {
         if (oldVersion < 79) MigrationTo79(db).updateDeleteMessageTrigger()
         if (oldVersion < 80) MigrationTo80(db).rewriteLastUpdatedColumn()
         if (oldVersion < 81) MigrationTo81(db).addNotificationsTable()
+        if (oldVersion < 82) MigrationTo82(db).addNewMessageColumn()
     }
 }

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/MessageDatabaseHelpers.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/MessageDatabaseHelpers.kt
@@ -62,7 +62,8 @@ fun SQLiteDatabase.createMessage(
     answered: Boolean = false,
     forwarded: Boolean = false,
     messagePartId: Long = 0L,
-    encryptionType: String? = null
+    encryptionType: String? = null,
+    newMessage: Boolean = false
 ): Long {
     val values = ContentValues().apply {
         put("deleted", if (deleted) 1 else 0)
@@ -90,6 +91,7 @@ fun SQLiteDatabase.createMessage(
         put("forwarded", if (forwarded) 1 else 0)
         put("message_part_id", messagePartId)
         put("encryption_type", encryptionType)
+        put("new_message", if (newMessage) 1 else 0)
     }
 
     return insert("messages", null, values)
@@ -125,7 +127,8 @@ fun SQLiteDatabase.readMessages(): List<MessageEntry> {
                 answered = cursor.getIntOrNull("answered"),
                 forwarded = cursor.getIntOrNull("forwarded"),
                 messagePartId = cursor.getLongOrNull("message_part_id"),
-                encryptionType = cursor.getStringOrNull("encryption_type")
+                encryptionType = cursor.getStringOrNull("encryption_type"),
+                newMessage = cursor.getIntOrNull("new_message")
             )
         }
     }
@@ -157,7 +160,8 @@ data class MessageEntry(
     val answered: Int?,
     val forwarded: Int?,
     val messagePartId: Long?,
-    val encryptionType: String?
+    val encryptionType: String?,
+    val newMessage: Int?
 )
 
 fun SQLiteDatabase.createMessagePart(

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/UpdateMessageOperationsTest.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/UpdateMessageOperationsTest.kt
@@ -34,4 +34,19 @@ class UpdateMessageOperationsTest : RobolectricTest() {
         val message = messages.first()
         assertThat(message.newMessage).isEqualTo(0)
     }
+
+    @Test
+    fun `clear new message state`() {
+        sqliteDatabase.createMessage(folderId = 1, uid = "uid1", newMessage = true)
+        sqliteDatabase.createMessage(folderId = 1, uid = "uid1", newMessage = false)
+
+        updateMessageOperations.clearNewMessageState()
+
+        val messages = sqliteDatabase.readMessages()
+        assertThat(messages).hasSize(2)
+
+        for (message in messages) {
+            assertThat(message.newMessage).isEqualTo(0)
+        }
+    }
 }

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/UpdateMessageOperationsTest.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/UpdateMessageOperationsTest.kt
@@ -1,0 +1,37 @@
+package com.fsck.k9.storage.messages
+
+import com.fsck.k9.storage.RobolectricTest
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class UpdateMessageOperationsTest : RobolectricTest() {
+    private val sqliteDatabase = createDatabase()
+    private val lockableDatabase = createLockableDatabaseMock(sqliteDatabase)
+    private val updateMessageOperations = UpdateMessageOperations(lockableDatabase)
+
+    @Test
+    fun `mark message as new`() {
+        sqliteDatabase.createMessage(folderId = 1, uid = "uid1", newMessage = false)
+
+        updateMessageOperations.setNewMessageState(folderId = 1, messageServerId = "uid1", newMessage = true)
+
+        val messages = sqliteDatabase.readMessages()
+        assertThat(messages).hasSize(1)
+
+        val message = messages.first()
+        assertThat(message.newMessage).isEqualTo(1)
+    }
+
+    @Test
+    fun `mark message as not new`() {
+        sqliteDatabase.createMessage(folderId = 1, uid = "uid1", newMessage = true)
+
+        updateMessageOperations.setNewMessageState(folderId = 1, messageServerId = "uid1", newMessage = false)
+
+        val messages = sqliteDatabase.readMessages()
+        assertThat(messages).hasSize(1)
+
+        val message = messages.first()
+        assertThat(message.newMessage).isEqualTo(0)
+    }
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -1694,6 +1694,16 @@ open class MessageList :
             }
         }
 
+        fun createNewMessagesIntent(context: Context, account: Account): Intent {
+            val search = LocalSearch().apply {
+                id = SearchAccount.NEW_MESSAGES
+                addAccountUuid(account.uuid)
+                and(SearchField.NEW_MESSAGE, "1", SearchSpecification.Attribute.EQUALS)
+            }
+
+            return intentDisplaySearch(context, search, noThreading = false, newTask = true, clearTop = true)
+        }
+
         @JvmStatic
         fun shortcutIntent(context: Context?, specialFolder: String?): Intent {
             return Intent(context, MessageList::class.java).apply {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -417,6 +417,10 @@ class MessageListFragment :
     }
 
     override fun onDestroyView() {
+        if (isNewMessagesView && !requireActivity().isChangingConfigurations) {
+            messagingController.clearNewMessages(account)
+        }
+
         savedListState = listView.onSaveInstanceState()
         super.onDestroyView()
     }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -123,6 +123,9 @@ class MessageListFragment :
     private val isUnifiedInbox: Boolean
         get() = localSearch.id == SearchAccount.UNIFIED_INBOX
 
+    private val isNewMessagesView: Boolean
+        get() = localSearch.id == SearchAccount.NEW_MESSAGES
+
     /**
      * `true` after [.onCreate] was executed. Used in [.updateTitle] to
      * make sure we don't access member variables before initialization is complete.
@@ -326,6 +329,7 @@ class MessageListFragment :
     private fun setWindowTitle() {
         val title = when {
             isUnifiedInbox -> getString(R.string.integrated_inbox_title)
+            isNewMessagesView -> getString(R.string.new_messages_title)
             isManualSearch -> getString(R.string.search_results)
             isThreadDisplay -> threadTitle ?: ""
             isSingleFolderMode -> currentFolder!!.displayName

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -476,7 +476,8 @@ class MessageListFragment :
         messagingController.addListener(activityListener)
 
         for (account in localSearch.getAccounts(preferences)) {
-            messagingController.cancelNotificationsForAccount(account)
+            // TODO: Only remove notifications for messages in the currently displayed message list
+            messagingController.removeNotificationsForAccount(account)
         }
 
         updateTitle()

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -130,6 +130,7 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="search_action">Search</string>
     <string name="search_everywhere_action">Search everywhere</string>
     <string name="search_results">Search results</string>
+    <string name="new_messages_title">New messages</string>
     <string name="preferences_action">Settings</string>
     <string name="folders_action">Manage folders</string>
     <string name="account_settings_action">Account settings</string>


### PR DESCRIPTION
When tapping the summary notification and messages span multiple folders that are not all included in the Unified Inbox (or the Unified Inbox has been disabled), open a "new messages" view.

Messages are marked as "not new" when…
* …the associated notification is dismissed.
* …the message is marked as read.
* …the message is moved.
* …the message is opened for viewing.
* …the user leaves the "new messages" view.

<img src="https://user-images.githubusercontent.com/218061/145655741-1da4d5cf-e234-4efe-89ac-3450b6cecea8.png" alt="k9mail__new_messages" width=300>

Closes #5565