### PR TITLE
ci(dependency-guard-update): add token to checkout job; add some logs before pushing to repository

### DIFF
--- a/.github/workflows/dependabot-dependency-guard-update.yml
+++ b/.github/workflows/dependabot-dependency-guard-update.yml
@@ -37,6 +37,7 @@ jobs:
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           ref: ${{ github.head_ref }}
+          token: ${{ steps.app-token.outputs.token || github.token }}
 
       - name: Prepares environment
         uses: ./.github/actions/setup
@@ -49,12 +50,20 @@ jobs:
           APP_SLUG: ${{ steps.app-token.outputs.app-slug || 'github-actions'}}
           APP_USER_ID: ${{ vars.BOT_USER_ID || '41898282' }}
         run: |
+          set -x
+          
           git config --global user.name "${APP_SLUG}"
           git config --global user.email "${APP_USER_ID}+${APP_SLUG}[bot]@users.noreply.github.com"
           git add .
           if ! git diff --cached --quiet; then
+            git config user.name
+            git config user.email
+            git status
             git commit -m "chore(deps): Update dependency guard files on behalf of @dependabot"
+            git log -n 2
             git push
           else
             echo "No changes to commit"
           fi
+
+          set +x


### PR DESCRIPTION
Trying to fix the GitHub Action not allowing `thunderbot` to commit and push to the repository via CI.