### PR TITLE
Message List: Use whole left side as contact picture click area

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -193,8 +193,8 @@ class MessageListAdapter internal constructor(
         listItemListener.onToggleMessageFlag(messageListItem)
     }
 
-    private val contactPictureClickListener = OnClickListener { view: View ->
-        val parentView = view.parent.parent as View
+    private val contactPictureContainerClickListener = OnClickListener { view: View ->
+        val parentView = view.parent as View
         val messageListItem = getItemFromView(parentView) ?: return@OnClickListener
         listItemListener.onToggleMessageSelection(messageListItem)
     }
@@ -258,8 +258,9 @@ class MessageListAdapter internal constructor(
 
         val holder = MessageViewHolder(view)
 
-        view.findViewById<View>(R.id.contact_picture_container).isVisible = appearance.showContactPicture
-        holder.contactPicture.setOnClickListener(contactPictureClickListener)
+        val contactPictureContainer = view.findViewById<View>(R.id.contact_picture_container)
+        contactPictureContainer.isVisible = appearance.showContactPicture
+        contactPictureContainer.setOnClickListener(contactPictureContainerClickListener)
 
         holder.chip.isVisible = appearance.showAccountChip
 

--- a/app/ui/legacy/src/main/res/layout/message_list_item.xml
+++ b/app/ui/legacy/src/main/res/layout/message_list_item.xml
@@ -15,24 +15,26 @@
     <FrameLayout
         android:id="@+id/contact_picture_container"
         android:layout_width="72dp"
-        android:layout_height="72dp"
-        android:layout_gravity="center_vertical"
+        android:layout_height="0dp"
         android:padding="16dp"
+        app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toTopOf="parent">
 
         <ImageView
             android:id="@+id/selected"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_gravity="top"
             android:contentDescription="@null"
             android:visibility="gone"
             app:srcCompat="@drawable/ic_check_circle_large" />
 
         <de.hdodenhof.circleimageview.CircleImageView
             android:id="@+id/contact_picture"
-            android:layout_width="match_parent"
-            android:layout_height="match_parent"
+            android:layout_width="40dp"
+            android:layout_height="40dp"
+            android:layout_gravity="top"
             android:background="@android:color/transparent"
             tools:src="@drawable/ic_contact_picture" />
 


### PR DESCRIPTION
It was very annoying to slightly miss the contact picture when trying to tap it, as this would trigger the open message action. With this change we're using the whole left side as clickable area to toggle message selection. 

![image](https://user-images.githubusercontent.com/218061/220622903-ada58cf8-4da9-4d8c-bd86-6ddbaf870c79.png)
