### PR TITLE
Fix warnings in build-plugin

### DIFF
--- a/build-plugin/build.gradle.kts
+++ b/build-plugin/build.gradle.kts
@@ -30,6 +30,12 @@ dependencies {
     implementation(platform(libs.kotlin.gradle.bom))
 }
 
+kotlin {
+    compilerOptions {
+        allWarningsAsErrors = true
+    }
+}
+
 fun plugin(provider: Provider<PluginDependency>) = with(provider.get()) {
     "$pluginId:$pluginId.gradle.plugin:$version"
 }

--- a/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.app.android.gradle.kts
@@ -20,13 +20,15 @@ android {
         isCoreLibraryDesugaringEnabled = true
     }
 
-    kotlinOptions {
-        jvmTarget = ThunderbirdProjectConfig.Compiler.javaCompatibility.toString()
-    }
-
     dependenciesInfo {
         includeInApk = false
         includeInBundle = false
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = ThunderbirdProjectConfig.Compiler.jvmTarget
     }
 }
 

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.compose.gradle.kts
@@ -1,3 +1,5 @@
+import com.android.build.api.variant.HostTestBuilder
+
 plugins {
     id("thunderbird.library.android")
     id("org.jetbrains.kotlin.plugin.compose")
@@ -12,7 +14,7 @@ android {
 
 androidComponents {
     beforeVariants(selector().withBuildType("release")) { variantBuilder ->
-        variantBuilder.enableUnitTest = false
+        variantBuilder.hostTests[HostTestBuilder.UNIT_TEST_TYPE]?.enable = false
         variantBuilder.enableAndroidTest = false
     }
 }

--- a/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
@@ -11,13 +11,12 @@ android {
     buildFeatures {
         buildConfig = false
     }
-
-    kotlinOptions {
-        jvmTarget = ThunderbirdProjectConfig.Compiler.javaCompatibility.toString()
-    }
 }
 
 kotlin {
+    compilerOptions {
+        jvmTarget.set(ThunderbirdProjectConfig.Compiler.jvmTarget)
+    }
     sourceSets.all {
         compilerOptions {
             freeCompilerArgs.add("-Xwhen-guards")


### PR DESCRIPTION
- Move to non-deprecated APIs
- Ensure it doesn't regress by setting allWarningsAsErrors

Test: ./gradlew build --dry-run -> success after PR
Fixes #10093 

