### PR TITLE
refactor(preferences): migrate SwipeActions from K9 object to new PreferenceManagers

### DIFF
--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/action/SwipeAction.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/action/SwipeAction.kt
@@ -16,9 +16,4 @@ enum class SwipeAction(val removesItem: Boolean) {
 data class SwipeActions(
     val leftAction: SwipeAction,
     val rightAction: SwipeAction,
-) {
-    companion object {
-        const val KEY_SWIPE_ACTION_LEFT = "swipeLeftAction"
-        const val KEY_SWIPE_ACTION_RIGHT = "swipeRightAction"
-    }
-}
+)

--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettings.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettings.kt
@@ -1,11 +1,19 @@
 package net.thunderbird.core.preference.interaction
 
+import net.thunderbird.core.common.action.SwipeAction
+import net.thunderbird.core.common.action.SwipeActions
+
 const val INTERACTION_SETTINGS_DEFAULT_USE_VOLUME_KEYS_NAVIGATION = false
 val INTERACTION_SETTINGS_DEFAULT_MESSAGE_VIEW_POST_REMOVE_NAVIGATION = PostRemoveNavigation.ReturnToMessageList.name
+val INTERACTION_SETTINGS_DEFAULT_SWIPE_ACTION = SwipeActions(
+    leftAction = SwipeAction.ToggleRead,
+    rightAction = SwipeAction.ToggleSelection,
+)
 
 data class InteractionSettings(
     val useVolumeKeysForNavigation: Boolean = INTERACTION_SETTINGS_DEFAULT_USE_VOLUME_KEYS_NAVIGATION,
     val messageViewPostRemoveNavigation: String = INTERACTION_SETTINGS_DEFAULT_MESSAGE_VIEW_POST_REMOVE_NAVIGATION,
+    val swipeActions: SwipeActions = INTERACTION_SETTINGS_DEFAULT_SWIPE_ACTION,
 )
 
 /**

--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettingsPreferenceManager.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/InteractionSettingsPreferenceManager.kt
@@ -4,4 +4,7 @@ import net.thunderbird.core.preference.PreferenceManager
 
 const val KEY_USE_VOLUME_KEYS_FOR_NAVIGATION = "useVolumeKeysForNavigation"
 const val KEY_MESSAGE_VIEW_POST_DELETE_ACTION = "messageViewPostDeleteAction"
+const val KEY_SWIPE_ACTION_LEFT = "swipeLeftAction"
+const val KEY_SWIPE_ACTION_RIGHT = "swipeRightAction"
+
 interface InteractionSettingsPreferenceManager : PreferenceManager<InteractionSettings>

--- a/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/DefaultInteractionSettingsPreferenceManager.kt
+++ b/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/DefaultInteractionSettingsPreferenceManager.kt
@@ -10,9 +10,12 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import net.thunderbird.core.common.action.SwipeActions
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.core.preference.storage.StorageEditor
+import net.thunderbird.core.preference.storage.getEnumOrDefault
+import net.thunderbird.core.preference.storage.putEnum
 
 private const val TAG = "DefaultInteractionSettingsPreferenceManager"
 
@@ -44,6 +47,16 @@ class DefaultInteractionSettingsPreferenceManager(
             KEY_MESSAGE_VIEW_POST_DELETE_ACTION,
             INTERACTION_SETTINGS_DEFAULT_MESSAGE_VIEW_POST_REMOVE_NAVIGATION,
         ),
+        swipeActions = SwipeActions(
+            leftAction = storage.getEnumOrDefault(
+                key = KEY_SWIPE_ACTION_LEFT,
+                default = INTERACTION_SETTINGS_DEFAULT_SWIPE_ACTION.leftAction,
+            ),
+            rightAction = storage.getEnumOrDefault(
+                key = KEY_SWIPE_ACTION_RIGHT,
+                default = INTERACTION_SETTINGS_DEFAULT_SWIPE_ACTION.rightAction,
+            ),
+        ),
     )
 
     private fun writeConfig(config: InteractionSettings) {
@@ -52,6 +65,8 @@ class DefaultInteractionSettingsPreferenceManager(
             mutex.withLock {
                 storageEditor.putBoolean(KEY_USE_VOLUME_KEYS_FOR_NAVIGATION, config.useVolumeKeysForNavigation)
                 storageEditor.putString(KEY_MESSAGE_VIEW_POST_DELETE_ACTION, config.messageViewPostRemoveNavigation)
+                storageEditor.putEnum(KEY_SWIPE_ACTION_LEFT, config.swipeActions.leftAction)
+                storageEditor.putEnum(KEY_SWIPE_ACTION_RIGHT, config.swipeActions.rightAction)
                 storageEditor.commit().also { commited ->
                     logger.verbose(TAG) { "writeConfig: storageEditor.commit() resulted in: $commited" }
                 }

--- a/feature/mail/message/list/src/main/kotlin/net/thunderbird/feature/mail/message/list/FeatureMessageListModule.kt
+++ b/feature/mail/message/list/src/main/kotlin/net/thunderbird/feature/mail/message/list/FeatureMessageListModule.kt
@@ -34,7 +34,6 @@ val featureMessageListModule = module {
         BuildSwipeActions(
             generalSettingsManager = get(),
             accountManager = get(),
-            storage = parameters.get(),
         )
     }
     viewModel { parameters ->

--- a/feature/mail/message/list/src/main/kotlin/net/thunderbird/feature/mail/message/list/domain/usecase/BuildSwipeActions.kt
+++ b/feature/mail/message/list/src/main/kotlin/net/thunderbird/feature/mail/message/list/domain/usecase/BuildSwipeActions.kt
@@ -3,8 +3,6 @@ package net.thunderbird.feature.mail.message.list.domain.usecase
 import net.thunderbird.core.common.action.SwipeAction
 import net.thunderbird.core.common.action.SwipeActions
 import net.thunderbird.core.preference.GeneralSettingsManager
-import net.thunderbird.core.preference.storage.Storage
-import net.thunderbird.core.preference.storage.getEnumOrDefault
 import net.thunderbird.feature.mail.account.api.AccountManager
 import net.thunderbird.feature.mail.account.api.BaseAccount
 import net.thunderbird.feature.mail.message.list.domain.DomainContract
@@ -12,16 +10,8 @@ import net.thunderbird.feature.mail.message.list.domain.DomainContract
 class BuildSwipeActions(
     private val generalSettingsManager: GeneralSettingsManager,
     private val accountManager: AccountManager<BaseAccount>,
-    storage: Storage,
 ) : DomainContract.UseCase.BuildSwipeActions<BaseAccount> {
-    private val defaultLeftSwipeAction = storage.getEnumOrDefault(
-        key = SwipeActions.KEY_SWIPE_ACTION_LEFT,
-        default = SwipeAction.ToggleRead,
-    )
-    private val defaultRightSwipeAction = storage.getEnumOrDefault(
-        key = SwipeActions.KEY_SWIPE_ACTION_RIGHT,
-        default = SwipeAction.ToggleRead,
-    )
+    private val defaultSwipeActions get() = generalSettingsManager.getConfig().interaction.swipeActions
 
     override fun invoke(
         accountUuids: Set<String>,
@@ -37,14 +27,14 @@ class BuildSwipeActions(
                 account.uuid to SwipeActions(
                     leftAction = buildSwipeAction(
                         account = account,
-                        defaultSwipeAction = defaultLeftSwipeAction,
+                        defaultSwipeAction = defaultSwipeActions.leftAction,
                         isIncomingServerPop3 = isIncomingServerPop3,
                         hasArchiveFolder = hasArchiveFolder,
                         shouldShowSetupArchiveFolderDialog = shouldShowSetupArchiveFolderDialog,
                     ),
                     rightAction = buildSwipeAction(
                         account = account,
-                        defaultSwipeAction = defaultRightSwipeAction,
+                        defaultSwipeAction = defaultSwipeActions.rightAction,
                         isIncomingServerPop3 = isIncomingServerPop3,
                         hasArchiveFolder = hasArchiveFolder,
                         shouldShowSetupArchiveFolderDialog = shouldShowSetupArchiveFolderDialog,

--- a/feature/mail/message/list/src/test/kotlin/net/thunderbird/feature/mail/message/list/domain/usecase/BuildSwipeActionsTest.kt
+++ b/feature/mail/message/list/src/test/kotlin/net/thunderbird/feature/mail/message/list/domain/usecase/BuildSwipeActionsTest.kt
@@ -17,10 +17,11 @@ import net.thunderbird.core.common.appConfig.PlatformConfigProvider
 import net.thunderbird.core.preference.GeneralSettings
 import net.thunderbird.core.preference.GeneralSettingsManager
 import net.thunderbird.core.preference.display.DisplaySettings
+import net.thunderbird.core.preference.interaction.KEY_SWIPE_ACTION_LEFT
+import net.thunderbird.core.preference.interaction.KEY_SWIPE_ACTION_RIGHT
 import net.thunderbird.core.preference.network.NetworkSettings
 import net.thunderbird.core.preference.notification.NotificationPreference
 import net.thunderbird.core.preference.privacy.PrivacySettings
-import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.feature.mail.message.list.fakes.FakeAccount
 import net.thunderbird.feature.mail.message.list.fakes.FakeAccountManager
 
@@ -56,7 +57,7 @@ class BuildSwipeActionsTest {
     }
 
     @Test
-    fun `invoke should return map with SwipeActions(ToggleRead, ToggleRead) when no user preference is stored`() {
+    fun `invoke should return map with SwipeActions(ToggleRead, ToggleSelection) when no user preference is stored`() {
         // Arrange
         val uuid = Uuid.random().toHexString()
         val uuids = setOf(uuid)
@@ -77,7 +78,7 @@ class BuildSwipeActionsTest {
             containsOnly(
                 uuid to SwipeActions(
                     leftAction = SwipeAction.ToggleRead,
-                    rightAction = SwipeAction.ToggleRead,
+                    rightAction = SwipeAction.ToggleSelection,
                 ),
             )
         }
@@ -107,7 +108,7 @@ class BuildSwipeActionsTest {
                     .associateWith {
                         SwipeActions(
                             leftAction = SwipeAction.ToggleRead,
-                            rightAction = SwipeAction.ToggleRead,
+                            rightAction = SwipeAction.ToggleSelection,
                         )
                     }
                     .map { it.key to it.value }
@@ -117,14 +118,14 @@ class BuildSwipeActionsTest {
     }
 
     @Test
-    fun `invoke should return map with SwipeActions(None, ToggleRead) when left action is stored as None but right is not`() {
+    fun `invoke should return map with SwipeActions(None, ToggleSelection) when left action is stored as None but right is not`() {
         // Arrange
         val uuid = Uuid.random().toHexString()
         val uuids = setOf(uuid)
         val testSubject = createTestSubject(
             accountsUuids = uuids.toList(),
             storageValues = mapOf(
-                SwipeActions.KEY_SWIPE_ACTION_LEFT to SwipeAction.None.name,
+                KEY_SWIPE_ACTION_LEFT to SwipeAction.None,
             ),
         )
 
@@ -141,7 +142,7 @@ class BuildSwipeActionsTest {
             containsOnly(
                 uuid to SwipeActions(
                     leftAction = SwipeAction.None,
-                    rightAction = SwipeAction.ToggleRead,
+                    rightAction = SwipeAction.ToggleSelection,
                 ),
             )
         }
@@ -155,7 +156,7 @@ class BuildSwipeActionsTest {
         val testSubject = createTestSubject(
             accountsUuids = uuids.toList(),
             storageValues = mapOf(
-                SwipeActions.KEY_SWIPE_ACTION_RIGHT to SwipeAction.Delete.name,
+                KEY_SWIPE_ACTION_RIGHT to SwipeAction.Delete,
             ),
         )
 
@@ -186,8 +187,8 @@ class BuildSwipeActionsTest {
         val testSubject = createTestSubject(
             accountsUuids = uuids.toList(),
             storageValues = mapOf(
-                SwipeActions.KEY_SWIPE_ACTION_LEFT to SwipeAction.Archive.name,
-                SwipeActions.KEY_SWIPE_ACTION_RIGHT to SwipeAction.Archive.name,
+                KEY_SWIPE_ACTION_LEFT to SwipeAction.Archive,
+                KEY_SWIPE_ACTION_RIGHT to SwipeAction.Archive,
             ),
         )
 
@@ -218,8 +219,8 @@ class BuildSwipeActionsTest {
         val testSubject = createTestSubject(
             accountsUuids = uuids.toList(),
             storageValues = mapOf(
-                SwipeActions.KEY_SWIPE_ACTION_LEFT to SwipeAction.Archive.name,
-                SwipeActions.KEY_SWIPE_ACTION_RIGHT to SwipeAction.Archive.name,
+                KEY_SWIPE_ACTION_LEFT to SwipeAction.Archive,
+                KEY_SWIPE_ACTION_RIGHT to SwipeAction.Archive,
             ),
         )
 
@@ -257,8 +258,8 @@ class BuildSwipeActionsTest {
             ),
             accountsUuids = uuids.toList(),
             storageValues = mapOf(
-                SwipeActions.KEY_SWIPE_ACTION_LEFT to SwipeAction.Archive.name,
-                SwipeActions.KEY_SWIPE_ACTION_RIGHT to SwipeAction.Archive.name,
+                KEY_SWIPE_ACTION_LEFT to SwipeAction.Archive,
+                KEY_SWIPE_ACTION_RIGHT to SwipeAction.Archive,
             ),
         )
 
@@ -302,8 +303,8 @@ class BuildSwipeActionsTest {
             ),
             accountsUuids = uuids.toList(),
             storageValues = mapOf(
-                SwipeActions.KEY_SWIPE_ACTION_LEFT to SwipeAction.Archive.name,
-                SwipeActions.KEY_SWIPE_ACTION_RIGHT to SwipeAction.Archive.name,
+                KEY_SWIPE_ACTION_LEFT to SwipeAction.Archive,
+                KEY_SWIPE_ACTION_RIGHT to SwipeAction.Archive,
             ),
         )
 
@@ -339,7 +340,7 @@ class BuildSwipeActionsTest {
         // Arrange
         val uuids = List(size = Random.nextInt(from = 1, until = 100)) { Uuid.random().toHexString() }
         val accountManagerUuids =
-            List(size = Random.nextInt(from = 1, until = 100)) { Uuid.random().toHexString() } - uuids
+            List(size = Random.nextInt(from = 1, until = 100)) { Uuid.random().toHexString() } - uuids.toSet()
         val testSubject = createTestSubject(accountsUuids = accountManagerUuids)
 
         // Act
@@ -356,11 +357,28 @@ class BuildSwipeActionsTest {
     private fun createTestSubject(
         initialGeneralSettings: GeneralSettings = defaultGeneralSettings,
         accountsUuids: List<String>,
-        storageValues: Map<String, String> = mapOf(),
+        storageValues: Map<String, SwipeAction> = mapOf(),
     ): BuildSwipeActions = BuildSwipeActions(
-        generalSettingsManager = FakeGeneralSettingsManager(initialGeneralSettings),
+        generalSettingsManager = FakeGeneralSettingsManager(
+            initialGeneralSettings.let { settings ->
+                if (storageValues.isNotEmpty() &&
+                    (KEY_SWIPE_ACTION_LEFT in storageValues || KEY_SWIPE_ACTION_RIGHT in storageValues)
+                ) {
+                    val swipeActions = settings.interaction.swipeActions
+                    settings.copy(
+                        interaction = settings.interaction.copy(
+                            swipeActions = swipeActions.copy(
+                                leftAction = storageValues[KEY_SWIPE_ACTION_LEFT] ?: swipeActions.leftAction,
+                                rightAction = storageValues[KEY_SWIPE_ACTION_RIGHT] ?: swipeActions.rightAction,
+                            ),
+                        ),
+                    )
+                } else {
+                    settings
+                }
+            },
+        ),
         accountManager = FakeAccountManager(accounts = accountsUuids.map { FakeAccount(uuid = it) }),
-        storage = FakeStorage(storageValues),
     )
 }
 
@@ -379,28 +397,6 @@ private class FakeGeneralSettingsManager(
     override fun getConfig(): GeneralSettings = generalSettings.value
 
     override fun getConfigFlow(): Flow<GeneralSettings> = generalSettings
-}
-
-private class FakeStorage(
-    private val values: Map<String, String>,
-) : Storage {
-    override fun isEmpty(): Boolean = error("not implemented")
-
-    override fun contains(key: String): Boolean = error("not implemented")
-
-    override fun getAll(): Map<String, String> = error("not implemented")
-
-    override fun getBoolean(key: String, defValue: Boolean): Boolean = error("not implemented")
-
-    override fun getInt(key: String, defValue: Int): Int = error("not implemented")
-
-    override fun getLong(key: String, defValue: Long): Long = error("not implemented")
-
-    override fun getString(key: String): String = error("not implemented")
-
-    override fun getStringOrDefault(key: String, defValue: String): String = error("not implemented")
-
-    override fun getStringOrNull(key: String): String? = values[key]
 }
 
 private class FakePlatformConfigProvider : PlatformConfigProvider {

--- a/legacy/core/src/main/java/com/fsck/k9/K9.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/K9.kt
@@ -12,8 +12,6 @@ import com.fsck.k9.mailstore.LocalStore
 import com.fsck.k9.preferences.DefaultGeneralSettingsManager
 import net.thunderbird.core.android.account.AccountDefaultsProvider
 import net.thunderbird.core.android.account.SortType
-import net.thunderbird.core.common.action.SwipeAction
-import net.thunderbird.core.common.action.SwipeActions
 import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.featureflag.toFeatureFlagKey
 import net.thunderbird.core.preference.storage.Storage
@@ -179,12 +177,6 @@ object K9 : KoinComponent {
     @JvmStatic
     var pgpSignOnlyDialogCounter: Int = 0
 
-    @JvmStatic
-    var swipeRightAction: SwipeAction = SwipeAction.ToggleSelection
-
-    @JvmStatic
-    var swipeLeftAction: SwipeAction = SwipeAction.ToggleRead
-
     // TODO: This is a feature-specific setting that doesn't need to be available to apps that don't include the
     //  feature. Extract `Storage` and `StorageEditor` to a separate module so feature modules can retrieve and store
     //  their own settings.
@@ -268,15 +260,6 @@ object K9 : KoinComponent {
         pgpInlineDialogCounter = storage.getInt("pgpInlineDialogCounter", 0)
         pgpSignOnlyDialogCounter = storage.getInt("pgpSignOnlyDialogCounter", 0)
 
-        swipeRightAction = storage.getEnum(
-            key = SwipeActions.KEY_SWIPE_ACTION_RIGHT,
-            defaultValue = SwipeAction.ToggleSelection,
-        )
-        swipeLeftAction = storage.getEnum(
-            key = SwipeActions.KEY_SWIPE_ACTION_LEFT,
-            defaultValue = SwipeAction.ToggleRead,
-        )
-
         if (telemetryManager.isTelemetryFeatureIncluded()) {
             isTelemetryEnabled = storage.getBoolean("enableTelemetry", true)
         }
@@ -314,9 +297,6 @@ object K9 : KoinComponent {
 
         editor.putInt("pgpInlineDialogCounter", pgpInlineDialogCounter)
         editor.putInt("pgpSignOnlyDialogCounter", pgpSignOnlyDialogCounter)
-
-        editor.putEnum(key = SwipeActions.KEY_SWIPE_ACTION_RIGHT, value = swipeRightAction)
-        editor.putEnum(key = SwipeActions.KEY_SWIPE_ACTION_LEFT, value = swipeLeftAction)
 
         if (telemetryManager.isTelemetryFeatureIncluded()) {
             editor.putBoolean("enableTelemetry", isTelemetryEnabled)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityConfig.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageListActivityConfig.kt
@@ -44,6 +44,7 @@ data class MessageListActivityConfig(
             generalSettingsManager: GeneralSettingsManager,
         ): MessageListActivityConfig {
             val settings = generalSettingsManager.getConfig()
+            val interactionSettings = generalSettingsManager.getConfig().interaction
             return MessageListActivityConfig(
                 appTheme = settings.display.coreSettings.appTheme,
                 isShowUnifiedInbox = settings.display.inboxSettings.isShowUnifiedInbox,
@@ -70,8 +71,8 @@ data class MessageListActivityConfig(
                 fontSizeMessageViewSubject = K9.fontSizes.messageViewSubject,
                 fontSizeMessageViewDate = K9.fontSizes.messageViewDate,
                 fontSizeMessageViewContentAsPercent = K9.fontSizes.messageViewContentAsPercent,
-                swipeRightAction = K9.swipeRightAction,
-                swipeLeftAction = K9.swipeLeftAction,
+                swipeRightAction = interactionSettings.swipeActions.rightAction,
+                swipeLeftAction = interactionSettings.swipeActions.leftAction,
                 generalSettingsManager = generalSettingsManager,
             )
         }


### PR DESCRIPTION
Part of #9497.

In order to enhance the state of the Message List, we need to migrate certain preferences to utilize the new PreferenceManager. This will allow us to eliminate some legacy dependencies, such as the `K9` object and `Storage`.

This PR is the first in a series of PRs needed as a prerequisite for improving the Message List state.