### PR TITLE
Add support for the `OAUTHBEARER` SASL method

### DIFF
--- a/app/core/src/test/java/com/fsck/k9/sasl/OAuthBearerTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/sasl/OAuthBearerTest.kt
@@ -1,0 +1,31 @@
+package com.fsck.k9.sasl
+
+import com.google.common.truth.Truth.assertThat
+import okio.ByteString.Companion.decodeBase64
+import org.junit.Test
+
+class OAuthBearerTest {
+    @Test
+    fun `username that does not need encoding`() {
+        val username = "user@domain.example"
+        val token = "token"
+
+        val result = buildOAuthBearerInitialClientResponse(username, token)
+
+        assertThat(result).isEqualTo("bixhPXVzZXJAZG9tYWluLmV4YW1wbGUsAWF1dGg9QmVhcmVyIHRva2VuAQE=")
+        assertThat(result.decodeBase64()?.utf8())
+            .isEqualTo("n,a=user@domain.example,\u0001auth=Bearer token\u0001\u0001")
+    }
+
+    @Test
+    fun `username contains equal sign that needs to be encoded`() {
+        val username = "user=name@domain.example"
+        val token = "token"
+
+        val result = buildOAuthBearerInitialClientResponse(username, token)
+
+        assertThat(result).isEqualTo("bixhPXVzZXI9M0RuYW1lQGRvbWFpbi5leGFtcGxlLAFhdXRoPUJlYXJlciB0b2tlbgEB")
+        assertThat(result.decodeBase64()?.utf8())
+            .isEqualTo("n,a=user=3Dname@domain.example,\u0001auth=Bearer token\u0001\u0001")
+    }
+}

--- a/mail/common/src/main/java/com/fsck/k9/mail/Authentication.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/Authentication.java
@@ -5,6 +5,8 @@ import java.security.MessageDigest;
 
 import com.fsck.k9.mail.filter.Base64;
 import com.fsck.k9.mail.filter.Hex;
+import okio.ByteString;
+
 
 public class Authentication {
     private static final String US_ASCII = "US-ASCII";
@@ -84,11 +86,8 @@ public class Authentication {
         }
     }
 
-    public static String computeXoauth(String username, String authToken) throws UnsupportedEncodingException {
+    public static String computeXoauth(String username, String authToken) {
         String formattedAuthenticationString = String.format(XOAUTH_FORMAT, username, authToken);
-        byte[] base64encodedAuthenticationString =
-                Base64.encodeBase64(formattedAuthenticationString.getBytes());
-
-        return new String(base64encodedAuthenticationString, US_ASCII);
+        return ByteString.encodeUtf8(formattedAuthenticationString).base64();
     }
 }

--- a/mail/common/src/main/java/com/fsck/k9/sasl/OAuthBearer.kt
+++ b/mail/common/src/main/java/com/fsck/k9/sasl/OAuthBearer.kt
@@ -1,0 +1,14 @@
+@file:JvmName("OAuthBearer")
+package com.fsck.k9.sasl
+
+import okio.ByteString.Companion.encodeUtf8
+
+/**
+ * Builds an initial client response for the SASL `OAUTHBEARER` mechanism.
+ *
+ * See [RFC 7628](https://datatracker.ietf.org/doc/html/rfc7628).
+ */
+fun buildOAuthBearerInitialClientResponse(username: String, token: String): String {
+    val saslName = username.replace(",", "=2C").replace("=", "=3D")
+    return "n,a=$saslName,\u0001auth=Bearer $token\u0001\u0001".encodeUtf8().base64()
+}

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Capabilities.java
@@ -6,6 +6,7 @@ class Capabilities {
     public static final String CONDSTORE = "CONDSTORE";
     public static final String SASL_IR = "SASL-IR";
     public static final String AUTH_XOAUTH2 = "AUTH=XOAUTH2";
+    public static final String AUTH_OAUTHBEARER = "AUTH=OAUTHBEARER";
     public static final String AUTH_CRAM_MD5 = "AUTH=CRAM-MD5";
     public static final String AUTH_PLAIN = "AUTH=PLAIN";
     public static final String AUTH_EXTERNAL = "AUTH=EXTERNAL";

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/Commands.java
@@ -8,6 +8,7 @@ class Commands {
     public static final String COMPRESS_DEFLATE = "COMPRESS DEFLATE";
     public static final String STARTTLS = "STARTTLS";
     public static final String AUTHENTICATE_XOAUTH2 = "AUTHENTICATE XOAUTH2";
+    public static final String AUTHENTICATE_OAUTHBEARER = "AUTHENTICATE OAUTHBEARER";
     public static final String AUTHENTICATE_CRAM_MD5 = "AUTHENTICATE CRAM-MD5";
     public static final String AUTHENTICATE_PLAIN = "AUTHENTICATE PLAIN";
     public static final String AUTHENTICATE_EXTERNAL = "AUTHENTICATE EXTERNAL";

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.java
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/RealImapConnection.java
@@ -40,6 +40,7 @@ import com.fsck.k9.mail.oauth.OAuth2TokenProvider;
 import com.fsck.k9.mail.oauth.XOAuth2ChallengeParser;
 import com.fsck.k9.mail.ssl.TrustedSocketFactory;
 import com.fsck.k9.mail.store.imap.IdGrouper.GroupedIds;
+import com.fsck.k9.sasl.OAuthBearer;
 import com.jcraft.jzlib.JZlib;
 import com.jcraft.jzlib.ZOutputStream;
 import javax.net.ssl.SSLException;
@@ -88,7 +89,7 @@ class RealImapConnection implements ImapConnection {
     private ImapSettings settings;
     private Exception stacktraceForClose;
     private boolean open = false;
-    private boolean retryXoauth2WithNewToken = true;
+    private boolean retryOAuthWithNewToken = true;
 
 
     public RealImapConnection(ImapSettings settings, TrustedSocketFactory socketFactory,
@@ -357,10 +358,14 @@ class RealImapConnection implements ImapConnection {
             case XOAUTH2:
                 if (oauthTokenProvider == null) {
                     throw new MessagingException("No OAuthToken Provider available.");
-                } else if (hasCapability(Capabilities.AUTH_XOAUTH2) && hasCapability(Capabilities.SASL_IR)) {
-                    return authXoauth2withSASLIR();
+                } else if (!hasCapability(Capabilities.SASL_IR)) {
+                    throw new MessagingException("SASL-IR capability is missing.");
+                } else if (hasCapability(Capabilities.AUTH_OAUTHBEARER)) {
+                    return authWithOAuthToken(OAuthMethod.OAUTHBEARER);
+                } else if (hasCapability(Capabilities.AUTH_XOAUTH2)) {
+                    return authWithOAuthToken(OAuthMethod.XOAUTH2);
                 } else {
-                    throw new MessagingException("Server doesn't support SASL XOAUTH2.");
+                    throw new MessagingException("Server doesn't support SASL OAUTHBEARER or XOAUTH2.");
                 }
             case CRAM_MD5: {
                 if (hasCapability(Capabilities.AUTH_CRAM_MD5)) {
@@ -393,66 +398,67 @@ class RealImapConnection implements ImapConnection {
         }
     }
 
-    private List<ImapResponse> authXoauth2withSASLIR() throws IOException, MessagingException {
-        retryXoauth2WithNewToken = true;
+    private List<ImapResponse> authWithOAuthToken(OAuthMethod method) throws IOException, MessagingException {
+        retryOAuthWithNewToken = true;
         try {
-            return attemptXOAuth2();
+            return attemptOAuth(method);
         } catch (NegativeImapResponseException e) {
             //TODO: Check response code so we don't needlessly invalidate the token.
             oauthTokenProvider.invalidateToken();
 
-            if (!retryXoauth2WithNewToken) {
-                throw handlePermanentXoauth2Failure(e);
+            if (!retryOAuthWithNewToken) {
+                throw handlePermanentOAuthFailure(e);
             } else {
-                return handleTemporaryXoauth2Failure(e);
+                return handleTemporaryOAuthFailure(method, e);
             }
         }
     }
 
-    private AuthenticationFailedException handlePermanentXoauth2Failure(NegativeImapResponseException e) {
-        Timber.v(e, "Permanent failure during XOAUTH2");
+    private AuthenticationFailedException handlePermanentOAuthFailure(NegativeImapResponseException e) {
+        Timber.v(e, "Permanent failure during authentication using OAuth token");
         return new AuthenticationFailedException(e.getMessage(), e, e.getAlertText());
     }
 
-    private List<ImapResponse> handleTemporaryXoauth2Failure(NegativeImapResponseException e) throws IOException, MessagingException {
-        //We got a response indicating a retry might suceed after token refresh
+    private List<ImapResponse> handleTemporaryOAuthFailure(OAuthMethod method, NegativeImapResponseException e)
+            throws IOException, MessagingException {
+        //We got a response indicating a retry might succeed after token refresh
         //We could avoid this if we had a reasonable chance of knowing
         //if a token was invalid before use (e.g. due to expiry). But we don't
         //This is the intended behaviour per AccountManager
 
         Timber.v(e, "Temporary failure - retrying with new token");
         try {
-            return attemptXOAuth2();
+            return attemptOAuth(method);
         } catch (NegativeImapResponseException e2) {
             //Okay, we failed on a new token.
             //Invalidate the token anyway but assume it's permanent.
             Timber.v(e, "Authentication exception for new token, permanent error assumed");
             oauthTokenProvider.invalidateToken();
-            throw handlePermanentXoauth2Failure(e2);
+            throw handlePermanentOAuthFailure(e2);
         }
     }
 
-    private List<ImapResponse> attemptXOAuth2() throws MessagingException, IOException {
+    private List<ImapResponse> attemptOAuth(OAuthMethod method) throws MessagingException, IOException {
         String token = oauthTokenProvider.getToken(OAuth2TokenProvider.OAUTH2_TIMEOUT);
-        String authString = Authentication.computeXoauth(settings.getUsername(), token);
-        String tag = sendSaslIrCommand(Commands.AUTHENTICATE_XOAUTH2, authString, true);
+        String authString = method.buildInitialClientResponse(settings.getUsername(), token);
+        String tag = sendSaslIrCommand(method.getCommand(), authString, true);
 
-        return responseParser.readStatusResponse(tag, Commands.AUTHENTICATE_XOAUTH2, getLogId(),
+        return responseParser.readStatusResponse(tag, method.getCommand(), getLogId(),
                 new UntaggedHandler() {
                     @Override
                     public void handleAsyncUntaggedResponse(ImapResponse response) throws IOException {
-                        handleXOAuthUntaggedResponse(response);
+                        handleOAuthUntaggedResponse(response);
                     }
                 });
     }
 
-    private void handleXOAuthUntaggedResponse(ImapResponse response) throws IOException {
+    private void handleOAuthUntaggedResponse(ImapResponse response) throws IOException {
         if (!response.isContinuationRequested()) {
             return;
         }
 
         if (response.isString(0)) {
-            retryXoauth2WithNewToken = XOAuth2ChallengeParser.shouldRetry(response.getString(0), settings.getHost());
+            retryOAuthWithNewToken = XOAuth2ChallengeParser.shouldRetry(response.getString(0), settings.getHost());
         }
 
         outputStream.write("\r\n".getBytes());
@@ -890,5 +896,34 @@ class RealImapConnection implements ImapConnection {
     @Override
     public int getConnectionGeneration() {
         return connectionGeneration;
+    }
+
+
+    private enum OAuthMethod {
+        XOAUTH2 {
+            @Override
+            String getCommand() {
+                return Commands.AUTHENTICATE_XOAUTH2;
+            }
+
+            @Override
+            String buildInitialClientResponse(String username, String token) {
+                return Authentication.computeXoauth(username, token);
+            }
+        },
+        OAUTHBEARER {
+            @Override
+            String getCommand() {
+                return Commands.AUTHENTICATE_OAUTHBEARER;
+            }
+
+            @Override
+            String buildInitialClientResponse(String username, String token) {
+                return OAuthBearer.buildOAuthBearerInitialClientResponse(username, token);
+            }
+        };
+
+        abstract String getCommand();
+        abstract String buildInitialClientResponse(String username, String token);
     }
 }


### PR DESCRIPTION
Use the `OAUTHBEARER` SASL method by default. Only use `XOAUTH2` as a fallback.