### PR TITLE
Close message details bottom sheet using `dismissAllowingStateLoss()`

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsFragment.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/ui/messagedetails/MessageDetailsFragment.kt
@@ -81,7 +81,7 @@ class MessageDetailsFragment : ToolbarBottomSheetDialogFragment() {
             navigationIcon = ContextCompat.getDrawable(requireContext(), R.drawable.ic_close)
 
             setNavigationOnClickListener {
-                dismiss()
+                dismissAllowingStateLoss()
             }
         }
 
@@ -328,7 +328,7 @@ class MessageDetailsFragment : ToolbarBottomSheetDialogFragment() {
             putExtra(MessageCompose.EXTRA_ACCOUNT, messageReference.accountUuid)
         }
 
-        dismiss()
+        dismissAllowingStateLoss()
         requireContext().startActivity(intent)
     }
 
@@ -338,12 +338,12 @@ class MessageDetailsFragment : ToolbarBottomSheetDialogFragment() {
 
     private fun searchCryptoKeys() {
         setFragmentResult(FRAGMENT_RESULT_KEY, bundleOf(RESULT_ACTION to ACTION_SEARCH_KEYS))
-        dismiss()
+        dismissAllowingStateLoss()
     }
 
     private fun showCryptoWarning() {
         setFragmentResult(FRAGMENT_RESULT_KEY, bundleOf(RESULT_ACTION to ACTION_SHOW_WARNING))
-        dismiss()
+        dismissAllowingStateLoss()
     }
 
     companion object {


### PR DESCRIPTION
This should avoid a crash where the dialog fragment is being dismissed after `onSaveInstanceState()` has been called.

Crash reported via Google Play Developer Console (K-9 Mail 6.510):

```text
Exception java.lang.IllegalStateException: Can not perform this action after onSaveInstanceState
  at androidx.fragment.app.FragmentManager.checkStateLoss (FragmentManager.java:1610)
  at androidx.fragment.app.FragmentManager.enqueueAction (FragmentManager.java:1650)
  at androidx.fragment.app.BackStackRecord.commitInternal (BackStackRecord.java:341)
  at androidx.fragment.app.BackStackRecord.commit (BackStackRecord.java:306)
  at androidx.fragment.app.DialogFragment.dismissInternal (DialogFragment.java:376)
  at androidx.fragment.app.DialogFragment.dismiss (DialogFragment.java:310)
  at app.k9mail.ui.utils.bottomsheet.ToolbarBottomSheetDialogFragment.dismissAfterAnimation (ToolbarBottomSheetDialogFragment.kt:93)
  at app.k9mail.ui.utils.bottomsheet.ToolbarBottomSheetDialogFragment.access$dismissAfterAnimation (ToolbarBottomSheetDialogFragment.kt:31)
  at app.k9mail.ui.utils.bottomsheet.ToolbarBottomSheetDialogFragment$BottomSheetDismissCallback.onStateChanged (ToolbarBottomSheetDialogFragment.kt:100)
  at com.google.android.material.bottomsheet.BottomSheetBehavior.setStateInternal (BottomSheetBehavior.java:1329)
  at com.google.android.material.bottomsheet.BottomSheetBehavior$StateSettlingTracker$1.run (BottomSheetBehavior.java:1891)
  at android.view.Choreographer$CallbackRecord.run (Choreographer.java:1058)
  at android.view.Choreographer.doCallbacks (Choreographer.java:880)
  at android.view.Choreographer.doFrame (Choreographer.java:809)
  at android.view.Choreographer$FrameDisplayEventReceiver.run (Choreographer.java:1043)
  at android.os.Handler.handleCallback (Handler.java:938)
  at android.os.Handler.dispatchMessage (Handler.java:99)
  at android.os.Looper.loop (Looper.java:236)
  at android.app.ActivityThread.main (ActivityThread.java:7876)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:656)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:967)
```