### PR TITLE
chore(ci): fix CodeQL Kotlin with manual build step

### DIFF
--- a/.github/workflows/quality-codeql.yml
+++ b/.github/workflows/quality-codeql.yml
@@ -25,7 +25,7 @@ jobs:
           - language: 'actions'
             build-mode: 'none'
           - language: 'java-kotlin'
-            build-mode: 'autobuild'
+            build-mode: 'manual'
           - language: 'python'
             build-mode: 'none'
 
@@ -44,6 +44,10 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+
+      - if: matrix.language == 'java-kotlin'
+        name: Build with Gradle
+        run: ./gradlew assemble
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3


### PR DESCRIPTION
The `autobuild` `build-mode` uses Java 17 (internally resolved), but it needs to use 21. This changes the `build-mode` to `manual` and adds a guarded build step.

Resolves #9899 