### PR TITLE
Changed default color for registered contacts to a better readability

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -171,7 +171,7 @@ object K9 : EarlyInit {
     var isChangeContactNameColor = false
 
     @JvmStatic
-    var contactNameColor = -638932 // #F6402C
+    var contactNameColor = 0xFF1093F5.toInt()
 
     @JvmStatic
     var isShowContactPicture = true
@@ -315,7 +315,7 @@ object K9 : EarlyInit {
         isShowContactName = storage.getBoolean("showContactName", false)
         isShowContactPicture = storage.getBoolean("showContactPicture", true)
         isChangeContactNameColor = storage.getBoolean("changeRegisteredNameColor", false)
-        contactNameColor = storage.getInt("registeredNameColor", -638932) // #F6402C
+        contactNameColor = storage.getInt("registeredNameColor", 0xFF1093F5.toInt())
         isUseMessageViewFixedWidthFont = storage.getBoolean("messageViewFixedWidthFont", false)
         isMessageViewReturnToList = storage.getBoolean("messageViewReturnToList", false)
         isMessageViewShowNext = storage.getBoolean("messageViewShowNext", false)

--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -2,7 +2,6 @@ package com.fsck.k9
 
 import android.content.Context
 import android.content.SharedPreferences
-import android.graphics.Color
 import com.fsck.k9.Account.SortType
 import com.fsck.k9.core.BuildConfig
 import com.fsck.k9.mail.K9MailLib

--- a/app/core/src/main/java/com/fsck/k9/K9.kt
+++ b/app/core/src/main/java/com/fsck/k9/K9.kt
@@ -2,6 +2,7 @@ package com.fsck.k9
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.graphics.Color
 import com.fsck.k9.Account.SortType
 import com.fsck.k9.core.BuildConfig
 import com.fsck.k9.mail.K9MailLib
@@ -171,7 +172,7 @@ object K9 : EarlyInit {
     var isChangeContactNameColor = false
 
     @JvmStatic
-    var contactNameColor = 0xff00008f.toInt()
+    var contactNameColor = -638932 // #F6402C
 
     @JvmStatic
     var isShowContactPicture = true
@@ -315,7 +316,7 @@ object K9 : EarlyInit {
         isShowContactName = storage.getBoolean("showContactName", false)
         isShowContactPicture = storage.getBoolean("showContactPicture", true)
         isChangeContactNameColor = storage.getBoolean("changeRegisteredNameColor", false)
-        contactNameColor = storage.getInt("registeredNameColor", -0xffff71)
+        contactNameColor = storage.getInt("registeredNameColor", -638932) // #F6402C
         isUseMessageViewFixedWidthFont = storage.getBoolean("messageViewFixedWidthFont", false)
         isMessageViewReturnToList = storage.getBoolean("messageViewReturnToList", false)
         isMessageViewShowNext = storage.getBoolean("messageViewShowNext", false)

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -159,7 +159,7 @@ public class GeneralSettingsDescriptions {
         ));
         s.put("registeredNameColor", Settings.versions(
                 new V(1, new ColorSetting(0xFF00008F)),
-                new V(79, new ColorSetting(-638932)) // #F6402C
+                new V(79, new ColorSetting(0xFF1093F5))
         ));
         s.put("showContactName", Settings.versions(
                 new V(1, new BooleanSetting(false))
@@ -420,10 +420,10 @@ public class GeneralSettingsDescriptions {
     }
 
     /**
-     * Upgrades the settings from version 75 to 76.
+     * Upgrades the settings from version 78 to 79.
      *
      * <p>
-     * Change default value of {@code registeredNameColor} from {@code 0xFF00008F} to {@code -638932 )} (#F6402C).
+     * Change default value of {@code registeredNameColor} to have enough contrast in both the light and dark theme.
      * </p>
      */
     private static class SettingsUpgraderV79 implements SettingsUpgrader {
@@ -432,9 +432,8 @@ public class GeneralSettingsDescriptions {
         public Set<String> upgrade(Map<String, Object> settings) {
             final Integer registeredNameColorValue = (Integer) settings.get("registeredNameColor");
 
-            // -0xffff71 is equivalent to 0xFF00008F.toInt() in Kotlin
-            if (registeredNameColorValue != null && registeredNameColorValue == -0xffff71) {
-                settings.put("registeredNameColor", -638932 ); // #F6402C
+            if (registeredNameColorValue != null && registeredNameColorValue == 0xFF00008F) {
+                settings.put("registeredNameColor", 0xFF1093F5);
             }
 
             return null;

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import android.content.Context;
+import android.graphics.Color;
 
 import com.fsck.k9.Account;
 import com.fsck.k9.Account.SortType;
@@ -157,7 +158,8 @@ public class GeneralSettingsDescriptions {
                 new V(1, new TimeSetting("21:00"))
         ));
         s.put("registeredNameColor", Settings.versions(
-                new V(1, new ColorSetting(0xFF00008F))
+                new V(1, new ColorSetting(0xFF00008F)),
+                new V(79, new ColorSetting(-638932)) // #F6402C
         ));
         s.put("showContactName", Settings.versions(
                 new V(1, new BooleanSetting(false))
@@ -284,6 +286,7 @@ public class GeneralSettingsDescriptions {
         u.put(31, new SettingsUpgraderV31());
         u.put(58, new SettingsUpgraderV58());
         u.put(69, new SettingsUpgraderV69());
+        u.put(79, new SettingsUpgraderV79());
 
         UPGRADERS = Collections.unmodifiableMap(u);
     }
@@ -413,6 +416,26 @@ public class GeneralSettingsDescriptions {
             settings.put("showUnifiedInbox", showUnifiedInbox);
 
             return new HashSet<>(Collections.singleton("hideSpecialAccounts"));
+        }
+    }
+
+    /**
+     * Upgrades the settings from version 75 to 76.
+     *
+     * <p>
+     * Change default value of {@code registeredNameColor} from {@code 0xFF00008F} to {@code -638932 )} (#F6402C).
+     * </p>
+     */
+    private static class SettingsUpgraderV79 implements SettingsUpgrader {
+
+        @Override
+        public Set<String> upgrade(Map<String, Object> settings) {
+            final Integer registeredNameColorValue = (Integer) settings.get("registeredNameColor");
+            if (registeredNameColorValue != null && registeredNameColorValue == 0xFF00008F) {
+                settings.put("registeredNameColor", -638932 ); // #F6402C
+            }
+
+            return null;
         }
     }
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -431,7 +431,9 @@ public class GeneralSettingsDescriptions {
         @Override
         public Set<String> upgrade(Map<String, Object> settings) {
             final Integer registeredNameColorValue = (Integer) settings.get("registeredNameColor");
-            if (registeredNameColorValue != null && registeredNameColorValue == 0xFF00008F) {
+
+            // -0xffff71 is equivalent to 0xFF00008F.toInt() in Kotlin
+            if (registeredNameColorValue != null && registeredNameColorValue == -0xffff71) {
                 settings.put("registeredNameColor", -638932 ); // #F6402C
             }
 

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 78;
+    public static final int VERSION = 79;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -21,7 +21,7 @@ import timber.log.Timber;
 
 
 public class K9StoragePersister implements StoragePersister {
-    private static final int DB_VERSION = 15;
+    private static final int DB_VERSION = 16;
     private static final String DB_NAME = "preferences_storage";
 
     private final Context context;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo16.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo16.kt
@@ -3,16 +3,16 @@ package com.fsck.k9.preferences.migrations
 import android.database.sqlite.SQLiteDatabase
 
 /**
- * Change default value of {@code registeredNameColor} from {@code 0xFF00008F} to {@code -638932)} (#F6402C).
+ * Change default value of {@code registeredNameColor} to have enough contrast in both the light and dark theme.
  */
 class StorageMigrationTo16(
     private val db: SQLiteDatabase,
     private val migrationsHelper: StorageMigrationsHelper
 ) {
-    fun rewriteIdleRefreshInterval() {
+    fun changeDefaultRegisteredNameColor() {
         val registeredNameColorValue = migrationsHelper.readValue(db, "registeredNameColor")?.toInt()
-        if (registeredNameColorValue != null && registeredNameColorValue == -0xffff71) {
-            migrationsHelper.writeValue(db, "registeredNameColor", "-638932") // #F6402C
+        if (registeredNameColorValue != null && registeredNameColorValue == 0xFF00008F.toInt()) {
+            migrationsHelper.writeValue(db, "registeredNameColor", 0xFF1093F5.toInt().toString())
         }
     }
 }

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo16.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo16.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.preferences.migrations
 
 import android.database.sqlite.SQLiteDatabase
-import android.graphics.Color
 
 /**
  * Change default value of {@code registeredNameColor} from {@code 0xFF00008F} to {@code -638932)} (#F6402C).
@@ -13,7 +12,7 @@ class StorageMigrationTo16(
     fun rewriteIdleRefreshInterval() {
         val registeredNameColorValue = migrationsHelper.readValue(db, "registeredNameColor")?.toInt()
         if (registeredNameColorValue != null && registeredNameColorValue == -0xffff71) {
-            migrationsHelper.writeValue(db, "registeredNameColor", "-638932" ) // #F6402C
+            migrationsHelper.writeValue(db, "registeredNameColor", "-638932") // #F6402C
         }
     }
 }

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo16.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo16.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.preferences.migrations
 import android.database.sqlite.SQLiteDatabase
 
 /**
- * Change default value of {@code registeredNameColor} to have enough contrast in both the light and dark theme.
+ * Change default value of `registeredNameColor` to have enough contrast in both the light and dark theme.
  */
 class StorageMigrationTo16(
     private val db: SQLiteDatabase,
@@ -11,7 +11,7 @@ class StorageMigrationTo16(
 ) {
     fun changeDefaultRegisteredNameColor() {
         val registeredNameColorValue = migrationsHelper.readValue(db, "registeredNameColor")?.toInt()
-        if (registeredNameColorValue != null && registeredNameColorValue == 0xFF00008F.toInt()) {
+        if (registeredNameColorValue == 0xFF00008F.toInt()) {
             migrationsHelper.writeValue(db, "registeredNameColor", 0xFF1093F5.toInt().toString())
         }
     }

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo16.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo16.kt
@@ -1,0 +1,19 @@
+package com.fsck.k9.preferences.migrations
+
+import android.database.sqlite.SQLiteDatabase
+import android.graphics.Color
+
+/**
+ * Change default value of {@code registeredNameColor} from {@code 0xFF00008F} to {@code -638932)} (#F6402C).
+ */
+class StorageMigrationTo16(
+    private val db: SQLiteDatabase,
+    private val migrationsHelper: StorageMigrationsHelper
+) {
+    fun rewriteIdleRefreshInterval() {
+        val registeredNameColorValue = migrationsHelper.readValue(db, "registeredNameColor")?.toInt()
+        if (registeredNameColorValue != null && registeredNameColorValue == -0xffff71) {
+            migrationsHelper.writeValue(db, "registeredNameColor", "-638932" ) // #F6402C
+        }
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
@@ -21,5 +21,6 @@ internal object StorageMigrations {
         if (oldVersion < 13) StorageMigrationTo13(db, migrationsHelper).renameHideSpecialAccounts()
         if (oldVersion < 14) StorageMigrationTo14(db, migrationsHelper).disablePushFoldersForNonImapAccounts()
         if (oldVersion < 15) StorageMigrationTo15(db, migrationsHelper).rewriteIdleRefreshInterval()
+        if (oldVersion < 16) StorageMigrationTo16(db, migrationsHelper).rewriteIdleRefreshInterval()
     }
 }

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
@@ -21,6 +21,6 @@ internal object StorageMigrations {
         if (oldVersion < 13) StorageMigrationTo13(db, migrationsHelper).renameHideSpecialAccounts()
         if (oldVersion < 14) StorageMigrationTo14(db, migrationsHelper).disablePushFoldersForNonImapAccounts()
         if (oldVersion < 15) StorageMigrationTo15(db, migrationsHelper).rewriteIdleRefreshInterval()
-        if (oldVersion < 16) StorageMigrationTo16(db, migrationsHelper).rewriteIdleRefreshInterval()
+        if (oldVersion < 16) StorageMigrationTo16(db, migrationsHelper).changeDefaultRegisteredNameColor()
     }
 }

--- a/app/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/general_settings.xml
@@ -293,7 +293,7 @@
                 android:dependency="messagelist_change_contact_name_color"
                 android:key="messagelist_contact_name_color"
                 android:title="Contact name color"
-                android:defaultValue="#F6402C" />
+                android:defaultValue="#FF1093F5" />
 
             <CheckBoxPreference
                 android:key="messagelist_show_contact_picture"

--- a/app/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/general_settings.xml
@@ -292,7 +292,8 @@
             <com.takisoft.preferencex.ColorPickerPreference
                 android:dependency="messagelist_change_contact_name_color"
                 android:key="messagelist_contact_name_color"
-                android:title="Contact name color" />
+                android:title="Contact name color"
+                android:defaultValue="#F6402C" />
 
             <CheckBoxPreference
                 android:key="messagelist_show_contact_picture"


### PR DESCRIPTION
- Changed default color for registered contacts from `0xFF00008F` to `0xFF1093F5` (`#1093F5`) for better readability on dark theme.
-  Migrate settings, if the old default is stored in the settings
- The color `#1093F5` is one of the colors from the preferance color picker

fix #5755