### PR TITLE
feat(account): add support for PNG avatars

### DIFF
--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/data/datasource/LocalAvatarImageDataSource.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/data/datasource/LocalAvatarImageDataSource.kt
@@ -5,6 +5,8 @@ import kotlin.time.Clock
 import kotlin.time.ExperimentalTime
 import net.thunderbird.core.file.DirectoryProvider
 import net.thunderbird.core.file.FileManager
+import net.thunderbird.core.file.MimeType
+import net.thunderbird.core.file.MimeTypeResolver
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.avatar.data.AvatarDataContract.DataSource.LocalAvatarImage
 
@@ -16,42 +18,62 @@ import net.thunderbird.feature.account.avatar.data.AvatarDataContract.DataSource
  *
  * @param fileManager The [FileManager] for file operations.
  * @param directoryProvider The [DirectoryProvider] to get app directories.
+ * @param mimeTypeResolver The [MimeTypeResolver] to determine image formats.
+ * @param clock The [Clock] used for cache invalidation.
  */
+
 @OptIn(ExperimentalTime::class)
 internal class LocalAvatarImageDataSource(
     private val fileManager: FileManager,
     private val directoryProvider: DirectoryProvider,
+    private val mimeTypeResolver: MimeTypeResolver,
     private val clock: Clock,
 ) : LocalAvatarImage {
 
     override suspend fun update(id: AccountId, imageUri: Uri): Uri {
-        val avatarImageUri = getAvatarImageUri(id)
+        val mimeType = mimeTypeResolver.getMimeType(imageUri)
+        val targetExtension = if (mimeType == MimeType.PNG) EXTENSION_PNG else EXTENSION_JPG
+
+        delete(id)
+
+        val avatarImageUri = getAvatarImageUri(id, targetExtension)
 
         fileManager.copy(imageUri, avatarImageUri)
 
         return avatarImageUri.buildUpon()
-            .clearQuery()
-            .appendQueryParameter("v", clock.now().toEpochMilliseconds().toString())
+            .appendQueryParameter(PARAMETER_VERSION, clock.now().toEpochMilliseconds().toString())
             .build()
     }
 
     override suspend fun delete(id: AccountId) {
-        val avatarImageUri = getAvatarImageUri(id)
-        fileManager.delete(avatarImageUri)
+        val now = clock.now().toEpochMilliseconds().toString()
+
+        fileManager.delete(
+            getAvatarImageUri(id, EXTENSION_JPG).buildUpon()
+                .appendQueryParameter(PARAMETER_VERSION, now)
+                .build(),
+        )
+        fileManager.delete(
+            getAvatarImageUri(id, EXTENSION_PNG).buildUpon()
+                .appendQueryParameter(PARAMETER_VERSION, now)
+                .build(),
+        )
     }
 
-    private suspend fun getAvatarImageUri(id: AccountId): Uri = getAvatarDirUri().buildUpon()
-        .appendPath("$id.$AVATAR_IMAGE_FILE_EXTENSION")
-        .build()
-
-    private suspend fun getAvatarDirUri(): Uri {
-        return directoryProvider.getFilesDir().buildUpon()
+    private suspend fun getAvatarImageUri(id: AccountId, extension: String): Uri {
+        val directory = directoryProvider.getFilesDir().buildUpon()
             .appendPath(LocalAvatarImage.DIRECTORY_NAME)
             .build()
             .also { fileManager.createDirectories(it) }
+
+        return directory.buildUpon()
+            .appendPath("$id.$extension")
+            .build()
     }
 
-    private companion object {
-        const val AVATAR_IMAGE_FILE_EXTENSION = "jpg"
+    companion object {
+        private const val EXTENSION_JPG = "jpg"
+        private const val EXTENSION_PNG = "png"
+        private const val PARAMETER_VERSION = "v"
     }
 }

--- a/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/di/FeatureAccountAvatarModule.kt
+++ b/feature/account/avatar/impl/src/main/kotlin/net/thunderbird/feature/account/avatar/di/FeatureAccountAvatarModule.kt
@@ -13,7 +13,8 @@ val featureAccountAvatarModule = module {
         LocalAvatarImageDataSource(
             fileManager = get(),
             directoryProvider = get(),
-            clock = get(),
+            mimeTypeResolver = get(),
+            clock = get(), // fetch the app's global 'Clock'
         )
     }
 

--- a/feature/account/avatar/impl/src/test/kotlin/net/thunderbird/feature/account/avatar/data/datasource/LocalAvatarImageDataSourceTest.kt
+++ b/feature/account/avatar/impl/src/test/kotlin/net/thunderbird/feature/account/avatar/data/datasource/LocalAvatarImageDataSourceTest.kt
@@ -1,18 +1,21 @@
 package net.thunderbird.feature.account.avatar.data.datasource
 
 import assertk.assertThat
+import assertk.assertions.contains
 import assertk.assertions.isEqualTo
-import assertk.assertions.isNotEqualTo
-import assertk.assertions.isNotNull
-import assertk.assertions.isNull
+import com.eygraber.uri.Uri
 import com.eygraber.uri.toKmpUri
 import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.ExperimentalTime
 import kotlin.time.Instant
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.core.file.DirectoryProvider
+import net.thunderbird.core.file.FileManager
+import net.thunderbird.core.file.FileOperationError
+import net.thunderbird.core.file.MimeType
+import net.thunderbird.core.file.MimeTypeResolver
+import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.core.testing.TestClock
 import net.thunderbird.feature.account.AccountIdFactory
 import net.thunderbird.feature.account.avatar.data.AvatarDataContract
@@ -27,7 +30,8 @@ class LocalAvatarImageDataSourceTest {
     val folder = TemporaryFolder()
 
     private lateinit var directoryProvider: DirectoryProvider
-    private lateinit var fileManager: CapturingFileManager
+    private lateinit var fileManager: SpyFileManager
+    private lateinit var mimeTypeResolver: FakeMimeTypeResolver
     private lateinit var clock: TestClock
     private lateinit var testSubject: LocalAvatarImageDataSource
 
@@ -35,69 +39,112 @@ class LocalAvatarImageDataSourceTest {
     fun setUp() {
         val appDir = folder.newFolder("app")
         directoryProvider = FakeDirectoryProvider(appDir.absolutePath.toKmpUri())
-        fileManager = CapturingFileManager()
+        fileManager = SpyFileManager()
+        mimeTypeResolver = FakeMimeTypeResolver()
         clock = TestClock(Instant.fromEpochMilliseconds(1_000))
-        testSubject = LocalAvatarImageDataSource(fileManager, directoryProvider, clock)
+
+        testSubject = LocalAvatarImageDataSource(
+            fileManager,
+            directoryProvider,
+            mimeTypeResolver,
+            clock,
+        )
     }
 
     @Test
-    fun `update should copy image to expected path and return versioned destination uri`() = runTest {
-        // Arrange
+    fun `update with JPG should copy image to JPG path and clean up old files`() = runTest {
         val accountId = AccountIdFactory.create()
         val source = "file:///external/picked/image.jpg".toKmpUri()
-        val expectedDir = directoryProvider.getFilesDir().buildUpon()
-            .appendPath(AvatarDataContract.DataSource.LocalAvatarImage.DIRECTORY_NAME)
-            .build()
+        val expectedDir = getAvatarDir()
         val expectedDest = expectedDir.buildUpon().appendPath("$accountId.jpg").build()
-        val expectedVersioned = expectedDest.buildUpon().appendQueryParameter("v", "1000").build()
+        val expectedVersioned = expectedDest.buildUpon()
+            .appendQueryParameter("v", "1000")
+            .build()
 
-        // Act
+        mimeTypeResolver.mimeTypeToReturn = MimeType.JPEG
+
         val returned = testSubject.update(accountId, source)
 
-        // Assert
         assertThat(returned).isEqualTo(expectedVersioned)
-        assertThat(fileManager.lastCreatedDir).isEqualTo(expectedDir)
         assertThat(fileManager.lastCopySource).isEqualTo(source)
         assertThat(fileManager.lastCopyDestination).isEqualTo(expectedDest)
-        assertThat(fileManager.lastDeleted).isNull()
-    }
 
-    @Test
-    fun `successive updates should return different URIs`() = runTest {
-        // Arrange
-        val accountId = AccountIdFactory.create()
-        val source = "file:///external/picked/image.jpg".toKmpUri()
-
-        // Act
-        val uri1 = testSubject.update(accountId, source)
-        clock.advanceTimeBy(1.milliseconds)
-        val uri2 = testSubject.update(accountId, source)
-
-        // Assert
-        assertThat(uri1).isNotEqualTo(uri2)
-        // Base paths should be the same
-        assertThat(uri1.buildUpon().clearQuery().build()).isEqualTo(uri2.buildUpon().clearQuery().build())
-    }
-
-    @Test
-    fun `delete should remove expected avatar path`() = runTest {
-        // Arrange
-        val accountId = AccountIdFactory.create()
-        val expectedDir = directoryProvider.getFilesDir().buildUpon()
-            .appendPath(AvatarDataContract.DataSource.LocalAvatarImage.DIRECTORY_NAME)
+        val expectedPngDel = expectedDir.buildUpon()
+            .appendPath("$accountId.png")
+            .appendQueryParameter("v", "1000")
             .build()
-        val expectedDest = expectedDir.buildUpon().appendPath("$accountId.jpg").build()
 
-        // Act
+        assertThat(fileManager.deletedPaths).contains(expectedPngDel)
+        assertThat(fileManager.deletedPaths).contains(expectedVersioned)
+    }
+
+    @Test
+    fun `update with PNG should copy image to PNG path`() = runTest {
+        val accountId = AccountIdFactory.create()
+        val source = "file:///external/picked/photo.png".toKmpUri()
+        val expectedDir = getAvatarDir()
+        val expectedDest = expectedDir.buildUpon().appendPath("$accountId.png").build()
+        val expectedVersioned = expectedDest.buildUpon()
+            .appendQueryParameter("v", "1000")
+            .build()
+
+        mimeTypeResolver.mimeTypeToReturn = MimeType.PNG
+
+        val returned = testSubject.update(accountId, source)
+
+        assertThat(returned).isEqualTo(expectedVersioned)
+        assertThat(fileManager.lastCopySource).isEqualTo(source)
+        assertThat(fileManager.lastCopyDestination).isEqualTo(expectedDest)
+    }
+
+    @Test
+    fun `delete should remove both JPG and PNG paths`() = runTest {
+        val accountId = AccountIdFactory.create()
+        val expectedDir = getAvatarDir()
+        val jpgPath = expectedDir.buildUpon()
+            .appendPath("$accountId.jpg")
+            .appendQueryParameter("v", "1000")
+            .build()
+        val pngPath = expectedDir.buildUpon()
+            .appendPath("$accountId.png")
+            .appendQueryParameter("v", "1000")
+            .build()
+
         testSubject.delete(accountId)
 
-        // Assert
-        assertThat(fileManager.lastDeleted).isEqualTo(expectedDest)
-        // No copy on delete
-        assertThat(fileManager.lastCopySource).isNull()
-        assertThat(fileManager.lastCopyDestination).isNull()
-        // Directory creation occurs when computing path even in delete(), due to getAvatarDirUri()
-        assertThat(fileManager.lastCreatedDir).isNotNull()
-        assertThat(fileManager.lastCreatedDir).isEqualTo(expectedDir)
+        assertThat(fileManager.deletedPaths).contains(jpgPath)
+        assertThat(fileManager.deletedPaths).contains(pngPath)
+    }
+
+    private fun getAvatarDir(): Uri {
+        return directoryProvider.getFilesDir().buildUpon()
+            .appendPath(AvatarDataContract.DataSource.LocalAvatarImage.DIRECTORY_NAME)
+            .build()
+    }
+
+    class FakeMimeTypeResolver : MimeTypeResolver {
+        var mimeTypeToReturn: MimeType? = null
+        override fun getMimeType(uri: Uri): MimeType? = mimeTypeToReturn
+    }
+
+    class SpyFileManager : FileManager {
+        var lastCopySource: Uri? = null
+        var lastCopyDestination: Uri? = null
+        val deletedPaths = mutableListOf<Uri>()
+
+        override suspend fun copy(sourceUri: Uri, destinationUri: Uri): Outcome<Unit, FileOperationError> {
+            lastCopySource = sourceUri
+            lastCopyDestination = destinationUri
+            return Outcome.Success(Unit)
+        }
+
+        override suspend fun delete(uri: Uri): Outcome<Unit, FileOperationError> {
+            deletedPaths.add(uri)
+            return Outcome.Success(Unit)
+        }
+
+        override suspend fun createDirectories(uri: Uri): Outcome<Unit, FileOperationError> {
+            return Outcome.Success(Unit)
+        }
     }
 }

--- a/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/domain/usecase/UpdateAvatarImage.kt
+++ b/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/domain/usecase/UpdateAvatarImage.kt
@@ -22,10 +22,11 @@ internal class UpdateAvatarImage(
     ): Outcome<Avatar.Image, AccountSettingError> {
         val mimeType = mimeTypeResolver.getMimeType(imageUri)
 
-        if (mimeType == null || mimeType != MimeType.JPEG) {
+        // Check for both JPEG and PNG
+        if (mimeType == null || (mimeType != MimeType.JPEG && mimeType != MimeType.PNG)) {
             return Outcome.Failure(
                 AccountSettingError.UnsupportedFormat(
-                    message = "Only JPEG images are supported. Found: ${mimeType ?: "unknown"}",
+                    message = "Only JPEG and PNG images are supported. Found: ${mimeType ?: "unknown"}",
                 ),
             )
         }

--- a/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/ui/general/GeneralSettingsScreen.kt
+++ b/feature/account/settings/impl/src/main/kotlin/net/thunderbird/feature/account/settings/impl/ui/general/GeneralSettingsScreen.kt
@@ -25,7 +25,7 @@ internal fun GeneralSettingsScreen(
     provider: SettingViewProvider = koinInject(),
     builder: SettingsBuilder = koinInject(),
 ) {
-    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.GetContent()) { uri ->
+    val imagePicker = rememberLauncherForActivityResult(ActivityResultContracts.OpenDocument()) { uri ->
         if (uri != null) {
             viewModel.event(Event.OnAvatarImagePicked(uri.toKmpUri()))
         }
@@ -35,7 +35,7 @@ internal fun GeneralSettingsScreen(
         when (effect) {
             is Effect.NavigateBack -> onBack()
             is Effect.OpenAvatarImagePicker -> {
-                imagePicker.launch("image/jpeg")
+                imagePicker.launch(arrayOf("image/jpeg", "image/png"))
             }
         }
     }


### PR DESCRIPTION
**Description**
This PR updates the account avatar logic to support both `.jpg` and `.png` file extensions. Previously, all avatars were forced to use the `.jpg` extension, which caused issues when someone uploaded PNGs, especially those with transparency (I tried some for my main email and did not understand why it failed at first, or rather did not show the images in the picker).

**Changes**
* Dynamic extension: `LocalAvatarImageDataSource` now detects if the source image is a PNG and saves it with the correct `.png` extension.
* Smart cleanup: the `delete()` function now checks for and removes both `.jpg` and `.png` files for the given account. This ensures that, when a user switches from a JPEG avatar to a PNG avatar (or vice versa), the old file is deleted and does not remain orphaned.
* Tests: updated `LocalAvatarImageDataSourceTest` to verify PNG support and ensure the clean-up logic works for multiple file types.

Fixes:
#10501