### PR TITLE
refactor: move validation to dedicated core:validation module

### DIFF
--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/domain/usecase/validation/ValidationError.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/domain/usecase/validation/ValidationError.kt
@@ -1,3 +1,0 @@
-package net.thunderbird.core.common.domain.usecase.validation
-
-interface ValidationError

--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/domain/usecase/validation/ValidationResult.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/domain/usecase/validation/ValidationResult.kt
@@ -1,7 +1,0 @@
-package net.thunderbird.core.common.domain.usecase.validation
-
-sealed interface ValidationResult {
-    data object Success : ValidationResult
-
-    data class Failure(val error: ValidationError) : ValidationResult
-}

--- a/core/validation/build.gradle.kts
+++ b/core/validation/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    id(ThunderbirdPlugins.Library.kmp)
+}
+
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            api(projects.core.outcome)
+        }
+    }
+}
+
+android {
+    namespace = "net.thunderbird.core.validation"
+}

--- a/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/ValidationError.kt
+++ b/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/ValidationError.kt
@@ -1,0 +1,6 @@
+package net.thunderbird.core.validation
+
+/**
+ * Represents a validation error.
+ */
+interface ValidationError

--- a/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/ValidationOutcome.kt
+++ b/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/ValidationOutcome.kt
@@ -1,0 +1,8 @@
+package net.thunderbird.core.validation
+
+import net.thunderbird.core.outcome.Outcome
+
+/**
+ * Represents the result of a validation operation.
+ */
+typealias ValidationOutcome = Outcome<Unit, ValidationError>

--- a/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/ValidationSuccess.kt
+++ b/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/ValidationSuccess.kt
@@ -1,0 +1,6 @@
+package net.thunderbird.core.validation
+
+import net.thunderbird.core.outcome.Outcome
+
+val ValidationSuccess: ValidationOutcome
+    get() = Outcome.Success(Unit)

--- a/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/input/BooleanInputField.kt
+++ b/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/input/BooleanInputField.kt
@@ -1,51 +1,51 @@
-package app.k9mail.feature.account.common.domain.input
+package net.thunderbird.core.validation.input
 
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
 
-class StringInputField(
-    override val value: String = "",
+class BooleanInputField(
+    override val value: Boolean? = null,
     override val error: ValidationError? = null,
     override val isValid: Boolean = false,
-) : InputField<String> {
-
-    override fun updateValue(value: String): StringInputField {
-        return StringInputField(
+) : InputField<Boolean?> {
+    override fun updateValue(value: Boolean?): BooleanInputField {
+        return BooleanInputField(
             value = value,
             error = null,
             isValid = false,
         )
     }
 
-    override fun updateError(error: ValidationError?): StringInputField {
-        return StringInputField(
+    override fun updateError(error: ValidationError?): BooleanInputField {
+        return BooleanInputField(
             value = value,
             error = error,
             isValid = false,
         )
     }
 
-    override fun updateValidity(isValid: Boolean): StringInputField {
+    override fun updateValidity(isValid: Boolean): BooleanInputField {
         if (isValid == this.isValid) return this
 
-        return StringInputField(
+        return BooleanInputField(
             value = value,
             error = null,
             isValid = isValid,
         )
     }
 
-    override fun updateFromValidationResult(result: ValidationResult): StringInputField {
-        return when (result) {
-            is ValidationResult.Success -> StringInputField(
+    override fun updateFromValidationOutcome(outcome: ValidationOutcome): BooleanInputField {
+        return when (outcome) {
+            is Outcome.Success -> BooleanInputField(
                 value = value,
                 error = null,
                 isValid = true,
             )
 
-            is ValidationResult.Failure -> StringInputField(
+            is Outcome.Failure -> BooleanInputField(
                 value = value,
-                error = result.error,
+                error = outcome.error,
                 isValid = false,
             )
         }
@@ -55,7 +55,7 @@ class StringInputField(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as StringInputField
+        other as BooleanInputField
 
         if (value != other.value) return false
         if (error != other.error) return false
@@ -63,13 +63,13 @@ class StringInputField(
     }
 
     override fun hashCode(): Int {
-        var result = value.hashCode()
+        var result = value?.hashCode() ?: 0
         result = 31 * result + (error?.hashCode() ?: 0)
         result = 31 * result + isValid.hashCode()
         return result
     }
 
     override fun toString(): String {
-        return "StringInputField(value='$value', error=$error, isValid=$isValid)"
+        return "BooleanInputField(value=$value, error=$error, isValid=$isValid)"
     }
 }

--- a/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/input/InputField.kt
+++ b/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/input/InputField.kt
@@ -1,7 +1,7 @@
-package app.k9mail.feature.account.common.domain.input
+package net.thunderbird.core.validation.input
 
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
 
 /**
  * InputField is an interface defining the state of an input field.
@@ -44,5 +44,5 @@ interface InputField<T> {
         return error != null
     }
 
-    fun updateFromValidationResult(result: ValidationResult): InputField<T>
+    fun updateFromValidationOutcome(outcome: ValidationOutcome): InputField<T>
 }

--- a/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/input/NumberInputField.kt
+++ b/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/input/NumberInputField.kt
@@ -1,50 +1,52 @@
-package app.k9mail.feature.account.common.domain.input
+package net.thunderbird.core.validation.input
 
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
 
-class BooleanInputField(
-    override val value: Boolean? = null,
+class NumberInputField(
+    override val value: Long? = null,
     override val error: ValidationError? = null,
     override val isValid: Boolean = false,
-) : InputField<Boolean?> {
-    override fun updateValue(value: Boolean?): BooleanInputField {
-        return BooleanInputField(
+) : InputField<Long?> {
+
+    override fun updateValue(value: Long?): NumberInputField {
+        return NumberInputField(
             value = value,
             error = null,
             isValid = false,
         )
     }
 
-    override fun updateError(error: ValidationError?): BooleanInputField {
-        return BooleanInputField(
+    override fun updateError(error: ValidationError?): NumberInputField {
+        return NumberInputField(
             value = value,
             error = error,
             isValid = false,
         )
     }
 
-    override fun updateValidity(isValid: Boolean): BooleanInputField {
+    override fun updateValidity(isValid: Boolean): NumberInputField {
         if (isValid == this.isValid) return this
 
-        return BooleanInputField(
+        return NumberInputField(
             value = value,
             error = null,
             isValid = isValid,
         )
     }
 
-    override fun updateFromValidationResult(result: ValidationResult): BooleanInputField {
-        return when (result) {
-            is ValidationResult.Success -> BooleanInputField(
+    override fun updateFromValidationOutcome(outcome: ValidationOutcome): NumberInputField {
+        return when (outcome) {
+            is Outcome.Success -> NumberInputField(
                 value = value,
                 error = null,
                 isValid = true,
             )
 
-            is ValidationResult.Failure -> BooleanInputField(
+            is Outcome.Failure -> NumberInputField(
                 value = value,
-                error = result.error,
+                error = outcome.error,
                 isValid = false,
             )
         }
@@ -54,7 +56,7 @@ class BooleanInputField(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as BooleanInputField
+        other as NumberInputField
 
         if (value != other.value) return false
         if (error != other.error) return false
@@ -69,6 +71,6 @@ class BooleanInputField(
     }
 
     override fun toString(): String {
-        return "BooleanInputField(value=$value, error=$error, isValid=$isValid)"
+        return "NumberInputField(value=$value, error=$error, isValid=$isValid)"
     }
 }

--- a/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/input/StringInputField.kt
+++ b/core/validation/src/commonMain/kotlin/net/thunderbird/core/validation/input/StringInputField.kt
@@ -1,51 +1,52 @@
-package app.k9mail.feature.account.common.domain.input
+package net.thunderbird.core.validation.input
 
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
 
-class NumberInputField(
-    override val value: Long? = null,
+class StringInputField(
+    override val value: String = "",
     override val error: ValidationError? = null,
     override val isValid: Boolean = false,
-) : InputField<Long?> {
+) : InputField<String> {
 
-    override fun updateValue(value: Long?): NumberInputField {
-        return NumberInputField(
+    override fun updateValue(value: String): StringInputField {
+        return StringInputField(
             value = value,
             error = null,
             isValid = false,
         )
     }
 
-    override fun updateError(error: ValidationError?): NumberInputField {
-        return NumberInputField(
+    override fun updateError(error: ValidationError?): StringInputField {
+        return StringInputField(
             value = value,
             error = error,
             isValid = false,
         )
     }
 
-    override fun updateValidity(isValid: Boolean): NumberInputField {
+    override fun updateValidity(isValid: Boolean): StringInputField {
         if (isValid == this.isValid) return this
 
-        return NumberInputField(
+        return StringInputField(
             value = value,
             error = null,
             isValid = isValid,
         )
     }
 
-    override fun updateFromValidationResult(result: ValidationResult): NumberInputField {
-        return when (result) {
-            is ValidationResult.Success -> NumberInputField(
+    override fun updateFromValidationOutcome(outcome: ValidationOutcome): StringInputField {
+        return when (outcome) {
+            is Outcome.Success -> StringInputField(
                 value = value,
                 error = null,
                 isValid = true,
             )
 
-            is ValidationResult.Failure -> NumberInputField(
+            is Outcome.Failure -> StringInputField(
                 value = value,
-                error = result.error,
+                error = outcome.error,
                 isValid = false,
             )
         }
@@ -55,7 +56,7 @@ class NumberInputField(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as NumberInputField
+        other as StringInputField
 
         if (value != other.value) return false
         if (error != other.error) return false
@@ -63,13 +64,13 @@ class NumberInputField(
     }
 
     override fun hashCode(): Int {
-        var result = value?.hashCode() ?: 0
+        var result = value.hashCode()
         result = 31 * result + (error?.hashCode() ?: 0)
         result = 31 * result + isValid.hashCode()
         return result
     }
 
     override fun toString(): String {
-        return "NumberInputField(value=$value, error=$error, isValid=$isValid)"
+        return "StringInputField(value='$value', error=$error, isValid=$isValid)"
     }
 }

--- a/core/validation/src/commonTest/kotlin/net/thunderbird/core/validation/input/InputFieldTest.kt
+++ b/core/validation/src/commonTest/kotlin/net/thunderbird/core/validation/input/InputFieldTest.kt
@@ -1,4 +1,4 @@
-package app.k9mail.feature.account.common.domain.input
+package net.thunderbird.core.validation.input
 
 import assertk.Assert
 import assertk.all
@@ -10,8 +10,8 @@ import assertk.assertions.isNull
 import assertk.assertions.isSameInstanceAs
 import assertk.assertions.isTrue
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.junit.runners.Parameterized
@@ -139,7 +139,7 @@ class InputFieldTest(
             false,
         )
 
-        val result = initialInput.updateFromValidationResult(ValidationResult.Success)
+        val result = initialInput.updateFromValidationOutcome(Outcome.Success(Unit))
 
         assertThat(result).all {
             isNotSameInstanceAs(initialInput)
@@ -157,7 +157,7 @@ class InputFieldTest(
             true,
         )
 
-        val result = initialInput.updateFromValidationResult(ValidationResult.Failure(TestValidationError))
+        val result = initialInput.updateFromValidationOutcome(Outcome.Failure(TestValidationError))
 
         assertThat(result).all {
             isNotSameInstanceAs(initialInput)

--- a/feature/account/edit/build.gradle.kts
+++ b/feature/account/edit/build.gradle.kts
@@ -15,6 +15,7 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+    implementation(projects.core.validation)
     implementation(projects.core.ui.compose.designsystem)
     implementation(projects.core.ui.compose.navigation)
 

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/modify/FakeIncomingServerSettingsValidator.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/modify/FakeIncomingServerSettingsValidator.kt
@@ -1,18 +1,19 @@
 package app.k9mail.feature.account.edit.ui.server.settings.modify
 
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 class FakeIncomingServerSettingsValidator(
-    private val serverAnswer: ValidationResult = ValidationResult.Success,
-    private val portAnswer: ValidationResult = ValidationResult.Success,
-    private val usernameAnswer: ValidationResult = ValidationResult.Success,
-    private val passwordAnswer: ValidationResult = ValidationResult.Success,
-    private val imapPrefixAnswer: ValidationResult = ValidationResult.Success,
+    private val serverAnswer: ValidationOutcome = ValidationSuccess,
+    private val portAnswer: ValidationOutcome = ValidationSuccess,
+    private val usernameAnswer: ValidationOutcome = ValidationSuccess,
+    private val passwordAnswer: ValidationOutcome = ValidationSuccess,
+    private val imapPrefixAnswer: ValidationOutcome = ValidationSuccess,
 ) : IncomingServerSettingsContract.Validator {
-    override fun validateServer(server: String): ValidationResult = serverAnswer
-    override fun validatePort(port: Long?): ValidationResult = portAnswer
-    override fun validateUsername(username: String): ValidationResult = usernameAnswer
-    override fun validatePassword(password: String): ValidationResult = passwordAnswer
-    override fun validateImapPrefix(imapPrefix: String): ValidationResult = imapPrefixAnswer
+    override fun validateServer(server: String): ValidationOutcome = serverAnswer
+    override fun validatePort(port: Long?): ValidationOutcome = portAnswer
+    override fun validateUsername(username: String): ValidationOutcome = usernameAnswer
+    override fun validatePassword(password: String): ValidationOutcome = passwordAnswer
+    override fun validateImapPrefix(imapPrefix: String): ValidationOutcome = imapPrefixAnswer
 }

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/modify/FakeOutgoingServerSettingsValidator.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/modify/FakeOutgoingServerSettingsValidator.kt
@@ -1,16 +1,17 @@
 package app.k9mail.feature.account.edit.ui.server.settings.modify
 
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 class FakeOutgoingServerSettingsValidator(
-    private val serverAnswer: ValidationResult = ValidationResult.Success,
-    private val portAnswer: ValidationResult = ValidationResult.Success,
-    private val usernameAnswer: ValidationResult = ValidationResult.Success,
-    private val passwordAnswer: ValidationResult = ValidationResult.Success,
+    private val serverAnswer: ValidationOutcome = ValidationSuccess,
+    private val portAnswer: ValidationOutcome = ValidationSuccess,
+    private val usernameAnswer: ValidationOutcome = ValidationSuccess,
+    private val passwordAnswer: ValidationOutcome = ValidationSuccess,
 ) : OutgoingServerSettingsContract.Validator {
-    override fun validateServer(server: String): ValidationResult = serverAnswer
-    override fun validatePort(port: Long?): ValidationResult = portAnswer
-    override fun validateUsername(username: String): ValidationResult = usernameAnswer
-    override fun validatePassword(password: String): ValidationResult = passwordAnswer
+    override fun validateServer(server: String): ValidationOutcome = serverAnswer
+    override fun validatePort(port: Long?): ValidationOutcome = portAnswer
+    override fun validateUsername(username: String): ValidationOutcome = usernameAnswer
+    override fun validatePassword(password: String): ValidationOutcome = passwordAnswer
 }

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/modify/ModifyIncomingServerSettingsViewModelTest.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/modify/ModifyIncomingServerSettingsViewModelTest.kt
@@ -8,8 +8,6 @@ import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
 import assertk.assertions.isEqualTo
@@ -18,6 +16,8 @@ import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings
 import kotlinx.coroutines.delay
 import net.thunderbird.core.testing.coroutines.MainDispatcherRule
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Rule
 import org.junit.Test
 

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/modify/ModifyOutgoingServerSettingsViewModelTest.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/ui/server/settings/modify/ModifyOutgoingServerSettingsViewModelTest.kt
@@ -8,8 +8,6 @@ import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
 import assertk.assertions.isEqualTo
@@ -17,6 +15,8 @@ import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ServerSettings
 import kotlinx.coroutines.delay
 import net.thunderbird.core.testing.coroutines.MainDispatcherRule
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Rule
 import org.junit.Test
 

--- a/feature/account/server/settings/build.gradle.kts
+++ b/feature/account/server/settings/build.gradle.kts
@@ -16,6 +16,7 @@ android {
 dependencies {
     implementation(projects.core.ui.compose.designsystem)
     implementation(projects.core.common)
+    implementation(projects.core.validation)
 
     implementation(projects.mail.common)
     implementation(projects.mail.protocols.imap)

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/ServerSettingsDomainContract.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/ServerSettingsDomainContract.kt
@@ -1,29 +1,29 @@
 package app.k9mail.feature.account.server.settings.domain
 
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
 
 interface ServerSettingsDomainContract {
 
     interface UseCase {
 
         fun interface ValidatePassword {
-            fun execute(password: String): ValidationResult
+            fun execute(password: String): ValidationOutcome
         }
 
         fun interface ValidateServer {
-            fun execute(server: String): ValidationResult
+            fun execute(server: String): ValidationOutcome
         }
 
         fun interface ValidatePort {
-            fun execute(port: Long?): ValidationResult
+            fun execute(port: Long?): ValidationOutcome
         }
 
         fun interface ValidateUsername {
-            fun execute(username: String): ValidationResult
+            fun execute(username: String): ValidationOutcome
         }
 
         fun interface ValidateImapPrefix {
-            fun execute(imapPrefix: String): ValidationResult
+            fun execute(imapPrefix: String): ValidationOutcome
         }
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateImapPrefix.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateImapPrefix.kt
@@ -1,17 +1,18 @@
 package app.k9mail.feature.account.server.settings.domain.usecase
 
 import app.k9mail.feature.account.server.settings.domain.ServerSettingsDomainContract.UseCase
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
 
 internal class ValidateImapPrefix : UseCase.ValidateImapPrefix {
 
-    override fun execute(imapPrefix: String): ValidationResult {
+    override fun execute(imapPrefix: String): ValidationOutcome {
         return when {
-            imapPrefix.isEmpty() -> ValidationResult.Success
-            imapPrefix.isBlank() -> ValidationResult.Failure(ValidateImapPrefixError.BlankImapPrefix)
+            imapPrefix.isEmpty() -> Outcome.Success(Unit)
+            imapPrefix.isBlank() -> Outcome.Failure(ValidateImapPrefixError.BlankImapPrefix)
 
-            else -> ValidationResult.Success
+            else -> Outcome.Success(Unit)
         }
     }
 

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidatePassword.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidatePassword.kt
@@ -1,17 +1,19 @@
 package app.k9mail.feature.account.server.settings.domain.usecase
 
 import app.k9mail.feature.account.server.settings.domain.ServerSettingsDomainContract.UseCase
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 class ValidatePassword : UseCase.ValidatePassword {
 
     // TODO change behavior to allow empty password when no password is required based on auth type
-    override fun execute(password: String): ValidationResult {
+    override fun execute(password: String): ValidationOutcome {
         return when {
-            password.isBlank() -> ValidationResult.Failure(ValidatePasswordError.EmptyPassword)
+            password.isBlank() -> Outcome.Failure(ValidatePasswordError.EmptyPassword)
 
-            else -> ValidationResult.Success
+            else -> ValidationSuccess
         }
     }
 

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidatePort.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidatePort.kt
@@ -1,16 +1,18 @@
 package app.k9mail.feature.account.server.settings.domain.usecase
 
 import app.k9mail.feature.account.server.settings.domain.ServerSettingsDomainContract.UseCase
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 internal class ValidatePort : UseCase.ValidatePort {
 
-    override fun execute(port: Long?): ValidationResult {
+    override fun execute(port: Long?): ValidationOutcome {
         return when (port) {
-            null -> ValidationResult.Failure(ValidatePortError.EmptyPort)
-            in MIN_PORT_NUMBER..MAX_PORT_NUMBER -> ValidationResult.Success
-            else -> ValidationResult.Failure(ValidatePortError.InvalidPort)
+            null -> Outcome.Failure(ValidatePortError.EmptyPort)
+            in MIN_PORT_NUMBER..MAX_PORT_NUMBER -> ValidationSuccess
+            else -> Outcome.Failure(ValidatePortError.InvalidPort)
         }
     }
 

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateServer.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateServer.kt
@@ -1,27 +1,29 @@
 package app.k9mail.feature.account.server.settings.domain.usecase
 
 import app.k9mail.feature.account.server.settings.domain.ServerSettingsDomainContract.UseCase
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
 import net.thunderbird.core.common.net.HostNameUtils
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 internal class ValidateServer : UseCase.ValidateServer {
 
-    override fun execute(server: String): ValidationResult {
+    override fun execute(server: String): ValidationOutcome {
         if (server.isBlank()) {
-            return ValidationResult.Failure(ValidateServerError.EmptyServer)
+            return Outcome.Failure(ValidateServerError.EmptyServer)
         }
 
         return validateHostnameOrIpAddress(server)
     }
 
-    private fun validateHostnameOrIpAddress(server: String): ValidationResult {
+    private fun validateHostnameOrIpAddress(server: String): ValidationOutcome {
         val isLegalHostNameOrIP = HostNameUtils.isLegalHostNameOrIP(server) != null
 
         return if (isLegalHostNameOrIP) {
-            ValidationResult.Success
+            ValidationSuccess
         } else {
-            ValidationResult.Failure(ValidateServerError.InvalidHostnameOrIpAddress)
+            Outcome.Failure(ValidateServerError.InvalidHostnameOrIpAddress)
         }
     }
 

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateUsername.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateUsername.kt
@@ -1,16 +1,18 @@
 package app.k9mail.feature.account.server.settings.domain.usecase
 
 import app.k9mail.feature.account.server.settings.domain.ServerSettingsDomainContract.UseCase
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 internal class ValidateUsername : UseCase.ValidateUsername {
 
-    override fun execute(username: String): ValidationResult {
+    override fun execute(username: String): ValidationOutcome {
         return when {
-            username.isBlank() -> ValidationResult.Failure(ValidateUsernameError.EmptyUsername)
+            username.isBlank() -> Outcome.Failure(ValidateUsernameError.EmptyUsername)
 
-            else -> ValidationResult.Success
+            else -> ValidationSuccess
         }
     }
 

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/common/mapper/ValidationErrorStringMapper.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/common/mapper/ValidationErrorStringMapper.kt
@@ -7,7 +7,7 @@ import app.k9mail.feature.account.server.settings.domain.usecase.ValidatePasswor
 import app.k9mail.feature.account.server.settings.domain.usecase.ValidatePort.ValidatePortError
 import app.k9mail.feature.account.server.settings.domain.usecase.ValidateServer.ValidateServerError
 import app.k9mail.feature.account.server.settings.domain.usecase.ValidateUsername.ValidateUsernameError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
+import net.thunderbird.core.validation.ValidationError
 
 fun ValidationError.toResourceString(resources: Resources): String {
     return when (this) {

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContract.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsContract.kt
@@ -5,10 +5,10 @@ import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
 import app.k9mail.feature.account.common.domain.entity.toDefaultPort
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.common.ui.WithInteractionMode
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 
 interface IncomingServerSettingsContract {
 
@@ -57,10 +57,10 @@ interface IncomingServerSettingsContract {
     }
 
     interface Validator {
-        fun validateServer(server: String): ValidationResult
-        fun validatePort(port: Long?): ValidationResult
-        fun validateUsername(username: String): ValidationResult
-        fun validatePassword(password: String): ValidationResult
-        fun validateImapPrefix(imapPrefix: String): ValidationResult
+        fun validateServer(server: String): ValidationOutcome
+        fun validatePort(port: Long?): ValidationOutcome
+        fun validateUsername(username: String): ValidationOutcome
+        fun validatePassword(password: String): ValidationOutcome
+        fun validateImapPrefix(imapPrefix: String): ValidationOutcome
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapper.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapper.kt
@@ -6,8 +6,6 @@ import app.k9mail.feature.account.common.domain.entity.toAuthType
 import app.k9mail.feature.account.common.domain.entity.toAuthenticationType
 import app.k9mail.feature.account.common.domain.entity.toConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toMailConnectionSecurity
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.common.toInvalidEmailDomain
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
 import com.fsck.k9.mail.ServerSettings
@@ -16,6 +14,8 @@ import com.fsck.k9.mail.store.imap.ImapStoreSettings.autoDetectNamespace
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.isSendClientInfo
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.isUseCompression
 import com.fsck.k9.mail.store.imap.ImapStoreSettings.pathPrefix
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 
 fun AccountState.toIncomingServerSettingsState() = incomingServerSettings?.toIncomingServerSettingsState()
     ?: State(

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsValidator.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsValidator.kt
@@ -6,7 +6,7 @@ import app.k9mail.feature.account.server.settings.domain.usecase.ValidatePasswor
 import app.k9mail.feature.account.server.settings.domain.usecase.ValidatePort
 import app.k9mail.feature.account.server.settings.domain.usecase.ValidateServer
 import app.k9mail.feature.account.server.settings.domain.usecase.ValidateUsername
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
 
 internal class IncomingServerSettingsValidator(
     private val serverValidator: UseCase.ValidateServer = ValidateServer(),
@@ -15,23 +15,23 @@ internal class IncomingServerSettingsValidator(
     private val passwordValidator: UseCase.ValidatePassword = ValidatePassword(),
     private val imapPrefixValidator: UseCase.ValidateImapPrefix = ValidateImapPrefix(),
 ) : IncomingServerSettingsContract.Validator {
-    override fun validateServer(server: String): ValidationResult {
+    override fun validateServer(server: String): ValidationOutcome {
         return serverValidator.execute(server)
     }
 
-    override fun validatePort(port: Long?): ValidationResult {
+    override fun validatePort(port: Long?): ValidationOutcome {
         return portValidator.execute(port)
     }
 
-    override fun validateUsername(username: String): ValidationResult {
+    override fun validateUsername(username: String): ValidationOutcome {
         return usernameValidator.execute(username)
     }
 
-    override fun validatePassword(password: String): ValidationResult {
+    override fun validatePassword(password: String): ValidationOutcome {
         return passwordValidator.execute(password)
     }
 
-    override fun validateImapPrefix(imapPrefix: String): ValidationResult {
+    override fun validateImapPrefix(imapPrefix: String): ValidationOutcome {
         return imapPrefixValidator.execute(imapPrefix)
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModel.kt
@@ -11,7 +11,8 @@ import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSett
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Validator
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.ViewModel
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 open class IncomingServerSettingsViewModel(
     initialState: State = State(),
@@ -98,20 +99,20 @@ open class IncomingServerSettingsViewModel(
         val passwordResult = if (authenticationType.isPasswordRequired) {
             validator.validatePassword(password.value)
         } else {
-            ValidationResult.Success
+            ValidationSuccess
         }
         val imapPrefixResult = validator.validateImapPrefix(imapPrefix.value)
 
         val hasError = listOf(serverResult, portResult, usernameResult, passwordResult, imapPrefixResult)
-            .any { it is ValidationResult.Failure }
+            .any { it is Outcome.Failure }
 
         updateState {
             it.copy(
-                server = it.server.updateFromValidationResult(serverResult),
-                port = it.port.updateFromValidationResult(portResult),
-                username = it.username.updateFromValidationResult(usernameResult),
-                password = it.password.updateFromValidationResult(passwordResult),
-                imapPrefix = it.imapPrefix.updateFromValidationResult(imapPrefixResult),
+                server = it.server.updateFromValidationOutcome(serverResult),
+                port = it.port.updateFromValidationOutcome(portResult),
+                username = it.username.updateFromValidationOutcome(usernameResult),
+                password = it.password.updateFromValidationOutcome(passwordResult),
+                imapPrefix = it.imapPrefix.updateFromValidationOutcome(imapPrefixResult),
             )
         }
 

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContract.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsContract.kt
@@ -4,10 +4,10 @@ import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toSmtpDefaultPort
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.common.ui.WithInteractionMode
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 
 interface OutgoingServerSettingsContract {
 
@@ -44,9 +44,9 @@ interface OutgoingServerSettingsContract {
     }
 
     interface Validator {
-        fun validateServer(server: String): ValidationResult
-        fun validatePort(port: Long?): ValidationResult
-        fun validateUsername(username: String): ValidationResult
-        fun validatePassword(password: String): ValidationResult
+        fun validateServer(server: String): ValidationOutcome
+        fun validatePort(port: Long?): ValidationOutcome
+        fun validateUsername(username: String): ValidationOutcome
+        fun validatePassword(password: String): ValidationOutcome
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapper.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapper.kt
@@ -5,11 +5,11 @@ import app.k9mail.feature.account.common.domain.entity.toAuthType
 import app.k9mail.feature.account.common.domain.entity.toAuthenticationType
 import app.k9mail.feature.account.common.domain.entity.toConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toMailConnectionSecurity
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.common.toInvalidEmailDomain
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
 import com.fsck.k9.mail.ServerSettings
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 
 fun AccountState.toOutgoingServerSettingsState(): State {
     val password = getOutgoingServerPassword()

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsValidator.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsValidator.kt
@@ -4,7 +4,7 @@ import app.k9mail.feature.account.server.settings.domain.usecase.ValidatePasswor
 import app.k9mail.feature.account.server.settings.domain.usecase.ValidatePort
 import app.k9mail.feature.account.server.settings.domain.usecase.ValidateServer
 import app.k9mail.feature.account.server.settings.domain.usecase.ValidateUsername
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
 
 internal class OutgoingServerSettingsValidator(
     private val serverValidator: ValidateServer = ValidateServer(),
@@ -12,19 +12,19 @@ internal class OutgoingServerSettingsValidator(
     private val usernameValidator: ValidateUsername = ValidateUsername(),
     private val passwordValidator: ValidatePassword = ValidatePassword(),
 ) : OutgoingServerSettingsContract.Validator {
-    override fun validateServer(server: String): ValidationResult {
+    override fun validateServer(server: String): ValidationOutcome {
         return serverValidator.execute(server)
     }
 
-    override fun validatePort(port: Long?): ValidationResult {
+    override fun validatePort(port: Long?): ValidationOutcome {
         return portValidator.execute(port)
     }
 
-    override fun validateUsername(username: String): ValidationResult {
+    override fun validateUsername(username: String): ValidationOutcome {
         return usernameValidator.execute(username)
     }
 
-    override fun validatePassword(password: String): ValidationResult {
+    override fun validatePassword(password: String): ValidationOutcome {
         return passwordValidator.execute(password)
     }
 }

--- a/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModel.kt
+++ b/feature/account/server/settings/src/main/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModel.kt
@@ -10,7 +10,7 @@ import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSett
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Validator
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.ViewModel
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
 
 open class OutgoingServerSettingsViewModel(
     initialState: State = State(),
@@ -64,18 +64,18 @@ open class OutgoingServerSettingsViewModel(
         val passwordResult = if (authenticationType.isPasswordRequired) {
             validator.validatePassword(password.value)
         } else {
-            ValidationResult.Success
+            Outcome.Success(Unit)
         }
 
         val hasError = listOf(serverResult, portResult, usernameResult, passwordResult)
-            .any { it is ValidationResult.Failure }
+            .any { it is Outcome.Failure }
 
         updateState {
             it.copy(
-                server = it.server.updateFromValidationResult(serverResult),
-                port = it.port.updateFromValidationResult(portResult),
-                username = it.username.updateFromValidationResult(usernameResult),
-                password = it.password.updateFromValidationResult(passwordResult),
+                server = it.server.updateFromValidationOutcome(serverResult),
+                port = it.port.updateFromValidationOutcome(portResult),
+                username = it.username.updateFromValidationOutcome(usernameResult),
+                password = it.password.updateFromValidationOutcome(passwordResult),
             )
         }
 

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateImapPrefixTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateImapPrefixTest.kt
@@ -3,7 +3,8 @@ package app.k9mail.feature.account.server.settings.domain.usecase
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 
 class ValidateImapPrefixTest {
@@ -14,22 +15,22 @@ class ValidateImapPrefixTest {
     fun `should success when imap prefix is set`() {
         val result = testSubject.execute("imap")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should succeed when imap prefix is empty`() {
         val result = testSubject.execute("")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when imap prefix is blank`() {
         val result = testSubject.execute(" ")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateImapPrefix.ValidateImapPrefixError.BlankImapPrefix>()
     }
 }

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidatePasswordTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidatePasswordTest.kt
@@ -3,7 +3,8 @@ package app.k9mail.feature.account.server.settings.domain.usecase
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 
 class ValidatePasswordTest {
@@ -14,15 +15,15 @@ class ValidatePasswordTest {
     fun `should succeed when password is set`() {
         val result = testSubject.execute("password")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when password is empty`() {
         val result = testSubject.execute("")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidatePassword.ValidatePasswordError.EmptyPassword>()
     }
 
@@ -30,8 +31,8 @@ class ValidatePasswordTest {
     fun `should fail when password is blank`() {
         val result = testSubject.execute(" ")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidatePassword.ValidatePasswordError.EmptyPassword>()
     }
 }

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidatePortTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidatePortTest.kt
@@ -4,7 +4,8 @@ import app.k9mail.feature.account.server.settings.domain.usecase.ValidatePort.Va
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 
 class ValidatePortTest {
@@ -15,15 +16,15 @@ class ValidatePortTest {
     fun `should succeed when port is set`() {
         val result = testSubject.execute(123L)
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when port is negative`() {
         val result = testSubject.execute(-1L)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidatePortError.InvalidPort>()
     }
 
@@ -31,8 +32,8 @@ class ValidatePortTest {
     fun `should fail when port is zero`() {
         val result = testSubject.execute(0)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidatePortError.InvalidPort>()
     }
 
@@ -40,8 +41,8 @@ class ValidatePortTest {
     fun `should fail when port exceeds maximum`() {
         val result = testSubject.execute(65536L)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidatePortError.InvalidPort>()
     }
 
@@ -49,8 +50,8 @@ class ValidatePortTest {
     fun `should fail when port is null`() {
         val result = testSubject.execute(null)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidatePortError.EmptyPort>()
     }
 }

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateServerTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateServerTest.kt
@@ -5,7 +5,9 @@ import assertk.Assert
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
 import org.junit.Test
 
 /**
@@ -105,19 +107,19 @@ class ValidateServerTest {
         assertThat(validate(domain)).isFailureInvalidDomainOrIpAddress()
     }
 
-    private fun validate(input: String): ValidationResult {
+    private fun validate(input: String): ValidationOutcome {
         return testSubject.execute(input)
     }
 
-    private fun Assert<ValidationResult>.isSuccess() = isInstanceOf<ValidationResult.Success>()
+    private fun Assert<ValidationOutcome>.isSuccess() = isInstanceOf<Outcome.Success<Unit>>()
 
-    private fun Assert<ValidationResult>.isFailureEmptyServer() =
-        isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+    private fun Assert<ValidationOutcome>.isFailureEmptyServer() =
+        isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf(ValidateServerError.EmptyServer::class)
 
-    private fun Assert<ValidationResult>.isFailureInvalidDomainOrIpAddress() =
-        isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+    private fun Assert<ValidationOutcome>.isFailureInvalidDomainOrIpAddress() =
+        isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf(ValidateServerError.InvalidHostnameOrIpAddress::class)
 }

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateUsernameTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/domain/usecase/ValidateUsernameTest.kt
@@ -3,7 +3,8 @@ package app.k9mail.feature.account.server.settings.domain.usecase
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 
 class ValidateUsernameTest {
@@ -14,15 +15,15 @@ class ValidateUsernameTest {
     fun `should succeed when username is set`() {
         val result = testSubject.execute("username")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when username is empty`() {
         val result = testSubject.execute("")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateUsername.ValidateUsernameError.EmptyUsername>()
     }
 
@@ -30,8 +31,8 @@ class ValidateUsernameTest {
     fun `should fail when username is blank`() {
         val result = testSubject.execute(" ")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateUsername.ValidateUsernameError.EmptyUsername>()
     }
 }

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/FakeIncomingServerSettingsValidator.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/FakeIncomingServerSettingsValidator.kt
@@ -1,17 +1,18 @@
 package app.k9mail.feature.account.server.settings.ui.incoming
 
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 class FakeIncomingServerSettingsValidator(
-    private val serverAnswer: ValidationResult = ValidationResult.Success,
-    private val portAnswer: ValidationResult = ValidationResult.Success,
-    private val usernameAnswer: ValidationResult = ValidationResult.Success,
-    private val passwordAnswer: ValidationResult = ValidationResult.Success,
-    private val imapPrefixAnswer: ValidationResult = ValidationResult.Success,
+    private val serverAnswer: ValidationOutcome = ValidationSuccess,
+    private val portAnswer: ValidationOutcome = ValidationSuccess,
+    private val usernameAnswer: ValidationOutcome = ValidationSuccess,
+    private val passwordAnswer: ValidationOutcome = ValidationSuccess,
+    private val imapPrefixAnswer: ValidationOutcome = ValidationSuccess,
 ) : IncomingServerSettingsContract.Validator {
-    override fun validateServer(server: String): ValidationResult = serverAnswer
-    override fun validatePort(port: Long?): ValidationResult = portAnswer
-    override fun validateUsername(username: String): ValidationResult = usernameAnswer
-    override fun validatePassword(password: String): ValidationResult = passwordAnswer
-    override fun validateImapPrefix(imapPrefix: String): ValidationResult = imapPrefixAnswer
+    override fun validateServer(server: String): ValidationOutcome = serverAnswer
+    override fun validatePort(port: Long?): ValidationOutcome = portAnswer
+    override fun validateUsername(username: String): ValidationOutcome = usernameAnswer
+    override fun validatePassword(password: String): ValidationOutcome = passwordAnswer
+    override fun validateImapPrefix(imapPrefix: String): ValidationOutcome = imapPrefixAnswer
 }

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapperKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateMapperKtTest.kt
@@ -5,8 +5,6 @@ import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.common.toInvalidEmailDomain
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
 import assertk.assertThat
@@ -14,6 +12,8 @@ import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Test
 
 class IncomingServerSettingsStateMapperKtTest {

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsStateTest.kt
@@ -4,11 +4,11 @@ import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
 import app.k9mail.feature.account.common.domain.entity.toImapDefaultPort
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Test
 
 class IncomingServerSettingsStateTest {

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModelTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/incoming/IncomingServerSettingsViewModelTest.kt
@@ -14,8 +14,6 @@ import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toImapDefaultPort
 import app.k9mail.feature.account.common.domain.entity.toPop3DefaultPort
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract.State
@@ -24,9 +22,11 @@ import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.core.testing.coroutines.MainDispatcherRule
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Rule
 import org.junit.Test
 
@@ -350,7 +350,7 @@ class IncomingServerSettingsViewModelTest {
             val testSubject = IncomingServerSettingsViewModel(
                 mode = InteractionMode.Create,
                 validator = FakeIncomingServerSettingsValidator(
-                    serverAnswer = ValidationResult.Failure(TestError),
+                    serverAnswer = Outcome.Failure(TestError),
                 ),
                 accountStateRepository = InMemoryAccountStateRepository(),
             )

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/FakeOutgoingServerSettingsValidator.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/FakeOutgoingServerSettingsValidator.kt
@@ -1,15 +1,16 @@
 package app.k9mail.feature.account.server.settings.ui.outgoing
 
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 class FakeOutgoingServerSettingsValidator(
-    private val serverAnswer: ValidationResult = ValidationResult.Success,
-    private val portAnswer: ValidationResult = ValidationResult.Success,
-    private val usernameAnswer: ValidationResult = ValidationResult.Success,
-    private val passwordAnswer: ValidationResult = ValidationResult.Success,
+    private val serverAnswer: ValidationOutcome = ValidationSuccess,
+    private val portAnswer: ValidationOutcome = ValidationSuccess,
+    private val usernameAnswer: ValidationOutcome = ValidationSuccess,
+    private val passwordAnswer: ValidationOutcome = ValidationSuccess,
 ) : OutgoingServerSettingsContract.Validator {
-    override fun validateServer(server: String): ValidationResult = serverAnswer
-    override fun validatePort(port: Long?): ValidationResult = portAnswer
-    override fun validateUsername(username: String): ValidationResult = usernameAnswer
-    override fun validatePassword(password: String): ValidationResult = passwordAnswer
+    override fun validateServer(server: String): ValidationOutcome = serverAnswer
+    override fun validatePort(port: Long?): ValidationOutcome = portAnswer
+    override fun validateUsername(username: String): ValidationOutcome = usernameAnswer
+    override fun validatePassword(password: String): ValidationOutcome = passwordAnswer
 }

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapperKtTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateMapperKtTest.kt
@@ -4,14 +4,14 @@ import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.common.toInvalidEmailDomain
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ServerSettings
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Test
 
 class OutgoingServerSettingsStateMapperKtTest {

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsStateTest.kt
@@ -3,11 +3,11 @@ package app.k9mail.feature.account.server.settings.ui.outgoing
 import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toSmtpDefaultPort
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Test
 
 class OutgoingServerSettingsStateTest {

--- a/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModelTest.kt
+++ b/feature/account/server/settings/src/test/kotlin/app/k9mail/feature/account/server/settings/ui/outgoing/OutgoingServerSettingsViewModelTest.kt
@@ -12,8 +12,6 @@ import app.k9mail.feature.account.common.domain.entity.ConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import app.k9mail.feature.account.common.domain.entity.MailConnectionSecurity
 import app.k9mail.feature.account.common.domain.entity.toSmtpDefaultPort
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Effect
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.Event
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract.State
@@ -21,9 +19,11 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import com.fsck.k9.mail.AuthType
 import com.fsck.k9.mail.ServerSettings
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.core.testing.coroutines.MainDispatcherRule
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Rule
 import org.junit.Test
 
@@ -251,7 +251,7 @@ class OutgoingServerSettingsViewModelTest {
             val initialState = State()
             val testSubject = createTestSubject(
                 validator = FakeOutgoingServerSettingsValidator(
-                    serverAnswer = ValidationResult.Failure(TestError),
+                    serverAnswer = Outcome.Failure(TestError),
                 ),
                 initialState = initialState,
             )

--- a/feature/account/setup/build.gradle.kts
+++ b/feature/account/setup/build.gradle.kts
@@ -15,6 +15,7 @@ android {
 
 dependencies {
     implementation(projects.core.common)
+    implementation(projects.core.validation)
     implementation(projects.core.ui.compose.designsystem)
     implementation(projects.core.ui.compose.navigation)
 

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContentPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContentPreview.kt
@@ -3,9 +3,9 @@ package app.k9mail.feature.account.setup.ui.autodiscovery
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithTheme
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.validation.ui.fake.FakeAccountOAuthViewModel
 import app.k9mail.feature.account.setup.ui.autodiscovery.fake.fakeAutoDiscoveryResultSettings
+import net.thunderbird.core.validation.input.StringInputField
 
 @Composable
 @Preview(showBackground = true)

--- a/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultApprovalViewPreview.kt
+++ b/feature/account/setup/src/debug/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultApprovalViewPreview.kt
@@ -3,7 +3,7 @@ package app.k9mail.feature.account.setup.ui.autodiscovery.view
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemes
-import app.k9mail.feature.account.common.domain.input.BooleanInputField
+import net.thunderbird.core.validation.input.BooleanInputField
 
 @Composable
 @Preview(showBackground = true)

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/DomainContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/DomainContract.kt
@@ -4,8 +4,8 @@ import app.k9mail.autodiscovery.api.AutoDiscoveryResult
 import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.SpecialFolderOptions
 import app.k9mail.feature.account.setup.AccountSetupExternalContract.AccountCreator.AccountCreatorResult
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
 
 interface DomainContract {
 
@@ -19,23 +19,23 @@ interface DomainContract {
         }
 
         fun interface ValidateEmailAddress {
-            fun execute(emailAddress: String): ValidationResult
+            fun execute(emailAddress: String): ValidationOutcome
         }
 
         fun interface ValidateConfigurationApproval {
-            fun execute(isApproved: Boolean?, isAutoDiscoveryTrusted: Boolean?): ValidationResult
+            fun execute(isApproved: Boolean?, isAutoDiscoveryTrusted: Boolean?): ValidationOutcome
         }
 
         fun interface ValidateAccountName {
-            fun execute(accountName: String): ValidationResult
+            fun execute(accountName: String): ValidationOutcome
         }
 
         fun interface ValidateDisplayName {
-            fun execute(displayName: String): ValidationResult
+            fun execute(displayName: String): ValidationOutcome
         }
 
         fun interface ValidateEmailSignature {
-            fun execute(emailSignature: String): ValidationResult
+            fun execute(emailSignature: String): ValidationOutcome
         }
 
         fun interface GetSpecialFolderOptions {
@@ -43,7 +43,7 @@ interface DomainContract {
         }
 
         fun interface ValidateSpecialFolderOptions {
-            operator fun invoke(specialFolderOptions: SpecialFolderOptions): ValidationResult
+            operator fun invoke(specialFolderOptions: SpecialFolderOptions): ValidationOutcome
 
             sealed interface Failure : ValidationError {
                 data object MissingDefaultSpecialFolderOption : Failure

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountName.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountName.kt
@@ -1,15 +1,17 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
 import app.k9mail.feature.account.setup.domain.DomainContract
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 internal class ValidateAccountName : DomainContract.UseCase.ValidateAccountName {
-    override fun execute(accountName: String): ValidationResult {
+    override fun execute(accountName: String): ValidationOutcome {
         return when {
-            accountName.isEmpty() -> ValidationResult.Success
-            accountName.isBlank() -> ValidationResult.Failure(ValidateAccountNameError.BlankAccountName)
-            else -> ValidationResult.Success
+            accountName.isEmpty() -> ValidationSuccess
+            accountName.isBlank() -> Outcome.Failure(ValidateAccountNameError.BlankAccountName)
+            else -> ValidationSuccess
         }
     }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateConfigurationApproval.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateConfigurationApproval.kt
@@ -1,19 +1,21 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
 import app.k9mail.feature.account.setup.domain.DomainContract.UseCase
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 class ValidateConfigurationApproval : UseCase.ValidateConfigurationApproval {
-    override fun execute(isApproved: Boolean?, isAutoDiscoveryTrusted: Boolean?): ValidationResult {
+    override fun execute(isApproved: Boolean?, isAutoDiscoveryTrusted: Boolean?): ValidationOutcome {
         return if (isApproved == null && isAutoDiscoveryTrusted == null) {
-            ValidationResult.Success
+            ValidationSuccess
         } else if (isAutoDiscoveryTrusted == true) {
-            ValidationResult.Success
+            ValidationSuccess
         } else if (isApproved == true) {
-            ValidationResult.Success
+            ValidationSuccess
         } else {
-            ValidationResult.Failure(ValidateConfigurationApprovalError.ApprovalRequired)
+            Outcome.Failure(ValidateConfigurationApprovalError.ApprovalRequired)
         }
     }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayName.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayName.kt
@@ -1,15 +1,17 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
 import app.k9mail.feature.account.setup.domain.DomainContract
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 internal class ValidateDisplayName : DomainContract.UseCase.ValidateDisplayName {
 
-    override fun execute(displayName: String): ValidationResult {
+    override fun execute(displayName: String): ValidationOutcome {
         return when {
-            displayName.isBlank() -> ValidationResult.Failure(ValidateDisplayNameError.EmptyDisplayName)
-            else -> ValidationResult.Success
+            displayName.isBlank() -> Outcome.Failure(ValidateDisplayNameError.EmptyDisplayName)
+            else -> ValidationSuccess
         }
     }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailAddress.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailAddress.kt
@@ -1,13 +1,15 @@
 package app.k9mail.feature.account.setup.domain.usecase
 
 import app.k9mail.feature.account.setup.domain.DomainContract.UseCase
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
 import net.thunderbird.core.common.mail.EmailAddressParserError
 import net.thunderbird.core.common.mail.EmailAddressParserException
 import net.thunderbird.core.common.mail.toEmailAddressOrNull
 import net.thunderbird.core.common.mail.toUserEmailAddress
 import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 /**
  * Validate an email address that the user wants to add to an account.
@@ -20,18 +22,18 @@ import net.thunderbird.core.logging.legacy.Log
  */
 class ValidateEmailAddress : UseCase.ValidateEmailAddress {
 
-    override fun execute(emailAddress: String): ValidationResult {
+    override fun execute(emailAddress: String): ValidationOutcome {
         if (emailAddress.isBlank()) {
-            return ValidationResult.Failure(ValidateEmailAddressError.EmptyEmailAddress)
+            return Outcome.Failure(ValidateEmailAddressError.EmptyEmailAddress)
         }
 
         return try {
             val parsedEmailAddress = emailAddress.toUserEmailAddress()
 
             if (parsedEmailAddress.warnings.isEmpty()) {
-                ValidationResult.Success
+                ValidationSuccess
             } else {
-                ValidationResult.Failure(ValidateEmailAddressError.NotAllowed)
+                Outcome.Failure(ValidateEmailAddressError.NotAllowed)
             }
         } catch (e: EmailAddressParserException) {
             Log.v(e, "Error parsing email address: %s", emailAddress)
@@ -60,7 +62,7 @@ class ValidateEmailAddress : UseCase.ValidateEmailAddress {
                 }
             }
 
-            ValidationResult.Failure(validationError)
+            Outcome.Failure(validationError)
         }
     }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignature.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignature.kt
@@ -2,17 +2,19 @@ package app.k9mail.feature.account.setup.domain.usecase
 
 import app.k9mail.feature.account.setup.domain.DomainContract
 import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.ValidateEmailSignatureError.BlankEmailSignature
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 // TODO check signature for input validity
 internal class ValidateEmailSignature : DomainContract.UseCase.ValidateEmailSignature {
 
-    override fun execute(emailSignature: String): ValidationResult {
+    override fun execute(emailSignature: String): ValidationOutcome {
         return when {
-            emailSignature.isEmpty() -> ValidationResult.Success
-            emailSignature.isBlank() -> ValidationResult.Failure(error = BlankEmailSignature)
-            else -> ValidationResult.Success
+            emailSignature.isEmpty() -> ValidationSuccess
+            emailSignature.isBlank() -> Outcome.Failure(error = BlankEmailSignature)
+            else -> ValidationSuccess
         }
     }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateSpecialFolderOptions.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateSpecialFolderOptions.kt
@@ -4,14 +4,16 @@ import app.k9mail.feature.account.common.domain.entity.SpecialFolderOption
 import app.k9mail.feature.account.common.domain.entity.SpecialFolderOptions
 import app.k9mail.feature.account.setup.domain.DomainContract.UseCase
 import app.k9mail.feature.account.setup.domain.DomainContract.UseCase.ValidateSpecialFolderOptions.Failure
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 class ValidateSpecialFolderOptions : UseCase.ValidateSpecialFolderOptions {
-    override fun invoke(specialFolderOptions: SpecialFolderOptions): ValidationResult {
+    override fun invoke(specialFolderOptions: SpecialFolderOptions): ValidationOutcome {
         return if (specialFolderOptions.hasMissingDefaultOption()) {
-            ValidationResult.Failure(error = Failure.MissingDefaultSpecialFolderOption)
+            Outcome.Failure(error = Failure.MissingDefaultSpecialFolderOption)
         } else {
-            ValidationResult.Success
+            ValidationSuccess
         }
     }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryContract.kt
@@ -5,11 +5,11 @@ import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
 import app.k9mail.core.ui.compose.designsystem.molecule.LoadingErrorState
 import app.k9mail.feature.account.common.domain.entity.AuthorizationState
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
-import app.k9mail.feature.account.common.domain.input.BooleanInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.oauth.domain.entity.OAuthResult
 import app.k9mail.feature.account.oauth.ui.AccountOAuthContract
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.input.BooleanInputField
+import net.thunderbird.core.validation.input.StringInputField
 
 interface AccountAutoDiscoveryContract {
 
@@ -62,9 +62,9 @@ interface AccountAutoDiscoveryContract {
     }
 
     interface Validator {
-        fun validateEmailAddress(emailAddress: String): ValidationResult
-        fun validatePassword(password: String): ValidationResult
-        fun validateConfigurationApproval(isApproved: Boolean?, isAutoDiscoveryTrusted: Boolean?): ValidationResult
+        fun validateEmailAddress(emailAddress: String): ValidationOutcome
+        fun validatePassword(password: String): ValidationOutcome
+        fun validateConfigurationApproval(isApproved: Boolean?, isAutoDiscoveryTrusted: Boolean?): ValidationOutcome
     }
 
     sealed interface Error {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryStateMapper.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryStateMapper.kt
@@ -3,8 +3,6 @@ package app.k9mail.feature.account.setup.ui.autodiscovery
 import app.k9mail.autodiscovery.api.ImapServerSettings
 import app.k9mail.autodiscovery.api.SmtpServerSettings
 import app.k9mail.feature.account.common.domain.entity.AccountState
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract
 import app.k9mail.feature.account.setup.domain.entity.toAuthenticationType
@@ -12,6 +10,8 @@ import app.k9mail.feature.account.setup.domain.entity.toConnectionSecurity
 import app.k9mail.feature.account.setup.domain.entity.toIncomingProtocolType
 import app.k9mail.feature.account.setup.domain.toServerSettings
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 
 internal fun AccountAutoDiscoveryContract.State.toAccountState(): AccountState {
     return AccountState(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryValidator.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryValidator.kt
@@ -4,7 +4,7 @@ import app.k9mail.feature.account.server.settings.domain.usecase.ValidatePasswor
 import app.k9mail.feature.account.setup.domain.DomainContract.UseCase
 import app.k9mail.feature.account.setup.domain.usecase.ValidateConfigurationApproval
 import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailAddress
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
 import app.k9mail.feature.account.server.settings.domain.ServerSettingsDomainContract.UseCase as ServerSettingsUseCase
 
 internal class AccountAutoDiscoveryValidator(
@@ -13,18 +13,18 @@ internal class AccountAutoDiscoveryValidator(
     private val configurationApprovalValidator: UseCase.ValidateConfigurationApproval = ValidateConfigurationApproval(),
 ) : AccountAutoDiscoveryContract.Validator {
 
-    override fun validateEmailAddress(emailAddress: String): ValidationResult {
+    override fun validateEmailAddress(emailAddress: String): ValidationOutcome {
         return emailAddressValidator.execute(emailAddress)
     }
 
-    override fun validatePassword(password: String): ValidationResult {
+    override fun validatePassword(password: String): ValidationOutcome {
         return passwordValidator.execute(password)
     }
 
     override fun validateConfigurationApproval(
         isApproved: Boolean?,
         isAutoDiscoveryTrusted: Boolean?,
-    ): ValidationResult {
+    ): ValidationOutcome {
         return configurationApprovalValidator.execute(isApproved, isAutoDiscoveryTrusted)
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryViewModel.kt
@@ -8,7 +8,6 @@ import app.k9mail.autodiscovery.demo.DemoServerSettings
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.account.common.domain.AccountDomainContract
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.oauth.domain.entity.OAuthResult
 import app.k9mail.feature.account.oauth.ui.AccountOAuthContract
 import app.k9mail.feature.account.setup.domain.DomainContract.UseCase
@@ -21,7 +20,8 @@ import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryCon
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.State
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.Validator
 import kotlinx.coroutines.launch
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.input.StringInputField
 
 @Suppress("TooManyFunctions")
 internal class AccountAutoDiscoveryViewModel(
@@ -110,11 +110,11 @@ internal class AccountAutoDiscoveryViewModel(
     private fun submitEmail() {
         with(state.value) {
             val emailValidationResult = validator.validateEmailAddress(emailAddress.value)
-            val hasError = emailValidationResult is ValidationResult.Failure
+            val hasError = emailValidationResult is Outcome.Failure
 
             updateState {
                 it.copy(
-                    emailAddress = it.emailAddress.updateFromValidationResult(emailValidationResult),
+                    emailAddress = it.emailAddress.updateFromValidationOutcome(emailValidationResult),
                 )
             }
 
@@ -208,13 +208,13 @@ internal class AccountAutoDiscoveryViewModel(
                 emailValidationResult,
                 passwordValidationResult,
                 configurationApprovalValidationResult,
-            ).any { it is ValidationResult.Failure }
+            ).any { it is Outcome.Failure }
 
             updateState {
                 it.copy(
-                    emailAddress = it.emailAddress.updateFromValidationResult(emailValidationResult),
-                    password = it.password.updateFromValidationResult(passwordValidationResult),
-                    configurationApproved = it.configurationApproved.updateFromValidationResult(
+                    emailAddress = it.emailAddress.updateFromValidationOutcome(emailValidationResult),
+                    password = it.password.updateFromValidationOutcome(passwordValidationResult),
+                    configurationApproved = it.configurationApproved.updateFromValidationOutcome(
                         configurationApprovalValidationResult,
                     ),
                 )

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AutoDiscoveryStringMapper.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AutoDiscoveryStringMapper.kt
@@ -6,7 +6,7 @@ import app.k9mail.feature.account.setup.R
 import app.k9mail.feature.account.setup.domain.entity.AutoDiscoveryConnectionSecurity
 import app.k9mail.feature.account.setup.domain.usecase.ValidateConfigurationApproval
 import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailAddress
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
+import net.thunderbird.core.validation.ValidationError
 
 internal fun AutoDiscoveryConnectionSecurity.toAutoDiscoveryConnectionSecurityString(resources: Resources): String {
     return when (this) {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultApprovalView.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/view/AutoDiscoveryResultApprovalView.kt
@@ -9,9 +9,9 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import app.k9mail.core.ui.compose.designsystem.molecule.input.CheckboxInput
 import app.k9mail.core.ui.compose.theme2.MainTheme
-import app.k9mail.feature.account.common.domain.input.BooleanInputField
 import app.k9mail.feature.account.setup.R
 import app.k9mail.feature.account.setup.ui.autodiscovery.toAutoDiscoveryValidationErrorString
+import net.thunderbird.core.validation.input.BooleanInputField
 
 @Composable
 internal fun AutoDiscoveryResultApprovalView(

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContract.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsContract.kt
@@ -1,8 +1,8 @@
 package app.k9mail.feature.account.setup.ui.options.display
 
 import app.k9mail.core.ui.compose.common.mvi.UnidirectionalViewModel
-import app.k9mail.feature.account.common.domain.input.StringInputField
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.input.StringInputField
 
 interface DisplayOptionsContract {
 
@@ -31,8 +31,8 @@ interface DisplayOptionsContract {
     }
 
     interface Validator {
-        fun validateAccountName(accountName: String): ValidationResult
-        fun validateDisplayName(displayName: String): ValidationResult
-        fun validateEmailSignature(emailSignature: String): ValidationResult
+        fun validateAccountName(accountName: String): ValidationOutcome
+        fun validateDisplayName(displayName: String): ValidationOutcome
+        fun validateEmailSignature(emailSignature: String): ValidationOutcome
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateMapper.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateMapper.kt
@@ -2,8 +2,8 @@ package app.k9mail.feature.account.setup.ui.options.display
 
 import app.k9mail.feature.account.common.domain.entity.AccountDisplayOptions
 import app.k9mail.feature.account.common.domain.entity.AccountState
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.State
+import net.thunderbird.core.validation.input.StringInputField
 
 internal fun AccountState.toDisplayOptionsState(): State {
     val options = displayOptions

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStringMapper.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStringMapper.kt
@@ -8,7 +8,7 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateDisplayName.Valid
 import app.k9mail.feature.account.setup.domain.usecase.ValidateDisplayName.ValidateDisplayNameError.EmptyDisplayName
 import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.ValidateEmailSignatureError
 import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.ValidateEmailSignatureError.BlankEmailSignature
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
+import net.thunderbird.core.validation.ValidationError
 
 internal fun ValidationError.toResourceString(resources: Resources): String {
     return when (this) {

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsValidator.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsValidator.kt
@@ -4,22 +4,22 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateAccountName
 import app.k9mail.feature.account.setup.domain.usecase.ValidateDisplayName
 import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Validator
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
 
 internal class DisplayOptionsValidator(
     private val accountNameValidator: ValidateAccountName = ValidateAccountName(),
     private val displayNameValidator: ValidateDisplayName = ValidateDisplayName(),
     private val emailSignatureValidator: ValidateEmailSignature = ValidateEmailSignature(),
 ) : Validator {
-    override fun validateAccountName(accountName: String): ValidationResult {
+    override fun validateAccountName(accountName: String): ValidationOutcome {
         return accountNameValidator.execute(accountName)
     }
 
-    override fun validateDisplayName(displayName: String): ValidationResult {
+    override fun validateDisplayName(displayName: String): ValidationOutcome {
         return displayNameValidator.execute(displayName)
     }
 
-    override fun validateEmailSignature(emailSignature: String): ValidationResult {
+    override fun validateEmailSignature(emailSignature: String): ValidationOutcome {
         return emailSignatureValidator.execute(emailSignature)
     }
 }

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsViewModel.kt
@@ -3,7 +3,6 @@ package app.k9mail.feature.account.setup.ui.options.display
 import androidx.lifecycle.viewModelScope
 import app.k9mail.core.ui.compose.common.mvi.BaseViewModel
 import app.k9mail.feature.account.common.domain.AccountDomainContract
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.setup.AccountSetupExternalContract
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Effect
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Event
@@ -11,7 +10,8 @@ import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContrac
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Validator
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.ViewModel
 import kotlinx.coroutines.launch
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.input.StringInputField
 
 internal class DisplayOptionsViewModel(
     private val validator: Validator,
@@ -76,13 +76,13 @@ internal class DisplayOptionsViewModel(
             accountNameResult,
             displayNameResult,
             emailSignatureResult,
-        ).any { it is ValidationResult.Failure }
+        ).any { it is Outcome.Failure }
 
         updateState {
             it.copy(
-                accountName = it.accountName.updateFromValidationResult(accountNameResult),
-                displayName = it.displayName.updateFromValidationResult(displayNameResult),
-                emailSignature = it.emailSignature.updateFromValidationResult(emailSignatureResult),
+                accountName = it.accountName.updateFromValidationOutcome(accountNameResult),
+                displayName = it.displayName.updateFromValidationOutcome(displayNameResult),
+                emailSignature = it.emailSignature.updateFromValidationOutcome(emailSignatureResult),
             )
         }
 

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersViewModel.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersViewModel.kt
@@ -16,8 +16,8 @@ import com.fsck.k9.mail.folders.FolderFetcherException
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
 import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.outcome.Outcome
 
 class SpecialFoldersViewModel(
     private val formUiModel: SpecialFoldersContract.FormUiModel,
@@ -60,7 +60,7 @@ class SpecialFoldersViewModel(
 
             val result = validateSpecialFolderOptions(specialFolderOptions)
             when (result) {
-                is ValidationResult.Failure -> {
+                is Outcome.Failure -> {
                     updateState {
                         it.copy(
                             isManualSetup = true,
@@ -70,7 +70,7 @@ class SpecialFoldersViewModel(
                     }
                 }
 
-                ValidationResult.Success -> {
+                is Outcome.Success<Unit> -> {
                     updateState {
                         it.copy(
                             isSuccess = true,

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountNameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateAccountNameTest.kt
@@ -4,7 +4,8 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateAccountName.Valid
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 
 class ValidateAccountNameTest {
@@ -15,22 +16,22 @@ class ValidateAccountNameTest {
     fun `should succeed when account name is set`() {
         val result = testSubject.execute("account name")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should succeed when account name is empty`() {
         val result = testSubject.execute("")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when account name is blank`() {
         val result = testSubject.execute(" ")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateAccountNameError.BlankAccountName>()
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateConfigurationApprovalTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateConfigurationApprovalTest.kt
@@ -3,7 +3,8 @@ package app.k9mail.feature.account.setup.domain.usecase
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 
 class ValidateConfigurationApprovalTest {
@@ -14,29 +15,29 @@ class ValidateConfigurationApprovalTest {
     fun `should succeed when auto discovery is approved and trusted`() {
         val result = testSubject.execute(isApproved = true, isAutoDiscoveryTrusted = true)
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should succeed when auto discovery not approved but is trusted`() {
         val result = testSubject.execute(isApproved = false, isAutoDiscoveryTrusted = true)
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should succeed when auto discovery is approved but not trusted`() {
         val result = testSubject.execute(isApproved = true, isAutoDiscoveryTrusted = false)
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when auto discovery is not approved and not trusted`() {
         val result = testSubject.execute(isApproved = false, isAutoDiscoveryTrusted = false)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateConfigurationApproval.ValidateConfigurationApprovalError.ApprovalRequired>()
     }
 
@@ -44,15 +45,15 @@ class ValidateConfigurationApprovalTest {
     fun `should succeed when auto discovery isApproved null and is trusted`() {
         val result = testSubject.execute(isApproved = null, isAutoDiscoveryTrusted = true)
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when auto discovery is isApproved null and is not trusted`() {
         val result = testSubject.execute(isApproved = null, isAutoDiscoveryTrusted = false)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateConfigurationApproval.ValidateConfigurationApprovalError.ApprovalRequired>()
     }
 
@@ -60,8 +61,8 @@ class ValidateConfigurationApprovalTest {
     fun `should fail when auto discovery is approved and trusted is null`() {
         val result = testSubject.execute(isApproved = false, isAutoDiscoveryTrusted = null)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateConfigurationApproval.ValidateConfigurationApprovalError.ApprovalRequired>()
     }
 
@@ -69,8 +70,8 @@ class ValidateConfigurationApprovalTest {
     fun `should fail when auto discovery is not approved and trusted is null`() {
         val result = testSubject.execute(isApproved = false, isAutoDiscoveryTrusted = null)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateConfigurationApproval.ValidateConfigurationApprovalError.ApprovalRequired>()
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayNameTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateDisplayNameTest.kt
@@ -4,7 +4,8 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateDisplayName.Valid
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 
 class ValidateDisplayNameTest {
@@ -15,15 +16,15 @@ class ValidateDisplayNameTest {
     fun `should succeed when display name is set`() {
         val result = testSubject.execute("display name")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when display name is empty`() {
         val result = testSubject.execute("")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateDisplayNameError.EmptyDisplayName>()
     }
 
@@ -31,8 +32,8 @@ class ValidateDisplayNameTest {
     fun `should fail when display name is blank`() {
         val result = testSubject.execute(" ")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateDisplayNameError.EmptyDisplayName>()
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailAddressTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailAddressTest.kt
@@ -4,9 +4,10 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailAddress.Vali
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Before
 import org.junit.Test
 
@@ -23,15 +24,15 @@ class ValidateEmailAddressTest {
     fun `should succeed when email address is valid`() {
         val result = testSubject.execute("test@example.com")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when email address is blank`() {
         val result = testSubject.execute(" ")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailAddressError.EmptyEmailAddress>()
     }
 
@@ -39,8 +40,8 @@ class ValidateEmailAddressTest {
     fun `should fail when email address is using unnecessary quoting in local part`() {
         val result = testSubject.execute("\"local-part\"@domain.example")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailAddressError.NotAllowed>()
     }
 
@@ -48,8 +49,8 @@ class ValidateEmailAddressTest {
     fun `should fail when email address requires quoted local part`() {
         val result = testSubject.execute("\"local part\"@domain.example")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailAddressError.NotAllowed>()
     }
 
@@ -57,8 +58,8 @@ class ValidateEmailAddressTest {
     fun `should fail when local part is empty`() {
         val result = testSubject.execute("\"\"@domain.example")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailAddressError.NotAllowed>()
     }
 
@@ -66,8 +67,8 @@ class ValidateEmailAddressTest {
     fun `should fail when domain part contains IPv4 literal`() {
         val result = testSubject.execute("user@[255.0.100.23]")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailAddressError.NotAllowed>()
     }
 
@@ -75,8 +76,8 @@ class ValidateEmailAddressTest {
     fun `should fail when domain part contains IPv6 literal`() {
         val result = testSubject.execute("user@[IPv6:2001:0db8:0000:0000:0000:ff00:0042:8329]")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailAddressError.NotAllowed>()
     }
 
@@ -84,8 +85,8 @@ class ValidateEmailAddressTest {
     fun `should fail when local part contains non-ASCII character`() {
         val result = testSubject.execute("töst@domain.example")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailAddressError.InvalidOrNotSupported>()
     }
 
@@ -93,8 +94,8 @@ class ValidateEmailAddressTest {
     fun `should fail when domain contains non-ASCII character`() {
         val result = testSubject.execute("test@dömain.example")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailAddressError.InvalidOrNotSupported>()
     }
 
@@ -102,8 +103,8 @@ class ValidateEmailAddressTest {
     fun `should fail when email address is invalid`() {
         val result = testSubject.execute("test")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailAddressError.InvalidEmailAddress>()
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignatureTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateEmailSignatureTest.kt
@@ -4,7 +4,8 @@ import app.k9mail.feature.account.setup.domain.usecase.ValidateEmailSignature.Va
 import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 
 class ValidateEmailSignatureTest {
@@ -15,22 +16,22 @@ class ValidateEmailSignatureTest {
     fun `should succeed when email signature is set`() {
         val result = testSubject.execute("email signature")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should succeed when email signature is empty`() {
         val result = testSubject.execute("")
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
     fun `should fail when email signature is blank`() {
         val result = testSubject.execute(" ")
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<ValidateEmailSignatureError.BlankEmailSignature>()
     }
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateSpecialFolderOptionsTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/domain/usecase/ValidateSpecialFolderOptionsTest.kt
@@ -8,7 +8,8 @@ import assertk.assertThat
 import assertk.assertions.isInstanceOf
 import assertk.assertions.prop
 import dev.forkhandles.fabrikate.Fabrikate
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
+import net.thunderbird.core.validation.ValidationError
 import org.junit.Test
 
 class ValidateSpecialFolderOptionsTest {
@@ -19,7 +20,7 @@ class ValidateSpecialFolderOptionsTest {
     fun `validate special folder options should succeed when all default options are present`() {
         val result = testSubject(SPECIAL_FOLDER_OPTIONS)
 
-        assertThat(result).isInstanceOf<ValidationResult.Success>()
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
     }
 
     @Test
@@ -34,8 +35,8 @@ class ValidateSpecialFolderOptionsTest {
 
         val result = testSubject(specialFolderOptions)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<Failure.MissingDefaultSpecialFolderOption>()
     }
 
@@ -51,8 +52,8 @@ class ValidateSpecialFolderOptionsTest {
 
         val result = testSubject(specialFolderOptions)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<Failure.MissingDefaultSpecialFolderOption>()
     }
 
@@ -68,8 +69,8 @@ class ValidateSpecialFolderOptionsTest {
 
         val result = testSubject(specialFolderOptions)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<Failure.MissingDefaultSpecialFolderOption>()
     }
 
@@ -85,8 +86,8 @@ class ValidateSpecialFolderOptionsTest {
 
         val result = testSubject(specialFolderOptions)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<Failure.MissingDefaultSpecialFolderOption>()
     }
 
@@ -102,8 +103,8 @@ class ValidateSpecialFolderOptionsTest {
 
         val result = testSubject(specialFolderOptions)
 
-        assertThat(result).isInstanceOf<ValidationResult.Failure>()
-            .prop(ValidationResult.Failure::error)
+        assertThat(result).isInstanceOf<Outcome.Failure<ValidationError>>()
+            .prop(Outcome.Failure<ValidationError>::error)
             .isInstanceOf<Failure.MissingDefaultSpecialFolderOption>()
     }
 

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryStateMapperKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryStateMapperKtTest.kt
@@ -6,8 +6,6 @@ import app.k9mail.autodiscovery.api.SmtpServerSettings
 import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.AuthenticationType
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
-import app.k9mail.feature.account.common.domain.input.NumberInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSettingsContract
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract
 import app.k9mail.feature.account.setup.domain.entity.AutoDiscoveryAuthenticationType
@@ -18,6 +16,8 @@ import assertk.assertThat
 import assertk.assertions.isEqualTo
 import net.thunderbird.core.common.net.toHostname
 import net.thunderbird.core.common.net.toPort
+import net.thunderbird.core.validation.input.NumberInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Test
 
 class AccountAutoDiscoveryStateMapperKtTest {

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryStateTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryStateTest.kt
@@ -1,11 +1,11 @@
 package app.k9mail.feature.account.setup.ui.autodiscovery
 
-import app.k9mail.feature.account.common.domain.input.BooleanInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.ConfigStep
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import net.thunderbird.core.validation.input.BooleanInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Test
 
 class AccountAutoDiscoveryStateTest {

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/AccountAutoDiscoveryViewModelTest.kt
@@ -9,8 +9,6 @@ import app.k9mail.feature.account.common.data.InMemoryAccountStateRepository
 import app.k9mail.feature.account.common.domain.AccountDomainContract
 import app.k9mail.feature.account.common.domain.entity.AccountState
 import app.k9mail.feature.account.common.domain.entity.IncomingProtocolType
-import app.k9mail.feature.account.common.domain.input.BooleanInputField
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.oauth.ui.fake.FakeAccountOAuthViewModel
 import app.k9mail.feature.account.setup.domain.entity.AutoDiscoverySettingsFixture
 import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryContract.AutoDiscoveryUiResult
@@ -22,9 +20,11 @@ import app.k9mail.feature.account.setup.ui.autodiscovery.AccountAutoDiscoveryCon
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import kotlinx.coroutines.delay
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.core.testing.coroutines.MainDispatcherRule
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.input.BooleanInputField
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Rule
 import org.junit.Test
 
@@ -212,7 +212,7 @@ class AccountAutoDiscoveryViewModelTest {
             )
             val testSubject = AccountAutoDiscoveryViewModel(
                 validator = FakeAccountAutoDiscoveryValidator(
-                    emailAddressAnswer = ValidationResult.Failure(TestError),
+                    emailAddressAnswer = Outcome.Failure(TestError),
                 ),
                 getAutoDiscovery = { AutoDiscoveryResult.NoUsableSettingsFound },
                 oAuthViewModel = FakeAccountOAuthViewModel(),
@@ -309,7 +309,7 @@ class AccountAutoDiscoveryViewModelTest {
             )
             val viewModel = AccountAutoDiscoveryViewModel(
                 validator = FakeAccountAutoDiscoveryValidator(
-                    passwordAnswer = ValidationResult.Failure(TestError),
+                    passwordAnswer = Outcome.Failure(TestError),
                 ),
                 getAutoDiscovery = { AutoDiscoveryResult.NoUsableSettingsFound },
                 oAuthViewModel = FakeAccountOAuthViewModel(),

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/FakeAccountAutoDiscoveryValidator.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/autodiscovery/FakeAccountAutoDiscoveryValidator.kt
@@ -1,16 +1,17 @@
 package app.k9mail.feature.account.setup.ui.autodiscovery
 
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 class FakeAccountAutoDiscoveryValidator(
-    private val emailAddressAnswer: ValidationResult = ValidationResult.Success,
-    private val passwordAnswer: ValidationResult = ValidationResult.Success,
-    private val configurationApprovalAnswer: ValidationResult = ValidationResult.Success,
+    private val emailAddressAnswer: ValidationOutcome = ValidationSuccess,
+    private val passwordAnswer: ValidationOutcome = ValidationSuccess,
+    private val configurationApprovalAnswer: ValidationOutcome = ValidationSuccess,
 ) : AccountAutoDiscoveryContract.Validator {
-    override fun validateEmailAddress(emailAddress: String): ValidationResult = emailAddressAnswer
-    override fun validatePassword(password: String): ValidationResult = passwordAnswer
+    override fun validateEmailAddress(emailAddress: String): ValidationOutcome = emailAddressAnswer
+    override fun validatePassword(password: String): ValidationOutcome = passwordAnswer
     override fun validateConfigurationApproval(
         isApproved: Boolean?,
         isAutoDiscoveryTrusted: Boolean?,
-    ): ValidationResult = configurationApprovalAnswer
+    ): ValidationOutcome = configurationApprovalAnswer
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateMapperKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateMapperKtTest.kt
@@ -1,10 +1,10 @@
 package app.k9mail.feature.account.setup.ui.options.display
 
 import app.k9mail.feature.account.common.domain.entity.AccountDisplayOptions
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isNull
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Test
 
 class DisplayOptionsStateMapperKtTest {

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsStateTest.kt
@@ -1,9 +1,9 @@
 package app.k9mail.feature.account.setup.ui.options.display
 
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Test
 
 class DisplayOptionsStateTest {

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/DisplayOptionsViewModelTest.kt
@@ -4,15 +4,15 @@ import app.k9mail.core.ui.compose.testing.mvi.eventStateTest
 import app.k9mail.core.ui.compose.testing.mvi.runMviTest
 import app.k9mail.core.ui.compose.testing.mvi.turbinesWithInitialStateCheck
 import app.k9mail.feature.account.common.data.InMemoryAccountStateRepository
-import app.k9mail.feature.account.common.domain.input.StringInputField
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Effect
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Event
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.State
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.core.testing.coroutines.MainDispatcherRule
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.input.StringInputField
 import org.junit.Rule
 import org.junit.Test
 
@@ -82,7 +82,7 @@ class DisplayOptionsViewModelTest {
         runMviTest {
             val viewModel = DisplayOptionsViewModel(
                 validator = FakeDisplayOptionsValidator(
-                    accountNameAnswer = ValidationResult.Failure(TestError),
+                    accountNameAnswer = Outcome.Failure(TestError),
                 ),
                 accountStateRepository = InMemoryAccountStateRepository(),
                 accountOwnerNameProvider = accountOwnerNameProvider,

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/FakeDisplayOptionsValidator.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/options/display/FakeDisplayOptionsValidator.kt
@@ -1,14 +1,15 @@
 package app.k9mail.feature.account.setup.ui.options.display
 
 import app.k9mail.feature.account.setup.ui.options.display.DisplayOptionsContract.Validator
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 
 internal class FakeDisplayOptionsValidator(
-    private val accountNameAnswer: ValidationResult = ValidationResult.Success,
-    private val displayNameAnswer: ValidationResult = ValidationResult.Success,
-    private val emailSignatureAnswer: ValidationResult = ValidationResult.Success,
+    private val accountNameAnswer: ValidationOutcome = ValidationSuccess,
+    private val displayNameAnswer: ValidationOutcome = ValidationSuccess,
+    private val emailSignatureAnswer: ValidationOutcome = ValidationSuccess,
 ) : Validator {
-    override fun validateAccountName(accountName: String): ValidationResult = accountNameAnswer
-    override fun validateDisplayName(displayName: String): ValidationResult = displayNameAnswer
-    override fun validateEmailSignature(emailSignature: String): ValidationResult = emailSignatureAnswer
+    override fun validateAccountName(accountName: String): ValidationOutcome = accountNameAnswer
+    override fun validateDisplayName(displayName: String): ValidationOutcome = displayNameAnswer
+    override fun validateEmailSignature(emailSignature: String): ValidationOutcome = emailSignatureAnswer
 }

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersViewModelTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/ui/specialfolders/SpecialFoldersViewModelTest.kt
@@ -23,9 +23,11 @@ import com.fsck.k9.mail.folders.FolderFetcherException
 import com.fsck.k9.mail.folders.FolderServerId
 import com.fsck.k9.mail.folders.RemoteFolder
 import kotlinx.coroutines.delay
-import net.thunderbird.core.common.domain.usecase.validation.ValidationError
-import net.thunderbird.core.common.domain.usecase.validation.ValidationResult
+import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.core.testing.coroutines.MainDispatcherRule
+import net.thunderbird.core.validation.ValidationError
+import net.thunderbird.core.validation.ValidationOutcome
+import net.thunderbird.core.validation.ValidationSuccess
 import org.junit.Rule
 import org.junit.Test
 
@@ -43,7 +45,7 @@ class SpecialFoldersViewModelTest {
             )
             val testSubject = createTestSubject(
                 formUiModel = FakeSpecialFoldersFormUiModel(),
-                validateSpecialFolderOptions = { ValidationResult.Success },
+                validateSpecialFolderOptions = { ValidationSuccess },
                 accountStateRepository = accountStateRepository,
                 initialState = initialState,
             )
@@ -98,7 +100,7 @@ class SpecialFoldersViewModelTest {
         )
         val testSubject = createTestSubject(
             formUiModel = FakeSpecialFoldersFormUiModel(),
-            validateSpecialFolderOptions = { ValidationResult.Failure(TestValidationError) },
+            validateSpecialFolderOptions = { Outcome.Failure(TestValidationError) },
             accountStateRepository = accountStateRepository,
             initialState = initialState,
         )
@@ -278,7 +280,7 @@ class SpecialFoldersViewModelTest {
         fun createTestSubject(
             formUiModel: SpecialFoldersContract.FormUiModel = FakeSpecialFoldersFormUiModel(),
             getSpecialFolderOptions: () -> SpecialFolderOptions = { SPECIAL_FOLDER_OPTIONS },
-            validateSpecialFolderOptions: (SpecialFolderOptions) -> ValidationResult = { ValidationResult.Success },
+            validateSpecialFolderOptions: (SpecialFolderOptions) -> ValidationOutcome = { ValidationSuccess },
             accountStateRepository: AccountDomainContract.AccountStateRepository = InMemoryAccountStateRepository(),
             initialState: State = State(),
         ) = SpecialFoldersViewModel(

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -170,6 +170,7 @@ include(
     ":core:preference:impl",
     ":core:outcome",
     ":core:testing",
+    ":core:validation",
 )
 
 include(


### PR DESCRIPTION
Part of #9031 

This moved the validation components from the account feature to a dedicated `:core:validation` module.