### PR TITLE
refactor(message-list): move LocalDeleteOperationDecider to feature module

### DIFF
--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/LocalDeleteOperationDecider.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/LocalDeleteOperationDecider.kt
@@ -1,0 +1,20 @@
+package net.thunderbird.feature.mail.message.list
+
+import net.thunderbird.core.android.account.LegacyAccountDto
+
+/**
+ * Decides whether deleting a message in the app moves it to the trash folder or deletes it immediately.
+ *
+ * Note: This only applies to local messages. What remote operation is performed when deleting a message is controlled
+ * by [LegacyAccountDto.deletePolicy].
+ */
+interface LocalDeleteOperationDecider {
+    /**
+     * Returns `true` if messages in the given folder should be deleted immediately
+     * rather than moved to the trash folder.
+     *
+     * @param account The account the message belongs to.
+     * @param folderId The ID of the folder the message is being deleted from.
+     */
+    fun isDeleteImmediately(account: LegacyAccountDto, folderId: Long): Boolean
+}

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/DefaultLocalDeleteOperationDecider.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/DefaultLocalDeleteOperationDecider.kt
@@ -1,15 +1,13 @@
-package com.fsck.k9.controller
+package net.thunderbird.feature.mail.message.list.internal
 
 import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.feature.mail.message.list.LocalDeleteOperationDecider
 
-/**
- * Decides whether deleting a message in the app moves it to the trash folder or deletes it immediately.
- *
- * Note: This only applies to local messages. What remote operation is performed when deleting a message is controlled
- * by [LegacyAccountDto.deletePolicy].
- */
-internal class LocalDeleteOperationDecider {
-    fun isDeleteImmediately(account: LegacyAccountDto, folderId: Long): Boolean {
+class DefaultLocalDeleteOperationDecider : LocalDeleteOperationDecider {
+    override fun isDeleteImmediately(
+        account: LegacyAccountDto,
+        folderId: Long,
+    ): Boolean {
         // If there's no trash folder configured, all messages are deleted immediately.
         if (!account.hasTrashFolder()) {
             return true

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/FeatureMessageListModule.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/FeatureMessageListModule.kt
@@ -2,6 +2,7 @@ package net.thunderbird.feature.mail.message.list.internal
 
 import net.thunderbird.core.common.inject.factoryListOf
 import net.thunderbird.core.common.inject.getList
+import net.thunderbird.feature.mail.message.list.LocalDeleteOperationDecider
 import net.thunderbird.feature.mail.message.list.domain.DomainContract
 import net.thunderbird.feature.mail.message.list.internal.domain.usecase.BuildSwipeActions
 import net.thunderbird.feature.mail.message.list.internal.domain.usecase.CreateArchiveFolder
@@ -117,4 +118,5 @@ val featureMessageListModule = module {
             stateSideEffectHandlersFactories = getList { parameters },
         )
     }
+    single<LocalDeleteOperationDecider> { DefaultLocalDeleteOperationDecider() }
 }

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/LocalDeleteOperationDeciderTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/LocalDeleteOperationDeciderTest.kt
@@ -1,4 +1,4 @@
-package com.fsck.k9.controller
+package net.thunderbird.feature.mail.message.list.internal
 
 import assertk.assertThat
 import assertk.assertions.isFalse
@@ -8,7 +8,7 @@ import kotlin.test.Test
 import net.thunderbird.core.android.account.LegacyAccountDto
 
 class LocalDeleteOperationDeciderTest {
-    private val localDeleteOperationDecider = LocalDeleteOperationDecider()
+    private val localDeleteOperationDecider = DefaultLocalDeleteOperationDecider()
     private val account = LegacyAccountDto(UUID.randomUUID().toString()).apply {
         spamFolderId = SPAM_FOLDER_ID
         trashFolderId = TRASH_FOLDER_ID

--- a/legacy/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/KoinModule.kt
@@ -14,6 +14,7 @@ import com.fsck.k9.notification.NotificationStrategy
 import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.mail.folder.api.OutboxFolderManager
+import net.thunderbird.feature.mail.message.list.LocalDeleteOperationDecider
 import net.thunderbird.feature.notification.api.NotificationManager
 import org.koin.core.qualifier.named
 import org.koin.dsl.binds
@@ -57,6 +58,4 @@ val controllerModule = module {
             outboxFolderManager = get(),
         )
     }
-
-    single { LocalDeleteOperationDecider() }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -88,6 +88,7 @@ import net.thunderbird.core.featureflag.FeatureFlagProvider;
 import net.thunderbird.core.featureflag.compat.FeatureFlagProviderCompat;
 import net.thunderbird.core.logging.Logger;
 import net.thunderbird.core.logging.legacy.Log;
+import net.thunderbird.feature.mail.message.list.LocalDeleteOperationDecider;
 import net.thunderbird.feature.mail.folder.api.OutboxFolderManager;
 import net.thunderbird.feature.mail.folder.api.OutboxFolderManagerKt;
 import net.thunderbird.feature.notification.api.NotificationManager;

--- a/legacy/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
+++ b/legacy/core/src/test/java/com/fsck/k9/controller/MessagingControllerTest.java
@@ -39,10 +39,12 @@ import com.fsck.k9.notification.NotificationStrategy;
 import net.thunderbird.core.common.mail.Protocols;
 import net.thunderbird.core.logging.Logger;
 import net.thunderbird.core.outcome.Outcome;
+import net.thunderbird.feature.mail.message.list.LocalDeleteOperationDecider;
 import net.thunderbird.feature.mail.folder.api.OutboxFolderManager;
 import net.thunderbird.feature.notification.api.NotificationManager;
 import net.thunderbird.feature.notification.testing.fake.FakeInAppOnlyNotification;
 import net.thunderbird.feature.notification.testing.fake.FakeNotificationManager;
+import net.thunderbird.legacy.core.StubLocalDeleteOperationDecider;
 import net.thunderbird.legacy.core.mailstore.folder.FakeOutboxFolderManager;
 import org.junit.After;
 import org.junit.Before;
@@ -131,6 +133,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
         appContext = RuntimeEnvironment.getApplication();
 
         preferences = Preferences.getPreferences();
+        final LocalDeleteOperationDecider noOpLocalDeleteOperationDecider = new StubLocalDeleteOperationDecider();
         featureFlagProvider = key -> Disabled.INSTANCE;
 
         final NotificationManager notificationManager = new FakeNotificationManager(
@@ -151,7 +154,7 @@ public class MessagingControllerTest extends K9RobolectricTest {
             messageStoreManager,
             saveMessageDataCreator,
             specialLocalFoldersCreator,
-            new LocalDeleteOperationDecider(),
+            noOpLocalDeleteOperationDecider,
             Collections.<ControllerExtension>emptyList(),
             featureFlagProvider,
             syncLogger,

--- a/legacy/core/src/test/java/net/thunderbird/legacy/core/StubLocalDeleteOperationDecider.kt
+++ b/legacy/core/src/test/java/net/thunderbird/legacy/core/StubLocalDeleteOperationDecider.kt
@@ -1,0 +1,14 @@
+package net.thunderbird.legacy.core
+
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.feature.mail.message.list.LocalDeleteOperationDecider
+
+/**
+ * A [LocalDeleteOperationDecider] that always returns false.
+ */
+class StubLocalDeleteOperationDecider : LocalDeleteOperationDecider {
+    override fun isDeleteImmediately(
+        account: LegacyAccountDto,
+        folderId: Long,
+    ): Boolean = false
+}


### PR DESCRIPTION
  ## Summary
  - Extract `LocalDeleteOperationDecider` interface into `:feature:mail:message:list:api`
  - Move implementation as `DefaultLocalDeleteOperationDecider` to `:feature:mail:message:list:internal`
  - Wire DI through `FeatureMessageListModule` instead of `controllerModule`
  - Move tests to internal module, add `StubLocalDeleteOperationDecider` for `MessagingControllerTest`

Closes #10515