### PR TITLE
Increase number of active notifications to 9

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/notification/NotificationDataStore.kt
+++ b/app/core/src/main/java/com/fsck/k9/notification/NotificationDataStore.kt
@@ -3,7 +3,7 @@ package com.fsck.k9.notification
 import com.fsck.k9.Account
 import com.fsck.k9.controller.MessageReference
 
-internal const val MAX_NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS = 8
+internal const val MAX_NUMBER_OF_NEW_MESSAGE_NOTIFICATIONS = 9
 
 /**
  * Stores information about new message notifications for all accounts.

--- a/app/core/src/test/java/com/fsck/k9/notification/NotificationDataStoreTest.kt
+++ b/app/core/src/test/java/com/fsck/k9/notification/NotificationDataStoreTest.kt
@@ -52,8 +52,9 @@ class NotificationDataStoreTest : RobolectricTest() {
         notificationDataStore.addNotification(account, createNotificationContent("6"), TIMESTAMP)
         notificationDataStore.addNotification(account, createNotificationContent("7"), TIMESTAMP)
         notificationDataStore.addNotification(account, createNotificationContent("8"), TIMESTAMP)
+        notificationDataStore.addNotification(account, createNotificationContent("9"), TIMESTAMP)
 
-        val result = notificationDataStore.addNotification(account, createNotificationContent("9"), TIMESTAMP)
+        val result = notificationDataStore.addNotification(account, createNotificationContent("10"), TIMESTAMP)
 
         assertNotNull(result)
         assertThat(result.shouldCancelNotification).isTrue()
@@ -86,7 +87,8 @@ class NotificationDataStoreTest : RobolectricTest() {
         notificationDataStore.addNotification(account, createNotificationContent("7"), TIMESTAMP)
         notificationDataStore.addNotification(account, createNotificationContent("8"), TIMESTAMP)
         notificationDataStore.addNotification(account, createNotificationContent("9"), TIMESTAMP)
-        val latestContent = createNotificationContent("10")
+        notificationDataStore.addNotification(account, createNotificationContent("10"), TIMESTAMP)
+        val latestContent = createNotificationContent("11")
         notificationDataStore.addNotification(account, latestContent, TIMESTAMP)
 
         val result = notificationDataStore.removeNotifications(account) { listOf(latestContent.messageReference) }
@@ -207,7 +209,8 @@ class NotificationDataStoreTest : RobolectricTest() {
         notificationDataStore.addNotification(account, createNotificationContent("6"), TIMESTAMP)
         notificationDataStore.addNotification(account, createNotificationContent("7"), TIMESTAMP)
         notificationDataStore.addNotification(account, createNotificationContent("8"), TIMESTAMP)
-        val latestNotificationContent = createNotificationContent("9")
+        notificationDataStore.addNotification(account, createNotificationContent("9"), TIMESTAMP)
+        val latestNotificationContent = createNotificationContent("10")
         notificationDataStore.addNotification(account, latestNotificationContent, TIMESTAMP)
         val content = createNotificationContent("1")
 


### PR DESCRIPTION
This way users can know that when the number 9 is displayed in the group summary, there's more notifications than the 8 they can currently see.

Fixes #6820