### PR TITLE
Use `Account.toString()` in log messages

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/Account.java
+++ b/app/core/src/main/java/com/fsck/k9/Account.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import android.text.TextUtils;
 
+import androidx.annotation.NonNull;
 import com.fsck.k9.backend.api.SyncConfig.ExpungePolicy;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.NetworkType;
@@ -704,9 +705,14 @@ public class Account implements BaseAccount {
         return oldMaxPushFolders != maxPushFolders;
     }
 
+    @NonNull
     @Override
     public synchronized String toString() {
-        return description;
+        if (K9.isSensitiveDebugLoggingEnabled()) {
+            return getDisplayName();
+        } else {
+            return accountUuid;
+        }
     }
 
     public synchronized void setCompression(NetworkType networkType, boolean useCompression) {

--- a/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -263,7 +263,7 @@ public class MessagingController {
         try {
             return localStoreProvider.getInstance(account);
         } catch (MessagingException e) {
-            throw new IllegalStateException("Couldn't get LocalStore for account " + account.getDescription());
+            throw new IllegalStateException("Couldn't get LocalStore for account " + account);
         }
     }
 
@@ -676,7 +676,7 @@ public class MessagingController {
 
         if (commandException != null && !syncListener.syncFailed) {
             String rootMessage = getRootCauseMessage(commandException);
-            Timber.e("Root cause failure in %s:%s was '%s'", account.getDescription(), folderServerId, rootMessage);
+            Timber.e("Root cause failure in %s:%s was '%s'", account, folderServerId, rootMessage);
             updateFolderStatus(account, folderServerId, rootMessage);
             listener.synchronizeMailboxFailed(account, folderId, rootMessage);
         }
@@ -946,7 +946,7 @@ public class MessagingController {
 
         if (operation != MoveOrCopyFlavor.COPY) {
             if (backend.getSupportsExpunge() && account.getExpungePolicy() == Expunge.EXPUNGE_IMMEDIATELY) {
-                Timber.i("processingPendingMoveOrCopy expunging folder %s:%s", account.getDescription(), srcFolderServerId);
+                Timber.i("processingPendingMoveOrCopy expunging folder %s:%s", account, srcFolderServerId);
                 backend.expungeMessages(srcFolderServerId, uids);
             }
 
@@ -2109,7 +2109,7 @@ public class MessagingController {
                 }
             }
 
-            Timber.d("Delete policy for account %s is %s", account.getDescription(), account.getDeletePolicy());
+            Timber.d("Delete policy for account %s is %s", account, account.getDeletePolicy());
 
             Long outboxFolderId = account.getOutboxFolderId();
             if (outboxFolderId != null && folderId == outboxFolderId && supportsUpload(account)) {
@@ -2269,11 +2269,11 @@ public class MessagingController {
             }
         });
 
-        Timber.v("performPeriodicMailSync(%s) about to await latch release", account.getDescription());
+        Timber.v("performPeriodicMailSync(%s) about to await latch release", account);
 
         try {
             latch.await();
-            Timber.v("performPeriodicMailSync(%s) got latch release", account.getDescription());
+            Timber.v("performPeriodicMailSync(%s) got latch release", account);
         } catch (Exception e) {
             Timber.e(e, "Interrupted while awaiting latch release");
         }
@@ -2358,7 +2358,7 @@ public class MessagingController {
     private void checkMailForAccount(final Context context, final Account account,
             final boolean ignoreLastCheckedTime,
             final MessagingListener listener) {
-        Timber.i("Synchronizing account %s", account.getDescription());
+        Timber.i("Synchronizing account %s", account);
 
         NotificationState notificationState = new NotificationState();
 
@@ -2403,12 +2403,12 @@ public class MessagingController {
                 synchronizeFolder(account, folder, ignoreLastCheckedTime, listener, notificationState);
             }
         } catch (MessagingException e) {
-            Timber.e(e, "Unable to synchronize account %s", account.getName());
+            Timber.e(e, "Unable to synchronize account %s", account);
         } finally {
-            putBackground("clear notification flag for " + account.getDescription(), null, new Runnable() {
+            putBackground("clear notification flag for " + account, null, new Runnable() {
                         @Override
                         public void run() {
-                            Timber.v("Clearing notification flag for %s", account.getDescription());
+                            Timber.v("Clearing notification flag for %s", account);
 
                             clearFetchingMailNotification(account);
 
@@ -2459,7 +2459,7 @@ public class MessagingController {
                 showEmptyFetchingMailNotificationIfNecessary(account);
             }
         } catch (Exception e) {
-            Timber.e(e, "Exception while processing folder %s:%s", account.getDescription(), folder.getServerId());
+            Timber.e(e, "Exception while processing folder %s:%s", account, folder.getServerId());
         }
     }
 
@@ -2480,7 +2480,7 @@ public class MessagingController {
     }
 
     public void compact(final Account account, final MessagingListener ml) {
-        putBackground("compact:" + account.getDescription(), ml, new Runnable() {
+        putBackground("compact:" + account, ml, new Runnable() {
             @Override
             public void run() {
                 try {
@@ -2492,7 +2492,7 @@ public class MessagingController {
                         l.accountSizeChanged(account, oldSize, newSize);
                     }
                 } catch (Exception e) {
-                    Timber.e(e, "Failed to compact account %s", account.getDescription());
+                    Timber.e(e, "Failed to compact account %s", account);
                 }
             }
         });

--- a/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
+++ b/app/core/src/main/java/com/fsck/k9/job/MailSyncWorkerManager.kt
@@ -16,7 +16,7 @@ import timber.log.Timber
 class MailSyncWorkerManager(private val workManager: WorkManager, val clock: Clock) {
 
     fun cancelMailSync(account: Account) {
-        Timber.v("Canceling mail sync worker for %s", account.description)
+        Timber.v("Canceling mail sync worker for %s", account)
         val uniqueWorkName = createUniqueWorkName(account.uuid)
         workManager.cancelUniqueWork(uniqueWorkName)
     }
@@ -25,7 +25,7 @@ class MailSyncWorkerManager(private val workManager: WorkManager, val clock: Clo
         if (isNeverSyncInBackground()) return
 
         getSyncIntervalIfEnabled(account)?.let { syncIntervalMinutes ->
-            Timber.v("Scheduling mail sync worker for %s", account.description)
+            Timber.v("Scheduling mail sync worker for %s", account)
             Timber.v("  sync interval: %d minutes", syncIntervalMinutes)
 
             val constraints = Constraints.Builder()

--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
@@ -257,7 +257,7 @@ class SettingsExporter(
                     Timber.w(
                         "Account setting \"%s\" (%s) has invalid value \"%s\" in preference storage. " +
                             "This shouldn't happen!",
-                        keyPart, account.description, valueString
+                        keyPart, account, valueString
                     )
                 }
             }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/account/AccountRemover.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/account/AccountRemover.kt
@@ -27,7 +27,7 @@ class AccountRemover(
             return
         }
 
-        val accountName = account.description
+        val accountName = account.toString()
         Timber.v("Removing account '%s'…", accountName)
 
         removeLocalStore(account)
@@ -47,7 +47,7 @@ class AccountRemover(
             val localStore = localStoreProvider.getInstance(account)
             localStore.delete()
         } catch (e: Exception) {
-            Timber.w(e, "Error removing message database for account '%s'", account.description)
+            Timber.w(e, "Error removing message database for account '%s'", account)
 
             // Ignore, this may lead to localStores on sd-cards that are currently not inserted to be left
         }
@@ -59,7 +59,7 @@ class AccountRemover(
         try {
             backendManager.removeBackend(account)
         } catch (e: Exception) {
-            Timber.e(e, "Failed to reset remote store for account %s", account.uuid)
+            Timber.e(e, "Failed to reset remote store for account %s", account)
         }
     }
 }


### PR DESCRIPTION
Have `Account.toString()` only return the account name when sensitive debug logging is enabled. Otherwise return the account UUID.