### PR TITLE
fix: display Settings reset/mix up when toggling "Colorize contact pictures"

### DIFF
--- a/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/display/visualSettings/message/list/DefaultMessageListPreferencesManager.kt
+++ b/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/display/visualSettings/message/list/DefaultMessageListPreferencesManager.kt
@@ -67,6 +67,9 @@ class DefaultMessageListPreferencesManager(
         storageEditor.putBoolean(KEY_SHOW_CORRESPONDENT_NAMES, preferences.isShowCorrespondentNames)
         storageEditor.putInt(KEY_MESSAGE_LIST_VIEW_PREVIEW_LINES, preferences.previewLines)
         storageEditor.putEnum(KEY_MESSAGE_LIST_VIEW_DENSITY, preferences.uiDensity)
+        storageEditor.commit().also { commited ->
+            logger.verbose(TAG) { "writeConfig: storageEditor.commit() resulted in: $commited" }
+        }
     }
 
     override fun getConfig(): DisplayMessageListSettings = preferences.value

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/KoinModule.kt
@@ -153,12 +153,14 @@ val preferencesModule = module {
             displayCoreSettingsPreferenceManager = get(),
             displayInboxSettingsPreferenceManager = get(),
             displayVisualSettingsPreferenceManager = get(),
+            messageListPreferencesManager = get(),
             displayMiscSettingsPreferenceManager = get(),
             networkSettingsPreferenceManager = get(),
             debuggingSettingsPreferenceManager = get(),
             interactionSettingsPreferenceManager = get(),
             debugLogConfigurator = get(),
             platformConfigProvider = get(),
+            logger = get(),
         )
     } bind GeneralSettingsManager::class
     single {


### PR DESCRIPTION
 - Fixes #9630 
### 🐛 Root Cause of the Bug
 - All Message List–related display settings were not being loaded from PreferenceStorage; instead, they were retrieved from the default values defined in their corresponding Settings class.
 -  Additionally, whenever Message List–related display settings were being saved, they were not persisted because the corresponding storage editors were not committing the changes.
### 💡 Solution
 - Integrate the message list preferences so they combine correctly with existing general and display settings.
 -  Commit changes to the preference store when the corresponding settings are saved.