### PR TITLE
Fix reading notification settings from `NotificationChannel`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationSettingsUpdater.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationSettingsUpdater.kt
@@ -18,17 +18,19 @@ class NotificationSettingsUpdater(
 
         accountUuids
             .mapNotNull { accountUuid -> preferences.getAccount(accountUuid) }
-            .forEach { account -> updateNotificationSettings(account) }
+            .forEach { account ->
+                updateNotificationSettings(account)
+                preferences.saveAccount(account)
+            }
     }
 
     @RequiresApi(Build.VERSION_CODES.O)
-    private fun updateNotificationSettings(account: Account) {
+    fun updateNotificationSettings(account: Account) {
         val notificationConfiguration = notificationChannelManager.getNotificationConfiguration(account)
         val notificationSettings = notificationConfigurationConverter.convert(account, notificationConfiguration)
 
         if (notificationSettings != account.notificationSettings) {
             account.updateNotificationSettings { notificationSettings }
-            preferences.saveAccount(account)
         }
     }
 }

--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationVibrationDecoder.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationVibrationDecoder.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.VibratePattern
 class NotificationVibrationDecoder {
     fun decode(isVibrationEnabled: Boolean, systemPattern: List<Long>?): NotificationVibration {
         if (systemPattern == null || systemPattern.size < 2 || systemPattern.size % 2 != 0) {
-            return NotificationVibration.DEFAULT
+            return NotificationVibration(isVibrationEnabled, VibratePattern.Default, repeatCount = 1)
         }
 
         val systemPatternArray = systemPattern.toLongArray()

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsFragment.kt
@@ -10,6 +10,7 @@ import android.view.MenuInflater
 import android.view.MenuItem
 import android.widget.Toast
 import androidx.core.content.getSystemService
+import androidx.core.net.toUri
 import androidx.preference.ListPreference
 import androidx.preference.Preference
 import androidx.preference.PreferenceCategory
@@ -28,8 +29,7 @@ import com.fsck.k9.mailstore.FolderType
 import com.fsck.k9.mailstore.RemoteFolder
 import com.fsck.k9.notification.NotificationChannelManager
 import com.fsck.k9.notification.NotificationChannelManager.ChannelType
-import com.fsck.k9.notification.NotificationLightDecoder
-import com.fsck.k9.notification.NotificationVibrationDecoder
+import com.fsck.k9.notification.NotificationSettingsUpdater
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.endtoend.AutocryptKeyTransferActivity
 import com.fsck.k9.ui.settings.onClick
@@ -52,8 +52,7 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
     private val messagingController: MessagingController by inject()
     private val accountRemover: BackgroundAccountRemover by inject()
     private val notificationChannelManager: NotificationChannelManager by inject()
-    private val notificationLightDecoder: NotificationLightDecoder by inject()
-    private val notificationVibrationDecoder: NotificationVibrationDecoder by inject()
+    private val notificationSettingsUpdater: NotificationSettingsUpdater by inject()
 
     private val vibrator by lazy { requireContext().getSystemService<Vibrator>() }
     private lateinit var dataStore: AccountSettingsDataStore
@@ -251,28 +250,21 @@ class AccountSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFr
 
     @SuppressLint("NewApi")
     private fun updateNotificationPreferences(account: Account) {
-        val notificationConfiguration = notificationChannelManager.getNotificationConfiguration(account)
+        notificationSettingsUpdater.updateNotificationSettings(account)
+        val notificationSettings = account.notificationSettings
 
         notificationSoundPreference?.let { preference ->
-            preference.setNotificationSound(notificationConfiguration.sound)
+            preference.setNotificationSound(notificationSettings.ringtone?.toUri())
             preference.isEnabled = true
         }
 
         notificationLightPreference?.let { preference ->
-            val notificationLightSetting = notificationLightDecoder.decode(
-                isBlinkLightsEnabled = notificationConfiguration.isBlinkLightsEnabled,
-                lightColor = notificationConfiguration.lightColor,
-                accountColor = account.chipColor
-            )
-            preference.value = notificationLightSetting.name
+            preference.value = notificationSettings.light.name
             preference.isEnabled = true
         }
 
         notificationVibrationPreference?.let { preference ->
-            val notificationVibration = notificationVibrationDecoder.decode(
-                isVibrationEnabled = notificationConfiguration.isVibrationEnabled,
-                systemPattern = notificationConfiguration.vibrationPattern
-            )
+            val notificationVibration = notificationSettings.vibration
             preference.setVibration(
                 isVibrationEnabled = notificationVibration.isEnabled,
                 vibratePattern = notificationVibration.pattern,


### PR DESCRIPTION
We didn't properly handle the case where vibration was enabled but the pattern was `null` (system default). Users who manually enabled vibration (using the system UI) are very likely to run into this after the update from K-9 Mail 5.8xx.

The changes to `AccountSettingsFragment` avoid recreating the notification channel when all we want to do is update the notification preferences during `onResume()`.
