### PR TITLE
Fix issues when switching between LTR and RTL languages

### DIFF
--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/K9Activity.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/K9Activity.kt
@@ -41,7 +41,7 @@ abstract class K9Activity(private val themeType: ThemeType) : AppCompatActivity(
     private fun listenForAppLanguageChanges() {
         appLanguageManager.overrideLocale.asLiveData().observe(this) { overrideLocale ->
             if (overrideLocale != overrideLocaleOnLaunch) {
-                ActivityCompat.recreate(this)
+                recreateCompat()
             }
         }
     }
@@ -64,6 +64,10 @@ abstract class K9Activity(private val themeType: ThemeType) : AppCompatActivity(
             ?: error("K9 layouts must provide a toolbar with id='toolbar'.")
 
         setSupportActionBar(toolbar)
+    }
+
+    protected fun recreateCompat() {
+        ActivityCompat.recreate(this)
     }
 }
 

--- a/app/ui/base/src/main/java/com/fsck/k9/ui/base/K9Activity.kt
+++ b/app/ui/base/src/main/java/com/fsck/k9/ui/base/K9Activity.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.ui.base
 
 import android.content.Context
+import android.os.Build
 import android.os.Bundle
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
@@ -35,7 +36,16 @@ abstract class K9Activity(private val themeType: ThemeType) : AppCompatActivity(
         initializePushController()
         super.onCreate(savedInstanceState)
 
+        setLayoutDirection()
         listenForAppLanguageChanges()
+    }
+
+    // On Android 12+ the layout direction doesn't seem to be updated when recreating the activity. This is a problem
+    // when switching from an LTR to an RTL language (or the other way around) using the language picker in the app.
+    private fun setLayoutDirection() {
+        if (Build.VERSION.SDK_INT >= 31) {
+            window.decorView.layoutDirection = resources.configuration.layoutDirection
+        }
     }
 
     private fun listenForAppLanguageChanges() {

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -542,7 +542,7 @@ open class MessageList :
         if (messageListActivityAppearance == null) {
             messageListActivityAppearance = MessageListActivityAppearance.create(generalSettingsManager)
         } else if (messageListActivityAppearance != MessageListActivityAppearance.create(generalSettingsManager)) {
-            recreate()
+            recreateCompat()
         }
 
         if (displayMode != DisplayMode.MESSAGE_VIEW) {
@@ -1512,7 +1512,7 @@ open class MessageList :
 
     private fun onToggleTheme() {
         themeManager.toggleMessageViewTheme()
-        recreate()
+        recreateCompat()
     }
 
     private fun showDefaultTitleView() {


### PR DESCRIPTION
- Always use `ActivityCompat.recreate()` (this is an update to #5998)
- Explicitly set the layout direction on Android 12+ (to work around a platform bug?)

Related issue: 
- #5961