### PR TITLE
Don't expose MessageProvider to third-party apps

### DIFF
--- a/app/k9mail/src/main/AndroidManifest.xml
+++ b/app/k9mail/src/main/AndroidManifest.xml
@@ -25,23 +25,6 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE"/>
 
-    <permission
-        android:name="${applicationId}.permission.READ_MESSAGES"
-        android:description="@string/read_messages_desc"
-        android:label="@string/read_messages_label"
-        android:permissionGroup="android.permission-group.MESSAGES"
-        android:protectionLevel="dangerous"/>
-    <uses-permission android:name="${applicationId}.permission.READ_MESSAGES"/>
-
-    <permission
-        android:name="${applicationId}.permission.DELETE_MESSAGES"
-        android:description="@string/delete_messages_desc"
-        android:label="@string/delete_messages_label"
-        android:permissionGroup="android.permission-group.MESSAGES"
-        android:protectionLevel="dangerous"/>
-    <uses-permission android:name="${applicationId}.permission.DELETE_MESSAGES"/>
-
-
     <application
         android:name="com.fsck.k9.App"
         android:allowTaskReparenting="false"
@@ -411,11 +394,7 @@
         <provider
             android:name=".external.MessageProvider"
             android:authorities="${applicationId}.messageprovider"
-            android:exported="true"
-            android:grantUriPermissions="true"
-            android:multiprocess="true"
-            android:readPermission="${applicationId}.permission.READ_MESSAGES"
-            android:writePermission="${applicationId}.permission.DELETE_MESSAGES"/>
+            android:exported="false" />
 
         <provider
             android:name=".provider.EmailProvider"

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -77,11 +77,6 @@ Please submit bug reports, contribute new features and ask questions at
 
     <string name="authors">Authors</string>
 
-    <string name="read_messages_label">Read Emails</string>
-    <string name="read_messages_desc">Allows this application to read your Emails.</string>
-    <string name="delete_messages_label">Delete Emails</string>
-    <string name="delete_messages_desc">Allows this application to delete your Emails.</string>
-
     <string name="about_title">About K-9 Mail</string>
     <string name="accounts_title">Accounts</string>
     <string name="advanced">Advanced</string>


### PR DESCRIPTION
If this was an important feature to you, please contact us and tell us a little bit about your use case.
