### PR TITLE
Disable edge to edge in Preferences

### DIFF
--- a/legacy/ui/legacy/src/main/res/layout/activity_account_settings.xml
+++ b/legacy/ui/legacy/src/main/res/layout/activity_account_settings.xml
@@ -5,6 +5,7 @@
     android:layout_width="fill_parent"
     android:layout_height="fill_parent"
     android:orientation="vertical"
+    android:fitsSystemWindows="true"
     tools:context=".settings.account.AccountSettingsActivity"
     >
 


### PR DESCRIPTION
Fix #9587 

Take safe area into account to not hide items under Android 16
