### PR TITLE
fix(oauth-config): add missing scope to ms oauth config causing SMTP auth unsuccessful on university accounts

### DIFF
--- a/app-k9mail/src/debug/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
@@ -67,6 +67,7 @@ class K9OAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e647013a-ada4-4114-b419-e43d250f99c5",
             scopes = listOf(
+                "profile",
                 "openid",
                 "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",

--- a/app-k9mail/src/release/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
+++ b/app-k9mail/src/release/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
@@ -67,6 +67,7 @@ class K9OAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e647013a-ada4-4114-b419-e43d250f99c5",
             scopes = listOf(
+                "profile",
                 "openid",
                 "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",

--- a/app-thunderbird/src/beta/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/beta/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -67,6 +67,7 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e6f8716e-299d-4ed9-bbf3-453f192f44e5",
             scopes = listOf(
+                "profile",
                 "openid",
                 "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",

--- a/app-thunderbird/src/daily/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/daily/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -67,6 +67,7 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e6f8716e-299d-4ed9-bbf3-453f192f44e5",
             scopes = listOf(
+                "profile",
                 "openid",
                 "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",

--- a/app-thunderbird/src/release/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
+++ b/app-thunderbird/src/release/kotlin/net/thunderbird/android/auth/TbOAuthConfigurationFactory.kt
@@ -67,6 +67,7 @@ class TbOAuthConfigurationFactory : OAuthConfigurationFactory {
         ) to OAuthConfiguration(
             clientId = "e6f8716e-299d-4ed9-bbf3-453f192f44e5",
             scopes = listOf(
+                "profile",
                 "openid",
                 "email",
                 "https://outlook.office.com/IMAP.AccessAsUser.All",


### PR DESCRIPTION
Fixes #10312.

It was missing the `profile` scope to MS OAuth configuration for the other build variants and for the K9 app. This PR adds this scope.