### PR TITLE
Change autoconfig code to match Thunderbird's current behavior

### DIFF
--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/AutoconfigUrlProvider.kt
@@ -1,47 +1,7 @@
 package app.k9mail.autodiscovery.autoconfig
 
-import com.fsck.k9.helper.EmailHelper
 import okhttp3.HttpUrl
-import okhttp3.HttpUrl.Companion.toHttpUrl
 
-class AutoconfigUrlProvider {
-    fun getAutoconfigUrls(email: String): List<HttpUrl> {
-        val domain = EmailHelper.getDomainFromEmailAddress(email)
-        requireNotNull(domain) { "Couldn't extract domain from email address: $email" }
-
-        return listOf(
-            createProviderUrl(domain, email),
-            createDomainUrl(scheme = "https", domain),
-            createDomainUrl(scheme = "http", domain),
-            createIspDbUrl(domain),
-        )
-    }
-
-    private fun createProviderUrl(domain: String?, email: String): HttpUrl {
-        // https://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
-        return HttpUrl.Builder()
-            .scheme("https")
-            .host("autoconfig.$domain")
-            .addEncodedPathSegments("mail/config-v1.1.xml")
-            .addQueryParameter("emailaddress", email)
-            .build()
-    }
-
-    private fun createDomainUrl(scheme: String, domain: String): HttpUrl {
-        // https://{domain}/.well-known/autoconfig/mail/config-v1.1.xml
-        // http://{domain}/.well-known/autoconfig/mail/config-v1.1.xml
-        return HttpUrl.Builder()
-            .scheme(scheme)
-            .host(domain)
-            .addEncodedPathSegments(".well-known/autoconfig/mail/config-v1.1.xml")
-            .build()
-    }
-
-    private fun createIspDbUrl(domain: String): HttpUrl {
-        // https://autoconfig.thunderbird.net/v1.1/{domain}
-        return "https://autoconfig.thunderbird.net/v1.1/".toHttpUrl()
-            .newBuilder()
-            .addPathSegment(domain)
-            .build()
-    }
+interface AutoconfigUrlProvider {
+    fun getAutoconfigUrls(email: String): List<HttpUrl>
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProvider.kt
@@ -1,0 +1,22 @@
+package app.k9mail.autodiscovery.autoconfig
+
+import com.fsck.k9.helper.EmailHelper
+import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
+
+class IspDbAutoconfigUrlProvider : AutoconfigUrlProvider {
+    override fun getAutoconfigUrls(email: String): List<HttpUrl> {
+        val domain = EmailHelper.getDomainFromEmailAddress(email)
+        requireNotNull(domain) { "Couldn't extract domain from email address: $email" }
+
+        return listOf(createIspDbUrl(domain))
+    }
+
+    private fun createIspDbUrl(domain: String): HttpUrl {
+        // https://autoconfig.thunderbird.net/v1.1/{domain}
+        return "https://autoconfig.thunderbird.net/v1.1/".toHttpUrl()
+            .newBuilder()
+            .addPathSegment(domain)
+            .build()
+    }
+}

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
@@ -9,29 +9,33 @@ class ProviderAutoconfigUrlProvider : AutoconfigUrlProvider {
         requireNotNull(domain) { "Couldn't extract domain from email address: $email" }
 
         return listOf(
-            createProviderUrl(domain, email),
-            createDomainUrl(scheme = "https", domain),
-            createDomainUrl(scheme = "http", domain),
+            createProviderUrl(domain, email, useHttps = true),
+            createDomainUrl(domain, email, useHttps = true),
+
+            createProviderUrl(domain, email, useHttps = false),
+            createDomainUrl(domain, email, useHttps = false),
         )
     }
 
-    private fun createProviderUrl(domain: String?, email: String): HttpUrl {
+    private fun createProviderUrl(domain: String, email: String, useHttps: Boolean): HttpUrl {
         // https://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
+        // http://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
         return HttpUrl.Builder()
-            .scheme("https")
+            .scheme(if (useHttps) "https" else "http")
             .host("autoconfig.$domain")
             .addEncodedPathSegments("mail/config-v1.1.xml")
             .addQueryParameter("emailaddress", email)
             .build()
     }
 
-    private fun createDomainUrl(scheme: String, domain: String): HttpUrl {
-        // https://{domain}/.well-known/autoconfig/mail/config-v1.1.xml
-        // http://{domain}/.well-known/autoconfig/mail/config-v1.1.xml
+    private fun createDomainUrl(domain: String, email: String, useHttps: Boolean): HttpUrl {
+        // https://{domain}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={email}
+        // http://{domain}/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress={email}
         return HttpUrl.Builder()
-            .scheme(scheme)
+            .scheme(if (useHttps) "https" else "http")
             .host(domain)
             .addEncodedPathSegments(".well-known/autoconfig/mail/config-v1.1.xml")
+            .addQueryParameter("emailaddress", email)
             .build()
     }
 }

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
@@ -3,18 +3,20 @@ package app.k9mail.autodiscovery.autoconfig
 import com.fsck.k9.helper.EmailHelper
 import okhttp3.HttpUrl
 
-class ProviderAutoconfigUrlProvider : AutoconfigUrlProvider {
+class ProviderAutoconfigUrlProvider(private val config: AutoconfigUrlConfig) : AutoconfigUrlProvider {
     override fun getAutoconfigUrls(email: String): List<HttpUrl> {
         val domain = EmailHelper.getDomainFromEmailAddress(email)
         requireNotNull(domain) { "Couldn't extract domain from email address: $email" }
 
-        return listOf(
-            createProviderUrl(domain, email, useHttps = true),
-            createDomainUrl(domain, email, useHttps = true),
+        return buildList {
+            add(createProviderUrl(domain, email, useHttps = true))
+            add(createDomainUrl(domain, email, useHttps = true))
 
-            createProviderUrl(domain, email, useHttps = false),
-            createDomainUrl(domain, email, useHttps = false),
-        )
+            if (!config.httpsOnly) {
+                add(createProviderUrl(domain, email, useHttps = false))
+                add(createDomainUrl(domain, email, useHttps = false))
+            }
+        }
     }
 
     private fun createProviderUrl(domain: String, email: String, useHttps: Boolean): HttpUrl {
@@ -24,7 +26,11 @@ class ProviderAutoconfigUrlProvider : AutoconfigUrlProvider {
             .scheme(if (useHttps) "https" else "http")
             .host("autoconfig.$domain")
             .addEncodedPathSegments("mail/config-v1.1.xml")
-            .addQueryParameter("emailaddress", email)
+            .apply {
+                if (config.includeEmailAddress) {
+                    addQueryParameter("emailaddress", email)
+                }
+            }
             .build()
     }
 
@@ -35,7 +41,16 @@ class ProviderAutoconfigUrlProvider : AutoconfigUrlProvider {
             .scheme(if (useHttps) "https" else "http")
             .host(domain)
             .addEncodedPathSegments(".well-known/autoconfig/mail/config-v1.1.xml")
-            .addQueryParameter("emailaddress", email)
+            .apply {
+                if (config.includeEmailAddress) {
+                    addQueryParameter("emailaddress", email)
+                }
+            }
             .build()
     }
 }
+
+data class AutoconfigUrlConfig(
+    val httpsOnly: Boolean,
+    val includeEmailAddress: Boolean,
+)

--- a/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
+++ b/feature/autodiscovery/autoconfig/src/main/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProvider.kt
@@ -1,0 +1,37 @@
+package app.k9mail.autodiscovery.autoconfig
+
+import com.fsck.k9.helper.EmailHelper
+import okhttp3.HttpUrl
+
+class ProviderAutoconfigUrlProvider : AutoconfigUrlProvider {
+    override fun getAutoconfigUrls(email: String): List<HttpUrl> {
+        val domain = EmailHelper.getDomainFromEmailAddress(email)
+        requireNotNull(domain) { "Couldn't extract domain from email address: $email" }
+
+        return listOf(
+            createProviderUrl(domain, email),
+            createDomainUrl(scheme = "https", domain),
+            createDomainUrl(scheme = "http", domain),
+        )
+    }
+
+    private fun createProviderUrl(domain: String?, email: String): HttpUrl {
+        // https://autoconfig.{domain}/mail/config-v1.1.xml?emailaddress={email}
+        return HttpUrl.Builder()
+            .scheme("https")
+            .host("autoconfig.$domain")
+            .addEncodedPathSegments("mail/config-v1.1.xml")
+            .addQueryParameter("emailaddress", email)
+            .build()
+    }
+
+    private fun createDomainUrl(scheme: String, domain: String): HttpUrl {
+        // https://{domain}/.well-known/autoconfig/mail/config-v1.1.xml
+        // http://{domain}/.well-known/autoconfig/mail/config-v1.1.xml
+        return HttpUrl.Builder()
+            .scheme(scheme)
+            .host(domain)
+            .addEncodedPathSegments(".well-known/autoconfig/mail/config-v1.1.xml")
+            .build()
+    }
+}

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProviderTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/IspDbAutoconfigUrlProviderTest.kt
@@ -4,17 +4,14 @@ import assertk.assertThat
 import assertk.assertions.containsExactly
 import org.junit.Test
 
-class AutoconfigUrlProviderTest {
-    private val urlProvider = AutoconfigUrlProvider()
+class IspDbAutoconfigUrlProviderTest {
+    private val urlProvider = IspDbAutoconfigUrlProvider()
 
     @Test
     fun `getAutoconfigUrls with ASCII email address`() {
         val autoconfigUrls = urlProvider.getAutoconfigUrls("test@domain.example")
 
         assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
-            "https://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
-            "https://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
-            "http://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
             "https://autoconfig.thunderbird.net/v1.1/domain.example",
         )
     }

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
@@ -5,10 +5,11 @@ import assertk.assertions.containsExactly
 import org.junit.Test
 
 class ProviderAutoconfigUrlProviderTest {
-    private val urlProvider = ProviderAutoconfigUrlProvider()
-
     @Test
-    fun `getAutoconfigUrls with ASCII email address`() {
+    fun `getAutoconfigUrls with http allowed and email address included`() {
+        val urlProvider = ProviderAutoconfigUrlProvider(
+            AutoconfigUrlConfig(httpsOnly = false, includeEmailAddress = true),
+        )
         val autoconfigUrls = urlProvider.getAutoconfigUrls("test@domain.example")
 
         assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
@@ -16,6 +17,47 @@ class ProviderAutoconfigUrlProviderTest {
             "https://domain.example/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress=test%40domain.example",
             "http://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
             "http://domain.example/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress=test%40domain.example",
+        )
+    }
+
+    @Test
+    fun `getAutoconfigUrls with only https and email address included`() {
+        val urlProvider = ProviderAutoconfigUrlProvider(
+            AutoconfigUrlConfig(httpsOnly = true, includeEmailAddress = true),
+        )
+        val autoconfigUrls = urlProvider.getAutoconfigUrls("test@domain.example")
+
+        assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
+            "https://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
+            "https://domain.example/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress=test%40domain.example",
+        )
+    }
+
+    @Test
+    fun `getAutoconfigUrls with only https and email address not included`() {
+        val urlProvider = ProviderAutoconfigUrlProvider(
+            AutoconfigUrlConfig(httpsOnly = true, includeEmailAddress = false),
+        )
+        val autoconfigUrls = urlProvider.getAutoconfigUrls("test@domain.example")
+
+        assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
+            "https://autoconfig.domain.example/mail/config-v1.1.xml",
+            "https://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
+        )
+    }
+
+    @Test
+    fun `getAutoconfigUrls with http allowed and email address not included`() {
+        val urlProvider = ProviderAutoconfigUrlProvider(
+            AutoconfigUrlConfig(httpsOnly = false, includeEmailAddress = false),
+        )
+        val autoconfigUrls = urlProvider.getAutoconfigUrls("test@domain.example")
+
+        assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
+            "https://autoconfig.domain.example/mail/config-v1.1.xml",
+            "https://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
+            "http://autoconfig.domain.example/mail/config-v1.1.xml",
+            "http://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
         )
     }
 }

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
@@ -1,0 +1,20 @@
+package app.k9mail.autodiscovery.autoconfig
+
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import org.junit.Test
+
+class ProviderAutoconfigUrlProviderTest {
+    private val urlProvider = ProviderAutoconfigUrlProvider()
+
+    @Test
+    fun `getAutoconfigUrls with ASCII email address`() {
+        val autoconfigUrls = urlProvider.getAutoconfigUrls("test@domain.example")
+
+        assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
+            "https://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
+            "https://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
+            "http://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
+        )
+    }
+}

--- a/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
+++ b/feature/autodiscovery/autoconfig/src/test/kotlin/app/k9mail/autodiscovery/autoconfig/ProviderAutoconfigUrlProviderTest.kt
@@ -13,8 +13,9 @@ class ProviderAutoconfigUrlProviderTest {
 
         assertThat(autoconfigUrls.map { it.toString() }).containsExactly(
             "https://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
-            "https://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
-            "http://domain.example/.well-known/autoconfig/mail/config-v1.1.xml",
+            "https://domain.example/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress=test%40domain.example",
+            "http://autoconfig.domain.example/mail/config-v1.1.xml?emailaddress=test%40domain.example",
+            "http://domain.example/.well-known/autoconfig/mail/config-v1.1.xml?emailaddress=test%40domain.example",
         )
     }
 }


### PR DESCRIPTION
The set of URLs checked by Thunderbird are slightly different from what I thought when reading the documentation.

https://searchfox.org/comm-central/rev/f1c212acd8e3c3c2d1f5e2d442bb66e1407243b5/mail/components/accountcreation/FetchConfig.jsm#94-154