### PR TITLE
chore: cleanup TfA build config

### DIFF
--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -172,7 +172,6 @@ android {
         }
     }
 
-    @Suppress("UnstableApiUsage")
     bundle {
         language {
             // Don't split by language. Otherwise our in-app language switcher won't work.
@@ -253,7 +252,6 @@ dependencies {
     implementation(projects.feature.migration.launcher.thunderbird)
 
     // TODO remove once OAuth ids have been moved from TBD to TBA
-    "betaImplementation"(libs.appauth)
     releaseImplementation(libs.appauth)
 
     // Required for DependencyInjectionTest


### PR DESCRIPTION
Small cleanup to remove the app auth dependency for beta and an outdated warning.