### PR TITLE
Fix #8241: Ensure UI back button navigates to Drafts folder when editing a draft

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1008,7 +1008,7 @@ public class MessageCompose extends K9Activity implements OnClickListener,
             if (draftMessageId == null) {
                 onDiscard();
             } else {
-                if (navigateUp) {
+                if (navigateUp && this.action != action.EDIT_DRAFT) {
                     openDefaultFolder();
                 } else {
                     super.onBackPressed();


### PR DESCRIPTION
### Issue
Fixes #8241: Closing a draft via Thunderbird's back button navigates to the inbox instead of the drafts folder.

### Summary of Changes
Modified the `prepareToFinish` method in `MessageCompose.java` to check if the current action is `EDIT_DRAFT`. If so, the UI back button uses `super.onBackPressed()` instead of `openDefaultFolder()`, ensuring the user is navigated back to the Drafts folder instead of the Inbox. This makes the UI back button behavior consistent with the system back button.

### Testing
- Tested manually by opening an existing draft, pressing the UI back button, and verifying navigation to the Drafts folder.
- Tested other flows (e.g., creating a new message, replying to a message) to ensure they are unaffected.
- Ran `./gradlew test` to confirm no regressions in existing tests.

### Additional Notes
I did not add new tests for this change, as it involves navigation behavior that may require UI/integration testing. I'm happy to add tests if the team provides guidance on how to test this scenario.