### PR TITLE
feat: introduce state machine class

### DIFF
--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/StateMachine.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/StateMachine.kt
@@ -1,0 +1,134 @@
+package net.thunderbird.core.common.state
+
+import kotlin.reflect.KClass
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+internal typealias TransactionKey<TState, TEvent> = Pair<KClass<out TState>, KClass<out TEvent>>
+
+/**
+ * Defines the core contract for a generic, thread-safe state machine.
+ *
+ * This interface provides a standardized way to manage state transitions in response to events.
+ * It is designed to be asynchronous, using Kotlin Coroutines and [StateFlow] to expose the
+ * current state to observers. The state machine guarantees that event processing and state
+ * updates are atomic operations.
+ *
+ * Implementations of this interface allow for defining a graph of states and the transitions
+ * between them, which are triggered by specific events.
+ *
+ * @param TState The base sealed interface for all possible states.
+ * @param TEvent The base sealed interface for all possible events.
+ */
+interface StateMachine<TState : Any, TEvent : Any> {
+    val currentState: StateFlow<TState>
+    val currentStateSnapshot: TState get() = currentState.value
+
+    /**
+     * Processes an incoming event against the current state.
+     *
+     * This function looks for a defined transition that matches the current state's type and the
+     * provided event's type. If a matching transition is found and its `guard` condition passes,
+     * the state machine will transition to a new state. The new state is then emitted to observers
+     * of the [currentState] flow.
+     *
+     * If no transition is defined for the state/event pair, or if the `guard` condition
+     * returns `false`, the event is ignored, and the state remains unchanged.
+     *
+     * This operation is thread-safe, ensuring that state transitions are processed atomically.
+     *
+     * @param event The event to process.
+     * @return The new state if a transition occurred, or the current state if no transition was made.
+     */
+    suspend fun process(event: TEvent): TState
+}
+
+internal class DefaultStateMachine<TState : Any, TEvent : Any>(
+    scope: CoroutineScope,
+    initialState: TState,
+    internal val stateRegistrar: Map<KClass<out TState>, StateRegistry<TState, TState, TEvent>>,
+    private val transitions: Map<TransactionKey<out TState, out TEvent>, Transition<TState, TEvent>>,
+) : StateMachine<TState, TEvent> {
+    data class StateRegistry<TCurrentState : TState, TState : Any, TEvent : Any>(
+        val stateClass: KClass<out TState>,
+        val isFinalState: Boolean,
+        val listeners: StateListeners<TCurrentState, TState, TEvent>,
+        val transitions: Map<TransactionKey<out TState, out TEvent>, Transition<TState, TEvent>>,
+    )
+
+    data class Transition<TState : Any, in TEvent : Any>(
+        val guard: (TState, TEvent) -> Boolean,
+        val createNewState: (TState, TEvent) -> TState,
+    )
+
+    data class StateListeners<in TCurrentState : TState, TState : Any, in TEvent : Any>(
+        val onEnter: (TState?.(event: TEvent?, newState: TCurrentState) -> Unit)?,
+        val onExit: (TCurrentState.(event: TEvent?) -> Unit)?,
+    )
+
+    private val mutex = Mutex()
+    private val _currentState = MutableStateFlow(initialState)
+    override val currentState: StateFlow<TState> = _currentState.asStateFlow()
+
+    init {
+        scope.launch {
+            // delay onEnter initialization so the viewModels are ready to receive the state
+            println("Executed init. $stateRegistrar")
+            delay(500.milliseconds)
+            println("Executed? $stateRegistrar")
+            stateRegistrar[initialState::class]?.listeners?.onEnter?.invoke(null, null, currentStateSnapshot)
+        }
+    }
+
+    override suspend fun process(event: TEvent): TState {
+        mutex.withLock {
+            val currentStateRegistry = stateRegistrar[_currentState.value::class]
+            if (currentStateRegistry?.isFinalState == true) return currentState.value
+
+            val key = _currentState.value::class to event::class
+            val transition = transitions[key]
+                ?: transitions
+                    .filterKeys { (stateClass, eventClass) ->
+                        stateClass.isInstance(_currentState.value) && eventClass == event::class
+                    }
+                    .firstNotNullOfOrNull { it.value }
+
+            return when {
+                transition != null && transition.guard(_currentState.value, event) -> {
+                    transition.createNewState(_currentState.value, event).also { newState ->
+                        _currentState.update { currentState ->
+                            val newStateRegistry = stateRegistrar[newState::class]
+                            when {
+                                newStateRegistry?.isFinalState == true -> {
+                                    currentStateRegistry?.listeners?.onExit?.invoke(currentState, event)
+                                    newStateRegistry.listeners.onEnter?.invoke(currentState, event, newState)
+                                    newStateRegistry.listeners.onExit?.invoke(newState, null)
+                                }
+
+                                currentState::class != newState::class -> {
+                                    currentStateRegistry?.listeners?.onExit?.invoke(currentState, event)
+                                    newStateRegistry?.listeners?.onEnter?.invoke(currentState, event, newState)
+                                }
+                            }
+
+                            newState
+                        }
+                    }
+                }
+
+                else -> {
+                    // No transition defined or guard failed -> Ignore event
+                    _currentState.value
+                }
+            }
+        }
+    }
+}

--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/builder/StateBuilder.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/builder/StateBuilder.kt
@@ -1,0 +1,224 @@
+package net.thunderbird.core.common.state.builder
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.reflect.KClass
+import net.thunderbird.core.common.state.DefaultStateMachine.StateListeners
+import net.thunderbird.core.common.state.DefaultStateMachine.StateRegistry
+import net.thunderbird.core.common.state.DefaultStateMachine.Transition
+import net.thunderbird.core.common.state.StateMachine
+import net.thunderbird.core.common.state.TransactionKey
+
+/**
+ * A builder for a state in a [StateMachine] that does not have any transitions defined yet.
+ * This is the initial builder returned when defining a new state.
+ *
+ * @param TCurrentState The specific type of the state being configured.
+ * @param TState The base type for all states in the state machine.
+ * @param TEvent The base type for all events that can trigger transitions.
+ */
+interface StateWithoutTransactionsBuilder<TCurrentState : TState, TState : Any, TEvent : Any> {
+    /**
+     * The [KClass] representing the specific state being configured by this builder.
+     * This is used to identify the state within the state machine.
+     */
+    val stateClass: KClass<out TCurrentState>
+
+    /**
+     * A flag indicating whether this state is a final state in the state machine.
+     *
+     * When a state machine enters a final state, it is considered "finished" and will no longer
+     * process any new events. Defaults to `false`.
+     */
+    var isFinalState: Boolean
+
+    /**
+     * Defines an action to be executed when the state machine enters this state.
+     *
+     * This action is triggered immediately after the transition to this state is complete, but
+     * before any subsequent events are processed. It is useful for performing setup tasks,
+     * logging, or triggering side effects specific to this state.
+     *
+     * The provided [block] is a lambda with a receiver of the *old state* ([TState]`?`) and
+     * two parameters: the `event` that caused the transition and the `newState` ([TCurrentState]).
+     *
+     * - The receiver (`this`) is the state *before* the transition. It is `null` if the
+     *   current state is the initial state of the state machine.
+     * - The `event` parameter is the event that triggered the transition into this state. It's
+     *   `null` if this is the initial state.
+     * - The `newState` parameter is the instance of the state being entered.
+     *
+     * Example:
+     * ```
+     * state<MyState.Loading> {
+     *     // `this` is the old state, `event` is the trigger, `loadingState` is the new state instance.
+     *     onEnter { event, loadingState ->
+     *         println("Entered Loading state from ${this?.javaClass?.simpleName} due to event: $event")
+     *         // e.g., show a progress spinner using data from loadingState
+     *     }
+     * }
+     * ```
+     *
+     * @param block A lambda function that will be executed upon entering the state.
+     *              It has the old state (`TState?`) as its receiver and receives the triggering
+     *              event (`TEvent?`) and the new state instance (`TCurrentState`) as parameters.
+     */
+    fun onEnter(block: TState?.(event: TEvent?, newState: TCurrentState) -> Unit)
+
+    /**
+     * Defines an action to be executed when the state machine exits this state.
+     *
+     * This action is invoked just before the state machine transitions to a new state. It is useful
+     * for performing cleanup tasks, logging, or other side effects associated with leaving a state.
+     *
+     * The provided [block] is a lambda with the *current state* ([TCurrentState]) as its receiver
+     * and two parameters: the `event` that triggered.
+     *
+     * - The receiver (`this`) is the state instance being exited.
+     * - The `event` parameter is the event that triggered the transition out of this state.
+     *
+     * Note: If this state is marked as a final state (`isFinalState = true`), the `onExit`
+     * block will be called immediately after the `onEnter` block, as the machine's lifecycle ends.
+     * In this specific case, the `event` parameter will always be `null`.
+     *
+     * Example:
+     * ```
+     * state<MyState.Active> {
+     *     // `this` is the Active state instance, `event` is the trigger, `newState` is the next state.
+     *     onExit { event ->
+     *         println("Exiting ${this::class.simpleName} state for new state due to event: $event")
+     *         // e.g., stop a timer or hide a UI component
+     *     }
+     *     // ... transitions
+     * }
+     * ```
+     *
+     * @param block A lambda function that will be executed upon exiting the state.
+     *              It has the current state ([TCurrentState]) as its receiver and receives the
+     */
+    fun onExit(block: TCurrentState.(event: TEvent?) -> Unit)
+}
+
+/**
+ * A builder for defining a specific state within a [StateMachine].
+ *
+ * This builder provides a DSL for configuring a state, including:
+ * - Defining transitions to other states via the [transition] function.
+ * - Setting entry and exit actions with [onEnter] and [onExit].
+ * - Marking a state as final with [isFinalState].
+ *
+ * It inherits from [StateWithoutTransactionsBuilder] to provide the base configuration methods.
+ *
+ * @param TCurrentState The specific type of the state being configured.
+ * @param TState The base type for all states in the state machine.
+ * @param TEvent The base type for all events that can trigger transitions.
+ */
+abstract class StateBuilder<TCurrentState : TState, TState : Any, TEvent : Any> :
+    StateWithoutTransactionsBuilder<TCurrentState, TState, TEvent> {
+
+    /**
+     * Defines a transition from the current state to a new state upon receiving a specific event.
+     *
+     * This function is used within the state machine DSL to declare how the machine should react
+     * to an event when it's in the state being configured. The transition will only occur if the
+     * incoming event matches the [targetEvent] and the optional [guard] condition is met.
+     *
+     * @param targetEvent The [KClass] of the event that triggers this transition.
+     * @param guard An optional predicate function that must return `true` for the transition to proceed.
+     *              It receives the current state and the incoming event. If not provided, it defaults
+     *              to a function that always returns `true`.
+     * @param block A function that executes to produce the new state. It receives the current
+     *              state and the incoming event, and its return value becomes the new state of the
+     *              state machine.
+     */
+    abstract fun transition(
+        currentState: KClass<out TCurrentState>,
+        targetEvent: KClass<out TEvent>,
+        guard: (currentState: TCurrentState, event: TEvent) -> Boolean = { _, _ -> true },
+        block: (currentState: TCurrentState, event: TEvent) -> TState,
+    )
+
+    /**
+     * Defines a transition from the current state to a new state upon receiving a specific event.
+     *
+     * This function is used within the state machine DSL to declare how the machine should react
+     * to an event when it's in the state being configured. The transition will only occur if the
+     * incoming event matches the [TTargetEvent] and the optional [guard] condition is met.
+     *
+     * @param TTargetEvent The [KClass] of the event that triggers this transition.
+     * @param guard An optional predicate function that must return `true` for the transition to proceed.
+     *              It receives the current state and the incoming event. If not provided, it defaults
+     *              to a function that always returns `true`.
+     * @param block A function that executes to produce the new state. It receives the current
+     *              state and the incoming event, and its return value becomes the new state of the
+     *              state machine.
+     */
+    @OptIn(ExperimentalContracts::class)
+    inline fun <reified TTargetEvent : TEvent> transition(
+        noinline guard: (currentState: TCurrentState, event: TTargetEvent) -> Boolean = { _, _ -> true },
+        noinline block: (currentState: TCurrentState, event: TTargetEvent) -> TState,
+    ) {
+        transition(
+            currentState = stateClass,
+            targetEvent = TTargetEvent::class,
+            guard = { currentState, event -> guard(currentState, event as TTargetEvent) },
+            block = { currentState, event -> block(currentState, event as TTargetEvent) },
+        )
+    }
+}
+
+@StateMachineBuilderDsl
+internal class InternalStateBuilder<TCurrentState : TState, TState : Any, TEvent : Any>(
+    override val stateClass: KClass<out TCurrentState>,
+) : StateBuilder<TCurrentState, TState, TEvent>() {
+    override var isFinalState = false
+    private val transitions = mutableMapOf<TransactionKey<out TState, out TEvent>, Transition<TState, TEvent>>()
+    private var onEnter: (TState?.(TEvent?, TCurrentState) -> Unit)? = null
+    private var onExit: (TCurrentState.(TEvent?) -> Unit)? = null
+
+    override fun onEnter(block: TState?.(event: TEvent?, newState: TCurrentState) -> Unit) {
+        onEnter = block
+    }
+
+    override fun onExit(block: TCurrentState.(TEvent?) -> Unit) {
+        onExit = block
+    }
+
+    override fun transition(
+        currentState: KClass<out TCurrentState>,
+        targetEvent: KClass<out TEvent>,
+        guard: (currentState: TCurrentState, event: TEvent) -> Boolean,
+        block: (currentState: TCurrentState, event: TEvent) -> TState,
+    ) {
+        val key = stateClass to targetEvent
+
+        // We wrap the specific types in a generic handler to store them safely
+        @Suppress("UNCHECKED_CAST")
+        val transition = Transition<TState, TEvent>(
+            guard = { s, e -> guard(s as TCurrentState, e) },
+            createNewState = { s, e -> block(s as TCurrentState, e) },
+        )
+
+        transitions[key] = transition
+    }
+
+    /**
+     * Finalizes the configuration for the current state and constructs the internal representation
+     * used by the state machine.
+     *
+     * This function is called internally by the state machine builder after the DSL block for this
+     * state has been executed. It gathers all the defined transitions, `onEnter`/`onExit` actions,
+     * and the `isFinalState` flag, and packages them into a [StateRegistry] object.
+     *
+     * @return A [Pair] where the first element is the [KClass] of the state being built, and the
+     *         second element is the [DefaultStateMachine.StateRegistry] containing all the
+     *         configuration for that state.
+     */
+    fun build(): StateRegistry<TCurrentState, TState, TEvent> {
+        return StateRegistry(
+            stateClass = stateClass,
+            isFinalState = isFinalState,
+            listeners = StateListeners(onEnter = onEnter, onExit = onExit),
+            transitions = transitions,
+        )
+    }
+}

--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/builder/StateMachineBuilder.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/builder/StateMachineBuilder.kt
@@ -1,0 +1,171 @@
+package net.thunderbird.core.common.state.builder
+
+import kotlin.reflect.KClass
+import kotlinx.coroutines.CoroutineScope
+import net.thunderbird.core.common.state.DefaultStateMachine
+import net.thunderbird.core.common.state.DefaultStateMachine.StateRegistry
+import net.thunderbird.core.common.state.DefaultStateMachine.Transition
+import net.thunderbird.core.common.state.StateMachine
+import net.thunderbird.core.common.state.TransactionKey
+
+/**
+ * A DSL builder for creating [StateMachine] instances.
+ * This builder provides a declarative way to define states and their transitions.
+ *
+ * Use the [stateMachine] function to start building a new state machine.
+ *
+ * @param TState The base sealed class/interface for all states in the machine.
+ * @param TEvent The base sealed class/interface for all events that can trigger transitions.
+ *
+ * @see StateBuilder
+ * @see stateMachine
+ */
+@StateMachineBuilderDsl
+class StateMachineBuilder<TState : Any, TEvent : Any> internal constructor(
+    private val scope: CoroutineScope,
+) {
+    private var initialState: TState? = null
+    private val stateRegistrar = mutableMapOf<KClass<out TState>, StateRegistry<TState, TState, TEvent>>()
+
+    /**
+     * Defines the initial state of the state machine.
+     *
+     * Each state machine must have exactly one initial state. This state is also
+     * implicitly registered, so there is no need to call `state()` for it separately.
+     *
+     * @param TCurrentState The specific type of the initial state.
+     * @param state The instance of the initial state object. This object's class is used
+     *              to identify the state.
+     * @param init A lambda with a [StateBuilder] receiver to configure the transitions
+     *             and actions (like `onEnter` or `onExit`) for this state.
+     */
+    fun <TCurrentState : TState> initialState(
+        state: TCurrentState,
+        init: StateBuilder<TCurrentState, TState, TEvent>.() -> Unit,
+    ) = state(state::class, init).also {
+        initialState = state
+    }
+
+    /**
+     * Defines a final state for the state machine.
+     *
+     * A final state is a terminal state from which no transitions are possible. When the state machine
+     * enters a final state, it stops processing any further events. A state machine can have multiple
+     * final states.
+     *
+     * @param TState The base type for all states in the state machine.
+     * @param finalStateClass The [KClass] of the state to be marked as final.
+     * @param init An optional lambda with a [StateWithoutTransactionsBuilder] receiver to configure actions
+     *             for this state, such as `onEnter` or `onExit`.
+     */
+    fun <TFinalState : TState> finalState(
+        finalStateClass: KClass<out TFinalState>,
+        init: StateWithoutTransactionsBuilder<TFinalState, TState, TEvent>.() -> Unit = {},
+    ) = state(stateClass = finalStateClass) {
+        isFinalState = true
+        init()
+    }
+
+    /**
+     * Defines a final state for the state machine.
+     *
+     * A final state is a terminal state from which no transitions are possible. When the state machine
+     * enters a final state, it stops processing any further events. A state machine can have multiple
+     * final states.
+     *
+     * @param TState The base type for all states in the state machine.
+     * @param TFinalState The type of the state to be marked as final.
+     * @param init An optional lambda with a [StateWithoutTransactionsBuilder] receiver to configure actions
+     *             for this state, such as `onEnter` or `onExit`.
+     */
+    inline fun <reified TFinalState : TState> finalState(
+        noinline init: StateWithoutTransactionsBuilder<TFinalState, TState, TEvent>.() -> Unit = {},
+    ) = finalState(finalStateClass = TFinalState::class, init = init)
+
+    /**
+     * Defines a state and its possible transitions within the state machine.
+     * This function registers a new state based on its class, allowing for the configuration
+     * of its transitions and actions (e.g., `onEnter`, `onExit`).
+     *
+     * It is an error to register the same state class more than once. If a state has already
+     * been defined as the `initialState`, it cannot be registered again using this function.
+     *
+     * @param TCurrentState The specific type of the state being defined, which must be a subtype of [TState].
+     * @param stateClass The [KClass] of the state to be defined.
+     * @param init A lambda with a [StateBuilder] receiver to configure the transitions and actions
+     *             for this state.
+     * @throws IllegalStateException if the state class is already registered or if it was already
+     *                               defined as the initial state.
+     */
+    fun <TCurrentState : TState> state(
+        stateClass: KClass<out TCurrentState>,
+        init: StateBuilder<TCurrentState, TState, TEvent>.() -> Unit,
+    ) {
+        check(stateClass !in stateRegistrar) { "${stateClass.simpleName} is already registered as a state." }
+        initialState?.let {
+            check(stateClass != it::class) {
+                "${stateClass.simpleName} is already defined as initial state."
+            }
+        }
+        val stateRegistry = InternalStateBuilder<TCurrentState, TState, TEvent>(stateClass).apply(init).build()
+        @Suppress("UNCHECKED_CAST")
+        stateRegistrar += stateClass to stateRegistry as StateRegistry<TState, TState, TEvent>
+    }
+
+    /**
+     * Defines a state and its possible transitions within the state machine.
+     * This function registers a new state based on its class.
+     *
+     * It's an error to register the same state class more than once or to register the initial
+     * state again using this function.
+     *
+     * @param TCurrentState The type of the state to be defined.
+     * @param init A lambda with a [StateBuilder] receiver to configure the transitions and actions for this state.
+     * @throws IllegalStateException if the state is already registered or if it's already defined as the initial state.
+     */
+    inline fun <reified TCurrentState : TState> state(
+        noinline init: StateBuilder<TCurrentState, TState, TEvent>.() -> Unit,
+    ) = state(stateClass = TCurrentState::class, init)
+
+    /**
+     * Builds and validates the [StateMachine] instance.
+     * This function should be called after all states and transitions have been defined.
+     *
+     * It performs several checks to ensure the state machine is valid:
+     * - An initial state must be set.
+     * - There must be at least two states defined.
+     * - There must be at least one transition defined in the entire machine.
+     * - All non-final states must have at least one outgoing transition.
+     *
+     * @return A fully configured and validated [StateMachine] instance.
+     * @throws IllegalStateException if any of the validation checks fail.
+     */
+    fun build(): StateMachine<TState, TEvent> {
+        val initialState = checkNotNull(initialState) { "Initial state is required." }
+        check(stateRegistrar.size > 1) { "At least two states must be defined." }
+
+        val transitions = stateRegistrar.values.fold(
+            initial = emptyMap<TransactionKey<out TState, out TEvent>, Transition<TState, TEvent>>(),
+        ) { acc, registry ->
+            acc + registry.transitions
+        }
+
+        check(transitions.isNotEmpty()) { "At least one transition must be defined." }
+        val nonFinalStatesWithoutTransitions = stateRegistrar.filterValues { registry ->
+            !registry.isFinalState && registry.transitions.isEmpty()
+        }
+        check(nonFinalStatesWithoutTransitions.isEmpty()) {
+            "Only the final states can have no transitions. States without transaction: [ ${
+                nonFinalStatesWithoutTransitions.entries.joinToString(", ") { (stateClass, _) ->
+                    stateClass.simpleName ?: stateClass.toString()
+                }
+            } ]"
+        }
+        return DefaultStateMachine(
+            scope = scope,
+            initialState = initialState,
+            transitions = transitions,
+            stateRegistrar = stateRegistrar,
+        )
+    }
+}

--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/builder/StateMachineBuilderDsl.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/builder/StateMachineBuilderDsl.kt
@@ -1,0 +1,52 @@
+package net.thunderbird.core.common.state.builder
+
+import kotlinx.coroutines.CoroutineScope
+import net.thunderbird.core.common.state.StateMachine
+
+@DslMarker
+annotation class StateMachineBuilderDsl
+
+/**
+ * Creates a [StateMachine] using the type-safe builder DSL.
+ *
+ * This function serves as the entry point for defining a state machine. It initializes a
+ * [StateMachineBuilder] and applies the provided configuration block [init] to it.
+ *
+ * Example usage:
+ * ```kotlin
+ * sealed class LightState {
+ *     data class On(val brightness: Int) : LightState()
+ *     data object Off : LightState()
+ * }
+ *
+ * sealed class LightEvent {
+ *     data object TurnOn : LightEvent()
+ *     data object TurnOff : LightEvent()
+ *     data class SetBrightness(val brightness: Int) : LightEvent()
+ * }
+ *
+ * val lightStateMachine = stateMachine<LightState, LightEvent> {
+ *     initialState(LightState.Off) {
+ *         transition<LightEvent.TurnOn> { _, _ -> LightState.On }
+ *     }
+ *
+ *     state<LightState.On> {
+ *         transition<LightEvent.TurnOff> { _, _ -> LightState.Off }
+ *         transition<LightEvent.SetBrightness> { currentState, event ->
+ *             currentState.copy(brightness = brightness, event.brightness)
+ *         }
+ *     }
+ * }
+ * ```
+ *
+ * @param TState The base type for all states in the machine. Must be a non-nullable type.
+ * @param TEvent The base type for all events that can be processed by the machine. Must be a non-nullable type.
+ * @param init A lambda with a receiver of type [StateMachineBuilder] where the state machine's
+ *             structure (states, transitions, etc.) is defined.
+ * @return The configured and built [StateMachine] instance, ready to process events.
+ */
+@StateMachineBuilderDsl
+fun <TState : Any, TEvent : Any> stateMachine(
+    scope: CoroutineScope,
+    init: StateMachineBuilder<TState, TEvent>.() -> Unit,
+): StateMachine<TState, TEvent> = StateMachineBuilder<TState, TEvent>(scope).apply(init).build()

--- a/core/common/src/commonTest/kotlin/net/thunderbird/core/common/state/StateMachineTest.kt
+++ b/core/common/src/commonTest/kotlin/net/thunderbird/core/common/state/StateMachineTest.kt
@@ -1,0 +1,386 @@
+package net.thunderbird.core.common.state
+
+import app.cash.turbine.test
+import assertk.all
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import kotlin.reflect.KClass
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.common.state.builder.stateMachine
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@Suppress("MaxLineLength")
+class StateMachineTest {
+    private sealed interface State {
+        data object Init : State
+        data object Loading : State
+        data object Success : State
+        data object Error : State
+    }
+
+    private sealed interface Event {
+        data object LoadData : Event
+        data object LoadedData : Event
+        data class Retry(val forceRetry: Boolean) : Event
+        data object Cancel : Event
+        data object Failure : Event
+    }
+
+    @Test
+    fun `onEntry from initialState should be called when state machine is created`() = runTest {
+        // Arrange && Act
+        var onEntryCalled = false
+        stateMachine<State, Event>(scope = this) {
+            initialState(State.Init) {
+                onEnter { _, _ -> onEntryCalled = true }
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            state<State.Loading> {
+                transition<Event.LoadedData> { _, _ -> State.Success }
+            }
+            finalState<State.Success>()
+        }
+        advanceTimeBy(1000.milliseconds)
+
+        // Assert
+        assertThat(onEntryCalled).isTrue()
+    }
+
+    @Test
+    fun `process should return the new state when transition is defined and guard passes`() = runTest {
+        // Arrange
+        val stateMachine = stateMachine(scope = this) {
+            initialState(State.Init) {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            state<State.Loading> {
+                transition<Event.LoadedData> { _, _ -> State.Success }
+            }
+            finalState<State.Success>()
+        }
+
+        stateMachine.currentState.test {
+            // Skip initial state.
+            skipItems(count = 1)
+            // Act (Phase 1)
+            stateMachine.process(Event.LoadData)
+
+            // Assert (Phase 1)
+            assertThat(awaitItem()).isEqualTo(State.Loading)
+
+            // Act (Phase 2)
+            stateMachine.process(Event.LoadedData)
+
+            // Assert (Phase 2)
+            assertThat(awaitItem()).isEqualTo(State.Success)
+        }
+    }
+
+    @Test
+    fun `process should return the current state when no transition between current state and even is defined`() =
+        runTest {
+            // Arrange
+            val stateMachine = stateMachine(scope = this) {
+                initialState(State.Init) {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                }
+                state<State.Loading> {
+                    transition<Event.LoadedData> { _, _ -> State.Success }
+                }
+                finalState<State.Success>()
+            }
+
+            stateMachine.currentState.test {
+                // Act
+                stateMachine.process(Event.Cancel)
+
+                // Assert
+                assertThat(awaitItem()).isEqualTo(State.Init)
+                expectNoEvents()
+            }
+        }
+
+    @Test
+    fun `process should return the current state when guard fails`() = runTest {
+        // Arrange
+        val stateMachine = stateMachine(scope = this) {
+            initialState(State.Init) {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            state<State.Loading> {
+                transition<Event.LoadedData> { _, _ -> State.Success }
+                transition<Event.Failure> { _, _ -> State.Error }
+            }
+            state<State.Error> {
+                transition<Event.Retry>(
+                    guard = { _, event -> event.forceRetry },
+                ) { _, _ -> State.Loading }
+            }
+            finalState<State.Success>()
+        }
+
+        stateMachine.currentState.test {
+            // Act (Phase 1)
+            stateMachine.process(Event.LoadData)
+            stateMachine.process(Event.Failure)
+            skipItems(count = 2)
+
+            // Assert (Phase 1)
+            assertThat(awaitItem()).isEqualTo(State.Error)
+
+            // Act (Phase 2)
+            val state = stateMachine.process(Event.Retry(forceRetry = false))
+
+            // Assert (Phase 2)
+            assertThat(state).isEqualTo(State.Error)
+            expectNoEvents()
+        }
+    }
+
+    @Test
+    fun `process should trigger onEnter(newState) and onExit(oldState) when state changes`() = runTest {
+        // Arrange
+        fun MutableMap<KClass<out State>, Int>.increment(stateClass: KClass<out State>) {
+            this[stateClass] = getOrElse(stateClass) { 0 } + 1
+        }
+
+        val onEnterCalled = mutableMapOf<KClass<out State>, Int>()
+        val onExitCalled = mutableMapOf<KClass<out State>, Int>()
+        val stateMachine = stateMachine<State, Event>(scope = this) {
+            initialState(State.Init) {
+                onEnter { _, _ -> onEnterCalled.increment(stateClass) }
+                onExit { _ -> onExitCalled.increment(stateClass) }
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            state<State.Loading> {
+                onEnter { _, _ -> onEnterCalled.increment(stateClass) }
+                onExit { _ -> onExitCalled.increment(stateClass) }
+                transition<Event.LoadedData> { _, _ -> State.Success }
+                transition<Event.Failure> { _, _ -> State.Error }
+            }
+            state<State.Error> {
+                onEnter { _, _ -> onEnterCalled.increment(stateClass) }
+                onExit { _ -> onExitCalled.increment(stateClass) }
+                transition<Event.Retry>(
+                    guard = { _, event -> event.forceRetry },
+                ) { _, _ -> State.Loading }
+            }
+            finalState<State.Success> {
+                onEnter { _, _ -> onEnterCalled.increment(stateClass) }
+                onExit { _ -> onExitCalled.increment(stateClass) }
+            }
+        }
+
+        // Act
+        advanceTimeBy(1000.milliseconds)
+        stateMachine.process(Event.LoadData)
+        stateMachine.process(Event.Failure)
+        stateMachine.process(Event.Retry(forceRetry = true))
+        stateMachine.process(Event.LoadedData)
+
+        assertThat(onEnterCalled).all {
+            transform { it[State.Init::class] }.isEqualTo(1)
+            transform { it[State.Loading::class] }.isEqualTo(2)
+            transform { it[State.Error::class] }.isEqualTo(1)
+            transform { it[State.Success::class] }.isEqualTo(1)
+        }
+
+        assertThat(onExitCalled).all {
+            transform { it[State.Init::class] }.isEqualTo(1)
+            transform { it[State.Loading::class] }.isEqualTo(2)
+            transform { it[State.Error::class] }.isEqualTo(1)
+            transform { it[State.Success::class] }.isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `process should not process events and return final state when state machine is in final state`() = runTest {
+        // Arrange
+        var successStateExited = 0
+        val stateMachine = stateMachine(scope = this) {
+            initialState(State.Init) {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            state<State.Loading> {
+                transition<Event.LoadedData> { _, _ -> State.Success }
+            }
+            finalState<State.Success> {
+                onExit { successStateExited++ }
+            }
+        }
+
+        // Act
+        stateMachine.currentState.test {
+            // Act (Phase 1)
+            stateMachine.process(Event.LoadData)
+            stateMachine.process(Event.LoadedData)
+
+            // Assert (Phase 1)
+            // Skip to the last state.
+            skipItems(count = 2)
+            assertThat(awaitItem()).isEqualTo(State.Success)
+
+            // Act (Phase 2)
+            stateMachine.process(Event.Cancel)
+
+            // Assert (Phase 2)
+            expectNoEvents()
+            assertThat(successStateExited).isEqualTo(1)
+
+            // Act (Phase 3)
+            stateMachine.process(Event.Retry(forceRetry = false))
+
+            // Assert (Phase 3)
+            expectNoEvents()
+            assertThat(successStateExited).isEqualTo(1)
+        }
+    }
+
+    @Test
+    fun `state onEnter - when initial state - should be triggered with null state receiver, null event and Init state`() =
+        runTest {
+            // Arrange & Act
+            var actualPreviousState: State? = null
+            var actualEvent: Event? = null
+            var actualNewState: State? = null
+            stateMachine<State, Event>(scope = this) {
+                initialState(State.Init) {
+                    onEnter { event, newState ->
+                        actualPreviousState = this
+                        actualNewState = newState
+                        actualEvent = event
+                    }
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                }
+                state<State.Loading> {
+                    transition<Event.LoadedData> { _, _ -> State.Success }
+                }
+                finalState<State.Success>()
+            }
+
+            // Assert
+            advanceTimeBy(1000.milliseconds)
+            assertThat(actualPreviousState).isNull()
+            assertThat(actualEvent).isNull()
+            assertThat(actualNewState)
+                .isNotNull()
+                .isEqualTo(State.Init)
+        }
+
+    @Test
+    fun `state onEnter - when not in initial state - should be triggered with previous state receiver, event and new state`() =
+        runTest {
+            // Arrange
+            var actualPreviousState: State? = null
+            var actualEvent: Event? = null
+            var actualNewState: State? = null
+            val stateMachine = stateMachine<State, Event>(scope = this) {
+                initialState(State.Init) {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                }
+                state<State.Loading> {
+                    onEnter { event, newState ->
+                        actualPreviousState = this
+                        actualNewState = newState
+                        actualEvent = event
+                    }
+                    transition<Event.LoadedData> { _, _ -> State.Success }
+                }
+                finalState<State.Success>()
+            }
+
+            // Act
+            stateMachine.process(Event.LoadData)
+
+            // Assert
+            stateMachine.currentState.test {
+                expectMostRecentItem()
+                assertThat(actualPreviousState)
+                    .isNotNull()
+                    .isEqualTo(State.Init)
+                assertThat(actualEvent)
+                    .isNotNull()
+                    .isEqualTo(Event.LoadData)
+                assertThat(actualNewState)
+                    .isNotNull()
+                    .isEqualTo(State.Loading)
+            }
+        }
+
+    @Test
+    fun `state onExit - when final state - should be triggered with final state receiver and null event`() = runTest {
+        // Arrange
+        var actualCurrentState: State? = null
+        var actualEvent: Event? = null
+        val stateMachine = stateMachine<State, Event>(scope = this) {
+            initialState(State.Init) {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            state<State.Loading> {
+                transition<Event.LoadedData> { _, _ -> State.Success }
+            }
+            finalState<State.Success> {
+                onExit { event ->
+                    actualCurrentState = this
+                    actualEvent = event
+                }
+            }
+        }
+
+        // Act
+        stateMachine.process(Event.LoadData)
+        stateMachine.process(Event.LoadedData)
+
+        // Assert
+        stateMachine.currentState.test {
+            expectMostRecentItem()
+            assertThat(actualCurrentState)
+                .isNotNull()
+                .isEqualTo(State.Success)
+            assertThat(actualEvent).isNull()
+        }
+    }
+
+    @Test
+    fun `state onExit - when not in final state - should be triggered with previous state receiver, event and new state`() =
+        runTest {
+            // Arrange
+            var actualCurrentState: State? = null
+            var actualEvent: Event? = null
+            val stateMachine = stateMachine<State, Event>(scope = this) {
+                initialState(State.Init) {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                }
+                state<State.Loading> {
+                    onExit { event ->
+                        actualCurrentState = this
+                        actualEvent = event
+                    }
+                    transition<Event.LoadedData> { _, _ -> State.Success }
+                }
+                finalState<State.Success>()
+            }
+
+            // Act
+            stateMachine.process(Event.LoadData)
+            stateMachine.process(Event.LoadedData)
+
+            // Assert
+            stateMachine.currentState.test {
+                expectMostRecentItem()
+                assertThat(actualCurrentState)
+                    .isNotNull()
+                    .isEqualTo(State.Loading)
+                assertThat(actualEvent)
+                    .isNotNull()
+                    .isEqualTo(Event.LoadedData)
+            }
+        }
+}

--- a/core/common/src/commonTest/kotlin/net/thunderbird/core/common/state/builder/StateMachineBuilderKtTest.kt
+++ b/core/common/src/commonTest/kotlin/net/thunderbird/core/common/state/builder/StateMachineBuilderKtTest.kt
@@ -1,0 +1,375 @@
+package net.thunderbird.core.common.state.builder
+
+import assertk.assertFailure
+import assertk.assertThat
+import assertk.assertions.hasMessage
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.common.state.DefaultStateMachine
+import org.junit.Test
+
+class StateMachineBuilderKtTest {
+    sealed interface State {
+        data object Init : State
+        data object Loading : State
+        data object Success : State
+        data object Error : State
+    }
+
+    sealed interface Event {
+        data object LoadData : Event
+        data object Retry : Event
+        data object Cancel : Event
+        data object Failure : Event
+    }
+
+    @Test
+    fun `stateMachine should create state machine successfully`() = runTest {
+        // Arrange & Act
+        val machine = stateMachine(scope = this) {
+            initialState(State.Init) {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+                transition<Event.Failure> { _, _ -> State.Error }
+            }
+            state<State.Loading> {
+                transition<Event.Cancel> { _, _ -> State.Init }
+                transition<Event.Retry> { _, _ -> State.Init }
+                transition<Event.LoadData> { _, _ -> State.Success }
+                transition<Event.Failure> { _, _ -> State.Success }
+            }
+            state<State.Error> {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            finalState<State.Success>()
+        }
+
+        // Assert
+        assertThat(machine.currentStateSnapshot).isEqualTo(State.Init)
+    }
+
+    @Test
+    fun `stateMachine should throw exception when missing initial state`() = runTest {
+        // Arrange & Act
+        val exception = assertFailure {
+            stateMachine(scope = this) {
+                state<State.Init> {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                    transition<Event.Failure> { _, _ -> State.Error }
+                }
+                state<State.Loading> {
+                    transition<Event.Cancel> { _, _ -> State.Init }
+                    transition<Event.Retry> { _, _ -> State.Init }
+                    transition<Event.LoadData> { _, _ -> State.Success }
+                    transition<Event.Failure> { _, _ -> State.Success }
+                }
+                state<State.Error> {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                }
+                finalState<State.Success>()
+            }
+        }
+
+        // Assert
+        exception
+            .isInstanceOf(IllegalStateException::class)
+            .hasMessage("Initial state is required.")
+    }
+
+    @Test
+    fun `stateMachine should throw exception when initial state is also registered as a state`() = runTest {
+        // Arrange & Act
+        val exception = assertFailure {
+            stateMachine(scope = this) {
+                initialState(State.Init) {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                    transition<Event.Failure> { _, _ -> State.Error }
+                }
+                state<State.Init> {}
+                state<State.Loading> {
+                    transition<Event.Cancel> { _, _ -> State.Init }
+                    transition<Event.Retry> { _, _ -> State.Init }
+                    transition<Event.LoadData> { _, _ -> State.Success }
+                    transition<Event.Failure> { _, _ -> State.Success }
+                }
+                state<State.Error> {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                }
+                finalState<State.Success>()
+            }
+        }
+
+        // Assert
+        exception
+            .isInstanceOf(IllegalStateException::class)
+            .hasMessage("${State.Init::class.simpleName} is already registered as a state.")
+    }
+
+    @Test
+    fun `stateMachine should throw exception when state is already registered`() = runTest {
+        // Arrange & Act
+        val exception = assertFailure {
+            stateMachine(scope = this) {
+                initialState(State.Init) {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                    transition<Event.Failure> { _, _ -> State.Error }
+                }
+                state<State.Loading> {
+                    transition<Event.Cancel> { _, _ -> State.Init }
+                    transition<Event.Retry> { _, _ -> State.Init }
+                }
+                state<State.Loading> {
+                    transition<Event.LoadData> { _, _ -> State.Success }
+                    transition<Event.Failure> { _, _ -> State.Success }
+                }
+                state<State.Error> {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                }
+                finalState<State.Success>()
+            }
+        }
+
+        // Assert
+        exception
+            .isInstanceOf(IllegalStateException::class)
+            .hasMessage("${State.Loading::class.simpleName} is already registered as a state.")
+    }
+
+    @Test
+    fun `stateMachine should throw exception when no transitions are defined`() = runTest {
+        // Arrange & Act
+        val exception = assertFailure {
+            stateMachine<State, Event>(scope = this) {
+                initialState(State.Init) {}
+                state<State.Loading> {}
+                state<State.Success> {}
+                state<State.Error> {}
+            }
+        }
+
+        // Assert
+        exception
+            .isInstanceOf(IllegalStateException::class)
+            .hasMessage("At least one transition must be defined.")
+    }
+
+    @Test
+    fun `stateMachine should throw exception when only the initial state is defined`() = runTest {
+        // Arrange & Act
+        val exception = assertFailure {
+            stateMachine<State, Event>(scope = this) {
+                initialState(State.Init) {}
+            }
+        }
+
+        // Assert
+        exception
+            .isInstanceOf(IllegalStateException::class)
+            .hasMessage("At least two states must be defined.")
+    }
+
+    @Test
+    fun `stateMachine should throw exception when a state has no transitions and it isn't the final state`() = runTest {
+        // Arrange & Act
+        val exception = assertFailure {
+            stateMachine(scope = this) {
+                initialState(State.Init) {
+                    transition<Event.LoadData> { _, _ -> State.Loading }
+                    transition<Event.Failure> { _, _ -> State.Error }
+                }
+                state<State.Loading> {
+                    transition<Event.Cancel> { _, _ -> State.Init }
+                    transition<Event.Retry> { _, _ -> State.Init }
+                    transition<Event.LoadData> { _, _ -> State.Success }
+                    transition<Event.Failure> { _, _ -> State.Success }
+                }
+                state<State.Error> { }
+                state<State.Success> {}
+            }
+        }
+
+        // Assert
+        exception
+            .isInstanceOf(IllegalStateException::class)
+            .hasMessage(
+                "Only the final states can have no transitions. States without transaction: [ Error, Success ]",
+            )
+    }
+
+    @Test
+    fun `stateMachine - initialState should allow setting onEntry listener`() = runTest {
+        // Arrange & Act
+        val machine = stateMachine<State, Event>(scope = this) {
+            initialState(State.Init) {
+                onEnter { _, _ -> println("No op.") }
+                transition<Event.LoadData> { _, _ -> State.Loading }
+                transition<Event.Failure> { _, _ -> State.Error }
+            }
+            state<State.Loading> {
+                transition<Event.Cancel> { _, _ -> State.Init }
+                transition<Event.Retry> { _, _ -> State.Init }
+                transition<Event.LoadData> { _, _ -> State.Success }
+                transition<Event.Failure> { _, _ -> State.Success }
+            }
+            state<State.Error> {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            finalState<State.Success>()
+        } as DefaultStateMachine
+
+        // Assert
+        assertThat(machine.currentStateSnapshot).isEqualTo(State.Init)
+        assertThat(machine.stateRegistrar[State.Init::class])
+            .isNotNull()
+            .transform { it.listeners.onEnter }
+            .isNotNull()
+    }
+
+    @Test
+    fun `stateMachine - initialState should allow setting onExit listener`() = runTest {
+        // Arrange & Act
+        val machine = stateMachine(scope = this) {
+            initialState(State.Init) {
+                onExit { println("No op.") }
+                transition<Event.LoadData> { _, _ -> State.Loading }
+                transition<Event.Failure> { _, _ -> State.Error }
+            }
+            state<State.Loading> {
+                transition<Event.Cancel> { _, _ -> State.Init }
+                transition<Event.Retry> { _, _ -> State.Init }
+                transition<Event.LoadData> { _, _ -> State.Success }
+                transition<Event.Failure> { _, _ -> State.Success }
+            }
+            state<State.Error> {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            finalState<State.Success>()
+        } as DefaultStateMachine
+
+        // Assert
+        assertThat(machine.currentStateSnapshot).isEqualTo(State.Init)
+        assertThat(machine.stateRegistrar[State.Init::class])
+            .isNotNull()
+            .transform { it.listeners.onExit }
+            .isNotNull()
+    }
+
+    @Test
+    fun `stateMachine - state should allow setting onEntry listener`() = runTest {
+        // Arrange & Act
+        val machine = stateMachine(scope = this) {
+            initialState(State.Init) {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+                transition<Event.Failure> { _, _ -> State.Error }
+            }
+            state<State.Loading> {
+                onEnter { _, _ -> println("No op.") }
+                transition<Event.Cancel> { _, _ -> State.Init }
+                transition<Event.Retry> { _, _ -> State.Init }
+                transition<Event.LoadData> { _, _ -> State.Success }
+                transition<Event.Failure> { _, _ -> State.Success }
+            }
+            state<State.Error> {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            finalState<State.Success>()
+        } as DefaultStateMachine
+
+        // Assert
+        assertThat(machine.currentStateSnapshot).isEqualTo(State.Init)
+        assertThat(machine.stateRegistrar[State.Loading::class])
+            .isNotNull()
+            .transform { it.listeners.onEnter }
+            .isNotNull()
+    }
+
+    @Test
+    fun `stateMachine - state should allow setting onExit listener`() = runTest {
+        // Arrange & Act
+        val machine = stateMachine(scope = this) {
+            initialState(State.Init) {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+                transition<Event.Failure> { _, _ -> State.Error }
+            }
+            state<State.Loading> {
+                onExit { println("No op.") }
+                transition<Event.Cancel> { _, _ -> State.Init }
+                transition<Event.Retry> { _, _ -> State.Init }
+                transition<Event.LoadData> { _, _ -> State.Success }
+                transition<Event.Failure> { _, _ -> State.Success }
+            }
+            state<State.Error> {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            finalState<State.Success>()
+        } as DefaultStateMachine
+
+        // Assert
+        assertThat(machine.currentStateSnapshot).isEqualTo(State.Init)
+        assertThat(machine.stateRegistrar[State.Loading::class])
+            .isNotNull()
+            .transform { it.listeners.onExit }
+            .isNotNull()
+    }
+
+    @Test
+    fun `stateMachine - finalState should allow setting onEntry listener`() = runTest {
+        // Arrange & Act
+        val machine = stateMachine(scope = this) {
+            initialState(State.Init) {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+                transition<Event.Failure> { _, _ -> State.Error }
+            }
+            state<State.Loading> {
+                transition<Event.Cancel> { _, _ -> State.Init }
+                transition<Event.Retry> { _, _ -> State.Init }
+                transition<Event.LoadData> { _, _ -> State.Success }
+                transition<Event.Failure> { _, _ -> State.Success }
+            }
+            state<State.Error> {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            finalState<State.Success> {
+                onEnter { _, _ -> println("No op.") }
+            }
+        } as DefaultStateMachine
+
+        // Assert
+        assertThat(machine.currentStateSnapshot).isEqualTo(State.Init)
+        assertThat(machine.stateRegistrar[State.Success::class])
+            .isNotNull()
+            .transform { it.listeners.onEnter }
+            .isNotNull()
+    }
+
+    @Test
+    fun `stateMachine - finalState should allow setting onExit listener`() = runTest {
+        // Arrange & Act
+        val machine = stateMachine(scope = this) {
+            initialState(State.Init) {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+                transition<Event.Failure> { _, _ -> State.Error }
+            }
+            state<State.Loading> {
+                transition<Event.Cancel> { _, _ -> State.Init }
+                transition<Event.Retry> { _, _ -> State.Init }
+                transition<Event.LoadData> { _, _ -> State.Success }
+                transition<Event.Failure> { _, _ -> State.Success }
+            }
+            state<State.Error> {
+                transition<Event.LoadData> { _, _ -> State.Loading }
+            }
+            finalState<State.Success> {
+                onExit { println("No op.") }
+            }
+        } as DefaultStateMachine
+
+        // Assert
+        assertThat(machine.currentStateSnapshot).isEqualTo(State.Init)
+        assertThat(machine.stateRegistrar[State.Success::class])
+            .isNotNull()
+            .transform { it.listeners.onExit }
+            .isNotNull()
+    }
+}


### PR DESCRIPTION
Part of #9497.

This PR introduces a `StateMachine` class, which allows us to define a set of states with transitions triggered by events. This will help in the refactor of the Message List, improving the state handling.