### PR TITLE
Enable edge-to-edge message list with navigation bar scrim behavior

### DIFF
--- a/core/ui/legacy/theme2/common/src/main/res/values/themes.xml
+++ b/core/ui/legacy/theme2/common/src/main/res/values/themes.xml
@@ -11,6 +11,9 @@
         <!-- Draw action mode above content -->
         <item name="windowActionModeOverlay">true</item>
 
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightNavigationBar">true</item>
+
         <item name="textAppearanceDisplayLarge">@style/TextAppearance.Material3.DisplayLarge</item>
         <item name="textAppearanceDisplayMedium">@style/TextAppearance.Material3.DisplayMedium</item>
         <item name="textAppearanceDisplaySmall">@style/TextAppearance.Material3.DisplaySmall</item>
@@ -35,6 +38,9 @@
     <style name="Theme2.Main.Dark.Common" parent="Theme2.Main.Dark.Base">
         <!-- Draw action mode above content -->
         <item name="windowActionModeOverlay">true</item>
+
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:windowLightNavigationBar">false</item>
 
         <item name="textAppearanceDisplayLarge">@style/TextAppearance.Material3.DisplayLarge</item>
         <item name="textAppearanceDisplayMedium">@style/TextAppearance.Material3.DisplayMedium</item>

--- a/legacy/ui/base/src/main/java/com/fsck/k9/ui/base/BaseActivity.kt
+++ b/legacy/ui/base/src/main/java/com/fsck/k9/ui/base/BaseActivity.kt
@@ -52,7 +52,9 @@ abstract class BaseActivity(
         enableEdgeToEdge()
 
         WindowCompat.getInsetsController(window, window.decorView).apply {
-            isAppearanceLightStatusBars = themeManager.appTheme == Theme.LIGHT
+            val isLightTheme = themeManager.appTheme == Theme.LIGHT
+            isAppearanceLightStatusBars = isLightTheme
+            isAppearanceLightNavigationBars = isLightTheme
         }
 
         super.onCreate(savedInstanceState)
@@ -87,6 +89,14 @@ abstract class BaseActivity(
 
     private fun initializePushController() {
         pushController.init()
+    }
+
+    protected open fun getContentContainerBottomInset(systemBarsBottom: Int, imeBottom: Int): Int {
+        return max(systemBarsBottom, imeBottom)
+    }
+
+    protected open fun shouldConsumeRootInsets(): Boolean {
+        return true
     }
 
     /**
@@ -131,10 +141,13 @@ abstract class BaseActivity(
             contentContainer.updatePadding(
                 left = insets.left,
                 right = insets.right,
-                bottom = max(insets.bottom, imeInsets.bottom),
+                bottom = getContentContainerBottomInset(
+                    systemBarsBottom = insets.bottom,
+                    imeBottom = imeInsets.bottom,
+                ),
             )
 
-            WindowInsetsCompat.CONSUMED
+            if (shouldConsumeRootInsets()) WindowInsetsCompat.CONSUMED else windowInsets
         }
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeActivity.kt
@@ -152,6 +152,14 @@ open class MessageHomeActivity :
     private val isShowAccountIndicator: Boolean
         get() = messageListFragment?.isShowAccountIndicator ?: true
 
+    override fun getContentContainerBottomInset(systemBarsBottom: Int, imeBottom: Int): Int {
+        return imeBottom
+    }
+
+    override fun shouldConsumeRootInsets(): Boolean {
+        return false
+    }
+
     @Suppress("ReturnCount")
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -27,6 +27,9 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.core.view.MenuHost
 import androidx.core.view.MenuProvider
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat.Type.systemBars
+import androidx.core.view.updatePadding
 import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.setFragmentResultListener
@@ -221,6 +224,16 @@ class MessageViewFragment :
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+
+        val initialBottomPadding = view.paddingBottom
+        ViewCompat.setOnApplyWindowInsetsListener(view) { insetView, windowInsets ->
+            val insets = windowInsets.getInsets(systemBars())
+
+            insetView.updatePadding(bottom = initialBottomPadding + insets.bottom)
+
+            windowInsets
+        }
+        ViewCompat.requestApplyInsets(view)
 
         val menuHost: MenuHost = requireActivity()
         menuHost.addMenuProvider(

--- a/legacy/ui/legacy/src/main/res/layout/message_list_fragment.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list_fragment.xml
@@ -55,6 +55,17 @@
 
     </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
 
+    <View
+        android:id="@+id/message_list_navigation_bar_scrim"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_gravity="bottom"
+        android:background="?attr/colorSurface"
+        android:importantForAccessibility="no"
+        android:clickable="false"
+        android:focusable="false"
+        />
+
 
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
This PR adds edge-to-edge rendering for the message list with a transparent system navigation bar and a bottom scrim behavior adapted to the active navigation mode.

## Changes
- Updated shared Theme2 light/dark themes:
  - `android:navigationBarColor` is transparent
  - `android:windowLightNavigationBar` is set per theme
- Updated `BaseActivity`:
  - Configures both `isAppearanceLightStatusBars` and `isAppearanceLightNavigationBars`
  - Adds protected inset extension points:
    - `getContentContainerBottomInset(systemBarsBottom, imeBottom)`
    - `shouldConsumeRootInsets()`
- Updated `MessageHomeActivity`:
  - Uses `imeBottom` for content bottom inset
  - Returns root insets to child views (`shouldConsumeRootInsets() = false`)
- Updated message list layout:
  - Added `@id/message_list_navigation_bar_scrim` as a bottom overlay scrim
- Updated `BaseMessageListFragment`:
  - Applies dynamic system-bar padding to the `RecyclerView` (left/right/bottom)
  - Sizes/positions the bottom scrim from navigation bar insets
  - Detects navigation mode from `WindowInsets`
  - Gesture navigation: scrim is visible by default, hides on scroll down, reappears on scroll up and at top
  - 3-button navigation: scrim remains visible at all times (opaque bottom area)
  - FAB insets handling uses a single `WindowInsets` listener with consistent system-bar-aware margins
- Updated `MessageViewFragment`:
  - Applies dynamic bottom padding from system bar insets to prevent overlap of bottom actions/content


## Manual Validation
- Light theme: transparent nav bar with readable dark nav icons
- Dark theme: transparent nav bar with readable light nav icons
- Gesture navigation:
  - List content scrolls under the bottom system area
  - Scrim visibility follows scroll direction
  - Last list item remains reachable
- 3-button navigation:
  - Bottom area remains opaque at all times
  - No transparency effect while scrolling
  - FAB remains correctly positioned relative to nav controls
- Message view:
  - Bottom actions/content are not obscured by the navigation area
