### PR TITLE
Allow remote search by default

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -173,7 +173,6 @@ public class Account implements BaseAccount {
     private boolean markMessageAsReadOnView;
     private boolean markMessageAsReadOnDelete;
     private boolean alwaysShowCcBcc;
-    private boolean allowRemoteSearch;
     private boolean remoteSearchFullText;
     private int remoteSearchNumResults;
     private boolean uploadSentMessages;
@@ -978,14 +977,6 @@ public class Account implements BaseAccount {
 
     public void setOpenPgpEncryptAllDrafts(boolean openPgpEncryptAllDrafts) {
         this.openPgpEncryptAllDrafts = openPgpEncryptAllDrafts;
-    }
-
-    public boolean isAllowRemoteSearch() {
-        return allowRemoteSearch;
-    }
-
-    public void setAllowRemoteSearch(boolean val) {
-        allowRemoteSearch = val;
     }
 
     public int getRemoteSearchNumResults() {

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -167,7 +167,6 @@ class AccountPreferenceSerializer(
             isOpenPgpEncryptSubject = storage.getBoolean("$accountUuid.openPgpEncryptSubject", true)
             isOpenPgpEncryptAllDrafts = storage.getBoolean("$accountUuid.openPgpEncryptAllDrafts", true)
             autocryptPreferEncryptMutual = storage.getBoolean("$accountUuid.autocryptMutualMode", false)
-            isAllowRemoteSearch = storage.getBoolean("$accountUuid.allowRemoteSearch", false)
             isRemoteSearchFullText = storage.getBoolean("$accountUuid.remoteSearchFullText", false)
             remoteSearchNumResults = storage.getInt("$accountUuid.remoteSearchNumResults", DEFAULT_REMOTE_SEARCH_NUM_RESULTS)
             isUploadSentMessages = storage.getBoolean("$accountUuid.uploadSentMessages", true)
@@ -321,7 +320,6 @@ class AccountPreferenceSerializer(
             editor.putBoolean("$accountUuid.openPgpEncryptAllDrafts", isOpenPgpEncryptAllDrafts)
             editor.putString("$accountUuid.openPgpProvider", openPgpProvider)
             editor.putBoolean("$accountUuid.autocryptMutualMode", autocryptPreferEncryptMutual)
-            editor.putBoolean("$accountUuid.allowRemoteSearch", isAllowRemoteSearch)
             editor.putBoolean("$accountUuid.remoteSearchFullText", isRemoteSearchFullText)
             editor.putInt("$accountUuid.remoteSearchNumResults", remoteSearchNumResults)
             editor.putBoolean("$accountUuid.uploadSentMessages", isUploadSentMessages)
@@ -441,6 +439,10 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.markMessageAsReadOnView")
         editor.remove("$accountUuid.markMessageAsReadOnDelete")
         editor.remove("$accountUuid.alwaysShowCcBcc")
+
+        // TODO: to leave this in or not? On one hand, if I don't leave it, this value will be "orphaned" and just hang
+        // around on the device once we remove this setting. OTOH, it may be overkill to keep this reference to an
+        // unused boolean value.
         editor.remove("$accountUuid.allowRemoteSearch")
         editor.remove("$accountUuid.remoteSearchFullText")
         editor.remove("$accountUuid.remoteSearchNumResults")
@@ -584,7 +586,6 @@ class AccountPreferenceSerializer(
             isStripSignature = DEFAULT_STRIP_SIGNATURE
             isSyncRemoteDeletions = true
             openPgpKey = NO_OPENPGP_KEY
-            isAllowRemoteSearch = false
             isRemoteSearchFullText = false
             remoteSearchNumResults = DEFAULT_REMOTE_SEARCH_NUM_RESULTS
             isUploadSentMessages = true

--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -439,11 +439,6 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.markMessageAsReadOnView")
         editor.remove("$accountUuid.markMessageAsReadOnDelete")
         editor.remove("$accountUuid.alwaysShowCcBcc")
-
-        // TODO: to leave this in or not? On one hand, if I don't leave it, this value will be "orphaned" and just hang
-        // around on the device once we remove this setting. OTOH, it may be overkill to keep this reference to an
-        // unused boolean value.
-        editor.remove("$accountUuid.allowRemoteSearch")
         editor.remove("$accountUuid.remoteSearchFullText")
         editor.remove("$accountUuid.remoteSearchNumResults")
         editor.remove("$accountUuid.uploadSentMessages")

--- a/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -219,9 +219,6 @@ public class AccountSettingsDescriptions {
         s.put("vibrateTimes", Settings.versions(
                 new V(1, new IntegerRangeSetting(1, 10, 5))
         ));
-        s.put("allowRemoteSearch", Settings.versions(
-                new V(18, new BooleanSetting(true))
-        ));
         s.put("remoteSearchNumResults", Settings.versions(
                 new V(18, new IntegerResourceSetting(AccountPreferenceSerializer.DEFAULT_REMOTE_SEARCH_NUM_RESULTS,
                         R.array.remote_search_num_results_values))

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -1436,7 +1436,7 @@ class MessageListFragment :
     }
 
     val isRemoteSearchAllowed: Boolean
-        get() = isManualSearch && !isRemoteSearch && isSingleFolderMode
+        get() = isManualSearch && !isRemoteSearch && isSingleFolderMode && messagingController.isPushCapable(account)
 
     fun onSearchRequested(query: String): Boolean {
         val folderId = currentFolder?.databaseId

--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListFragment.kt
@@ -1436,7 +1436,7 @@ class MessageListFragment :
     }
 
     val isRemoteSearchAllowed: Boolean
-        get() = isManualSearch && !isRemoteSearch && isSingleFolderMode && account?.isAllowRemoteSearch == true
+        get() = isManualSearch && !isRemoteSearch && isSingleFolderMode
 
     fun onSearchRequested(query: String): Boolean {
         val folderId = currentFolder?.databaseId

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -36,7 +36,6 @@ class AccountSettingsDataStore(
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject
             "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts
-            "remote_search_enabled" -> account.isAllowRemoteSearch
             "autocrypt_prefer_encrypt" -> account.autocryptPreferEncryptMutual
             "upload_sent_messages" -> account.isUploadSentMessages
             "ignore_chat_messages" -> account.isIgnoreChatMessages
@@ -60,7 +59,6 @@ class AccountSettingsDataStore(
             "account_vibrate" -> account.notificationSetting.isVibrateEnabled = value
             "account_led" -> account.notificationSetting.setLed(value)
             "account_notify_sync" -> account.isNotifySync = value
-            "remote_search_enabled" -> account.isAllowRemoteSearch = value
             "openpgp_hide_sign_only" -> account.isOpenPgpHideSignOnly = value
             "openpgp_encrypt_subject" -> account.isOpenPgpEncryptSubject = value
             "openpgp_encrypt_all_drafts" -> account.isOpenPgpEncryptAllDrafts = value

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -185,7 +185,6 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         if (!messagingController.isPushCapable(account)) {
             findPreference<Preference>(PREFERENCE_PUSH_MODE)?.remove()
             findPreference<Preference>(PREFERENCE_ADVANCED_PUSH_SETTINGS)?.remove()
-            findPreference<Preference>(PREFERENCE_REMOTE_SEARCH)?.remove()
         }
     }
 
@@ -429,7 +428,6 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
         private const val PREFERENCE_MESSAGE_AGE = "account_message_age"
         private const val PREFERENCE_PUSH_MODE = "folder_push_mode"
         private const val PREFERENCE_ADVANCED_PUSH_SETTINGS = "push_advanced"
-        private const val PREFERENCE_REMOTE_SEARCH = "search"
         private const val PREFERENCE_OPENPGP_ENABLE = "openpgp_provider"
         private const val PREFERENCE_OPENPGP_KEY = "openpgp_key"
         private const val PREFERENCE_AUTOCRYPT_TRANSFER = "autocrypt_transfer"

--- a/app/ui/legacy/src/main/res/values-ar/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ar/strings.xml
@@ -684,7 +684,6 @@
   <string name="account_settings_remote_search_num_results_entries_1000">1000</string>
   <string name="remote_search_sending_query">إرسال الطلب إلى الخادوم</string>
   <string name="account_settings_search">ابحث</string>
-  <string name="account_settings_remote_search_enabled">تمكين البحث في الخادوم</string>
   <string name="action_remote_search">ابحث عن الرسائل في الخادم</string>
   <string name="global_settings_background_as_unread_indicator_label">تغيير لون الرسالة بعد قراءتها</string>
   <string name="global_settings_threaded_view_summary">إجمع الرسائل في محادثات</string>

--- a/app/ui/legacy/src/main/res/values-be/strings.xml
+++ b/app/ui/legacy/src/main/res/values-be/strings.xml
@@ -811,8 +811,6 @@ K-9 Mail - шматфункцыянальны свабодны паштовы к
   </plurals>
   <string name="remote_search_error">Не атрымалася выканаць адлеглы пошук</string>
   <string name="account_settings_search">Пошук</string>
-  <string name="account_settings_remote_search_enabled">Уключыць пошук на серверы</string>
-  <string name="account_settings_remote_search_enabled_summary">Шукаць лісты на серверы і прыладзе</string>
   <string name="action_remote_search">Пошук лістоў на серверы</string>
   <string name="remote_search_unavailable_no_network">Для пошуку на серверы патрабуецца злучэнне з сеткай.</string>
   <string name="global_settings_background_as_unread_indicator_label">Змяняць колер падчас чытання</string>

--- a/app/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/app/ui/legacy/src/main/res/values-bg/strings.xml
@@ -799,8 +799,6 @@ K-9 Mail е мощен, безплатен имейл клиент за Андр
   </plurals>
   <string name="remote_search_error">Търсенето на сървърва е неуспешно</string>
   <string name="account_settings_search">Търсене</string>
-  <string name="account_settings_remote_search_enabled">Разреши търсене на сървъра</string>
-  <string name="account_settings_remote_search_enabled_summary">Търсене на съобщения на сървъра, в допълнение към тези, на вашето устройство</string>
   <string name="action_remote_search">Търсене на съобщения в сървъра</string>
   <string name="remote_search_unavailable_no_network">Нужна е връзка с мрежата, за да бъде извършено търсене в сървъра.</string>
   <string name="global_settings_background_as_unread_indicator_label">Промяна на цвета след прочитане</string>

--- a/app/ui/legacy/src/main/res/values-br/strings.xml
+++ b/app/ui/legacy/src/main/res/values-br/strings.xml
@@ -754,8 +754,6 @@ Danevellit beugoù, kenlabourit war keweriusterioù nevez ha savit goulennoù wa
   </plurals>
   <string name="remote_search_error">C’hwitadenn war ar c’hlask</string>
   <string name="account_settings_search">Klask</string>
-  <string name="account_settings_remote_search_enabled">Gweredekaat klask war an dafariad</string>
-  <string name="account_settings_remote_search_enabled_summary">Klask kemennadennoù war an dafariad ouzhpenn d’ar re war ho trevnad</string>
   <string name="action_remote_search">Klask kemennadennoù war an dafariad</string>
   <string name="remote_search_unavailable_no_network">Ret eo deoc’h bezañ kennasket evit klask war an dafariad</string>
   <string name="global_settings_background_as_unread_indicator_label">Kemmañ al liv p’eo lennet</string>

--- a/app/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ca/strings.xml
@@ -830,8 +830,6 @@ Si us plau, envieu informes d\'errors, contribuïu-hi amb noves millores i feu p
   </plurals>
   <string name="remote_search_error">No s\'ha pogut fer la cerca remota.</string>
   <string name="account_settings_search">Cerca</string>
-  <string name="account_settings_remote_search_enabled">Activa la cerca del servidor</string>
-  <string name="account_settings_remote_search_enabled_summary">Es cerquen els missatges al vostre dispositiu així com al servidor.</string>
   <string name="action_remote_search">Cerca missatges al servidor</string>
   <string name="remote_search_unavailable_no_network">No es pot fer la cerca sense connectivitat a la xarxa.</string>
   <string name="global_settings_background_as_unread_indicator_label">Canvia el color quan s\'hagi llegit</string>

--- a/app/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cs/strings.xml
@@ -838,8 +838,6 @@ Hlášení o chyb, úpravy pro nové funkce a dotazy zadávejte prostřednictví
   </plurals>
   <string name="remote_search_error">Vzdálené vyhledávání se nezdařilo</string>
   <string name="account_settings_search">Hledání</string>
-  <string name="account_settings_remote_search_enabled">Povolit vyhledávání na serveru</string>
-  <string name="account_settings_remote_search_enabled_summary">Hledat zprávy na serveru navíc k těm v zařízení</string>
   <string name="action_remote_search">Hledat zprávy na serveru</string>
   <string name="remote_search_unavailable_no_network">Vzdálené vyhledávání není k dispozici bez připojení k síti.</string>
   <string name="global_settings_background_as_unread_indicator_label">Ztmavit zprávy po přečtení</string>

--- a/app/ui/legacy/src/main/res/values-cy/strings.xml
+++ b/app/ui/legacy/src/main/res/values-cy/strings.xml
@@ -806,8 +806,6 @@ Plîs rho wybod am unrhyw wallau, syniadau am nodweddion newydd, neu ofyn cwesti
   </plurals>
   <string name="remote_search_error">Methodd y chwilio o bell</string>
   <string name="account_settings_search">Chwilio</string>
-  <string name="account_settings_remote_search_enabled">Galluogi chwilio\'r gweinydd</string>
-  <string name="account_settings_remote_search_enabled_summary">Chwilio negeseuon ar y gweinydd yn ogystal â\'r rhai ar dy ddyfais.</string>
   <string name="action_remote_search">Chwilio negeseuon ar y gweinydd</string>
   <string name="remote_search_unavailable_no_network">Rhaid bod cysylltiad rhyngrwyd er mwyn chwilio\'r gweinydd.</string>
   <string name="global_settings_background_as_unread_indicator_label">Newid lliw ar ôl darllen</string>

--- a/app/ui/legacy/src/main/res/values-da/strings.xml
+++ b/app/ui/legacy/src/main/res/values-da/strings.xml
@@ -806,8 +806,6 @@ Rapporter venligst fejl, forslag til nye funktioner eller stil spørgsmål på:
   </plurals>
   <string name="remote_search_error">Fjernsøgning fejlede</string>
   <string name="account_settings_search">Søg</string>
-  <string name="account_settings_remote_search_enabled">Aktiver søgning på server</string>
-  <string name="account_settings_remote_search_enabled_summary">Søg meddelelser på både enhed og server</string>
   <string name="action_remote_search">Søg i meddelelser på server</string>
   <string name="remote_search_unavailable_no_network">En netværksforbindelse er nødvendig når der søges på server.</string>
   <string name="global_settings_background_as_unread_indicator_label">Skift farve når læst</string>

--- a/app/ui/legacy/src/main/res/values-de/strings.xml
+++ b/app/ui/legacy/src/main/res/values-de/strings.xml
@@ -830,8 +830,6 @@ Bitte senden Sie Fehlerberichte, Ideen für neue Funktionen und stellen Sie Frag
   </plurals>
   <string name="remote_search_error">Suche fehlgeschlagen</string>
   <string name="account_settings_search">Suche</string>
-  <string name="account_settings_remote_search_enabled">Serverseitige Suche</string>
-  <string name="account_settings_remote_search_enabled_summary">Nachrichten nicht nur auf dem Gerät, sondern auch auf dem Server suchen</string>
   <string name="action_remote_search">Nachrichten auf Server suchen</string>
   <string name="remote_search_unavailable_no_network">Für die Suche auf dem Server ist eine Netzverbindung nötig.</string>
   <string name="global_settings_background_as_unread_indicator_label">Farbe ändern, wenn gelesen</string>

--- a/app/ui/legacy/src/main/res/values-el/strings.xml
+++ b/app/ui/legacy/src/main/res/values-el/strings.xml
@@ -817,8 +817,6 @@
   </plurals>
   <string name="remote_search_error">Η απομακρυσμένη αναζήτηση απέτυχε.</string>
   <string name="account_settings_search">Αναζήτηση</string>
-  <string name="account_settings_remote_search_enabled">Ενεργοποίηση αναζήτησης στον εξυπηρετητή</string>
-  <string name="account_settings_remote_search_enabled_summary">Αναζήτηση μηνυμάτων στον εξυπηρετητή, πέραν εκείνων που βρίσκονται στη συσκευή σας</string>
   <string name="action_remote_search">Αναζήτηση μηνυμάτων στον εξυπηρετητή</string>
   <string name="remote_search_unavailable_no_network">Η απομακρυσμένη αναζήτηση δεν είναι διαθέσιμη χωρίς σύνδεση δικτύου.</string>
   <string name="global_settings_background_as_unread_indicator_label">Αλλαγή χρώματος μετά την ανάγνωση</string>

--- a/app/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eo/strings.xml
@@ -817,8 +817,6 @@ Bonvolu raporti erarojn, kontribui novajn eblojn kaj peti pri novaj funkcioj per
   </plurals>
   <string name="remote_search_error">Fora serĉo fiaskis</string>
   <string name="account_settings_search">Serĉi</string>
-  <string name="account_settings_remote_search_enabled">Aktivigi serĉado en servilo</string>
-  <string name="account_settings_remote_search_enabled_summary">Serĉi mesaĝojn en la servilo kaj en via aparato</string>
   <string name="action_remote_search">Serĉi mesaĝojn en servilo</string>
   <string name="remote_search_unavailable_no_network">Interreta konekto estas bezonata por serĉi en servilo.</string>
   <string name="global_settings_background_as_unread_indicator_label">Ŝanĝi koloron se legita</string>

--- a/app/ui/legacy/src/main/res/values-es/strings.xml
+++ b/app/ui/legacy/src/main/res/values-es/strings.xml
@@ -828,8 +828,6 @@ Puedes informar de fallos, contribuir con su desarrollo y hacer preguntas en <a 
   </plurals>
   <string name="remote_search_error">Ha fallado la búsqueda remota</string>
   <string name="account_settings_search">Buscar</string>
-  <string name="account_settings_remote_search_enabled">Habilitar búsqueda en servidor</string>
-  <string name="account_settings_remote_search_enabled_summary">Buscar mensajes en servidor y en dispositivo</string>
   <string name="action_remote_search">Buscar mensajes en servidor</string>
   <string name="remote_search_unavailable_no_network">No se puede buscar en remoto sin conexión de red.</string>
   <string name="global_settings_background_as_unread_indicator_label">Cambiar el color al leer</string>

--- a/app/ui/legacy/src/main/res/values-et/strings.xml
+++ b/app/ui/legacy/src/main/res/values-et/strings.xml
@@ -833,8 +833,6 @@ Veateated saad saata, kaastööd teha ning küsida teavet järgmisel lehel:
   </plurals>
   <string name="remote_search_error">Kaugotsing ebaõnnestus</string>
   <string name="account_settings_search">Otsi</string>
-  <string name="account_settings_remote_search_enabled">Luba serverist otsimine</string>
-  <string name="account_settings_remote_search_enabled_summary">Lisaks seadmes olevatele kirjadele otsi ka serveris asuvate kirjade seast</string>
   <string name="action_remote_search">Otsi serveris olevate kirjade seast</string>
   <string name="remote_search_unavailable_no_network">Serverist otsimiseks on vajalik võrguühendus.</string>
   <string name="global_settings_background_as_unread_indicator_label">Muuda lugemisel värvi</string>

--- a/app/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-eu/strings.xml
@@ -804,8 +804,6 @@ Mesedez akatsen berri emateko, ezaugarri berriak gehitzeko eta galderak egiteko
   </plurals>
   <string name="remote_search_error">Urruneko bilaketak huts egin du</string>
   <string name="account_settings_search">Bilatu</string>
-  <string name="account_settings_remote_search_enabled">Gaitu zerbitzarian bilatzea</string>
-  <string name="account_settings_remote_search_enabled_summary">Bilatu mezuak zerbitzarian zure gailuan dauden horiez gain</string>
   <string name="action_remote_search">Bilatu mezuak zerbitzarian</string>
   <string name="remote_search_unavailable_no_network">Zerbitzarian bilatzeko sareko konexioa behar da.</string>
   <string name="global_settings_background_as_unread_indicator_label">Aldatu kolorea irakurritakoan</string>

--- a/app/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fa/strings.xml
@@ -819,8 +819,6 @@
   </plurals>
   <string name="remote_search_error">جستجو از دور ناموفق بود</string>
   <string name="account_settings_search">جستجو</string>
-  <string name="account_settings_remote_search_enabled">فعال‌سازی جستجو در کارساز</string>
-  <string name="account_settings_remote_search_enabled_summary">هنگام جستجو علاوه بر پیام‌های روی دستگاه، پیام‌های روی کارساز را هم می‌گردد</string>
   <string name="action_remote_search">جستجوی پیام‌ها در کارساز</string>
   <string name="remote_search_unavailable_no_network">برای جستجو در کارساز به اتصال شبکه نیاز دارید.</string>
   <string name="global_settings_background_as_unread_indicator_label">تغییر رنگ پس از خواندن</string>

--- a/app/ui/legacy/src/main/res/values-fi/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fi/strings.xml
@@ -829,8 +829,6 @@ Ilmoita virheistä, ota osaa sovelluskehitykseen ja esitä kysymyksiä osoittees
   </plurals>
   <string name="remote_search_error">Etähaku epäonnistui</string>
   <string name="account_settings_search">Hae</string>
-  <string name="account_settings_remote_search_enabled">Ota etähaku käyttöön</string>
-  <string name="account_settings_remote_search_enabled_summary">Etsi viestejä palvelimelta laitteessasi olevien lisäksi</string>
   <string name="action_remote_search">Etsi viestejä palvelimelta</string>
   <string name="remote_search_unavailable_no_network">Etähaku ei ole käytettävissä ilman verkkoyhteyttä.</string>
   <string name="global_settings_background_as_unread_indicator_label">Vaihda väriä kun luettu</string>

--- a/app/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-fr/strings.xml
@@ -831,8 +831,6 @@ Rapportez les bogues, recommandez de nouvelles fonctions et posez vos questions 
   </plurals>
   <string name="remote_search_error">Échec de recherche distante</string>
   <string name="account_settings_search">Rechercher</string>
-  <string name="account_settings_remote_search_enabled">Activer la recherche sur le serveur</string>
-  <string name="account_settings_remote_search_enabled_summary">Rechercher des courriels sur le serveur en plus de ceux sur votre appareil</string>
   <string name="action_remote_search">Rechercher des courriels sur le serveur</string>
   <string name="remote_search_unavailable_no_network">Une connexion réseau est nécessaire pour la recherche sur le serveur.</string>
   <string name="global_settings_background_as_unread_indicator_label">Changer la couleur quand le courriel est lu</string>

--- a/app/ui/legacy/src/main/res/values-gd/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gd/strings.xml
@@ -769,8 +769,6 @@
   </plurals>
   <string name="remote_search_error">Dh’fhàillig an lorg cèin</string>
   <string name="account_settings_search">Lorg</string>
-  <string name="account_settings_remote_search_enabled">Cuir an comas lorg air an fhrithealaiche</string>
-  <string name="account_settings_remote_search_enabled_summary">Lorg teachdaireachdan air an fhrithealaiche a bharrachd air an fheadhainn air an uidheam agad</string>
   <string name="action_remote_search">Lorg teachdaireachdan air an fhrithealaiche</string>
   <string name="remote_search_unavailable_no_network">Feumaidh tu ceangal ris an lìonra mus urrainn dhut lorg a dhèanamh air an fhrithealaiche.</string>
   <string name="global_settings_background_as_unread_indicator_label">Atharraich an dath nuair a chaidh a leughadh</string>

--- a/app/ui/legacy/src/main/res/values-gl-rES/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gl-rES/strings.xml
@@ -615,8 +615,6 @@
   <string name="remote_search_sending_query">Enviando consulta ao servidor</string>
   <string name="remote_search_error">Erro na procura en remoto</string>
   <string name="account_settings_search">Procurar</string>
-  <string name="account_settings_remote_search_enabled">Habilitar procuras no servidor</string>
-  <string name="account_settings_remote_search_enabled_summary">Procurar mensaxes no servidor ademais de no teu dispositivo</string>
   <string name="action_remote_search">Procurar mensaxes no servidor</string>
   <string name="remote_search_unavailable_no_network">Requírese unha conexión á rede para procurar no servidor.</string>
   <string name="global_settings_threaded_view_label">Vistar en conversación</string>

--- a/app/ui/legacy/src/main/res/values-gl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-gl/strings.xml
@@ -823,8 +823,6 @@ Por favor envíen informes de fallos, contribúa con novas características e co
   </plurals>
   <string name="remote_search_error">Fallou a busca remota</string>
   <string name="account_settings_search">Procurar</string>
-  <string name="account_settings_remote_search_enabled">Habilitar a busca en servidor</string>
-  <string name="account_settings_remote_search_enabled_summary">Buscar mensaxes no servidor ademáis de no seu dispositivo</string>
   <string name="action_remote_search">Buscar mensaxes no servidor</string>
   <string name="remote_search_unavailable_no_network">Precísase conexión a rede para buscar no servidor.</string>
   <string name="global_settings_background_as_unread_indicator_label">Cambiar a cor cando lido</string>

--- a/app/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hr/strings.xml
@@ -760,8 +760,6 @@
   </plurals>
   <string name="remote_search_error">Udaljeno pretraživanje nije uspjelo</string>
   <string name="account_settings_search">Pretraga</string>
-  <string name="account_settings_remote_search_enabled">Omogući pretraživanje poslužitelja</string>
-  <string name="account_settings_remote_search_enabled_summary">Pretraži poruke na poslužitelju a potom one na vašem uređaju</string>
   <string name="action_remote_search">Pretraži poruke na poslužitelju</string>
   <string name="remote_search_unavailable_no_network">Potrebna je mrežna veza za pretragu poslužitelja.</string>
   <string name="global_settings_background_as_unread_indicator_label">Promijeni boju kada je pročitano</string>

--- a/app/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/app/ui/legacy/src/main/res/values-hu/strings.xml
@@ -817,8 +817,6 @@ Hibajelentések beküldésével közreműködhet az új funkciókban, és kérd�
   </plurals>
   <string name="remote_search_error">A távoli keresés sikertelen</string>
   <string name="account_settings_search">Keresés</string>
-  <string name="account_settings_remote_search_enabled">Kiszolgálón keresés engedélyezése</string>
-  <string name="account_settings_remote_search_enabled_summary">Üzenetek keresése a kiszolgálón az eszközön lévők mellett</string>
   <string name="action_remote_search">Üzenetek keresése a kiszolgálón</string>
   <string name="remote_search_unavailable_no_network">Hálózati kapcsolat szükséges a kiszolgálón kereséshez.</string>
   <string name="global_settings_background_as_unread_indicator_label">Szín megváltoztatása olvasáskor</string>

--- a/app/ui/legacy/src/main/res/values-in/strings.xml
+++ b/app/ui/legacy/src/main/res/values-in/strings.xml
@@ -790,8 +790,6 @@ Kirimkan laporan bug, kontribusikan fitur baru dan ajukan pertanyaan di
   </plurals>
   <string name="remote_search_error">Penelusuran jarak jauh gagal</string>
   <string name="account_settings_search">Cari</string>
-  <string name="account_settings_remote_search_enabled">Aktifkan pencarian server</string>
-  <string name="account_settings_remote_search_enabled_summary">Cari pesan di server selain yang ada di perangkat Anda</string>
   <string name="action_remote_search">Cari pesan di server</string>
   <string name="remote_search_unavailable_no_network">Sambungan jaringan diperlukan untuk pencarian server.</string>
   <string name="global_settings_background_as_unread_indicator_label">Ubah warna saat dibaca</string>

--- a/app/ui/legacy/src/main/res/values-is/strings.xml
+++ b/app/ui/legacy/src/main/res/values-is/strings.xml
@@ -818,8 +818,6 @@ Sendu inn villuskýrslur, leggðu fram nýja eiginleika og spurðu spurninga á
   </plurals>
   <string name="remote_search_error">Fjartengd leit mistókst</string>
   <string name="account_settings_search">Leita</string>
-  <string name="account_settings_remote_search_enabled">Virkja leit á póstþjóni</string>
-  <string name="account_settings_remote_search_enabled_summary">Leita að skilaboðum á póstþjóninum auk þeirra sem eru á tækinu þínu</string>
   <string name="action_remote_search">Leita að skilaboðum á póstþjóni</string>
   <string name="remote_search_unavailable_no_network">Nettenging er nauðsynleg til að geta leitað á póstþjóni.</string>
   <string name="global_settings_background_as_unread_indicator_label">Breyta lit þegar búið er að lesa</string>

--- a/app/ui/legacy/src/main/res/values-it/strings.xml
+++ b/app/ui/legacy/src/main/res/values-it/strings.xml
@@ -820,8 +820,6 @@ Invia segnalazioni di bug, contribuisci con nuove funzionalità e poni domande s
   </plurals>
   <string name="remote_search_error">Ricerca remota non riuscita</string>
   <string name="account_settings_search">Cerca</string>
-  <string name="account_settings_remote_search_enabled">Abilita la ricerca sul server</string>
-  <string name="account_settings_remote_search_enabled_summary">Cerca messaggi sul server oltre a quelli sul dispositivo</string>
   <string name="action_remote_search">Cerca messaggi sul server</string>
   <string name="remote_search_unavailable_no_network">Le ricerche sul server richiedono una connessione alla rete.</string>
   <string name="global_settings_background_as_unread_indicator_label">Cambia colore dopo la lettura</string>

--- a/app/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ja/strings.xml
@@ -816,8 +816,6 @@ K-9 は大多数のメールクライアントと同様に、ほとんどのフ�
   </plurals>
   <string name="remote_search_error">サーバ検索失敗</string>
   <string name="account_settings_search">検索</string>
-  <string name="account_settings_remote_search_enabled">サーバでの検索を有効にする</string>
-  <string name="account_settings_remote_search_enabled_summary">デバイス内での検索に加え、サーバでメッセージを検索する</string>
   <string name="action_remote_search">サーバでメッセージを検索する</string>
   <string name="remote_search_unavailable_no_network">サーバでの検索にはネットワーク接続が必要</string>
   <string name="global_settings_background_as_unread_indicator_label">既読の色を変更</string>

--- a/app/ui/legacy/src/main/res/values-ko/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ko/strings.xml
@@ -657,8 +657,6 @@
   </plurals>
   <string name="remote_search_error">원격 검색 실패</string>
   <string name="account_settings_search">검색</string>
-  <string name="account_settings_remote_search_enabled">서버 검색 사용</string>
-  <string name="account_settings_remote_search_enabled_summary">장치에 있는 메일과 서버에 있는 메일을 모두 검색합니다</string>
   <string name="action_remote_search">서버에서 메시지 검색</string>
   <string name="remote_search_unavailable_no_network">네트워크 연결이 없어 서버 검색을 할 수 없습니다.</string>
   <string name="global_settings_threaded_view_label">대화형 보기</string>

--- a/app/ui/legacy/src/main/res/values-lt/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lt/strings.xml
@@ -587,8 +587,6 @@
   <string name="remote_search_sending_query">Užklausiamas serveris</string>
   <string name="remote_search_error">Nuotolinė paieška nepavyko</string>
   <string name="account_settings_search">Ieškoti</string>
-  <string name="account_settings_remote_search_enabled">Įgalinti paiešką serveryje</string>
-  <string name="account_settings_remote_search_enabled_summary">Ieškoti laiškų ir serveryje, ne vien įrenginyje</string>
   <string name="action_remote_search">Ieškoti laiškų serveryje</string>
   <string name="remote_search_unavailable_no_network">Paieškai serveryje reikia interneto ryšio.</string>
   <string name="global_settings_threaded_view_label">Teminis rodinys</string>

--- a/app/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-lv/strings.xml
@@ -829,8 +829,6 @@ pat <xliff:g id="messages_to_load">%d</xliff:g> vairāk</string>
   </plurals>
   <string name="remote_search_error">Attālinātā meklēšana neizdevās</string>
   <string name="account_settings_search">Meklēt</string>
-  <string name="account_settings_remote_search_enabled">Iestatīt meklēšanu serverī</string>
-  <string name="account_settings_remote_search_enabled_summary">Meklēt vēstules gan serverī, gan ierīcē</string>
   <string name="action_remote_search">Meklēt vēstules serverī</string>
   <string name="remote_search_unavailable_no_network">Nepieciešams tīkla savienojums, lai meklētu serverī.</string>
   <string name="global_settings_background_as_unread_indicator_label">Nomainīt krāsu pēc izlasīšanas</string>

--- a/app/ui/legacy/src/main/res/values-ml/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ml/strings.xml
@@ -796,8 +796,6 @@
   </plurals>
   <string name="remote_search_error">വിദൂര തിരയൽ പരാജയപ്പെട്ടു</string>
   <string name="account_settings_search">തിരയുക</string>
-  <string name="account_settings_remote_search_enabled">സെർവർ തിരയൽ പ്രാപ്തമാക്കുക</string>
-  <string name="account_settings_remote_search_enabled_summary">നിങ്ങളുടെ ഉപകരണത്തിലുള്ളവയ്‌ക്ക് പുറമേ സെർവറിൽ സന്ദേശങ്ങൾ തിരയുക</string>
   <string name="action_remote_search">സെർവറിൽ സന്ദേശങ്ങൾ തിരയുക</string>
   <string name="remote_search_unavailable_no_network">സെർവർ തിരയലിനായി ഒരു നെറ്റ്‌വർക്ക് കണക്ഷൻ ആവശ്യമാണ്.</string>
   <string name="global_settings_background_as_unread_indicator_label">വായിക്കുമ്പോൾ നിറം മാറ്റുക</string>

--- a/app/ui/legacy/src/main/res/values-nb/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nb/strings.xml
@@ -782,8 +782,6 @@ til <xliff:g id="messages_to_load">%d</xliff:g> flere</string>
   </plurals>
   <string name="remote_search_error">Eksternt søk mislyktes</string>
   <string name="account_settings_search">Søk</string>
-  <string name="account_settings_remote_search_enabled">Aktiver søk på tjener</string>
-  <string name="account_settings_remote_search_enabled_summary">Søk etter meldinger på tjeneren i tillegg til de på enheten din</string>
   <string name="action_remote_search">Søk etter meldinger på tjener</string>
   <string name="remote_search_unavailable_no_network">En nettverksforbindelse er nødvendig for søk på tjener.</string>
   <string name="global_settings_background_as_unread_indicator_label">Endre farge når lest</string>

--- a/app/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-nl/strings.xml
@@ -818,8 +818,6 @@ Graag foutrapporten sturen, bijdragen voor nieuwe functies en vragen stellen op
   </plurals>
   <string name="remote_search_error">Zoekopdracht mislukt</string>
   <string name="account_settings_search">Zoeken</string>
-  <string name="account_settings_remote_search_enabled">Server zoeken toestaan</string>
-  <string name="account_settings_remote_search_enabled_summary">Zoek berichten op de server en op je eigen toestel</string>
   <string name="action_remote_search">Zoek berichten op server</string>
   <string name="remote_search_unavailable_no_network">Er is een netwerk verbinding nodig voor server zoeken.</string>
   <string name="global_settings_background_as_unread_indicator_label">Kleur wijzigen na lezen</string>

--- a/app/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pl/strings.xml
@@ -843,8 +843,6 @@ Wysłane z urządzenia Android za pomocą K-9 Mail. Proszę wybaczyć moją zwi�
   </plurals>
   <string name="remote_search_error">Wyszukiwanie na serwerze nie powiodło się</string>
   <string name="account_settings_search">Wyszukiwanie</string>
-  <string name="account_settings_remote_search_enabled">Włącz wyszukiwanie na serwerze</string>
-  <string name="account_settings_remote_search_enabled_summary">Szukaj wiadomości na serwerze oraz tych na urządzeniu</string>
   <string name="action_remote_search">Wyszukuj wiadomości na serwerze</string>
   <string name="remote_search_unavailable_no_network">Połączenie sieciowe jest wymagane aby korzystać z wyszukiwania na serwerze.</string>
   <string name="global_settings_background_as_unread_indicator_label">Zmień kolor przeczytanych</string>

--- a/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -829,8 +829,6 @@ Por favor encaminhe relatórios de bugs, contribua com novos recursos e tire dú
   </plurals>
   <string name="remote_search_error">Não foi possível efetuar a pesquisa remota</string>
   <string name="account_settings_search">Pesquisar</string>
-  <string name="account_settings_remote_search_enabled">Habilitar pesquisa no servidor</string>
-  <string name="account_settings_remote_search_enabled_summary">Pesquisa mensagens também no servidor, além do seu dispositivo</string>
   <string name="action_remote_search">Pesquisar mensagens no servidor</string>
   <string name="remote_search_unavailable_no_network">É necessária uma conexão de rede para pesquisar no servidor.</string>
   <string name="global_settings_background_as_unread_indicator_label">Alterar a cor após a leitura</string>

--- a/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/app/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -787,8 +787,6 @@ Por favor envie relatórios de falhas, contribua com novas funcionalidades e col
   </plurals>
   <string name="remote_search_error">A pesquisa remota falhou</string>
   <string name="account_settings_search">Pesquisa</string>
-  <string name="account_settings_remote_search_enabled">Ativar pesquisa no servidor</string>
-  <string name="account_settings_remote_search_enabled_summary">Pesquisar mensagens no servidor em adição às que se encontram no seu dispositivo</string>
   <string name="action_remote_search">Pesquisar mensagens no servidor</string>
   <string name="remote_search_unavailable_no_network">É necessária uma ligação à rede para pesquisar no servidor.</string>
   <string name="global_settings_background_as_unread_indicator_label">Mudar de cor quando lido</string>

--- a/app/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ro/strings.xml
@@ -839,8 +839,6 @@ Uneori datorită faptului că cineva încearcă să te atace pe tine sau serveru
   </plurals>
   <string name="remote_search_error">Căutare la distanță eșuată</string>
   <string name="account_settings_search">Căutare</string>
-  <string name="account_settings_remote_search_enabled">Activează căutarea pe server</string>
-  <string name="account_settings_remote_search_enabled_summary">Caută în mesajele de pe server în plus față de cele de pe dispozitiv</string>
   <string name="action_remote_search">Caută în mesajele de pe server</string>
   <string name="remote_search_unavailable_no_network">Este necesară conexiunea la rețea pentru căutarea pe server.</string>
   <string name="global_settings_background_as_unread_indicator_label">Schimbă culoarea după citire</string>

--- a/app/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/app/ui/legacy/src/main/res/values-ru/strings.xml
@@ -836,8 +836,6 @@ K-9 Mail — почтовый клиент для Android.
   </plurals>
   <string name="remote_search_error">Сбой поиска на сервере</string>
   <string name="account_settings_search">Поиск</string>
-  <string name="account_settings_remote_search_enabled">Поиск на сервере</string>
-  <string name="account_settings_remote_search_enabled_summary">Искать сообщения локально и на сервере</string>
   <string name="action_remote_search">Поиск на сервере</string>
   <string name="remote_search_unavailable_no_network">Для поиска на сервере необходимо подключение к сети</string>
   <string name="global_settings_background_as_unread_indicator_label">Менять цвет при прочтении</string>

--- a/app/ui/legacy/src/main/res/values-sk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sk/strings.xml
@@ -794,8 +794,6 @@ Prosím, nahlasujte prípadné chyby, prispievajte novými funkciami a pýtajte 
   <string name="remote_search_sending_query">Odoslanie dotazu na server</string>
   <string name="remote_search_error">Vzdialené vyhľadávanie sa nepodarilo</string>
   <string name="account_settings_search">Vyhľadávanie</string>
-  <string name="account_settings_remote_search_enabled">Povoliť vyhľadávanie na serveri</string>
-  <string name="account_settings_remote_search_enabled_summary">Hľadať správy na serveri, okrem tých na vašom zariadení</string>
   <string name="action_remote_search">Vyhľadávať správy na serveri</string>
   <string name="remote_search_unavailable_no_network">Pripojenie k sieti je nevyhnutné pre vzdialené vyhľadávanie.</string>
   <string name="global_settings_background_as_unread_indicator_label">Zmeniť farbu po prečítaní</string>

--- a/app/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sl/strings.xml
@@ -844,8 +844,6 @@ dodatnih <xliff:g id="messages_to_load">%d</xliff:g> sporočil</string>
   </plurals>
   <string name="remote_search_error">Oddaljeno iskanje je spodletelo</string>
   <string name="account_settings_search">Iskanje</string>
-  <string name="account_settings_remote_search_enabled">Omogoči iskanje na strežniku</string>
-  <string name="account_settings_remote_search_enabled_summary">Preišči krajevna in tudi neusklajena sporočila na strežniku</string>
   <string name="action_remote_search">Poišči sporočila na strežniku</string>
   <string name="remote_search_unavailable_no_network">Za iskanje na strežniku je zahtevana dejavna omrežna povezava.</string>
   <string name="global_settings_background_as_unread_indicator_label">Spremeni barvo prebranega sporočila</string>

--- a/app/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sq/strings.xml
@@ -831,8 +831,6 @@ Ju lutemi, parashtrim njoftimesh për të meta, kontribute për veçori të reaj
   </plurals>
   <string name="remote_search_error">Kërkimi në largësi dështoi</string>
   <string name="account_settings_search">Kërko</string>
-  <string name="account_settings_remote_search_enabled">Aktivizo kërkime në shërbyes</string>
-  <string name="account_settings_remote_search_enabled_summary">Kërkoni te mesazhet në shërbyes, përtej atyre te pajisja juaj</string>
   <string name="action_remote_search">Kërko mesazhe në shërbyes</string>
   <string name="remote_search_unavailable_no_network">Për kërkime në shërbyes lypset lidhje në rrjet.</string>
   <string name="global_settings_background_as_unread_indicator_label">Ndryshoji ngjyrën kur lexohet</string>

--- a/app/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sr/strings.xml
@@ -804,8 +804,6 @@
   </plurals>
   <string name="remote_search_error">Претрага сервера није успела</string>
   <string name="account_settings_search">Претрага</string>
-  <string name="account_settings_remote_search_enabled">Укључи и сервер у претрагу</string>
-  <string name="account_settings_remote_search_enabled_summary">Претраживаће и поруке на серверу уз оне на вашем уређају</string>
   <string name="action_remote_search">Тражи поруке на серверу</string>
   <string name="remote_search_unavailable_no_network">За претрагу сервера потребна је мрежна веза.</string>
   <string name="global_settings_background_as_unread_indicator_label">Промени боју након читања</string>

--- a/app/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/app/ui/legacy/src/main/res/values-sv/strings.xml
@@ -830,8 +830,6 @@ Skicka gärna in felrapporter, bidra med nya funktioner och ställ frågor på
   </plurals>
   <string name="remote_search_error">Fjärrsökning misslyckades</string>
   <string name="account_settings_search">Sök</string>
-  <string name="account_settings_remote_search_enabled">Aktivera serversökning</string>
-  <string name="account_settings_remote_search_enabled_summary">Sök även meddelanden på servern utöver de som finns på din enhet</string>
   <string name="action_remote_search">Sök meddelanden på servern</string>
   <string name="remote_search_unavailable_no_network">Nätverksanslutning krävs för att söka på servern.</string>
   <string name="global_settings_background_as_unread_indicator_label">Byt färg efter läst</string>

--- a/app/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/app/ui/legacy/src/main/res/values-tr/strings.xml
@@ -814,8 +814,6 @@ Microsoft Exchange ile konuşurken bazı tuhaflıklar yaşadığını not ediniz
   </plurals>
   <string name="remote_search_error">Başarısız uzaktan arama</string>
   <string name="account_settings_search">Ara</string>
-  <string name="account_settings_remote_search_enabled">Sunucu aramasını etkinleştir</string>
-  <string name="account_settings_remote_search_enabled_summary">Cihazınıza ek olarak sunucu üzerinde mesaj ara</string>
   <string name="action_remote_search">Sunucuda mesaj ara</string>
   <string name="remote_search_unavailable_no_network">Sunucuda arama için ağ bağlantısı gereklidir.</string>
   <string name="global_settings_background_as_unread_indicator_label">Okunduğunda rengi değiştir</string>

--- a/app/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/app/ui/legacy/src/main/res/values-uk/strings.xml
@@ -824,8 +824,6 @@ K-9 Mail — це вільний клієнт електронної пошти 
   </plurals>
   <string name="remote_search_error">Віддалений пошук не вдався</string>
   <string name="account_settings_search">Пошук</string>
-  <string name="account_settings_remote_search_enabled">Увімкнути пошук на сервері</string>
-  <string name="account_settings_remote_search_enabled_summary">Шукати повідомлення на сервері на додаток до тих, що є на вашому пристрої</string>
   <string name="action_remote_search">Шукати повідомлення на сервері</string>
   <string name="remote_search_unavailable_no_network">Для пошуку на сервері необхідне з\'єднання з мережею.</string>
   <string name="global_settings_background_as_unread_indicator_label">Змінювати колір при прочитанні</string>

--- a/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -823,8 +823,6 @@ K-9 Mail 是 Android 上一款功能强大的免费邮件客户端。
   </plurals>
   <string name="remote_search_error">远程搜索失败</string>
   <string name="account_settings_search">搜索</string>
-  <string name="account_settings_remote_search_enabled">启用服务器搜索</string>
-  <string name="account_settings_remote_search_enabled_summary">除了您的设备之外也在服务器上进行搜索</string>
   <string name="action_remote_search">在服务器上搜索</string>
   <string name="remote_search_unavailable_no_network">服务器搜索需要网络连接。</string>
   <string name="global_settings_background_as_unread_indicator_label">阅读时改变颜色</string>

--- a/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
+++ b/app/ui/legacy/src/main/res/values-zh-rTW/strings.xml
@@ -812,8 +812,6 @@ K-9 Mail 是 Android 上一款功能強大，免費的電子郵件用戶端。
   </plurals>
   <string name="remote_search_error">遠端搜尋失敗</string>
   <string name="account_settings_search">搜尋</string>
-  <string name="account_settings_remote_search_enabled">啟用伺服器搜尋</string>
-  <string name="account_settings_remote_search_enabled_summary">除了搜尋您的裝置外，同時搜尋伺服器上的訊息</string>
   <string name="action_remote_search">搜尋伺服器上的訊息內容</string>
   <string name="remote_search_unavailable_no_network">沒有網路連線，無法進行遠端搜尋。</string>
   <string name="global_settings_background_as_unread_indicator_label">讀取時變更顏色</string>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -1003,8 +1003,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="remote_search_error">Remote search failed</string>
 
     <string name="account_settings_search">Search</string>
-    <string name="account_settings_remote_search_enabled">Enable server search</string>
-    <string name="account_settings_remote_search_enabled_summary">Search messages on the server in addition to those on your device</string>
     <string name="action_remote_search">Search messages on server</string>
     <string name="remote_search_unavailable_no_network">A network connection is required for server search.</string>
 

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -391,13 +391,7 @@
         android:key="search"
         android:title="@string/account_settings_search">
 
-        <CheckBoxPreference
-            android:key="remote_search_enabled"
-            android:summary="@string/account_settings_remote_search_enabled_summary"
-            android:title="@string/account_settings_remote_search_enabled" />
-
         <ListPreference
-            android:dependency="remote_search_enabled"
             android:dialogTitle="@string/account_settings_remote_search_num_label"
             android:entries="@array/remote_search_num_results_entries"
             android:entryValues="@array/remote_search_num_results_values"


### PR DESCRIPTION
Removes the option for the user; just assume that remote search is allowed.

Still requires user to tap the button to search remote.

Preserves the ability to limit number of remote results.

Open question for the maintainers: should I preserve "editor.remove("$accountUuid.allowRemoteSearch")" in AccountPreferenceSerializer? On one hand, it retains a reference to an old setting. OTOH, without removing it, it will just be a dangling preference that never goes away (unless user uninstalls or Clears Data).

Other question: do I need to do anything with the SettingsUpgrader code at all, to delete the old value?

Tested on my Galaxy S 10 with remote IMAP search, clean install. Haven't tested upgrade scenarios yet, but that seems low-risk. I can check that after the above open questions are answered.

Fixes #5499