### PR TITLE
Fix crash on Android 7 when fetching emails.

### DIFF
--- a/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
@@ -31,7 +31,7 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring(libs.android.desugar)
+    coreLibraryDesugaring(libs.android.desugar.nio)
 
     implementation(platform(libs.kotlin.bom))
     implementation(platform(libs.koin.bom))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -126,6 +126,7 @@ spotless = { id = "com.diffplug.spotless", version.ref = "spotlessPlugin" }
 android-billing = { module = "com.android.billingclient:billing", version.ref = "androidBilling" }
 android-billing-ktx = { module = "com.android.billingclient:billing-ktx", version.ref = "androidBilling" }
 android-desugar = { module = "com.android.tools:desugar_jdk_libs", version.ref = "androidDesugar" }
+android-desugar-nio = { module = "com.android.tools:desugar_jdk_libs_nio", version.ref = "androidDesugar" }
 android-material = { module = "com.google.android.material:material", version.ref = "androidMaterial" }
 android-tools-common = { module = "com.android.tools:common", version.ref = "androidTools" }
 androidx-activity = { module = "androidx.activity:activity", version.ref = "androidxActivity" }


### PR DESCRIPTION
Fixes https://github.com/thunderbird/thunderbird-android/issues/9184

It appears that `desugar_jdk_libs` has been split into three different configurations. The default one no longer supports desugaring for `java.nio` packages.

See the following for more details:
- [CHANGELOG – Version 2.0.0 (2022-09-16)](https://github.com/google/desugar_jdk_libs/blob/master/CHANGELOG.md#version-200-2022-09-16)
- [Java 11+ NIO support in Android desugaring](https://developer.android.com/studio/write/java11-nio-support-table)