### PR TITLE
feat(db): add account id to folder and messages database table

### DIFF
--- a/legacy/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -12,7 +12,7 @@ import net.thunderbird.core.logging.legacy.Log;
 
 
 class StoreSchemaDefinition implements SchemaDefinition {
-    static final int DB_VERSION = 88;
+    static final int DB_VERSION = 89;
 
     private final MigrationsHelper migrationsHelper;
 
@@ -98,11 +98,13 @@ class StoreSchemaDefinition implements SchemaDefinition {
                 "more_messages TEXT default \"unknown\", " +
                 "server_id TEXT, " +
                 "local_only INTEGER, " +
-                "type TEXT DEFAULT \"regular\"" +
+                "type TEXT DEFAULT \"regular\", " +
+                "account_id TEXT" +
                 ")");
 
         db.execSQL("DROP INDEX IF EXISTS folder_server_id");
         db.execSQL("CREATE INDEX folder_server_id ON folders (server_id)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS folders_account_id ON folders(account_id)");
 
         db.execSQL("DROP TABLE IF EXISTS folder_extra_values");
         db.execSQL("CREATE TABLE folder_extra_values (" +
@@ -141,11 +143,13 @@ class StoreSchemaDefinition implements SchemaDefinition {
                 "forwarded INTEGER default 0, " +
                 "message_part_id INTEGER," +
                 "encryption_type TEXT," +
-                "new_message INTEGER DEFAULT 0" +
+                "new_message INTEGER DEFAULT 0," +
+                "account_id TEXT" +
                 ")");
 
         db.execSQL("DROP INDEX IF EXISTS new_messages");
         db.execSQL("CREATE INDEX IF NOT EXISTS new_messages ON messages(new_message)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS messages_account_id ON messages(account_id)");
 
         db.execSQL("CREATE TRIGGER new_message_reset " +
                 "AFTER UPDATE OF read ON messages " +

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/CopyMessageOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/CopyMessageOperations.kt
@@ -9,11 +9,13 @@ import androidx.core.database.getStringOrNull
 import com.fsck.k9.K9
 import com.fsck.k9.mailstore.LockableDatabase
 import java.util.UUID
+import net.thunderbird.feature.account.AccountId
 
 internal class CopyMessageOperations(
     private val lockableDatabase: LockableDatabase,
     private val attachmentFileManager: AttachmentFileManager,
     private val threadMessageOperations: ThreadMessageOperations,
+    private val accountId: AccountId,
 ) {
     fun copyMessage(messageId: Long, destinationFolderId: Long): Long {
         return lockableDatabase.execute(true) { database ->
@@ -196,6 +198,7 @@ ORDER BY message_parts.seq
             put("folder_id", destinationFolderId)
             put("uid", K9.LOCAL_UID_PREFIX + UUID.randomUUID().toString())
             put("message_part_id", rootMessagePartId)
+            put("account_id", accountId.asRaw())
         }
     }
 

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/CreateFolderOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/CreateFolderOperations.kt
@@ -4,8 +4,12 @@ import android.content.ContentValues
 import app.k9mail.legacy.mailstore.CreateFolderInfo
 import com.fsck.k9.mailstore.LockableDatabase
 import com.fsck.k9.mailstore.toDatabaseFolderType
+import net.thunderbird.feature.account.AccountId
 
-internal class CreateFolderOperations(private val lockableDatabase: LockableDatabase) {
+internal class CreateFolderOperations(
+    private val lockableDatabase: LockableDatabase,
+    private val accountId: AccountId,
+) {
     fun createFolders(folders: List<CreateFolderInfo>): Set<Long> = buildSet {
         lockableDatabase.execute(true) { db ->
             for (folder in folders) {
@@ -22,6 +26,7 @@ internal class CreateFolderOperations(private val lockableDatabase: LockableData
                     put("server_id", folder.serverId)
                     put("local_only", false)
                     put("type", folder.type.toDatabaseFolderType())
+                    put("account_id", accountId.asRaw())
                 }
 
                 db.insert("folders", null, values)

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -15,6 +15,7 @@ import com.fsck.k9.message.extractors.BasicPartInfoExtractor
 import java.util.Date
 import net.thunderbird.core.common.exception.MessagingException
 import net.thunderbird.core.preference.GeneralSettingsManager
+import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.folder.api.FolderDetails
 import net.thunderbird.feature.search.legacy.SearchConditionTreeNode
 
@@ -23,23 +24,34 @@ class K9MessageStore(
     storageFilesProvider: StorageFilesProvider,
     basicPartInfoExtractor: BasicPartInfoExtractor,
     generalSettingsManager: GeneralSettingsManager,
+    accountId: AccountId,
 ) : MessageStore {
     private val attachmentFileManager = AttachmentFileManager(storageFilesProvider, generalSettingsManager)
     private val threadMessageOperations = ThreadMessageOperations()
     private val saveMessageOperations = SaveMessageOperations(
-        database,
-        attachmentFileManager,
-        basicPartInfoExtractor,
-        threadMessageOperations,
+        lockableDatabase = database,
+        attachmentFileManager = attachmentFileManager,
+        partInfoExtractor = basicPartInfoExtractor,
+        threadMessageOperations = threadMessageOperations,
+        accountId = accountId,
     )
-    private val copyMessageOperations = CopyMessageOperations(database, attachmentFileManager, threadMessageOperations)
-    private val moveMessageOperations = MoveMessageOperations(database, threadMessageOperations)
+    private val copyMessageOperations = CopyMessageOperations(
+        lockableDatabase = database,
+        attachmentFileManager = attachmentFileManager,
+        threadMessageOperations = threadMessageOperations,
+        accountId = accountId,
+    )
+    private val moveMessageOperations = MoveMessageOperations(
+        database = database,
+        threadMessageOperations = threadMessageOperations,
+        accountId = accountId,
+    )
     private val flagMessageOperations = FlagMessageOperations(database)
     private val updateMessageOperations = UpdateMessageOperations(database)
     private val retrieveMessageOperations = RetrieveMessageOperations(database)
     private val retrieveMessageListOperations = RetrieveMessageListOperations(database)
     private val deleteMessageOperations = DeleteMessageOperations(database, attachmentFileManager)
-    private val createFolderOperations = CreateFolderOperations(database)
+    private val createFolderOperations = CreateFolderOperations(database, accountId)
     private val retrieveFolderOperations = RetrieveFolderOperations(database)
     private val checkFolderOperations = CheckFolderOperations(database)
     private val updateFolderOperations = UpdateFolderOperations(database)

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStoreFactory.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStoreFactory.kt
@@ -30,6 +30,7 @@ class K9MessageStoreFactory(
             storageFilesProvider,
             basicPartInfoExtractor,
             generalSettingsManager,
+            account.id,
         )
         val notifierMessageStore = NotifierMessageStore(messageStore, localStore)
         return ListenableMessageStore(notifierMessageStore)

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/MoveMessageOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/MoveMessageOperations.kt
@@ -9,10 +9,12 @@ import com.fsck.k9.K9
 import com.fsck.k9.mailstore.LockableDatabase
 import java.util.UUID
 import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.feature.account.AccountId
 
 internal class MoveMessageOperations(
     private val database: LockableDatabase,
     private val threadMessageOperations: ThreadMessageOperations,
+    private val accountId: AccountId,
 ) {
     fun moveMessage(messageId: Long, destinationFolderId: Long): Long {
         Log.d("Moving message [ID: $messageId] to folder [ID: $destinationFolderId]")
@@ -90,6 +92,7 @@ internal class MoveMessageOperations(
                 put("forwarded", cursor.getIntOrNull("forwarded"))
                 put("message_part_id", cursor.getLongOrNull("message_part_id"))
                 put("encryption_type", cursor.getStringOrNull("encryption_type"))
+                put("account_id", accountId.asRaw())
             }
         }
 

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/SaveMessageOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/SaveMessageOperations.kt
@@ -30,6 +30,7 @@ import java.io.IOException
 import java.io.InputStream
 import java.util.Stack
 import java.util.UUID
+import net.thunderbird.feature.account.AccountId
 import org.apache.commons.io.IOUtils
 import org.apache.james.mime4j.codec.Base64InputStream
 import org.apache.james.mime4j.codec.QuotedPrintableInputStream
@@ -42,6 +43,7 @@ internal class SaveMessageOperations(
     private val attachmentFileManager: AttachmentFileManager,
     private val partInfoExtractor: BasicPartInfoExtractor,
     private val threadMessageOperations: ThreadMessageOperations,
+    private val accountId: AccountId,
 ) {
     fun saveRemoteMessage(folderId: Long, messageServerId: String, messageData: SaveMessageData) {
         saveMessage(folderId, messageServerId, messageData)
@@ -419,6 +421,8 @@ internal class SaveMessageOperations(
             } else {
                 putNull("preview")
             }
+
+            put("account_id", accountId.asRaw())
         }
 
         return if (replaceMessageId != null) {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo89.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo89.kt
@@ -1,0 +1,23 @@
+package com.fsck.k9.storage.migrations
+
+import android.database.sqlite.SQLiteDatabase
+import com.fsck.k9.mailstore.MigrationsHelper
+
+/**
+ * Migration to version 89.
+ *
+ * Adds the `account_id` column to the `folders` and `messages` tables.
+ */
+internal class MigrationTo89(private val db: SQLiteDatabase, private val migrationsHelper: MigrationsHelper) {
+    fun addAccountIdColumn() {
+        db.execSQL("ALTER TABLE folders ADD account_id TEXT")
+        db.execSQL("ALTER TABLE messages ADD account_id TEXT")
+
+        val accountUuid = migrationsHelper.account.uuid
+        db.execSQL("UPDATE messages SET account_id = ?", arrayOf(accountUuid))
+        db.execSQL("UPDATE folders SET account_id = ?", arrayOf(accountUuid))
+
+        db.execSQL("CREATE INDEX IF NOT EXISTS folders_account_id ON folders(account_id)")
+        db.execSQL("CREATE INDEX IF NOT EXISTS messages_account_id ON messages(account_id)")
+    }
+}

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
@@ -35,5 +35,6 @@ object Migrations {
         if (oldVersion < 86) MigrationTo86(db, migrationsHelper).addFoldersPushEnabledColumn()
         if (oldVersion < 87) MigrationTo87(db, migrationsHelper).addFoldersSyncEnabledColumn()
         if (oldVersion < 88) MigrationTo88(db, migrationsHelper).addFoldersVisibleColumn()
+        if (oldVersion < 89) MigrationTo89(db, migrationsHelper).addAccountIdColumn()
     }
 }

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/CopyMessageOperationsTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/CopyMessageOperationsTest.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isNull
 import com.fsck.k9.mail.testing.crlf
 import com.fsck.k9.mailstore.StorageFilesProvider
 import com.fsck.k9.storage.RobolectricTest
+import net.thunderbird.feature.account.AccountIdFactory
 import okio.buffer
 import okio.sink
 import okio.source
@@ -16,6 +17,8 @@ import org.junit.Test
 import org.mockito.kotlin.mock
 
 class CopyMessageOperationsTest : RobolectricTest() {
+
+    private val accountId = AccountIdFactory.create()
     private val messagePartDirectory = createRandomTempDirectory()
     private val sqliteDatabase = createDatabase()
     private val storageFilesProvider = object : StorageFilesProvider {
@@ -29,6 +32,7 @@ class CopyMessageOperationsTest : RobolectricTest() {
         lockableDatabase,
         attachmentFileManager,
         threadMessageOperations,
+        accountId,
     )
 
     @After
@@ -114,6 +118,7 @@ class CopyMessageOperationsTest : RobolectricTest() {
                 uid = destinationMessage.uid,
                 folderId = 2,
                 messagePartId = destinationMessage.messagePartId,
+                accountId = accountId.asRaw(),
             ),
         )
 
@@ -229,6 +234,7 @@ class CopyMessageOperationsTest : RobolectricTest() {
                 uid = destinationMessage.uid,
                 folderId = 2,
                 messagePartId = destinationMessage.messagePartId,
+                accountId = accountId.asRaw(),
             ),
         )
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/CreateFolderOperationsTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/CreateFolderOperationsTest.kt
@@ -7,12 +7,15 @@ import assertk.assertions.hasSize
 import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.FolderType
 import com.fsck.k9.storage.RobolectricTest
+import net.thunderbird.feature.account.AccountIdFactory
 import org.junit.Test
 
 class CreateFolderOperationsTest : RobolectricTest() {
+
+    private val accountId = AccountIdFactory.create()
     private val sqliteDatabase = createDatabase()
     private val lockableDatabase = createLockableDatabaseMock(sqliteDatabase)
-    private val createFolderOperations = CreateFolderOperations(lockableDatabase)
+    private val createFolderOperations = CreateFolderOperations(lockableDatabase, accountId)
 
     @Test
     fun `create single folder`() {

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/FolderHelpers.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/FolderHelpers.kt
@@ -69,6 +69,7 @@ fun SQLiteDatabase.readFolders(): List<FolderEntry> {
                 status = cursor.getStringOrNull("status"),
                 flaggedCount = cursor.getIntOrNull("flagged_count"),
                 moreMessages = cursor.getStringOrNull("more_messages"),
+                accountId = cursor.getStringOrNull("account_id"),
             )
         }
     }
@@ -92,4 +93,5 @@ data class FolderEntry(
     val status: String?,
     val flaggedCount: Int?,
     val moreMessages: String?,
+    val accountId: String? = null,
 )

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/MessageDatabaseHelpers.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/MessageDatabaseHelpers.kt
@@ -129,6 +129,7 @@ fun SQLiteDatabase.readMessages(): List<MessageEntry> {
                 messagePartId = cursor.getLongOrNull("message_part_id"),
                 encryptionType = cursor.getStringOrNull("encryption_type"),
                 newMessage = cursor.getIntOrNull("new_message"),
+                accountId = cursor.getStringOrNull("account_id"),
             )
         }
     }
@@ -162,6 +163,7 @@ data class MessageEntry(
     val messagePartId: Long?,
     val encryptionType: String?,
     val newMessage: Int?,
+    val accountId: String? = null,
 )
 
 fun SQLiteDatabase.createMessagePart(

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/MoveMessageOperationsTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/MoveMessageOperationsTest.kt
@@ -8,6 +8,7 @@ import assertk.assertions.isNull
 import assertk.assertions.startsWith
 import com.fsck.k9.K9
 import com.fsck.k9.storage.RobolectricTest
+import net.thunderbird.feature.account.AccountIdFactory
 import org.junit.Test
 
 private const val SOURCE_FOLDER_ID = 3L
@@ -15,9 +16,15 @@ private const val DESTINATION_FOLDER_ID = 23L
 private const val MESSAGE_ID_HEADER = "<00000000-0000-4000-0000-000000000000@domain.example>"
 
 class MoveMessageOperationsTest : RobolectricTest() {
+
+    private val accountId = AccountIdFactory.create()
     private val sqliteDatabase = createDatabase()
     private val lockableDatabase = createLockableDatabaseMock(sqliteDatabase)
-    private val moveMessageOperations = MoveMessageOperations(lockableDatabase, ThreadMessageOperations())
+    private val moveMessageOperations = MoveMessageOperations(
+        lockableDatabase,
+        ThreadMessageOperations(),
+        accountId,
+    )
 
     @Test
     fun `move message not part of a thread`() {
@@ -53,6 +60,7 @@ class MoveMessageOperationsTest : RobolectricTest() {
                 uid = destinationMessage.uid,
                 deleted = 0,
                 empty = 0,
+                accountId = accountId.asRaw(),
             ),
         )
 
@@ -120,6 +128,7 @@ class MoveMessageOperationsTest : RobolectricTest() {
                 uid = destinationMessage.uid,
                 deleted = 0,
                 empty = 0,
+                accountId = accountId.asRaw(),
             ),
         )
 
@@ -172,6 +181,7 @@ class MoveMessageOperationsTest : RobolectricTest() {
                 uid = destinationMessage.uid,
                 deleted = 0,
                 empty = 0,
+                accountId = accountId.asRaw(),
             ),
         )
 

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/SaveMessageOperationsTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/SaveMessageOperationsTest.kt
@@ -23,12 +23,16 @@ import java.io.ByteArrayOutputStream
 import java.util.Stack
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.feature.account.AccountIdFactory
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
 import org.mockito.Mockito.mock
 
 class SaveMessageOperationsTest : RobolectricTest() {
+
+    private val accountId = AccountIdFactory.create()
+
     private val messagePartDirectory = createRandomTempDirectory()
     private val sqliteDatabase = createDatabase()
     private val storageFilesProvider = object : StorageFilesProvider {
@@ -44,6 +48,7 @@ class SaveMessageOperationsTest : RobolectricTest() {
         attachmentFileManager,
         basicPartInfoExtractor,
         threadMessageOperations,
+        accountId,
     )
 
     @Before

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo89Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/migrations/MigrationTo89Test.kt
@@ -1,0 +1,137 @@
+package com.fsck.k9.storage.migrations
+
+import android.database.sqlite.SQLiteDatabase
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import com.fsck.k9.mailstore.MigrationsHelper
+import com.fsck.k9.storage.messages.createFolder
+import com.fsck.k9.storage.messages.createMessage
+import com.fsck.k9.storage.messages.readFolders
+import com.fsck.k9.storage.messages.readMessages
+import kotlin.test.Test
+import net.thunderbird.core.android.account.LegacyAccount
+import org.junit.After
+import org.junit.runner.RunWith
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MigrationTo89Test {
+    private val database = createDatabaseVersion88()
+    private val account = createAccount()
+    private val migrationHelper = createMigrationsHelper(account)
+    private val migration = MigrationTo89(database, migrationHelper)
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `should add account_id column to folders and messages tables`() {
+        // Arrange
+        val folderId = database.createFolder(name = "Folder")
+        database.createMessage(folderId = folderId, subject = "Message")
+
+        // Act
+        migration.addAccountIdColumn()
+
+        // Assert
+        val folders = database.readFolders()
+        assertThat(folders).isNotNull()
+        assertThat(folders.size).isEqualTo(1)
+        assertThat(folders[0].accountId).isEqualTo(ACCOUNT_UUID)
+
+        val messages = database.readMessages()
+        assertThat(messages).isNotNull()
+        assertThat(messages.size).isEqualTo(1)
+        assertThat(messages[0].accountId).isEqualTo(ACCOUNT_UUID)
+    }
+
+    private fun createAccount(): LegacyAccount {
+        return mock {
+            on { uuid } doReturn ACCOUNT_UUID
+        }
+    }
+
+    private fun createMigrationsHelper(account: LegacyAccount): MigrationsHelper {
+        return object : MigrationsHelper {
+            override fun getAccount(): LegacyAccount {
+                return account
+            }
+
+            override fun saveAccount() {
+                throw UnsupportedOperationException("not implemented")
+            }
+        }
+    }
+
+    @Suppress("LongMethod")
+    private fun createDatabaseVersion88(): SQLiteDatabase {
+        return SQLiteDatabase.create(null).apply {
+            execSQL(
+                """
+                CREATE TABLE folders (
+                    id INTEGER PRIMARY KEY,
+                    name TEXT,
+                    last_updated INTEGER,
+                    unread_count INTEGER,
+                    visible_limit INTEGER,
+                    status TEXT,
+                    flagged_count INTEGER default 0,
+                    integrate INTEGER,
+                    top_group INTEGER,
+                    sync_enabled INTEGER DEFAULT 0,
+                    push_enabled INTEGER DEFAULT 0,
+                    notifications_enabled INTEGER DEFAULT 0,
+                    more_messages TEXT default "unknown",
+                    server_id TEXT,
+                    local_only INTEGER,
+                    type TEXT DEFAULT "regular",
+                    visible INTEGER DEFAULT 1
+                )
+                """.trimIndent(),
+            )
+
+            execSQL(
+                """
+                CREATE TABLE messages (
+                    id INTEGER PRIMARY KEY,
+                    deleted INTEGER default 0,
+                    folder_id INTEGER,
+                    uid TEXT,
+                    subject TEXT,
+                    date INTEGER,
+                    flags TEXT,
+                    sender_list TEXT,
+                    to_list TEXT,
+                    cc_list TEXT,
+                    bcc_list TEXT,
+                    reply_to_list TEXT,
+                    attachment_count INTEGER,
+                    internal_date INTEGER,
+                    message_id TEXT,
+                    preview_type TEXT default "none",
+                    preview TEXT,
+                    mime_type TEXT,
+                    normalized_subject_hash INTEGER,
+                    empty INTEGER default 0,
+                    read INTEGER default 0,
+                    flagged INTEGER default 0,
+                    answered INTEGER default 0,
+                    forwarded INTEGER default 0,
+                    message_part_id INTEGER,
+                    encryption_type TEXT,
+                    new_message INTEGER default 0
+                )
+                """.trimIndent(),
+            )
+        }
+    }
+
+    companion object {
+        private const val ACCOUNT_UUID = "00000000-0000-0000-0000-000000000000"
+    }
+}


### PR DESCRIPTION
Part of [#9370](https://github.com/thunderbird/thunderbird-android/issues/9370)

This adds the account id to the folder and message database table.
