### PR TITLE
fix: CodeQL not working with cache and daemon enabled

### DIFF
--- a/.github/actions/setup-gradle/action.yml
+++ b/.github/actions/setup-gradle/action.yml
@@ -1,16 +1,16 @@
 name: Set up Gradle build environment
 description: Prepares environment for building with JDK and Gradle
 inputs:
-  run-release:
-    description: 'Whether to run in release mode (true/false). In release mode, Gradle cache is not used.'
-    required: false
-    default: 'false'
   add-job-summary:
     description: 'Whether to add a job summary (always, never, on-failure).'
     required: false
     default: 'always'
   write-cache:
     description: 'Whether to write to the cache (true/false).'
+    required: false
+    default: 'false'
+  disable-cache:
+    description: 'Whether to disable the cache (true/false).'
     required: false
     default: 'false'
 runs:
@@ -29,6 +29,6 @@ runs:
     - name: Set up Gradle without cache
       uses: gradle/actions/setup-gradle@4d9f0ba0025fe599b4ebab900eb7f3a1d93ef4c2 # v5.0.0
       with:
-        cache-disabled: ${{ inputs.run-release }}
+        cache-disabled: ${{ inputs.disable-cache }}
         add-job-summary: ${{ inputs.add-job-summary }}
-        cache-read-only: ${{ inputs.write-cache == 'false' || inputs.run-release == 'true' }}
+        cache-read-only: ${{ inputs.write-cache == 'false' }}

--- a/.github/workflows/quality-codeql.yml
+++ b/.github/workflows/quality-codeql.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Setup Gradle environment
         if: matrix.language == 'java-kotlin'
         uses: ./.github/actions/setup-gradle
+        with:
+          add-job-summary: 'never'
+          disable-cache: 'true'
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3
@@ -47,7 +50,7 @@ jobs:
 
       - if: matrix.language == 'java-kotlin'
         name: Build with Gradle
-        run: ./gradlew assemble
+        run: ./gradlew assemble --no-daemon
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@192325c86100d080feab897ff886c34abd4c83a3 # v3.30.3

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -224,7 +224,7 @@ jobs:
         if: ${{ contains(matrix.releaseTarget, 'github') || needs.dump_config.outputs.releaseType == 'daily' }}
         uses: ./.github/actions/setup-gradle
         with:
-          run-release: "${{ contains(fromJSON('[\"beta\", \"release\"]'), needs.dump_config.outputs.releaseType) }}"
+          disable-cache: "${{ contains(fromJSON('[\"beta\", \"release\"]'), needs.dump_config.outputs.releaseType) }}"
           add-job-summary: never
 
       - name: Get application info
@@ -462,7 +462,7 @@ jobs:
       - name: Setup Gradle environment
         uses: ./.github/actions/setup-gradle
         with:
-          run-release: "${{ contains(fromJSON('[\"beta\", \"release\"]'), needs.dump_config.outputs.releaseType) }}"
+          disable-cache: "${{ contains(fromJSON('[\"beta\", \"release\"]'), needs.dump_config.outputs.releaseType) }}"
           add-job-summary: on-failure
 
       - name: Set Version Code for Daily


### PR DESCRIPTION
This fixes the CodeQL error 32: https://github.com/thunderbird/thunderbird-android/actions/runs/18347175123/job/52256901231

> CodeQL detected code written in Java/Kotlin but this run didn't build any of it, or CodeQL could not process any of it.

After reading through issues reported for CodeQL analysing Java/Kotlin, I found that cache should be disabled to allow CodeQL to observe the code compilation. Similarly Gradle daemons can't be augmented by CodeQL, so I disabled it too.

I streamlined the `setup-gradle` to use `disable-cache` instead of `run-release` to control cache availability.
