### PR TITLE
Switch to mockito-inline

### DIFF
--- a/app/autodiscovery/providersxml/build.gradle
+++ b/app/autodiscovery/providersxml/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     testImplementation "androidx.test:core:${versions.androidxTestCore}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-inline:${versions.mockito}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "io.insert-koin:koin-test-junit4:${versions.koin}"
 }

--- a/app/autodiscovery/providersxml/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/autodiscovery/providersxml/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/app/autodiscovery/srvrecords/build.gradle
+++ b/app/autodiscovery/srvrecords/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation "androidx.test:core:${versions.androidxTestCore}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-inline:${versions.mockito}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "io.insert-koin:koin-test-junit4:${versions.koin}"
 }

--- a/app/autodiscovery/srvrecords/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/autodiscovery/srvrecords/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/app/autodiscovery/thunderbird/build.gradle
+++ b/app/autodiscovery/thunderbird/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation "androidx.test:core:${versions.androidxTestCore}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-inline:${versions.mockito}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "io.insert-koin:koin-test-junit4:${versions.koin}"
 }

--- a/app/autodiscovery/thunderbird/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/autodiscovery/thunderbird/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/app/core/build.gradle
+++ b/app/core/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     testImplementation "androidx.test:core:${versions.androidxTestCore}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-inline:${versions.mockito}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "org.jdom:jdom2:2.0.6"
     testImplementation "io.insert-koin:koin-test-junit4:${versions.koin}"

--- a/app/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/core/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/app/k9mail/build.gradle
+++ b/app/k9mail/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-inline:${versions.mockito}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "io.insert-koin:koin-test-junit4:${versions.koin}"
 }

--- a/app/k9mail/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/k9mail/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/app/storage/build.gradle
+++ b/app/storage/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-inline:${versions.mockito}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "io.insert-koin:koin-test-junit4:${versions.koin}"
     testImplementation "commons-io:commons-io:${versions.commonsIo}"

--- a/app/storage/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/storage/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/app/ui/legacy/build.gradle
+++ b/app/ui/legacy/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "org.jetbrains.kotlin:kotlin-test:${versions.kotlin}"
     testImplementation "com.google.truth:truth:${versions.truth}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-inline:${versions.mockito}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "io.insert-koin:koin-test-junit4:${versions.koin}"
     testImplementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.kotlinCoroutines}"

--- a/app/ui/legacy/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/app/ui/legacy/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/backend/imap/build.gradle
+++ b/backend/imap/build.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation project(":mail:testing")
     testImplementation project(":backend:testing")
     testImplementation "junit:junit:${versions.junit}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-inline:${versions.mockito}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "com.google.truth:truth:${versions.truth}"
     testImplementation "org.apache.james:apache-mime4j-dom:${versions.mime4j}"

--- a/backend/imap/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/backend/imap/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline

--- a/mail/common/build.gradle
+++ b/mail/common/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     testImplementation "org.robolectric:robolectric:${versions.robolectric}"
     testImplementation "junit:junit:${versions.junit}"
     testImplementation "com.google.truth:truth:${versions.truth}"
-    testImplementation "org.mockito:mockito-core:${versions.mockito}"
+    testImplementation "org.mockito:mockito-inline:${versions.mockito}"
     testImplementation "org.mockito.kotlin:mockito-kotlin:${versions.mockitoKotlin}"
     testImplementation "com.ibm.icu:icu4j-charset:70.1"
 }

--- a/mail/common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/mail/common/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,1 +1,0 @@
-mock-maker-inline


### PR DESCRIPTION
This allows us to get rid of the `org.mockito.plugins.MockMaker` files.