### PR TITLE
Clean up `Identity` properties

### DIFF
--- a/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -21,7 +21,7 @@ import timber.log.Timber;
 
 
 public class K9StoragePersister implements StoragePersister {
-    private static final int DB_VERSION = 19;
+    private static final int DB_VERSION = 20;
     private static final String DB_NAME = "preferences_storage";
 
     private final Context context;

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo20.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrationTo20.kt
@@ -1,0 +1,56 @@
+package com.fsck.k9.preferences.migrations
+
+import android.database.sqlite.SQLiteDatabase
+import com.fsck.k9.mail.Address
+
+/**
+ * Clean up [Identity][com.fsck.k9.Identity] properties stored in the database
+ *
+ * Previously, we didn't validate input in the "Edit identity" screen, and so there was no guarantee that the `email`
+ * and `replyTo` values contained a valid email address.
+ *
+ * Additionally, we now rewrite blank values in `description`, `name`, and `replyTo` to `null`.
+ */
+class StorageMigrationTo20(
+    private val db: SQLiteDatabase,
+    private val migrationsHelper: StorageMigrationsHelper,
+) {
+    fun fixIdentities() {
+        val accountUuidsListValue = migrationsHelper.readValue(db, "accountUuids")
+        if (accountUuidsListValue.isNullOrEmpty()) {
+            return
+        }
+
+        val accountUuids = accountUuidsListValue.split(",")
+        for (accountUuid in accountUuids) {
+            fixIdentitiesInAccount(accountUuid)
+        }
+    }
+
+    private fun fixIdentitiesInAccount(accountUuid: String) {
+        var identityIndex = 0
+
+        while (true) {
+            val email = migrationsHelper.readValue(db, "$accountUuid.email.$identityIndex") ?: break
+            val description = migrationsHelper.readValue(db, "$accountUuid.description.$identityIndex")
+            val name = migrationsHelper.readValue(db, "$accountUuid.name.$identityIndex")
+            val replyTo = migrationsHelper.readValue(db, "$accountUuid.replyTo.$identityIndex")
+
+            val newDescription = description?.takeUnless { it.isBlank() }
+            val newName = name?.takeUnless { it.isBlank() }
+
+            val emailAddress = Address.parse(email).firstOrNull()
+            val newEmail = emailAddress?.address ?: "please.fix@invalid"
+
+            val replyToAddress = Address.parse(replyTo).firstOrNull()
+            val newReplyTo = replyToAddress?.address
+
+            migrationsHelper.writeValue(db, "$accountUuid.description.$identityIndex", newDescription)
+            migrationsHelper.writeValue(db, "$accountUuid.name.$identityIndex", newName)
+            migrationsHelper.writeValue(db, "$accountUuid.email.$identityIndex", newEmail)
+            migrationsHelper.writeValue(db, "$accountUuid.replyTo.$identityIndex", newReplyTo)
+
+            identityIndex++
+        }
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/preferences/migrations/StorageMigrations.kt
@@ -25,5 +25,6 @@ internal object StorageMigrations {
         if (oldVersion < 17) StorageMigrationTo17(db, migrationsHelper).rewriteNotificationLightSettings()
         if (oldVersion < 18) StorageMigrationTo18(db, migrationsHelper).rewriteImapCompressionSettings()
         if (oldVersion < 19) StorageMigrationTo19(db, migrationsHelper).markGmailAccounts()
+        if (oldVersion < 20) StorageMigrationTo20(db, migrationsHelper).fixIdentities()
     }
 }

--- a/app/ui/legacy/src/main/java/com/fsck/k9/UiKoinModules.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/UiKoinModules.kt
@@ -10,6 +10,7 @@ import com.fsck.k9.ui.changelog.changelogUiModule
 import com.fsck.k9.ui.choosefolder.chooseFolderUiModule
 import com.fsck.k9.ui.endtoend.endToEndUiModule
 import com.fsck.k9.ui.folders.foldersUiModule
+import com.fsck.k9.ui.identity.identityUiModule
 import com.fsck.k9.ui.managefolders.manageFoldersUiModule
 import com.fsck.k9.ui.messagedetails.messageDetailsUiModule
 import com.fsck.k9.ui.messagelist.messageListUiModule
@@ -38,4 +39,5 @@ val uiModules = listOf(
     accountUiModule,
     messageDetailsUiModule,
     messageViewUiModule,
+    identityUiModule,
 )

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/ChooseIdentity.java
@@ -10,12 +10,17 @@ import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.Toast;
 import com.fsck.k9.Account;
+import com.fsck.k9.DI;
 import com.fsck.k9.Identity;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.ui.R;
+import com.fsck.k9.ui.identity.IdentityFormatter;
+
 import java.util.List;
 
 public class ChooseIdentity extends K9ListActivity {
+    private final IdentityFormatter identityFormatter = DI.get(IdentityFormatter.class);
+
     Account mAccount;
     ArrayAdapter<String> adapter;
 
@@ -59,11 +64,8 @@ public class ChooseIdentity extends K9ListActivity {
 
         identities = mAccount.getIdentities();
         for (Identity identity : identities) {
-            String description = identity.getDescription();
-            if (description == null || description.trim().isEmpty()) {
-                description = getString(R.string.message_view_from_format, identity.getName(), identity.getEmail());
-            }
-            adapter.add(description);
+            String identityDisplayName = identityFormatter.getDisplayName(identity);
+            adapter.add(identityDisplayName);
         }
 
         adapter.notifyDataSetChanged();

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
@@ -95,7 +95,7 @@ class EditIdentity : K9Activity() {
     }
 
     private fun isValidEmailAddress(textView: TextView): Boolean {
-        return emailAddressValidator.isValidAddressOnly(textView.text)
+        return emailAddressValidator.isValidAddressOnly(textView.text.trim())
     }
 
     private fun isValidEmailAddressOrEmpty(textView: TextView): Boolean {
@@ -105,11 +105,11 @@ class EditIdentity : K9Activity() {
     private fun saveIdentity() {
         identity = identity.copy(
             description = description.text.toString().takeUnless { it.isBlank() },
-            email = email.text.toString(),
+            email = email.text.toString().trim(),
             name = name.text.toString().takeUnless { it.isBlank() },
             signatureUse = signatureUse.isChecked,
             signature = signature.text.toString(),
-            replyTo = replyTo.text.toString().takeUnless { it.isBlank() },
+            replyTo = replyTo.text.toString().trim().takeUnless { it.isBlank() },
         )
 
         val identities = account.identities

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/EditIdentity.kt
@@ -104,12 +104,12 @@ class EditIdentity : K9Activity() {
 
     private fun saveIdentity() {
         identity = identity.copy(
-            description = description.text.toString(),
+            description = description.text.toString().takeUnless { it.isBlank() },
             email = email.text.toString(),
-            name = name.text.toString(),
+            name = name.text.toString().takeUnless { it.isBlank() },
             signatureUse = signatureUse.isChecked,
             signature = signature.text.toString(),
-            replyTo = if (replyTo.text.isNotEmpty()) replyTo.text.toString() else null,
+            replyTo = replyTo.text.toString().takeUnless { it.isBlank() },
         )
 
         val identities = account.identities

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/IdentityAdapter.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/compose/IdentityAdapter.java
@@ -8,9 +8,11 @@ import android.widget.BaseAdapter;
 import android.widget.TextView;
 
 import com.fsck.k9.Account;
+import com.fsck.k9.DI;
 import com.fsck.k9.Identity;
 import com.fsck.k9.Preferences;
 import com.fsck.k9.ui.R;
+import com.fsck.k9.ui.identity.IdentityFormatter;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -24,6 +26,8 @@ import java.util.List;
  * </p>
  */
 public class IdentityAdapter extends BaseAdapter {
+    private final IdentityFormatter identityFormatter = DI.get(IdentityFormatter.class);
+
     private LayoutInflater mLayoutInflater;
     private List<Object> mItems;
 
@@ -114,14 +118,10 @@ public class IdentityAdapter extends BaseAdapter {
             Identity identity = identityContainer.identity;
             IdentityHolder holder = (IdentityHolder) view.getTag();
             holder.name.setText(identity.getDescription());
-            holder.description.setText(getIdentityDescription(identity));
+            holder.description.setText(identityFormatter.getEmailDisplayName(identity));
         }
 
         return view;
-    }
-
-    private static String getIdentityDescription(Identity identity) {
-        return String.format("%s <%s>", identity.getName(), identity.getEmail());
     }
 
     /**

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/identity/IdentityFormatter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/identity/IdentityFormatter.kt
@@ -1,0 +1,20 @@
+package com.fsck.k9.ui.identity
+
+import com.fsck.k9.Identity
+
+class IdentityFormatter {
+    fun getDisplayName(identity: Identity): String {
+        return identity.description ?: getEmailDisplayName(identity)
+    }
+
+    fun getEmailDisplayName(identity: Identity): String {
+        val senderDisplayName = identity.name
+        val emailAddress = identity.email ?: "Invalid"
+
+        return if (senderDisplayName != null) {
+            "$senderDisplayName <$emailAddress>"
+        } else {
+            emailAddress
+        }
+    }
+}

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/identity/KoinModule.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/identity/KoinModule.kt
@@ -1,0 +1,7 @@
+package com.fsck.k9.ui.identity
+
+import org.koin.dsl.module
+
+val identityUiModule = module {
+    factory { IdentityFormatter() }
+}

--- a/app/ui/legacy/src/main/res/values/strings.xml
+++ b/app/ui/legacy/src/main/res/values/strings.xml
@@ -255,7 +255,6 @@ Please submit bug reports, contribute new features and ask questions at
     <string name="message_compose_description_edit_quoted_text">Edit quoted text</string>
     <string name="remove_attachment_action">Remove attachment</string>
 
-    <string name="message_view_from_format">From: <xliff:g id="name">%1$s</xliff:g> &lt;<xliff:g id="email">%2$s</xliff:g>&gt;</string>
     <string name="message_to_label">To:</string>
     <string name="message_view_cc_label">Cc:</string>
     <string name="message_view_bcc_label">Bcc:</string>

--- a/app/ui/legacy/src/test/java/com/fsck/k9/ui/identity/IdentityFormatterTest.kt
+++ b/app/ui/legacy/src/test/java/com/fsck/k9/ui/identity/IdentityFormatterTest.kt
@@ -1,0 +1,67 @@
+package com.fsck.k9.ui.identity
+
+import com.fsck.k9.Identity
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+private const val IDENTITY_NAME = "Identity Name"
+private const val SENDER_NAME = "Display Name"
+private const val EMAIL = "test@domain.example"
+
+class IdentityFormatterTest {
+    private val identityFormatter = IdentityFormatter()
+
+    @Test
+    fun `getDisplayName() with identity name`() {
+        val identity = Identity(description = IDENTITY_NAME, name = "irrelevant", email = EMAIL)
+
+        val displayName = identityFormatter.getDisplayName(identity)
+
+        assertThat(displayName).isEqualTo(IDENTITY_NAME)
+    }
+
+    @Test
+    fun `getDisplayName() without identity name, but sender name`() {
+        val identity = Identity(description = null, name = SENDER_NAME, email = EMAIL)
+
+        val displayName = identityFormatter.getDisplayName(identity)
+
+        assertThat(displayName).isEqualTo("$SENDER_NAME <$EMAIL>")
+    }
+
+    @Test
+    fun `getDisplayName() without identity name and sender name`() {
+        val identity = Identity(description = null, name = null, email = EMAIL)
+
+        val displayName = identityFormatter.getDisplayName(identity)
+
+        assertThat(displayName).isEqualTo(EMAIL)
+    }
+
+    @Test
+    fun `getEmailDisplayName() with sender name`() {
+        val identity = Identity(name = SENDER_NAME, email = EMAIL)
+
+        val displayName = identityFormatter.getEmailDisplayName(identity)
+
+        assertThat(displayName).isEqualTo("$SENDER_NAME <$EMAIL>")
+    }
+
+    @Test
+    fun `getEmailDisplayName() without sender name`() {
+        val identity = Identity(name = null, email = EMAIL)
+
+        val displayName = identityFormatter.getEmailDisplayName(identity)
+
+        assertThat(displayName).isEqualTo(EMAIL)
+    }
+
+    @Test
+    fun `getEmailDisplayName() should ignore identity name`() {
+        val identity = Identity(description = IDENTITY_NAME, name = null, email = EMAIL)
+
+        val displayName = identityFormatter.getEmailDisplayName(identity)
+
+        assertThat(displayName).isEqualTo(EMAIL)
+    }
+}


### PR DESCRIPTION
We didn't do any input validation when users created or edited identities. This PR adds input validation and a database migration that fixes existing data if necessary.

Fixes part of #6689
