### PR TITLE
Migrate messageViewPostRemoveNavigation to PreferenceDataStore

### DIFF
--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettings.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettings.kt
@@ -1,7 +1,19 @@
 package net.thunderbird.core.preference.interaction
 
 const val INTERACTION_SETTINGS_DEFAULT_USE_VOLUME_KEYS_NAVIGATION = false
+val INTERACTION_SETTINGS_DEFAULT_MESSAGE_VIEW_POST_REMOVE_NAVIGATION = PostRemoveNavigation.ReturnToMessageList.name
 
 data class InteractionSettings(
     val useVolumeKeysForNavigation: Boolean = INTERACTION_SETTINGS_DEFAULT_USE_VOLUME_KEYS_NAVIGATION,
+    val messageViewPostRemoveNavigation: String = INTERACTION_SETTINGS_DEFAULT_MESSAGE_VIEW_POST_REMOVE_NAVIGATION,
 )
+
+/**
+ * The navigation actions that can be to performed after the user has deleted or moved a message from the message
+ * view screen.
+ */
+enum class PostRemoveNavigation {
+    ReturnToMessageList,
+    ShowPreviousMessage,
+    ShowNextMessage,
+}

--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettingsPreferenceManager.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettingsPreferenceManager.kt
@@ -3,4 +3,5 @@ package net.thunderbird.core.preference.interaction
 import net.thunderbird.core.preference.PreferenceManager
 
 const val KEY_USE_VOLUME_KEYS_FOR_NAVIGATION = "useVolumeKeysForNavigation"
+const val KEY_MESSAGE_VIEW_POST_DELETE_ACTION = "messageViewPostDeleteAction"
 interface InteractionSettingsPreferenceManager : PreferenceManager<InteractionSettings>

--- a/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/DefaultInteractionSettingsPreferenceManager.kt
+++ b/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/DefaultInteractionSettingsPreferenceManager.kt
@@ -40,6 +40,10 @@ class DefaultInteractionSettingsPreferenceManager(
             KEY_USE_VOLUME_KEYS_FOR_NAVIGATION,
             INTERACTION_SETTINGS_DEFAULT_USE_VOLUME_KEYS_NAVIGATION,
         ),
+        messageViewPostRemoveNavigation = storage.getStringOrDefault(
+            KEY_MESSAGE_VIEW_POST_DELETE_ACTION,
+            INTERACTION_SETTINGS_DEFAULT_MESSAGE_VIEW_POST_REMOVE_NAVIGATION,
+        ),
     )
 
     private fun writeConfig(config: InteractionSettings) {
@@ -47,6 +51,7 @@ class DefaultInteractionSettingsPreferenceManager(
         scope.launch(ioDispatcher) {
             mutex.withLock {
                 storageEditor.putBoolean(KEY_USE_VOLUME_KEYS_FOR_NAVIGATION, config.useVolumeKeysForNavigation)
+                storageEditor.putString(KEY_MESSAGE_VIEW_POST_DELETE_ACTION, config.messageViewPostRemoveNavigation)
                 storageEditor.commit().also { commited ->
                     logger.verbose(TAG) { "writeConfig: storageEditor.commit() resulted in: $commited" }
                 }

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -149,8 +149,6 @@ object K9 : KoinComponent {
     @JvmStatic
     var contactNameColor = 0xFF1093F5.toInt()
 
-    var messageViewPostRemoveNavigation: PostRemoveNavigation = PostRemoveNavigation.ReturnToMessageList
-
     var messageViewPostMarkAsUnreadNavigation: PostMarkAsUnreadNavigation =
         PostMarkAsUnreadNavigation.ReturnToMessageList
 
@@ -243,8 +241,6 @@ object K9 : KoinComponent {
 
         messageListDensity = storage.getEnum("messageListDensity", UiDensity.Default)
         contactNameColor = storage.getInt("registeredNameColor", 0xFF1093F5.toInt())
-        messageViewPostRemoveNavigation =
-            storage.getEnum("messageViewPostDeleteAction", PostRemoveNavigation.ReturnToMessageList)
         messageViewPostMarkAsUnreadNavigation =
             storage.getEnum("messageViewPostMarkAsUnreadAction", PostMarkAsUnreadNavigation.ReturnToMessageList)
 
@@ -305,7 +301,6 @@ object K9 : KoinComponent {
         editor.putBoolean("showAccountSelector", isShowAccountSelector)
         editor.putInt("messageListPreviewLines", messageListPreviewLines)
         editor.putInt("registeredNameColor", contactNameColor)
-        editor.putEnum("messageViewPostDeleteAction", messageViewPostRemoveNavigation)
         editor.putEnum("messageViewPostMarkAsUnreadAction", messageViewPostMarkAsUnreadNavigation)
 
         editor.putBoolean("confirmDelete", isConfirmDelete)
@@ -396,16 +391,6 @@ object K9 : KoinComponent {
         MESSAGE_COUNT,
         APP_NAME,
         NOTHING,
-    }
-
-    /**
-     * The navigation actions that can be to performed after the user has deleted or moved a message from the message
-     * view screen.
-     */
-    enum class PostRemoveNavigation {
-        ReturnToMessageList,
-        ShowPreviousMessage,
-        ShowNextMessage,
     }
 
     /**

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -14,7 +14,6 @@ import app.k9mail.legacy.di.DI;
 import com.fsck.k9.FontSizes;
 import com.fsck.k9.K9.NotificationQuickDelete;
 import com.fsck.k9.K9.PostMarkAsUnreadNavigation;
-import com.fsck.k9.K9.PostRemoveNavigation;
 import com.fsck.k9.UiDensity;
 import com.fsck.k9.core.R;
 import com.fsck.k9.preferences.Settings.BooleanSetting;
@@ -42,6 +41,7 @@ import net.thunderbird.core.preference.GeneralSettingsManager;
 import net.thunderbird.core.preference.SplitViewMode;
 import net.thunderbird.core.preference.SubTheme;
 import net.thunderbird.core.preference.display.coreSettings.DisplayCoreSettingsKt;
+import net.thunderbird.core.preference.interaction.PostRemoveNavigation;
 import net.thunderbird.core.preference.network.NetworkSettingsKt;
 import net.thunderbird.core.preference.storage.Storage;
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageList.kt
@@ -34,7 +34,6 @@ import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.CoreResourceProvider
 import com.fsck.k9.K9
 import com.fsck.k9.K9.PostMarkAsUnreadNavigation
-import com.fsck.k9.K9.PostRemoveNavigation
 import com.fsck.k9.Preferences
 import com.fsck.k9.account.BackgroundAccountRemover
 import com.fsck.k9.activity.compose.MessageActions
@@ -65,6 +64,7 @@ import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.core.preference.SplitViewMode
+import net.thunderbird.core.preference.interaction.PostRemoveNavigation
 import net.thunderbird.feature.account.storage.legacy.mapper.LegacyAccountDataMapper
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawer
 import net.thunderbird.feature.navigation.drawer.dropdown.DropDownDrawer
@@ -1292,10 +1292,10 @@ open class MessageList :
     }
 
     override fun performNavigationAfterMessageRemoval() {
-        when (K9.messageViewPostRemoveNavigation) {
-            PostRemoveNavigation.ReturnToMessageList -> returnToMessageList()
-            PostRemoveNavigation.ShowPreviousMessage -> showPreviousMessageOrReturn()
-            PostRemoveNavigation.ShowNextMessage -> showNextMessageOrReturn()
+        when (generalSettingsManager.getConfig().interaction.messageViewPostRemoveNavigation) {
+            PostRemoveNavigation.ReturnToMessageList.name -> returnToMessageList()
+            PostRemoveNavigation.ShowPreviousMessage.name -> showPreviousMessageOrReturn()
+            PostRemoveNavigation.ShowNextMessage.name -> showNextMessageOrReturn()
         }
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -4,7 +4,6 @@ import androidx.preference.PreferenceDataStore
 import app.k9mail.feature.telemetry.api.TelemetryManager
 import com.fsck.k9.K9
 import com.fsck.k9.K9.PostMarkAsUnreadNavigation
-import com.fsck.k9.K9.PostRemoveNavigation
 import com.fsck.k9.UiDensity
 import com.fsck.k9.job.K9JobManager
 import com.fsck.k9.ui.base.AppLanguageManager
@@ -173,7 +172,7 @@ class GeneralSettingsDataStore(
             "swipe_action_right" -> swipeActionToString(K9.swipeRightAction)
             "swipe_action_left" -> swipeActionToString(K9.swipeLeftAction)
             "message_list_density" -> K9.messageListDensity.toString()
-            "post_remove_navigation" -> K9.messageViewPostRemoveNavigation.name
+            "post_remove_navigation" -> generalSettingsManager.getConfig().interaction.messageViewPostRemoveNavigation
             "post_mark_as_unread_navigation" -> K9.messageViewPostMarkAsUnreadNavigation.name
             else -> defValue
         }
@@ -217,7 +216,7 @@ class GeneralSettingsDataStore(
             "swipe_action_right" -> K9.swipeRightAction = stringToSwipeAction(value)
             "swipe_action_left" -> K9.swipeLeftAction = stringToSwipeAction(value)
             "message_list_density" -> K9.messageListDensity = UiDensity.valueOf(value)
-            "post_remove_navigation" -> K9.messageViewPostRemoveNavigation = PostRemoveNavigation.valueOf(value)
+            "post_remove_navigation" -> setMessageViewPostRemoveNavigation(value)
             "post_mark_as_unread_navigation" -> {
                 K9.messageViewPostMarkAsUnreadNavigation = PostMarkAsUnreadNavigation.valueOf(value)
             }
@@ -647,6 +646,17 @@ class GeneralSettingsDataStore(
             settings.copy(
                 privacy = settings.privacy.copy(
                     isHideUserAgent = isHideUserAgent,
+                ),
+            )
+        }
+    }
+
+    private fun setMessageViewPostRemoveNavigation(value: String) {
+        skipSaveSettings = true
+        generalSettingsManager.update { settings ->
+            settings.copy(
+                interaction = settings.interaction.copy(
+                    messageViewPostRemoveNavigation = value,
                 ),
             )
         }


### PR DESCRIPTION
### Description
This PR migrates the` K9.messageViewPostRemoveNavigation` flag to `PreferenceDataStore`.
### Changes
- Replaced direct usage of` K9.messageViewPostRemoveNavigation` with `PreferenceDataStore` via `InteractionSettings`.
- Updated related getter/setter logic to read and write through preferences.
- Ensured existing behavior for post-remove navigation is preserved.
### Why
- Aligns with the ongoing migration of K9 static flags to PreferenceDataStore.
- Improves consistency, maintainability, and persistence of preferences.
### Related
 - Fixes #9833
 - Part of #9232 