### PR TITLE
fix(message-list): prevent the pull-to-refresh gesture from taking over the swipe gesture while swiping

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -1899,6 +1899,7 @@ class MessageListFragment :
 
     private val swipeListener = object : MessageListSwipeListener {
         override fun onSwipeStarted(item: MessageListItem, action: SwipeAction) {
+            swipeRefreshLayout?.isEnabled = false
             itemSelectedOnSwipeStart = isMessageSelected(item)
             if (itemSelectedOnSwipeStart && action != SwipeAction.ToggleSelection) {
                 deselectMessage(item)
@@ -1969,6 +1970,7 @@ class MessageListFragment :
         }
 
         override fun onSwipeEnded(item: MessageListItem) {
+            swipeRefreshLayout?.isEnabled = true
             if (itemSelectedOnSwipeStart && !isMessageSelected(item)) {
                 selectMessage(item)
             }


### PR DESCRIPTION
Fixes #9548.

Screen recording:

https://github.com/user-attachments/assets/f9a529a5-b9f4-430a-80db-8268998746ac

