### PR TITLE
Fix bug in `CharsetSupport.readToString()`

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/CharsetSupport.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/CharsetSupport.java
@@ -15,6 +15,8 @@ import java.util.Locale;
 import static com.fsck.k9.mail.internet.JisSupport.SHIFT_JIS;
 
 public class CharsetSupport {
+    private static final String DEFAULT_CHARSET = "US-ASCII";
+
     /**
      * Table for character set fall-back.
      *
@@ -23,15 +25,13 @@ public class CharsetSupport {
     private static final String[][] CHARSET_FALLBACK_MAP = new String[][] {
             // Some Android versions don't support KOI8-U
             {"koi8-u", "koi8-r"},
-            {"iso-2022-jp-[\\d]+", "iso-2022-jp"},
-            // Default fall-back is US-ASCII
-            {".*", "US-ASCII"}
+            {"iso-2022-jp-[\\d]+", "iso-2022-jp"}
     };
 
 
     static String fixupCharset(String charset, Message message) throws MessagingException {
         if (charset == null || "0".equals(charset))
-            charset = "US-ASCII";  // No encoding, so use us-ascii, which is the standard.
+            charset = DEFAULT_CHARSET;
 
         charset = charset.toLowerCase(Locale.US);
         if (charset.equals("cp932"))
@@ -91,6 +91,10 @@ public class CharsetSupport {
                     supported = false;
                 }
             }
+        }
+
+        if (!supported) {
+            charset = DEFAULT_CHARSET;
         }
 
         /*

--- a/mail/common/src/test/java/com/fsck/k9/mail/internet/CharsetSupportTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/internet/CharsetSupportTest.java
@@ -1,6 +1,10 @@
 package com.fsck.k9.mail.internet;
 
 
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -94,5 +98,25 @@ public class CharsetSupportTest {
         charsetOnMail = "shift_jis";
         expect = "x-kddi-shift_jis-2007";
         assertEquals(expect, CharsetSupport.fixupCharset(charsetOnMail, message));
+    }
+
+    @Test
+    public void readToString_withUnsupportedCharset_shouldFallBackToAscii() throws IOException {
+        InputStream inputStream = new ByteArrayInputStream("input".getBytes());
+        String charset = "unsupported";
+
+        String result = CharsetSupport.readToString(inputStream, charset);
+
+        assertEquals("input", result);
+    }
+
+    @Test
+    public void readToString_withInvalidCharset_shouldFallBackToAscii() throws IOException {
+        InputStream inputStream = new ByteArrayInputStream("input".getBytes());
+        String charset = "invalid\n";
+
+        String result = CharsetSupport.readToString(inputStream, charset);
+
+        assertEquals("input", result);
     }
 }


### PR DESCRIPTION
`charset` arguments containing a newline character didn't match the regular expression meant to always match (`.*`).