### PR TITLE
Check isInitialized before updating footer text

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/BaseMessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/BaseMessageListFragment.kt
@@ -1437,6 +1437,8 @@ abstract class BaseMessageListFragment :
     }
 
     fun updateFooterText(text: String?) {
+        if (!::adapter.isInitialized) return
+
         val currentItems = adapter
             .viewItems
             .filter { it !is MessageListViewItem.Footer }


### PR DESCRIPTION
This exception happens when opening the app when it's recycled (I guess).

```
kotlin.UninitializedPropertyAccessException: lateinit property adapter has not been initialized
  at com.fsck.k9.ui.messagelist.BaseMessageListFragment.updateFooterText(BaseMessageListFragment.kt:1441)
  at com.fsck.k9.ui.messagelist.BaseMessageListFragment.updateFooterText(BaseMessageListFragment.kt:1437)
  at com.fsck.k9.ui.messagelist.BaseMessageListFragment.folderLoading(BaseMessageListFragment.kt:763)
  at com.fsck.k9.ui.messagelist.MessageListHandler.handleMessage(MessageListHandler.java:88)
  at android.os.Handler.dispatchMessage(Handler.java:132)
  at android.os.Looper.dispatchMessage(Looper.java:333)
  at android.os.Looper.loopOnce(Looper.java:263)
  at android.os.Looper.loop(Looper.java:367)
  at android.app.ActivityThread.main(ActivityThread.java:9287)
  at java.lang.reflect.Method.invoke(Native Method)
  at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:566)
  at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:929)
```

