### PR TITLE
Make `AutocryptPreferEncryptDialogFragment` a proper preference dialog

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AutocryptPreferEncryptDialogFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AutocryptPreferEncryptDialogFragment.kt
@@ -1,54 +1,48 @@
 package com.fsck.k9.ui.settings.account
 
-import android.annotation.SuppressLint
 import android.app.Dialog
 import android.os.Bundle
 import android.text.method.LinkMovementMethod
-import android.view.LayoutInflater
 import android.view.View
 import android.widget.CheckBox
 import android.widget.TextView
 import androidx.appcompat.app.AlertDialog
-import androidx.fragment.app.DialogFragment
-import androidx.preference.DialogPreference
+import androidx.preference.PreferenceDialogFragmentCompat
 import com.fsck.k9.ui.R
 
-class AutocryptPreferEncryptDialogFragment : DialogFragment() {
-    private val preference: AutocryptPreferEncryptPreference by lazy {
-        val preferenceKey = arguments?.getString(ARG_KEY) ?: throw IllegalStateException("Argument $ARG_KEY missing")
-        val fragment = targetFragment as DialogPreference.TargetFragment
+class AutocryptPreferEncryptDialogFragment : PreferenceDialogFragmentCompat() {
+    private val preferEncryptPreference: AutocryptPreferEncryptPreference
+        get() = preference as AutocryptPreferEncryptPreference
 
-        fragment.findPreference<AutocryptPreferEncryptPreference>(preferenceKey)!!
-    }
+    private lateinit var preferEncryptCheckbox: CheckBox
 
     override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
-        @SuppressLint("InflateParams")
-        val view = LayoutInflater.from(context).inflate(R.layout.dialog_autocrypt_prefer_encrypt, null)
+        val view = layoutInflater.inflate(R.layout.dialog_autocrypt_prefer_encrypt, null)
 
         view.findViewById<TextView>(R.id.prefer_encrypt_learn_more).makeLinksClickable()
 
-        val preferEncryptCheckbox = view.findViewById<CheckBox>(R.id.prefer_encrypt_check).apply {
-            isChecked = preference.isChecked
+        preferEncryptCheckbox = view.findViewById<CheckBox>(R.id.prefer_encrypt_check).apply {
+            isChecked = preferEncryptPreference.isPreferEncryptEnabled
         }
 
         view.findViewById<View>(R.id.prefer_encrypt).setOnClickListener {
             preferEncryptCheckbox.performClick()
-            preference.userChangedValue(preferEncryptCheckbox.isChecked)
         }
 
         return AlertDialog.Builder(requireContext())
-            // TODO add autocrypt logo?
-            // .setIcon(R.drawable.autocrypt)
             .setView(view)
-            .setPositiveButton(R.string.done_action, null)
+            .setPositiveButton(R.string.okay_action, ::onClick)
+            .setNegativeButton(R.string.cancel_action, ::onClick)
             .create()
+    }
+
+    override fun onDialogClosed(positiveResult: Boolean) {
+        if (positiveResult) {
+            preferEncryptPreference.setPreferEncryptEnabled(preferEncryptCheckbox.isChecked)
+        }
     }
 
     private fun TextView.makeLinksClickable() {
         this.movementMethod = LinkMovementMethod.getInstance()
-    }
-
-    companion object {
-        private const val ARG_KEY = "key"
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AutocryptPreferEncryptPreference.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AutocryptPreferEncryptPreference.kt
@@ -5,8 +5,7 @@ import android.content.Context
 import android.util.AttributeSet
 import androidx.core.content.res.TypedArrayUtils
 import androidx.core.content.withStyledAttributes
-import androidx.preference.PreferenceViewHolder
-import androidx.preference.TwoStatePreference
+import androidx.preference.DialogPreference
 import com.fsck.k9.ui.R
 import com.takisoft.preferencex.PreferenceFragmentCompat
 
@@ -22,7 +21,13 @@ constructor(
         android.R.attr.preferenceStyle
     ),
     defStyleRes: Int = 0
-) : TwoStatePreference(context, attrs, defStyleAttr, defStyleRes) {
+) : DialogPreference(context, attrs, defStyleAttr, defStyleRes) {
+
+    internal var isPreferEncryptEnabled: Boolean = false
+        private set
+
+    private var summaryOn: String? = null
+    private var summaryOff: String? = null
 
     init {
         context.withStyledAttributes(attrs, R.styleable.AutocryptPreferEncryptPreference, defStyleAttr, defStyleRes) {
@@ -35,15 +40,22 @@ constructor(
         preferenceManager.showDialog(this)
     }
 
-    override fun onBindViewHolder(holder: PreferenceViewHolder) {
-        super.onBindViewHolder(holder)
-        syncSummaryView(holder)
+    override fun onSetInitialValue(defaultValue: Any?) {
+        isPreferEncryptEnabled = getPersistedBoolean(defaultValue as? Boolean ?: false)
+        updateSummary()
     }
 
-    fun userChangedValue(newValue: Boolean) {
+    fun setPreferEncryptEnabled(newValue: Boolean) {
         if (callChangeListener(newValue)) {
-            isChecked = newValue
+            isPreferEncryptEnabled = newValue
+            persistBoolean(newValue)
+
+            updateSummary()
         }
+    }
+
+    private fun updateSummary() {
+        summary = if (isPreferEncryptEnabled) summaryOn else summaryOff
     }
 
     companion object {


### PR DESCRIPTION
I noticed this when looking at the context of the changes in #6629.

This PR changes `AutocryptPreferEncryptDialogFragment` to extend `PreferenceDialogFragmentCompat`. It also changes the behavior to only commit the change when the dialog was closed using the "OK" button.

### Before

https://user-images.githubusercontent.com/218061/217275725-4692e0e7-ce7c-4eb9-bb8e-8241b0a74f38.mp4

### After

https://user-images.githubusercontent.com/218061/217275749-406e0d46-9212-4d75-98f1-9619acc7033f.mp4
