### PR TITLE
Simplify creation of `FolderNameFormatter`

### DIFF
--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/KoinModule.kt
@@ -11,7 +11,7 @@ val unreadWidgetModule = module {
             messageCountsProvider = get(),
             defaultFolderProvider = get(),
             folderRepository = get(),
-            folderNameFormatterFactory = get()
+            folderNameFormatter = get()
         )
     }
     single { UnreadWidgetUpdater(context = get()) }

--- a/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetDataProvider.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/widget/unread/UnreadWidgetDataProvider.kt
@@ -9,7 +9,7 @@ import com.fsck.k9.controller.MessageCountsProvider
 import com.fsck.k9.mailstore.FolderRepository
 import com.fsck.k9.search.LocalSearch
 import com.fsck.k9.search.SearchAccount
-import com.fsck.k9.ui.folders.FolderNameFormatterFactory
+import com.fsck.k9.ui.folders.FolderNameFormatter
 import com.fsck.k9.ui.messagelist.DefaultFolderProvider
 import timber.log.Timber
 import com.fsck.k9.ui.R as UiR
@@ -20,7 +20,7 @@ class UnreadWidgetDataProvider(
     private val messageCountsProvider: MessageCountsProvider,
     private val defaultFolderProvider: DefaultFolderProvider,
     private val folderRepository: FolderRepository,
-    private val folderNameFormatterFactory: FolderNameFormatterFactory
+    private val folderNameFormatter: FolderNameFormatter
 ) {
     fun loadUnreadWidgetData(configuration: UnreadWidgetConfiguration): UnreadWidgetData? = with(configuration) {
         if (SearchAccount.UNIFIED_INBOX == accountUuid) {
@@ -79,7 +79,6 @@ class UnreadWidgetDataProvider(
     private fun getFolderDisplayName(account: Account, folderId: Long): String {
         val folder = folderRepository.getFolder(account, folderId)
         return if (folder != null) {
-            val folderNameFormatter = folderNameFormatterFactory.create(context)
             folderNameFormatter.displayName(folder)
         } else {
             Timber.e("Error loading folder for account %s, folder ID: %d", account, folderId)

--- a/app/k9mail/src/test/java/com/fsck/k9/widget/unread/UnreadWidgetDataProviderTest.kt
+++ b/app/k9mail/src/test/java/com/fsck/k9/widget/unread/UnreadWidgetDataProviderTest.kt
@@ -11,11 +11,9 @@ import com.fsck.k9.mailstore.FolderRepository
 import com.fsck.k9.mailstore.FolderType
 import com.fsck.k9.search.SearchAccount
 import com.fsck.k9.ui.folders.FolderNameFormatter
-import com.fsck.k9.ui.folders.FolderNameFormatterFactory
 import com.fsck.k9.ui.messagelist.DefaultFolderProvider
 import com.google.common.truth.Truth.assertThat
 import org.junit.Test
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.robolectric.RuntimeEnvironment
@@ -27,14 +25,14 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
     private val messageCountsProvider = createMessageCountsProvider()
     private val defaultFolderStrategy = createDefaultFolderStrategy()
     private val folderRepository = createFolderRepository()
-    private val folderNameFormatterFactory = createFolderNameFormatterFactory()
+    private val folderNameFormatter = createFolderNameFormatter()
     private val provider = UnreadWidgetDataProvider(
         context,
         preferences,
         messageCountsProvider,
         defaultFolderStrategy,
         folderRepository,
-        folderNameFormatterFactory
+        folderNameFormatter
     )
 
     @Test
@@ -120,13 +118,6 @@ class UnreadWidgetDataProviderTest : AppRobolectricTest() {
     private fun createFolderRepository(): FolderRepository {
         return mock {
             on { getFolder(account, FOLDER_ID) } doReturn FOLDER
-        }
-    }
-
-    private fun createFolderNameFormatterFactory(): FolderNameFormatterFactory {
-        val folderNameFormatter = createFolderNameFormatter()
-        return mock {
-            on { create(any()) } doReturn folderNameFormatter
         }
     }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/K9Drawer.kt
@@ -55,7 +55,6 @@ import java.util.ArrayList
 import org.koin.androidx.viewmodel.ext.android.viewModel
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
-import org.koin.core.parameter.parametersOf
 import com.fsck.k9.core.R as CoreR
 import com.mikepenz.materialdrawer.R as MaterialDrawerR
 
@@ -67,7 +66,7 @@ private const val EN_SPACE = "\u2000"
 class K9Drawer(private val parent: MessageList, savedInstanceState: Bundle?) : KoinComponent {
     private val foldersViewModel: FoldersViewModel by parent.viewModel()
     private val accountsViewModel: AccountsViewModel by parent.viewModel()
-    private val folderNameFormatter: FolderNameFormatter by inject { parametersOf(parent) }
+    private val folderNameFormatter: FolderNameFormatter by inject()
     private val themeManager: ThemeManager by inject()
     private val resources: Resources by inject()
     private val messagingController: MessagingController by inject()

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -30,7 +30,7 @@ class ChooseFolderActivity : K9Activity() {
     private val viewModel: ChooseFolderViewModel by viewModel()
     private val preferences: Preferences by inject()
     private val messagingController: MessagingController by inject()
-    private val folderNameFormatter: FolderNameFormatter by inject { parametersOf(this) }
+    private val folderNameFormatter: FolderNameFormatter by inject()
     private val folderIconProvider: FolderIconProvider by inject { parametersOf(theme) }
 
     private lateinit var recyclerView: RecyclerView

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/folders/FolderNameFormatterFactory.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/folders/FolderNameFormatterFactory.kt
@@ -1,9 +1,0 @@
-package com.fsck.k9.ui.folders
-
-import android.content.Context
-
-class FolderNameFormatterFactory {
-    fun create(context: Context): FolderNameFormatter {
-        return FolderNameFormatter(context.resources)
-    }
-}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/folders/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/folders/KoinModule.kt
@@ -1,13 +1,11 @@
 package com.fsck.k9.ui.folders
 
-import android.content.Context
 import android.content.res.Resources.Theme
 import org.koin.androidx.viewmodel.dsl.viewModel
 import org.koin.dsl.module
 
 val foldersUiModule = module {
-    single { FolderNameFormatterFactory() }
-    factory { (context: Context) -> FolderNameFormatter(context.resources) }
+    factory { FolderNameFormatter(resources = get()) }
     viewModel { FoldersViewModel(folderRepository = get(), messageCountsProvider = get()) }
     factory { (theme: Theme) -> FolderIconProvider(theme) }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/FolderSettingsFragment.kt
@@ -15,11 +15,10 @@ import com.fsck.k9.ui.observeNotNull
 import com.takisoft.preferencex.PreferenceFragmentCompat
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
-import org.koin.core.parameter.parametersOf
 
 class FolderSettingsFragment : PreferenceFragmentCompat(), ConfirmationDialogFragmentListener {
     private val viewModel: FolderSettingsViewModel by viewModel()
-    private val folderNameFormatter: FolderNameFormatter by inject { parametersOf(requireActivity()) }
+    private val folderNameFormatter: FolderNameFormatter by inject()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
@@ -29,7 +29,7 @@ import org.koin.core.parameter.parametersOf
 
 class ManageFoldersFragment : Fragment() {
     private val viewModel: ManageFoldersViewModel by viewModel()
-    private val folderNameFormatter: FolderNameFormatter by inject { parametersOf(requireActivity()) }
+    private val folderNameFormatter: FolderNameFormatter by inject()
     private val messagingController: MessagingController by inject()
     private val preferences: Preferences by inject()
     private val folderIconProvider: FolderIconProvider by inject { parametersOf(requireActivity().theme) }


### PR DESCRIPTION
`FolderNameFormatter` is only retrieving string resources. For this the global `Resources` instance will do. There's no need to pass instances retrieved from an `Activity`.

This shouldn't introduce any behavior changes.