### PR TITLE
feat(notifications): add banner inline notification host composable

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/BannerNotificationCardDefaults.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/BannerNotificationCardDefaults.kt
@@ -20,6 +20,8 @@ import app.k9mail.core.ui.compose.theme2.MainTheme
  * Contains the default values used by [BannerInlineNotificationCard] and [BannerGlobalNotificationCard] types
  */
 object BannerNotificationCardDefaults {
+    const val TEST_TAG_BANNER_INLINE_CARD_ACTION_ROW = "banner_inline_card_action_row"
+
     /** The default shape of the [BannerGlobalNotificationCard] */
     val bannerGlobalShape: Shape = RectangleShape
 

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/BannerInlineNotificationCard.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/organism/banner/inline/BannerInlineNotificationCard.kt
@@ -20,8 +20,10 @@ import app.k9mail.core.ui.compose.designsystem.atom.card.CardOutlined
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextBodyMedium
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleSmall
 import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificationCardDefaults
+import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificationCardDefaults.TEST_TAG_BANNER_INLINE_CARD_ACTION_ROW
 import app.k9mail.core.ui.compose.theme2.LocalContentColor
 import app.k9mail.core.ui.compose.theme2.MainTheme
+import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 
 private const val MAX_TITLE_LENGTH = 100
 private const val MAX_SUPPORTING_TEXT_LENGTH = 200
@@ -131,7 +133,9 @@ internal fun BannerInlineNotificationCard(
                     alignment = Alignment.End,
                 ),
                 verticalAlignment = Alignment.CenterVertically,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTagAsResourceId(TEST_TAG_BANNER_INLINE_CARD_ACTION_ROW),
             ) {
                 CompositionLocalProvider(LocalContentColor provides colors.contentColor) {
                     actions()

--- a/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/BannerInlineNotificationListHost.kt
+++ b/feature/notification/api/src/androidMain/kotlin/net/thunderbird/feature/notification/api/ui/BannerInlineNotificationListHost.kt
@@ -1,0 +1,144 @@
+package net.thunderbird.feature.notification.api.ui
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.molecule.notification.NotificationActionButton
+import app.k9mail.core.ui.compose.designsystem.organism.banner.inline.BannerInlineNotificationCardBehaviour
+import app.k9mail.core.ui.compose.designsystem.organism.banner.inline.ErrorBannerInlineNotificationCard
+import app.k9mail.core.ui.compose.theme2.MainTheme
+import kotlinx.collections.immutable.ImmutableSet
+import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
+import net.thunderbird.feature.notification.api.ui.BannerInlineNotificationListHostDefaults.TEST_TAG_BANNER_INLINE_LIST
+import net.thunderbird.feature.notification.api.ui.BannerInlineNotificationListHostDefaults.TEST_TAG_CHECK_ERROR_NOTIFICATIONS
+import net.thunderbird.feature.notification.api.ui.BannerInlineNotificationListHostDefaults.TEST_TAG_HOST_PARENT
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.api.ui.action.ResolvedNotificationActionButton
+import net.thunderbird.feature.notification.api.ui.animation.bannerSlideInSlideOutAnimationSpec
+import net.thunderbird.feature.notification.api.ui.host.InAppNotificationHostStateHolder
+import net.thunderbird.feature.notification.api.ui.host.visual.BannerInlineVisual
+import net.thunderbird.feature.notification.resources.api.Res
+import net.thunderbird.feature.notification.resources.api.banner_inline_notification_check_error_notifications
+import net.thunderbird.feature.notification.resources.api.banner_inline_notification_open_notifications
+import net.thunderbird.feature.notification.resources.api.banner_inline_notification_some_messages_need_attention
+import org.jetbrains.compose.resources.stringResource
+
+private const val MAX_VISIBLE_NOTIFICATIONS = 2
+
+/**
+ * Displays a list of banner inline notifications.
+ *
+ * This composable function is responsible for rendering a list of banner inline notifications,
+ * which are typically used to display important information or alerts to the user within the app's UI.
+ *
+ * It observes the state of banner inline notifications from the [hostStateHolder] and updates the UI accordingly.
+ * The notifications are displayed with an animation when they appear or disappear.
+ *
+ * If there are more notifications than the maximum allowed to be displayed ([MAX_VISIBLE_NOTIFICATIONS]),
+ * a summary notification is shown, prompting the user to open the full list of error notifications.
+ *
+ * @param hostStateHolder The [InAppNotificationHostStateHolder] that manages the state of in-app notifications.
+ * @param onActionClick A callback function that is invoked when an action button on a notification is clicked.
+ * It receives the [NotificationAction] associated with the clicked button.
+ * @param onOpenErrorNotificationsClick A callback function that is invoked when the "Open Notifications" button
+ * on the summary notification (if shown) is clicked.
+ * @param modifier An optional [Modifier] to be applied to the root container of the notification list.
+ *
+ * @see BannerInlineNotificationListHostLayout
+ * @see ErrorBannerInlineNotificationCard
+ * @see MAX_VISIBLE_NOTIFICATIONS
+ */
+@Composable
+fun BannerInlineNotificationListHost(
+    hostStateHolder: InAppNotificationHostStateHolder,
+    onActionClick: (NotificationAction) -> Unit,
+    onOpenErrorNotificationsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val state by hostStateHolder.currentInAppNotificationHostState.collectAsState()
+    val bannerInlineSet = state.bannerInlineVisuals
+    AnimatedContent(
+        targetState = bannerInlineSet,
+        modifier = modifier.testTagAsResourceId(TEST_TAG_HOST_PARENT),
+        transitionSpec = { bannerSlideInSlideOutAnimationSpec() },
+    ) { bannerInlineSet ->
+        if (bannerInlineSet.isNotEmpty()) {
+            BannerInlineNotificationListHostLayout(
+                visuals = bannerInlineSet,
+                onActionClick = onActionClick,
+                onOpenErrorNotificationsClick = onOpenErrorNotificationsClick,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        }
+    }
+}
+
+@Composable
+private fun BannerInlineNotificationListHostLayout(
+    visuals: ImmutableSet<BannerInlineVisual>,
+    onActionClick: (NotificationAction) -> Unit,
+    onOpenErrorNotificationsClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val displayableNotifications = remember(visuals) {
+        if (visuals.size > MAX_VISIBLE_NOTIFICATIONS) {
+            visuals.take(MAX_VISIBLE_NOTIFICATIONS - 1)
+        } else {
+            visuals
+        }
+    }
+    val leftOver = remember(visuals) { visuals.size - MAX_VISIBLE_NOTIFICATIONS }
+    Column(
+        modifier = modifier
+            .padding(vertical = MainTheme.spacings.half, horizontal = MainTheme.spacings.double)
+            .testTagAsResourceId(TEST_TAG_BANNER_INLINE_LIST),
+        verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+    ) {
+        displayableNotifications.forEach { banner ->
+            ErrorBannerInlineNotificationCard(
+                title = banner.title,
+                supportingText = banner.supportingText,
+                actions = {
+                    banner.actions.forEach { action ->
+                        ResolvedNotificationActionButton(
+                            action = action,
+                            onActionClick = onActionClick,
+                        )
+                    }
+                },
+                behaviour = BannerInlineNotificationCardBehaviour.Clipped,
+            )
+        }
+
+        if (leftOver > 0) {
+            ErrorBannerInlineNotificationCard(
+                title = stringResource(resource = Res.string.banner_inline_notification_check_error_notifications),
+                supportingText = stringResource(
+                    resource = Res.string.banner_inline_notification_some_messages_need_attention,
+                ),
+                actions = {
+                    NotificationActionButton(
+                        text = stringResource(
+                            resource = Res.string.banner_inline_notification_open_notifications,
+                        ),
+                        onClick = onOpenErrorNotificationsClick,
+                    )
+                },
+                modifier = Modifier.testTagAsResourceId(TEST_TAG_CHECK_ERROR_NOTIFICATIONS),
+            )
+        }
+    }
+}
+
+object BannerInlineNotificationListHostDefaults {
+    internal const val TEST_TAG_HOST_PARENT = "banner_inline_notification_host"
+    internal const val TEST_TAG_BANNER_INLINE_LIST = "banner_inline_notification_list"
+    internal const val TEST_TAG_CHECK_ERROR_NOTIFICATIONS = "check_notifications_composable"
+}

--- a/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerGlobalNotificationHostTest.kt
+++ b/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerGlobalNotificationHostTest.kt
@@ -38,7 +38,7 @@ import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyles
 import net.thunderbird.feature.notification.testing.fake.FakeInAppOnlyNotification
 import net.thunderbird.feature.notification.testing.fake.ui.action.createFakeNotificationAction
 
-const val BUTTON_NOTIFICATION_TEST_TAG = "button_notification_test_tag"
+private const val BUTTON_NOTIFICATION_TEST_TAG = "button_notification_test_tag"
 
 class BannerGlobalNotificationHostTest : ComposeTest() {
     @Test

--- a/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerInlineNotificationListHostTest.kt
+++ b/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerInlineNotificationListHostTest.kt
@@ -1,0 +1,419 @@
+package net.thunderbird.feature.notification.api.ui
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.SemanticsProperties
+import androidx.compose.ui.test.SemanticsMatcher
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionCollection
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.assertIsNotDisplayed
+import androidx.compose.ui.test.filterToOne
+import androidx.compose.ui.test.hasClickAction
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasTextExactly
+import androidx.compose.ui.test.onChildAt
+import androidx.compose.ui.test.onChildren
+import androidx.compose.ui.test.onRoot
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.printToString
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
+import app.k9mail.core.ui.compose.designsystem.organism.banner.BannerNotificationCardDefaults.TEST_TAG_BANNER_INLINE_CARD_ACTION_ROW
+import app.k9mail.core.ui.compose.testing.ComposeTest
+import app.k9mail.core.ui.compose.testing.onNodeWithTag
+import app.k9mail.core.ui.compose.testing.onNodeWithText
+import app.k9mail.core.ui.compose.testing.setContentWithTheme
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
+import net.thunderbird.feature.notification.api.ui.action.NotificationAction
+import net.thunderbird.feature.notification.api.ui.host.rememberInAppNotificationHostState
+import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyles
+import net.thunderbird.feature.notification.testing.fake.FakeInAppOnlyNotification
+import net.thunderbird.feature.notification.testing.fake.ui.action.createFakeNotificationAction
+import org.jetbrains.compose.resources.PreviewContextConfigurationEffect
+
+private const val BUTTON_NOTIFICATION_TEST_TAG = "button_notification_test_tag"
+
+@Suppress("MaxLineLength")
+class BannerInlineNotificationListHostTest : ComposeTest() {
+    @Test
+    fun `should display banner inline notification list`() = runComposeTest {
+        // Arrange
+        val title = "Notification in test"
+        val supportingText = "The supporting text"
+        val action = createFakeNotificationAction(title = "Action 1")
+        val notification = createNotification(title = title, supportingText = supportingText, actions = setOf(action))
+        mainClock.autoAdvance = false
+        setContentWithTheme {
+            Column {
+                val state = rememberInAppNotificationHostState()
+                ButtonText(
+                    text = "Trigger Notification",
+                    onClick = {
+                        state.showInAppNotification(notification)
+                    },
+                    modifier = Modifier.testTagAsResourceId(BUTTON_NOTIFICATION_TEST_TAG),
+                )
+                BannerInlineNotificationListHost(
+                    hostStateHolder = state,
+                    onActionClick = { },
+                    onOpenErrorNotificationsClick = { },
+                )
+            }
+        }
+
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+
+        // Advance Animation
+        mainClock.advanceTimeBy(10000L)
+
+        // Assert
+        printSemanticTree()
+        onNodeWithTag(BannerInlineNotificationListHostDefaults.TEST_TAG_HOST_PARENT)
+            .assertIsDisplayed()
+
+        val listHost = onNodeWithTag(
+            BannerInlineNotificationListHostDefaults.TEST_TAG_BANNER_INLINE_LIST,
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+
+        listHost
+            .onChildren()
+            .assertCountEquals(1)
+
+        listHost.assertBannerInline(
+            index = 0,
+            title = title,
+            supportingText = supportingText,
+            assertActions = {
+                assertCountEquals(1)
+                val actionButton = filterToOne(
+                    matcher = SemanticsMatcher.expectValue(
+                        key = SemanticsProperties.Role,
+                        expectedValue = Role.Button,
+                    ) and hasClickAction(),
+                ).assertIsDisplayed()
+
+                actionButton
+                    .onChildren()
+                    .filterToOne(hasTextExactly(action.title))
+                    .assertIsDisplayed()
+            },
+        )
+
+        onNodeWithTag(BannerInlineNotificationListHostDefaults.TEST_TAG_CHECK_ERROR_NOTIFICATIONS)
+            .assertIsNotDisplayed()
+    }
+
+    @Test
+    fun `should display banner inline notification list with all banners when there are 2 notifications`() =
+        runComposeTest {
+            // Arrange
+            val notification1 = createNotification(title = "Notification 1", supportingText = "The supporting text")
+            val notification2 = createNotification(title = "Notification 2", supportingText = "The supporting text")
+            val notifications = listOf(notification1, notification2)
+
+            mainClock.autoAdvance = false
+            setContentWithPreviewAndResources {
+                TestSubject(notifications = notifications)
+            }
+
+            // Act
+            onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+
+            // Advance Animation
+            mainClock.advanceTimeBy(1000L)
+
+            // Assert
+            printSemanticTree()
+            onNodeWithTag(BannerInlineNotificationListHostDefaults.TEST_TAG_HOST_PARENT)
+                .assertIsDisplayed()
+
+            val listHost = onNodeWithTag(
+                BannerInlineNotificationListHostDefaults.TEST_TAG_BANNER_INLINE_LIST,
+                useUnmergedTree = true,
+            ).assertIsDisplayed()
+
+            listHost
+                .onChildren()
+                .assertCountEquals(2)
+
+            listHost.assertBannerInline(
+                index = 0,
+                title = notification1.title,
+                supportingText = requireNotNull(notification1.contentText),
+                assertActions = { assertCountEquals(2) },
+            )
+
+            listHost.assertBannerInline(
+                index = 1,
+                title = notification2.title,
+                supportingText = requireNotNull(notification2.contentText),
+                assertActions = { assertCountEquals(2) },
+            )
+        }
+
+    @Test
+    fun `should display banner inline notification list with check notification banner when there are more than 2 notifications`() =
+        runComposeTest {
+            // Arrange
+            val notification1 = createNotification(title = "Notification 1", supportingText = "The supporting text")
+            val notification2 = createNotification(title = "Notification 2", supportingText = "The supporting text")
+            val notification3 = createNotification(title = "Notification 3", supportingText = "The supporting text")
+            val notifications = listOf(notification1, notification2, notification3)
+            mainClock.autoAdvance = false
+            setContentWithPreviewAndResources {
+                TestSubject(notifications = notifications)
+            }
+
+            // Act
+            onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+
+            // Advance Animation
+            mainClock.advanceTimeBy(1000L)
+
+            // Assert
+            printSemanticTree()
+            onNodeWithTag(BannerInlineNotificationListHostDefaults.TEST_TAG_HOST_PARENT)
+                .assertIsDisplayed()
+
+            val listHost = onNodeWithTag(
+                BannerInlineNotificationListHostDefaults.TEST_TAG_BANNER_INLINE_LIST,
+                useUnmergedTree = true,
+            ).assertIsDisplayed()
+
+            listHost
+                .onChildren()
+                .assertCountEquals(2)
+
+            listHost.assertBannerInline(
+                index = 0,
+                title = notification1.title,
+                supportingText = requireNotNull(notification1.contentText),
+                assertActions = { assertCountEquals(2) },
+            )
+
+            listHost.assertBannerInline(
+                index = 1,
+                title = "Check Error Notifications",
+                supportingText = "Some messages need your attention.",
+                assertActions = {
+                    assertCountEquals(1)
+                    val actionButton = filterToOne(
+                        matcher = SemanticsMatcher.expectValue(
+                            key = SemanticsProperties.Role,
+                            expectedValue = Role.Button,
+                        ) and hasClickAction(),
+                    ).assertIsDisplayed()
+
+                    actionButton
+                        .onChildren()
+                        .filterToOne(hasTextExactly("Open notifications"))
+                        .assertIsDisplayed()
+                },
+            )
+        }
+
+    @Test
+    fun `should trigger onActionClick when action button is clicked`() = runComposeTest {
+        // Arrange
+        val title = "Notification in test"
+        val supportingText = "The supporting text"
+        val action = createFakeNotificationAction(title = "Action 1")
+        val notification = createNotification(title = title, supportingText = supportingText, actions = setOf(action))
+        mainClock.autoAdvance = false
+        val actionClicked = mutableStateOf<NotificationAction?>(value = null)
+        setContentWithTheme {
+            TestSubject(
+                notifications = listOf(notification),
+                onActionClick = { notification -> actionClicked.value = notification },
+            )
+        }
+
+        // Act
+        onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+        // Advance Animation
+        mainClock.advanceTimeBy(1000L)
+        onNodeWithText(action.title).performClick()
+
+        // Assert
+        printSemanticTree()
+        onNodeWithTag(BannerInlineNotificationListHostDefaults.TEST_TAG_HOST_PARENT)
+            .assertIsDisplayed()
+
+        val listHost = onNodeWithTag(
+            BannerInlineNotificationListHostDefaults.TEST_TAG_BANNER_INLINE_LIST,
+            useUnmergedTree = true,
+        ).assertIsDisplayed()
+
+        listHost
+            .onChildren()
+            .assertCountEquals(1)
+
+        listHost.assertBannerInline(
+            index = 0,
+            title = title,
+            supportingText = supportingText,
+            assertActions = { assertCountEquals(1) },
+        )
+
+        assertThat(actionClicked.value)
+            .isEqualTo(action)
+    }
+
+    @Test
+    fun `should trigger onOpenErrorNotificationsClick when open error notifications button is clicked`() =
+        runComposeTest {
+            // Arrange
+            val notifications = List(size = 3) { index ->
+                createNotification(
+                    title = "Notification $index",
+                    supportingText = "The supporting text",
+                )
+            }
+            val openErrorNotificationsActionTitle = "Open notifications"
+            val openErrorNotificationsClicked = mutableStateOf(false)
+            mainClock.autoAdvance = false
+            setContentWithPreviewAndResources {
+                TestSubject(
+                    notifications = notifications,
+                    onOpenErrorNotificationsClick = { openErrorNotificationsClicked.value = true },
+                )
+            }
+
+            // Act
+            onNodeWithTag(BUTTON_NOTIFICATION_TEST_TAG).performClick()
+            // Advance Animation
+            mainClock.advanceTimeBy(1000L)
+            onNodeWithText(openErrorNotificationsActionTitle).performClick()
+
+            // Assert
+            printSemanticTree()
+            onNodeWithTag(BannerInlineNotificationListHostDefaults.TEST_TAG_HOST_PARENT)
+                .assertIsDisplayed()
+
+            val listHost = onNodeWithTag(
+                BannerInlineNotificationListHostDefaults.TEST_TAG_BANNER_INLINE_LIST,
+                useUnmergedTree = true,
+            ).assertIsDisplayed()
+
+            listHost
+                .onChildren()
+                .assertCountEquals(2)
+
+            listHost.assertBannerInline(
+                index = 0,
+                title = notifications.first().title,
+                supportingText = requireNotNull(notifications.first().contentText),
+                assertActions = { assertCountEquals(2) },
+            )
+
+            listHost.assertBannerInline(
+                index = 1,
+                title = "Check Error Notifications",
+                supportingText = "Some messages need your attention.",
+                assertActions = {
+                    assertCountEquals(1)
+                    val actionButton = filterToOne(
+                        matcher = SemanticsMatcher.expectValue(
+                            key = SemanticsProperties.Role,
+                            expectedValue = Role.Button,
+                        ) and hasClickAction(),
+                    ).assertIsDisplayed()
+
+                    actionButton
+                        .onChildren()
+                        .filterToOne(hasTextExactly(openErrorNotificationsActionTitle))
+                        .assertIsDisplayed()
+                },
+            )
+        }
+
+    private fun printSemanticTree(root: SemanticsNodeInteraction = composeTestRule.onRoot(useUnmergedTree = true)) {
+        println("-----")
+        println("Semantic tree:")
+        println(root.printToString())
+        println("-----")
+        println()
+    }
+
+    private fun SemanticsNodeInteraction.assertBannerInline(
+        index: Int,
+        title: String,
+        supportingText: String,
+        assertActions: SemanticsNodeInteractionCollection.() -> Unit = {},
+    ) {
+        val banner = onChildAt(index)
+        val children = banner.onChildren()
+        children
+            .filterToOne(hasTextExactly(title))
+            .assertIsDisplayed()
+
+        children
+            .filterToOne(hasTextExactly(supportingText))
+            .assertIsDisplayed()
+
+        children
+            .filterToOne(hasTestTag(TEST_TAG_BANNER_INLINE_CARD_ACTION_ROW))
+            .onChildren()
+            .assertActions()
+    }
+
+    @Composable
+    private fun TestSubject(
+        notifications: List<FakeInAppOnlyNotification>,
+        modifier: Modifier = Modifier,
+        onActionClick: (NotificationAction) -> Unit = {},
+        onOpenErrorNotificationsClick: () -> Unit = {},
+    ) {
+        Column(modifier = modifier) {
+            val state = rememberInAppNotificationHostState()
+            ButtonText(
+                text = "Trigger Notification",
+                onClick = {
+                    notifications.forEach { state.showInAppNotification(it) }
+                },
+                modifier = Modifier.testTagAsResourceId(BUTTON_NOTIFICATION_TEST_TAG),
+            )
+            BannerInlineNotificationListHost(
+                hostStateHolder = state,
+                onActionClick = onActionClick,
+                onOpenErrorNotificationsClick = onOpenErrorNotificationsClick,
+            )
+        }
+    }
+
+    private fun createNotification(
+        title: String,
+        supportingText: String,
+        actions: Set<NotificationAction> = setOf(
+            createFakeNotificationAction(title = "Action 1"),
+            createFakeNotificationAction(title = "Action 2"),
+        ),
+    ): FakeInAppOnlyNotification {
+        return FakeInAppOnlyNotification(
+            title = title,
+            contentText = supportingText,
+            actions = actions,
+            inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+        )
+    }
+}
+
+private fun ComposeTest.setContentWithPreviewAndResources(content: @Composable () -> Unit) = setContentWithTheme {
+    // https://github.com/robolectric/robolectric/issues/9603
+    // https://youtrack.jetbrains.com/issue/CMP-6612/Support-non-compose-UI-tests-with-resources
+    CompositionLocalProvider(LocalInspectionMode provides true) {
+        PreviewContextConfigurationEffect()
+        content()
+    }
+}

--- a/feature/notification/api/src/commonMain/composeResources/values/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values/strings.xml
@@ -56,4 +56,7 @@
     <string name="notification_action_retry">Retry</string>
     <string name="notification_action_update_server_settings">Update Server Settings</string>
 
+    <string name="banner_inline_notification_check_error_notifications">Check Error Notifications</string>
+    <string name="banner_inline_notification_some_messages_need_attention">Some messages need your attention.</string>
+    <string name="banner_inline_notification_open_notifications">Open notifications</string>
 </resources>


### PR DESCRIPTION
Part of #9537 and #9312.

- Introduce `BannerInlineNotificationListHost` used to display the banner globals observing the `InAppNotificationHostState`
- Add test tag to `BannerInlineNotificationListHost` action's row
- Unit test