### PR TITLE
Remove `MessageListHandler.goBack()`

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -596,7 +596,7 @@ class MessageListFragment :
         messagingController.removeListener(activityListener)
     }
 
-    fun goBack() {
+    private fun goBack() {
         fragmentListener.goBack()
     }
 
@@ -1420,7 +1420,7 @@ class MessageListFragment :
     private fun setMessageList(messageListInfo: MessageListInfo) {
         val messageListItems = messageListInfo.messageListItems
         if (isThreadDisplay && messageListItems.isEmpty()) {
-            handler.goBack()
+            goBack()
             return
         }
 

--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListHandler.java
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListHandler.java
@@ -20,7 +20,6 @@ public class MessageListHandler extends Handler {
     private static final int ACTION_REFRESH_TITLE = 2;
     private static final int ACTION_PROGRESS = 3;
     private static final int ACTION_REMOTE_SEARCH_FINISHED = 4;
-    private static final int ACTION_GO_BACK = 5;
 
     private WeakReference<MessageListFragment> mFragment;
 
@@ -61,11 +60,6 @@ public class MessageListHandler extends Handler {
         });
     }
 
-    public void goBack() {
-        android.os.Message msg = android.os.Message.obtain(this, ACTION_GO_BACK);
-        sendMessage(msg);
-    }
-
     @Override
     public void handleMessage(android.os.Message msg) {
         MessageListFragment fragment = mFragment.get();
@@ -101,10 +95,6 @@ public class MessageListHandler extends Handler {
             case ACTION_PROGRESS: {
                 boolean progress = (msg.arg1 == 1);
                 fragment.progress(progress);
-                break;
-            }
-            case ACTION_GO_BACK: {
-                fragment.goBack();
                 break;
             }
         }


### PR DESCRIPTION
We no longer call `goBack()` from a background thread. So using `MessageListHandler` is no longer necessary. This change should also avoid trying to modify the back stack after `onSaveInstanceState()` has been called.

Fixes #6775