### PR TITLE
add data loss restoration to email login

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AccountSetupBasics.java
@@ -3,6 +3,7 @@ package com.fsck.k9.activity.setup;
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.text.Editable;
 import android.text.TextWatcher;
@@ -13,6 +14,7 @@ import android.widget.Button;
 import android.widget.CheckBox;
 import android.widget.CompoundButton;
 import android.widget.CompoundButton.OnCheckedChangeListener;
+import android.widget.EditText;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Core;
@@ -87,6 +89,33 @@ public class AccountSetupBasics extends K9Activity
         mManualSetupButton = findViewById(R.id.manual_setup);
         mNextButton.setOnClickListener(this);
         mManualSetupButton.setOnClickListener(this);
+    }
+
+    private SharedPreferences spGen;
+
+    private boolean isSubmit;
+
+    @Override
+    protected void onPause() {
+        super.onPause();
+        SharedPreferences.Editor spGenEditor = spGen.edit();
+        if (isSubmit) {
+            spGenEditor.putString("editEmail", "");
+            spGenEditor.putString("editPassword", "");
+        } else {
+            spGenEditor.putString("editEmail", mEmailView.getText().toString());
+            spGenEditor.putString("editPassword", mPasswordView.getText().toString());
+        }
+        spGenEditor.commit();
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+        spGen = getSharedPreferences("AccountSetupBasic", MODE_PRIVATE);
+        mEmailView.setText(spGen.getString("editEmail", ""));
+        mPasswordView.setText(spGen.getString("editPassword", ""));
+        isSubmit = false;
     }
 
     private void initializeViewListeners() {
@@ -241,6 +270,7 @@ public class AccountSetupBasics extends K9Activity
 
         // Check incoming here.  Then check outgoing in onActivityResult()
         AccountSetupCheckSettings.actionCheckSettings(this, mAccount, CheckDirection.INCOMING);
+        isSubmit = true;
     }
 
     private ConnectionSettings providersXmlDiscoveryDiscover(String email, DiscoveryTarget discoveryTarget) {
@@ -346,6 +376,7 @@ public class AccountSetupBasics extends K9Activity
                 clientCertificateAlias);
 
         AccountSetupAccountType.actionSelectAccountType(this, mAccount, false, initialAccountSettings);
+        isSubmit = true;
     }
 
     public void onClick(View v) {


### PR DESCRIPTION
Hello again developers of K9 mail

I want to patch a separate activity

Here is a picture to help illustrate what activity that are changed in this patch:

https://ibb.co/W3kPSKq

When the user tries to add a new email account. If the screen focus goes to another app or activity(for example if an incoming call forces the user to go into the phone app and the app is force closed by Android), or if the user accidentally closes the app, the user will lose any data they had put into this page

This feature will automatically store the data when the user leaves the activity without submitting and restore said data when they restart the activity(this can be seen here where I closed the activity and restarted it https://ibb.co/hDNGW7Z). Therefore, the user does not have to fill in the data again thus improving the user experience.

It will clear the data once the user logs in.

I have tested out the feature to ensure it works.

If you have any questions or if you would like me to change anything, please do not hesitate to let me know!

Thank you for your time,
Tim