### PR TITLE
Fix crash in `DefaultMessageCountsProvider`

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/controller/MessageCountsProvider.kt
+++ b/app/core/src/main/java/com/fsck/k9/controller/MessageCountsProvider.kt
@@ -61,7 +61,7 @@ internal class DefaultMessageCountsProvider(
         }
     }
 
-    private fun getMessageCounts(account: Account, conditions: ConditionsTreeNode): MessageCounts {
+    private fun getMessageCounts(account: Account, conditions: ConditionsTreeNode?): MessageCounts {
         return try {
             val messageStore = messageStoreManager.getMessageStore(account)
             return MessageCounts(

--- a/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/mailstore/MessageStore.kt
@@ -235,12 +235,12 @@ interface MessageStore {
     /**
      * Retrieve the number of unread messages matching [conditions].
      */
-    fun getUnreadMessageCount(conditions: ConditionsTreeNode): Int
+    fun getUnreadMessageCount(conditions: ConditionsTreeNode?): Int
 
     /**
      * Retrieve the number of starred messages matching [conditions].
      */
-    fun getStarredMessageCount(conditions: ConditionsTreeNode): Int
+    fun getStarredMessageCount(conditions: ConditionsTreeNode?): Int
 
     /**
      * Update a folder's name and type.

--- a/app/core/src/test/java/com/fsck/k9/controller/DefaultMessageCountsProviderTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/controller/DefaultMessageCountsProviderTest.kt
@@ -1,0 +1,48 @@
+package com.fsck.k9.controller
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import com.fsck.k9.Account
+import com.fsck.k9.Account.FolderMode
+import com.fsck.k9.Preferences
+import com.fsck.k9.mailstore.ListenableMessageStore
+import com.fsck.k9.mailstore.MessageStoreManager
+import com.fsck.k9.search.ConditionsTreeNode
+import org.junit.Test
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+
+private const val ACCOUNT_UUID = "irrelevant"
+private const val UNREAD_COUNT = 2
+private const val STARRED_COUNT = 3
+
+class DefaultMessageCountsProviderTest {
+    private val preferences = mock<Preferences>()
+    private val account = Account(ACCOUNT_UUID)
+    private val messageStore = mock<ListenableMessageStore> {
+        on { getUnreadMessageCount(anyOrNull<ConditionsTreeNode>()) } doReturn UNREAD_COUNT
+        on { getStarredMessageCount(anyOrNull()) } doReturn STARRED_COUNT
+    }
+    private val messageStoreManager = mock<MessageStoreManager> {
+        on { getMessageStore(account) } doReturn messageStore
+    }
+
+    private val messageCountsProvider = DefaultMessageCountsProvider(preferences, messageStoreManager)
+
+    @Test
+    fun `getMessageCounts() without any special folders and displayMode = ALL`() {
+        account.inboxFolderId = null
+        account.trashFolderId = null
+        account.draftsFolderId = null
+        account.spamFolderId = null
+        account.outboxFolderId = null
+        account.sentFolderId = null
+        account.folderDisplayMode = FolderMode.ALL
+
+        val messageCounts = messageCountsProvider.getMessageCounts(account)
+
+        assertThat(messageCounts.unread).isEqualTo(UNREAD_COUNT)
+        assertThat(messageCounts.starred).isEqualTo(STARRED_COUNT)
+    }
+}

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -185,11 +185,11 @@ class K9MessageStore(
         return retrieveFolderOperations.getUnreadMessageCount(folderId)
     }
 
-    override fun getUnreadMessageCount(conditions: ConditionsTreeNode): Int {
+    override fun getUnreadMessageCount(conditions: ConditionsTreeNode?): Int {
         return retrieveFolderOperations.getUnreadMessageCount(conditions)
     }
 
-    override fun getStarredMessageCount(conditions: ConditionsTreeNode): Int {
+    override fun getStarredMessageCount(conditions: ConditionsTreeNode?): Int {
         return retrieveFolderOperations.getStarredMessageCount(conditions)
     }
 

--- a/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveFolderOperations.kt
+++ b/app/storage/src/main/java/com/fsck/k9/storage/messages/RetrieveFolderOperations.kt
@@ -172,15 +172,15 @@ $displayModeSelection
         }
     }
 
-    fun getUnreadMessageCount(conditions: ConditionsTreeNode): Int {
+    fun getUnreadMessageCount(conditions: ConditionsTreeNode?): Int {
         return getMessageCount(condition = "messages.read = 0", conditions)
     }
 
-    fun getStarredMessageCount(conditions: ConditionsTreeNode): Int {
+    fun getStarredMessageCount(conditions: ConditionsTreeNode?): Int {
         return getMessageCount(condition = "messages.flagged = 1", conditions)
     }
 
-    private fun getMessageCount(condition: String, extraConditions: ConditionsTreeNode): Int {
+    private fun getMessageCount(condition: String, extraConditions: ConditionsTreeNode?): Int {
         val whereBuilder = StringBuilder()
         val queryArgs = mutableListOf<String>()
         SqlQueryBuilder.buildWhereClause(extraConditions, whereBuilder, queryArgs)

--- a/app/storage/src/test/java/com/fsck/k9/storage/messages/RetrieveFolderOperationsTest.kt
+++ b/app/storage/src/test/java/com/fsck/k9/storage/messages/RetrieveFolderOperationsTest.kt
@@ -413,10 +413,25 @@ class RetrieveFolderOperationsTest : RobolectricTest() {
         val folderId2 = sqliteDatabase.createFolder(integrate = true)
         sqliteDatabase.createMessage(folderId = folderId2, read = false)
         sqliteDatabase.createMessage(folderId = folderId2, read = true)
+        val folderId3 = sqliteDatabase.createFolder(integrate = false)
+        sqliteDatabase.createMessage(folderId = folderId3, read = false)
 
         val result = retrieveFolderOperations.getUnreadMessageCount(unifiedInboxConditions)
 
         assertThat(result).isEqualTo(3)
+    }
+
+    @Test
+    fun `get unread message count without condition`() {
+        val folderId1 = sqliteDatabase.createFolder(integrate = true)
+        sqliteDatabase.createMessage(folderId = folderId1, read = false)
+        val folderId2 = sqliteDatabase.createFolder(integrate = false)
+        sqliteDatabase.createMessage(folderId = folderId2, read = false)
+        sqliteDatabase.createMessage(folderId = folderId2, read = true)
+
+        val result = retrieveFolderOperations.getUnreadMessageCount(conditions = null)
+
+        assertThat(result).isEqualTo(2)
     }
 
     @Test
@@ -444,10 +459,25 @@ class RetrieveFolderOperationsTest : RobolectricTest() {
         sqliteDatabase.createMessage(folderId = folderId2, flagged = true)
         sqliteDatabase.createMessage(folderId = folderId2, flagged = true)
         sqliteDatabase.createMessage(folderId = folderId2, flagged = false)
+        val folderId3 = sqliteDatabase.createFolder(integrate = false)
+        sqliteDatabase.createMessage(folderId = folderId3, flagged = true)
 
         val result = retrieveFolderOperations.getStarredMessageCount(unifiedInboxConditions)
 
         assertThat(result).isEqualTo(3)
+    }
+
+    @Test
+    fun `get starred message count without condition`() {
+        val folderId1 = sqliteDatabase.createFolder(integrate = true)
+        sqliteDatabase.createMessage(folderId = folderId1, flagged = true)
+        val folderId2 = sqliteDatabase.createFolder(integrate = false)
+        sqliteDatabase.createMessage(folderId = folderId2, flagged = true)
+        sqliteDatabase.createMessage(folderId = folderId2, flagged = false)
+
+        val result = retrieveFolderOperations.getStarredMessageCount(conditions = null)
+
+        assertThat(result).isEqualTo(2)
     }
 
     @Test


### PR DESCRIPTION
Reported via Google Play Developer Console (K-9 Mail 6.509):

```text
Exception java.lang.NullPointerException:
  at com.fsck.k9.controller.DefaultMessageCountsProvider.getMessageCounts (MessageCountsProvider.kt:32)
  at com.fsck.k9.ui.account.AccountsViewModel$getMessageCountsFlow$1.invokeSuspend (AccountsViewModel.kt:47)
  at com.fsck.k9.ui.account.AccountsViewModel$getMessageCountsFlow$1.invoke (AccountsViewModel.kt)
  at com.fsck.k9.ui.account.AccountsViewModel$getMessageCountsFlow$1.invoke (AccountsViewModel.kt)
  at kotlinx.coroutines.flow.ChannelFlowBuilder.collectTo$suspendImpl (Builders.kt:322)
  at kotlinx.coroutines.flow.ChannelFlowBuilder.collectTo (Builders.kt)
  at kotlinx.coroutines.flow.CallbackFlowBuilder.collectTo (Builders.kt:336)
  at kotlinx.coroutines.flow.internal.ChannelFlow$collectToFun$1.invokeSuspend (ChannelFlow.kt:60)
  at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith (ContinuationImpl.kt:33)
  at kotlinx.coroutines.DispatchedTask.run (DispatchedTask.kt:106)
  at kotlinx.coroutines.internal.LimitedDispatcher.run (LimitedDispatcher.kt:42)
  at kotlinx.coroutines.scheduling.TaskImpl.run (Tasks.kt:95)
  at kotlinx.coroutines.scheduling.CoroutineScheduler.runSafely (CoroutineScheduler.kt:570)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.executeTask (CoroutineScheduler.kt:750)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.runWorker (CoroutineScheduler.kt:677)
  at kotlinx.coroutines.scheduling.CoroutineScheduler$Worker.run (CoroutineScheduler.kt:664)
```