### PR TITLE
Rework notification light setting

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
+++ b/app/core/src/main/java/com/fsck/k9/AccountPreferenceSerializer.kt
@@ -141,8 +141,7 @@ class AccountPreferenceSerializer(
                 NotificationSettings(
                     isRingEnabled = storage.getBoolean("$accountUuid.ring", true),
                     ringtone = storage.getString("$accountUuid.ringtone", DEFAULT_RINGTONE_URI),
-                    isLedEnabled = storage.getBoolean("$accountUuid.led", true),
-                    ledColor = storage.getInt("$accountUuid.ledColor", chipColor),
+                    light = getEnumStringPref(storage, "$accountUuid.notificationLight", NotificationLight.Disabled),
                     isVibrateEnabled = storage.getBoolean("$accountUuid.vibrate", false),
                     vibratePattern = VibratePattern.deserialize(storage.getInt("$accountUuid.vibratePattern", 0)),
                     vibrateTimes = storage.getInt("$accountUuid.vibrateTimes", 5)
@@ -328,8 +327,7 @@ class AccountPreferenceSerializer(
             editor.putInt("$accountUuid.vibrateTimes", notificationSettings.vibrateTimes)
             editor.putBoolean("$accountUuid.ring", notificationSettings.isRingEnabled)
             editor.putString("$accountUuid.ringtone", notificationSettings.ringtone)
-            editor.putBoolean("$accountUuid.led", notificationSettings.isLedEnabled)
-            editor.putInt("$accountUuid.ledColor", notificationSettings.ledColor)
+            editor.putString("$accountUuid.notificationLight", notificationSettings.light.name)
             editor.putLong("$accountUuid.lastSyncTime", lastSyncTime)
             editor.putLong("$accountUuid.lastFolderListRefreshTime", lastFolderListRefreshTime)
             editor.putBoolean("$accountUuid.isFinishedSetup", isFinishedSetup)
@@ -408,8 +406,7 @@ class AccountPreferenceSerializer(
         editor.remove("$accountUuid.maxPushFolders")
         editor.remove("$accountUuid.searchableFolders")
         editor.remove("$accountUuid.chipColor")
-        editor.remove("$accountUuid.led")
-        editor.remove("$accountUuid.ledColor")
+        editor.remove("$accountUuid.notificationLight")
         editor.remove("$accountUuid.subscribedFoldersOnly")
         editor.remove("$accountUuid.maximumPolledMessageAge")
         editor.remove("$accountUuid.maximumAutoDownloadMessageSize")
@@ -609,8 +606,7 @@ class AccountPreferenceSerializer(
                 NotificationSettings(
                     isRingEnabled = true,
                     ringtone = DEFAULT_RINGTONE_URI,
-                    isLedEnabled = false,
-                    ledColor = chipColor,
+                    light = NotificationLight.Disabled,
                     isVibrateEnabled = false,
                     vibratePattern = VibratePattern.Default,
                     vibrateTimes = 5

--- a/app/core/src/main/java/com/fsck/k9/NotificationLight.kt
+++ b/app/core/src/main/java/com/fsck/k9/NotificationLight.kt
@@ -1,0 +1,33 @@
+package com.fsck.k9
+
+import android.app.Notification
+
+enum class NotificationLight {
+    Disabled,
+    AccountColor,
+    SystemDefaultColor,
+    White,
+    Red,
+    Green,
+    Blue,
+    Yellow,
+    Cyan,
+    Magenta;
+
+    fun toColor(account: Account): Int? {
+        return when (this) {
+            Disabled -> null
+            AccountColor -> account.chipColor.toArgb()
+            SystemDefaultColor -> Notification.COLOR_DEFAULT
+            White -> 0xFFFFFF.toArgb()
+            Red -> 0xFF0000.toArgb()
+            Green -> 0x00FF00.toArgb()
+            Blue -> 0x0000FF.toArgb()
+            Yellow -> 0xFFFF00.toArgb()
+            Cyan -> 0x00FFFF.toArgb()
+            Magenta -> 0xFF00FF.toArgb()
+        }
+    }
+
+    private fun Int.toArgb() = this or 0xFF000000L.toInt()
+}

--- a/app/core/src/main/java/com/fsck/k9/NotificationSettings.kt
+++ b/app/core/src/main/java/com/fsck/k9/NotificationSettings.kt
@@ -6,8 +6,7 @@ package com.fsck.k9
 data class NotificationSettings(
     val isRingEnabled: Boolean = false,
     val ringtone: String? = null,
-    val isLedEnabled: Boolean = false,
-    val ledColor: Int = 0,
+    val light: NotificationLight = NotificationLight.Disabled,
     val isVibrateEnabled: Boolean = false,
     val vibratePattern: VibratePattern = VibratePattern.Default,
     val vibrateTimes: Int = 0

--- a/app/core/src/main/java/com/fsck/k9/notification/BaseNotificationDataCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/BaseNotificationDataCreator.kt
@@ -42,7 +42,7 @@ internal class BaseNotificationDataCreator {
     private fun createNotificationAppearance(account: Account): NotificationAppearance {
         return with(account.notificationSettings) {
             val vibrationPattern = if (isVibrateEnabled) vibrationPattern else null
-            NotificationAppearance(ringtone, vibrationPattern, ledColor)
+            NotificationAppearance(ringtone, vibrationPattern, account.notificationSettings.light.toColor(account))
         }
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/CoreKoinModule.kt
@@ -24,7 +24,8 @@ val coreNotificationModule = module {
             preferences = get(),
             backgroundExecutor = Executors.newSingleThreadExecutor(),
             notificationManager = get<Context>().getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager,
-            resourceProvider = get()
+            resourceProvider = get(),
+            notificationLightDecoder = get()
         )
     }
     single {
@@ -112,4 +113,5 @@ val coreNotificationModule = module {
             notificationContentCreator = get()
         )
     }
+    factory { NotificationLightDecoder() }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationLightDecoder.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationLightDecoder.kt
@@ -1,0 +1,27 @@
+package com.fsck.k9.notification
+
+import com.fsck.k9.NotificationLight
+
+/**
+ * Converts the "blink lights" values read from a `NotificationChannel` into [NotificationLight].
+ */
+class NotificationLightDecoder {
+    fun decode(isBlinkLightsEnabled: Boolean, lightColor: Int, accountColor: Int): NotificationLight {
+        if (!isBlinkLightsEnabled) return NotificationLight.Disabled
+
+        return when (lightColor.rgb) {
+            accountColor.rgb -> NotificationLight.AccountColor
+            0xFFFFFF -> NotificationLight.White
+            0xFF0000 -> NotificationLight.Red
+            0x00FF00 -> NotificationLight.Green
+            0x0000FF -> NotificationLight.Blue
+            0xFFFF00 -> NotificationLight.Yellow
+            0x00FFFF -> NotificationLight.Cyan
+            0xFF00FF -> NotificationLight.Magenta
+            else -> NotificationLight.SystemDefaultColor
+        }
+    }
+
+    private val Int.rgb
+        get() = this and 0x00FFFFFF
+}

--- a/app/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SyncNotificationController.kt
@@ -41,7 +41,7 @@ internal class SyncNotificationController(
                 builder = notificationBuilder,
                 ringtone = null,
                 vibrationPattern = null,
-                ledColor = account.notificationSettings.ledColor,
+                ledColor = account.notificationSettings.light.toColor(account),
                 ledSpeed = NotificationHelper.NOTIFICATION_LED_BLINK_FAST,
                 ringAndVibrate = true
             )
@@ -88,7 +88,7 @@ internal class SyncNotificationController(
                 builder = notificationBuilder,
                 ringtone = null,
                 vibrationPattern = null,
-                ledColor = account.notificationSettings.ledColor,
+                ledColor = account.notificationSettings.light.toColor(account),
                 ledSpeed = NotificationHelper.NOTIFICATION_LED_BLINK_FAST,
                 ringAndVibrate = true
             )
@@ -118,7 +118,7 @@ internal class SyncNotificationController(
                 builder = notificationBuilder,
                 ringtone = null,
                 vibrationPattern = null,
-                ledColor = account.notificationSettings.ledColor,
+                ledColor = account.notificationSettings.light.toColor(account),
                 ledSpeed = NotificationHelper.NOTIFICATION_LED_BLINK_FAST,
                 ringAndVibrate = true
             )

--- a/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/app/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -36,7 +36,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 79;
+    public static final int VERSION = 80;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/app/core/src/main/res/values/arrays_account_settings_values.xml
+++ b/app/core/src/main/res/values/arrays_account_settings_values.xml
@@ -24,42 +24,6 @@
         <item>0xFF455A64</item> <!-- Blue gray 700 -->
     </integer-array>
 
-    <!-- Keep first part in sync with 'account_colors' -->
-    <integer-array name="notification_light_colors">
-        <!-- Account colors -->
-        <item>0xFFFFB300</item> <!-- Amber 600 -->
-        <item>0xFFFB8C00</item> <!-- Orange 600 -->
-        <item>0xFFF4511E</item> <!-- Deep orange 600 -->
-        <item>0xFFE53935</item> <!-- Red 600 -->
-
-        <item>0xFFC0CA33</item> <!-- Lime 600 -->
-        <item>0xFF7CB342</item> <!-- Light green 600 -->
-        <item>0xFF388E3C</item> <!-- Green 700 -->
-        <item>0xFF00897B</item> <!-- Teal 600 -->
-
-        <item>0xFF00ACC1</item> <!-- Cyan 600 -->
-        <item>0xFF039BE5</item> <!-- Light blue 600 -->
-        <item>0xFF1976D2</item> <!-- Blue 700 -->
-        <item>0xFF3949AB</item> <!-- Indigo 600 -->
-
-        <item>0xFFE91E63</item> <!-- Pink 500 -->
-        <item>0xFF8E24AA</item> <!-- Purple 600 -->
-        <item>0xFF5E35B1</item> <!-- Deep purple 600 -->
-        <item>0xFF455A64</item> <!-- Blue gray 700 -->
-
-        <!-- Full brightness colors (not part of 'account_colors') -->
-        <item>0xFFFF0000</item> <!-- Red -->
-        <item>0xFF00FF00</item> <!-- Green -->
-        <item>0xFF0000FF</item> <!-- Blue -->
-        <item>0xFFFFFFFF</item> <!-- White -->
-
-        <item>0xFFFFFF00</item> <!-- Yellow -->
-        <item>0xFF00FFFF</item> <!-- Cyan -->
-        <item>0xFFFF00FF</item> <!-- Magenta -->
-        <item>0x00000000</item> <!-- Transparent (default notification color) -->
-
-    </integer-array>
-
     <string-array name="check_frequency_values" translatable="false">
         <item>-1</item>
         <item>15</item>
@@ -210,6 +174,20 @@
         <item>3</item>
         <item>4</item>
         <item>5</item>
+    </string-array>
+
+    <!-- Must be kept in sync with `NotificationLight` enum -->
+    <string-array name="notification_light_values" translatable="false">
+        <item>Disabled</item>
+        <item>AccountColor</item>
+        <item>SystemDefaultColor</item>
+        <item>White</item>
+        <item>Red</item>
+        <item>Green</item>
+        <item>Blue</item>
+        <item>Yellow</item>
+        <item>Cyan</item>
+        <item>Magenta</item>
     </string-array>
 
     <string-array name="quote_style_values" translatable="false">

--- a/app/core/src/test/java/com/fsck/k9/notification/BaseNotificationDataCreatorTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/BaseNotificationDataCreatorTest.kt
@@ -4,6 +4,7 @@ import com.fsck.k9.Account
 import com.fsck.k9.Identity
 import com.fsck.k9.K9
 import com.fsck.k9.K9.LockScreenNotificationVisibility
+import com.fsck.k9.NotificationLight
 import com.fsck.k9.NotificationSettings
 import com.fsck.k9.VibratePattern
 import com.google.common.truth.Truth.assertThat
@@ -163,12 +164,12 @@ class BaseNotificationDataCreatorTest {
 
     @Test
     fun `led color`() {
-        account.updateNotificationSettings { it.copy(ledColor = 0x00FF00) }
+        account.updateNotificationSettings { it.copy(light = NotificationLight.Green) }
         val notificationData = createNotificationData()
 
         val result = notificationDataCreator.createBaseNotificationData(notificationData)
 
-        assertThat(result.appearance.ledColor).isEqualTo(0x00FF00)
+        assertThat(result.appearance.ledColor).isEqualTo(0xFF00FF00L.toInt())
     }
 
     private fun setLockScreenMode(mode: LockScreenNotificationVisibility) {

--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -21,7 +21,7 @@ import timber.log.Timber;
 
 
 public class K9StoragePersister implements StoragePersister {
-    private static final int DB_VERSION = 16;
+    private static final int DB_VERSION = 17;
     private static final String DB_NAME = "preferences_storage";
 
     private final Context context;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo17.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo17.kt
@@ -1,0 +1,54 @@
+package com.fsck.k9.preferences.migrations
+
+import android.database.sqlite.SQLiteDatabase
+
+/**
+ * Rewrite 'led' and 'ledColor' values to 'notificationLight'.
+ */
+class StorageMigrationTo17(
+    private val db: SQLiteDatabase,
+    private val migrationsHelper: StorageMigrationsHelper
+) {
+    fun rewriteNotificationLightSettings() {
+        val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")
+        if (accountUuidsListValue == null || accountUuidsListValue.isEmpty()) {
+            return
+        }
+
+        val accountUuids = accountUuidsListValue.split(",")
+        for (accountUuid in accountUuids) {
+            rewriteNotificationLightSettings(accountUuid)
+        }
+    }
+
+    private fun rewriteNotificationLightSettings(accountUuid: String) {
+        val isLedEnabled = migrationsHelper.readValue(db, "$accountUuid.led").toBoolean()
+        val ledColor = migrationsHelper.readValue(db, "$accountUuid.ledColor")?.toInt() ?: 0
+        val accountColor = migrationsHelper.readValue(db, "$accountUuid.chipColor")?.toInt() ?: 0
+
+        val notificationLight = convertToNotificationLightValue(isLedEnabled, ledColor, accountColor)
+
+        migrationsHelper.writeValue(db, "$accountUuid.notificationLight", notificationLight)
+        migrationsHelper.writeValue(db, "$accountUuid.led", null)
+        migrationsHelper.writeValue(db, "$accountUuid.ledColor", null)
+    }
+
+    private fun convertToNotificationLightValue(isLedEnabled: Boolean, ledColor: Int, accountColor: Int): String {
+        if (!isLedEnabled) return "Disabled"
+
+        return when (ledColor.rgb) {
+            accountColor.rgb -> "AccountColor"
+            0xFFFFFF -> "White"
+            0xFF0000 -> "Red"
+            0x00FF00 -> "Green"
+            0x0000FF -> "Blue"
+            0xFFFF00 -> "Yellow"
+            0x00FFFF -> "Cyan"
+            0xFF00FF -> "Magenta"
+            else -> "SystemDefaultColor"
+        }
+    }
+
+    private val Int.rgb
+        get() = this and 0x00FFFFFF
+}

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
@@ -22,5 +22,6 @@ internal object StorageMigrations {
         if (oldVersion < 14) StorageMigrationTo14(db, migrationsHelper).disablePushFoldersForNonImapAccounts()
         if (oldVersion < 15) StorageMigrationTo15(db, migrationsHelper).rewriteIdleRefreshInterval()
         if (oldVersion < 16) StorageMigrationTo16(db, migrationsHelper).changeDefaultRegisteredNameColor()
+        if (oldVersion < 17) StorageMigrationTo17(db, migrationsHelper).rewriteNotificationLightSettings()
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/KoinModule.kt
@@ -29,7 +29,8 @@ val settingsUiModule = module {
             preferences = get(),
             jobManager = get(),
             executorService = get(named("SaveSettingsExecutorService")),
-            notificationChannelManager = get()
+            notificationChannelManager = get(),
+            notificationController = get()
         )
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreFactory.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStoreFactory.kt
@@ -4,15 +4,24 @@ import com.fsck.k9.Account
 import com.fsck.k9.Preferences
 import com.fsck.k9.job.K9JobManager
 import com.fsck.k9.notification.NotificationChannelManager
+import com.fsck.k9.notification.NotificationController
 import java.util.concurrent.ExecutorService
 
 class AccountSettingsDataStoreFactory(
     private val preferences: Preferences,
     private val jobManager: K9JobManager,
     private val executorService: ExecutorService,
-    private val notificationChannelManager: NotificationChannelManager
+    private val notificationChannelManager: NotificationChannelManager,
+    private val notificationController: NotificationController
 ) {
     fun create(account: Account): AccountSettingsDataStore {
-        return AccountSettingsDataStore(preferences, executorService, account, jobManager, notificationChannelManager)
+        return AccountSettingsDataStore(
+            preferences,
+            executorService,
+            account,
+            jobManager,
+            notificationChannelManager,
+            notificationController
+        )
     }
 }

--- a/app/ui/legacy/src/main/res/values/arrays_account_settings_strings.xml
+++ b/app/ui/legacy/src/main/res/values/arrays_account_settings_strings.xml
@@ -153,6 +153,19 @@
         <item>@string/account_settings_vibrate_pattern_5</item>
     </string-array>
 
+    <string-array name="notification_light_entries">
+        <item>@string/account_settings_notification_light_disabled</item>
+        <item>@string/account_settings_notification_light_account_color</item>
+        <item>@string/account_settings_notification_light_default_color</item>
+        <item>@string/account_settings_notification_light_white</item>
+        <item>@string/account_settings_notification_light_red</item>
+        <item>@string/account_settings_notification_light_green</item>
+        <item>@string/account_settings_notification_light_blue</item>
+        <item>@string/account_settings_notification_light_yellow</item>
+        <item>@string/account_settings_notification_light_cyan</item>
+        <item>@string/account_settings_notification_light_magenta</item>
+    </string-array>
+
     <string-array name="quote_style_entries">
         <item>@string/account_settings_quote_style_prefix</item>
         <item>@string/account_settings_quote_style_header</item>

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -551,9 +551,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_color_label">Account color</string>
     <string name="account_settings_color_summary">The accent color of this account used in folder and account list</string>
 
-    <string name="account_settings_led_color_label">Notification LED color</string>
-    <string name="account_settings_led_color_summary">The color your device LED should blink for this account</string>
-
     <string name="account_settings_mail_display_count_label">Local folder size</string>
 
     <string name="account_settings_autodownload_message_size_label">Fetch messages up to</string>
@@ -666,8 +663,17 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="account_settings_vibrate_times">Repeat vibration</string>
     <string name="account_settings_vibrate_summary_disabled">Disabled</string>
     <string name="account_settings_ringtone">New mail ringtone</string>
-    <string name="account_settings_led_label">Blink LED</string>
-    <string name="account_settings_led_summary">Blink LED when mail arrives</string>
+    <string name="account_settings_notification_light_label">Notification light</string>
+    <string name="account_settings_notification_light_disabled">Disabled</string>
+    <string name="account_settings_notification_light_account_color">Account color</string>
+    <string name="account_settings_notification_light_default_color">System default color</string>
+    <string name="account_settings_notification_light_white">White</string>
+    <string name="account_settings_notification_light_red">Red</string>
+    <string name="account_settings_notification_light_green">Green</string>
+    <string name="account_settings_notification_light_blue">Blue</string>
+    <string name="account_settings_notification_light_yellow">Yellow</string>
+    <string name="account_settings_notification_light_cyan">Cyan</string>
+    <string name="account_settings_notification_light_magenta">Magenta</string>
 
     <string name="account_settings_composition_title">Message composition options</string>
     <string name="account_settings_composition_label">Composition defaults</string>

--- a/app/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/account_settings.xml
@@ -342,19 +342,13 @@
             android:entries="@array/vibrate_pattern_entries"
             android:entryValues="@array/vibrate_pattern_values" />
 
-        <CheckBoxPreference
-            android:defaultValue="true"
+        <ListPreference
             android:dependency="account_notify"
-            android:key="account_led"
-            android:summary="@string/account_settings_led_summary"
-            android:title="@string/account_settings_led_label" />
-
-        <com.takisoft.preferencex.ColorPickerPreference
-            android:dependency="account_led"
-            android:key="led_color"
-            android:summary="@string/account_settings_led_color_summary"
-            android:title="@string/account_settings_led_color_label"
-            app:pref_colors="@array/notification_light_colors" />
+            android:key="notification_light"
+            android:title="@string/account_settings_notification_light_label"
+            android:entries="@array/notification_light_entries"
+            android:entryValues="@array/notification_light_values"
+            app:useSimpleSummaryProvider="true" />
 
         <CheckBoxPreference
             android:defaultValue="true"


### PR DESCRIPTION
Before and after:

<img src="https://user-images.githubusercontent.com/218061/153319073-d30bc0cd-65f8-4bba-96a5-673aeae7f29c.png" alt="k9mail__notification_light__before" width=300> <img src="https://user-images.githubusercontent.com/218061/153319070-2da42228-2683-4616-a5dd-dc8c4dc78aaa.png" alt="k9mail__notification_light__after" width=300>

Previously the notification color could only be changed inside the app when it was enabled using the system screen to configure a notification category.

See #5544