### PR TITLE
Fix markdown

### DIFF
--- a/build-plugin/src/main/kotlin/SpotlessExtension.kt
+++ b/build-plugin/src/main/kotlin/SpotlessExtension.kt
@@ -40,7 +40,13 @@ fun SpotlessExtension.configureMarkdownCheck(
     targets: List<String>,
 ) {
     format("markdown") {
-        prettier()
+        // Set the prettier version explicitly, as the default version set in Spotless is outdated.
+        // Check https://github.com/prettier/prettier for the latest version and update the version here.
+        prettier("3.3.3").config(
+            mapOf(
+                "parser" to "markdown",
+            )
+        )
         target(targets)
         targetExclude(
             "**/build/",


### PR DESCRIPTION
This is an attempt to fix the markdown formatting check failure by settings the prettier version explicitly and limit the parser to markdown.