### PR TITLE
fix: don't warn 'Sent folder not found' if 'Upload sent messages to Sent folder' is off

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -622,7 +622,7 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
     }
 
     private void triggerIfNeededSentFolderNotFoundInAppNotification() {
-        if (account != null && account.getSentFolderId() == null) {
+        if (account != null && account.isUploadSentMessages() && !account.hasSentFolder()) {
             final SentFolderNotFoundNotification notification = NotificationFactoryCoroutineCompat.create(
                 continuation -> SentFolderNotFoundNotification(account.getUuid(), continuation)
             );
@@ -875,7 +875,8 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
             return;
         }
 
-        if (!ignoreSentFolderNotAssigned && !account.hasSentFolder()) {
+        if (account.isUploadSentMessages()
+            && !ignoreSentFolderNotAssigned && !account.hasSentFolder()) {
             sentFolderNotFoundDialogFragmentFactory.show(account.getUuid(), getSupportFragmentManager());
             return;
         }


### PR DESCRIPTION
Fixes #10420 


**Behaviour**:
- Upload sent messages to Sent folder -> off
Sent folder -> None

https://github.com/user-attachments/assets/9edf6ed6-bf1e-4c96-b744-d7b792c32263



- Upload sent messages to Sent folder -> on
Sent folder -> None

https://github.com/user-attachments/assets/43647ee2-a075-4069-a443-26917a4548e3

