### PR TITLE
Append a space to » and › in messages list.

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/fragment/MessageListAdapter.kt
@@ -83,8 +83,8 @@ class MessageListAdapter internal constructor(
     }
 
     private fun recipientSigil(toMe: Boolean, ccMe: Boolean) = when {
-        toMe -> res.getString(R.string.messagelist_sent_to_me_sigil)
-        ccMe -> res.getString(R.string.messagelist_sent_cc_me_sigil)
+        toMe -> res.getString(R.string.messagelist_sent_to_me_sigil) + " "
+        ccMe -> res.getString(R.string.messagelist_sent_cc_me_sigil) + " "
         else -> ""
     }
 


### PR DESCRIPTION
Thought about concatenate a space to sigils so that there is a gap before sender's name. 
This enhancement make (in my opinion) viewer less compact.

Before:
![without](https://user-images.githubusercontent.com/32033845/161089509-f83eee53-8002-46d5-84d5-da94db8bd345.png)

After:
![with](https://user-images.githubusercontent.com/32033845/161089498-b3bcf8f9-c6cc-48e0-b007-d0cbfb4d9967.png)

I've noticed the sender name's last letter is not dark anymore, but grey like for the message preview. I'm looking for fix it.

Thanks!