### PR TITLE
Don't fail when exporting an identity without a sender name

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
+++ b/app/core/src/main/java/com/fsck/k9/preferences/SettingsExporter.kt
@@ -329,9 +329,11 @@ class SettingsExporter(
 
         // Write name belonging to the identity
         val name = prefs[prefix + IDENTITY_NAME_KEY + suffix] as String?
-        serializer.startTag(null, NAME_ELEMENT)
-        serializer.text(name)
-        serializer.endTag(null, NAME_ELEMENT)
+        if (name != null) {
+            serializer.startTag(null, NAME_ELEMENT)
+            serializer.text(name)
+            serializer.endTag(null, NAME_ELEMENT)
+        }
 
         // Write email address belonging to the identity
         val email = prefs[prefix + IDENTITY_EMAIL_KEY + suffix] as String?


### PR DESCRIPTION
To test this, create an identity where the "Your name" field is left empty, then export settings.