### PR TITLE
fix: koin experimental verify warning

### DIFF
--- a/core/android/common/src/test/kotlin/app/k9mail/core/android/common/CoreCommonAndroidModuleKtTest.kt
+++ b/core/android/common/src/test/kotlin/app/k9mail/core/android/common/CoreCommonAndroidModuleKtTest.kt
@@ -2,10 +2,12 @@ package app.k9mail.core.android.common
 
 import android.content.Context
 import org.junit.Test
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.verify.verify
 
 internal class CoreCommonAndroidModuleKtTest {
 
+    @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `should have a valid di module`() {
         coreCommonAndroidModule.verify(

--- a/core/android/common/src/test/kotlin/app/k9mail/core/android/common/contact/ContactKoinModuleKtTest.kt
+++ b/core/android/common/src/test/kotlin/app/k9mail/core/android/common/contact/ContactKoinModuleKtTest.kt
@@ -1,10 +1,12 @@
 package app.k9mail.core.android.common.contact
 
 import org.junit.Test
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.verify.verify
 
 internal class ContactKoinModuleKtTest {
 
+    @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `should have a valid di module`() {
         contactModule.verify()

--- a/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/AccountEditModuleKtTest.kt
+++ b/feature/account/edit/src/test/kotlin/app/k9mail/feature/account/edit/AccountEditModuleKtTest.kt
@@ -9,11 +9,13 @@ import app.k9mail.feature.account.server.settings.ui.incoming.IncomingServerSett
 import app.k9mail.feature.account.server.settings.ui.outgoing.OutgoingServerSettingsContract
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract
 import org.junit.Test
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.KoinTest
 import org.koin.test.verify.verify
 
 class AccountEditModuleKtTest : KoinTest {
 
+    @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `should have a valid di module`() {
         featureAccountEditModule.verify(

--- a/feature/account/server/certificate/src/test/kotlin/app/k9mail/feature/account/server/certificate/ServerCertificateModuleKtTest.kt
+++ b/feature/account/server/certificate/src/test/kotlin/app/k9mail/feature/account/server/certificate/ServerCertificateModuleKtTest.kt
@@ -2,11 +2,13 @@ package app.k9mail.feature.account.server.certificate
 
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract
 import org.junit.Test
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.KoinTest
 import org.koin.test.verify.verify
 
 class ServerCertificateModuleKtTest : KoinTest {
 
+    @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `should have a valid di module`() {
         featureAccountServerCertificateModule.verify(

--- a/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ServerValidationModuleKtTest.kt
+++ b/feature/account/server/validation/src/test/kotlin/app/k9mail/feature/account/server/validation/ServerValidationModuleKtTest.kt
@@ -8,11 +8,13 @@ import app.k9mail.feature.account.server.certificate.domain.ServerCertificateDom
 import app.k9mail.feature.account.server.certificate.ui.ServerCertificateErrorContract
 import app.k9mail.feature.account.server.validation.ui.ServerValidationContract
 import org.junit.Test
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.KoinTest
 import org.koin.test.verify.verify
 
 class ServerValidationModuleKtTest : KoinTest {
 
+    @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `should have a valid di module`() {
         featureAccountServerValidationModule.verify(

--- a/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
+++ b/feature/account/setup/src/test/kotlin/app/k9mail/feature/account/setup/AccountSetupModuleKtTest.kt
@@ -16,11 +16,13 @@ import app.k9mail.feature.account.setup.ui.options.sync.SyncOptionsContract
 import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersContract
 import com.fsck.k9.mail.oauth.AuthStateStorage
 import org.junit.Test
+import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.KoinTest
 import org.koin.test.verify.verify
 
 class AccountSetupModuleKtTest : KoinTest {
 
+    @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `should have a valid di module`() {
         featureAccountSetupModule.verify(

--- a/feature/mail/message/list/src/test/kotlin/net/thunderbird/feature/mail/message/list/FeatureMessageListModuleKtTest.kt
+++ b/feature/mail/message/list/src/test/kotlin/net/thunderbird/feature/mail/message/list/FeatureMessageListModuleKtTest.kt
@@ -10,8 +10,9 @@ import org.koin.test.KoinTest
 import org.koin.test.verify.definition
 import org.koin.test.verify.verify
 
-@OptIn(KoinExperimentalAPI::class)
 class FeatureMessageListModuleKtTest : KoinTest {
+
+    @OptIn(KoinExperimentalAPI::class)
     @Test
     fun `should have a valid di module`() {
         featureMessageListModule.verify(


### PR DESCRIPTION
Add `OptIn` to resolve the Koin experimental warning.
