### PR TITLE
Fix search by changing the delimiter in address fields from ASCII 0 to 1

### DIFF
--- a/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/app/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -12,7 +12,7 @@ import timber.log.Timber;
 
 
 class StoreSchemaDefinition implements SchemaDefinition {
-    static final int DB_VERSION = 83;
+    static final int DB_VERSION = 84;
 
     private final MigrationsHelper migrationsHelper;
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo84.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo84.kt
@@ -1,0 +1,54 @@
+package com.fsck.k9.storage.migrations
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import com.fsck.k9.helper.map
+import com.fsck.k9.mailstore.MigrationsHelper
+
+/**
+ * Write the address fields to use ASCII 1 instead of ASCII 0 as separator.
+ * Separator was previously ASCII 0 but this caused problems with LIKE and searching.
+ */
+internal class MigrationTo84(private val db: SQLiteDatabase, private val migrationsHelper: MigrationsHelper) {
+
+    fun rewriteAddresses() {
+        val addressSets = db.rawQuery(
+            "SELECT id, to_list, cc_list, bcc_list, reply_to_list, sender_list FROM messages",
+            null
+        ).use { cursor ->
+            cursor.map {
+
+                val colVals = ArrayList<String?>(5)
+                for (i in 1..5) {
+                    colVals.add(if (it.isNull(i)) null else it.getString(i))
+                }
+                it.getLong(0) to AddressSet(colVals[0], colVals[1], colVals[2], colVals[3], colVals[4])
+            }.toMap()
+        }
+
+        var i = 0
+        for ((messageId, addressSet) in addressSets) {
+            rewriteAddresses(messageId, addressSet)
+            ++i
+        }
+    }
+
+    private fun rewriteAddress(inAddress: String?): String? {
+        val oldSeparator = '\u0000'
+        val newSeparator = '\u0001'
+        return inAddress?.replace(oldSeparator, newSeparator)
+    }
+
+    private fun rewriteAddresses(messageId: Long, addressSet: AddressSet) {
+        val cv = ContentValues().apply {
+            put("to_list", rewriteAddress(addressSet.toList))
+            put("cc_list", rewriteAddress(addressSet.ccList))
+            put("bcc_list", rewriteAddress(addressSet.bccList))
+            put("reply_to_list", rewriteAddress(addressSet.replyToList))
+            put("sender_list", rewriteAddress(addressSet.senderList))
+        }
+        db.update("messages", cv, "id = ?", arrayOf(messageId.toString()))
+    }
+}
+
+private data class AddressSet(val toList: String?, val ccList: String?, val bccList: String?, val replyToList: String?, val senderList: String?)

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
@@ -29,5 +29,6 @@ object Migrations {
         if (oldVersion < 81) MigrationTo81(db).addNotificationsTable()
         if (oldVersion < 82) MigrationTo82(db).addNewMessageColumn()
         if (oldVersion < 83) MigrationTo83(db, migrationsHelper).rewriteHighestKnownUid()
+        if (oldVersion < 84) MigrationTo84(db, migrationsHelper).rewriteAddresses()
     }
 }

--- a/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
@@ -29,6 +29,6 @@ object Migrations {
         if (oldVersion < 81) MigrationTo81(db).addNotificationsTable()
         if (oldVersion < 82) MigrationTo82(db).addNewMessageColumn()
         if (oldVersion < 83) MigrationTo83(db, migrationsHelper).rewriteHighestKnownUid()
-        if (oldVersion < 84) MigrationTo84(db, migrationsHelper).rewriteAddresses()
+        if (oldVersion < 84) MigrationTo84(db).rewriteAddresses()
     }
 }

--- a/mail/common/src/main/java/com/fsck/k9/mail/Address.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Address.java
@@ -219,11 +219,11 @@ public class Address implements Serializable {
         int pairEndIndex = 0;
         int addressEndIndex = 0;
         while (pairStartIndex < length) {
-            pairEndIndex = addressList.indexOf(",\u0000", pairStartIndex);
+            pairEndIndex = addressList.indexOf(",\u0001", pairStartIndex);
             if (pairEndIndex == -1) {
                 pairEndIndex = length;
             }
-            addressEndIndex = addressList.indexOf(";\u0000", pairStartIndex);
+            addressEndIndex = addressList.indexOf(";\u0001", pairStartIndex);
             String address = null;
             String personal = null;
             if (addressEndIndex == -1 || addressEndIndex > pairEndIndex) {
@@ -241,8 +241,8 @@ public class Address implements Serializable {
     /**
      * Packs an address list into a String that is very quick to read
      * and parse. Packed lists can be unpacked with unpackAddressList()
-     * The packed list is a ",\u0000" separated list of:
-     * address;\u0000personal
+     * The packed list is a ",\u0001" separated list of:
+     * address;\u0001personal
      * @param addresses Array of addresses to pack.
      * @return Packed addresses.
      */
@@ -256,13 +256,13 @@ public class Address implements Serializable {
             sb.append(address.getAddress());
             String personal = address.getPersonal();
             if (personal != null) {
-                sb.append(";\u0000");
+                sb.append(";\u0001");
                 // Escape quotes in the address part on the way in
                 personal = personal.replaceAll("\"", "\\\"");
                 sb.append(personal);
             }
             if (i < count - 1) {
-                sb.append(",\u0000");
+                sb.append(",\u0001");
             }
         }
         return sb.toString();


### PR DESCRIPTION
This should fix the search so that includes the names, not just the emails, in to/from/bcc/cc/reply-to. E.g. if you were searching for an email from:

```text
cketti <notifications@github.com>
```

You could search cketti -or- github. (current app wouldn't find "cketti"

I tested this on a gmail and a non-gmail IMAP account (hosted by IONOS/1and1). Tested on local and remote. It would be my first commit on the project, though, so I'm open to feedback on what else I should test, etc.

Fixes #5776