### PR TITLE
feat(debug): add AuthDebugActions to help debug OAuth issues

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/KoinModule.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/KoinModule.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.ui.messagelist
 
+import com.fsck.k9.ui.messagelist.debug.AuthDebugActions
 import net.thunderbird.feature.navigation.drawer.dropdown.navigationDropDownDrawerModule
 import net.thunderbird.feature.navigation.drawer.siderail.navigationSideRailDrawerModule
 import org.koin.core.module.dsl.viewModel
@@ -25,6 +26,12 @@ val messageListUiModule = module {
             messageListLoader = get(),
             accountManager = get(),
             messageListRepository = get(),
+        )
+    }
+    factory {
+        AuthDebugActions(
+            accountManager = get(),
+            oAuth2TokenProviderFactory = get(),
         )
     }
     single { SortTypeToastProvider() }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/debug/AuthDebugActions.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/debug/AuthDebugActions.kt
@@ -1,0 +1,76 @@
+package com.fsck.k9.ui.messagelist.debug
+
+import com.fsck.k9.mail.oauth.AuthStateStorage
+import com.fsck.k9.mail.oauth.OAuth2TokenProviderFactory
+import net.thunderbird.core.android.account.LegacyAccount
+import net.thunderbird.core.android.account.LegacyAccountManager
+import net.thunderbird.core.outcome.Outcome
+
+/**
+ * Encapsulates debug-only authentication test actions.
+ *
+ * These methods mutate the stored OAuth state to simulate different scenarios.
+ */
+class AuthDebugActions(
+    private val accountManager: LegacyAccountManager,
+    private val oAuth2TokenProviderFactory: OAuth2TokenProviderFactory,
+) {
+    sealed interface Error {
+        data object AccountNotFound : Error
+        data object NoOAuthState : Error
+        data object CannotModifyAccessToken : Error
+        data object AlreadyModified : Error
+    }
+
+    fun invalidateAccessTokenLocal(accountUuid: String): Outcome<Unit, Error> {
+        val account = accountManager.getAccount(accountUuid)
+
+        return when {
+            account == null -> Outcome.failure(Error.AccountNotFound)
+            account.oAuthState == null -> Outcome.failure(Error.NoOAuthState)
+            else -> {
+                val storage = object : AuthStateStorage {
+                    override fun getAuthorizationState(): String? = account.oAuthState
+                    override fun updateAuthorizationState(authorizationState: String?) {
+                        val updated = account.copy(oAuthState = authorizationState)
+                        accountManager.saveAccount(updated)
+                    }
+                }
+                val provider = oAuth2TokenProviderFactory.create(storage)
+                provider.invalidateToken()
+                Outcome.success(Unit)
+            }
+        }
+    }
+
+    fun invalidateAccessTokenServer(accountUuid: String): Outcome<Unit, Error> {
+        val account = accountManager.getAccount(accountUuid)
+        return when {
+            account == null -> Outcome.failure(Error.AccountNotFound)
+            account.oAuthState == null -> Outcome.failure(Error.NoOAuthState)
+            else -> {
+                // Corrupt the serialized access_token value by replacing its value with a known invalid marker.
+                val current = account.oAuthState!!
+                val regex = "\"access_token\"\\s*:\\s*\"[^\"]*\"".toRegex()
+                val modified = regex.replaceFirst(current, "\"access_token\":\"invalid_access_token\"")
+
+                if (modified == current) {
+                    return Outcome.failure(Error.AlreadyModified)
+                }
+
+                val updated = account.copy(oAuthState = modified)
+                accountManager.saveAccount(updated)
+                Outcome.success(Unit)
+            }
+        }
+    }
+
+    fun forceAuthFailure(accountUuid: String): Outcome<Unit, Error> {
+        val account: LegacyAccount = accountManager.getAccount(accountUuid)
+            ?: return Outcome.failure(Error.AccountNotFound)
+        // Clear OAuth state to force immediate authentication failure
+        val updated = account.copy(oAuthState = null)
+        accountManager.saveAccount(updated)
+        return Outcome.success(Unit)
+    }
+}

--- a/legacy/ui/legacy/src/main/res/menu/message_list_option_menu.xml
+++ b/legacy/ui/legacy/src/main/res/menu/message_list_option_menu.xml
@@ -242,4 +242,23 @@
         app:showAsAction="never"
         />
 
+    <!-- MessageList (Debug) -->
+    <item
+        android:id="@+id/debug_invalidate_access_token_local"
+        android:title="@string/debug_invalidate_access_token_local"
+        android:visible="false"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/debug_invalidate_access_token_server"
+        android:title="@string/debug_invalidate_access_token_server"
+        android:visible="false"
+        app:showAsAction="never" />
+
+    <item
+        android:id="@+id/debug_force_auth_failure"
+        android:title="@string/debug_force_auth_failure"
+        android:visible="false"
+        app:showAsAction="never" />
+
 </menu>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -1092,4 +1092,17 @@ You can keep this message and use it as a backup for your secret key. If you wan
     <!-- Description of the "Usage and technical data" setting used in the "data collection" section of the general settings screen -->
     <string name="settings_ui_telemetry_description">Shares performance, usage, hardware and customization data about this app with Mozilla to help us make Thunderbird better</string>
     <string name="archiving_not_available_for_this_account">Archiving is not available for this account.</string>
+    <!-- Debug/testing menu items -->
+    <string name="debug_invalidate_access_token">Test: Invalidate access token</string>
+    <string name="debug_invalidate_access_token_done">Access token invalidated. Next request will refresh.</string>
+    <string name="debug_invalidate_access_token_unavailable">No OAuth token available for this account.</string>
+    <string name="debug_invalidate_access_token_local">Test: Invalidate access token (local)</string>
+    <string name="debug_invalidate_access_token_local_done">Local invalidation requested. Next request will fetch a new token.</string>
+    <string name="debug_invalidate_access_token_server">Test: Invalidate access token (server)</string>
+    <string name="debug_invalidate_access_token_server_done">Stored access token corrupted. Next request will fail then refresh.</string>
+    <string name="debug_force_auth_failure">Test: Force auth failure now</string>
+    <string name="debug_force_auth_failure_done">OAuth state cleared. Next request will fail.</string>
+    <string name="debug_force_auth_failure_unavailable">No OAuth configuration available for this account.</string>
+    <string name="debug_invalidate_access_token_cannot_modify">Could not modify stored access token. Try local invalidation.</string>
+    <string name="debug_invalidate_access_token_already_modified">Stored access token already modified.</string>
 </resources>


### PR DESCRIPTION
This introduces debug-only authentication actions for OAuth accounts in the message list UI. 

It adds new menu options (visible only in debug builds for OAuth accounts) that allow developers to simulate invalid or expired OAuth tokens and force authentication failures. 

These actions help with testing and debugging authentication flows.