### PR TITLE
Fix of "Configure manually" distracts users to hit the "Next" button

### DIFF
--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultHeaderView.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultHeaderView.kt
@@ -50,7 +50,6 @@ internal fun AutoDiscoveryResultHeaderView(
             )
             TextBodyMedium(
                 text = stringResource(state.subtitleResourceId),
-                color = selectColor(state),
             )
         }
         if (state.isExpandable) {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultView.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultView.kt
@@ -25,6 +25,14 @@ internal fun AutoDiscoveryResultView(
         mutableStateOf(settings?.isTrusted?.not() ?: false)
     }
 
+    val discoveryResultHeaderState = if (settings == null) {
+        AutoDiscoveryResultHeaderState.NoSettings
+    } else if (settings.isTrusted) {
+        AutoDiscoveryResultHeaderState.Trusted
+    } else {
+        AutoDiscoveryResultHeaderState.Untrusted
+    }
+
     Column(
         modifier = modifier,
     ) {
@@ -36,19 +44,13 @@ internal fun AutoDiscoveryResultView(
                     color = Color.Gray.copy(alpha = 0.5f),
                     shape = MainTheme.shapes.small,
                 )
-                .clickable { expanded.value = !expanded.value },
+                .clickable(enabled = discoveryResultHeaderState.isExpandable) { expanded.value = !expanded.value },
         ) {
             Column(
                 modifier = Modifier.padding(MainTheme.spacings.default),
             ) {
                 AutoDiscoveryResultHeaderView(
-                    state = if (settings == null) {
-                        AutoDiscoveryResultHeaderState.NoSettings
-                    } else if (settings.isTrusted) {
-                        AutoDiscoveryResultHeaderState.Trusted
-                    } else {
-                        AutoDiscoveryResultHeaderState.Untrusted
-                    },
+                    state = discoveryResultHeaderState,
                     isExpanded = expanded.value,
                 )
 


### PR DESCRIPTION
In manual mail configuration screen made the following update:
1: Toggle click ripple effect  on "Configure manually" based on configuration availability.
2: Custom color removal of the text "Configure manually" so it doesn't feel like link anymore.
- Fixes #8512 