### PR TITLE
fix(message-list): recycler view in stale state

### DIFF
--- a/legacy/ui/legacy/src/main/res/layout/message_list.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <androidx.drawerlayout.widget.DrawerLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/navigation_drawer_layout"
     android:layout_width="match_parent"
@@ -9,11 +8,29 @@
     tools:context="com.fsck.k9.activity.MessageHomeActivity"
     >
 
-    <androidx.coordinatorlayout.widget.CoordinatorLayout
+    <!--
+     As the navigation of Message List (MessageHomeActivity) is based on the ViewSwitcher,
+     which just toggle the visibility of existing views rather than creating/destroying the
+     Fragments, the Fragment's lifecycle methods, such as onViewCreated, are not properly called.
+
+     Modern layouts (ConstraintLayout, CoordinatorLayout) optimize measurement during visibility
+     toggles and WindowInsets updates, sometimes causing a transient layout pass with incorrect bounds.
+     The RecyclerView incorrectly treats this pass as a successful update and marks its state as "clean".
+     Consequently, it fails to trigger onBindViewHolder when the view is fully restored, leaving the
+     UI stuck displaying the previous stale state instead of the new data.
+
+     RelativeLayout is used to enforce strict vertical dependencies. By using layout_below, it
+     ensures the Toolbar is measured before the container. This prevents the race condition and forces
+     the RecyclerView to recognize its actual bounds, ensuring the adapter binds correctly without
+     performance-heavy requestLayout() calls.
+
+     Until we move this screen to use a modern navigation system, or rewrite it using Jetpack Compose,
+     we need to use this workaround.
+    -->
+    <RelativeLayout
         android:id="@+id/coordinator_layout"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        android:orientation="vertical"
         >
 
         <com.google.android.material.appbar.AppBarLayout
@@ -21,6 +38,7 @@
             style="@style/Widget.App.AppBarLayout"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:layout_alignParentTop="true"
             >
 
             <include
@@ -28,7 +46,6 @@
                 layout="@layout/message_list_toolbar"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_alignParentTop="true"
                 />
 
         </com.google.android.material.appbar.AppBarLayout>
@@ -37,7 +54,7 @@
             android:id="@+id/content_container"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            app:layout_behavior="@string/appbar_scrolling_view_behavior"
+            android:layout_below="@id/app_bar_layout"
             >
 
             <ProgressBar
@@ -58,15 +75,15 @@
 
                 <androidx.fragment.app.FragmentContainerView
                     android:id="@+id/message_list_container"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
                     tools:layout="@layout/message_list_fragment"
                     />
 
                 <androidx.fragment.app.FragmentContainerView
                     android:id="@+id/message_view_container"
-                    android:layout_width="fill_parent"
-                    android:layout_height="fill_parent"
+                    android:layout_width="match_parent"
+                    android:layout_height="match_parent"
                     tools:layout="@layout/message"
                     />
 
@@ -74,7 +91,7 @@
 
         </FrameLayout>
 
-    </androidx.coordinatorlayout.widget.CoordinatorLayout>
+    </RelativeLayout>
 
     <include layout="@layout/navigation_drawer_content" />
 


### PR DESCRIPTION
Fixes #10243.

## TL;DR
Fixed a stale UI state in MessageListFragment where RecyclerView failed to re-bind data after navigation. Switched root layout to RelativeLayout to enforce strict measurement dependencies, bypassing a 0-height measurement race condition caused by the ViewSwitcher navigation pattern and edge-to-edge insets.


## Description

As the navigation of Message List (`MessageHomeActivity`) is based on a [ViewSwitcher](https://github.com/thunderbird/thunderbird-android/blob/main/legacy/ui/legacy/src/main/java/com/fsck/k9/view/ViewSwitcher.java) which toggles the visibility of existing views rather than creating/destroying Fragments, standard lifecycle methods like `onViewCreated` are not re-triggered upon navigation.

## The Issue
This architecture creates a layout race condition when combined with edge-to-edge `WindowInsets`. Modern layouts like `ConstraintLayout` and `CoordinatorLayout` optimize measurement passes in a way that can momentarily report 0-height bounds to the `RecyclerView` during the `GONE` -> `VISIBLE` transition. 

Because the `RecyclerView` completes a layout pass at 0-height, it marks its internal state as "clean" but leaves the UI stuck displaying the **previous stale state** instead of the new data. When the layout finally settles at the correct height, the `RecyclerView` remains stale: it "thinks" it is up-to-date, thereby skipping the `onBindViewHolder` calls necessary to refresh the view.

## The Fix
`RelativeLayout` is used here specifically to enforce **strict, synchronous measurement dependencies**. By using `android:layout_below`, it mandates that the Toolbar's dimensions are finalized before the container measurement begins. This prevents the transient 0-height state and ensures the `RecyclerView` correctly identifies its visible viewport, triggering the adapter binding without requiring `requestLayout()` hacks.

---

<details>
<summary><b>Alternative Fix (Rejected)</b></summary>

An alternative fix is to keep the modern XML definition and force the `RecyclerView` to update by calling `requestLayout()` manually when the fragment becomes active:

```diff
Index: legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListFragment.kt
...
+    private fun onActiveChange(wasActive: Boolean) {
+        if (!wasActive) {
+            recyclerView?.requestLayout()
+        }
+    }
```
</details>

This workaround functions but is likely to cause "flashing" on low-end devices due to the extra layout pass and hides the underlying measurement issue. I chose the RelativeLayout approach as it solves the root cause at the layout engine level.