### PR TITLE
Switch from `Random` to `SecureRandom`

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/BoundaryGenerator.kt
+++ b/mail/common/src/main/java/com/fsck/k9/mail/BoundaryGenerator.kt
@@ -1,9 +1,9 @@
 package com.fsck.k9.mail
 
-import java.util.Random
+import java.security.SecureRandom
 import org.jetbrains.annotations.VisibleForTesting
 
-class BoundaryGenerator @VisibleForTesting internal constructor(private val random: Random) {
+class BoundaryGenerator @VisibleForTesting internal constructor(private val random: SecureRandom) {
 
     fun generateBoundary(): String {
         return buildString(4 + BOUNDARY_CHARACTER_COUNT) {
@@ -25,7 +25,7 @@ class BoundaryGenerator @VisibleForTesting internal constructor(private val rand
             'U', 'V', 'W', 'X', 'Y', 'Z',
         )
 
-        private val INSTANCE = BoundaryGenerator(Random())
+        private val INSTANCE = BoundaryGenerator(SecureRandom())
 
         @JvmStatic
         fun getInstance() = INSTANCE

--- a/mail/common/src/test/java/com/fsck/k9/mail/BoundaryGeneratorTest.kt
+++ b/mail/common/src/test/java/com/fsck/k9/mail/BoundaryGeneratorTest.kt
@@ -2,7 +2,7 @@ package com.fsck.k9.mail
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import java.util.Random
+import java.security.SecureRandom
 import org.junit.Test
 import org.mockito.kotlin.mock
 
@@ -29,7 +29,7 @@ class BoundaryGeneratorTest {
         assertThat(result).isEqualTo("----0123456789ABCDEFGHIJKLMNOPQRSZ")
     }
 
-    private fun createRandom(vararg values: Int): Random {
+    private fun createRandom(vararg values: Int): SecureRandom {
         return mock {
             var ongoingStubbing = on { nextInt(36) }
             for (value in values) {


### PR DESCRIPTION
`BoundaryGenerator`'s use of `java.util.Random` isn't security critical. But changing to `java.security.SecureRandom` avoids warnings by security scanners.