### PR TITLE
Disable messageview_show_next item when messageview_return_to_list is checked

### DIFF
--- a/app/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/app/ui/legacy/src/main/res/xml/general_settings.xml
@@ -366,11 +366,13 @@
             android:title="@string/volume_navigation_title" />
 
         <CheckBoxPreference
+            android:disableDependentsState="true"
             android:key="messageview_return_to_list"
             android:summary="@string/global_settings_messageview_return_to_list_summary"
             android:title="@string/global_settings_messageview_return_to_list_label" />
 
         <CheckBoxPreference
+            android:dependency="messageview_return_to_list"
             android:key="messageview_show_next"
             android:summary="@string/global_settings_messageview_show_next_summary"
             android:title="@string/global_settings_messageview_show_next_label" />


### PR DESCRIPTION
We could enable both **Return to list after delete** and **Show next message after delete** options which was not logical.
I replaced those two options with a simple ListPreference that the user can only select one of them.
![Screenshot_20220410_162809](https://user-images.githubusercontent.com/8654398/162617078-8a0fcd39-1ea9-4813-b826-733ab1117d0d.png)
![Screenshot_20220410_162825](https://user-images.githubusercontent.com/8654398/162617076-680daf4f-ddf8-4755-8412-c5cef1ff76b5.png)

Fix #6007