### PR TITLE
fix: add gradle jvm flags to suppress sharing warnings

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,8 @@ android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 # Gradle
 ## Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750
-org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx8g -Xms8g
+## To remove warnings about "Sharing is only supported for boot loader classes", these properties have been added: -XX:+IgnoreUnrecognizedVMOptions -XX:+SuppressCDSWarning
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx8g -Xms8g -XX:+IgnoreUnrecognizedVMOptions -XX:+SuppressCDSWarning
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true


### PR DESCRIPTION
Added JVM options `-XX:+IgnoreUnrecognizedVMOptions` and `-XX:+SuppressCDSWarning` to suppress warnings about "Sharing is only supported for boot loader classes" during Gradle builds.

Fixes #9465