### PR TITLE
Message View: Tweak appearance of account chip

### DIFF
--- a/app/ui/legacy/src/main/res/layout/message_view_header.xml
+++ b/app/ui/legacy/src/main/res/layout/message_view_header.xml
@@ -11,33 +11,24 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content">
 
-        <Space
-            android:id="@+id/margin_top"
-            android:layout_width="match_parent"
-            android:layout_height="16dp"
-            app:layout_constraintTop_toTopOf="parent" />
-
         <com.google.android.material.chip.Chip
             android:id="@+id/account_name"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginStart="16dp"
-            android:layout_marginTop="8dp"
+            android:layout_marginTop="16dp"
             android:clickable="false"
+            android:paddingVertical="4sp"
             android:textColor="@android:color/white"
             android:textSize="14sp"
-            app:layout_constraintBottom_toTopOf="@+id/subject"
+            app:chipMinHeight="0dp"
+            app:ensureMinTouchTargetSize="false"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent"
+            app:textEndPadding="6sp"
+            app:textStartPadding="8sp"
             tools:chipBackgroundColor="#1976D2"
             tools:text="Account name" />
-
-        <androidx.constraintlayout.widget.Barrier
-            android:id="@+id/top_margin_barrier"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:barrierDirection="bottom"
-            app:constraint_referenced_ids="account_name,margin_top" />
 
         <com.fsck.k9.ui.helper.BottomBaselineTextView
             android:id="@+id/subject"
@@ -45,16 +36,18 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/account_name"
             android:layout_marginStart="16dp"
+            android:layout_marginTop="8dp"
             android:layout_marginEnd="8dp"
             android:layout_marginBottom="16dp"
             android:ellipsize="end"
             android:maxLines="3"
             android:textColor="?android:attr/textColorPrimary"
             android:textSize="20sp"
+            app:layout_goneMarginTop="16dp"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/flagged"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/top_margin_barrier"
+            app:layout_constraintTop_toBottomOf="@id/account_name"
             app:layout_constraintVertical_bias="0.0"
             tools:text="Message subject" />
 


### PR DESCRIPTION
- Scale account chip with the font size
- This change reduces the chip height a little bit when using the default font size.

### Before

<img src="https://user-images.githubusercontent.com/218061/225088088-f7eb7e5e-22b4-4823-97c0-afa59e54a46a.png" alt="image" width=300>

### After

#### Font size: default

<img src="https://user-images.githubusercontent.com/218061/225087433-d77460f4-c097-4b3f-90e0-9b803fe13c79.png" alt="image" width=300>

#### Font size: tiniest

<img src="https://user-images.githubusercontent.com/218061/225087630-997f46ef-b821-435f-ad69-89b3fbc06f37.png" alt="image" width=300>

#### Font size: larger

<img src="https://user-images.githubusercontent.com/218061/225087750-4c8453c3-a9b8-4b19-89df-44a1ccf97535.png" alt="image" width=300>
