### PR TITLE
feat(account-setting): enable avatar customization for beta and release

### DIFF
--- a/app-k9mail/src/release/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
+++ b/app-k9mail/src/release/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
@@ -25,7 +25,7 @@ class K9FeatureFlagFactory : FeatureFlagFactory {
                 FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = false),
                 FeatureFlag(MessageListFeatureFlags.UseComposeForMessageListItems, enabled = false),
                 FeatureFlag(MessageViewFeatureFlags.ActionExportEml, enabled = false),
-                FeatureFlag(AccountSettingsFeatureFlags.EnableAvatarCustomization, enabled = false),
+                FeatureFlag(AccountSettingsFeatureFlags.EnableAvatarCustomization, enabled = true),
                 FeatureFlag(MessageReaderFeatureFlags.UseNewMessageReaderCssStyles, enabled = false),
                 FeatureFlag(MessageListFeatureFlags.EnableMessageListNewState, enabled = false),
             ),

--- a/app-thunderbird/src/beta/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/beta/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -25,7 +25,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
                 FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = false),
                 FeatureFlag(MessageListFeatureFlags.UseComposeForMessageListItems, enabled = false),
                 FeatureFlag(MessageViewFeatureFlags.ActionExportEml, enabled = false),
-                FeatureFlag(AccountSettingsFeatureFlags.EnableAvatarCustomization, enabled = false),
+                FeatureFlag(AccountSettingsFeatureFlags.EnableAvatarCustomization, enabled = true),
                 FeatureFlag(MessageReaderFeatureFlags.UseNewMessageReaderCssStyles, enabled = true),
                 FeatureFlag(MessageListFeatureFlags.EnableMessageListNewState, enabled = false),
             ),

--- a/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -25,7 +25,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
                 FeatureFlag(FeatureFlagKey.UseNotificationSenderForSystemNotifications, enabled = false),
                 FeatureFlag(MessageListFeatureFlags.UseComposeForMessageListItems, enabled = false),
                 FeatureFlag(MessageViewFeatureFlags.ActionExportEml, enabled = false),
-                FeatureFlag(AccountSettingsFeatureFlags.EnableAvatarCustomization, enabled = false),
+                FeatureFlag(AccountSettingsFeatureFlags.EnableAvatarCustomization, enabled = true),
                 FeatureFlag(MessageReaderFeatureFlags.UseNewMessageReaderCssStyles, enabled = false),
                 FeatureFlag(MessageListFeatureFlags.EnableMessageListNewState, enabled = false),
             ),


### PR DESCRIPTION
Resolves #10335


Enables the avatar customization for beta and release.
