### PR TITLE
Launch outbox from send-failed notification (issue #5870)

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
@@ -16,16 +16,18 @@ internal class SendFailedNotificationController(
         val text = ExceptionHelper.getRootCauseMessage(exception)
 
         val notificationId = NotificationIds.getSendFailedNotificationId(account)
-        val pendingIntent =
-            if (account.outboxFolderId != null) {
+
+        val pendingIntent = account.outboxFolderId.let { outboxFolderId ->
+            if (outboxFolderId != null) {
                 actionBuilder.createViewFolderPendingIntent(
-                    account, account.outboxFolderId!!, notificationId
+                    account, outboxFolderId, notificationId
                 )
             } else {
                 actionBuilder.createViewFolderListPendingIntent(
                     account, notificationId
                 )
             }
+        }
 
         val notificationBuilder = notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)

--- a/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SendFailedNotificationController.kt
@@ -16,9 +16,16 @@ internal class SendFailedNotificationController(
         val text = ExceptionHelper.getRootCauseMessage(exception)
 
         val notificationId = NotificationIds.getSendFailedNotificationId(account)
-        val folderListPendingIntent = actionBuilder.createViewFolderListPendingIntent(
-            account, notificationId
-        )
+        val pendingIntent =
+            if (account.outboxFolderId != null) {
+                actionBuilder.createViewFolderPendingIntent(
+                    account, account.outboxFolderId!!, notificationId
+                )
+            } else {
+                actionBuilder.createViewFolderListPendingIntent(
+                    account, notificationId
+                )
+            }
 
         val notificationBuilder = notificationHelper
             .createNotificationBuilder(account, NotificationChannelManager.ChannelType.MISCELLANEOUS)
@@ -29,7 +36,7 @@ internal class SendFailedNotificationController(
             .setTicker(title)
             .setContentTitle(title)
             .setContentText(text)
-            .setContentIntent(folderListPendingIntent)
+            .setContentIntent(pendingIntent)
             .setStyle(NotificationCompat.BigTextStyle().bigText(text))
             .setPublicVersion(createLockScreenNotification(account))
             .setCategory(NotificationCompat.CATEGORY_ERROR)

--- a/app/core/src/test/java/com/fsck/k9/notification/SendFailedNotificationControllerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/SendFailedNotificationControllerTest.kt
@@ -10,6 +10,7 @@ import com.fsck.k9.RobolectricTest
 import com.fsck.k9.testing.MockHelper.mockBuilder
 import org.junit.Test
 import org.mockito.ArgumentMatchers.anyInt
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
@@ -88,6 +89,7 @@ class SendFailedNotificationControllerTest : RobolectricTest() {
     private fun createActionBuilder(contentIntent: PendingIntent): NotificationActionCreator {
         return mock {
             on { createViewFolderListPendingIntent(any(), anyInt()) } doReturn contentIntent
+            on { createViewFolderPendingIntent(any(), anyLong(), anyInt()) } doReturn contentIntent
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/k9mail/k-9/issues/5870

Tested with my 2 accounts, one IMAP, non-gmail, and one gmail. Both had an outbox folder. I wasn't able to test the null behavior for outbox folder, but this seems to be the right way to do it. I'm also still getting comfortable with the control flow for Kotlin around nulls, so let me know if there's a more elegant way to do that if/else.