### PR TITLE
refactor(notifications): change in-app notifications to accept only a single style per type

### DIFF
--- a/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerGlobalNotificationHostTest.kt
+++ b/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerGlobalNotificationHostTest.kt
@@ -31,7 +31,7 @@ import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 import net.thunderbird.feature.notification.api.NotificationSeverity
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
 import net.thunderbird.feature.notification.api.ui.host.rememberInAppNotificationHostStateHolder
-import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyles
+import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyle
 import net.thunderbird.feature.notification.api.ui.util.printSemanticTree
 import net.thunderbird.feature.notification.testing.fake.FakeInAppOnlyNotification
 import net.thunderbird.feature.notification.testing.fake.ui.action.createFakeNotificationAction
@@ -380,7 +380,7 @@ class BannerGlobalNotificationHostTest : ComposeTest() {
         title = title,
         contentText = contentText,
         severity = severity,
-        inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+        inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
         actions = action?.let { setOf(it) }.orEmpty(),
     )
 }

--- a/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerInlineNotificationListHostTest.kt
+++ b/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/BannerInlineNotificationListHostTest.kt
@@ -31,7 +31,7 @@ import kotlinx.collections.immutable.toPersistentList
 import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
 import net.thunderbird.feature.notification.api.ui.host.rememberInAppNotificationHostStateHolder
-import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyles
+import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyle
 import net.thunderbird.feature.notification.api.ui.util.assertBannerInline
 import net.thunderbird.feature.notification.api.ui.util.assertBannerInlineList
 import net.thunderbird.feature.notification.api.ui.util.printSemanticTree
@@ -328,7 +328,7 @@ class BannerInlineNotificationListHostTest : ComposeTest() {
             title = title,
             contentText = supportingText,
             actions = actions,
-            inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+            inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
         )
     }
 }

--- a/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/InAppNotificationScaffoldTest.kt
+++ b/feature/notification/api/src/androidUnitTest/kotlin/net/thunderbird/feature/notification/api/ui/InAppNotificationScaffoldTest.kt
@@ -44,7 +44,7 @@ import kotlinx.coroutines.flow.SharedFlow
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationEvent
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationReceiver
 import net.thunderbird.feature.notification.api.ui.action.NotificationAction
-import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyles
+import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyle
 import net.thunderbird.feature.notification.api.ui.util.assertBannerInline
 import net.thunderbird.feature.notification.api.ui.util.assertBannerInlineList
 import net.thunderbird.feature.notification.api.ui.util.printSemanticTree
@@ -174,7 +174,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             // Arrange
             val event = InAppNotificationEvent.Show(
                 notification = FakeInAppOnlyNotification(
-                    inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                    inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
                 ),
             )
             val receiver = FakeInAppNotificationReceiver()
@@ -207,7 +207,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             val action = createFakeNotificationAction(actionTitle)
             val event = InAppNotificationEvent.Show(
                 notification = FakeInAppOnlyNotification(
-                    inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                    inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
                     actions = setOf(action),
                 ),
             )
@@ -254,7 +254,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             // Arrange
             val event = InAppNotificationEvent.Show(
                 notification = FakeInAppOnlyNotification(
-                    inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                    inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
                 ),
             )
             val receiver = FakeInAppNotificationReceiver()
@@ -281,7 +281,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             // Arrange
             val event = InAppNotificationEvent.Show(
                 notification = FakeInAppOnlyNotification(
-                    inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                    inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                     actions = setOf(createFakeNotificationAction("Action")),
                 ),
             )
@@ -314,7 +314,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             val notification = FakeInAppOnlyNotification(
                 title = "The notification",
                 contentText = "The content",
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 actions = setOf(createFakeNotificationAction("Action")),
             )
             val event = InAppNotificationEvent.Show(notification = notification)
@@ -355,7 +355,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             val notification = FakeInAppOnlyNotification(
                 title = "The notification",
                 contentText = "The content",
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 actions = setOf(createFakeNotificationAction("Action")),
             )
             val event = InAppNotificationEvent.Show(notification = notification)
@@ -376,7 +376,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
                     InAppNotificationEvent.Show(
                         notification = FakeInAppOnlyNotification(
                             title = "Notification $it",
-                            inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                            inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                             actions = setOf(createFakeNotificationAction("Action")),
                         ),
                     ),
@@ -426,7 +426,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             val action = createFakeNotificationAction(actionTitle)
             val event = InAppNotificationEvent.Show(
                 notification = FakeInAppOnlyNotification(
-                    inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                    inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                     actions = setOf(action),
                 ),
             )
@@ -494,7 +494,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
                     InAppNotificationEvent.Show(
                         notification = FakeInAppOnlyNotification(
                             title = "Notification $it",
-                            inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                            inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                             actions = setOf(createFakeNotificationAction("Action")),
                         ),
                     ),
@@ -527,7 +527,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             // Arrange
             val event = InAppNotificationEvent.Show(
                 notification = FakeInAppOnlyNotification(
-                    inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                    inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
                 ),
             )
             val receiver = FakeInAppNotificationReceiver()
@@ -562,7 +562,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             // Arrange
             val event = InAppNotificationEvent.Show(
                 notification = FakeInAppOnlyNotification(
-                    inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                    inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                     actions = setOf(createFakeNotificationAction("Action")),
                 ),
             )
@@ -595,7 +595,7 @@ class InAppNotificationScaffoldTest : ComposeTest() {
             // Arrange
             val event = InAppNotificationEvent.Show(
                 notification = FakeInAppOnlyNotification(
-                    inAppNotificationStyles = inAppNotificationStyles { snackbar() },
+                    inAppNotificationStyle = inAppNotificationStyle { snackbar() },
                     actions = setOf(createFakeNotificationAction("Action")),
                 ),
             )

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/AppNotification.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/content/AppNotification.kt
@@ -104,11 +104,11 @@ interface SystemNotification : Notification {
 /**
  * Represents a notification displayed within the application.
  *
- * @property inAppNotificationStyles The styles of the in-app notification.
+ * @property inAppNotificationStyle The style of the in-app notification.
  * Defaults to [InAppNotificationStyle.Undefined].
  * @see InAppNotificationStyle
- * @see net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyles
+ * @see net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyle
  */
 interface InAppNotification : Notification {
-    val inAppNotificationStyles: List<InAppNotificationStyle> get() = InAppNotificationStyle.Undefined
+    val inAppNotificationStyle: InAppNotificationStyle get() = InAppNotificationStyle.Undefined
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/InAppNotificationHostStateHolder.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/InAppNotificationHostStateHolder.kt
@@ -123,7 +123,9 @@ class InAppNotificationHostStateHolder(private val enabled: ImmutableSet<Display
     private fun InAppNotification.toInAppNotificationData(): InAppNotificationHostState =
         InAppNotificationHostStateImpl(
             bannerGlobalVisual = BannerGlobalVisual.from(notification = this),
-            bannerInlineVisuals = BannerInlineVisual.from(notification = this).toPersistentSet(),
+            bannerInlineVisuals = BannerInlineVisual.from(notification = this)
+                ?.let { persistentSetOf(it) }
+                ?: persistentSetOf(),
             snackbarVisual = SnackbarVisual.from(notification = this),
         )
 

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/visual/InAppNotificationVisual.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/host/visual/InAppNotificationVisual.kt
@@ -1,7 +1,6 @@
 package net.thunderbird.feature.notification.api.ui.host.visual
 
 import androidx.compose.runtime.Stable
-import androidx.compose.ui.util.fastFilter
 import kotlin.time.Duration
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toPersistentList
@@ -56,7 +55,7 @@ data class BannerGlobalVisual(
          * @throws IllegalStateException fails the check validations.
          */
         fun from(notification: InAppNotification): BannerGlobalVisual? =
-            notification.toVisuals<InAppNotificationStyle.BannerGlobalNotification, BannerGlobalVisual> { style ->
+            notification.toVisual<InAppNotificationStyle.BannerGlobalNotification, BannerGlobalVisual> { style ->
                 BannerGlobalVisual(
                     message = checkNotNull(notification.contentText) {
                         "A notification with a BannerGlobalNotification style must have a contentText not null"
@@ -73,7 +72,7 @@ data class BannerGlobalVisual(
                         .firstOrNull(),
                     priority = style.priority,
                 )
-            }.singleOrNull()
+            }
     }
 }
 
@@ -119,8 +118,8 @@ data class BannerInlineVisual(
          * @return A list containing a [BannerInlineVisual] if the conversion is successful, an empty list otherwise.
          * @throws IllegalStateException if any of the validation checks fail.
          */
-        fun from(notification: InAppNotification): List<BannerInlineVisual> =
-            notification.toVisuals<InAppNotificationStyle.BannerInlineNotification, BannerInlineVisual> { style ->
+        fun from(notification: InAppNotification): BannerInlineVisual? =
+            notification.toVisual<InAppNotificationStyle.BannerInlineNotification, BannerInlineVisual> { style ->
                 BannerInlineVisual(
                     title = checkTitle(notification.title),
                     supportingText = checkContentText(notification.contentText),
@@ -193,7 +192,7 @@ data class SnackbarVisual(
          * when the style is [InAppNotificationStyle.SnackbarNotification].
          */
         fun from(notification: InAppNotification): SnackbarVisual? =
-            notification.toVisuals<InAppNotificationStyle.SnackbarNotification, SnackbarVisual> { style ->
+            notification.toVisual<InAppNotificationStyle.SnackbarNotification, SnackbarVisual> { style ->
                 SnackbarVisual(
                     message = checkNotNull(notification.contentText) {
                         "A notification with a SnackbarNotification style must have a contentText not null"
@@ -203,19 +202,19 @@ data class SnackbarVisual(
                     },
                     duration = style.duration,
                 )
-            }.singleOrNull()
+            }
     }
 }
 
 private inline fun <
     reified TStyle : InAppNotificationStyle,
     reified TVisual : InAppNotificationVisual,
-    > InAppNotification.toVisuals(
+    > InAppNotification.toVisual(
     transform: (TStyle) -> TVisual,
-): List<TVisual> {
-    return inAppNotificationStyles
-        .fastFilter { style -> style is TStyle }
-        .map { style ->
+): TVisual? {
+    return inAppNotificationStyle
+        .takeIf { style -> style is TStyle }
+        ?.let { style ->
             check(style is TStyle)
             transform(style)
         }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
@@ -9,13 +9,11 @@ import net.thunderbird.feature.notification.api.ui.style.builder.InAppNotificati
  * feedback or information.
  */
 sealed interface InAppNotificationStyle {
-    companion object {
-        /**
-         * Represents an undefined in-app notification style.
-         * This can be used as a default or placeholder when no specific style is applicable.
-         */
-        val Undefined: List<InAppNotificationStyle> = emptyList()
-    }
+    /**
+     * Represents an undefined in-app notification style.
+     * This can be used as a default or placeholder when no specific style is applicable.
+     */
+    data object Undefined : InAppNotificationStyle
 
     /**
      * @see InAppNotificationStyleBuilder.bannerInline
@@ -49,9 +47,12 @@ enum class SnackbarDuration { Short, Long, Indefinite }
  *
  * Example:
  * ```
- * inAppNotificationStyles {
+ * inAppNotificationStyle {
+ *     bannerInline()
+ * }
+ *
+ * inAppNotificationStyle {
  *     snackbar(duration = 30.seconds)
- *     bottomSheet()
  * }
  * ```
  *
@@ -60,8 +61,8 @@ enum class SnackbarDuration { Short, Long, Indefinite }
  * @return a list of [InAppNotificationStyle]
  */
 @NotificationStyleMarker
-fun inAppNotificationStyles(
+fun inAppNotificationStyle(
     builder: @NotificationStyleMarker InAppNotificationStyleBuilder.() -> Unit,
-): List<InAppNotificationStyle> {
+): InAppNotificationStyle {
     return InAppNotificationStyleBuilder().apply(builder).build()
 }

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InAppNotificationStyleBuilder.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InAppNotificationStyleBuilder.kt
@@ -13,7 +13,7 @@ import net.thunderbird.feature.notification.api.ui.style.SnackbarDuration
  * This interface defines the methods available for configuring the style of an in-app notification.
  */
 class InAppNotificationStyleBuilder internal constructor() {
-    private var styles = mutableListOf<InAppNotificationStyle>()
+    private var style: InAppNotificationStyle = InAppNotificationStyle.Undefined
 
     /**
      * Use inline error banners to surface issues that must be resolved before the user can continue
@@ -39,7 +39,7 @@ class InAppNotificationStyleBuilder internal constructor() {
     @NotificationStyleMarker
     fun bannerInline() {
         checkSingleStyleEntry<BannerInlineNotification>()
-        styles += BannerInlineNotification
+        style = BannerInlineNotification
     }
 
     /**
@@ -69,7 +69,7 @@ class InAppNotificationStyleBuilder internal constructor() {
     @NotificationStyleMarker
     fun bannerGlobal(priority: Int = 0) {
         checkSingleStyleEntry<BannerGlobalNotification>()
-        styles += BannerGlobalNotification(priority = priority)
+        style = BannerGlobalNotification(priority = priority)
     }
 
     /**
@@ -90,7 +90,7 @@ class InAppNotificationStyleBuilder internal constructor() {
     @NotificationStyleMarker
     fun snackbar(duration: SnackbarDuration = SnackbarDuration.Short) {
         checkSingleStyleEntry<SnackbarNotification>()
-        styles += SnackbarNotification(duration)
+        style = SnackbarNotification(duration)
     }
 
     /**
@@ -112,7 +112,7 @@ class InAppNotificationStyleBuilder internal constructor() {
     @NotificationStyleMarker
     fun dialog() {
         checkSingleStyleEntry<DialogNotification>()
-        styles += DialogNotification
+        style = DialogNotification
     }
 
     /**
@@ -120,16 +120,17 @@ class InAppNotificationStyleBuilder internal constructor() {
      *
      * @return The constructed [InAppNotificationStyle].
      */
-    fun build(): List<InAppNotificationStyle> {
-        check(styles.isNotEmpty()) {
-            "You must add at least one in-app notification style."
+    fun build(): InAppNotificationStyle {
+        check(style != InAppNotificationStyle.Undefined) {
+            "You must pick one in-app notification style."
         }
-        return styles.takeUnless { it.isEmpty() } ?: InAppNotificationStyle.Undefined
+        return style
     }
 
     private inline fun <reified T> checkSingleStyleEntry() {
-        check(styles.none { it is T }) {
-            "An in-app notification can only have at most one type of ${T::class.simpleName} style"
+        check(style == InAppNotificationStyle.Undefined) {
+            "An in-app notification can only have one type of style. " +
+                "Current style is ${style::class.simpleName}, trying to set ${T::class.simpleName}."
         }
     }
 }

--- a/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/host/InAppNotificationHostStateHolderTest.kt
+++ b/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/host/InAppNotificationHostStateHolderTest.kt
@@ -28,7 +28,7 @@ import net.thunderbird.feature.notification.api.ui.host.visual.BannerInlineVisua
 import net.thunderbird.feature.notification.api.ui.host.visual.InAppNotificationHostState
 import net.thunderbird.feature.notification.api.ui.host.visual.SnackbarVisual
 import net.thunderbird.feature.notification.api.ui.style.SnackbarDuration
-import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyles
+import net.thunderbird.feature.notification.api.ui.style.inAppNotificationStyle
 import net.thunderbird.feature.notification.testing.fake.FakeInAppOnlyNotification
 import net.thunderbird.feature.notification.testing.fake.ui.action.createFakeNotificationAction
 
@@ -43,7 +43,7 @@ class InAppNotificationHostStateHolderTest {
             val expectedSeverity = NotificationSeverity.Warning
             val notification = FakeInAppOnlyNotification(
                 contentText = expectedContentText,
-                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
                 actions = setOf(expectedAction),
                 severity = expectedSeverity,
             )
@@ -79,7 +79,7 @@ class InAppNotificationHostStateHolderTest {
             val expectedSeverity = NotificationSeverity.Warning
             val notification = FakeInAppOnlyNotification(
                 contentText = expectedContentText,
-                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
                 actions = setOf(expectedAction),
                 severity = expectedSeverity,
             )
@@ -111,7 +111,7 @@ class InAppNotificationHostStateHolderTest {
         runTest {
             // Arrange
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
                 contentText = "not important in this test case",
                 actions = setOf(createFakeNotificationAction()),
             )
@@ -136,7 +136,7 @@ class InAppNotificationHostStateHolderTest {
             // Arrange
             val expectedMessage = "A notification with a BannerGlobalNotification style must have at zero or one action"
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
                 actions = setOf(
                     createFakeNotificationAction(title = "fake action 1"),
                     createFakeNotificationAction(title = "fake action 2"),
@@ -163,7 +163,7 @@ class InAppNotificationHostStateHolderTest {
             val expectedMessage =
                 "A notification with a BannerGlobalNotification style must have a contentText not null"
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
                 contentText = null,
                 actions = setOf(createFakeNotificationAction()),
             )
@@ -190,7 +190,7 @@ class InAppNotificationHostStateHolderTest {
             val expectedSeverity = NotificationSeverity.Warning
             val notification = FakeInAppOnlyNotification(
                 contentText = expectedContentText,
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 actions = setOf(expectedAction),
                 severity = expectedSeverity,
             )
@@ -232,7 +232,7 @@ class InAppNotificationHostStateHolderTest {
             val expectedSeverity = NotificationSeverity.Warning
             val notification = FakeInAppOnlyNotification(
                 contentText = expectedContentText,
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 actions = setOf(expectedAction),
                 severity = expectedSeverity,
             )
@@ -270,7 +270,7 @@ class InAppNotificationHostStateHolderTest {
         runTest {
             // Arrange
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 contentText = "not important in this test case",
                 actions = setOf(createFakeNotificationAction()),
             )
@@ -297,7 +297,7 @@ class InAppNotificationHostStateHolderTest {
         val expectedSeverity = NotificationSeverity.Warning
         val notification = FakeInAppOnlyNotification(
             contentText = expectedContentText,
-            inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+            inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
             actions = setOf(expectedAction),
             severity = expectedSeverity,
         )
@@ -355,7 +355,7 @@ class InAppNotificationHostStateHolderTest {
                 FakeInAppOnlyNotification(
                     title = "fake title $index",
                     contentText = "fake notification $index",
-                    inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                    inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                     actions = setOf(getAction(index)),
                     severity = getSeverity(index),
                 )
@@ -402,7 +402,7 @@ class InAppNotificationHostStateHolderTest {
             // Arrange
             val expectedMessage = "A notification with a BannerInlineNotification style must have at one or two actions"
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 contentText = "not important in this test case",
             )
             val flags = persistentSetOf<DisplayInAppNotificationFlag>()
@@ -427,7 +427,7 @@ class InAppNotificationHostStateHolderTest {
                 "A notification with a BannerInlineNotification style must have a title length of 1 to " +
                     "$MAX_TITLE_LENGTH characters."
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 title = "", // empty
             )
             val flags = persistentSetOf<DisplayInAppNotificationFlag>()
@@ -452,7 +452,7 @@ class InAppNotificationHostStateHolderTest {
                 "A notification with a BannerInlineNotification style must have a title length of 1 to " +
                     "$MAX_TITLE_LENGTH characters."
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 title = "*".repeat(101),
             )
             val flags = persistentSetOf<DisplayInAppNotificationFlag>()
@@ -476,7 +476,7 @@ class InAppNotificationHostStateHolderTest {
             val expectedMessage =
                 "A notification with a BannerInlineNotification style must have a contentText not null"
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 title = "fake title",
                 contentText = null,
             )
@@ -502,7 +502,7 @@ class InAppNotificationHostStateHolderTest {
                 "A notification with a BannerInlineNotification style must have a contentText length " +
                     "of 1 to $MAX_SUPPORTING_TEXT_LENGTH characters."
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 title = "fake title",
                 contentText = "", // empty
             )
@@ -528,7 +528,7 @@ class InAppNotificationHostStateHolderTest {
                 "A notification with a BannerInlineNotification style must have a contentText length of " +
                     "1 to $MAX_SUPPORTING_TEXT_LENGTH characters."
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 title = "fake title",
                 contentText = "*".repeat(201),
             )
@@ -552,7 +552,7 @@ class InAppNotificationHostStateHolderTest {
             // Arrange
             val expectedMessage = "A notification with a BannerInlineNotification style must have at one or two actions"
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 contentText = "not important in this test case",
                 actions = setOf(
                     createFakeNotificationAction(title = "fake action 1"),
@@ -584,7 +584,7 @@ class InAppNotificationHostStateHolderTest {
             val expectedDuration = SnackbarDuration.Long
             val notification = FakeInAppOnlyNotification(
                 contentText = expectedContentText,
-                inAppNotificationStyles = inAppNotificationStyles { snackbar(expectedDuration) },
+                inAppNotificationStyle = inAppNotificationStyle { snackbar(expectedDuration) },
                 actions = setOf(expectedAction),
                 severity = expectedSeverity,
             )
@@ -621,7 +621,7 @@ class InAppNotificationHostStateHolderTest {
             val expectedDuration = SnackbarDuration.Long
             val notification = FakeInAppOnlyNotification(
                 contentText = expectedContentText,
-                inAppNotificationStyles = inAppNotificationStyles { snackbar(expectedDuration) },
+                inAppNotificationStyle = inAppNotificationStyle { snackbar(expectedDuration) },
                 actions = setOf(expectedAction),
                 severity = expectedSeverity,
             )
@@ -653,7 +653,7 @@ class InAppNotificationHostStateHolderTest {
         runTest {
             // Arrange
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { snackbar() },
+                inAppNotificationStyle = inAppNotificationStyle { snackbar() },
                 contentText = "not important in this test case",
                 actions = setOf(createFakeNotificationAction()),
             )
@@ -678,7 +678,7 @@ class InAppNotificationHostStateHolderTest {
             // Arrange
             val expectedMessage = "A notification with a SnackbarNotification style must have exactly one action"
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { snackbar() },
+                inAppNotificationStyle = inAppNotificationStyle { snackbar() },
                 contentText = "not important in this test case",
             )
             val flags = persistentSetOf<DisplayInAppNotificationFlag>()
@@ -701,7 +701,7 @@ class InAppNotificationHostStateHolderTest {
             // Arrange
             val expectedMessage = "A notification with a SnackbarNotification style must have exactly one action"
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { snackbar() },
+                inAppNotificationStyle = inAppNotificationStyle { snackbar() },
                 actions = setOf(
                     createFakeNotificationAction(title = "fake action 1"),
                     createFakeNotificationAction(title = "fake action 2"),
@@ -727,7 +727,7 @@ class InAppNotificationHostStateHolderTest {
             // Arrange
             val expectedMessage = "A notification with a SnackbarNotification style must have a contentText not null"
             val notification = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { snackbar() },
+                inAppNotificationStyle = inAppNotificationStyle { snackbar() },
                 contentText = null,
                 actions = setOf(createFakeNotificationAction()),
             )
@@ -749,7 +749,7 @@ class InAppNotificationHostStateHolderTest {
     fun `dismiss should remove bannerGlobal notification given a BannerGlobalVisual`() = runTest {
         // Arrange
         val notification = FakeInAppOnlyNotification(
-            inAppNotificationStyles = inAppNotificationStyles { bannerGlobal() },
+            inAppNotificationStyle = inAppNotificationStyle { bannerGlobal() },
             actions = setOf(createFakeNotificationAction()),
         )
         val visual = requireNotNull(BannerGlobalVisual.from(notification))
@@ -777,11 +777,11 @@ class InAppNotificationHostStateHolderTest {
         val expectedSeverity = NotificationSeverity.Warning
         val notification = FakeInAppOnlyNotification(
             contentText = expectedContentText,
-            inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+            inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
             actions = setOf(expectedAction),
             severity = expectedSeverity,
         )
-        val visual = BannerInlineVisual.from(notification).first()
+        val visual = requireNotNull(BannerInlineVisual.from(notification))
         val flags = DisplayInAppNotificationFlag.AllNotifications
         val testSubject = InAppNotificationHostStateHolder(enabled = flags)
         testSubject.showInAppNotification(notification)
@@ -818,15 +818,15 @@ class InAppNotificationHostStateHolderTest {
 
             val expectedSize = 99
             val notificationToDismiss = FakeInAppOnlyNotification(
-                inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                 actions = setOf(createFakeNotificationAction()),
             )
-            val visualToDismiss = BannerInlineVisual.from(notificationToDismiss).first()
+            val visualToDismiss = requireNotNull(BannerInlineVisual.from(notificationToDismiss))
             val notifications = List(size = expectedSize) { index ->
                 FakeInAppOnlyNotification(
                     title = "fake title $index",
                     contentText = "fake notification $index",
-                    inAppNotificationStyles = inAppNotificationStyles { bannerInline() },
+                    inAppNotificationStyle = inAppNotificationStyle { bannerInline() },
                     actions = setOf(getAction(index)),
                     severity = getSeverity(index),
                 )
@@ -873,7 +873,7 @@ class InAppNotificationHostStateHolderTest {
     fun `dismiss should remove snackbar notification given a SnackbarVisual`() = runTest {
         // Arrange
         val notification = FakeInAppOnlyNotification(
-            inAppNotificationStyles = inAppNotificationStyles { snackbar(SnackbarDuration.Short) },
+            inAppNotificationStyle = inAppNotificationStyle { snackbar(SnackbarDuration.Short) },
             actions = setOf(createFakeNotificationAction()),
         )
         val visual = requireNotNull(SnackbarVisual.from(notification))

--- a/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyleTest.kt
+++ b/feature/notification/api/src/commonTest/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyleTest.kt
@@ -1,8 +1,8 @@
 package net.thunderbird.feature.notification.api.ui.style
 
 import assertk.assertThat
-import assertk.assertions.containsExactly
 import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
 import kotlin.test.Test
 import kotlin.test.assertFails
@@ -12,109 +12,98 @@ class InAppNotificationStyleTest {
     @Test
     fun `inAppNotificationStyle dsl should create a banner inline in-app notification style`() {
         // Arrange
-        val expectedStyles = arrayOf<InAppNotificationStyle>(InAppNotificationStyle.BannerInlineNotification)
+        val expectedStyle = InAppNotificationStyle.BannerInlineNotification
 
         // Act
-        val inAppStyles = inAppNotificationStyles {
-            bannerInline()
-        }
+        val inAppStyle = inAppNotificationStyle { bannerInline() }
 
         // Assert
-        assertThat(inAppStyles).containsExactly(elements = expectedStyles)
+        assertThat(inAppStyle).isEqualTo(expectedStyle)
     }
 
     @Test
     fun `inAppNotificationStyle dsl should create a banner global in-app notification style`() {
         // Arrange
-        val expectedStyles = arrayOf<InAppNotificationStyle>(
-            InAppNotificationStyle.BannerGlobalNotification(priority = 0),
-        )
+        val expectedStyle = InAppNotificationStyle.BannerGlobalNotification(priority = 0)
 
         // Act
-        val inAppStyles = inAppNotificationStyles {
-            bannerGlobal()
-        }
+        val inAppStyle = inAppNotificationStyle { bannerGlobal() }
 
         // Assert
-        assertThat(inAppStyles).containsExactly(elements = expectedStyles)
+        assertThat(inAppStyle).isEqualTo(expectedStyle)
     }
 
     @Test
     fun `inAppNotificationStyle dsl should create a snackbar in-app notification style`() {
         // Arrange
-        val expectedStyles = arrayOf<InAppNotificationStyle>(InAppNotificationStyle.SnackbarNotification())
+        val expectedStyle = InAppNotificationStyle.SnackbarNotification()
 
         // Act
-        val inAppStyles = inAppNotificationStyles {
-            snackbar()
-        }
+        val inAppStyle = inAppNotificationStyle { snackbar() }
 
         // Assert
-        assertThat(inAppStyles).containsExactly(elements = expectedStyles)
+        assertThat(inAppStyle).isEqualTo(expectedStyle)
     }
 
     @Test
     fun `inAppNotificationStyle dsl should create a snackbar with 30 seconds duration in-app notification style`() {
         // Arrange
         val duration = SnackbarDuration.Short
-        val expectedStyles = arrayOf<InAppNotificationStyle>(InAppNotificationStyle.SnackbarNotification(duration))
+        val expectedStyle = InAppNotificationStyle.SnackbarNotification(duration)
 
         // Act
-        val inAppStyles = inAppNotificationStyles {
-            snackbar(duration = duration)
-        }
+        val inAppStyle = inAppNotificationStyle { snackbar(duration = duration) }
 
         // Assert
-        assertThat(inAppStyles).containsExactly(elements = expectedStyles)
+        assertThat(inAppStyle).isEqualTo(expectedStyle)
     }
 
     @Test
     fun `inAppNotificationStyle dsl should create a dialog in-app notification style`() {
         // Arrange
-        val expectedStyles = arrayOf<InAppNotificationStyle>(InAppNotificationStyle.DialogNotification)
+        val expectedStyle = InAppNotificationStyle.DialogNotification
 
         // Act
-        val inAppStyles = inAppNotificationStyles {
-            dialog()
-        }
+        val inAppStyle = inAppNotificationStyle { dialog() }
 
         // Assert
-        assertThat(inAppStyles).containsExactly(elements = expectedStyles)
+        assertThat(inAppStyle).isEqualTo(expectedStyle)
     }
 
     @Test
-    fun `inAppNotificationStyle dsl should create multiple styles in-app notification style`() {
+    fun `inAppNotificationStyle dsl should not create multiple styles in-app notification style`() {
         // Arrange
-        val expectedStyles = arrayOf(
-            InAppNotificationStyle.BannerInlineNotification,
-            InAppNotificationStyle.BannerGlobalNotification(priority = 0),
-            InAppNotificationStyle.SnackbarNotification(),
-            InAppNotificationStyle.DialogNotification,
-        )
+        val firstStyle = InAppNotificationStyle.BannerInlineNotification::class.simpleName
+        val secondStyle = InAppNotificationStyle.BannerGlobalNotification::class.simpleName
+        val expectedErrorMessage = "An in-app notification can only have one type of style. " +
+            "Current style is $firstStyle, trying to set $secondStyle."
 
         // Act
-        val inAppStyles = inAppNotificationStyles {
-            bannerInline()
-            bannerGlobal()
-            snackbar()
-            dialog()
+        val actual = assertFails {
+            inAppNotificationStyle {
+                bannerInline()
+                bannerGlobal()
+                snackbar()
+                dialog()
+            }
         }
 
         // Assert
-        assertThat(inAppStyles).containsExactly(elements = expectedStyles)
+        assertThat(actual)
+            .isInstanceOf<IllegalStateException>()
+            .hasMessage(expectedErrorMessage)
     }
 
     @Test
     fun `inAppNotificationStyle dsl should throw IllegalStateException when bannerInline style is added multiple times`() {
         // Arrange
-        val expectedErrorMessage =
-            "An in-app notification can only have at most one type of ${
-                InAppNotificationStyle.BannerInlineNotification::class.simpleName
-            } style"
+        val styleName = InAppNotificationStyle.BannerInlineNotification::class.simpleName
+        val expectedErrorMessage = "An in-app notification can only have one type of style. " +
+            "Current style is $styleName, trying to set $styleName."
 
         // Act
         val actual = assertFails {
-            inAppNotificationStyles {
+            inAppNotificationStyle {
                 bannerInline()
                 bannerInline()
                 bannerInline()
@@ -130,14 +119,13 @@ class InAppNotificationStyleTest {
     @Test
     fun `inAppNotificationStyle dsl should throw IllegalStateException when bannerGlobal style is added multiple times`() {
         // Arrange
-        val expectedErrorMessage =
-            "An in-app notification can only have at most one type of ${
-                InAppNotificationStyle.BannerGlobalNotification::class.simpleName
-            } style"
+        val styleName = InAppNotificationStyle.BannerGlobalNotification::class.simpleName
+        val expectedErrorMessage = "An in-app notification can only have one type of style. " +
+            "Current style is $styleName, trying to set $styleName."
 
         // Act
         val actual = assertFails {
-            inAppNotificationStyles {
+            inAppNotificationStyle {
                 bannerGlobal()
                 bannerGlobal()
                 bannerGlobal()
@@ -153,14 +141,13 @@ class InAppNotificationStyleTest {
     @Test
     fun `inAppNotificationStyle dsl should throw IllegalStateException when snackbar style is added multiple times`() {
         // Arrange
-        val expectedErrorMessage =
-            "An in-app notification can only have at most one type of ${
-                InAppNotificationStyle.SnackbarNotification::class.simpleName
-            } style"
+        val styleName = InAppNotificationStyle.SnackbarNotification::class.simpleName
+        val expectedErrorMessage = "An in-app notification can only have one type of style. " +
+            "Current style is $styleName, trying to set $styleName."
 
         // Act
         val actual = assertFails {
-            inAppNotificationStyles {
+            inAppNotificationStyle {
                 snackbar()
                 snackbar(duration = SnackbarDuration.Short)
                 snackbar(duration = SnackbarDuration.Long)
@@ -177,7 +164,7 @@ class InAppNotificationStyleTest {
     fun `inAppNotificationStyle dsl should throw IllegalStateException when in-app notification style is called without any style configuration`() {
         // Arrange & Act
         val exception = assertFails {
-            inAppNotificationStyles {
+            inAppNotificationStyle {
                 // intentionally empty.
             }
         }
@@ -185,6 +172,6 @@ class InAppNotificationStyleTest {
         // Assert
         assertThat(exception)
             .isInstanceOf<IllegalStateException>()
-            .hasMessage("You must add at least one in-app notification style.")
+            .hasMessage("You must pick one in-app notification style.")
     }
 }

--- a/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/FakeInAppOnlyNotification.kt
+++ b/feature/notification/testing/src/commonMain/kotlin/net/thunderbird/feature/notification/testing/fake/FakeInAppOnlyNotification.kt
@@ -21,6 +21,6 @@ data class FakeInAppOnlyNotification(
             viewportHeight = 0f,
         ).build(),
     ),
-    override val inAppNotificationStyles: List<InAppNotificationStyle> = listOf(),
+    override val inAppNotificationStyle: InAppNotificationStyle = InAppNotificationStyle.Undefined,
     override val actions: Set<NotificationAction> = setOf(),
 ) : AppNotification(), InAppNotification


### PR DESCRIPTION
Part of #9312.

After talking with the design team, we conclude that each notification type should have only one in-app notification style. This PR is meant to address that change by migrating `InAppNotification.inAppNotificationStyles: List<InAppNotificationStyle>` to `InAppNotification.inAppNotificationStyle: InAppNotificationStyle`.