### PR TITLE
chore(ci): set app-thunderbird beta suffix to b0

### DIFF
--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -121,7 +121,7 @@ android {
             signingConfig = signingConfigs.getByType(SigningType.TB_BETA)
 
             applicationIdSuffix = ".beta"
-            versionNameSuffix = "b1"
+            versionNameSuffix = "b0"
 
             isMinifyEnabled = true
             isShrinkResources = true


### PR DESCRIPTION
This eliminates the need to select “Skip version bump (beta)” for b1 releases.

Fixes: #10475