### PR TITLE
Contact names in message details (2)

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/KoinModule.kt
@@ -10,10 +10,13 @@ val messageDetailsUiModule = module {
             messageRepository = get(),
             contactSettingsProvider = get(),
             contacts = get(),
-            clipboardManager = get()
+            clipboardManager = get(),
+            accountManager = get(),
+            participantFormatter = get()
         )
     }
     factory { ContactSettingsProvider() }
     factory { AddToContactsLauncher() }
     factory { ShowContactLauncher() }
+    factory { createMessageDetailsParticipantFormatter(contactNameProvider = get()) }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsParticipantFormatter.kt
@@ -1,0 +1,57 @@
+package com.fsck.k9.ui.messagedetails
+
+import android.text.Spannable.SPAN_EXCLUSIVE_EXCLUSIVE
+import android.text.SpannableString
+import android.text.style.ForegroundColorSpan
+import com.fsck.k9.Account
+import com.fsck.k9.K9
+import com.fsck.k9.helper.ContactNameProvider
+import com.fsck.k9.mail.Address
+
+/**
+ * Get the display name for a participant to be shown in the message details screen.
+ */
+internal interface MessageDetailsParticipantFormatter {
+    fun getDisplayName(address: Address, account: Account): CharSequence?
+}
+
+internal class RealMessageDetailsParticipantFormatter(
+    private val contactNameProvider: ContactNameProvider,
+    private val showContactNames: Boolean,
+    private val contactNameColor: Int?
+) : MessageDetailsParticipantFormatter {
+    override fun getDisplayName(address: Address, account: Account): CharSequence? {
+        val identityDisplayName = account.findIdentity(address)?.name
+        if (identityDisplayName != null) {
+            return identityDisplayName
+        }
+
+        return if (showContactNames) {
+            getContactNameOrNull(address) ?: address.personal
+        } else {
+            address.personal
+        }
+    }
+
+    private fun getContactNameOrNull(address: Address): CharSequence? {
+        val contactName = contactNameProvider.getNameForAddress(address.address) ?: return null
+
+        return if (contactNameColor != null) {
+            SpannableString(contactName).apply {
+                setSpan(ForegroundColorSpan(contactNameColor), 0, contactName.length, SPAN_EXCLUSIVE_EXCLUSIVE)
+            }
+        } else {
+            contactName
+        }
+    }
+}
+
+internal fun createMessageDetailsParticipantFormatter(
+    contactNameProvider: ContactNameProvider
+): MessageDetailsParticipantFormatter {
+    return RealMessageDetailsParticipantFormatter(
+        contactNameProvider = contactNameProvider,
+        showContactNames = K9.isShowContactName,
+        contactNameColor = if (K9.isChangeContactNameColor) K9.contactNameColor else null
+    )
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsUi.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsUi.kt
@@ -21,9 +21,13 @@ data class CryptoDetails(
 )
 
 data class Participant(
-    val address: Address,
+    val displayName: CharSequence?,
+    val emailAddress: String,
     val contactLookupUri: Uri?
 ) {
     val isInContacts: Boolean
         get() = contactLookupUri != null
+
+    val address: Address
+        get() = Address(emailAddress, displayName?.toString())
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/ParticipantItem.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/ParticipantItem.kt
@@ -38,20 +38,18 @@ internal class ParticipantItem(
 
         override fun bindView(item: ParticipantItem, payloads: List<Any>) {
             val participant = item.participant
-            val address = participant.address
-            val participantName = address.personal
 
-            if (participantName != null) {
-                name.text = participantName
-                email.text = address.address
+            if (participant.displayName != null) {
+                name.text = participant.displayName
+                email.text = participant.emailAddress
             } else {
-                name.text = address.address
+                name.text = participant.emailAddress
                 email.isVisible = false
             }
             menuAddContact.isVisible = !participant.isInContacts
 
             if (item.showContactsPicture) {
-                item.contactPictureLoader.setContactPicture(contactPicture, address)
+                item.contactPictureLoader.setContactPicture(contactPicture, participant.address)
             } else {
                 contactPicture.isVisible = false
             }


### PR DESCRIPTION
Supersedes #6632.

Respect *Settings → General settings → Display → Show contact names* (and *Colorize contacts* and *Contact name color*) in the message details screen.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/218061/217046872-c63c68df-3b18-4ed5-afec-5f3a008402a4.png)|![image](https://user-images.githubusercontent.com/218061/217047059-b726a840-aa3f-4f61-a3b6-a33d5f6b56b5.png)|
