### PR TITLE
refactor(message-list): replace MessageListAppearance with MessageListPreferences

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAdapter.kt
@@ -44,7 +44,7 @@ class MessageListAdapter internal constructor(
     private val layoutInflater: LayoutInflater,
     private val contactsPictureLoader: ContactPictureLoader,
     private val listItemListener: MessageListItemActionListener,
-    private val appearance: MessageListAppearance,
+    private val appearance: () -> MessageListAppearance,
     private val relativeDateTimeFormatter: RelativeDateTimeFormatter,
     private val themeProvider: FeatureThemeProvider,
     private val featureFlagProvider: FeatureFlagProvider,
@@ -350,7 +350,7 @@ class MessageListAdapter internal constructor(
     private fun calculateSelectionCount(): Int {
         return when {
             selected.isEmpty() -> 0
-            !appearance.showingThreadedList -> selected.size
+            !appearance().showingThreadedList -> selected.size
             else ->
                 viewItems
                     .asSequence()

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAppearance.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListAppearance.kt
@@ -1,10 +1,15 @@
 package com.fsck.k9.ui.messagelist
 
+import android.os.Parcelable
 import com.fsck.k9.FontSizes
+import kotlinx.parcelize.IgnoredOnParcel
+import kotlinx.parcelize.Parcelize
 import net.thunderbird.core.preference.display.visualSettings.message.list.UiDensity
 
+@Parcelize
 data class MessageListAppearance(
-    val fontSizes: FontSizes,
+    @IgnoredOnParcel
+    val fontSizes: FontSizes = FontSizes(),
     val previewLines: Int,
     val stars: Boolean,
     val senderAboveSubject: Boolean,
@@ -16,4 +21,4 @@ data class MessageListAppearance(
      */
     val showAccountIndicator: Boolean,
     val density: UiDensity,
-)
+) : Parcelable

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
@@ -7,14 +7,17 @@ import androidx.core.os.bundleOf
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import net.thunderbird.core.common.action.SwipeActions
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.AccountIdFactory
+import net.thunderbird.feature.mail.message.list.preferences.MessageListPreferences
 import net.thunderbird.feature.mail.message.list.ui.MessageListContract
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.serialization.LocalMessageSearchSerializer
@@ -54,6 +57,21 @@ class MessageListFragment : BaseMessageListFragment() {
             }
         }
     }
+
+    override suspend fun fetchMessageListAppearance(): Flow<MessageListAppearance> = viewModel
+        .state
+        .mapNotNull { state -> state.preferences?.toMessageListAppearance() }
+
+    private fun MessageListPreferences.toMessageListAppearance(): MessageListAppearance = MessageListAppearance(
+        previewLines = excerptLines,
+        stars = showFavouriteButton,
+        senderAboveSubject = senderAboveSubject,
+        showContactPicture = showMessageAvatar,
+        showingThreadedList = groupConversations,
+        backGroundAsReadIndicator = colorizeBackgroundWhenRead,
+        showAccountIndicator = isShowAccountIndicator,
+        density = density,
+    )
 
     companion object Factory : BaseMessageListFragment.Factory {
         override fun newInstance(

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/item/ComposableMessageViewHolder.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/item/ComposableMessageViewHolder.kt
@@ -19,7 +19,7 @@ class ComposableMessageViewHolder(
     private val onLongClick: (MessageListItem) -> Unit,
     private val onAvatarClick: (MessageListItem) -> Unit,
     private val onFavouriteClick: (MessageListItem) -> Unit,
-    private val appearance: MessageListAppearance,
+    private val appearance: () -> MessageListAppearance,
     private val contactRepository: ContactRepository,
     private val avatarMonogramCreator: AvatarMonogramCreator,
 ) : MessageListViewHolder(composeView) {
@@ -41,7 +41,7 @@ class ComposableMessageViewHolder(
                     onLongClick = { onLongClick(item) },
                     onAvatarClick = { onAvatarClick(item) },
                     onFavouriteClick = { onFavouriteClick(item) },
-                    appearance = appearance,
+                    appearance = appearance(),
                 )
             }
         }
@@ -58,7 +58,7 @@ class ComposableMessageViewHolder(
             onLongClick: (MessageListItem) -> Unit,
             onFavouriteClick: (MessageListItem) -> Unit,
             onAvatarClick: (MessageListItem) -> Unit,
-            appearance: MessageListAppearance,
+            appearance: () -> MessageListAppearance,
         ): ComposableMessageViewHolder {
             val composeView = ComposeView(context)
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/item/MessageViewHolder.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/item/MessageViewHolder.kt
@@ -35,7 +35,7 @@ import net.thunderbird.core.preference.display.visualSettings.message.list.UiDen
 @Suppress("TooManyFunctions")
 class MessageViewHolder(
     view: View,
-    private val appearance: MessageListAppearance,
+    private val appearance: () -> MessageListAppearance,
     private val theme: Resources.Theme,
     private val res: Resources,
     private val contactsPictureLoader: ContactPictureLoader,
@@ -60,6 +60,7 @@ class MessageViewHolder(
 
     @Suppress("LongMethod", "CyclomaticComplexMethod")
     fun bind(messageListItem: MessageListItem, isActive: Boolean, isSelected: Boolean) {
+        val appearance = appearance()
         if (appearance.showContactPicture) {
             contactPictureClickArea.isSelected = isSelected
             if (isSelected) {
@@ -215,6 +216,7 @@ class MessageViewHolder(
     }
 
     private fun addBeforePreviewSpan(text: Spannable, length: Int, messageRead: Boolean) {
+        val appearance = appearance()
         val fontSize = if (appearance.senderAboveSubject) {
             appearance.fontSizes.messageListSubject
         } else {
@@ -243,7 +245,7 @@ class MessageViewHolder(
     }
 
     private fun selectBackgroundColor(selected: Boolean, read: Boolean, active: Boolean): Int {
-        val backGroundAsReadIndicator = appearance.backGroundAsReadIndicator
+        val backGroundAsReadIndicator = appearance().backGroundAsReadIndicator
         return when {
             selected -> colors.selectedBackground
             active -> colors.activeBackground
@@ -279,7 +281,7 @@ class MessageViewHolder(
         fun create(
             layoutInflater: LayoutInflater,
             parent: ViewGroup?,
-            appearance: MessageListAppearance,
+            appearance: () -> MessageListAppearance,
             theme: Resources.Theme,
             res: Resources,
             contactsPictureLoader: ContactPictureLoader,
@@ -303,6 +305,7 @@ class MessageViewHolder(
                 relativeDateTimeFormatter = relativeDateTimeFormatter,
                 colors = colors,
             )
+            val appearance = appearance()
 
             applyFontSizes(holder, appearance.fontSizes, appearance.senderAboveSubject)
             applyDensityValue(holder, appearance.density, res)

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
@@ -434,7 +434,7 @@ class MessageListAdapterTest : RobolectricTest() {
             layoutInflater = LayoutInflater.from(context),
             contactsPictureLoader = contactsPictureLoader,
             listItemListener = listItemListener,
-            appearance = appearance,
+            appearance = { appearance },
             relativeDateTimeFormatter = RelativeDateTimeFormatter(context, TestClock()),
             themeProvider = FakeThemeProvider(),
             featureFlagProvider = FakeFeatureFlagProvider(),


### PR DESCRIPTION
Part of #9497.

We are slowly replacing the old Message List state with the new one. This PR replaces the old `MessageListAppearance` with the new `MessageListPreference`, loading it using the new `MessageListViewModel` and its state machine.

As the implementation of the ViewHolders still uses the `MessageListAppearance`, we still need to map the `MessageListPreference` to it, but that must be removed in the future, when the refactor is finished.