### PR TITLE
chore(l10n): add missing translation to notification resources

### DIFF
--- a/feature/notification/api/src/commonMain/composeResources/values-ar/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">تزامن (إرسال)</string>
+    <string name="notification_channel_push_description">يتم عرضها أثناء انتظار رسائل جديدة</string>
+    <string name="notification_channel_messages_title">الرسائل</string>
+    <string name="notification_channel_messages_description">إشعارات ذات علاقة بالرسائل</string>
+    <string name="notification_channel_miscellaneous_title">مُتنوع</string>
+    <string name="notification_channel_miscellaneous_description">تنبيهات متفرقة مثل الأخطاء وغيرها من الأمور.</string>
+    <string name="notification_notify_error_title">إشعار خطأ</string>
+    <string name="notification_notify_error_text">حدث خطأ أثناء محاولة إنشاء إشعار نظام برسالة جديدة. السبب على الأرجح هو فقدان صوت الإشعار. \n\nانقر لفتح إعدادات الإشعارات.</string>
+    <string name="notification_authentication_error_title">فشل المصادقة</string>
+    <string name="notification_certificate_error_public">خطأ في الشهادة</string>
+    <string name="notification_certificate_error_title">خطأ في شهادة %1$s</string>
+    <string name="notification_certificate_error_text">تأكد من إعدادات الخادم</string>
+    <string name="notification_bg_sync_ticker">تفقد البريد: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">التحقق من البريد</string>
+    <string name="notification_bg_send_ticker">إرسال البريد: %1$s</string>
+    <string name="notification_bg_send_title">إرسال البريد</string>
+    <string name="send_failure_subject">فشِلَت عملية إرسال بعض الرسائل</string>
+    <string name="notification_additional_messages">+%1$d المزيد علي %2$s</string>
+    <string name="push_notification_state_initializing">جار تهيئة… </string>
+    <string name="push_notification_state_listening">في انتظار رسائل البريد الإلكتروني الجديدة </string>
+    <string name="push_notification_state_wait_background_sync">السكون حتى يتم السماح بالمزامنة في الخلفية </string>
+    <string name="push_notification_state_wait_network">السكون حتى تتوفر الشبكة </string>
+    <string name="push_notification_state_alarm_permission_missing">إذن مفقود لجدولة التنبيهات</string>
+    <string name="push_notification_info">انقر لمعرفة المزيد. </string>
+    <string name="push_notification_grant_alarm_permission">انقر لمنح الإذن.</string>
+    <string name="push_info_disable_push_action">تعطيل الدفع </string>
+    <string name="notification_action_reply">رُد</string>
+    <string name="notification_action_mark_as_read">إعتبارها مقروءة</string>
+    <string name="notification_action_mark_all_as_read">إعتبار الكل كمقروء</string>
+    <string name="notification_action_delete">احذف</string>
+    <string name="notification_action_delete_all">احذف الكل</string>
+    <string name="notification_action_archive">أرشيف</string>
+    <string name="notification_action_archive_all">أرشفة الكل</string>
+    <string name="notification_action_spam">بريد مُزعج</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ast/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ast/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_messages_title">Mensaxes</string>
+    <string name="notification_action_delete">Desaniciar</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-az/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-az/strings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_action_reply">Cavab ver</string>
+    <string name="notification_action_delete">Sil</string>
+    <string name="notification_action_archive">Arxiv</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-be/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-be/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Сінхранізаваць (прымусовае правяранне)</string>
+    <string name="notification_channel_push_description">Паказваецца падчас чакання новых лістоў</string>
+    <string name="notification_channel_messages_title">Лісты</string>
+    <string name="notification_channel_messages_description">Апавяшчэнні пра лісты</string>
+    <string name="notification_channel_miscellaneous_title">Рознае</string>
+    <string name="notification_channel_miscellaneous_description">Іншыя апавяшчэнні.</string>
+    <string name="notification_notify_error_title">Памылка апавяшчэння</string>
+    <string name="notification_notify_error_text">Падчас стварэння сістэмнага апавяшчэння пра новы ліст адбылася памылка. Хутчэй за ўсё, прычына ў адсутнасці гуку апавяшчэння.\n\nНацісніце, каб адкрыць налады апавяшчэнняў.</string>
+    <string name="notification_authentication_error_title">Аўтэнтыфікацыя схібіла</string>
+    <string name="notification_certificate_error_public">Памылка сертыфіката</string>
+    <string name="notification_certificate_error_title">Збой сертыфіката %1$s</string>
+    <string name="notification_certificate_error_text">Праверце налады сервера</string>
+    <string name="notification_bg_sync_ticker">Правяранне пошты: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Правяранне пошты</string>
+    <string name="notification_bg_send_ticker">Адпраўленне пошты: %1$s</string>
+    <string name="notification_bg_send_title">Адпраўленне пошты</string>
+    <string name="send_failure_subject">Не ўдалося адправіць лісты</string>
+    <string name="notification_additional_messages">+ %1$d яшчэ %2$s</string>
+    <string name="push_notification_state_initializing">Ініцыялізацыя…</string>
+    <string name="push_notification_state_listening">Чаканне новых лістоў</string>
+    <string name="push_notification_state_wait_background_sync">Знаходзіцца ў рэжыме сну, пакуль фонавая сінхранізацыя не будзе дазволеная</string>
+    <string name="push_notification_state_wait_network">Знаходзіцца ў рэжыме сну, пакуль не стане даступная сетка</string>
+    <string name="push_notification_state_alarm_permission_missing">Няма дазволу на прызначэнне будзільнікаў</string>
+    <string name="push_notification_info">Націсніце, каб даведацца больш.</string>
+    <string name="push_notification_grant_alarm_permission">Націсніце, каб даць дазвол.</string>
+    <string name="push_info_disable_push_action">Адключыць прымусовае правяранне</string>
+    <string name="notification_action_reply">Адказаць</string>
+    <string name="notification_action_mark_as_read">Пазначыць прачытаным</string>
+    <string name="notification_action_mark_all_as_read">Пазначыць усё прачытаным</string>
+    <string name="notification_action_delete">Выдаліць</string>
+    <string name="notification_action_delete_all">Выдаліць усе</string>
+    <string name="notification_action_archive">Архіў</string>
+    <string name="notification_action_archive_all">Усе ў архіў</string>
+    <string name="notification_action_spam">Спам</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-bg/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-bg/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Синхронизирай (Push)</string>
+    <string name="notification_channel_push_description">Да се показва докато чака за нови съобщения</string>
+    <string name="notification_channel_messages_title">Съобщения</string>
+    <string name="notification_channel_messages_description">Известия свързани със съобщения</string>
+    <string name="notification_channel_miscellaneous_title">Разни</string>
+    <string name="notification_channel_miscellaneous_description">Разни известия като грешки и т.н.</string>
+    <string name="notification_notify_error_title">Грешка при известие</string>
+    <string name="notification_notify_error_text">Възникна грешка при създаването на известие за ново съобщение. Причината най-вероятно е липсващ звук за известия.
+\n
+\nДокоснете тук, за да отворите настройките на известията.</string>
+    <string name="notification_authentication_error_title">Неуспешна идентификация</string>
+    <string name="notification_certificate_error_public">Грешка в сертификата</string>
+    <string name="notification_certificate_error_title">Грешка в сертификата на %1$s</string>
+    <string name="notification_certificate_error_text">Проверете настройките на сървара</string>
+    <string name="notification_bg_sync_ticker">Проверка на поща: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Проверка на поща</string>
+    <string name="notification_bg_send_ticker">Изпраща писмо: %1$s</string>
+    <string name="notification_bg_send_title">Изпраща писмо</string>
+    <string name="send_failure_subject">Грешка при изпращане на някой съобщения</string>
+    <string name="notification_additional_messages">+ %1$d в %2$s</string>
+    <string name="push_notification_state_initializing">Инициализира…</string>
+    <string name="push_notification_state_listening">Изчаква за нови съобщения</string>
+    <string name="push_notification_state_wait_background_sync">Заспива докато синхронизирането на заден фон е разрешено</string>
+    <string name="push_notification_state_wait_network">Спи докато чака за мрежа</string>
+    <string name="push_notification_state_alarm_permission_missing">Липсва разрешение за настройка на будилник</string>
+    <string name="push_notification_info">Натиснете за да научите повече.</string>
+    <string name="push_notification_grant_alarm_permission">Докоснете, за да дадете разрешение.</string>
+    <string name="push_info_disable_push_action">Изключи Push</string>
+    <string name="notification_action_reply">Отговори</string>
+    <string name="notification_action_mark_as_read">Маркирай като прочетено</string>
+    <string name="notification_action_mark_all_as_read">Маркирате всички като прочетени</string>
+    <string name="notification_action_delete">Изтриване</string>
+    <string name="notification_action_delete_all">Изтрите всички</string>
+    <string name="notification_action_archive">Архивиране</string>
+    <string name="notification_action_archive_all">Архивиране на всички</string>
+    <string name="notification_action_spam">Спам</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-br/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-br/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Goubredañ (bountañ)</string>
+    <string name="notification_channel_push_description">Skrammet pa vez gortozet posteloù nevez</string>
+    <string name="notification_channel_messages_title">Kemennadennoù</string>
+    <string name="notification_channel_messages_description">Rebuzadurioù liammet da gemennadennoù</string>
+    <string name="notification_channel_miscellaneous_title">Liesseurt</string>
+    <string name="notification_channel_miscellaneous_description">Rebuzadurioù a-bep seurt evel fazioù hag all.</string>
+    <string name="notification_notify_error_title">Fazi rebuzadur</string>
+    <string name="notification_notify_error_text">Degouezhet ez eus bet ur fazi en ur glask krouiñ ur rebuzadur evit ur postel nevez. Moarvat e vank ur son evit ar rebuzadur.\n\nStokit da zigeriñ arventennoù ar rebuzadurioù.</string>
+    <string name="notification_authentication_error_title">C’hwiadenn war an dilesa</string>
+    <string name="notification_certificate_error_public">Fazi testeni</string>
+    <string name="notification_certificate_error_title">Fazi testeni evit %1$s</string>
+    <string name="notification_certificate_error_text">Gwiriit an arventennoù dafariad</string>
+    <string name="notification_bg_sync_ticker">O kerc’hat ar posteloù: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Kerc’hat ar posteloù</string>
+    <string name="notification_bg_send_ticker">O kas ar postel: %1$s</string>
+    <string name="notification_bg_send_title">O kas ar postel</string>
+    <string name="send_failure_subject">C’hwitadenn en ur gas kemennadennoù ’zo</string>
+    <string name="notification_additional_messages">+ %1$d ouzhpenn war %2$s</string>
+    <string name="push_notification_state_initializing">O teraouekaat…</string>
+    <string name="push_notification_state_listening">O c\'hortoz posteloù nevez</string>
+    <string name="push_notification_state_wait_background_sync">O kousket betek ma vefe gweredekaet ar goubredañ en-dro</string>
+    <string name="push_notification_state_wait_network">O kousket betek ma vefe kennasket ar rouedad</string>
+    <string name="push_notification_state_alarm_permission_missing">Mankout a ra un aotren evit programmiñ galvoù-diwall</string>
+    <string name="push_notification_info">Stokit da zeskiñ muioc\'h.</string>
+    <string name="push_notification_grant_alarm_permission">Stokit da reiñ an aotre.</string>
+    <string name="push_info_disable_push_action">Diweredekaat ar bountañ</string>
+    <string name="notification_action_reply">Respont</string>
+    <string name="notification_action_mark_as_read">Merkañ evel lennet</string>
+    <string name="notification_action_mark_all_as_read">Merkañ an holl evel lennet</string>
+    <string name="notification_action_delete">Dilemel</string>
+    <string name="notification_action_delete_all">Dilemel an holl</string>
+    <string name="notification_action_archive">Diellaouiñ</string>
+    <string name="notification_action_archive_all">Diellaouiñ an holl</string>
+    <string name="notification_action_spam">Lastez</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-bs/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-bs/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sinhronizacija (Push)</string>
+    <string name="notification_channel_push_description">Prikazano dok se čeka na nove poruke</string>
+    <string name="notification_channel_messages_title">Poruke</string>
+    <string name="notification_channel_messages_description">Obavještenja vezana za poruke</string>
+    <string name="notification_channel_miscellaneous_title">Razno</string>
+    <string name="notification_channel_miscellaneous_description">Raznovrsne obavijesti kao greške itd.</string>
+    <string name="notification_notify_error_title">Greška pri kreiranju obavještenja</string>
+    <string name="notification_notify_error_text">Dogodila se greška tokom kreiranja sistemskog obavještenja za novu poruku. Razlog je vjerovatno nemanje zvuka obavještenja.
+\n
+\nDodirnite da otvorite podešavanja obavještenja.</string>
+    <string name="notification_authentication_error_title">Autentifikacija nije uspjela</string>
+    <string name="notification_certificate_error_public">Greška sertifikata</string>
+    <string name="notification_certificate_error_title">Greška sertifikata za %1$s</string>
+    <string name="notification_certificate_error_text">Provjerite postavke vašeg servera</string>
+    <string name="notification_bg_sync_ticker">Provjeravanje pošte: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Provjeravanje pošte</string>
+    <string name="notification_bg_send_ticker">Slanje pošte: %1$s</string>
+    <string name="notification_bg_send_title">Slanje pošte</string>
+    <string name="send_failure_subject">Slanje nekih poruka nije uspjelo</string>
+    <string name="notification_additional_messages">+ %1$d više na %2$s</string>
+    <string name="notification_action_reply">Odgovori</string>
+    <string name="notification_action_mark_as_read">Označi pročitanim</string>
+    <string name="notification_action_mark_all_as_read">Označi sve kao pročitane</string>
+    <string name="notification_action_delete">Obriši</string>
+    <string name="notification_action_delete_all">Obriši sve</string>
+    <string name="notification_action_archive">Arhiviraj</string>
+    <string name="notification_action_archive_all">Arhiviraj sve</string>
+    <string name="notification_action_spam">Neželjena pošta</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ca/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ca/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sincronitza-ho (Empeny)</string>
+    <string name="notification_channel_push_description">Mostrat mentre s\'esperen missatges nous</string>
+    <string name="notification_channel_messages_title">Missatges</string>
+    <string name="notification_channel_messages_description">Notificacions relacionades amb missatges</string>
+    <string name="notification_channel_miscellaneous_title">Miscel·lània</string>
+    <string name="notification_channel_miscellaneous_description">Notificacions diverses, com ara errors, etc.</string>
+    <string name="notification_notify_error_title">Error de notificació</string>
+    <string name="notification_notify_error_text">S\'ha produït un error en intentar crear una notificació del sistema per a un missatge nou. El motiu més probable és que falti un so de notificació.
+\n
+\nToqueu per obrir la configuració de notificació.</string>
+    <string name="notification_authentication_error_title">Ha fallat l\'autenticació</string>
+    <string name="notification_certificate_error_public">Error de certificat</string>
+    <string name="notification_certificate_error_title">Error al certificat de %1$s</string>
+    <string name="notification_certificate_error_text">Comproveu la configuració del servidor</string>
+    <string name="notification_bg_sync_ticker">S\'està comprovant el correu: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">S\'està comprovant el correu</string>
+    <string name="notification_bg_send_ticker">S\'està enviant correu: %1$s</string>
+    <string name="notification_bg_send_title">S\'està enviant correu</string>
+    <string name="send_failure_subject">La tramesa d\'alguns missatges ha fallat</string>
+    <string name="notification_additional_messages">+ %1$d més sobre %2$s</string>
+    <string name="push_notification_state_initializing">S\'està iniciant…</string>
+    <string name="push_notification_state_listening">S\'està esperant nous correus electrònics</string>
+    <string name="push_notification_state_wait_background_sync">Inactiu fins que es permeti la sincronització</string>
+    <string name="push_notification_state_wait_network">Inactiu fins que la xarxa estigui disponible</string>
+    <string name="push_notification_state_alarm_permission_missing">Falta permís per a programar alarmes</string>
+    <string name="push_notification_info">Toca per obtenir més informació.</string>
+    <string name="push_notification_grant_alarm_permission">Toca per a concedir permís.</string>
+    <string name="push_info_disable_push_action">Desactiva la Tramesa</string>
+    <string name="notification_action_reply">Respon</string>
+    <string name="notification_action_mark_as_read">Marca com a llegit</string>
+    <string name="notification_action_mark_all_as_read">Marca\'ls tots com a llegits</string>
+    <string name="notification_action_delete">Suprimeix</string>
+    <string name="notification_action_delete_all">Elimina-ho tot</string>
+    <string name="notification_action_archive">Arxiva</string>
+    <string name="notification_action_archive_all">Arxiva-ho tot</string>
+    <string name="notification_action_spam">Correu brossa</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-co/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-co/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sincrunizà (Catapughjà)</string>
+    <string name="notification_channel_push_description">Affissatu durante l’attesa di i messaghji novi</string>
+    <string name="notification_channel_messages_title">Messaghji</string>
+    <string name="notification_channel_messages_description">Nutificazioni relative à i messaghji</string>
+    <string name="notification_channel_miscellaneous_title">Diversi</string>
+    <string name="notification_channel_miscellaneous_description">Nutificazioni diverse tale chì sbaglii, ecc.</string>
+    <string name="notification_notify_error_title">Sbagliu di nutificazione</string>
+    <string name="notification_notify_error_text">Un sbagliu hè accadutu pruvendu di creà una nutificazione di sistema per un messaghju novu. A ragione prubabile hè l’assenza di sonu di nutificazione.
+\n
+\nPicchichjà per apre i parametri di nutificazione.</string>
+    <string name="notification_authentication_error_title">Fiascu d’autenticazione</string>
+    <string name="notification_certificate_error_public">Sbagliu di certificatu</string>
+    <string name="notification_certificate_error_title">Sbagliu di certificatu per %1$s</string>
+    <string name="notification_certificate_error_text">Verificate i vostri parametri di servitore</string>
+    <string name="notification_bg_sync_ticker">Rileva di i messaghji : %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Rileva di i messaghji</string>
+    <string name="notification_bg_send_ticker">Inviu di i messaghji : %1$s</string>
+    <string name="notification_bg_send_title">Inviu di i messaghji</string>
+    <string name="send_failure_subject">Fiascu per mandà certi messaghji</string>
+    <string name="notification_additional_messages">+ %1$d di più nant’à %2$s</string>
+    <string name="push_notification_state_initializing">Iniziu…</string>
+    <string name="push_notification_state_listening">In attesa di i messaghji novi</string>
+    <string name="push_notification_state_wait_background_sync">Inattiva finchè a sincrunizazione in tacca di sfondulu sia permessa</string>
+    <string name="push_notification_state_wait_network">Inattiva finchè a reta sia dispunibule</string>
+    <string name="push_notification_state_alarm_permission_missing">Un permessu hè assente per pianificà l’alarme</string>
+    <string name="push_notification_info">Tuccà per sapene di più.</string>
+    <string name="push_notification_grant_alarm_permission">Tuccà per cunsente u permessu.</string>
+    <string name="push_info_disable_push_action">Disattivà a catapughjata</string>
+    <string name="notification_action_reply">Risponde</string>
+    <string name="notification_action_mark_as_read">Marcà cum’è lettu</string>
+    <string name="notification_action_mark_all_as_read">Tuttu marcà cum’è lettu</string>
+    <string name="notification_action_delete">Squassà</string>
+    <string name="notification_action_delete_all">Tuttu squassà</string>
+    <string name="notification_action_archive">Archiviu</string>
+    <string name="notification_action_archive_all">Tuttu in archiviu</string>
+    <string name="notification_action_spam">Merzaghju</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-cs/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-cs/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synchronizovat (Push)</string>
+    <string name="notification_channel_push_description">Zobrazeno po dobu čekání na nové zprávy</string>
+    <string name="notification_channel_messages_title">Zpráva</string>
+    <string name="notification_channel_messages_description">Oznámení související se zprávami</string>
+    <string name="notification_channel_miscellaneous_title">Různé</string>
+    <string name="notification_channel_miscellaneous_description">Různá oznámení, jako chyby atd.</string>
+    <string name="notification_notify_error_title">Chyba oznámení</string>
+    <string name="notification_notify_error_text">Vyskytla se chyba při vytvoření systémového oznámení pro novou zprávu. Důvodem je nejspíš chybějící zvuk oznámení.
+\n
+\nKlepnutím otevřete nastavení oznámení.</string>
+    <string name="notification_authentication_error_title">Přihlášení se nezdařilo</string>
+    <string name="notification_certificate_error_public">Chyba certifikátu</string>
+    <string name="notification_certificate_error_title">Chyba certifikátu účtu %1$s</string>
+    <string name="notification_certificate_error_text">Zkontrolujte nastavení serveru</string>
+    <string name="notification_bg_sync_ticker">Kontrola nové pošty: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Kontrola nové pošty</string>
+    <string name="notification_bg_send_ticker">Odesílání pošty: %1$s</string>
+    <string name="notification_bg_send_title">Odesílání pošty</string>
+    <string name="send_failure_subject">Selhalo odeslání některých zpráv</string>
+    <string name="notification_additional_messages">+ %1$d pro účet %2$s</string>
+    <string name="push_notification_state_initializing">Inicializace…</string>
+    <string name="push_notification_state_listening">Čeká se na nové e-maily</string>
+    <string name="push_notification_state_wait_background_sync">Uspáno do doby, než bude umožněna synchronizace na pozadí</string>
+    <string name="push_notification_state_wait_network">Uspáno do doby, než bude k dispozici síť</string>
+    <string name="push_notification_state_alarm_permission_missing">Chybí oprávnění pro nastavování alarmů</string>
+    <string name="push_notification_info">Klepněte, pokud se chcete dozvědět víc.</string>
+    <string name="push_notification_grant_alarm_permission">Klepnutím udělíte oprávnění.</string>
+    <string name="push_info_disable_push_action">Vypnout Push</string>
+    <string name="notification_action_reply">Odpovědět</string>
+    <string name="notification_action_mark_as_read">Přečteno</string>
+    <string name="notification_action_mark_all_as_read">Označit vše jako přečtené</string>
+    <string name="notification_action_delete">Smazat</string>
+    <string name="notification_action_delete_all">Smazat vše</string>
+    <string name="notification_action_archive">Archivovat</string>
+    <string name="notification_action_archive_all">Archivovat vše</string>
+    <string name="notification_action_spam">Nevyžádaná</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-cy/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-cy/strings.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Cydweddu (Gwthio)</string>
+    <string name="notification_channel_push_description">Dangosir wrth aros am negeseuon newydd</string>
+    <string name="notification_channel_messages_title">Negeseuon</string>
+    <string name="notification_channel_messages_description">Hysbysiadau yn ymwneud â negeseuon</string>
+    <string name="notification_channel_miscellaneous_title">Amrywiol</string>
+    <string name="notification_channel_miscellaneous_description">Hysbysiadau amryw, fel gwallau ayyb.</string>
+    <string name="notification_notify_error_title">Gwall hysbysiad</string>
+    <string name="notification_notify_error_text">Bu gwall wrth geisio creu hysbysiad system am neges newydd. Mae\'n debyg mai\'r rheswm yw bod sain hysbysiad ar goll.\n\nTapia i agor gosodiadau hysbysiadau.</string>
+    <string name="notification_authentication_error_title">Methwyd a dilysu</string>
+    <string name="notification_certificate_error_public">Gwall tystysgrif</string>
+    <string name="notification_certificate_error_title">Gwall tystysgrif ar gyfer %1$s</string>
+    <string name="notification_certificate_error_text">Gwiria osodiadau\'r gweinydd</string>
+    <string name="notification_bg_sync_ticker">Yn gwirio am negeseuon: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Yn gwirio am negeseuon</string>
+    <string name="notification_bg_send_ticker">Yn anfon negeseuon: %1$s</string>
+    <string name="notification_bg_send_title">Yn anfon neges</string>
+    <string name="send_failure_subject">Methwyd ag anfon rhai negeseuon</string>
+    <string name="notification_additional_messages">+ %1$d yn rhagor ar %2$s</string>
+    <string name="push_notification_state_initializing">Yn ymgychwyn…</string>
+    <string name="push_notification_state_listening">Yn aros am negeseuon e-bost newydd</string>
+    <string name="push_notification_state_wait_background_sync">Yn cysgu nes bod cysoni yn y cefndir wedi\'i ganiatáu</string>
+    <string name="push_notification_state_wait_network">Yn cysgu nes bod rhwydwaith ar gael</string>
+    <string name="push_notification_info">Tapiwch i ddysgu rhagor.</string>
+    <string name="push_info_disable_push_action">Analluogi Gwthio</string>
+    <string name="notification_action_reply">Ateb</string>
+    <string name="notification_action_mark_as_read">Nodi wedi ei Darllen</string>
+    <string name="notification_action_mark_all_as_read">Nodi\'r Cwbl wedi eu Darllen</string>
+    <string name="notification_action_delete">Dileu</string>
+    <string name="notification_action_delete_all">Dileu\'r Cwbl</string>
+    <string name="notification_action_archive">Archifo</string>
+    <string name="notification_action_archive_all">Archifo\'r Cwbl</string>
+    <string name="notification_action_spam">Sbam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-da/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-da/strings.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synkronisér (Push)</string>
+    <string name="notification_channel_push_description">Vist når der lyttes efter nye emails</string>
+    <string name="notification_channel_messages_title">Meddelelse</string>
+    <string name="notification_channel_messages_description">Påmindelser med forbindelse til beskeder</string>
+    <string name="notification_channel_miscellaneous_title">Diverse</string>
+    <string name="notification_channel_miscellaneous_description">Diverse påmindelser såsom fejl etc.</string>
+    <string name="notification_notify_error_title">Notifikation fejl</string>
+    <string name="notification_authentication_error_title">Godkendelse mislykkedes</string>
+    <string name="notification_certificate_error_public">Certifikat fejl</string>
+    <string name="notification_certificate_error_title">Certifikat fejl for %1$s</string>
+    <string name="notification_certificate_error_text">Kontroller dine serverindstillinger</string>
+    <string name="notification_bg_sync_ticker">Synkroniserer mail: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Kontrollere post</string>
+    <string name="notification_bg_send_ticker">Sender mail: %1$s</string>
+    <string name="notification_bg_send_title">Sender post</string>
+    <string name="send_failure_subject">Mislykkedes med at sende nogle beskeder</string>
+    <string name="notification_additional_messages">+ %1$d mere på %2$s</string>
+    <string name="push_notification_state_initializing">Initialiserer…</string>
+    <string name="push_notification_state_listening">Venter på nye emails</string>
+    <string name="push_notification_state_wait_background_sync">I dvale indtil baggrundssynkronisering er tilladt</string>
+    <string name="push_notification_state_wait_network">I dvale indtil netværk er tilgængelig</string>
+    <string name="push_notification_info">Tryk for at lære mere.</string>
+    <string name="push_info_disable_push_action">Deaktivere skub handling </string>
+    <string name="notification_action_reply">Svar</string>
+    <string name="notification_action_mark_as_read">Markér som læst</string>
+    <string name="notification_action_mark_all_as_read">Markér alle som læst</string>
+    <string name="notification_action_delete">Slet</string>
+    <string name="notification_action_delete_all">Slet alle</string>
+    <string name="notification_action_archive">Arkivér</string>
+    <string name="notification_action_archive_all">Arkivér alle</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-de/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synchronisieren (Push)</string>
+    <string name="notification_channel_push_description">Wird während des Wartens auf neue Nachrichten angezeigt</string>
+    <string name="notification_channel_messages_title">Nachrichtenanzeige</string>
+    <string name="notification_channel_messages_description">Benachrichtigungen zu Nachrichten</string>
+    <string name="notification_channel_miscellaneous_title">Verschiedenes</string>
+    <string name="notification_channel_miscellaneous_description">Diverse Benachrichtigungen wie Fehler etc.</string>
+    <string name="notification_notify_error_title">Benachrichtigungsfehler</string>
+    <string name="notification_notify_error_text">Beim Versuch, eine Systembenachrichtigung für eine neue Nachricht zu erstellen, ist ein Fehler aufgetreten. Der Grund dafür ist höchstwahrscheinlich ein fehlender Benachrichtigungston.\n\nAntippen, um die Benachrichtigungseinstellungen zu öffnen.</string>
+    <string name="notification_authentication_error_title">Authentifizierung fehlgeschlagen</string>
+    <string name="notification_certificate_error_public">Zertifikatsfehler</string>
+    <string name="notification_certificate_error_title">Zertifikatsproblem (%1$s)</string>
+    <string name="notification_certificate_error_text">Überprüfe deine Servereinstellungen</string>
+    <string name="notification_bg_sync_ticker">Neue E-Mails in %1$s:%2$s werden abgerufen</string>
+    <string name="notification_bg_sync_title">E-Mails werden abgerufen</string>
+    <string name="notification_bg_send_ticker">E-Mail in %1$s wird gesendet</string>
+    <string name="notification_bg_send_title">E-Mail wird gesendet</string>
+    <string name="send_failure_subject">Nachrichten konnten nicht gesendet werden</string>
+    <string name="notification_additional_messages">+ %1$d weitere auf %2$s</string>
+    <string name="push_notification_state_initializing">Initialisieren…</string>
+    <string name="push_notification_state_listening">Warte auf neue E-Mails</string>
+    <string name="push_notification_state_wait_background_sync">Wartet, bis die Hintergrundsynchronisation erlaubt ist</string>
+    <string name="push_notification_state_wait_network">Wartet, bis ein Netzwerk verfügbar ist</string>
+    <string name="push_notification_state_alarm_permission_missing">Fehlende Berechtigung zur Zeitplanung von Alarmen</string>
+    <string name="push_notification_info">Antippen, um mehr zu erfahren.</string>
+    <string name="push_notification_grant_alarm_permission">Antippen, um die Berechtigung zu erteilen.</string>
+    <string name="push_info_disable_push_action">Push deaktivieren</string>
+    <string name="notification_action_reply">Antworten</string>
+    <string name="notification_action_mark_as_read">Gelesen</string>
+    <string name="notification_action_mark_all_as_read">Alle als gelesen markieren</string>
+    <string name="notification_action_delete">Löschen</string>
+    <string name="notification_action_delete_all">Alle löschen</string>
+    <string name="notification_action_archive">Archiv</string>
+    <string name="notification_action_archive_all">Alle archivieren</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-el/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-el/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Συγχρονισμός (Push)</string>
+    <string name="notification_channel_push_description">Εμφανίζεται κατά την αναμονή για νέα μηνύματα</string>
+    <string name="notification_channel_messages_title">Μηνύματα</string>
+    <string name="notification_channel_messages_description">Ειδοποιήσεις που αφορούν μηνύματα</string>
+    <string name="notification_channel_miscellaneous_title">Διάφορα</string>
+    <string name="notification_channel_miscellaneous_description">Διάφορες ειδοποιήσεις όπως σφάλματα κ.τ.λ.</string>
+    <string name="notification_notify_error_title">Σφάλμα ειδοποίησης</string>
+    <string name="notification_notify_error_text">Σφάλμα στην προσπάθεια δημιουργίας ειδοποίησης συστήματος για νέο μήνυμα. Η ατία είναι μάλλον λείπει ο ήχος της ειδοπίησης.\n\nΠατήστε για να ανοίξετε τις ρυθμίσεων των ειδοποιήσεων.</string>
+    <string name="notification_authentication_error_title">Αποτυχία πιστοποίησης</string>
+    <string name="notification_certificate_error_public">Σφάλμα πιστοποιητικού</string>
+    <string name="notification_certificate_error_title">Σφάλμα πιστοποιητικού για %1$s</string>
+    <string name="notification_certificate_error_text">Ελέγξτε τις ρυθμίσεις του διακομιστή σας</string>
+    <string name="notification_bg_sync_ticker">Έλεγχος μηνύματος: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Έλεγχος μηνύματος</string>
+    <string name="notification_bg_send_ticker">Αποστολή μηνύματος: %1$s</string>
+    <string name="notification_bg_send_title">Αποστολή μηνύματος</string>
+    <string name="send_failure_subject">Αποτυχία αποστολής μερικών μηνυμάτων</string>
+    <string name="notification_additional_messages">+ %1$d περισσότερα για %2$s</string>
+    <string name="push_notification_state_initializing">Αρχικοποίηση…</string>
+    <string name="push_notification_state_listening">Αναμονή για νέα μηνύματα</string>
+    <string name="push_notification_state_wait_background_sync">Σε αδράνεια μέχρι να επιτραπεί ο συγχρονισμός στο παρασκήνιο</string>
+    <string name="push_notification_state_wait_network">Σε αδράνεια μέχρι να υπάρξει διαθέσιμο δίκτυο</string>
+    <string name="push_notification_state_alarm_permission_missing">Λείπει η άδεια για τον προγραμματισμό ειδοποιήσεων</string>
+    <string name="push_notification_info">Πατήστε για να μάθετε περισσότερα.</string>
+    <string name="push_notification_grant_alarm_permission">Πατήστε για να παραχωρήσετε την άδεια.</string>
+    <string name="push_info_disable_push_action">Απενεργοποίηση σπρωξίματος</string>
+    <string name="notification_action_reply">Απάντηση</string>
+    <string name="notification_action_mark_as_read">Σήμανση ως αναγνωσμένο</string>
+    <string name="notification_action_mark_all_as_read">Σήμανση όλων ως αναγνωσμένων</string>
+    <string name="notification_action_delete">Διαγραφή</string>
+    <string name="notification_action_delete_all">Διαγραφή όλων</string>
+    <string name="notification_action_archive">Αρχειοθέτηση</string>
+    <string name="notification_action_archive_all">Αρχειοθέτηση όλων</string>
+    <string name="notification_action_spam">Ανεπιθύμητα</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-en-rGB/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-en-rGB/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synchronise (Push)</string>
+    <string name="notification_channel_push_description">Displayed while waiting for new messages</string>
+    <string name="notification_channel_messages_title">Messages</string>
+    <string name="notification_channel_messages_description">Notifications related to messages</string>
+    <string name="notification_channel_miscellaneous_title">Miscellaneous</string>
+    <string name="notification_channel_miscellaneous_description">Miscellaneous notifications like errors etc.</string>
+    <string name="notification_notify_error_title">Notification error</string>
+    <string name="notification_notify_error_text">An error has occurred while trying to create a system notification for a new message. The reason is most likely a missing notification sound.
+\n
+\nTap to open notification settings.</string>
+    <string name="notification_authentication_error_title">Authentication failed</string>
+    <string name="notification_certificate_error_public">Certificate error</string>
+    <string name="notification_certificate_error_title">Certificate error for %1$s</string>
+    <string name="notification_certificate_error_text">Check your server settings</string>
+    <string name="notification_bg_sync_ticker">Checking mail: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Checking mail</string>
+    <string name="notification_bg_send_ticker">Sending mail: %1$s</string>
+    <string name="notification_bg_send_title">Sending mail</string>
+    <string name="send_failure_subject">Failed to send some messages</string>
+    <string name="notification_additional_messages">+ %1$d more on %2$s</string>
+    <string name="push_notification_state_initializing">Initialising…</string>
+    <string name="push_notification_state_listening">Waiting for new emails</string>
+    <string name="push_notification_state_wait_background_sync">Sleeping until background sync is allowed</string>
+    <string name="push_notification_state_wait_network">Sleeping until network is available</string>
+    <string name="push_notification_state_alarm_permission_missing">Missing permission to schedule alarms</string>
+    <string name="push_notification_info">Tap to learn more.</string>
+    <string name="push_notification_grant_alarm_permission">Tap to grant permission.</string>
+    <string name="push_info_disable_push_action">Disable Push</string>
+    <string name="notification_action_reply">Reply</string>
+    <string name="notification_action_mark_as_read">Mark Read</string>
+    <string name="notification_action_mark_all_as_read">Mark All Read</string>
+    <string name="notification_action_delete">Delete</string>
+    <string name="notification_action_delete_all">Delete All</string>
+    <string name="notification_action_archive">Archive</string>
+    <string name="notification_action_archive_all">Archive All</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-eo/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-eo/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Samtempigo (puŝ-sciigo)</string>
+    <string name="notification_channel_push_description">Vidigita atendante novajn mesaĝojn</string>
+    <string name="notification_channel_messages_title">Mesaĝoj</string>
+    <string name="notification_channel_messages_description">Sciigoj pri novaj mesaĝoj</string>
+    <string name="notification_channel_miscellaneous_title">Diversaj</string>
+    <string name="notification_channel_miscellaneous_description">Aliaj sciigoj, ekzemple pri eraroj, ktp.</string>
+    <string name="notification_notify_error_title">Sciiga eraro</string>
+    <string name="notification_notify_error_text">Eraro okazis provante krei sisteman sciigon pri nova mesaĝo. Estas probable kaŭze de manka sciiga sono.\n\nTuŝetu por malfermi sciigajn agordojn.</string>
+    <string name="notification_authentication_error_title">Aŭtentigo malsukcesis</string>
+    <string name="notification_certificate_error_public">Atestila eraro</string>
+    <string name="notification_certificate_error_title">Eraro pri atestilo por %1$s</string>
+    <string name="notification_certificate_error_text">Kontrolu agordojn de servilo</string>
+    <string name="notification_bg_sync_ticker">Kontrolado de retpoŝto: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Kontrolado de retpoŝto</string>
+    <string name="notification_bg_send_ticker">Sendado de retletero: %1$s</string>
+    <string name="notification_bg_send_title">Sendado de retletero</string>
+    <string name="send_failure_subject">Malsukcesis sendi iujn mesaĝojn</string>
+    <string name="notification_additional_messages">+ %1$d pliaj en %2$s</string>
+    <string name="push_notification_state_initializing">Komencante…</string>
+    <string name="push_notification_state_listening">Atendante novajn retleterojn</string>
+    <string name="push_notification_state_wait_background_sync">Haltigita ĝis “fona samtempigo” estos aktiva</string>
+    <string name="push_notification_state_wait_network">Haltigita ĝis interreta konekto estos disponebla</string>
+    <string name="push_notification_state_alarm_permission_missing">Mankas permeson plani alarmojn</string>
+    <string name="push_notification_info">Frapetu por pli da informoj.</string>
+    <string name="push_notification_grant_alarm_permission">Tuŝu por doni la permeson.</string>
+    <string name="push_info_disable_push_action">Malaktivigi puŝ-sciigojn</string>
+    <string name="notification_action_reply">Respondi</string>
+    <string name="notification_action_mark_as_read">Marki kiel legitan</string>
+    <string name="notification_action_mark_all_as_read">Marki ĉiujn kiel legitajn</string>
+    <string name="notification_action_delete">Forigi</string>
+    <string name="notification_action_delete_all">Forigi ĉiujn</string>
+    <string name="notification_action_archive">Arĥivi</string>
+    <string name="notification_action_archive_all">Arĥivi ĉiujn</string>
+    <string name="notification_action_spam">Trudmesaĝo</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-es/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sincronización rápida («push»)</string>
+    <string name="notification_channel_push_description">Necesaria para buscar correos entrantes en segundo plano</string>
+    <string name="notification_channel_messages_title">Correos</string>
+    <string name="notification_channel_messages_description">Notificaciones relacionadas con los correos</string>
+    <string name="notification_channel_miscellaneous_title">Varios</string>
+    <string name="notification_channel_miscellaneous_description">Notificaciones varias, como errores, etc.</string>
+    <string name="notification_notify_error_title">Notificación fallida</string>
+    <string name="notification_notify_error_text">Ha ocurrido un problema al intentar crear una notificación del sistema alertando de un correo nuevo. Seguramente sea por no tener un sonido de alerta puesto.\n\nToca para ver los ajustes de notificaciones.</string>
+    <string name="notification_authentication_error_title">Fallo de autenticación</string>
+    <string name="notification_certificate_error_public">El certificado no funciona</string>
+    <string name="notification_certificate_error_title">Error de certificado para %1$s</string>
+    <string name="notification_certificate_error_text">Comprueba los ajustes del servidor</string>
+    <string name="notification_bg_sync_ticker">Comprobando correo: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Comprobando correo</string>
+    <string name="notification_bg_send_ticker">Enviando correo: %1$s</string>
+    <string name="notification_bg_send_title">Enviando correo</string>
+    <string name="send_failure_subject">Hubo un error al enviar algunos correos</string>
+    <string name="notification_additional_messages">+ %1$d más en %2$s</string>
+    <string name="push_notification_state_initializing">Iniciando…</string>
+    <string name="push_notification_state_listening">Esperando correos electrónicos nuevos</string>
+    <string name="push_notification_state_wait_background_sync">Esperar hasta que se permita la sincronización en segundo plano</string>
+    <string name="push_notification_state_wait_network">Esperar hasta que la red esté disponible</string>
+    <string name="push_notification_state_alarm_permission_missing">Falta el permiso para programar alarmas</string>
+    <string name="push_notification_info">Toca aquí para leer más sobre el tema.</string>
+    <string name="push_notification_grant_alarm_permission">Toca aquí para conceder el permiso.</string>
+    <string name="push_info_disable_push_action">Desactivar sincronización rápida («push»)</string>
+    <string name="notification_action_reply">Responder</string>
+    <string name="notification_action_mark_as_read">Marcar como leído</string>
+    <string name="notification_action_mark_all_as_read">Marcar todo como leído</string>
+    <string name="notification_action_delete">Borrar</string>
+    <string name="notification_action_delete_all">Borrar todo</string>
+    <string name="notification_action_archive">Archivar</string>
+    <string name="notification_action_archive_all">Archivar todo</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-et/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-et/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sünkroniseeri (kasuta tõuketeenust)</string>
+    <string name="notification_channel_push_description">Näidatakse uute kirjade ootamisel</string>
+    <string name="notification_channel_messages_title">E-kirjad</string>
+    <string name="notification_channel_messages_description">E-kirjadega seotud teated</string>
+    <string name="notification_channel_miscellaneous_title">Muu</string>
+    <string name="notification_channel_miscellaneous_description">Mitmesugused teated nagu vead jms.</string>
+    <string name="notification_notify_error_title">Viga teavitusel</string>
+    <string name="notification_notify_error_text">Uue saabunud sõnumi kohta süsteemise teavituse loomisel tekkis viga. Üks võimalik põhjus on teavitusele määratud heli puudumine.\n\nAva teavituste seadistused.</string>
+    <string name="notification_authentication_error_title">Autentimine ebaõnnestus</string>
+    <string name="notification_certificate_error_public">Sertifikaadiviga</string>
+    <string name="notification_certificate_error_title">Sertifikaadi viga kontol %1$s</string>
+    <string name="notification_certificate_error_text">Kontrolli serveri seadistusi</string>
+    <string name="notification_bg_sync_ticker">Kontrollib e-kirju: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Kontrollib e-kirju</string>
+    <string name="notification_bg_send_ticker">Saadab e-kirja: %1$s</string>
+    <string name="notification_bg_send_title">Saadab e-kirja</string>
+    <string name="send_failure_subject">Mõne kirja saatmine ebaõnnestus</string>
+    <string name="notification_additional_messages">+ %1$d veel kontol %2$s</string>
+    <string name="push_notification_state_initializing">Käivitamine…</string>
+    <string name="push_notification_state_listening">Ootan uusi e-kirju</string>
+    <string name="push_notification_state_wait_background_sync">Ootan taustal kuni sünkroniseerimine on lubatud</string>
+    <string name="push_notification_state_wait_network">Ootan taustal kuni võrguühendus taastub</string>
+    <string name="push_notification_state_alarm_permission_missing">Puuduvad õigused alarmide seadistamiseks</string>
+    <string name="push_notification_info">Lisateabe saamiseks klõpsi.</string>
+    <string name="push_notification_grant_alarm_permission">Õiguste jagamiseks klõpsi.</string>
+    <string name="push_info_disable_push_action">Ära kasuta tõuketeenuseid</string>
+    <string name="notification_action_reply">Vasta</string>
+    <string name="notification_action_mark_as_read">Märgi loetuks</string>
+    <string name="notification_action_mark_all_as_read">Märgi kõik loetuks</string>
+    <string name="notification_action_delete">Kustuta</string>
+    <string name="notification_action_delete_all">Kustuta kõik</string>
+    <string name="notification_action_archive">Arhiveeri</string>
+    <string name="notification_action_archive_all">Arhiveeri kõik</string>
+    <string name="notification_action_spam">Rämps</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-eu/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-eu/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sinkronizatu (Push)</string>
+    <string name="notification_channel_push_description">Bistaratuta mezu berrien zain geundenean</string>
+    <string name="notification_channel_messages_title">Mezuak</string>
+    <string name="notification_channel_messages_description">Mezuekin erlazionatutako jakinarazpenak</string>
+    <string name="notification_channel_miscellaneous_title">Denetarik</string>
+    <string name="notification_channel_miscellaneous_description">Denetariko jakinarazpenak, esaterako erroreak.</string>
+    <string name="notification_notify_error_title">Jakinarazpen errorea</string>
+    <string name="notification_notify_error_text">Errore bat gertatu da mezu berri baterako sistemaren jakinarazpena sortzen saiatzean. Arrazoia ziurrenik jakinarazpen-soinu bat falta da.\n\nSakatu jakinarazpen-ezarpenak irekitzeko.</string>
+    <string name="notification_authentication_error_title">Autentifikazioak huts egin du</string>
+    <string name="notification_certificate_error_public">Ziurtagiri errorea</string>
+    <string name="notification_certificate_error_title">%1$s-(r)entzako ziurtagiri errorea</string>
+    <string name="notification_certificate_error_text">Egiaztatu zerbitzariaren ezarpenak</string>
+    <string name="notification_bg_sync_ticker">Posta egiaztatzen: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Posta egiaztatzen</string>
+    <string name="notification_bg_send_ticker">Posta bidaltzen: %1$s</string>
+    <string name="notification_bg_send_title">Posta bidaltzea</string>
+    <string name="send_failure_subject">Ezin izan dira mezu batzuk bidali</string>
+    <string name="notification_additional_messages">+ %1$d gehiago %2$s-(e)n</string>
+    <string name="push_notification_state_initializing">Hasieratzen…</string>
+    <string name="push_notification_state_listening">e-posta berrien zain</string>
+    <string name="push_notification_state_wait_background_sync">Lo, atzeko planoko sinkronizazioa baimendu arte</string>
+    <string name="push_notification_state_wait_network">Lo, sarea eskuragarri izan arte</string>
+    <string name="push_notification_state_alarm_permission_missing">Alarmak programatzeko baimena falta da</string>
+    <string name="push_notification_info">Sakatu informazio gehiago lortzeko.</string>
+    <string name="push_notification_grant_alarm_permission">Sakatu baimena emateko.</string>
+    <string name="push_info_disable_push_action">Desgaitu \"Push\"a</string>
+    <string name="notification_action_reply">Erantzun</string>
+    <string name="notification_action_mark_as_read">Markatu irakurritako gisa</string>
+    <string name="notification_action_mark_all_as_read">Markatu denak irakurritako gisa</string>
+    <string name="notification_action_delete">Ezabatu</string>
+    <string name="notification_action_delete_all">Ezabatu denak</string>
+    <string name="notification_action_archive">Artxibatu</string>
+    <string name="notification_action_archive_all">Artxibatu denak</string>
+    <string name="notification_action_spam">Zabor-posta</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-fa/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-fa/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">همگام‌سازی (پیشرانی)</string>
+    <string name="notification_channel_push_description">هنگام انتظار برای پیام‌های تازه نشان داده می‌شود</string>
+    <string name="notification_channel_messages_title">پیام‌ها</string>
+    <string name="notification_channel_messages_description">آگاهی‌های مربوط به پیام‌ها</string>
+    <string name="notification_channel_miscellaneous_title">متفرقه</string>
+    <string name="notification_channel_miscellaneous_description">سایر آگاهی‌ها مانند خطاها و غیره.</string>
+    <string name="notification_notify_error_title">خطای آگاهی‌ها</string>
+    <string name="notification_notify_error_text">هنگام ساخت هشدار برای پیام جدید سامانه خطایی رخ داد. اغلب خطا به علت عدم وجود آهنگ هشدارها است.
+\n
+\n برای بازکردن تنظیمات آگاهی‌ها، بزنید.</string>
+    <string name="notification_authentication_error_title">احراز هویت ناموفق بود</string>
+    <string name="notification_certificate_error_public">خطای گواهی</string>
+    <string name="notification_certificate_error_title">خطای گواهی برای %1$s</string>
+    <string name="notification_certificate_error_text">تنظیمات کارساز خود را بررسی کنید</string>
+    <string name="notification_bg_sync_ticker">بررسی کردن نامه: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">بررسی کردن نامه</string>
+    <string name="notification_bg_send_ticker">فرستادن نامه: %1$s</string>
+    <string name="notification_bg_send_title">فرستادن نامه</string>
+    <string name="send_failure_subject">ارسال برخی پیام‌ها ناموفق بود</string>
+    <string name="notification_additional_messages">+ %1$d تای دیگر در %2$s</string>
+    <string name="push_notification_state_initializing">مقداردهی اولیه…</string>
+    <string name="push_notification_state_listening">در انتظار رایانامه‌های جدید</string>
+    <string name="push_notification_state_wait_background_sync">می‌خوابد تا هنگامی که اجازهٔ همگام‌سازی در پس‌زمینه داده شود</string>
+    <string name="push_notification_state_wait_network">می‌خوابد تا هنگامی که شبکه در دسترس باشد</string>
+    <string name="push_notification_state_alarm_permission_missing">اجازهٔ زمان‌بندی هشدارها وجود نداره</string>
+    <string name="push_notification_info">لمس کنید تا بیشتر بدانید.</string>
+    <string name="push_notification_grant_alarm_permission">زدن برای اعطای اجازه.</string>
+    <string name="push_info_disable_push_action">غیرفعال‌سازی پیشرانی</string>
+    <string name="notification_action_reply">پاسخ</string>
+    <string name="notification_action_mark_as_read">خوانده شد</string>
+    <string name="notification_action_mark_all_as_read">همگی خوانده شد</string>
+    <string name="notification_action_delete">حذف</string>
+    <string name="notification_action_delete_all">حذف همه</string>
+    <string name="notification_action_archive">بایگانی</string>
+    <string name="notification_action_archive_all">بایگانی همه</string>
+    <string name="notification_action_spam">هرزنامه</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-fi/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-fi/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synkronoi (Push)</string>
+    <string name="notification_channel_push_description">Näytetään kun odotetaan uusia viestejä</string>
+    <string name="notification_channel_messages_title">Viestit</string>
+    <string name="notification_channel_messages_description">Viesteihin liittyvät ilmoitukset</string>
+    <string name="notification_channel_miscellaneous_title">Muut</string>
+    <string name="notification_channel_miscellaneous_description">Virheet ja muut sekalaiset ilmoitukset</string>
+    <string name="notification_notify_error_title">Ilmoitusvirhe</string>
+    <string name="notification_notify_error_text">Uuteen viestiin liittyvää järjestelmäilmoitusta luotaessa tapahtui virhe. Syy on mitä luultavimmin puuttuva ilmoitusääni.\n\nNapauta avataksesi ilmoitusasetukset.</string>
+    <string name="notification_authentication_error_title">Tunnistautuminen epäonnistui</string>
+    <string name="notification_certificate_error_public">Varmennevirhe</string>
+    <string name="notification_certificate_error_title">Varmennevirhe tilissä %1$s</string>
+    <string name="notification_certificate_error_text">Tarkista palvelinasetuksesi</string>
+    <string name="notification_bg_sync_ticker">Tarkistetaan viestejä: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Tarkistetaan viestejä</string>
+    <string name="notification_bg_send_ticker">Lähetetään viestejä: %1$s</string>
+    <string name="notification_bg_send_title">Lähetetään viestejä</string>
+    <string name="send_failure_subject">Joidenkin viestien lähettäminen epäonnistui</string>
+    <string name="notification_additional_messages">+ %1$d lisää tilillä %2$s</string>
+    <string name="push_notification_state_initializing">Alustetaan…</string>
+    <string name="push_notification_state_listening">Odotetaan uusia viestejä</string>
+    <string name="push_notification_state_wait_background_sync">Nukutaan kunnes taustasynkronointi on sallittu</string>
+    <string name="push_notification_state_wait_network">Nukutaan kunnes verkko on käytettävissä</string>
+    <string name="push_notification_state_alarm_permission_missing">Puuttuva lupa hälytysten ajoittamiseksi</string>
+    <string name="push_notification_info">Napauta saadaksesi lisätietoja.</string>
+    <string name="push_notification_grant_alarm_permission">Napauta myöntääksesi luvan.</string>
+    <string name="push_info_disable_push_action">Poista push käytöstä</string>
+    <string name="notification_action_reply">Vastaa</string>
+    <string name="notification_action_mark_as_read">Merkitse luetuksi</string>
+    <string name="notification_action_mark_all_as_read">Merkitse kaikki luetuiksi</string>
+    <string name="notification_action_delete">Poista</string>
+    <string name="notification_action_delete_all">Poista kaikki</string>
+    <string name="notification_action_archive">Arkistoi</string>
+    <string name="notification_action_archive_all">Arkistoi kaikki</string>
+    <string name="notification_action_spam">Roskaposti</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-fr/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synchroniser (poussé)</string>
+    <string name="notification_channel_push_description">Affiché lors de l’attente de nouveaux courriels</string>
+    <string name="notification_channel_messages_title">Courriels</string>
+    <string name="notification_channel_messages_description">Notifications relatives aux courriels</string>
+    <string name="notification_channel_miscellaneous_title">Divers</string>
+    <string name="notification_channel_miscellaneous_description">Notifications diverses telles que les erreurs, etc.</string>
+    <string name="notification_notify_error_title">Erreur de notification</string>
+    <string name="notification_notify_error_text">Impossible de créer une notification système de nouveau courriel. Un son de notification manquant en est probablement la cause.\n\nTouchez pour ouvrir les paramètres de notification.</string>
+    <string name="notification_authentication_error_title">Échec d’authentification</string>
+    <string name="notification_certificate_error_public">Erreur de certificat</string>
+    <string name="notification_certificate_error_title">Erreur de certificat pour (%1$s)</string>
+    <string name="notification_certificate_error_text">Vérifiez les paramètres du serveur</string>
+    <string name="notification_bg_sync_ticker">Relève des courriels : %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Relève des courriels</string>
+    <string name="notification_bg_send_ticker">Envoi du courriel : %1$s</string>
+    <string name="notification_bg_send_title">Envoi du courriel</string>
+    <string name="send_failure_subject">Échec d’envoi de certains courriels</string>
+    <string name="notification_additional_messages">+ %1$d de plus sur %2$s</string>
+    <string name="push_notification_state_initializing">Initialisation…</string>
+    <string name="push_notification_state_listening">En attente de nouveaux courriels</string>
+    <string name="push_notification_state_wait_background_sync">Inactif tant que la synchronisation en arrière-plan n’est pas autorisée</string>
+    <string name="push_notification_state_wait_network">Inactif tant que le réseau n’est pas connecté</string>
+    <string name="push_notification_state_alarm_permission_missing">Il manque une autorisation pour programmer des alarmes</string>
+    <string name="push_notification_info">Touchez pour en apprendre davantage.</string>
+    <string name="push_notification_grant_alarm_permission">Touchez pour accorder l’autorisation.</string>
+    <string name="push_info_disable_push_action">Désactiver le poussé</string>
+    <string name="notification_action_reply">Répondre</string>
+    <string name="notification_action_mark_as_read">Marquer comme lu</string>
+    <string name="notification_action_mark_all_as_read">Tout marquer comme lu</string>
+    <string name="notification_action_delete">Supprimer</string>
+    <string name="notification_action_delete_all">Tout supprimer</string>
+    <string name="notification_action_archive">Archiver</string>
+    <string name="notification_action_archive_all">Tout archiver</string>
+    <string name="notification_action_spam">Pourriel (indésirable)</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-fy/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-fy/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Syngronisearje (Push)</string>
+    <string name="notification_channel_push_description">Wurdt yn ôfwachting fan nije berjochten toand</string>
+    <string name="notification_channel_messages_title">Berjochten</string>
+    <string name="notification_channel_messages_description">Meldingen relatearre oan berjochten</string>
+    <string name="notification_channel_miscellaneous_title">Diversken</string>
+    <string name="notification_channel_miscellaneous_description">Oare meldingen, lykas flaters en soksawat.</string>
+    <string name="notification_notify_error_title">Meldingsflater</string>
+    <string name="notification_notify_error_text">Der is in flater bard wylst it meitsjen fan in systeemmelding foar in nij berjocht. De reden is wierskynlik in ûntbrekken fan in meldingslûd.\n\nTik om meldingsynstellingen te iepenjen.</string>
+    <string name="notification_authentication_error_title">Autentikaasje mislearre</string>
+    <string name="notification_certificate_error_public">Sertifikaatflater</string>
+    <string name="notification_certificate_error_title">Sertifikaatflater foar %1$s</string>
+    <string name="notification_certificate_error_text">Kontrolearje de serverynstellingen</string>
+    <string name="notification_bg_sync_ticker">Berjochten kontrolearje: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Berjochten kontrolearje</string>
+    <string name="notification_bg_send_ticker">Berjochten ferstjoere: %1$s</string>
+    <string name="notification_bg_send_title">Berjochten ferstjoere</string>
+    <string name="send_failure_subject">Flater by ferstjoeren fan berjochten</string>
+    <string name="notification_additional_messages">+ %1$d mear by %2$s</string>
+    <string name="push_notification_state_initializing">Oan it inisjalisearjen…</string>
+    <string name="push_notification_state_listening">Yn ôfwachting fan nije e-mailberjochten</string>
+    <string name="push_notification_state_wait_background_sync">Docht neat oant eftergrûnsyngronisaasje tastien wurdt</string>
+    <string name="push_notification_state_wait_network">Docht neat oant der in netwurk beskikber is</string>
+    <string name="push_notification_state_alarm_permission_missing">Tastimming om alarms te plannen ûntbrekt</string>
+    <string name="push_notification_info">Tik hjir foar mear ynfo.</string>
+    <string name="push_notification_grant_alarm_permission">Tik om tastimming te jaan.</string>
+    <string name="push_info_disable_push_action">Push útskeakelje</string>
+    <string name="notification_action_reply">Beäntwurdzje</string>
+    <string name="notification_action_mark_as_read">As lêzen markearje</string>
+    <string name="notification_action_mark_all_as_read">Alle as lêzen markearje</string>
+    <string name="notification_action_delete">Fuortsmite</string>
+    <string name="notification_action_delete_all">Alle fuortsmite</string>
+    <string name="notification_action_archive">Argivearje</string>
+    <string name="notification_action_archive_all">Alle argivearje</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ga/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ga/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sioncrónaigh (Brúigh)</string>
+    <string name="notification_channel_push_description">Ar taispeáint agus tú ag fanacht le teachtaireachtaí nua</string>
+    <string name="notification_channel_messages_title">Teachtaireachtaí</string>
+    <string name="notification_channel_messages_description">Fógraí a bhaineann le teachtaireachtaí</string>
+    <string name="notification_channel_miscellaneous_title">Ilghnéitheach</string>
+    <string name="notification_channel_miscellaneous_description">Fógraí ilghnéitheacha amhail earráidí etc.</string>
+    <string name="notification_notify_error_title">Earráid fógra</string>
+    <string name="notification_notify_error_text">Tharla earráid agus iarracht á déanamh fógra córais a chruthú le haghaidh teachtaireacht nua. Is é an chúis is dóichí ná fuaim fógra ar iarraidh.\n\nTapáil chun socruithe fógartha a oscailt.</string>
+    <string name="notification_authentication_error_title">Theip ar fhíordheimhniú</string>
+    <string name="notification_certificate_error_public">Earráid teastais</string>
+    <string name="notification_certificate_error_title">Earráid deimhnithe le haghaidh %1$s</string>
+    <string name="notification_certificate_error_text">Seiceáil socruithe do fhreastalaí</string>
+    <string name="notification_bg_sync_ticker">Ríomhphost á sheiceáil: %1$s: %2$s</string>
+    <string name="notification_bg_sync_title">Post á sheiceáil</string>
+    <string name="notification_bg_send_ticker">Ríomhphost á sheoladh: %1$s</string>
+    <string name="notification_bg_send_title">Post á sheoladh</string>
+    <string name="send_failure_subject">Theip ar sheoladh roinnt teachtaireachtaí</string>
+    <string name="notification_additional_messages">+ %1$d níos mó ar %2$s</string>
+    <string name="push_notification_state_initializing">Á Thúsú…</string>
+    <string name="push_notification_state_listening">Ag fanacht le ríomhphoist nua</string>
+    <string name="push_notification_state_wait_background_sync">Codladh go dtí go gceadaítear sioncronú cúlra</string>
+    <string name="push_notification_state_wait_network">Codladh go dtí go bhfuil líonra ar fáil</string>
+    <string name="push_notification_state_alarm_permission_missing">Cead ar iarraidh chun aláraim a sceidealú</string>
+    <string name="push_notification_info">Tapáil chun níos mó a fhoghlaim.</string>
+    <string name="push_notification_grant_alarm_permission">Tapáil chun cead a thabhairt.</string>
+    <string name="push_info_disable_push_action">Díchumasaigh Brú</string>
+    <string name="notification_action_reply">Freagra</string>
+    <string name="notification_action_mark_as_read">Marcáil Léite</string>
+    <string name="notification_action_mark_all_as_read">Marcáil Gach Léigh</string>
+    <string name="notification_action_delete">Scrios</string>
+    <string name="notification_action_delete_all">Scrios Gach Rud</string>
+    <string name="notification_action_archive">Cartlann</string>
+    <string name="notification_action_archive_all">Cartlann Gach Rud</string>
+    <string name="notification_action_spam">Turscar</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-gd/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-gd/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sioncronaich (Put)</string>
+    <string name="notification_channel_push_description">Ga shealltainn fhad ’s a thathar a’ feitheamh ri teachdaireachdan ùra</string>
+    <string name="notification_channel_messages_title">Teachdaireachdan</string>
+    <string name="notification_channel_messages_description">Brathan co-cheangailte ri teachdaireachdan</string>
+    <string name="notification_channel_miscellaneous_title">An corr</string>
+    <string name="notification_channel_miscellaneous_description">Measgachadh de bhrathan, mar mhearachdan is msaa.</string>
+    <string name="notification_notify_error_title">Mearachd bratha</string>
+    <string name="notification_notify_error_text">Dh’èirich mearachd fhad ’s a bha sinn airson brath siostaim a chruthachadh airson teachdaireachd ùr. Mar is trice, tachraidh sin ma tha fuaim bratha a dhìth.\n\nThoir gnogag a dh’fhosgladh roghainnean nam fuaimean.</string>
+    <string name="notification_authentication_error_title">Dh’fhàillig an dearbhadh</string>
+    <string name="notification_certificate_error_public">Mearachd an teisteanais</string>
+    <string name="notification_certificate_error_title">Mearachd an teisteanais aig %1$s</string>
+    <string name="notification_certificate_error_text">Thoir sùil air roghainnean an fhrithealaiche agad</string>
+    <string name="notification_bg_sync_ticker">A’ toirt sùil airson post: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">A’ toirt sùil airson post</string>
+    <string name="notification_bg_send_ticker">A’ cur a’ phuist: %1$s</string>
+    <string name="notification_bg_send_title">A’ cur a’ phuist</string>
+    <string name="send_failure_subject">Cha deach cuid dhe na teachdaireachdan a chur</string>
+    <string name="notification_additional_messages">⁊ %1$d a bharrachd air %2$s</string>
+    <string name="push_notification_state_initializing">Ga ro-shuidheachadh…</string>
+    <string name="push_notification_state_listening">A’ feitheamh ri post-d ùr</string>
+    <string name="push_notification_state_wait_background_sync">Na chadal gus an tèid sioncronachadh sa chùlaich a cheadachadh</string>
+    <string name="push_notification_state_wait_network">Na chadal gus am bi lìonra ri làimh</string>
+    <string name="push_notification_state_alarm_permission_missing">Chan eil cead againn caismeachadh a sgeidealachadh</string>
+    <string name="push_notification_info">Thoir gnogag airson barrachd fiosrachaidh.</string>
+    <string name="push_notification_grant_alarm_permission">Thoir gnogag airson cead a thoirt.</string>
+    <string name="push_info_disable_push_action">Cuir Push à comas</string>
+    <string name="notification_action_reply">Freagair</string>
+    <string name="notification_action_mark_as_read">Comharraich gun deach a leughadh</string>
+    <string name="notification_action_mark_all_as_read">Comharraich gun deach iad uile a leughadh</string>
+    <string name="notification_action_delete">Sguab às</string>
+    <string name="notification_action_delete_all">Sguab às na h-uile</string>
+    <string name="notification_action_archive">Tasglannaich</string>
+    <string name="notification_action_archive_all">Tasglannaich na h-uile</string>
+    <string name="notification_action_spam">Spama</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-gl/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-gl/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sincronizar (Preme)</string>
+    <string name="notification_channel_push_description">Amosado mentres agardas por novas mensaxes</string>
+    <string name="notification_channel_messages_title">mensaxes</string>
+    <string name="notification_channel_messages_description">Notificacións relacionadas coas mensaxes</string>
+    <string name="notification_channel_miscellaneous_title">Varios</string>
+    <string name="notification_channel_miscellaneous_description">Notificacións varias como erros, etc.</string>
+    <string name="notification_notify_error_title">Erro de notificación</string>
+    <string name="notification_notify_error_text">Produciuse un erro ao tentar crear unha notificación do sistema para unha mensaxe nova. O motivo é probablemente un son de notificación que falta.
+\n
+\nToca para abrir a configuración de notificacións.</string>
+    <string name="notification_authentication_error_title">Fallo de autenticación</string>
+    <string name="notification_certificate_error_public">Erro certificado</string>
+    <string name="notification_certificate_error_title">Fallo no certificado para %1$s</string>
+    <string name="notification_certificate_error_text">Comprobe os axustes do servidor</string>
+    <string name="notification_bg_sync_ticker">Comprobando correo: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Comprobando correo</string>
+    <string name="notification_bg_send_ticker">Enviando correo: %1$s</string>
+    <string name="notification_bg_send_title">Enviando correo</string>
+    <string name="send_failure_subject">Erro ao enviar algunhas mensaxes</string>
+    <string name="notification_additional_messages">+ %1$d máis en %2$s</string>
+    <string name="push_notification_state_initializing">Iniciando…</string>
+    <string name="push_notification_state_listening">Agardando por novos correos</string>
+    <string name="push_notification_state_wait_background_sync">Suspender ata que sexa permitida a sincronización de fondo </string>
+    <string name="push_notification_state_wait_network">Suspender ata que estea dispoñible a rede</string>
+    <string name="push_notification_state_alarm_permission_missing">Faltan permisos para programar alarmas</string>
+    <string name="push_notification_info">Prema para saber máis.</string>
+    <string name="push_notification_grant_alarm_permission">Toque para garantir o permiso.</string>
+    <string name="push_info_disable_push_action">Desactivar Push</string>
+    <string name="notification_action_reply">Responder</string>
+    <string name="notification_action_mark_as_read">Marcar Lido</string>
+    <string name="notification_action_mark_all_as_read">Marcar todos lidos</string>
+    <string name="notification_action_delete">Eliminar</string>
+    <string name="notification_action_delete_all">Borrar todo</string>
+    <string name="notification_action_archive">Archivo</string>
+    <string name="notification_action_archive_all">Arquivar todo</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-hi/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">सिंक (पुश)</string>
+    <string name="notification_channel_push_description">नए मैसेज का इंतज़ार करते टाइम दिखाया जाएगा</string>
+    <string name="notification_channel_messages_title">मैसेज</string>
+    <string name="notification_channel_messages_description">मैसेजवाले नोटिफिकेशन</string>
+    <string name="notification_channel_miscellaneous_title">बाकी</string>
+    <string name="notification_channel_miscellaneous_description">गड़बड़ वगैरह जैसे बाकी नोटिफिकेशन।</string>
+    <string name="notification_notify_error_title">नोटिफिकेशन गड़बड़</string>
+    <string name="notification_notify_error_text">एक नए मैसेज के लिए सिस्टम नोटिफिकेशन बनाते टाइम एक गड़बड़ हुई। इसका वजह किसी नोटिफिकेशन आवाज़ का गुम होना होना चाहिए।
+\n
+\nनोटिफिकेशन सेटिंग खोलने के लिए दबाएं।</string>
+    <string name="notification_authentication_error_title">ऑथेंटिकेशन नहीं हुआ</string>
+    <string name="notification_certificate_error_public">सर्टिफिकेट गड़बड़</string>
+    <string name="notification_certificate_error_title">%1$s पे सर्टिफिकेट गड़बड़</string>
+    <string name="notification_certificate_error_text">अपनी सर्वर सेटिंग चेक करें</string>
+    <string name="notification_bg_sync_ticker">मेल चेक कर रहे: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">मेल चेक कर रहे</string>
+    <string name="notification_bg_send_ticker">मेल भेज रहे: %1$s</string>
+    <string name="notification_bg_send_title">मेल भेज रहे</string>
+    <string name="send_failure_subject">कुछ मैसेज भेज नहीं सके</string>
+    <string name="notification_additional_messages">+ %1$d और %2$s पे</string>
+    <string name="notification_action_reply">जवाब दें</string>
+    <string name="notification_action_mark_as_read">पढ़ा मार्क करें</string>
+    <string name="notification_action_mark_all_as_read">सब पढ़ा मार्क करें</string>
+    <string name="notification_action_delete">मिटाएं</string>
+    <string name="notification_action_delete_all">सब मिटाएं</string>
+    <string name="notification_action_archive">आर्काइव करें</string>
+    <string name="notification_action_archive_all">सब आर्काइव करें</string>
+    <string name="notification_action_spam">स्पैम</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-hr/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-hr/strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sinkroniziraj (Slanje)</string>
+    <string name="notification_channel_push_description">Prikazano dok čekate nove poruke</string>
+    <string name="notification_channel_messages_title">Poruke</string>
+    <string name="notification_channel_messages_description">Obavijesti vezane za poruke</string>
+    <string name="notification_channel_miscellaneous_title">Razna</string>
+    <string name="notification_channel_miscellaneous_description">Raznovrsne obavijesti kao greške itd.</string>
+    <string name="notification_notify_error_title">Greška u obavijesti</string>
+    <string name="notification_notify_error_text">Došlo je do greške prilikom pokušaja stvaranja sistemske obavijesti za novu poruku. Razlog je najvjerojatnije nedostatak zvuka obavijesti.\n\nDodirnite za otvaranje postavki obavijesti.</string>
+    <string name="notification_authentication_error_title">Identifikacija nije uspjela</string>
+    <string name="notification_certificate_error_public">Greška certifikata</string>
+    <string name="notification_certificate_error_title">Greška certifikata za %1$s</string>
+    <string name="notification_certificate_error_text">provjerite postavke vašeg poslužitelja</string>
+    <string name="notification_bg_sync_ticker">Provjeravam poštu: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Provjeravanje pošte</string>
+    <string name="notification_bg_send_ticker">Šaljem poštu: %1$s</string>
+    <string name="notification_bg_send_title">Slanje pošte</string>
+    <string name="send_failure_subject">Slanje nekih poruka nije uspjelo</string>
+    <string name="notification_additional_messages">+ %1$d više na %2$s</string>
+    <string name="notification_action_reply">Odgovori</string>
+    <string name="notification_action_mark_as_read">Označi Pročitanim</string>
+    <string name="notification_action_mark_all_as_read">Označi sve kao pročitane</string>
+    <string name="notification_action_delete">Obriši</string>
+    <string name="notification_action_delete_all">Obriši sve</string>
+    <string name="notification_action_archive">Arhiva</string>
+    <string name="notification_action_archive_all">Arhiviraj sve</string>
+    <string name="notification_action_spam">Neželjena pošta</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-hu/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-hu/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Szinkronizálás (leküldés)</string>
+    <string name="notification_channel_push_description">Az új levelekre várakozáskor jelenik meg</string>
+    <string name="notification_channel_messages_title">Üzenetek</string>
+    <string name="notification_channel_messages_description">Az üzenetekkel kapcsolatos értesítések</string>
+    <string name="notification_channel_miscellaneous_title">Egyebek</string>
+    <string name="notification_channel_miscellaneous_description">Egyéb értesítések, például hibák, stb.</string>
+    <string name="notification_notify_error_title">Értesítési hiba</string>
+    <string name="notification_notify_error_text">Hiba történt egy új üzenethez tartozó rendszerértesítés létrehozásának kísérletekor. Az ok valószínűleg egy hiányzó értesítési hang.\n\nKoppintson az értesítési beállítások megnyitásához.</string>
+    <string name="notification_authentication_error_title">A hitelesítés sikertelen</string>
+    <string name="notification_certificate_error_public">Tanúsítványhiba</string>
+    <string name="notification_certificate_error_title">Tanúsítványhiba: %1$s</string>
+    <string name="notification_certificate_error_text">Kiszolgálóbeállítások ellenőrzése</string>
+    <string name="notification_bg_sync_ticker">Levelek ellenőrzése: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Levelek ellenőrzése</string>
+    <string name="notification_bg_send_ticker">Levél küldése: %1$s</string>
+    <string name="notification_bg_send_title">Levél küldése</string>
+    <string name="send_failure_subject">Néhány üzenetet nem sikerült elküldeni</string>
+    <string name="notification_additional_messages">+ %1$d további: %2$s</string>
+    <string name="push_notification_state_initializing">Előkészítés…</string>
+    <string name="push_notification_state_listening">Várakozás az új e-mailekre</string>
+    <string name="push_notification_state_wait_background_sync">Alvás addig, amíg a háttérbeli szinkronizálás engedélyezésre nem kerül</string>
+    <string name="push_notification_state_wait_network">Alvás addig, amíg a hálózat elérhetővé nem válik</string>
+    <string name="push_notification_state_alarm_permission_missing">Hiányzó engedély a riasztások ütemezéséhez</string>
+    <string name="push_notification_info">Koppintson ide a további tudnivalókért.</string>
+    <string name="push_notification_grant_alarm_permission">Koppintson az engedély megadásához.</string>
+    <string name="push_info_disable_push_action">Leküldés letiltása</string>
+    <string name="notification_action_reply">Válasz</string>
+    <string name="notification_action_mark_as_read">Megjelölés olvasottként</string>
+    <string name="notification_action_mark_all_as_read">Összes megjelölése olvasottként</string>
+    <string name="notification_action_delete">Törlés</string>
+    <string name="notification_action_delete_all">Összes törlése</string>
+    <string name="notification_action_archive">Archiválás</string>
+    <string name="notification_action_archive_all">Összes archiválása</string>
+    <string name="notification_action_spam">Levélszemét</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-hy/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-hy/strings.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_authentication_error_title">Վաւերացումը խափանուել է</string>
+    <string name="notification_certificate_error_title">Արտոնագրի սխալ %1$s֊ի համար</string>
+    <string name="notification_certificate_error_text">Վերանայէք սպասարկչի կարգաւորումները</string>
+    <string name="notification_bg_sync_ticker">Ստուգւում է փոստը %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Ստուգել էլ․ փոստ</string>
+    <string name="notification_bg_send_ticker">Ուղարկւում է՝ %1$s</string>
+    <string name="notification_bg_send_title">Ուղարկւում է</string>
+    <string name="send_failure_subject">Որոշ հաղորդագրութիւնների ուղարկումը խափանուել է</string>
+    <string name="notification_action_reply">Պատասխանել</string>
+    <string name="notification_action_mark_as_read">Նշել ընթերցուածները</string>
+    <string name="notification_action_mark_all_as_read">Նշել բոլոր ընթերցուածները</string>
+    <string name="notification_action_delete">Հեռացնել</string>
+    <string name="notification_action_delete_all">Հեռացնել բոլորը</string>
+    <string name="notification_action_archive">Արխիւացնել</string>
+    <string name="notification_action_archive_all">Արխիւացնել բոլորը</string>
+    <string name="notification_action_spam">Լցօն</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-in/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-in/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sinkronisasi (Dorongan)</string>
+    <string name="notification_channel_push_description">Ditampilkan saat menunggu pesan baru</string>
+    <string name="notification_channel_messages_title">Pesan</string>
+    <string name="notification_channel_messages_description">Notifikasi terkait dengan pesan</string>
+    <string name="notification_channel_miscellaneous_title">Lain-lain</string>
+    <string name="notification_channel_miscellaneous_description">Notifikasi lainnya seperti kesalahan, dll.</string>
+    <string name="notification_notify_error_title">Kesalahan notifikasi</string>
+    <string name="notification_notify_error_text">Kesalahan telah terjadi saat mencoba untuk membuat notifikasi sistem untuk pesan baru. Kemungkinan besar penyebabnya yaitu hilangnya suara notifikasi.
+\n
+\nKetuk untuk membuka pengaturan notifikasi.</string>
+    <string name="notification_authentication_error_title">Autentikasi gagal</string>
+    <string name="notification_certificate_error_public">Kesalahan sertifikat</string>
+    <string name="notification_certificate_error_title">Kesalahan sertifikat untuk %1$s</string>
+    <string name="notification_certificate_error_text">Periksa pengaturan server Anda</string>
+    <string name="notification_bg_sync_ticker">Memeriksa pesan: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Memeriksa pesan</string>
+    <string name="notification_bg_send_ticker">Mengirimkan pesan: %1$s</string>
+    <string name="notification_bg_send_title">Mengirimkan pesan</string>
+    <string name="send_failure_subject">Gagal mengirim beberapa pesan</string>
+    <string name="notification_additional_messages">+ %1$d lagi pada %2$s</string>
+    <string name="push_notification_state_initializing">Inisialisasi…</string>
+    <string name="push_notification_state_listening">Menunggu surel baru</string>
+    <string name="push_notification_state_wait_background_sync">Tidur hingga sinkronisasi latar belakang diizinkan</string>
+    <string name="push_notification_state_wait_network">Tidur hingga jaringan tersedia</string>
+    <string name="push_notification_state_alarm_permission_missing">Tidak ada izin untuk menjadwalkan alarm</string>
+    <string name="push_notification_info">Ketuk untuk mempelajari lebih lanjut.</string>
+    <string name="push_notification_grant_alarm_permission">Ketuk untuk memberikan izin.</string>
+    <string name="push_info_disable_push_action">Nonaktifkan Dorongan</string>
+    <string name="notification_action_reply">Balas</string>
+    <string name="notification_action_mark_as_read">Tandai Sudah Dibaca</string>
+    <string name="notification_action_mark_all_as_read">Tandai Semua Sudah Dibaca</string>
+    <string name="notification_action_delete">Hapus</string>
+    <string name="notification_action_delete_all">Hapus Semua</string>
+    <string name="notification_action_archive">Arsipkan</string>
+    <string name="notification_action_archive_all">Arsipkan Semua</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-is/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-is/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Samstilla (Ýta)</string>
+    <string name="notification_channel_push_description">Birtist á meðan beðið er eftir nýjum skilaboðum</string>
+    <string name="notification_channel_messages_title">Skilaboð</string>
+    <string name="notification_channel_messages_description">Tilkynning tengdar skilaboðum</string>
+    <string name="notification_channel_miscellaneous_title">Ýmislegt</string>
+    <string name="notification_channel_miscellaneous_description">Ýmsar tilkynningar, eins og villur o.s.frv.</string>
+    <string name="notification_notify_error_title">Villa í tilkynningu</string>
+    <string name="notification_notify_error_text">Villa kom upp þegar reynt var að útbúa kerfistilkynningu vegna nýrra skilaboða. Ástæðan er líklegast sú að það vanti hljóð fyrir tilkynningar.\n\nPikkaðu til að opna stillingar á tilkynningum.</string>
+    <string name="notification_authentication_error_title">Auðkenning mistókst</string>
+    <string name="notification_certificate_error_public">Villa í skilríki</string>
+    <string name="notification_certificate_error_title">Villa í skilríki fyrir %1$s</string>
+    <string name="notification_certificate_error_text">Athugaðu stillingar póstþjónsins</string>
+    <string name="notification_bg_sync_ticker">Athuga með póst: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Athuga með póst</string>
+    <string name="notification_bg_send_ticker">Sendi póst: %1$s</string>
+    <string name="notification_bg_send_title">Sendi póst</string>
+    <string name="send_failure_subject">Náði ekki að senda einhver skilaboð</string>
+    <string name="notification_additional_messages">+ %1$d fleiri á %2$s</string>
+    <string name="push_notification_state_initializing">Frumstilli…</string>
+    <string name="push_notification_state_listening">Bíð eftir nýjum tölvupóstum</string>
+    <string name="push_notification_state_wait_background_sync">Í dvala þar til samstilling í bakgrunni er heimil</string>
+    <string name="push_notification_state_wait_network">Í dvala þar til netkerfi er til taks</string>
+    <string name="push_notification_state_alarm_permission_missing">Vantar heimild til að setja áminningar á áætlun</string>
+    <string name="push_notification_info">Ýttu til að kanna nánar.</string>
+    <string name="push_notification_grant_alarm_permission">Ýttu til að veita heimild.</string>
+    <string name="push_info_disable_push_action">Gera ýtitilkynningar óvirkar</string>
+    <string name="notification_action_reply">Svara</string>
+    <string name="notification_action_mark_as_read">Merkja sem lesið</string>
+    <string name="notification_action_mark_all_as_read">Merkja allt sem lesið</string>
+    <string name="notification_action_delete">Fjarlægja</string>
+    <string name="notification_action_delete_all">Fjarlægja allt</string>
+    <string name="notification_action_archive">Geymsla</string>
+    <string name="notification_action_archive_all">Setja allt í geymslu</string>
+    <string name="notification_action_spam">Ruslpóstur</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-it/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-it/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sincronizzazione (Push)</string>
+    <string name="notification_channel_push_description">Visualizzata in attesa di nuovi messaggi</string>
+    <string name="notification_channel_messages_title">Messaggi</string>
+    <string name="notification_channel_messages_description">Notifiche relative ai messaggi</string>
+    <string name="notification_channel_miscellaneous_title">Varie</string>
+    <string name="notification_channel_miscellaneous_description">Notifiche varie come errori ecc.</string>
+    <string name="notification_notify_error_title">Notifica errore</string>
+    <string name="notification_notify_error_text">Errore nella generazione di una notifica di ricezione di un nuovo messaggio. Errore probabilmente dovuto alla mancanza di un suono di notifica. \n \nTocca per le impostazioni di notifica.</string>
+    <string name="notification_authentication_error_title">Autenticazione non riuscita</string>
+    <string name="notification_certificate_error_public">Errore certificato</string>
+    <string name="notification_certificate_error_title">Errore certificato per %1$s</string>
+    <string name="notification_certificate_error_text">Controlla le impostazioni del server</string>
+    <string name="notification_bg_sync_ticker">Controllo posta: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Controllo posta</string>
+    <string name="notification_bg_send_ticker">Invio posta: %1$s</string>
+    <string name="notification_bg_send_title">Invio posta</string>
+    <string name="send_failure_subject">Impossibile inviare alcuni messaggi</string>
+    <string name="notification_additional_messages">+ %1$d altri in %2$s</string>
+    <string name="push_notification_state_initializing">Inizializzazione…</string>
+    <string name="push_notification_state_listening">In attesa di nuove email</string>
+    <string name="push_notification_state_wait_background_sync">Inattivo fino a quando la sincronizzazione in background non sarà consentita</string>
+    <string name="push_notification_state_wait_network">Inattivo fino a quando la rete non sarà disponibile</string>
+    <string name="push_notification_state_alarm_permission_missing">Autorizzazione mancante per pianificare gli allarmi</string>
+    <string name="push_notification_info">Tocca per saperne di più</string>
+    <string name="push_notification_grant_alarm_permission">Tocca per concedere l\'autorizzazione.</string>
+    <string name="push_info_disable_push_action">Disabilita Push</string>
+    <string name="notification_action_reply">Rispondi</string>
+    <string name="notification_action_mark_as_read">Letto</string>
+    <string name="notification_action_mark_all_as_read">Segna tutti come letti</string>
+    <string name="notification_action_delete">Elimina</string>
+    <string name="notification_action_delete_all">Elimina tutto</string>
+    <string name="notification_action_archive">Archivia</string>
+    <string name="notification_action_archive_all">Archivia tutto</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-iw/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-iw/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">סנכרן (דחיפה)</string>
+    <string name="notification_channel_push_description">מוצג בעת המתנה להודעות חדשות</string>
+    <string name="notification_channel_messages_title">הודעות</string>
+    <string name="notification_channel_messages_description">התראות הקשורות להודעות</string>
+    <string name="notification_channel_miscellaneous_title">שונות</string>
+    <string name="notification_channel_miscellaneous_description">התראות שונות כגון שגיאות וכו\'.</string>
+    <string name="notification_notify_error_title">שגיאת התראה</string>
+    <string name="notification_notify_error_text">אירעה שגיאה בעת נסיון יצירת התראת מערכת עבור הודעה חדשה. הסיבה ככל הנראה היא צליל התראה חסר.
+\n
+\nלחץ כדי לפתוח הגדרות התראה.</string>
+    <string name="notification_authentication_error_title">נכשל באימות</string>
+    <string name="notification_certificate_error_public">שגיאה בתעודה</string>
+    <string name="notification_certificate_error_title">בעיה בתעודה עבור %1$s</string>
+    <string name="notification_certificate_error_text">בדוק את הגדרות השרת</string>
+    <string name="notification_bg_sync_ticker">בודק דואל: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">בודק דוא\"ל</string>
+    <string name="notification_bg_send_ticker">שולח דוא"ל: %1$s</string>
+    <string name="notification_bg_send_title">שולח דוא\"ל</string>
+    <string name="send_failure_subject">נכשל בשליחת חלק מההודעות</string>
+    <string name="notification_additional_messages">+ %1$d עוד עלינו%2$s</string>
+    <string name="push_notification_state_initializing">מאתחל…</string>
+    <string name="push_notification_state_listening">ממתין לדוא\"ל חדש</string>
+    <string name="push_notification_state_wait_background_sync">במצב שינה עד שיאופשר סנכרון ברקע</string>
+    <string name="push_notification_state_wait_network">במצב שינה עד שתהיה רשת זמינה</string>
+    <string name="push_notification_state_alarm_permission_missing">חסרות הרשאות לתזמון התרעות</string>
+    <string name="push_notification_info">לחץ כדי ללמוד עוד.</string>
+    <string name="push_notification_grant_alarm_permission">לחצו למתן הרשאות.</string>
+    <string name="push_info_disable_push_action">כבה דחיפה (Push)</string>
+    <string name="notification_action_reply">השב</string>
+    <string name="notification_action_mark_as_read">סמן כנקרא</string>
+    <string name="notification_action_mark_all_as_read">סמן הכל כנקרא</string>
+    <string name="notification_action_delete">מחק</string>
+    <string name="notification_action_delete_all">מחק הכל</string>
+    <string name="notification_action_archive">העבר לארכיון</string>
+    <string name="notification_action_archive_all">העבר הכל לארכיון</string>
+    <string name="notification_action_spam">דואר זבל</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ja/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">同期 (プッシュ)</string>
+    <string name="notification_channel_push_description">新着メッセージの待機中に表示します</string>
+    <string name="notification_channel_messages_title">メッセージ</string>
+    <string name="notification_channel_messages_description">メッセージに関連した通知</string>
+    <string name="notification_channel_miscellaneous_title">その他</string>
+    <string name="notification_channel_miscellaneous_description">エラーなどその他さまざまな通知</string>
+    <string name="notification_notify_error_title">通知エラー</string>
+    <string name="notification_notify_error_text">新着メッセージのシステム通知の作成中にエラーが発生しました。通知サウンドが存在しないことが原因と思われます。
+\n
+\nタップして通知設定を開いてください。</string>
+    <string name="notification_authentication_error_title">認証に失敗しました</string>
+    <string name="notification_certificate_error_public">証明書エラー</string>
+    <string name="notification_certificate_error_title">%1$s の証明書エラー</string>
+    <string name="notification_certificate_error_text">サーバーの設定を確認してください</string>
+    <string name="notification_bg_sync_ticker">メール確認中: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">メール確認中</string>
+    <string name="notification_bg_send_ticker">メール送信中: %1$s</string>
+    <string name="notification_bg_send_title">メール送信中</string>
+    <string name="send_failure_subject">メール送信に失敗しました</string>
+    <string name="notification_additional_messages">+ %1$d 続く %2$s</string>
+    <string name="push_notification_state_initializing">初期化中…</string>
+    <string name="push_notification_state_listening">新着メール待機中</string>
+    <string name="push_notification_state_wait_background_sync">バックグラウンド同期が許可されるまでスリープ中</string>
+    <string name="push_notification_state_wait_network">ネットワークが利用できるようになるまでスリープ中</string>
+    <string name="push_notification_state_alarm_permission_missing">アラームを設定する権限がありません</string>
+    <string name="push_notification_info">タップすると詳細を表示します。</string>
+    <string name="push_notification_grant_alarm_permission">タップして権限を付与してください。</string>
+    <string name="push_info_disable_push_action">プッシュ同期を無効化</string>
+    <string name="notification_action_reply">返信</string>
+    <string name="notification_action_mark_as_read">既読</string>
+    <string name="notification_action_mark_all_as_read">すべて既読</string>
+    <string name="notification_action_delete">削除</string>
+    <string name="notification_action_delete_all">すべて削除</string>
+    <string name="notification_action_archive">アーカイブ</string>
+    <string name="notification_action_archive_all">すべてアーカイブ</string>
+    <string name="notification_action_spam">迷惑メール</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ka/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ka/strings.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_messages_title">მესიჯები</string>
+    <string name="notification_authentication_error_title">აუთენტიკაცია ჩავარდა</string>
+    <string name="notification_certificate_error_title">სერტიფიკატის შეცდომა: %1$s</string>
+    <string name="notification_certificate_error_text">შეამოწმეთ თქვენი სერვერის პარამეტრები</string>
+    <string name="notification_bg_sync_ticker">წერილის ძებნა: %1$s:%2$s</string>
+    <string name="notification_bg_send_ticker">წერილის გაგზავნა: %1$s</string>
+    <string name="notification_bg_send_title">წერილის გაგზავნა</string>
+    <string name="notification_action_reply">პასუხი</string>
+    <string name="notification_action_mark_as_read">მონიშვნა წაკითხულად</string>
+    <string name="notification_action_mark_all_as_read">ყველას მონიშვნა წაკითხულად</string>
+    <string name="notification_action_delete">წაშლა</string>
+    <string name="notification_action_delete_all">ყველას წაშლა</string>
+    <string name="notification_action_archive">არქივაცია</string>
+    <string name="notification_action_archive_all">ყველას დაარქივება</string>
+    <string name="notification_action_spam">სპამი</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-kab/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-kab/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_messages_title">Iznan</string>
+    <string name="notification_channel_miscellaneous_title">Ayen nniḍen</string>
+    <string name="notification_action_reply">Tiririt</string>
+    <string name="notification_action_delete">Kkes</string>
+    <string name="notification_action_archive">Seɣber</string>
+    <string name="notification_action_spam">Aspam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ko/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ko/strings.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">동기화하기 (푸시)</string>
+    <string name="notification_channel_push_description">새 메시지 받는 동안 표시됨</string>
+    <string name="notification_channel_messages_title">메시지</string>
+    <string name="notification_channel_messages_description">메시지와 관련된 알림</string>
+    <string name="notification_channel_miscellaneous_title">기타 설정</string>
+    <string name="notification_channel_miscellaneous_description">오류 같은 기타 알림.</string>
+    <string name="notification_notify_error_title">알림 오류</string>
+    <string name="notification_notify_error_text">새로운 메시지를 위한 시스템 알림을 만드는 중에 오류가 발생했습니다. 알림 소리가 지정되지 않아 그럴 가능성이 높습니다.\n\n여기를 눌러 알림 설정으로 이동하세요.</string>
+    <string name="notification_authentication_error_title">인증 실패</string>
+    <string name="notification_certificate_error_public">인증 요류</string>
+    <string name="notification_certificate_error_title">계정 인증 오류 (%1$s)</string>
+    <string name="notification_certificate_error_text">서버 설정을 확인해 주세요</string>
+    <string name="notification_bg_sync_ticker">메일 확인 중: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">메일 확인 중</string>
+    <string name="notification_bg_send_ticker">메일 전송 중: %1$s</string>
+    <string name="notification_bg_send_title">메일 전송 중</string>
+    <string name="send_failure_subject">일부 메시지를 보내는 데 실패했습니다</string>
+    <string name="notification_additional_messages">+ %1$d more on %2$s</string>
+    <string name="notification_action_reply">답장</string>
+    <string name="notification_action_mark_as_read">읽은 것으로 표시</string>
+    <string name="notification_action_mark_all_as_read">모두 읽은 것으로 표시</string>
+    <string name="notification_action_delete">삭제</string>
+    <string name="notification_action_delete_all">모두 삭제</string>
+    <string name="notification_action_archive">보관</string>
+    <string name="notification_action_archive_all">모두 보관</string>
+    <string name="notification_action_spam">스팸</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-lt/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-lt/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sinchronizuoti (Push)</string>
+    <string name="notification_channel_push_description">Rodoma laukiant naujų laiškų</string>
+    <string name="notification_channel_messages_title">Laiškai</string>
+    <string name="notification_channel_messages_description">Pranešimai susiję su laiškais</string>
+    <string name="notification_channel_miscellaneous_title">Įvairūs</string>
+    <string name="notification_channel_miscellaneous_description">Įvairūs pranešimai, pavyzdžiui, apie klaidas ir pan.</string>
+    <string name="notification_notify_error_title">Pranešimo klaida</string>
+    <string name="notification_notify_error_text">Bandant sukurti sistemos pranešimą apie naują laišką, įvyko klaida. Tikėtina priežastis – trūkstamas pranešimo garsas.
+\n
+\nBakstelėkite pranešimų nustatymams atverti.</string>
+    <string name="notification_authentication_error_title">Autentifikavimas nepavyko</string>
+    <string name="notification_certificate_error_public">Sertifikato klaida.</string>
+    <string name="notification_certificate_error_title">Sertifikato klaida %1$s</string>
+    <string name="notification_certificate_error_text">Patikrinkite serverio nustatymus</string>
+    <string name="notification_bg_sync_ticker">Tikrinamas paštas: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Tikrinamas paštas</string>
+    <string name="notification_bg_send_ticker">Siunčiamas paštas: %1$s</string>
+    <string name="notification_bg_send_title">Siunčiamas paštas</string>
+    <string name="send_failure_subject">Kai kurių laiškų išsiųsti nepavyko</string>
+    <string name="notification_additional_messages">+ %1$d daugiau paskyroje %2$s</string>
+    <string name="push_notification_state_initializing">Inicializuojama…</string>
+    <string name="push_notification_state_listening">Laukiama naujų laiškų</string>
+    <string name="push_notification_state_wait_background_sync">Miegama iki kol fono sinchronizacija bus leidžiama</string>
+    <string name="push_notification_state_wait_network">Miegama, kol bus prieinamas tinklas</string>
+    <string name="push_notification_info">Bakstelėkite, jei norite sužinoti daugiau.</string>
+    <string name="push_info_disable_push_action">Išjungti Push</string>
+    <string name="notification_action_reply">Atsakyti</string>
+    <string name="notification_action_mark_as_read">Žymėti kaip skaitytą</string>
+    <string name="notification_action_mark_all_as_read">Žymėti viską kaip skaitytą</string>
+    <string name="notification_action_delete">Ištrinti</string>
+    <string name="notification_action_delete_all">Ištrinti viską</string>
+    <string name="notification_action_archive">Archyvuoti</string>
+    <string name="notification_action_archive_all">Archyvuoti viską</string>
+    <string name="notification_action_spam">Brukalas</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-lv/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-lv/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sinhronizē grūdeni/stūmekli (push)</string>
+    <string name="notification_channel_push_description">Tiek rādīts, kamēr gaida jaunas ziņas</string>
+    <string name="notification_channel_messages_title">Ziņas</string>
+    <string name="notification_channel_messages_description">Paziņojumi par ziņām</string>
+    <string name="notification_channel_miscellaneous_title">Dažādi</string>
+    <string name="notification_channel_miscellaneous_description">Dažādi paziņojumi, piemēram, par kļūdām u.tml.</string>
+    <string name="notification_notify_error_title">Paziņojuma kļūda</string>
+    <string name="notification_notify_error_text">Neizdevās izveidot sistēmas paziņojumu par jaunu ziņu. Visdrīzākais, ka trūkst paziņojuma skaņas.
+\n
+\nPieskarieties, lai atvērtu paziņojumu iestatījumus.</string>
+    <string name="notification_authentication_error_title">Autentifikācija neizdevās</string>
+    <string name="notification_certificate_error_public">Sertifikāta kļūda</string>
+    <string name="notification_certificate_error_title">Sertifikāta kļūda kontam %1$s</string>
+    <string name="notification_certificate_error_text">Pārbaudiet sava servera iestatījumus</string>
+    <string name="notification_bg_sync_ticker">Pārbauda pastu: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Pārbauda pastu</string>
+    <string name="notification_bg_send_ticker">Sūta pastu: %1$s</string>
+    <string name="notification_bg_send_title">Sūta pastu</string>
+    <string name="send_failure_subject">Neizdevās nosūtīt dažas ziņas</string>
+    <string name="notification_additional_messages">+ %1$d vairāk %2$s</string>
+    <string name="push_notification_state_initializing">Inicializē…</string>
+    <string name="push_notification_state_listening">Tiek gaidītas jaunas ziņas</string>
+    <string name="push_notification_state_wait_background_sync">Snauduļot, kamēr fona sinhronizēšana atļauta</string>
+    <string name="push_notification_state_wait_network">Snaust, kamēr pieejams tīkls</string>
+    <string name="push_notification_state_alarm_permission_missing">Trūkst atļaujas ieplānot trauksmes signālus</string>
+    <string name="push_notification_info">Pieskarieties, lai uzzinātu vairāk.</string>
+    <string name="push_notification_grant_alarm_permission">Pieskarieties, lai piešķirtu atļauju.</string>
+    <string name="push_info_disable_push_action">Atspējot grūdeni/stūmekli (push)</string>
+    <string name="notification_action_reply">Atbildēt</string>
+    <string name="notification_action_mark_as_read">Atzīmēt kā lasītu</string>
+    <string name="notification_action_mark_all_as_read">Atzīmēt visas kā lasītas</string>
+    <string name="notification_action_delete">Dzēst</string>
+    <string name="notification_action_delete_all">Dzēst visu</string>
+    <string name="notification_action_archive">Arhivēt</string>
+    <string name="notification_action_archive_all">Arhivēt visu</string>
+    <string name="notification_action_spam">Surogātpasts</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ml/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ml/strings.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">സമന്വയിപ്പിക്കുക (പുഷ്)</string>
+    <string name="notification_channel_push_description">പുതിയ സന്ദേശങ്ങൾക്കായി കാത്തിരിക്കുമ്പോൾ പ്രദർശിപ്പിക്കുന്നു</string>
+    <string name="notification_channel_messages_title">സന്ദേശങ്ങൾ</string>
+    <string name="notification_channel_messages_description">സന്ദേശങ്ങളുമായി ബന്ധപ്പെട്ട അറിയിപ്പുകൾ</string>
+    <string name="notification_channel_miscellaneous_title">പലവക</string>
+    <string name="notification_channel_miscellaneous_description">പിശകുകൾ പോലുള്ള പലവിധ അറിയിപ്പുകൾ.</string>
+    <string name="notification_authentication_error_title">പ്രാമാണീകരണം പരാജയപ്പെട്ടു</string>
+    <string name="notification_certificate_error_public">സർട്ടിഫിക്കറ്റ് പിശക്</string>
+    <string name="notification_certificate_error_title">%1$sനുള്ള സർട്ടിഫിക്കറ്റ് പിശക്</string>
+    <string name="notification_certificate_error_text">നിങ്ങളുടെ സെർവർ ക്രമീകരണങ്ങൾ പരിശോധിക്കുക</string>
+    <string name="notification_bg_sync_ticker">മെയിൽ പരിശോധിക്കുന്നു: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">മെയിൽ പരിശോധിക്കുന്നു</string>
+    <string name="notification_bg_send_ticker">മെയിൽ അയയ്ക്കുന്നു: %1$s</string>
+    <string name="notification_bg_send_title">മെയിൽ അയയ്ക്കുന്നു</string>
+    <string name="send_failure_subject">ചില സന്ദേശങ്ങൾ അയയ്ക്കുന്നതിൽ പരാജയപ്പെട്ടു</string>
+    <string name="notification_additional_messages">+%1$d %2$s ൽ കൂടുതൽ</string>
+    <string name="notification_action_reply">മറുപടി പറയുക</string>
+    <string name="notification_action_mark_as_read">വായന അടയാളപ്പെടുത്തുക</string>
+    <string name="notification_action_mark_all_as_read">എല്ലാത്തിലും വായന അടയാളപ്പെടുത്തുക</string>
+    <string name="notification_action_delete">ഇല്ലാതാക്കുക</string>
+    <string name="notification_action_delete_all">എല്ലാം ഇല്ലാതാക്കുക</string>
+    <string name="notification_action_archive">ശേഖരം</string>
+    <string name="notification_action_archive_all">എല്ലാം ശേഖരത്തിൽ ചേർക്കുക</string>
+    <string name="notification_action_spam">സ്പാം</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-nb/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-nb/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synkroniser (dytting)</string>
+    <string name="notification_channel_push_description">Vist i påvente av nye meldinger</string>
+    <string name="notification_channel_messages_title">Meldinger</string>
+    <string name="notification_channel_messages_description">Varslinger relatert til meldinger</string>
+    <string name="notification_channel_miscellaneous_title">Diverse</string>
+    <string name="notification_channel_miscellaneous_description">Forskjellige varslinger, som feil, etc.</string>
+    <string name="notification_notify_error_title">Merknadsfeil</string>
+    <string name="notification_notify_error_text">Kunne ikke opprette systemmerknad for ny melding. Dette skyldes antagelig merknadslyden.
+\n
+\nTrykk for å åpne merknadsinnstillinger.</string>
+    <string name="notification_authentication_error_title">Autentisering feilet</string>
+    <string name="notification_certificate_error_public">Sertifikatsfeil</string>
+    <string name="notification_certificate_error_title">Sertifikatfeil for %1$s</string>
+    <string name="notification_certificate_error_text">Sjekk dine tjenerinnstillinger</string>
+    <string name="notification_bg_sync_ticker">Sjekker e-post: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Sjekker e-post</string>
+    <string name="notification_bg_send_ticker">Sender e-post: %1$s</string>
+    <string name="notification_bg_send_title">Sender e-post</string>
+    <string name="send_failure_subject">Mislyktes i å sende noen meldinger</string>
+    <string name="notification_additional_messages">+ %1$d flere på %2$s</string>
+    <string name="push_notification_state_initializing">Igangsetter …</string>
+    <string name="push_notification_state_listening">Venter på nye e-poster</string>
+    <string name="push_notification_state_wait_background_sync">I dvale til bakgrunnssynkronisering er tillatt</string>
+    <string name="push_notification_state_wait_network">I dvale til nettverk er tilgjengelig</string>
+    <string name="push_notification_state_alarm_permission_missing">Mangler tillatelse til å planlegge alarmer</string>
+    <string name="push_notification_info">Trykk for å lære mer.</string>
+    <string name="push_notification_grant_alarm_permission">Trykk for å gi tillatelse.</string>
+    <string name="push_info_disable_push_action">Skru av dytting</string>
+    <string name="notification_action_reply">Svar</string>
+    <string name="notification_action_mark_as_read">Merk som lest</string>
+    <string name="notification_action_mark_all_as_read">Merk alle som lest</string>
+    <string name="notification_action_delete">Slett</string>
+    <string name="notification_action_delete_all">Slett alle</string>
+    <string name="notification_action_archive">Arkiver</string>
+    <string name="notification_action_archive_all">Arkiver alle</string>
+    <string name="notification_action_spam">Søppelpost</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-nl/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-nl/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synchroniseren (Push)</string>
+    <string name="notification_channel_push_description">Wordt in afwachting van nieuwe berichten getoond</string>
+    <string name="notification_channel_messages_title">Berichten</string>
+    <string name="notification_channel_messages_description">Meldingen gerelateerd aan berichten</string>
+    <string name="notification_channel_miscellaneous_title">Diversen</string>
+    <string name="notification_channel_miscellaneous_description">Overige meldingen, zoals fouten en dergelijke.</string>
+    <string name="notification_notify_error_title">Meldingsfout</string>
+    <string name="notification_notify_error_text">Er is een fout opgetreden tijdens het maken van een systeemmelding voor een nieuw bericht. De reden is waarschijnlijk een ontbrekend meldingsgeluid.\n\nTik om meldingsinstellingen te openen.</string>
+    <string name="notification_authentication_error_title">Authenticatie mislukt</string>
+    <string name="notification_certificate_error_public">Certificaatfout</string>
+    <string name="notification_certificate_error_title">Certificaatfout voor %1$s</string>
+    <string name="notification_certificate_error_text">Controleer de serverinstellingen</string>
+    <string name="notification_bg_sync_ticker">Op berichten controleren: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Berichten controleren</string>
+    <string name="notification_bg_send_ticker">Berichten versturen: %1$s</string>
+    <string name="notification_bg_send_title">Berichten versturen</string>
+    <string name="send_failure_subject">Fout bij verzenden van berichten</string>
+    <string name="notification_additional_messages">+ %1$d meer bij %2$s</string>
+    <string name="push_notification_state_initializing">Initialiseren…</string>
+    <string name="push_notification_state_listening">In afwachting van nieuwe e-mailberichten</string>
+    <string name="push_notification_state_wait_background_sync">Doet niets totdat achtergrondsynchronisatie wordt toegestaan</string>
+    <string name="push_notification_state_wait_network">Doet niets totdat er een netwerk beschikbaar is</string>
+    <string name="push_notification_state_alarm_permission_missing">Toestemming om alarmen te plannen ontbreekt</string>
+    <string name="push_notification_info">Tik hier voor meer info.</string>
+    <string name="push_notification_grant_alarm_permission">Tik om toestemming te geven.</string>
+    <string name="push_info_disable_push_action">Push uitschakelen</string>
+    <string name="notification_action_reply">Beantwoorden</string>
+    <string name="notification_action_mark_as_read">Als gelezen markeren</string>
+    <string name="notification_action_mark_all_as_read">Alle als gelezen markeren</string>
+    <string name="notification_action_delete">Verwijderen</string>
+    <string name="notification_action_delete_all">Alle verwijderen</string>
+    <string name="notification_action_archive">Archiveren</string>
+    <string name="notification_action_archive_all">Alle archiveren</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-nn/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-nn/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synkroniser (dytting)</string>
+    <string name="notification_channel_push_description">Vist under venting på nye meldingar</string>
+    <string name="notification_channel_messages_title">Meldingar</string>
+    <string name="notification_channel_messages_description">Notifikasjonar relatert til meldingar</string>
+    <string name="notification_channel_miscellaneous_title">Ymse</string>
+    <string name="notification_channel_miscellaneous_description">Diverse notifikasjonar, som feil, osb.</string>
+    <string name="notification_notify_error_title">Varslingsfeil</string>
+    <string name="notification_notify_error_text">Ein feil har oppstått under oppretting av systemnotifikasjon for ny melding. Grunnen er sannsynlegvis på grunn av manglande notifikasjonslyd.\n\nKlikk for å opne notifikasjonsinnstillingar.</string>
+    <string name="notification_authentication_error_title">Autentisering feila</string>
+    <string name="notification_certificate_error_public">Sertifikatfeil</string>
+    <string name="notification_certificate_error_title">Sertifikatfeil for %1$s</string>
+    <string name="notification_certificate_error_text">Sjekk tenarinnstillingane dine</string>
+    <string name="notification_bg_sync_ticker">Sjekkar e-post: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Sjekkar e-post</string>
+    <string name="notification_bg_send_ticker">Sender e-post: %1$s</string>
+    <string name="notification_bg_send_title">Sending av e-post</string>
+    <string name="send_failure_subject">Klarte ikkje å senda enkelte meldingar</string>
+    <string name="notification_additional_messages">+ %1$d fleire på %2$s</string>
+    <string name="push_notification_state_initializing">Initialiserer…</string>
+    <string name="push_notification_state_listening">Ventar på nye e-postar</string>
+    <string name="push_notification_state_wait_background_sync">Søv til bakgrunnsynkronisering er lov</string>
+    <string name="push_notification_state_wait_network">Søv til nettverket er tilgjengeleg</string>
+    <string name="push_notification_state_alarm_permission_missing">Manglande løyve til å planleggje alarmar</string>
+    <string name="push_notification_info">Trykk for å lære meir.</string>
+    <string name="push_notification_grant_alarm_permission">For å gje tillating.</string>
+    <string name="push_info_disable_push_action">Deaktiver dytting</string>
+    <string name="notification_action_reply">Svar</string>
+    <string name="notification_action_mark_as_read">Merk som lesen</string>
+    <string name="notification_action_mark_all_as_read">Merk alle som lesne</string>
+    <string name="notification_action_delete">Slett</string>
+    <string name="notification_action_delete_all">Slett alle</string>
+    <string name="notification_action_archive">Arkiver</string>
+    <string name="notification_action_archive_all">Arkiver alle</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-pl/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-pl/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synchronizuj (push)</string>
+    <string name="notification_channel_push_description">Wyświetlane podczas oczekiwania na nowe wiadomości</string>
+    <string name="notification_channel_messages_title">Wiadomości</string>
+    <string name="notification_channel_messages_description">Powiadomienia związane z wiadomościami</string>
+    <string name="notification_channel_miscellaneous_title">Różne</string>
+    <string name="notification_channel_miscellaneous_description">Dodatkowe powiadomienia, takie jak błędy itp.</string>
+    <string name="notification_notify_error_title">Błąd powiadomienia</string>
+    <string name="notification_notify_error_text">Wystąpił błąd podczas próby utworzenia powiadomienia systemowego dla nowej wiadomości. Powodem jest najprawdopodobniej brak dźwięku powiadomienia.\n\nStuknij, aby otworzyć ustawienia powiadomień.</string>
+    <string name="notification_authentication_error_title">Uwierzytelnianie nie powiodło się</string>
+    <string name="notification_certificate_error_public">Błąd certyfikatu</string>
+    <string name="notification_certificate_error_title">Błąd certyfikatu dla %1$s</string>
+    <string name="notification_certificate_error_text">Sprawdź ustawienia serwera</string>
+    <string name="notification_bg_sync_ticker">Sprawdzam: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Sprawdzam</string>
+    <string name="notification_bg_send_ticker">Wysyłam: %1$s</string>
+    <string name="notification_bg_send_title">Wysyłam</string>
+    <string name="send_failure_subject">Niektóre wiadomości nie zostały wysłane</string>
+    <string name="notification_additional_messages">+ %1$d więcej na %2$s</string>
+    <string name="push_notification_state_initializing">Inicjowanie…</string>
+    <string name="push_notification_state_listening">Oczekiwanie na nowe e-maile</string>
+    <string name="push_notification_state_wait_background_sync">Uśpione, dopóki synchronizacja w tle nie będzie dozwolona</string>
+    <string name="push_notification_state_wait_network">Uśpione, dopóki sieć nie będzie dostępna</string>
+    <string name="push_notification_state_alarm_permission_missing">Brak uprawnień do planowania alarmów</string>
+    <string name="push_notification_info">Stuknij, aby dowiedzieć się więcej.</string>
+    <string name="push_notification_grant_alarm_permission">Stuknij, aby udzielić uprawnienia.</string>
+    <string name="push_info_disable_push_action">Wyłącz funkcję push</string>
+    <string name="notification_action_reply">Odpowiedz</string>
+    <string name="notification_action_mark_as_read">Oznacz jako przeczytane</string>
+    <string name="notification_action_mark_all_as_read">Oznacz wszystkie jako przeczytane</string>
+    <string name="notification_action_delete">Usuń</string>
+    <string name="notification_action_delete_all">Usuń wszystkie</string>
+    <string name="notification_action_archive">Archiwizuj</string>
+    <string name="notification_action_archive_all">Archiwizuj wszystkie</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-pt-rBR/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-pt-rBR/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sincronizar (Push)</string>
+    <string name="notification_channel_push_description">Exibido enquanto aguarda por novas mensagens</string>
+    <string name="notification_channel_messages_title">Mensagens</string>
+    <string name="notification_channel_messages_description">Notificações relacionadas a mensagens</string>
+    <string name="notification_channel_miscellaneous_title">Diversos</string>
+    <string name="notification_channel_miscellaneous_description">Notificações diversas, como erros, etc.</string>
+    <string name="notification_notify_error_title">Notificação de erro</string>
+    <string name="notification_notify_error_text">Ocorreu um erro ao tentar criar uma notificação de sistema para uma nova mensagem. O provável motivo é a ausência de um som de notificação.\n\nToque para abrir as configurações de notificação.</string>
+    <string name="notification_authentication_error_title">Falha na autenticação</string>
+    <string name="notification_certificate_error_public">Erro no certificado</string>
+    <string name="notification_certificate_error_title">Erro no certificado de %1$s</string>
+    <string name="notification_certificate_error_text">Verifique suas configurações de servidor</string>
+    <string name="notification_bg_sync_ticker">Verificando e-mail: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Verificando e-mail</string>
+    <string name="notification_bg_send_ticker">Enviando mensagem: %1$s</string>
+    <string name="notification_bg_send_title">Enviando mensagem</string>
+    <string name="send_failure_subject">Não foi possível enviar algumas mensagens</string>
+    <string name="notification_additional_messages">+ %1$d a mais em %2$s</string>
+    <string name="push_notification_state_initializing">Inicializando…</string>
+    <string name="push_notification_state_listening">Aguardando novas mensagens</string>
+    <string name="push_notification_state_wait_background_sync">Suspenso até que a sincronização em segundo plano seja permitida</string>
+    <string name="push_notification_state_wait_network">Suspenso até que a rede esteja disponível</string>
+    <string name="push_notification_state_alarm_permission_missing">Falta permissão para agendar alarmes</string>
+    <string name="push_notification_info">Toque para aprender mais.</string>
+    <string name="push_notification_grant_alarm_permission">Toque para conceder a permissão.</string>
+    <string name="push_info_disable_push_action">Desativar Push</string>
+    <string name="notification_action_reply">Responder</string>
+    <string name="notification_action_mark_as_read">Marcar como lida</string>
+    <string name="notification_action_mark_all_as_read">Marcar todas como lidas</string>
+    <string name="notification_action_delete">Excluir</string>
+    <string name="notification_action_delete_all">Excluir todas</string>
+    <string name="notification_action_archive">Arquivar</string>
+    <string name="notification_action_archive_all">Arquivar todas</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-pt-rPT/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-pt-rPT/strings.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sincronizar (Push)</string>
+    <string name="notification_channel_push_description">Mostrado enquanto à espera de novas mensagens</string>
+    <string name="notification_channel_messages_title">Mensagens</string>
+    <string name="notification_channel_messages_description">Notificações relacionadas com mensagens</string>
+    <string name="notification_channel_miscellaneous_title">Diversos</string>
+    <string name="notification_channel_miscellaneous_description">Notificações várias como erros, etc.</string>
+    <string name="notification_notify_error_title">Erro de notificação</string>
+    <string name="notification_notify_error_text">Occoreu um erro ao tentar criar uma notificação do sistema para uma nova mensagem. A causa mais provavel é a falta de um som de notificação.\n\nToque para abrir as definições de notificação
+.</string>
+    <string name="notification_authentication_error_title">A autenticação falhou</string>
+    <string name="notification_certificate_error_public">Erro de certificado</string>
+    <string name="notification_certificate_error_title">Erro de certificado para %1$s</string>
+    <string name="notification_certificate_error_text">Verifique as configurações do servidor</string>
+    <string name="notification_bg_sync_ticker">A verificar correio: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">A verificar correio</string>
+    <string name="notification_bg_send_ticker">A enviar correio: %1$s</string>
+    <string name="notification_bg_send_title">A enviar correio</string>
+    <string name="send_failure_subject">Falha ao enviar algumas mensagens</string>
+    <string name="notification_additional_messages">+ %1$d em %2$s</string>
+    <string name="push_notification_state_initializing">Inicializando…</string>
+    <string name="push_notification_state_listening">À espera de novos e-mails</string>
+    <string name="push_notification_state_wait_background_sync">Suspenso até que a sincronização em segundo plano seja permitida</string>
+    <string name="push_notification_state_wait_network">Suspenso até que a rede esteja disponível</string>
+    <string name="push_notification_state_alarm_permission_missing">Falta a permissão para agendar alarmes</string>
+    <string name="push_notification_info">Toque para saber mais.</string>
+    <string name="push_notification_grant_alarm_permission">Toque para conceder a permissão.</string>
+    <string name="push_info_disable_push_action">Desativar o Push</string>
+    <string name="notification_action_reply">Responder</string>
+    <string name="notification_action_mark_as_read">Marcar como lido</string>
+    <string name="notification_action_mark_all_as_read">Marcar tudo como lido</string>
+    <string name="notification_action_delete">Eliminar</string>
+    <string name="notification_action_delete_all">Eliminar tudo</string>
+    <string name="notification_action_archive">Arquivar</string>
+    <string name="notification_action_archive_all">Arquivar tudo</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-pt/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_notify_error_title">Erro de notificação</string>
+    <string name="notification_authentication_error_title">Falha na autenticação</string>
+    <string name="notification_certificate_error_text">Verifique as suas definições do servidor</string>
+    <string name="notification_action_delete">Apagar</string>
+    <string name="notification_action_delete_all">Apagar tudo</string>
+    <string name="notification_action_archive">Arquivar</string>
+    <string name="notification_action_archive_all">Arquivar Todos</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ro/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ro/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Sincronizare (Push)</string>
+    <string name="notification_channel_push_description">Afișat când se așteaptă mesaje noi</string>
+    <string name="notification_channel_messages_title">Mesaje</string>
+    <string name="notification_channel_messages_description">Notificări asociate cu mesaje</string>
+    <string name="notification_channel_miscellaneous_title">Diverse</string>
+    <string name="notification_channel_miscellaneous_description">Notificări diverse ca erori etc.</string>
+    <string name="notification_notify_error_title">Eroare de notificare</string>
+    <string name="notification_notify_error_text">S-a produs o eroare în timpul încercării de a crea o notificare de sistem pentru un mesaj nou. Motivul este cel mai probabil lipsa unui sunet de notificare.\n\nApasă pentru a deschide setările de notificare.</string>
+    <string name="notification_authentication_error_title">Autentificarea a eșuat</string>
+    <string name="notification_certificate_error_public">Eroare de certificat</string>
+    <string name="notification_certificate_error_title">Eroare de certificat pentru %1$s</string>
+    <string name="notification_certificate_error_text">Verifică setările serverului</string>
+    <string name="notification_bg_sync_ticker">Se verifică emailul: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Se verifică emailul</string>
+    <string name="notification_bg_send_ticker">Se trimite emailul: %1$s</string>
+    <string name="notification_bg_send_title">Se trimite emailul</string>
+    <string name="send_failure_subject">Eșuare la trimiterea unor mesaje</string>
+    <string name="notification_additional_messages">+ %1$d mai multe %2$s</string>
+    <string name="push_notification_state_initializing">Inițializare…</string>
+    <string name="push_notification_state_listening">Așteptând noi e-mailuri</string>
+    <string name="push_notification_state_wait_background_sync">Adormire până când este permisă sincronizarea în fundal</string>
+    <string name="push_notification_state_wait_network">În așteptare până când rețeaua este disponibilă</string>
+    <string name="push_notification_state_alarm_permission_missing">Lipsește permisiunea de a programa alarme</string>
+    <string name="push_notification_info">Apasă pentru a afla mai multe.</string>
+    <string name="push_notification_grant_alarm_permission">Atinge pentru a acorda permisiunea.</string>
+    <string name="push_info_disable_push_action">Dezactivare Push</string>
+    <string name="notification_action_reply">Răspunde</string>
+    <string name="notification_action_mark_as_read">Marchează ca citit</string>
+    <string name="notification_action_mark_all_as_read">Marchează totul ca citit</string>
+    <string name="notification_action_delete">Șterge</string>
+    <string name="notification_action_delete_all">Șterge tot</string>
+    <string name="notification_action_archive">Arhivă</string>
+    <string name="notification_action_archive_all">Arhivează tot</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ru/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Синхронизация (Push)</string>
+    <string name="notification_channel_push_description">Отображается во время ожидания новых сообщений</string>
+    <string name="notification_channel_messages_title">Сообщение</string>
+    <string name="notification_channel_messages_description">Уведомления о сообщениях</string>
+    <string name="notification_channel_miscellaneous_title">Разное</string>
+    <string name="notification_channel_miscellaneous_description">Различные уведомления, например, об ошибках и т.д.</string>
+    <string name="notification_notify_error_title">Ошибка уведомления</string>
+    <string name="notification_notify_error_text">При попытке создать системное уведомление для нового сообщения произошла ошибка. Причина, скорее всего, заключается в отсутствующем звуке уведомления.
+\n
+\nНажмите, чтобы открыть настройки уведомлений.</string>
+    <string name="notification_authentication_error_title">Сбой аутентификации</string>
+    <string name="notification_certificate_error_public">Ошибка сертификата</string>
+    <string name="notification_certificate_error_title">Сбой сертификата %1$s</string>
+    <string name="notification_certificate_error_text">Проверьте настройки сервера</string>
+    <string name="notification_bg_sync_ticker">Проверка %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Проверка почты</string>
+    <string name="notification_bg_send_ticker">Отправка %1$s</string>
+    <string name="notification_bg_send_title">Отправка почты</string>
+    <string name="send_failure_subject">Сбой отправки почты</string>
+    <string name="notification_additional_messages">+ ещё %1$d в %2$s</string>
+    <string name="push_notification_state_initializing">Инициализация…</string>
+    <string name="push_notification_state_listening">Ожидание новых писем</string>
+    <string name="push_notification_state_wait_background_sync">Спящий режим до тех пор, пока не будет разрешена фоновая синхронизация</string>
+    <string name="push_notification_state_wait_network">Спящий режим до появления сети</string>
+    <string name="push_notification_state_alarm_permission_missing">Отсутствует разрешение на установку будильников</string>
+    <string name="push_notification_info">Нажмите, чтобы узнать больше.</string>
+    <string name="push_notification_grant_alarm_permission">Нажмите, чтобы дать разрешение.</string>
+    <string name="push_info_disable_push_action">Отключить push</string>
+    <string name="notification_action_reply">Ответить</string>
+    <string name="notification_action_mark_as_read">Прочитано</string>
+    <string name="notification_action_mark_all_as_read">Прочитаны все</string>
+    <string name="notification_action_delete">Удалить</string>
+    <string name="notification_action_delete_all">Удалить все</string>
+    <string name="notification_action_archive">Архив</string>
+    <string name="notification_action_archive_all">Архивировать все</string>
+    <string name="notification_action_spam">Спам</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-sk/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-sk/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synchronizovať (Push)</string>
+    <string name="notification_channel_push_description">Zobrazené po dobu čakania na nové správy</string>
+    <string name="notification_channel_messages_title">Správy</string>
+    <string name="notification_channel_messages_description">Oznámenia súvisiace so správami</string>
+    <string name="notification_channel_miscellaneous_title">Rôzne</string>
+    <string name="notification_channel_miscellaneous_description">Rôzne oznámenia, napr. chyby atď.</string>
+    <string name="notification_notify_error_title">Chyba oznámení</string>
+    <string name="notification_notify_error_text">Vyskytla sa chyba počas pokusu o vytvorenie notifikácie pre noú správu. Dôvodom je pravdepodobne nenastavený zvuk notifikácie.\n\nKliknite pre otvorenie nastavení notifikácií.</string>
+    <string name="notification_authentication_error_title">Overenie zlyhalo</string>
+    <string name="notification_certificate_error_public">Chyba certifikátu</string>
+    <string name="notification_certificate_error_title">Chyba certifikátu pre %1$s</string>
+    <string name="notification_certificate_error_text">Skontrolujte nastavenia servera</string>
+    <string name="notification_bg_sync_ticker">Kontrolovanie pošty: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Kontrolovanie pošty</string>
+    <string name="notification_bg_send_ticker">Odosielanie pošty: %1$s</string>
+    <string name="notification_bg_send_title">Odosielanie pošty</string>
+    <string name="send_failure_subject">Nepodarilo sa odoslať niektoré správy</string>
+    <string name="notification_additional_messages">+ %1$d ďalších v %2$s</string>
+    <string name="push_notification_state_initializing">Inicializujem…</string>
+    <string name="push_notification_state_listening">Čakám na nové e-maily</string>
+    <string name="push_notification_state_wait_background_sync">Pozastavený pokiaľ nebude povolená synchronizácia na pozadí</string>
+    <string name="push_notification_state_wait_network">Pozastavený pokiaľ nebude dostupná sieť</string>
+    <string name="push_notification_state_alarm_permission_missing">Chýbajúce oprávnenie na nastavovanie alarmov</string>
+    <string name="push_notification_info">Kliknite aby ste sa dozvedeli viac.</string>
+    <string name="push_notification_grant_alarm_permission">Kliknite na udelenie oprávnení.</string>
+    <string name="push_info_disable_push_action">Vypnúť Push</string>
+    <string name="notification_action_reply">Odpovedať</string>
+    <string name="notification_action_mark_as_read">Označiť ako prečítané</string>
+    <string name="notification_action_mark_all_as_read">Označiť všetky ako prečítané</string>
+    <string name="notification_action_delete">Vymazať</string>
+    <string name="notification_action_delete_all">Vymazať všetko</string>
+    <string name="notification_action_archive">Archivovať</string>
+    <string name="notification_action_archive_all">Archivovať všetko</string>
+    <string name="notification_action_spam">Nevyžiadaná pošta</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-sl/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-sl/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Usklajevanje (potisno)</string>
+    <string name="notification_channel_push_description">Prikazano med čakanjem na nova sporočila</string>
+    <string name="notification_channel_messages_title">Sporočila</string>
+    <string name="notification_channel_messages_description">Obvestila v zvezi s sporočili</string>
+    <string name="notification_channel_miscellaneous_title">Razno</string>
+    <string name="notification_channel_miscellaneous_description">Razna obvestila, kot so npr. napake itd.</string>
+    <string name="notification_notify_error_title">Napaka obveščanja</string>
+    <string name="notification_notify_error_text">Med poskusom ustvarjanja sistemskega obvestila za novo sporočilo je prišlo do napake. Razlog je najverjetneje manjkajoči zvok obvestila.\n\nDotaknite se, če želite odpreti nastavitve obvestil.</string>
+    <string name="notification_authentication_error_title">Overjanje je spodletelo</string>
+    <string name="notification_certificate_error_public">Napaka potrdila</string>
+    <string name="notification_certificate_error_title">Napaka potrdila za račun %1$s</string>
+    <string name="notification_certificate_error_text">Preverite nastavitve strežnika</string>
+    <string name="notification_bg_sync_ticker">Preverjanje pošte: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Preverjanje pošte</string>
+    <string name="notification_bg_send_ticker">Pošiljanje pošte: %1$s</string>
+    <string name="notification_bg_send_title">Pošiljanje pošte</string>
+    <string name="send_failure_subject">Nekaterih sporočil ni bilo mogoče poslati</string>
+    <string name="notification_additional_messages">in %1$d na %2$s</string>
+    <string name="push_notification_state_initializing">Začenjanje …</string>
+    <string name="push_notification_state_listening">Čakam na nova e-poštna sporočila</string>
+    <string name="push_notification_state_wait_background_sync">Spanje, dokler ni dovoljena sinhronizacija v ozadju </string>
+    <string name="push_notification_state_wait_network">Spanje, dokler ni na voljo omrežja</string>
+    <string name="push_notification_state_alarm_permission_missing">Manjka dovoljenje za nastavitev alarma.</string>
+    <string name="push_notification_info">Dotakni se, če želiš izvedeti več.</string>
+    <string name="push_notification_grant_alarm_permission">Tapnite za odobritev dovoljenja.</string>
+    <string name="push_info_disable_push_action">Onemogoči potisne storitve</string>
+    <string name="notification_action_reply">Odgovori</string>
+    <string name="notification_action_mark_as_read">Označi kot prebrano</string>
+    <string name="notification_action_mark_all_as_read">Označi vsa kot prebrana</string>
+    <string name="notification_action_delete">Izbriši</string>
+    <string name="notification_action_delete_all">Izbriši vse</string>
+    <string name="notification_action_archive">Arhiviraj</string>
+    <string name="notification_action_archive_all">Arhiviraj vse</string>
+    <string name="notification_action_spam">Označi kot neželeno pošto</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-sq/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-sq/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Njëkohëso (Push)</string>
+    <string name="notification_channel_push_description">Shfaqur teksa pritet për mesazhe të reja</string>
+    <string name="notification_channel_messages_title">Mesazhe</string>
+    <string name="notification_channel_messages_description">Njoftime lidhur me mesazhe</string>
+    <string name="notification_channel_miscellaneous_title">Të ndryshme</string>
+    <string name="notification_channel_miscellaneous_description">Njoftime të ndryshme, si gabime, etj.</string>
+    <string name="notification_notify_error_title">Gabim njoftimi</string>
+    <string name="notification_notify_error_text">Ndodhi një gabim teksa provohej të krijohej një njoftim sistemi për një mesazh të ri. Arsyeja ka shumë gjasa të jetë mungesa e një tingulli njoftimesh. \n \nPrekeni që të hapen rregullimet për njoftimet.</string>
+    <string name="notification_authentication_error_title">Mirëfilltësimi dështoi</string>
+    <string name="notification_certificate_error_public">Gabim dëshmie</string>
+    <string name="notification_certificate_error_title">Gabim dëshmie për %1$s</string>
+    <string name="notification_certificate_error_text">Kontrolloni rregullimet e shërbyesit tuaj</string>
+    <string name="notification_bg_sync_ticker">Po merret postë: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Marrje poste</string>
+    <string name="notification_bg_send_ticker">Po dërgohet postë: %1$s</string>
+    <string name="notification_bg_send_title">Dërgim poste</string>
+    <string name="send_failure_subject">Dështoi dërgimi i disa mesazhe</string>
+    <string name="notification_additional_messages">+ %1$d më tepër te %2$s</string>
+    <string name="push_notification_state_initializing">Po fillohet…</string>
+    <string name="push_notification_state_listening">Po pritet për email-e të rinj</string>
+    <string name="push_notification_state_wait_background_sync">Po dremitet, deri sa të lejohet njëkohësimi në prapaskenë</string>
+    <string name="push_notification_state_wait_network">Po dremitet, deri sa të ketë rrjet</string>
+    <string name="push_notification_state_alarm_permission_missing">Mungojnë leje për të planifikuar alarme</string>
+    <string name="push_notification_info">Që të mësoni më tepër, prekeni.</string>
+    <string name="push_notification_grant_alarm_permission">Për të akorduar leje, prekeni.</string>
+    <string name="push_info_disable_push_action">Çaktivizoje Push-in</string>
+    <string name="notification_action_reply">Përgjigjuni</string>
+    <string name="notification_action_mark_as_read">Vëri Shenjë Si të Lexuar</string>
+    <string name="notification_action_mark_all_as_read">Shënoji Krejt Si të Lexuar</string>
+    <string name="notification_action_delete">Fshije</string>
+    <string name="notification_action_delete_all">Fshiji Krejt</string>
+    <string name="notification_action_archive">Arkivoje</string>
+    <string name="notification_action_archive_all">Arkivoji Krejt</string>
+    <string name="notification_action_spam">Mesazh i Padëshiruar</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-sr/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-sr/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Синхронизуј (Push)</string>
+    <string name="notification_channel_push_description">Приказано док чекате нове поруке</string>
+    <string name="notification_channel_messages_title">Поруке</string>
+    <string name="notification_channel_messages_description">Обавештења о порукама</string>
+    <string name="notification_channel_miscellaneous_title">Разно</string>
+    <string name="notification_channel_miscellaneous_description">Разна обавештења, попут грешака итд.</string>
+    <string name="notification_notify_error_title">Грешка обавештења</string>
+    <string name="notification_notify_error_text">Дошло је до грешке приликом покушаја прављења системског обавештења за нову поруку. Разлог је највероватније недостатак звука обавештења. \n \nДодирните да отворите подешавања обавештења.</string>
+    <string name="notification_authentication_error_title">Аутентификација није успела</string>
+    <string name="notification_certificate_error_public">Грешка сертификата</string>
+    <string name="notification_certificate_error_title">Грешка сертификата за %1$s</string>
+    <string name="notification_certificate_error_text">Проверите подешавања сервера</string>
+    <string name="notification_bg_sync_ticker">Проверавање мејла: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Проверавање мејла</string>
+    <string name="notification_bg_send_ticker">Слање мејла: %1$s</string>
+    <string name="notification_bg_send_title">Слање мејла</string>
+    <string name="send_failure_subject">Неуспешно слање неких порука</string>
+    <string name="notification_additional_messages">+ још %1$d на %2$s</string>
+    <string name="push_notification_state_initializing">Покретање…</string>
+    <string name="push_notification_state_listening">Чекање нових имејлова</string>
+    <string name="push_notification_state_wait_background_sync">Спавање док се не дозволи синхронизација у позадини</string>
+    <string name="push_notification_state_wait_network">Спавање док мрежа не буде доступна</string>
+    <string name="push_notification_state_alarm_permission_missing">Недостаје дозвола за заказивање аларма</string>
+    <string name="push_notification_info">Додирните да сазнате више.</string>
+    <string name="push_notification_grant_alarm_permission">Додирните да бисте дали дозволу.</string>
+    <string name="push_info_disable_push_action">Онемогући push</string>
+    <string name="notification_action_reply">Одговори</string>
+    <string name="notification_action_mark_as_read">Означи као прочитано</string>
+    <string name="notification_action_mark_all_as_read">Означи све као прочитано</string>
+    <string name="notification_action_delete">Избриши</string>
+    <string name="notification_action_delete_all">Избриши све</string>
+    <string name="notification_action_archive">Архивирај</string>
+    <string name="notification_action_archive_all">Архивирај све</string>
+    <string name="notification_action_spam">Непожељно</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-sv/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-sv/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Synkronisera (Push)</string>
+    <string name="notification_channel_push_description">Visas i väntan på nya meddelanden</string>
+    <string name="notification_channel_messages_title">Meddelanden</string>
+    <string name="notification_channel_messages_description">Aviseringar relaterade till meddelanden</string>
+    <string name="notification_channel_miscellaneous_title">Diverse</string>
+    <string name="notification_channel_miscellaneous_description">Diverse aviseringar som fel m.m.</string>
+    <string name="notification_notify_error_title">Aviseringsfel</string>
+    <string name="notification_notify_error_text">Ett fel uppstod vid försök att skapa en systemavisering för ett nytt meddelande. Anledningen är troligen att ett aviseringsljud saknas.\n\nTryck för att öppna aviseringsinställningarna.</string>
+    <string name="notification_authentication_error_title">Autentisering misslyckades</string>
+    <string name="notification_certificate_error_public">Certifikatfel</string>
+    <string name="notification_certificate_error_title">Certifikatfel för %1$s</string>
+    <string name="notification_certificate_error_text">Kontrollera dina serverinställningar</string>
+    <string name="notification_bg_sync_ticker">Kontrollerar e-post: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Kontrollerar e-post</string>
+    <string name="notification_bg_send_ticker">Skickar e-post: %1$s</string>
+    <string name="notification_bg_send_title">Skickar e-post</string>
+    <string name="send_failure_subject">Det gick inte att skicka några meddelanden</string>
+    <string name="notification_additional_messages">+ %1$d fler på %2$s</string>
+    <string name="push_notification_state_initializing">Initierar…</string>
+    <string name="push_notification_state_listening">Väntar på nya e-postmeddelanden</string>
+    <string name="push_notification_state_wait_background_sync">Sover tills bakgrundssynkronisering är tillåten</string>
+    <string name="push_notification_state_wait_network">Sover tills nätverket är tillgängligt</string>
+    <string name="push_notification_state_alarm_permission_missing">Saknar behörigheter för att schemalägga larm</string>
+    <string name="push_notification_info">Tryck för att läsa mer.</string>
+    <string name="push_notification_grant_alarm_permission">Tryck för att ge behörigheter.</string>
+    <string name="push_info_disable_push_action">Inaktivera Push</string>
+    <string name="notification_action_reply">Svara</string>
+    <string name="notification_action_mark_as_read">Markera som läst</string>
+    <string name="notification_action_mark_all_as_read">Markera alla som lästa</string>
+    <string name="notification_action_delete">Ta bort</string>
+    <string name="notification_action_delete_all">Ta bort alla</string>
+    <string name="notification_action_archive">Arkivera</string>
+    <string name="notification_action_archive_all">Arkivera alla</string>
+    <string name="notification_action_spam">Skräppost</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-ta-rIN/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-ta-rIN/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">ஒத்திசைக்கவும் (புச்)</string>
+    <string name="notification_channel_push_description">புதிய செய்திகளுக்காக காத்திருக்கும்போது காட்டப்படும்</string>
+    <string name="notification_channel_messages_title">செய்திகள்</string>
+    <string name="notification_channel_messages_description">செய்திகள் தொடர்பான அறிவிப்புகள்</string>
+    <string name="notification_channel_miscellaneous_title">மற்றவை</string>
+    <string name="notification_channel_miscellaneous_description">பிழைகள் போன்ற இதர அறிவிப்புகள்.</string>
+    <string name="notification_notify_error_title">அறிவிப்பு பிழை</string>
+    <string name="notification_notify_error_text">புதிய செய்திக்கு கணினி அறிவிப்பை உருவாக்க முயற்சிக்கும்போது பிழை ஏற்பட்டது. காரணம் பெரும்பாலும் காணாமல் போன அறிவிப்பு ஒலி.\n\n அறிவிப்பு அமைப்புகளைத் திறக்க தட்டவும்.</string>
+    <string name="notification_authentication_error_title">ஏற்பு தோல்வியடைந்தது</string>
+    <string name="notification_certificate_error_public">சான்றிதழ் பிழை</string>
+    <string name="notification_certificate_error_title">%1$s சான்றிதழ் பிழை </string>
+    <string name="notification_certificate_error_text">வழங்கியை சோதி</string>
+    <string name="notification_bg_sync_ticker">%1$s:%2$s கணக்கு பார்க்கப்படுகிறது</string>
+    <string name="notification_bg_sync_title">கணக்கு பார்க்கப்படுகிறது</string>
+    <string name="notification_bg_send_ticker">அஞ்சல் அனுப்புதல்: %1$s</string>
+    <string name="notification_bg_send_title">அஞ்சல் அனுப்புதல்</string>
+    <string name="send_failure_subject">அஞ்சல்கள் அனுப்புவதில் பிழை</string>
+    <string name="notification_additional_messages">+ %1$d %2$s இல் மேலும்</string>
+    <string name="push_notification_state_initializing">தொடங்குதல்…</string>
+    <string name="push_notification_state_listening">புதிய மின்னஞ்சல்களுக்காக காத்திருக்கிறது</string>
+    <string name="push_notification_state_wait_background_sync">பின்னணி ஒத்திசைவு அனுமதிக்கப்படும் வரை தூங்குகிறது</string>
+    <string name="push_notification_state_wait_network">பிணையம் கிடைக்கும் வரை தூங்குகிறது</string>
+    <string name="push_notification_state_alarm_permission_missing">அலாரங்களை திட்டமிட இசைவு இல்லை</string>
+    <string name="push_notification_info">மேலும் அறிய தட்டவும்.</string>
+    <string name="push_notification_grant_alarm_permission">இசைவு வழங்க தட்டவும்.</string>
+    <string name="push_info_disable_push_action">புச் முடக்கு</string>
+    <string name="notification_action_reply">பதில்</string>
+    <string name="notification_action_mark_as_read">படித்ததாக குறி</string>
+    <string name="notification_action_mark_all_as_read">எல்லா வாசிப்பையும் குறிக்கவும்</string>
+    <string name="notification_action_delete">அழி</string>
+    <string name="notification_action_delete_all">அனைத்தையும் நீக்கு</string>
+    <string name="notification_action_archive">காப்பகம்</string>
+    <string name="notification_action_archive_all">அனைத்தையும் காப்பகப்படுத்துங்கள்</string>
+    <string name="notification_action_spam">பயனற்றது</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-tr/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-tr/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Eşitle (anında ilet)</string>
+    <string name="notification_channel_push_description">Yeni iletiler beklenirken görüntülenir</string>
+    <string name="notification_channel_messages_title">İletiler</string>
+    <string name="notification_channel_messages_description">İletilerle ilgili bildirimler</string>
+    <string name="notification_channel_miscellaneous_title">Çeşitli</string>
+    <string name="notification_channel_miscellaneous_description">Hata vb. çeşitli bildirimler</string>
+    <string name="notification_notify_error_title">Bildirim hatası</string>
+    <string name="notification_notify_error_text">Yeni bir ileti için sistem bildirimi oluşturmaya çalışırken bir hata oluştu. Bunun nedeni büyük olasılıkla eksik bir bildirim sesidir.\n\nBildirim ayarlarını açmak için dokunun.</string>
+    <string name="notification_authentication_error_title">Kimlik doğrulama başarısız oldu</string>
+    <string name="notification_certificate_error_public">Sertifika hatası</string>
+    <string name="notification_certificate_error_title">%1$s için sertifika hatası</string>
+    <string name="notification_certificate_error_text">Sunucu ayarlarınızı gözden geçirin</string>
+    <string name="notification_bg_sync_ticker">E-posta denetleniyor: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">E-posta denetleniyor</string>
+    <string name="notification_bg_send_ticker">E-posta gönderiliyor: %1$s</string>
+    <string name="notification_bg_send_title">E-posta gönderiliyor</string>
+    <string name="send_failure_subject">Bazı iletiler gönderilemedi</string>
+    <string name="notification_additional_messages">%2$s hesabında %1$d tane daha</string>
+    <string name="push_notification_state_initializing">Başlatılıyor…</string>
+    <string name="push_notification_state_listening">Yeni e-postalar bekleniyor</string>
+    <string name="push_notification_state_wait_background_sync">Arka planda eşitlemeye izin verilene kadar uyku halinde</string>
+    <string name="push_notification_state_wait_network">Ağa erişilene kadar uyku halinde</string>
+    <string name="push_notification_state_alarm_permission_missing">Alarmları zamanlamak için izin eksik</string>
+    <string name="push_notification_info">Bilgi almak için dokunun.</string>
+    <string name="push_notification_grant_alarm_permission">İzin vermek için dokunun.</string>
+    <string name="push_info_disable_push_action">Anında iletmeyi devre dışı bırak</string>
+    <string name="notification_action_reply">Yanıtla</string>
+    <string name="notification_action_mark_as_read">Okundu olarak işaretle</string>
+    <string name="notification_action_mark_all_as_read">Tümünü okundu olarak işaretle</string>
+    <string name="notification_action_delete">Sil</string>
+    <string name="notification_action_delete_all">Tümünü sil</string>
+    <string name="notification_action_archive">Arşivle</string>
+    <string name="notification_action_archive_all">Tümünü arşivle</string>
+    <string name="notification_action_spam">Spam</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-uk/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-uk/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Синхронізація (Push)</string>
+    <string name="notification_channel_push_description">Показується під час очікування нових повідомлень</string>
+    <string name="notification_channel_messages_title">Повідомлення</string>
+    <string name="notification_channel_messages_description">Сповіщення, пов\'язані з повідомленнями</string>
+    <string name="notification_channel_miscellaneous_title">Різне</string>
+    <string name="notification_channel_miscellaneous_description">Різні сповіщення, наприклад, про помилки тощо.</string>
+    <string name="notification_notify_error_title">Помилка сповіщення</string>
+    <string name="notification_notify_error_text">Сталася помилка під час створення системного сповіщення про нове повідомлення. Найчастіше це стається через відсутність звуку сповіщення.\n\nТоркніться, щоб відкрити налаштування сповіщень.</string>
+    <string name="notification_authentication_error_title">Не вдалося автентифікувати</string>
+    <string name="notification_certificate_error_public">Помилка сертифіката</string>
+    <string name="notification_certificate_error_title">Помилка сертифіката для %1$s</string>
+    <string name="notification_certificate_error_text">Перевірте налаштування вашого сервера</string>
+    <string name="notification_bg_sync_ticker">Перевірка пошти: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Перевірка пошти</string>
+    <string name="notification_bg_send_ticker">Надсилання пошти: %1$s</string>
+    <string name="notification_bg_send_title">Надсилання пошти</string>
+    <string name="send_failure_subject">Не вдалося надіслати повідомлення</string>
+    <string name="notification_additional_messages">ще %1$d у %2$s</string>
+    <string name="push_notification_state_initializing">Ініціалізація…</string>
+    <string name="push_notification_state_listening">Очікування нових листів</string>
+    <string name="push_notification_state_wait_background_sync">Очікування дозволу на фонову синхронізацію</string>
+    <string name="push_notification_state_wait_network">Очікування доступності мережі</string>
+    <string name="push_notification_state_alarm_permission_missing">Відсутній дозвіл на планування оповіщень</string>
+    <string name="push_notification_info">Натисніть, щоб дізнатися більше.</string>
+    <string name="push_notification_grant_alarm_permission">Торкніться, щоб надати дозвіл.</string>
+    <string name="push_info_disable_push_action">Вимкнути Push</string>
+    <string name="notification_action_reply">Відповісти</string>
+    <string name="notification_action_mark_as_read">Позначити прочитаним</string>
+    <string name="notification_action_mark_all_as_read">Позначити всі прочитаними</string>
+    <string name="notification_action_delete">Видалити</string>
+    <string name="notification_action_delete_all">Видалити всі</string>
+    <string name="notification_action_archive">Архівувати</string>
+    <string name="notification_action_archive_all">Архівувати всі</string>
+    <string name="notification_action_spam">Спам</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-vi/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-vi/strings.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">Đồng bộ hóa (Push)</string>
+    <string name="notification_channel_push_description">Hiển thị khi chờ tin nhắn mới</string>
+    <string name="notification_channel_messages_title">Tin nhắn</string>
+    <string name="notification_channel_messages_description">Thông báo liên quan đến tin nhắn</string>
+    <string name="notification_channel_miscellaneous_title">Khác</string>
+    <string name="notification_channel_miscellaneous_description">Thông báo khác như lỗi, v.v.</string>
+    <string name="notification_notify_error_title">Thông báo lỗi</string>
+    <string name="notification_notify_error_text">Có lỗi xảy ra khi tạo thông báo hệ thống cho tin nhắn mới. Nguyên nhân có thể do thiếu âm thanh thông báo.
+\n
+\nNhấn để mở thiết đặt thông báo.</string>
+    <string name="notification_authentication_error_title">Xác thực không thành công</string>
+    <string name="notification_certificate_error_public">Lỗi xác thực</string>
+    <string name="notification_certificate_error_title">Lỗi xác thực đối với %1$s</string>
+    <string name="notification_certificate_error_text">Kiểm tra các thiết đặt máy chủ bạn đã nhập</string>
+    <string name="notification_bg_sync_ticker">Đang kiểm tra thư cho: %1$s:%2$s</string>
+    <string name="notification_bg_sync_title">Kiểm tra thư</string>
+    <string name="notification_bg_send_ticker">Đang gửi thư: %1$s</string>
+    <string name="notification_bg_send_title">Đang gửi thư</string>
+    <string name="send_failure_subject">Không gửi được một số tin nhắn</string>
+    <string name="notification_additional_messages">+ %1$d thêm cho %2$s</string>
+    <string name="push_notification_state_initializing">Đang hình thành…</string>
+    <string name="push_notification_state_listening">Đang đợi email mới</string>
+    <string name="push_notification_state_wait_background_sync">Đang ngủ cho đến khi đồng bộ nền được cho phép</string>
+    <string name="push_notification_state_wait_network">Đang ngủ đến khi có kết nối mạng</string>
+    <string name="push_notification_state_alarm_permission_missing">Thiếu quyền cho phép đặt báo thức</string>
+    <string name="push_notification_info">Nhấn để đọc thêm.</string>
+    <string name="push_notification_grant_alarm_permission">Nhấn để cấp quyền.</string>
+    <string name="push_info_disable_push_action">Vô hiệu hóa Đẩy</string>
+    <string name="notification_action_reply">Trả lời</string>
+    <string name="notification_action_mark_as_read">Đánh dấu đã đọc</string>
+    <string name="notification_action_mark_all_as_read">Đánh Dấu Tất Cả Đã Đọc</string>
+    <string name="notification_action_delete">Xóa</string>
+    <string name="notification_action_delete_all">Xóa tất cả</string>
+    <string name="notification_action_archive">Lưu trữ</string>
+    <string name="notification_action_archive_all">Lưu trữ tất cả</string>
+    <string name="notification_action_spam">Thư rác</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-zh-rCN/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-zh-rCN/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">同步（推送）</string>
+    <string name="notification_channel_push_description">等待新邮件时显示</string>
+    <string name="notification_channel_messages_title">邮件</string>
+    <string name="notification_channel_messages_description">与邮件相关的通知</string>
+    <string name="notification_channel_miscellaneous_title">杂项</string>
+    <string name="notification_channel_miscellaneous_description">错误等杂项通知。</string>
+    <string name="notification_notify_error_title">通知错误</string>
+    <string name="notification_notify_error_text">尝试为新邮件创建系统通知时出错。原因很可能是缺少通知提示音。\n\n请点按以打开通知设置。</string>
+    <string name="notification_authentication_error_title">身份验证失败</string>
+    <string name="notification_certificate_error_public">证书错误</string>
+    <string name="notification_certificate_error_title">%1$s 的证书错误</string>
+    <string name="notification_certificate_error_text">请检查您的服务器设置</string>
+    <string name="notification_bg_sync_ticker">正在检查邮件：%1$s：%2$s</string>
+    <string name="notification_bg_sync_title">正在检查邮件</string>
+    <string name="notification_bg_send_ticker">正在发送邮件：%1$s</string>
+    <string name="notification_bg_send_title">正在发送邮件</string>
+    <string name="send_failure_subject">无法发送某些邮件</string>
+    <string name="notification_additional_messages">加载 %2$s 上的另外 %1$d 封邮件</string>
+    <string name="push_notification_state_initializing">正在初始化…</string>
+    <string name="push_notification_state_listening">正在等待新电子邮件</string>
+    <string name="push_notification_state_wait_background_sync">在允许后台同步之前一直处于睡眠状态</string>
+    <string name="push_notification_state_wait_network">在网络可用之前一直处于睡眠状态</string>
+    <string name="push_notification_state_alarm_permission_missing">缺少设置闹钟的权限</string>
+    <string name="push_notification_info">点按即可了解详情。</string>
+    <string name="push_notification_grant_alarm_permission">点按即可授予权限。</string>
+    <string name="push_info_disable_push_action">禁用推送</string>
+    <string name="notification_action_reply">回复</string>
+    <string name="notification_action_mark_as_read">标记为已读</string>
+    <string name="notification_action_mark_all_as_read">全部标记为已读</string>
+    <string name="notification_action_delete">删除</string>
+    <string name="notification_action_delete_all">删除全部</string>
+    <string name="notification_action_archive">归档</string>
+    <string name="notification_action_archive_all">归档全部</string>
+    <string name="notification_action_spam">垃圾邮件</string>
+</resources>

--- a/feature/notification/api/src/commonMain/composeResources/values-zh-rTW/strings.xml
+++ b/feature/notification/api/src/commonMain/composeResources/values-zh-rTW/strings.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<resources>
+    <string name="notification_channel_push_title">同步（推送）</string>
+    <string name="notification_channel_push_description">等待新郵件時顯示</string>
+    <string name="notification_channel_messages_title">郵件</string>
+    <string name="notification_channel_messages_description">與郵件相關的通知</string>
+    <string name="notification_channel_miscellaneous_title">雜項設定</string>
+    <string name="notification_channel_miscellaneous_description">其他通知，如錯誤通知等。</string>
+    <string name="notification_notify_error_title">通知錯誤</string>
+    <string name="notification_notify_error_text">嘗試建立新訊息的系統通知時發生錯誤。最有可能的原因是缺少通知聲音。\n\n按一下開啟通知設定。</string>
+    <string name="notification_authentication_error_title">身份驗證失敗</string>
+    <string name="notification_certificate_error_public">證書錯誤</string>
+    <string name="notification_certificate_error_title">%1$s驗證錯誤</string>
+    <string name="notification_certificate_error_text">檢查你的伺服器設定</string>
+    <string name="notification_bg_sync_ticker">正在檢查郵件：%1$s:%2$s</string>
+    <string name="notification_bg_sync_title">正在檢查郵件</string>
+    <string name="notification_bg_send_ticker">正在寄送郵件：%1$s</string>
+    <string name="notification_bg_send_title">正在寄送郵件</string>
+    <string name="send_failure_subject">有些郵件沒有成功寄送</string>
+    <string name="notification_additional_messages">+ 來自%2$s已超過%1$d則訊息</string>
+    <string name="push_notification_state_initializing">初始化…</string>
+    <string name="push_notification_state_listening">正在等待新郵件</string>
+    <string name="push_notification_state_wait_background_sync">等待背景同步允許</string>
+    <string name="push_notification_state_wait_network">等待網路可用</string>
+    <string name="push_notification_state_alarm_permission_missing">缺少排程鬧鐘的權限</string>
+    <string name="push_notification_info">點擊以瞭解更多。</string>
+    <string name="push_notification_grant_alarm_permission">點擊以授予權限。</string>
+    <string name="push_info_disable_push_action">停用推送</string>
+    <string name="notification_action_reply">回覆</string>
+    <string name="notification_action_mark_as_read">標示為已讀取</string>
+    <string name="notification_action_mark_all_as_read">全部標示為已讀取</string>
+    <string name="notification_action_delete">刪除</string>
+    <string name="notification_action_delete_all">刪除全部</string>
+    <string name="notification_action_archive">封存</string>
+    <string name="notification_action_archive_all">全部封存</string>
+    <string name="notification_action_spam">垃圾郵件</string>
+</resources>


### PR DESCRIPTION
Part of #9418.

This PR adds the missing translations for notification resources.