### PR TITLE
Don't parse `Content-Transfer-Encoding` as header containing named parameters

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/DefaultBodyFactory.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/DefaultBodyFactory.java
@@ -7,7 +7,6 @@ import java.io.OutputStream;
 
 import com.fsck.k9.mail.internet.BinaryTempFileBody;
 import com.fsck.k9.mail.internet.BinaryTempFileMessageBody;
-import com.fsck.k9.mail.internet.MimeUtility;
 import org.apache.commons.io.IOUtils;
 import org.apache.james.mime4j.util.MimeUtil;
 
@@ -15,10 +14,6 @@ import org.apache.james.mime4j.util.MimeUtil;
 public class DefaultBodyFactory implements BodyFactory {
     public Body createBody(String contentTransferEncoding, String contentType, InputStream inputStream)
             throws IOException {
-
-        if (contentTransferEncoding != null) {
-            contentTransferEncoding = MimeUtility.getHeaderParameter(contentTransferEncoding, null);
-        }
 
         final BinaryTempFileBody tempBody;
         if (MimeUtil.isMessage(contentType)) {


### PR DESCRIPTION
I stumbled over this when looking into the bug fixed in #6810.

`Content-Transfer-Encoding` should only have simple values like `7bit`, `8bit`, `binary`, `quoted-printable`, `base64`, etc.