### PR TITLE
Remove "Send…" menu

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -279,7 +279,6 @@ class MessageViewFragment :
         }
 
         menu.findItem(R.id.move_to_drafts).isVisible = isOutbox
-        menu.findItem(R.id.single_message_options).isVisible = true
         menu.findItem(R.id.unsubscribe).isVisible = canMessageBeUnsubscribed()
         menu.findItem(R.id.show_headers).isVisible = true
         menu.findItem(R.id.compose).isVisible = true
@@ -396,6 +395,7 @@ class MessageViewFragment :
                 R.id.reply_all -> onReplyAll()
                 R.id.forward -> onForward()
                 R.id.forward_as_attachment -> onForwardAsAttachment()
+                R.id.edit_as_new_message -> onEditAsNewMessage()
                 R.id.share -> onSendAlternate()
                 else -> error("Missing handler for reply menu item $itemId")
             }

--- a/app/ui/legacy/src/main/res/layout/message_view_header.xml
+++ b/app/ui/legacy/src/main/res/layout/message_view_header.xml
@@ -162,7 +162,7 @@
             android:paddingHorizontal="12dp"
             app:layout_constraintEnd_toStartOf="@id/menu_overflow"
             app:layout_constraintTop_toTopOf="@+id/menu_overflow"
-            app:srcCompat="?iconActionSingleMessageOptions" />
+            tools:srcCompat="@drawable/ic_reply_all" />
 
         <ImageView
             android:id="@+id/menu_overflow"

--- a/app/ui/legacy/src/main/res/menu/message_list_option.xml
+++ b/app/ui/legacy/src/main/res/menu/message_list_option.xml
@@ -81,35 +81,6 @@
 
     <!-- MessageView -->
     <item
-        android:id="@+id/single_message_options"
-        android:icon="?attr/iconActionSingleMessageOptions"
-        android:title="@string/single_message_options_action"
-        android:visible="false"
-        app:showAsAction="ifRoom">
-        <menu>
-            <item
-                android:id="@+id/reply"
-                android:title="@string/reply_action" />
-            <item
-                android:id="@+id/reply_all"
-                android:title="@string/reply_all_action" />
-            <item
-                android:id="@+id/forward"
-                android:title="@string/forward_action" />
-            <item
-                android:id="@+id/forward_as_attachment"
-                android:title="@string/forward_as_attachment_action" />
-            <item
-                android:id="@+id/edit_as_new_message"
-                android:title="@string/edit_as_new_message_action" />
-            <item
-                android:id="@+id/share"
-                android:title="@string/send_alternate_action" />
-        </menu>
-    </item>
-
-    <!-- MessageView -->
-    <item
         android:id="@+id/refile"
         android:icon="?attr/iconActionSingleMessageOptions"
         android:title="@string/refile_action"

--- a/app/ui/legacy/src/main/res/menu/message_list_option.xml
+++ b/app/ui/legacy/src/main/res/menu/message_list_option.xml
@@ -82,7 +82,6 @@
     <!-- MessageView -->
     <item
         android:id="@+id/refile"
-        android:icon="?attr/iconActionSingleMessageOptions"
         android:title="@string/refile_action"
         android:visible="false"
         app:showAsAction="never">

--- a/app/ui/legacy/src/main/res/menu/single_message_options.xml
+++ b/app/ui/legacy/src/main/res/menu/single_message_options.xml
@@ -13,6 +13,9 @@
         android:id="@+id/forward_as_attachment"
         android:title="@string/forward_as_attachment_action"/>
     <item
+        android:id="@+id/edit_as_new_message"
+        android:title="@string/edit_as_new_message_action" />
+    <item
         android:id="@+id/share"
         android:title="@string/send_alternate_action"/>
 </menu>

--- a/app/ui/legacy/src/main/res/values/attrs.xml
+++ b/app/ui/legacy/src/main/res/values/attrs.xml
@@ -29,7 +29,6 @@
         <attr name="iconActionSearchFolder" format="reference" />
         <attr name="iconActionSend" format="reference" />
         <attr name="iconActionSettings" format="reference" />
-        <attr name="iconActionSingleMessageOptions" format="reference" />
         <attr name="iconActionSort" format="reference" />
         <attr name="iconActionSpam" format="reference" />
         <attr name="iconActionFlag" format="reference" />

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -111,7 +111,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="edit_as_new_message_action">Edit as new message</string>
     <string name="move_action">Move</string>
     <string name="move_to_drafts_action">Move to Drafts</string>
-    <string name="single_message_options_action">Send…</string>
     <string name="refile_action">Refile…</string>
     <string name="done_action">Done</string>
     <string name="discard_action">Discard</string>

--- a/app/ui/legacy/src/main/res/values/themes.xml
+++ b/app/ui/legacy/src/main/res/values/themes.xml
@@ -52,7 +52,6 @@
         <item name="iconActionSearchFolder">@drawable/ic_folder_magnify</item>
         <item name="iconActionSend">@drawable/ic_send</item>
         <item name="iconActionSettings">@drawable/ic_cog</item>
-        <item name="iconActionSingleMessageOptions">@drawable/ic_reply_all</item>
         <item name="iconActionSort">@drawable/ic_sort</item>
         <item name="iconActionSpam">@drawable/ic_alert_octagon</item>
         <item name="iconActionFlag">@drawable/ic_star</item>
@@ -215,7 +214,6 @@
         <item name="iconActionSearchFolder">@drawable/ic_folder_magnify</item>
         <item name="iconActionSend">@drawable/ic_send</item>
         <item name="iconActionSettings">@drawable/ic_cog</item>
-        <item name="iconActionSingleMessageOptions">@drawable/ic_reply_all</item>
         <item name="iconActionSort">@drawable/ic_sort</item>
         <item name="iconActionSpam">@drawable/ic_alert_octagon</item>
         <item name="iconActionFlag">@drawable/ic_star</item>


### PR DESCRIPTION
All of the menu items previously available in the "Send…" submenu in the toolbar are now part of the menu displayed in the message header view.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/218061/218800409-70ca02ed-2e63-4578-9a70-ef9406ded7b1.png)|![image](https://user-images.githubusercontent.com/218061/218800092-b21337ab-c796-41c0-840c-51b81a7c6420.png)|
|![image](https://user-images.githubusercontent.com/218061/218800956-bdc7642a-742b-4c7c-b92d-e757ae95b275.png)|n/a|
|![image](https://user-images.githubusercontent.com/218061/218800679-d435b116-e467-406d-8fcd-580863cc5efe.png)|![image](https://user-images.githubusercontent.com/218061/218800132-b758688e-2937-4124-ac5a-5555e94e9cee.png)|



