### PR TITLE
Data loss fixfor message compose

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -597,7 +597,8 @@ public class MessageCompose extends K9Activity implements OnClickListener,
 
     @Override
     protected void onResume() {
-        super.onResume();spGen = getSharedPreferences("MainActivity", MODE_PRIVATE);
+        super.onResume();
+        spGen = getSharedPreferences("MessageCompose", MODE_PRIVATE);
         subjectView.setText(spGen.getString("editSubject", ""));
         messageContentView.setText(spGen.getString("editContent", ""));
         isSubmit = false;

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -19,6 +19,7 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
+import android.content.SharedPreferences;
 import android.content.pm.ActivityInfo;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -588,9 +589,18 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         return startedByExternalIntent;
     }
 
+
+    private SharedPreferences spGen;
+
+    private boolean isSubmit;
+
+
     @Override
     protected void onResume() {
-        super.onResume();
+        super.onResume();spGen = getSharedPreferences("MainActivity", MODE_PRIVATE);
+        subjectView.setText(spGen.getString("editSubject", ""));
+        messageContentView.setText(spGen.getString("editContent", ""));
+        isSubmit = false;
         messagingController.addListener(messagingListener);
     }
 
@@ -598,6 +608,16 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     public void onPause() {
         super.onPause();
         messagingController.removeListener(messagingListener);
+
+        SharedPreferences.Editor spGenEditor = spGen.edit();
+        if (isSubmit) {
+            spGenEditor.putString("editSubject", "");
+            spGenEditor.putString("editContent", "");
+        } else {
+            spGenEditor.putString("editSubject", subjectView.getText().toString());
+            spGenEditor.putString("editContent", messageContentView .getText().toString());
+        }
+        spGenEditor.commit();
 
         boolean isPausingOnConfigurationChange = (getChangingConfigurations() & ActivityInfo.CONFIG_ORIENTATION)
                 == ActivityInfo.CONFIG_ORIENTATION;
@@ -789,6 +809,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     }
 
     private void performSaveAfterChecks() {
+        isSubmit = true;
         currentMessageBuilder = createMessageBuilder(true);
         if (currentMessageBuilder != null) {
             setProgressBarIndeterminateVisibility(true);
@@ -797,6 +818,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     }
 
     public void performSendAfterChecks() {
+        isSubmit = true;
         currentMessageBuilder = createMessageBuilder(false);
         if (currentMessageBuilder != null) {
             changesMadeSinceLastSave = false;
@@ -806,6 +828,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     }
 
     private void onDiscard() {
+        isSubmit = true;
         if (draftMessageId != null) {
             messagingController.deleteDraft(account, draftMessageId);
         }
@@ -814,6 +837,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
     }
 
     private void finishWithoutChanges() {
+        isSubmit = true;
         draftMessageId = null;
         changesMadeSinceLastSave = false;
 


### PR DESCRIPTION
Hello developers of K9 mail

I am using your app K9 mail. I think the app is great but I have one minor patch that could improve the user experience.

Here is a picture to help illustrate what activity that are changed in my patch:

https://ibb.co/Jx4vcb4

When the user tries to compose a new email. If the screen focus goes to another app or activity(for example if an incoming call forces the user to go into the phone app and the app is force closed by Android), or if the user accidentally closes the app, the user will lose any data they had put into this page 

This feature will automatically store the data when the user leaves the activity without submitting and restore said data when they restart the activity(this can be seen here where I closed the activity and restarted it https://ibb.co/cCdw2CG). Therefore, the user does not have to fill in the data again thus improving the user experience.

It will still clear the data if the user sends the email, presses discard, or saves it as a draft.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim