### PR TITLE
Fix NotificationChannel recreation avoidance logic

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationChannelManager.kt
@@ -193,6 +193,7 @@ class NotificationChannelManager(
     @RequiresApi(Build.VERSION_CODES.O)
     private fun NotificationChannel.matches(notificationSetting: NotificationSetting): Boolean {
         return lightColor == notificationSetting.ledColor &&
+            shouldVibrate() == notificationSetting.isVibrateEnabled &&
             vibrationPattern.contentEquals(notificationSetting.vibration)
     }
 


### PR DESCRIPTION
The `NotificationChannel` wasn't recreated when only the vibration was toggled on/off.