### PR TITLE
Don't intercept key events when the search view in the toolbar is expanded

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -662,7 +662,7 @@ open class MessageList :
 
     override fun dispatchKeyEvent(event: KeyEvent): Boolean {
         var eventHandled = false
-        if (KeyEvent.ACTION_DOWN == event.action) {
+        if (event.action == KeyEvent.ACTION_DOWN && searchView.isIconified) {
             eventHandled = onCustomKeyDown(event)
         }
 


### PR DESCRIPTION
Quick and dirty fix to not intercept hotkeys when the user is entering a search term.