### PR TITLE
Limit summary notification actions to active notifications

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationData.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationData.kt
@@ -29,6 +29,9 @@ internal data class NotificationData(
             }
         }
 
+    val activeMessageReferences: List<MessageReference>
+        get() = activeNotifications.map { it.content.messageReference }
+
     fun isEmpty() = activeNotifications.isEmpty()
 
     companion object {

--- a/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationDataCreator.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/SummaryNotificationDataCreator.kt
@@ -37,7 +37,7 @@ internal class SummaryNotificationDataCreator(
             timestamp = timestamp,
             content = data.summaryContent,
             additionalMessagesCount = data.additionalMessagesCount,
-            messageReferences = data.messageReferences,
+            messageReferences = data.activeMessageReferences,
             actions = createSummaryNotificationActions(),
             wearActions = createSummaryWearNotificationActions(data.account)
         )


### PR DESCRIPTION
The app only creates system notifications for the 8 most recent new messages in an account (active notifications). However, we do keep track of older new messages (inactive notifications). Whenever one of the currently displayed (active) notifications is dismissed, the app promotes an inactive notification to an active one, i.e. creates a system notification for the associated message. This allows us to support notifying the user of an arbitrary number of new messages without exceeding the number of system notifications an app is allowed to create.

In addition to the (at most) 8 notifications for individual messages, the app also creates a summary notification. On modern Android versions it is mostly used to group notifications for an account, but much of the notification's configuration, like the the actions, are ignored. On older Android versions and (older?) Android Wear devices the notifcation actions on the summary notification are displayed. Previously, the actions we added to a summary notification would operate on all notifications, active and inactive. We did this by adding a list of serialized `MessageReference`s as an Intent extra. But when there are a **lot** of new message (in my test ~8600 messages), this will exceed the [binder transaction limit](https://developer.android.com/reference/android/os/TransactionTooLargeException) when creating the `PendingIntent` of a summary action. This would crash loop the app because we restore notifications when the app is launched.

This change limits summary notification actions to the messages that belong to the active notifications. That's at most 8 messages, which will never exceed the Binder transaction limit. It also makes sense, because users probably don't want to perform an action (e.g. delete) on messages that they can't see (because the associated notifications are inactive).

While it's a behavior change, I don't expect this to affect many users. On modern Android versions the summary notification actions are not displayed to the user.

Fixes #6660