### PR TITLE
chore: remove noisy log

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewModel.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListViewModel.kt
@@ -31,7 +31,6 @@ class MessageListViewModel(
         currentMessageListLiveData = liveData
 
         messageListLiveData.addSource(liveData) { items ->
-            logger.debug { "Received new MessageListInfo: $items" }
             messageListLiveData.value = items
         }
     }


### PR DESCRIPTION
Resolves #9956.

Removes a log triggered in the `MessageListViewModel` that is only creating noise and not helping with debugging errors