### PR TITLE
Tweak appearance of "Download complete message" button

### DIFF
--- a/app/ui/legacy/src/main/res/layout/message.xml
+++ b/app/ui/legacy/src/main/res/layout/message.xml
@@ -103,6 +103,8 @@
     </com.fsck.k9.view.NonLockingScrollView>
 
     <Button android:id="@+id/download_remainder"
+        style="@style/Widget.MaterialComponents.Button.OutlinedButton"
+        android:layout_marginHorizontal="16dp"
         android:text="@string/message_view_download_remainder"
         android:layout_height="wrap_content"
         android:visibility="gone"


### PR DESCRIPTION
Make the button we currently use less prominent. This is a stopgap measure until #6619 is implemented.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/218061/217232391-64ac5d3e-9507-456b-b999-6e3cc4733cfd.png)|![image](https://user-images.githubusercontent.com/218061/217232489-ccac1bf9-f058-4749-a6c8-a0664a2f8ca8.png)|

