### PR TITLE
feat(configstore): add testing utilities and improve ConfigKey behavior

### DIFF
--- a/core/configstore/api/src/commonMain/kotlin/net/thunderbird/core/configstore/Config.kt
+++ b/core/configstore/api/src/commonMain/kotlin/net/thunderbird/core/configstore/Config.kt
@@ -3,14 +3,20 @@ package net.thunderbird.core.configstore
 /**
  * A configuration holds key-value pairs of [ConfigKey] and their corresponding values.
  *
- * It is used to store and retrieve configuration settings in a type-safe manner.
+ * This is used to store and retrieve configuration settings in a type-safe manner.
  */
 class Config(
     private val entries: MutableMap<ConfigKey<*>, Any?> = mutableMapOf(),
 ) {
+    /**
+     * Returns the value associated with the given [ConfigKey], or null if the key is not present.
+     */
     @Suppress("UNCHECKED_CAST")
     operator fun <T> get(key: ConfigKey<T>): T? = entries[key] as? T
 
+    /**
+     * Sets the value for the given [ConfigKey]. The value must be of the correct type corresponding to the key.
+     */
     operator fun <T> set(key: ConfigKey<T>, value: T) {
         entries[key] = value
     }
@@ -19,4 +25,9 @@ class Config(
      * Returns a map representation of the configuration.
      */
     fun toMap(): Map<ConfigKey<*>, Any?> = entries.toMap()
+
+    /**
+     * Returns a copy of the configuration.
+     */
+    fun copy(): Config = Config(entries.toMutableMap())
 }

--- a/core/configstore/api/src/commonMain/kotlin/net/thunderbird/core/configstore/ConfigKey.kt
+++ b/core/configstore/api/src/commonMain/kotlin/net/thunderbird/core/configstore/ConfigKey.kt
@@ -16,4 +16,19 @@ sealed class ConfigKey<T>(val name: String) {
     class LongKey(name: String) : ConfigKey<Long>(name)
     class FloatKey(name: String) : ConfigKey<Float>(name)
     class DoubleKey(name: String) : ConfigKey<Double>(name)
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other == null || this::class != other::class) return false
+        other as ConfigKey<*>
+        return name == other.name
+    }
+
+    override fun hashCode(): Int {
+        return name.hashCode() + 31 * this::class.hashCode()
+    }
+
+    override fun toString(): String {
+        return "${this::class.simpleName}(name='$name')"
+    }
 }

--- a/core/configstore/api/src/commonTest/kotlin/net/thunderbird/core/configstore/ConfigKeyTest.kt
+++ b/core/configstore/api/src/commonTest/kotlin/net/thunderbird/core/configstore/ConfigKeyTest.kt
@@ -3,6 +3,7 @@ package net.thunderbird.core.configstore
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotEqualTo
 import kotlin.test.Test
 
 class ConfigKeyTest {
@@ -83,5 +84,37 @@ class ConfigKeyTest {
         // Assert
         assertThat(key.name).isEqualTo(name)
         assertThat(key).isInstanceOf(ConfigKey.DoubleKey::class)
+    }
+
+    @Test
+    fun `equals should return true for same key type and same name`() {
+        val key1 = ConfigKey.StringKey("test")
+        val key2 = ConfigKey.StringKey("test")
+
+        assertThat(key1).isEqualTo(key2)
+        assertThat(key1.hashCode()).isEqualTo(key2.hashCode())
+    }
+
+    @Test
+    fun `equals should return false for different key type and same name`() {
+        val key1 = ConfigKey.StringKey("test")
+        val key2 = ConfigKey.IntKey("test")
+
+        assertThat(key1).isNotEqualTo(key2)
+    }
+
+    @Test
+    fun `equals should return false for same key type and different name`() {
+        val key1 = ConfigKey.StringKey("test1")
+        val key2 = ConfigKey.StringKey("test2")
+
+        assertThat(key1).isNotEqualTo(key2)
+    }
+
+    @Test
+    fun `toString should return correct representation`() {
+        val key = ConfigKey.IntKey("myKey")
+
+        assertThat(key.toString()).isEqualTo("IntKey(name='myKey')")
     }
 }

--- a/core/configstore/api/src/commonTest/kotlin/net/thunderbird/core/configstore/ConfigTest.kt
+++ b/core/configstore/api/src/commonTest/kotlin/net/thunderbird/core/configstore/ConfigTest.kt
@@ -2,6 +2,7 @@ package net.thunderbird.core.configstore
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import assertk.assertions.isNotSameInstanceAs
 import assertk.assertions.isNull
 import kotlin.test.Test
 
@@ -96,5 +97,20 @@ class ConfigTest {
         assertThat(map.size).isEqualTo(2)
         assertThat(map[key1]).isEqualTo("value1")
         assertThat(map[key2]).isEqualTo(2)
+    }
+
+    @Test
+    fun `copy should return a new instance with the same entries`() {
+        // Arrange
+        val config = Config()
+        val key = ConfigKey.StringKey("key")
+        config[key] = "value"
+
+        // Act
+        val copy = config.copy()
+
+        // Assert
+        assertThat(copy).isNotSameInstanceAs(config)
+        assertThat(copy[key]).isEqualTo("value")
     }
 }

--- a/core/configstore/testing/build.gradle.kts
+++ b/core/configstore/testing/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    id(ThunderbirdPlugins.Library.kmp)
+}
+
+kotlin {
+    androidLibrary {
+        namespace = "net.thunderbird.core.configstore.testing"
+        withHostTest {}
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            api(projects.core.configstore.api)
+        }
+    }
+}
+
+codeCoverage {
+    branchCoverage = 0
+    lineCoverage = 0
+}

--- a/core/configstore/testing/src/commonMain/kotlin/net/thunderbird/core/configstore/testing/TestConfigBackend.kt
+++ b/core/configstore/testing/src/commonMain/kotlin/net/thunderbird/core/configstore/testing/TestConfigBackend.kt
@@ -1,0 +1,61 @@
+package net.thunderbird.core.configstore.testing
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import net.thunderbird.core.configstore.Config
+import net.thunderbird.core.configstore.ConfigKey
+import net.thunderbird.core.configstore.backend.ConfigBackend
+
+/**
+ * A mutable, in-memory implementation of [ConfigBackend] designed for testing.
+ *
+ * This implementation allows tests to simulate configuration storage without relying on
+ * actual persistence mechanisms like DataStore. It stores configuration in a [MutableStateFlow],
+ * providing reactive updates and thread-safe access.
+ *
+ * Use this in unit tests where you need to verify how components interact with the config store
+ * or to provide a controlled environment for configuration-dependent logic.
+ *
+ * @param initialConfig The starting configuration state. Defaults to an empty [Config].
+ */
+class TestConfigBackend(
+    initialConfig: Config = Config(),
+) : ConfigBackend {
+
+    private val config: MutableStateFlow<Config> = MutableStateFlow(initialConfig)
+
+    override fun read(keys: List<ConfigKey<*>>): Flow<Config> = config.asStateFlow()
+
+    override suspend fun update(
+        keys: List<ConfigKey<*>>,
+        transform: (Config) -> Config,
+    ) {
+        config.update { transform(it) }
+    }
+
+    override suspend fun clear() {
+        config.value = Config()
+    }
+
+    override suspend fun readVersion(versionKey: String): Int {
+        return config.value[ConfigKey.IntKey(versionKey)] ?: 0
+    }
+
+    override suspend fun writeVersion(versionKey: String, version: Int) {
+        config.update { current ->
+            val newConfig = current.copy()
+            newConfig[ConfigKey.IntKey(versionKey)] = version
+            newConfig
+        }
+    }
+
+    override suspend fun removeKeys(keys: Set<ConfigKey<*>>) {
+        config.update { current ->
+            val newMap = current.toMap().toMutableMap()
+            keys.forEach { newMap.remove(it) }
+            Config(newMap)
+        }
+    }
+}

--- a/core/configstore/testing/src/commonTest/kotlin/net/thunderbird/core/configstore/testing/TestConfigBackendTest.kt
+++ b/core/configstore/testing/src/commonTest/kotlin/net/thunderbird/core/configstore/testing/TestConfigBackendTest.kt
@@ -1,0 +1,90 @@
+package net.thunderbird.core.configstore.testing
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isNull
+import kotlin.test.Test
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.configstore.Config
+import net.thunderbird.core.configstore.ConfigKey
+
+class TestConfigBackendTest {
+
+    private val booleanKey = ConfigKey.BooleanKey("boolean")
+    private val intKey = ConfigKey.IntKey("int")
+    private val stringKey = ConfigKey.StringKey("string")
+
+    @Test
+    fun `read should return initial config`() = runTest {
+        val initialConfig = Config().apply {
+            set(booleanKey, true)
+        }
+        val backend = TestConfigBackend(initialConfig)
+
+        val config = backend.read(listOf(booleanKey)).first()
+
+        assertThat(config[booleanKey]).isEqualTo(true)
+    }
+
+    @Test
+    fun `update should modify config`() = runTest {
+        val backend = TestConfigBackend()
+
+        backend.update(listOf(intKey)) { config ->
+            val newConfig = config.copy()
+            newConfig[intKey] = 42
+            newConfig
+        }
+
+        val config = backend.read(listOf(intKey)).first()
+        assertThat(config[intKey]).isEqualTo(42)
+    }
+
+    @Test
+    fun `clear should reset config`() = runTest {
+        val initialConfig = Config().apply {
+            set(stringKey, "value")
+        }
+        val backend = TestConfigBackend(initialConfig)
+
+        backend.clear()
+
+        val config = backend.read(listOf(stringKey)).first()
+        assertThat(config[stringKey]).isNull()
+    }
+
+    @Test
+    fun `readVersion should return 0 by default`() = runTest {
+        val backend = TestConfigBackend()
+
+        val version = backend.readVersion("version_key")
+
+        assertThat(version).isEqualTo(0)
+    }
+
+    @Test
+    fun `writeVersion should update version`() = runTest {
+        val backend = TestConfigBackend()
+
+        backend.writeVersion("version_key", 5)
+
+        val version = backend.readVersion("version_key")
+        assertThat(version).isEqualTo(5)
+    }
+
+    @Test
+    fun `removeKeys should remove specified keys`() = runTest {
+        val initialConfig = Config().apply {
+            set(booleanKey, true)
+            set(intKey, 42)
+        }
+        val backend = TestConfigBackend(initialConfig)
+
+        backend.removeKeys(setOf(booleanKey))
+
+        val config = backend.read(listOf(booleanKey, intKey)).first()
+        assertThat(config[booleanKey]).isNull()
+        assertThat(config[intKey]).isEqualTo(42)
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -161,6 +161,7 @@ include(
     ":core:common",
     ":core:configstore:api",
     ":core:configstore:impl-backend",
+    ":core:configstore:testing",
     ":core:featureflag",
     ":core:logging:api",
     ":core:logging:config",


### PR DESCRIPTION
Part of #10364 

This resolves an issue with not comparable config keys and adds a `TestConfigBackend` to ease test setups.
