### PR TITLE
Opt-in to Arm MTE for debug and daily

### DIFF
--- a/app-thunderbird/src/daily/AndroidManifest.xml
+++ b/app-thunderbird/src/daily/AndroidManifest.xml
@@ -4,7 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     >
 
-    <application tools:ignore="MissingApplicationIcon">
+    <application
+        tools:ignore="MissingApplicationIcon"
+        android:memtagMode="async">
 
         <!-- This component is disabled by default (if possible). It will be enabled programmatically if necessary. -->
         <!-- IMPORTANT: The component name must be -->

--- a/app-thunderbird/src/debug/AndroidManifest.xml
+++ b/app-thunderbird/src/debug/AndroidManifest.xml
@@ -4,7 +4,9 @@
     xmlns:tools="http://schemas.android.com/tools"
     >
 
-    <application tools:ignore="MissingApplicationIcon">
+    <application
+        tools:ignore="MissingApplicationIcon"
+        android:memtagMode="async">
 
         <!-- This component is disabled by default (if possible). It will be enabled programmatically if necessary. -->
         <!-- IMPORTANT: The component name must be -->


### PR DESCRIPTION
This is an easy security improvement (at least for users with Google Pixel 8 and later, which have the hardware for MTE).

TFA doesn't have any explicit native code afaik, but there are some .so files in the APK (from Compose?), and also Android framework code that TFA calls might have native code. All of that runs in the app's process, so opting in to MTE will cover that. TFA parses attacker controlled data (emails), so enabling MTE is an easy defense-in-depth.

I've been running TFA on a Pixel 8a with GrapheneOS and MTE force-enabled for a few months now without any issues.
Still, I recommend you to test this again on an MTE-compatible device (Pixel 8 and later), just to be sure :)

For background on MTE, see:

- Android docs: https://source.android.com/docs/security/test/memory-safety/arm-mte
- My blog post :innocent: : https://thore.io/posts/2025/09/introduction-to-arm-memory-tagging-extensions/