### PR TITLE
chore(in-app-notifications): add `display_in_app_notification` and `use_notification_sender_for_system_notifications` feature flag

### DIFF
--- a/app-k9mail/src/debug/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
@@ -2,6 +2,7 @@ package app.k9mail.featureflag
 
 import net.thunderbird.core.featureflag.FeatureFlag
 import net.thunderbird.core.featureflag.FeatureFlagFactory
+import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.toFeatureFlagKey
 
 class K9FeatureFlagFactory : FeatureFlagFactory {
@@ -13,6 +14,8 @@ class K9FeatureFlagFactory : FeatureFlagFactory {
             FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer_ui".toFeatureFlagKey(), enabled = true),
+            FeatureFlag(FeatureFlagKey.DisplayInAppNotifications, enabled = true),
+            FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = true),
         )
     }
 }

--- a/app-k9mail/src/release/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
+++ b/app-k9mail/src/release/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
@@ -2,6 +2,7 @@ package app.k9mail.featureflag
 
 import net.thunderbird.core.featureflag.FeatureFlag
 import net.thunderbird.core.featureflag.FeatureFlagFactory
+import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.toFeatureFlagKey
 
 class K9FeatureFlagFactory : FeatureFlagFactory {
@@ -13,6 +14,8 @@ class K9FeatureFlagFactory : FeatureFlagFactory {
             FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = false),
             FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = false),
             FeatureFlag("enable_dropdown_drawer_ui".toFeatureFlagKey(), enabled = false),
+            FeatureFlag(FeatureFlagKey.DisplayInAppNotifications, enabled = false),
+            FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = false),
         )
     }
 }

--- a/app-thunderbird/src/beta/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/beta/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -2,6 +2,7 @@ package net.thunderbird.android.featureflag
 
 import net.thunderbird.core.featureflag.FeatureFlag
 import net.thunderbird.core.featureflag.FeatureFlagFactory
+import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.toFeatureFlagKey
 
 /**
@@ -16,6 +17,8 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
             FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer_ui".toFeatureFlagKey(), enabled = false),
+            FeatureFlag(FeatureFlagKey.DisplayInAppNotifications, enabled = true),
+            FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = false),
         )
     }
 }

--- a/app-thunderbird/src/daily/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/daily/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -2,6 +2,7 @@ package net.thunderbird.android.featureflag
 
 import net.thunderbird.core.featureflag.FeatureFlag
 import net.thunderbird.core.featureflag.FeatureFlagFactory
+import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.toFeatureFlagKey
 
 /**
@@ -16,6 +17,8 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
             FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer_ui".toFeatureFlagKey(), enabled = true),
+            FeatureFlag(FeatureFlagKey.DisplayInAppNotifications, enabled = true),
+            FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = true),
         )
     }
 }

--- a/app-thunderbird/src/debug/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/debug/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -2,6 +2,7 @@ package net.thunderbird.android.featureflag
 
 import net.thunderbird.core.featureflag.FeatureFlag
 import net.thunderbird.core.featureflag.FeatureFlagFactory
+import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.toFeatureFlagKey
 
 /**
@@ -16,6 +17,8 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
             FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = true),
             FeatureFlag("enable_dropdown_drawer_ui".toFeatureFlagKey(), enabled = true),
+            FeatureFlag(FeatureFlagKey.DisplayInAppNotifications, enabled = true),
+            FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = true),
         )
     }
 }

--- a/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -2,6 +2,7 @@ package net.thunderbird.android.featureflag
 
 import net.thunderbird.core.featureflag.FeatureFlag
 import net.thunderbird.core.featureflag.FeatureFlagFactory
+import net.thunderbird.core.featureflag.FeatureFlagKey
 import net.thunderbird.core.featureflag.toFeatureFlagKey
 
 /**
@@ -16,6 +17,8 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
             FeatureFlag("email_notification_default".toFeatureFlagKey(), enabled = false),
             FeatureFlag("enable_dropdown_drawer".toFeatureFlagKey(), enabled = false),
             FeatureFlag("enable_dropdown_drawer_ui".toFeatureFlagKey(), enabled = false),
+            FeatureFlag(FeatureFlagKey.DisplayInAppNotifications, enabled = false),
+            FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = false),
         )
     }
 }

--- a/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/FeatureFlagKey.kt
+++ b/core/featureflag/src/commonMain/kotlin/net/thunderbird/core/featureflag/FeatureFlagKey.kt
@@ -1,6 +1,12 @@
 package net.thunderbird.core.featureflag
 
 @JvmInline
-value class FeatureFlagKey(val key: String)
+value class FeatureFlagKey(val key: String) {
+    companion object Keys {
+        val DisplayInAppNotifications = "display_in_app_notifications".toFeatureFlagKey()
+        val UseNotificationSenderForSystemNotifications =
+            "use_notification_sender_for_system_notifications".toFeatureFlagKey()
+    }
+}
 
 fun String.toFeatureFlagKey(): FeatureFlagKey = FeatureFlagKey(this)


### PR DESCRIPTION
Resolves #9421.

- Add  `display_in_app_notifications` feature flag enabled on debug, daily, beta
- Add `use_notification_sender_for_system_notifications` feature flag enabled on debug, daily.
- Add companion object `Keys` to `FeatureFlagKey` to centralize feature flag keys and avoid possible typo when checking if Feature flag is enabled via `FeatureFlagProvider`.