### PR TITLE
Add support for custom notification light color on Android 8+

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -616,6 +616,10 @@ public class Account implements BaseAccount {
         messagesNotificationChannelVersion = notificationChannelVersion;
     }
 
+    public synchronized void incrementMessagesNotificationChannelVersion() {
+        messagesNotificationChannelVersion++;
+    }
+
     public synchronized SortType getSortType() {
         return sortType;
     }

--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -11,15 +11,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import android.content.Context;
 import android.text.TextUtils;
 
 import com.fsck.k9.backend.api.SyncConfig.ExpungePolicy;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.NetworkType;
 import com.fsck.k9.mail.ServerSettings;
-import com.fsck.k9.mailstore.StorageManager;
-import com.fsck.k9.mailstore.StorageManager.StorageProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
@@ -183,6 +180,7 @@ public class Account implements BaseAccount {
     private long lastSyncTime;
     private long lastFolderListRefreshTime;
     private boolean isFinishedSetup = false;
+    private int messagesNotificationChannelVersion;
 
     private boolean changedVisibleLimits = false;
 
@@ -608,6 +606,14 @@ public class Account implements BaseAccount {
 
     public synchronized void setNotifySync(boolean notifySync) {
         this.notifySync = notifySync;
+    }
+
+    public synchronized int getMessagesNotificationChannelVersion() {
+        return messagesNotificationChannelVersion;
+    }
+
+    public synchronized void setMessagesNotificationChannelVersion(int notificationChannelVersion) {
+        messagesNotificationChannelVersion = notificationChannelVersion;
     }
 
     public synchronized SortType getSortType() {

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -53,6 +53,7 @@ class AccountPreferenceSerializer(
             isNotifyContactsMailOnly = storage.getBoolean("$accountUuid.notifyContactsMailOnly", false)
             isIgnoreChatMessages = storage.getBoolean("$accountUuid.ignoreChatMessages", false)
             isNotifySync = storage.getBoolean("$accountUuid.notifyMailCheck", false)
+            messagesNotificationChannelVersion = storage.getInt("$accountUuid.messagesNotificationChannelVersion", 0)
             deletePolicy = DeletePolicy.fromInt(storage.getInt("$accountUuid.deletePolicy", DeletePolicy.NEVER.setting))
             legacyInboxFolder = storage.getString("$accountUuid.inboxFolderName", null)
             importedDraftsFolder = storage.getString("$accountUuid.draftsFolderName", null)
@@ -259,6 +260,7 @@ class AccountPreferenceSerializer(
             editor.putBoolean("$accountUuid.notifyContactsMailOnly", isNotifyContactsMailOnly)
             editor.putBoolean("$accountUuid.ignoreChatMessages", isIgnoreChatMessages)
             editor.putBoolean("$accountUuid.notifyMailCheck", isNotifySync)
+            editor.putInt("$accountUuid.messagesNotificationChannelVersion", messagesNotificationChannelVersion)
             editor.putInt("$accountUuid.deletePolicy", deletePolicy.setting)
             editor.putString("$accountUuid.inboxFolderName", legacyInboxFolder)
             editor.putString("$accountUuid.draftsFolderName", importedDraftsFolder)
@@ -382,6 +384,7 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.notifyNewMail")
         editor.remove("$accountUuid.notifySelfNewMail")
         editor.remove("$accountUuid.ignoreChatMessages")
+        editor.remove("$accountUuid.messagesNotificationChannelVersion")
         editor.remove("$accountUuid.deletePolicy")
         editor.remove("$accountUuid.draftsFolderName")
         editor.remove("$accountUuid.sentFolderName")
@@ -555,6 +558,7 @@ class AccountPreferenceSerializer(
             isNotifySelfNewMail = true
             isNotifyContactsMailOnly = false
             isIgnoreChatMessages = false
+            messagesNotificationChannelVersion = 0
             folderDisplayMode = FolderMode.NOT_SECOND_CLASS
             folderSyncMode = FolderMode.FIRST_CLASS
             folderPushMode = FolderMode.NONE

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
@@ -137,12 +137,13 @@ class NotificationChannelManager(
     }
 
     fun getChannelIdFor(account: Account, channelType: ChannelType): String {
-        val accountUuid = account.uuid
-
         return if (channelType == ChannelType.MESSAGES) {
-            "messages_channel_$accountUuid"
+            "messages_channel_${account.uuid}${account.messagesNotificationChannelSuffix}"
         } else {
-            "miscellaneous_channel_$accountUuid"
+            "miscellaneous_channel_${account.uuid}"
         }
     }
+
+    private val Account.messagesNotificationChannelSuffix: String
+        get() = messagesNotificationChannelVersion.let { version -> if (version == 0) "" else "_$version" }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
@@ -144,6 +144,22 @@ class NotificationChannelManager(
         }
     }
 
+    @RequiresApi(Build.VERSION_CODES.O)
+    fun getNotificationLightConfiguration(account: Account): NotificationLightConfiguration {
+        val channelId = getChannelIdFor(account, ChannelType.MESSAGES)
+        val notificationChannel = notificationManager.getNotificationChannel(channelId)
+
+        return NotificationLightConfiguration(
+            isEnabled = notificationChannel.shouldShowLights(),
+            color = notificationChannel.lightColor
+        )
+    }
+
     private val Account.messagesNotificationChannelSuffix: String
         get() = messagesNotificationChannelVersion.let { version -> if (version == 0) "" else "_$version" }
 }
+
+data class NotificationLightConfiguration(
+    val isEnabled: Boolean,
+    val color: Int
+)

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
@@ -6,8 +6,10 @@ import android.app.NotificationManager
 import android.os.Build
 import androidx.annotation.RequiresApi
 import com.fsck.k9.Account
+import com.fsck.k9.NotificationSetting
 import com.fsck.k9.Preferences
 import java.util.concurrent.Executor
+import timber.log.Timber
 
 class NotificationChannelManager(
     private val preferences: Preferences,
@@ -153,6 +155,61 @@ class NotificationChannelManager(
             isEnabled = notificationChannel.shouldShowLights(),
             color = notificationChannel.lightColor
         )
+    }
+
+    fun recreateMessagesNotificationChannel(account: Account) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) return
+
+        val oldChannelId = getChannelIdFor(account, ChannelType.MESSAGES)
+        val oldNotificationChannel = notificationManager.getNotificationChannel(oldChannelId)
+
+        if (oldNotificationChannel.matches(account.notificationSetting)) {
+            Timber.v("Not recreating NotificationChannel. The current one already matches the app's settings.")
+            return
+        }
+
+        notificationManager.deleteNotificationChannel(oldChannelId)
+
+        account.incrementMessagesNotificationChannelVersion()
+
+        val newChannelId = getChannelIdFor(account, ChannelType.MESSAGES)
+        val channelName = resourceProvider.messagesChannelName
+        val importance = oldNotificationChannel.importance
+
+        val newNotificationChannel = NotificationChannel(newChannelId, channelName, importance).apply {
+            description = resourceProvider.messagesChannelDescription
+            group = account.uuid
+
+            copyPropertiesFrom(oldNotificationChannel)
+            copyPropertiesFrom(account.notificationSetting)
+        }
+
+        Timber.v("Recreating NotificationChannel(%s => %s)", oldChannelId, newChannelId)
+        notificationManager.createNotificationChannel(newNotificationChannel)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun NotificationChannel.matches(notificationSetting: NotificationSetting): Boolean {
+        return lightColor == notificationSetting.ledColor
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun NotificationChannel.copyPropertiesFrom(otherNotificationChannel: NotificationChannel) {
+        setShowBadge(otherNotificationChannel.canShowBadge())
+        setSound(otherNotificationChannel.sound, otherNotificationChannel.audioAttributes)
+        vibrationPattern = otherNotificationChannel.vibrationPattern
+        enableVibration(otherNotificationChannel.shouldVibrate())
+        enableLights(otherNotificationChannel.shouldShowLights())
+        setBypassDnd(otherNotificationChannel.canBypassDnd())
+        lockscreenVisibility = otherNotificationChannel.lockscreenVisibility
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            setAllowBubbles(otherNotificationChannel.canBubble())
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    private fun NotificationChannel.copyPropertiesFrom(notificationSetting: NotificationSetting) {
+        lightColor = notificationSetting.ledColor
     }
 
     private val Account.messagesNotificationChannelSuffix: String

--- a/app/core/src/main/res/values/arrays_account_settings_values.xml
+++ b/app/core/src/main/res/values/arrays_account_settings_values.xml
@@ -24,6 +24,42 @@
         <item>0xFF455A64</item> <!-- Blue gray 700 -->
     </integer-array>
 
+    <!-- Keep first part in sync with 'account_colors' -->
+    <integer-array name="notification_light_colors">
+        <!-- Account colors -->
+        <item>0xFFFFB300</item> <!-- Amber 600 -->
+        <item>0xFFFB8C00</item> <!-- Orange 600 -->
+        <item>0xFFF4511E</item> <!-- Deep orange 600 -->
+        <item>0xFFE53935</item> <!-- Red 600 -->
+
+        <item>0xFFC0CA33</item> <!-- Lime 600 -->
+        <item>0xFF7CB342</item> <!-- Light green 600 -->
+        <item>0xFF388E3C</item> <!-- Green 700 -->
+        <item>0xFF00897B</item> <!-- Teal 600 -->
+
+        <item>0xFF00ACC1</item> <!-- Cyan 600 -->
+        <item>0xFF039BE5</item> <!-- Light blue 600 -->
+        <item>0xFF1976D2</item> <!-- Blue 700 -->
+        <item>0xFF3949AB</item> <!-- Indigo 600 -->
+
+        <item>0xFFE91E63</item> <!-- Pink 500 -->
+        <item>0xFF8E24AA</item> <!-- Purple 600 -->
+        <item>0xFF5E35B1</item> <!-- Deep purple 600 -->
+        <item>0xFF455A64</item> <!-- Blue gray 700 -->
+
+        <!-- Full brightness colors (not part of 'account_colors') -->
+        <item>0xFFFF0000</item> <!-- Red -->
+        <item>0xFF00FF00</item> <!-- Green -->
+        <item>0xFF0000FF</item> <!-- Blue -->
+        <item>0xFFFFFFFF</item> <!-- White -->
+
+        <item>0xFFFFFF00</item> <!-- Yellow -->
+        <item>0xFF00FFFF</item> <!-- Cyan -->
+        <item>0xFFFF00FF</item> <!-- Magenta -->
+        <item>0x00000000</item> <!-- Transparent (default notification color) -->
+
+    </integer-array>
+
     <string-array name="check_frequency_values" translatable="false">
         <item>-1</item>
         <item>15</item>

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
@@ -24,7 +24,14 @@ val settingsUiModule = module {
     }
 
     viewModel { AccountSettingsViewModel(get(), get(), get()) }
-    single { AccountSettingsDataStoreFactory(get(), get(), get(named("SaveSettingsExecutorService"))) }
+    single {
+        AccountSettingsDataStoreFactory(
+            preferences = get(),
+            jobManager = get(),
+            executorService = get(named("SaveSettingsExecutorService")),
+            notificationChannelManager = get()
+        )
+    }
 
     viewModel { SettingsExportViewModel(context = get(), preferences = get(), settingsExporter = get()) }
     viewModel { SettingsImportViewModel(get(), get()) }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreFactory.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreFactory.kt
@@ -3,14 +3,16 @@ package com.fsck.k9.ui.settings.account
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import com.fsck.k9.job.K9JobManager
+import com.fsck.k9.notification.NotificationChannelManager
 import java.util.concurrent.ExecutorService
 
 class AccountSettingsDataStoreFactory(
     private val preferences: Preferences,
     private val jobManager: K9JobManager,
-    private val executorService: ExecutorService
+    private val executorService: ExecutorService,
+    private val notificationChannelManager: NotificationChannelManager
 ) {
     fun create(account: Account): AccountSettingsDataStore {
-        return AccountSettingsDataStore(preferences, executorService, account, jobManager)
+        return AccountSettingsDataStore(preferences, executorService, account, jobManager, notificationChannelManager)
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -196,12 +196,15 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
             PRE_SDK26_NOTIFICATION_PREFERENCES.forEach { findPreference<Preference>(it).remove() }
 
             findPreference<NotificationsPreference>(PREFERENCE_NOTIFICATION_SETTINGS_MESSAGES)?.let {
-                it.notificationChannelId = notificationChannelManager.getChannelIdFor(account, ChannelType.MESSAGES)
+                it.notificationChannelIdProvider = {
+                    notificationChannelManager.getChannelIdFor(account, ChannelType.MESSAGES)
+                }
             }
 
             findPreference<NotificationsPreference>(PREFERENCE_NOTIFICATION_SETTINGS_MISCELLANEOUS)?.let {
-                it.notificationChannelId =
+                it.notificationChannelIdProvider = {
                     notificationChannelManager.getChannelIdFor(account, ChannelType.MISCELLANEOUS)
+                }
             }
         } else {
             findPreference<PreferenceCategory>(PREFERENCE_NOTIFICATION_CHANNELS).remove()

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/NotificationsPreference.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/NotificationsPreference.kt
@@ -13,6 +13,8 @@ import androidx.fragment.app.DialogFragment
 import androidx.preference.Preference
 import com.takisoft.preferencex.PreferenceFragmentCompat
 
+typealias NotificationChannelIdProvider = () -> String
+
 @SuppressLint("RestrictedApi")
 @RequiresApi(Build.VERSION_CODES.O)
 class NotificationsPreference
@@ -27,18 +29,21 @@ constructor(
     defStyleRes: Int = 0
 ) : Preference(context, attrs, defStyleAttr, defStyleRes) {
 
-    var notificationChannelId: String? = null
+    var notificationChannelIdProvider: NotificationChannelIdProvider? = null
 
     override fun onClick() {
-        val intent = if (notificationChannelId == null) {
-            Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
-        } else {
-            Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {
-                putExtra(Settings.EXTRA_CHANNEL_ID, notificationChannelId)
+        notificationChannelIdProvider.let { provider ->
+            val intent = if (provider == null) {
+                Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS)
+            } else {
+                val notificationChannelId = provider.invoke()
+                Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS).apply {
+                    putExtra(Settings.EXTRA_CHANNEL_ID, notificationChannelId)
+                }
             }
+            intent.putExtra(Settings.EXTRA_APP_PACKAGE, this.context.packageName)
+            startActivity(this.context, intent, null)
         }
-        intent.putExtra(Settings.EXTRA_APP_PACKAGE, this.context.packageName)
-        startActivity(this.context, intent, null)
     }
 
     companion object {

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -373,7 +373,8 @@
             android:dependency="account_led"
             android:key="led_color"
             android:summary="@string/account_settings_led_color_summary"
-            android:title="@string/account_settings_led_color_label" />
+            android:title="@string/account_settings_led_color_label"
+            app:pref_colors="@array/notification_light_colors" />
 
         <CheckBoxPreference
             android:defaultValue="true"


### PR DESCRIPTION
Android only allows specifying the notification light color when creating a `NotificationChannel`. So we delete the existing one and create a new one when the user changes the notification light color setting. The existing configuration is copied from the old `NotificationChannel`, but some values might be ignored by Android when creating the new `NotificationChannel` :disappointed:

Closes #5544