### PR TITLE
Change star position in the message list

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -190,7 +190,8 @@ class MessageListAdapter internal constructor(
     }
 
     private val starClickListener = OnClickListener { view: View ->
-        val messageListItem = getItemFromView(view) ?: return@OnClickListener
+        val parentView = view.parent as View
+        val messageListItem = getItemFromView(parentView) ?: return@OnClickListener
         listItemListener.onToggleMessageFlag(messageListItem)
     }
 
@@ -277,8 +278,7 @@ class MessageListAdapter internal constructor(
         ) // thread count is next to subject
 
         holder.star.isVisible = appearance.stars
-        holder.star.tag = holder
-        holder.star.setOnClickListener(starClickListener)
+        holder.starClickArea.setOnClickListener(starClickListener)
 
         view.tag = holder
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewHolder.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewHolder.kt
@@ -19,6 +19,7 @@ class MessageViewHolder(view: View) : MessageListViewHolder(view) {
     val chip: ImageView = view.findViewById(R.id.account_color_chip)
     val threadCount: TextView = view.findViewById(R.id.thread_count)
     val star: ImageView = view.findViewById(R.id.star)
+    val starClickArea: View = view.findViewById(R.id.star_click_area)
     val attachment: ImageView = view.findViewById(R.id.attachment)
     val status: ImageView = view.findViewById(R.id.status)
 }

--- a/app/ui/legacy/src/main/res/layout/message_list_item.xml
+++ b/app/ui/legacy/src/main/res/layout/message_list_item.xml
@@ -173,4 +173,12 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toEndOf="@+id/contact_picture_container" />
 
+    <View
+        android:id="@+id/star_click_area"
+        android:layout_width="48dp"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/ui/legacy/src/main/res/layout/message_list_item.xml
+++ b/app/ui/legacy/src/main/res/layout/message_list_item.xml
@@ -45,6 +45,7 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginBottom="12dp"
+        android:layout_marginEnd="8dp"
         android:bufferType="spannable"
         android:singleLine="false"
         android:textAppearance="@style/TextAppearance.K9.Small"
@@ -133,15 +134,15 @@
 
     <ImageView
         android:id="@+id/star"
-        android:layout_width="48dp"
-        android:layout_height="48dp"
-        android:layout_marginTop="-8dp"
-        android:paddingHorizontal="12dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="2dp"
+        android:layout_marginEnd="14dp"
         android:src="@drawable/btn_select_star"
-        app:layout_constraintBottom_toBottomOf="@+id/divider"
+        app:layout_constraintBottom_toBottomOf="@+id/bottom_guideline"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@+id/date"
-        app:layout_constraintVertical_bias="1.0" />
+        app:layout_constraintTop_toTopOf="@+id/preview"
+        app:layout_constraintVertical_bias="0.0" />
 
     <androidx.constraintlayout.widget.Guideline
         android:id="@+id/top_guideline"
@@ -149,6 +150,13 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal"
         app:layout_constraintGuide_begin="12dp" />
+
+    <androidx.constraintlayout.widget.Guideline
+        android:id="@+id/bottom_guideline"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        app:layout_constraintGuide_end="12dp" />
 
     <androidx.constraintlayout.widget.Barrier
         android:id="@+id/barrier_first_line_bottom"


### PR DESCRIPTION
|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/218061/221227639-d0a71659-e291-4909-82fa-c0a150d76574.png)|![image](https://user-images.githubusercontent.com/218061/221226277-f78c90f1-a35e-4d9b-a124-35d0c7c1a77d.png)|

The whole right side is now used as the click area for the star.

![image](https://user-images.githubusercontent.com/218061/221228151-5d098939-34ee-41c4-8bf6-032e417ee138.png)

