### PR TITLE
chore(migration-v90): add extra where clause to ensure the outbox folder or local folder's won't change

### DIFF
--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo90.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/MigrationTo90.kt
@@ -130,7 +130,10 @@ internal class MigrationTo90(
             |UPDATE folders
             |    SET server_id = REPLACE(server_id, '$imapPrefix', '')
             |WHERE
-            |    server_id LIKE '$imapPrefix%'
+            |    server_id IS NOT NULL
+            |    AND server_id LIKE '$imapPrefix%'
+            |    AND type <> 'outbox'
+            |    AND local_only <> 1
         """.trimMargin()
     }
 }


### PR DESCRIPTION
This PR adds more clauses to the WHERE clause in the Migration to version 90 to ensure that the migration does not touch any local folders or the Outbox folder.