### PR TITLE
Fix size of star in message view

### DIFF
--- a/app/ui/legacy/src/main/res/layout/message_view_header.xml
+++ b/app/ui/legacy/src/main/res/layout/message_view_header.xml
@@ -64,7 +64,7 @@
             android:layout_height="48dp"
             android:background="?attr/controlBackground"
             android:baseline="33dp"
-            android:paddingHorizontal="10dp"
+            android:paddingHorizontal="12dp"
             android:src="@drawable/btn_select_star"
             app:layout_constraintBaseline_toBaselineOf="@+id/subject"
             app:layout_constraintEnd_toEndOf="parent" />


### PR DESCRIPTION
When changing `btn_select_star` in #6706, I forgot to adjust the padding in `message_view_header`. This resulted in the star icon getting displayed larger. This PR restores the previous size.

|Before|After|
|-|-|
|![image](https://user-images.githubusercontent.com/218061/222219149-48201e0a-0c48-4189-88ea-b29140c8684a.png)|![image](https://user-images.githubusercontent.com/218061/222218898-962d8cc9-d6e6-47ae-94ce-962e0e5b17fe.png)|
