### PR TITLE
Avoid crash when setting up an account using OAuth 2.0

### DIFF
--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AuthViewModel.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/AuthViewModel.kt
@@ -56,7 +56,8 @@ class AuthViewModel(
         return authService ?: AuthorizationService(getApplication<Application>()).also { authService = it }
     }
 
-    fun init(activityResultRegistry: ActivityResultRegistry, lifecycle: Lifecycle) {
+    fun init(activityResultRegistry: ActivityResultRegistry, lifecycle: Lifecycle, account: Account) {
+        this.account = account
         resultObserver = AppAuthResultObserver(activityResultRegistry)
         lifecycle.addObserver(resultObserver)
     }
@@ -83,8 +84,8 @@ class AuthViewModel(
         }
     }
 
-    fun login(account: Account) {
-        this.account = account
+    fun login() {
+        val account = checkNotNull(account)
 
         viewModelScope.launch {
             val config = findOAuthConfiguration(account)

--- a/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/OAuthFlowActivity.kt
+++ b/app/ui/legacy/src/main/java/com/fsck/k9/activity/setup/OAuthFlowActivity.kt
@@ -7,7 +7,6 @@ import android.widget.Button
 import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.core.view.isVisible
-import com.fsck.k9.Account
 import com.fsck.k9.preferences.AccountManager
 import com.fsck.k9.ui.R
 import com.fsck.k9.ui.base.K9Activity
@@ -40,7 +39,7 @@ class OAuthFlowActivity : K9Activity() {
         }
 
         signInButton.isVisible = true
-        signInButton.setOnClickListener { startOAuthFlow(account) }
+        signInButton.setOnClickListener { startOAuthFlow() }
 
         savedInstanceState?.let {
             val signInRunning = it.getBoolean(STATE_PROGRESS)
@@ -48,7 +47,7 @@ class OAuthFlowActivity : K9Activity() {
             signInProgress.isVisible = signInRunning
         }
 
-        authViewModel.init(activityResultRegistry, lifecycle)
+        authViewModel.init(activityResultRegistry, lifecycle, account)
 
         authViewModel.uiState.observe(this) { state ->
             handleUiUpdates(state)
@@ -87,12 +86,12 @@ class OAuthFlowActivity : K9Activity() {
         errorText.text = getString(errorTextResId, *args)
     }
 
-    private fun startOAuthFlow(account: Account) {
+    private fun startOAuthFlow() {
         signInButton.isVisible = false
         signInProgress.isVisible = true
         errorText.text = ""
 
-        authViewModel.login(account)
+        authViewModel.login()
     }
 
     override fun onSaveInstanceState(outState: Bundle) {


### PR DESCRIPTION
This will avoid a NullPointerException when the activity result is handled after recovering from a process death.

To test:
1. In Developer options set *Background process limit* to *No background processes*.
2. Launch K-9 Mail and start setting up an account using OAuth 2.0.
3. If the browser is displayed in a custom tab, select "Open in browser" from the menu.
4. Go to the home screen.
5. Go back to the browser, authenticate if necessary and authorize K-9 Mail to access the email account.
6. Without this change, the app will crash (and maybe restart automatically). With this change, the app should continue the account setup flow.

Stack trace from Google Play Developer Console (K-9 Mail 6.509):
```text
Exception java.lang.NullPointerException:
  at com.fsck.k9.activity.setup.AuthViewModel$exchangeToken$1.invokeSuspend$lambda$2 (AuthViewModel.kt:169)
  at com.fsck.k9.activity.setup.AuthViewModel$exchangeToken$1.$r8$lambda$wovrrnf-mKzKG19-4VtOs5lPFCA (AuthViewModel.kt)
  at com.fsck.k9.activity.setup.AuthViewModel$exchangeToken$1$$ExternalSyntheticLambda0.onTokenRequestCompleted (R8$$SyntheticClass)
  at net.openid.appauth.AuthorizationService$TokenRequestTask.onPostExecute (AuthorizationService.java:722)
  at net.openid.appauth.AuthorizationService$TokenRequestTask.onPostExecute (AuthorizationService.java:579)
  at android.os.AsyncTask.finish (AsyncTask.java:771)
  at android.os.AsyncTask.access$900 (AsyncTask.java:199)
  at android.os.AsyncTask$InternalHandler.handleMessage (AsyncTask.java:788)
  at android.os.Handler.dispatchMessage (Handler.java:106)
  at android.os.Looper.loopOnce (Looper.java:201)
  at android.os.Looper.loop (Looper.java:288)
  at android.app.ActivityThread.main (ActivityThread.java:8064)
  at java.lang.reflect.Method.invoke
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run (RuntimeInit.java:548)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1026)
```