### PR TITLE
Refactor `AddressFormatter` to `MessageViewRecipientFormatter`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/helper/KoinModule.kt
+++ b/app/core/src/main/java/com/fsck/k9/helper/KoinModule.kt
@@ -11,4 +11,5 @@ val helperModule = module {
     factory<KeyStoreDirectoryProvider> { AndroidKeyStoreDirectoryProvider(context = get()) }
     factory { get<Context>().getSystemService(Context.ALARM_SERVICE) as AlarmManager }
     single { AlarmManagerCompat(alarmManager = get()) }
+    factory<ContactNameProvider> { RealContactNameProvider(contacts = get()) }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/UiKoinModules.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/UiKoinModules.kt
@@ -14,6 +14,7 @@ import com.fsck.k9.ui.managefolders.manageFoldersUiModule
 import com.fsck.k9.ui.messagedetails.messageDetailsUiModule
 import com.fsck.k9.ui.messagelist.messageListUiModule
 import com.fsck.k9.ui.messagesource.messageSourceModule
+import com.fsck.k9.ui.messageview.messageViewUiModule
 import com.fsck.k9.ui.settings.settingsUiModule
 import com.fsck.k9.ui.uiModule
 import com.fsck.k9.view.viewModule
@@ -35,5 +36,6 @@ val uiModules = listOf(
     changelogUiModule,
     messageSourceModule,
     accountUiModule,
-    messageDetailsUiModule
+    messageDetailsUiModule,
+    messageViewUiModule
 )

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractor.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractor.kt
@@ -1,7 +1,6 @@
 package com.fsck.k9.ui.messageview
 
 import com.fsck.k9.Account
-import com.fsck.k9.helper.AddressFormatter
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.Message
 
@@ -9,10 +8,10 @@ import com.fsck.k9.mail.Message
  * Extract recipient names from a message to display them in the message view.
  *
  * This class extracts up to [maxNumberOfDisplayRecipients] recipients from the message and converts them to their
- * display name using an [AddressFormatter].
+ * display name using an [MessageViewRecipientFormatter].
  */
 internal class DisplayRecipientsExtractor(
-    private val addressFormatter: AddressFormatter,
+    private val recipientFormatter: MessageViewRecipientFormatter,
     private val maxNumberOfDisplayRecipients: Int
 ) {
     fun extractDisplayRecipients(message: Message, account: Account): DisplayRecipients {
@@ -37,13 +36,13 @@ internal class DisplayRecipientsExtractor(
         val recipientNames = sequenceOf(toRecipients, ccRecipients, bccRecipients)
             .flatMap { addressArray -> addressArray.asSequence() }
             .filter { address -> address.address != identityEmail }
-            .map { address -> addressFormatter.getDisplayName(address) }
+            .map { address -> recipientFormatter.getDisplayName(address, account) }
             .take(maxAdditionalRecipients)
             .toList()
 
         return if (identity != null) {
             val identityAddress = Address(identity.email)
-            val meName = addressFormatter.getDisplayName(identityAddress)
+            val meName = recipientFormatter.getDisplayName(identityAddress, account)
             val recipients = listOf(meName) + recipientNames
 
             DisplayRecipients(recipients, numberOfRecipients)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/KoinModule.kt
@@ -1,0 +1,7 @@
+package com.fsck.k9.ui.messageview
+
+import org.koin.dsl.module
+
+val messageViewUiModule = module {
+    factory { createMessageViewRecipientFormatter(contactNameProvider = get(), resources = get()) }
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
@@ -1,31 +1,34 @@
-package com.fsck.k9.helper
+package com.fsck.k9.ui.messageview
 
+import android.content.res.Resources
 import android.text.Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
 import android.text.SpannableString
 import android.text.style.ForegroundColorSpan
 import com.fsck.k9.Account
 import com.fsck.k9.Identity
+import com.fsck.k9.K9
+import com.fsck.k9.helper.ContactNameProvider
 import com.fsck.k9.mail.Address
+import com.fsck.k9.ui.R
 
 /**
- * Get the display name for an email address.
+ * Get the display name for a recipient to be shown in the message view screen.
  */
-interface AddressFormatter {
-    fun getDisplayName(address: Address): CharSequence
+internal interface MessageViewRecipientFormatter {
+    fun getDisplayName(address: Address, account: Account): CharSequence
 }
 
-class RealAddressFormatter(
+internal class RealMessageViewRecipientFormatter(
     private val contactNameProvider: ContactNameProvider,
-    private val account: Account,
     private val showCorrespondentNames: Boolean,
     private val showContactNames: Boolean,
     private val contactNameColor: Int?,
     private val meText: String
-) : AddressFormatter {
-    override fun getDisplayName(address: Address): CharSequence {
+) : MessageViewRecipientFormatter {
+    override fun getDisplayName(address: Address, account: Account): CharSequence {
         val identity = account.findIdentity(address)
         if (identity != null) {
-            return getIdentityName(identity)
+            return getIdentityName(identity, account)
         }
 
         return if (!showCorrespondentNames) {
@@ -37,7 +40,7 @@ class RealAddressFormatter(
         }
     }
 
-    private fun getIdentityName(identity: Identity): String {
+    private fun getIdentityName(identity: Identity, account: Account): String {
         return if (account.identities.size == 1) {
             meText
         } else {
@@ -71,4 +74,17 @@ class RealAddressFormatter(
             false
         }
     }
+}
+
+internal fun createMessageViewRecipientFormatter(
+    contactNameProvider: ContactNameProvider,
+    resources: Resources
+): MessageViewRecipientFormatter {
+    return RealMessageViewRecipientFormatter(
+        contactNameProvider = contactNameProvider,
+        showCorrespondentNames = K9.isShowCorrespondentNames,
+        showContactNames = K9.isShowContactName,
+        contactNameColor = if (K9.isChangeContactNameColor) K9.contactNameColor else null,
+        meText = resources.getString(R.string.message_view_me_text)
+    )
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/view/MessageHeader.java
@@ -25,10 +25,8 @@ import com.fsck.k9.K9;
 import com.fsck.k9.activity.misc.ContactPicture;
 import com.fsck.k9.contacts.ContactPictureLoader;
 import com.fsck.k9.helper.ClipboardManager;
-import com.fsck.k9.helper.Contacts;
 import com.fsck.k9.helper.MessageHelper;
-import com.fsck.k9.helper.RealAddressFormatter;
-import com.fsck.k9.helper.RealContactNameProvider;
+import com.fsck.k9.ui.messageview.MessageViewRecipientFormatter;
 import com.fsck.k9.mail.Address;
 import com.fsck.k9.mail.Flag;
 import com.fsck.k9.mail.Message;
@@ -47,6 +45,7 @@ import com.google.android.material.chip.Chip;
 public class MessageHeader extends LinearLayout implements OnClickListener, OnLongClickListener {
     private static final int DEFAULT_SUBJECT_LINES = 3;
 
+    private final MessageViewRecipientFormatter recipientFormatter = DI.get(MessageViewRecipientFormatter.class);
     private final ReplyActionStrategy replyActionStrategy = DI.get(ReplyActionStrategy.class);
     private final FontSizes fontSizes = K9.getFontSizes();
 
@@ -244,15 +243,7 @@ public class MessageHeader extends LinearLayout implements OnClickListener, OnLo
     }
 
     private void setRecipientNames(Message message, Account account) {
-        Integer contactNameColor = K9.isChangeContactNameColor() ? K9.getContactNameColor() : null;
-
-        RealContactNameProvider contactNameProvider = new RealContactNameProvider(Contacts.getInstance(getContext()));
-
-        RealAddressFormatter addressFormatter = new RealAddressFormatter(contactNameProvider, account,
-                K9.isShowCorrespondentNames(), K9.isShowContactName(), contactNameColor,
-                getContext().getString(R.string.message_view_me_text));
-
-        DisplayRecipientsExtractor displayRecipientsExtractor = new DisplayRecipientsExtractor(addressFormatter,
+        DisplayRecipientsExtractor displayRecipientsExtractor = new DisplayRecipientsExtractor(recipientFormatter,
                 recipientNamesView.getMaxNumberOfRecipientNames());
 
         DisplayRecipients displayRecipients = displayRecipientsExtractor.extractDisplayRecipients(message, account);

--- a/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/DisplayRecipientsExtractorTest.kt
@@ -2,7 +2,6 @@ package com.fsck.k9.ui.messageview
 
 import com.fsck.k9.Account
 import com.fsck.k9.Identity
-import com.fsck.k9.helper.AddressFormatter
 import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.buildMessage
 import com.google.common.truth.Truth.assertThat
@@ -17,8 +16,8 @@ class DisplayRecipientsExtractorTest {
         )
     }
 
-    private val addressFormatter = object : AddressFormatter {
-        override fun getDisplayName(address: Address): CharSequence {
+    private val recipientFormatter = object : MessageViewRecipientFormatter {
+        override fun getDisplayName(address: Address, account: Account): CharSequence {
             return when (address.address) {
                 IDENTITY_ADDRESS -> "me"
                 "user1@domain.example" -> "Contact One"
@@ -31,7 +30,7 @@ class DisplayRecipientsExtractorTest {
     }
 
     private val displayRecipientsExtractor = DisplayRecipientsExtractor(
-        addressFormatter,
+        recipientFormatter,
         maxNumberOfDisplayRecipients = 5
     )
 
@@ -123,20 +122,20 @@ class DisplayRecipientsExtractorTest {
     }
 
     @Test
-    fun `100 recipients, AddressFormatter_getDisplayName() should only be called maxNumberOfDisplayRecipients times`() {
+    fun `100 recipients, RecipientFormatter_getDisplayName should only be called maxNumberOfDisplayRecipients times`() {
         val recipients = (1..100).joinToString(separator = ", ") { "unknown$it@domain.example" }
         val message = buildMessage {
             header("To", recipients)
         }
         var numberOfTimesCalled = 0
-        val addressFormatter = object : AddressFormatter {
-            override fun getDisplayName(address: Address): CharSequence {
+        val recipientFormatter = object : MessageViewRecipientFormatter {
+            override fun getDisplayName(address: Address, account: Account): CharSequence {
                 numberOfTimesCalled++
                 return address.address
             }
         }
         val displayRecipientsExtractor = DisplayRecipientsExtractor(
-            addressFormatter,
+            recipientFormatter,
             maxNumberOfDisplayRecipients = 5
         )
 

--- a/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatterTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatterTest.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.helper
+package com.fsck.k9.ui.messageview
 
 import android.graphics.Color
 import android.text.Spannable
@@ -7,6 +7,7 @@ import androidx.core.text.getSpans
 import com.fsck.k9.Account
 import com.fsck.k9.Identity
 import com.fsck.k9.RobolectricTest
+import com.fsck.k9.helper.ContactNameProvider
 import com.fsck.k9.mail.Address
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
@@ -14,7 +15,7 @@ import org.junit.Test
 private const val IDENTITY_ADDRESS = "me@domain.example"
 private const val ME_TEXT = "me"
 
-class RealAddressFormatterTest : RobolectricTest() {
+class MessageViewRecipientFormatterTest : RobolectricTest() {
     private val contactNameProvider = object : ContactNameProvider {
         override fun getNameForAddress(address: String): String? {
             return when (address) {
@@ -31,9 +32,9 @@ class RealAddressFormatterTest : RobolectricTest() {
 
     @Test
     fun `single identity`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"))
+        val displayName = recipientFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"), account)
 
         assertThat(displayName).isEqualTo(ME_TEXT)
     }
@@ -44,9 +45,9 @@ class RealAddressFormatterTest : RobolectricTest() {
             identities += Identity(description = "My identity", email = IDENTITY_ADDRESS)
             identities += Identity(email = "another.one@domain.example")
         }
-        val addressFormatter = createAddressFormatter(account)
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"))
+        val displayName = recipientFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"), account)
 
         assertThat(displayName).isEqualTo("My identity")
     }
@@ -57,9 +58,9 @@ class RealAddressFormatterTest : RobolectricTest() {
             identities += Identity(name = "My name", email = IDENTITY_ADDRESS)
             identities += Identity(email = "another.one@domain.example")
         }
-        val addressFormatter = createAddressFormatter(account)
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"))
+        val displayName = recipientFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"), account)
 
         assertThat(displayName).isEqualTo("My name")
     }
@@ -70,63 +71,63 @@ class RealAddressFormatterTest : RobolectricTest() {
             identities += Identity(email = IDENTITY_ADDRESS)
             identities += Identity(email = "another.one@domain.example")
         }
-        val addressFormatter = createAddressFormatter(account)
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"))
+        val displayName = recipientFormatter.getDisplayName(Address(IDENTITY_ADDRESS, "irrelevant"), account)
 
         assertThat(displayName).isEqualTo(IDENTITY_ADDRESS)
     }
 
     @Test
     fun `email address without display name`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address("alice@domain.example"))
+        val displayName = recipientFormatter.getDisplayName(Address("alice@domain.example"), account)
 
         assertThat(displayName).isEqualTo("alice@domain.example")
     }
 
     @Test
     fun `email address with display name`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address("alice@domain.example", "Alice"))
+        val displayName = recipientFormatter.getDisplayName(Address("alice@domain.example", "Alice"), account)
 
         assertThat(displayName).isEqualTo("Alice")
     }
 
     @Test
     fun `don't look up contact when showContactNames = false`() {
-        val addressFormatter = createAddressFormatter(showContactNames = false)
+        val recipientFormatter = createRecipientFormatter(showContactNames = false)
 
-        val displayName = addressFormatter.getDisplayName(Address("user1@domain.example", "User 1"))
+        val displayName = recipientFormatter.getDisplayName(Address("user1@domain.example", "User 1"), account)
 
         assertThat(displayName).isEqualTo("User 1")
     }
 
     @Test
     fun `contact lookup`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address("user1@domain.example"))
+        val displayName = recipientFormatter.getDisplayName(Address("user1@domain.example"), account)
 
         assertThat(displayName).isEqualTo("Contact One")
     }
 
     @Test
     fun `contact lookup despite display name`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address("user1@domain.example", "User 1"))
+        val displayName = recipientFormatter.getDisplayName(Address("user1@domain.example", "User 1"), account)
 
         assertThat(displayName).isEqualTo("Contact One")
     }
 
     @Test
     fun `colored contact name`() {
-        val addressFormatter = createAddressFormatter(contactNameColor = Color.RED)
+        val recipientFormatter = createRecipientFormatter(contactNameColor = Color.RED)
 
-        val displayName = addressFormatter.getDisplayName(Address("user1@domain.example"))
+        val displayName = recipientFormatter.getDisplayName(Address("user1@domain.example"), account)
 
         assertThat(displayName.toString()).isEqualTo("Contact One")
         assertThat(displayName).isInstanceOf(Spannable::class.java)
@@ -136,67 +137,74 @@ class RealAddressFormatterTest : RobolectricTest() {
 
     @Test
     fun `email address with display name but not showing correspondent names`() {
-        val addressFormatter = createAddressFormatter(showCorrespondentNames = false)
+        val recipientFormatter = createRecipientFormatter(showCorrespondentNames = false)
 
-        val displayName = addressFormatter.getDisplayName(Address("alice@domain.example", "Alice"))
+        val displayName = recipientFormatter.getDisplayName(Address("alice@domain.example", "Alice"), account)
 
         assertThat(displayName).isEqualTo("alice@domain.example")
     }
 
     @Test
     fun `do not show display name that looks like an email address`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address("mallory@domain.example", "potus@whitehouse.gov"))
+        val displayName = recipientFormatter.getDisplayName(
+            Address("mallory@domain.example", "potus@whitehouse.gov"),
+            account
+        )
 
         assertThat(displayName).isEqualTo("mallory@domain.example")
     }
 
     @Test
     fun `do show display name that contains an @ preceded by an opening parenthesis`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address("gitlab@gitlab.example", "username (@username)"))
+        val displayName = recipientFormatter.getDisplayName(
+            Address("gitlab@gitlab.example", "username (@username)"),
+            account
+        )
 
         assertThat(displayName).isEqualTo("username (@username)")
     }
 
     @Test
     fun `do show display name that starts with an @`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address("address@domain.example", "@username"))
+        val displayName = recipientFormatter.getDisplayName(Address("address@domain.example", "@username"), account)
 
         assertThat(displayName).isEqualTo("@username")
     }
 
     @Test
     fun `spoof prevention doesn't apply to contact names`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address("spoof@domain.example", "contact@important.example"))
+        val displayName = recipientFormatter.getDisplayName(
+            Address("spoof@domain.example", "contact@important.example"),
+            account
+        )
 
         assertThat(displayName).isEqualTo("contact@important.example")
     }
 
     @Test
     fun `display name matches me text`() {
-        val addressFormatter = createAddressFormatter()
+        val recipientFormatter = createRecipientFormatter()
 
-        val displayName = addressFormatter.getDisplayName(Address("someone_named_me@domain.example", "ME"))
+        val displayName = recipientFormatter.getDisplayName(Address("someone_named_me@domain.example", "ME"), account)
 
         assertThat(displayName).isEqualTo("someone_named_me@domain.example")
     }
 
-    private fun createAddressFormatter(
-        account: Account = this.account,
+    private fun createRecipientFormatter(
         showCorrespondentNames: Boolean = true,
         showContactNames: Boolean = true,
         contactNameColor: Int? = null
-    ): RealAddressFormatter {
-        return RealAddressFormatter(
+    ): RealMessageViewRecipientFormatter {
+        return RealMessageViewRecipientFormatter(
             contactNameProvider = contactNameProvider,
-            account = account,
             showCorrespondentNames = showCorrespondentNames,
             showContactNames = showContactNames,
             contactNameColor = contactNameColor,


### PR DESCRIPTION
The way recipient names are displayed in the message view screen is subtly different from the other places where we display recipient names. Now the name of the class reflects that.

This is a pure refactoring and shouldn't introduce any behavior changes.

(A variant of this change was part of #6632)