### PR TITLE
Don't use Push when the app doesn't have permission to schedule exact alarms

### DIFF
--- a/app/core/src/main/java/com/fsck/k9/helper/AlarmManagerCompat.kt
+++ b/app/core/src/main/java/com/fsck/k9/helper/AlarmManagerCompat.kt
@@ -5,6 +5,14 @@ import android.app.PendingIntent
 import android.os.Build
 
 class AlarmManagerCompat(private val alarmManager: AlarmManager) {
+    fun canScheduleExactAlarms(): Boolean {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            alarmManager.canScheduleExactAlarms()
+        } else {
+            true
+        }
+    }
+
     fun scheduleAlarm(triggerAtMillis: Long, operation: PendingIntent) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             alarmManager.setExactAndAllowWhileIdle(AlarmManager.ELAPSED_REALTIME_WAKEUP, triggerAtMillis, operation)

--- a/app/k9mail/src/main/java/com/fsck/k9/backends/AndroidAlarmManager.kt
+++ b/app/k9mail/src/main/java/com/fsck/k9/backends/AndroidAlarmManager.kt
@@ -57,6 +57,10 @@ class AndroidAlarmManager(
         )
     }
 
+    override fun canScheduleExactAlarms(): Boolean {
+        return alarmManager.canScheduleExactAlarms()
+    }
+
     override fun setAlarm(triggerTime: Long, callback: Callback) {
         this.callback.set(callback)
         alarmManager.scheduleAlarm(triggerTime, pendingIntent)

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/BackendIdleRefreshManager.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/BackendIdleRefreshManager.kt
@@ -19,6 +19,10 @@ class BackendIdleRefreshManager(private val alarmManager: SystemAlarmManager) : 
     private var minTimeout = Long.MAX_VALUE
     private var minTimeoutTimestamp = 0L
 
+    override fun canScheduleTimers(): Boolean {
+        return alarmManager.canScheduleExactAlarms()
+    }
+
     @Synchronized
     override fun startTimer(timeout: Long, callback: Callback): IdleRefreshTimer {
         require(timeout > MIN_TIMER_DELTA) { "Timeout needs to be greater than $MIN_TIMER_DELTA ms" }

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/ImapBackendPusher.kt
@@ -50,6 +50,11 @@ internal class ImapBackendPusher(
     private var currentIdleRefreshMs = 15 * 60 * 1000L
 
     override fun start() {
+        if (!idleRefreshManager.canScheduleTimers()) {
+            Timber.v("Not starting ImapBackendPusher for %s because the app can't schedule timers", accountName)
+            return
+        }
+
         coroutineScope.launch {
             pushConfigProvider.maxPushFoldersFlow.collect { maxPushFolders ->
                 currentMaxPushFolders = maxPushFolders

--- a/backend/imap/src/main/java/com/fsck/k9/backend/imap/SystemAlarmManager.kt
+++ b/backend/imap/src/main/java/com/fsck/k9/backend/imap/SystemAlarmManager.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.backend.imap
 
 interface SystemAlarmManager {
+    fun canScheduleExactAlarms(): Boolean
     fun setAlarm(triggerTime: Long, callback: () -> Unit)
     fun cancelAlarm()
     fun now(): Long

--- a/backend/imap/src/test/java/com/fsck/k9/backend/imap/BackendIdleRefreshManagerTest.kt
+++ b/backend/imap/src/test/java/com/fsck/k9/backend/imap/BackendIdleRefreshManagerTest.kt
@@ -156,6 +156,10 @@ class MockSystemAlarmManager(startTime: Long) : SystemAlarmManager {
     var callback: Callback? = null
     val alarmTimes = mutableListOf<Long>()
 
+    override fun canScheduleExactAlarms(): Boolean {
+        throw UnsupportedOperationException("not implemented")
+    }
+
     override fun setAlarm(triggerTime: Long, callback: () -> Unit) {
         this.triggerTime = triggerTime
         this.callback = callback

--- a/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/IdleRefreshManager.kt
+++ b/mail/protocols/imap/src/main/java/com/fsck/k9/mail/store/imap/IdleRefreshManager.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.mail.store.imap
 
 interface IdleRefreshManager {
+    fun canScheduleTimers(): Boolean
     fun startTimer(timeout: Long, callback: () -> Unit): IdleRefreshTimer
     fun resetTimers()
 }

--- a/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestIdleRefreshManager.kt
+++ b/mail/protocols/imap/src/test/java/com/fsck/k9/mail/store/imap/TestIdleRefreshManager.kt
@@ -1,7 +1,13 @@
 package com.fsck.k9.mail.store.imap
 
-class TestIdleRefreshManager : IdleRefreshManager {
+class TestIdleRefreshManager(
+    private val areTimersSupported: Boolean = true,
+) : IdleRefreshManager {
     private val timers = mutableListOf<TestIdleRefreshTimer>()
+
+    override fun canScheduleTimers(): Boolean {
+        return areTimersSupported
+    }
 
     @Synchronized
     override fun startTimer(timeout: Long, callback: () -> Unit): TestIdleRefreshTimer {


### PR DESCRIPTION
Don't try to schedule exact alarms on Android 14 when we don't have permission to do so. For a proper fix, see #7363.

Fixes #7395