### PR TITLE
fix: wrong icon for find folder

### DIFF
--- a/legacy/ui/legacy/src/main/res/menu/folder_list_option.xml
+++ b/legacy/ui/legacy/src/main/res/menu/folder_list_option.xml
@@ -5,7 +5,7 @@
     >
     <item
         android:id="@+id/filter_folders"
-        android:icon="@drawable/ic_filter_list"
+        android:icon="@drawable/ic_search"
         android:title="@string/filter_folders_action"
         app:showAsAction="collapseActionView|ifRoom"
         app:actionViewClass="androidx.appcompat.widget.SearchView"


### PR DESCRIPTION
Fixes :-  #10271 
![wrong_icon_dark](https://github.com/user-attachments/assets/88b12c4d-ee29-414f-964a-0077ad24b2d0)
![wrong_icon](https://github.com/user-attachments/assets/fe21c91c-4dfe-4144-9d8d-6912179c4243)
