### PR TITLE
fix(build): VersioningPlugin failing on clean build

### DIFF
--- a/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/app/versioning/PrintVersionInfoTask.kt
+++ b/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/app/versioning/PrintVersionInfoTask.kt
@@ -1,22 +1,29 @@
 package net.thunderbird.gradle.plugin.app.versioning
 
 import org.gradle.api.DefaultTask
+import org.gradle.api.file.ConfigurableFileCollection
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputFile
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+import javax.xml.xpath.XPathConstants
+import javax.xml.xpath.XPathFactory
 
 abstract class PrintVersionInfoTask : DefaultTask() {
     @get:Input
     abstract val applicationId: Property<String>
 
-    @get:Input
-    abstract val applicationLabel: Property<String>
+    @get:InputFile
+    abstract val mergedManifest: RegularFileProperty
+
+    @get:InputFiles
+    abstract val resourceFiles: ConfigurableFileCollection
 
     @get:Input
     abstract val versionCode: Property<Int>
@@ -31,20 +38,16 @@ abstract class PrintVersionInfoTask : DefaultTask() {
     @get:Optional
     abstract val outputFile: RegularFileProperty
 
-    @get:InputFiles
-    @get:Optional
-    @get:PathSensitive(PathSensitivity.RELATIVE)
-    abstract val stringsXmlFile: RegularFileProperty
-
     init {
         outputs.upToDateWhen { false } // This forces Gradle to always re-run the task
     }
 
     @TaskAction
     fun printVersionInfo() {
+        val label = getApplicationLabel()
         val output = """
             APPLICATION_ID=${applicationId.get()}
-            APPLICATION_LABEL=${applicationLabel.get()}
+            APPLICATION_LABEL=$label
             VERSION_CODE=${versionCode.get()}
             VERSION_NAME=${versionName.get()}
             VERSION_NAME_SUFFIX=${versionNameSuffix.get()}
@@ -56,5 +59,50 @@ abstract class PrintVersionInfoTask : DefaultTask() {
         if (outputFile.isPresent) {
             outputFile.get().asFile.writeText(output + "\n")
         }
+    }
+
+    private fun getApplicationLabel(): String {
+        val manifestFile = mergedManifest.get().asFile
+        if (!manifestFile.exists()) return "Unknown"
+
+        val labelRaw = readManifestApplicationLabel(manifestFile) ?: return "Unknown"
+
+        // Return raw label if not a resource string
+        val match = STRING_RESOURCE_REGEX.matchEntire(labelRaw.trim()) ?: return labelRaw
+        val resourceName = match.groupValues[1]
+
+        val resolvedApplicationLabel = resourceFiles
+            .map { it }
+            .mapNotNull { dir -> File(dir, "values/strings.xml").takeIf { it.exists() } }
+            .firstNotNullOfOrNull { stringResourceFile -> readStringResource(stringResourceFile, resourceName) }
+
+        return resolvedApplicationLabel ?: "Unknown"
+    }
+
+    private fun readManifestApplicationLabel(manifest: File): String? {
+        val document = DocumentBuilderFactory.newInstance()
+            .apply { isNamespaceAware = true }
+            .newDocumentBuilder()
+            .parse(manifest)
+
+        val apps = document.getElementsByTagName("application")
+        if (apps.length == 0) return null
+
+        val appElement = apps.item(0)
+        return appElement.attributes?.getNamedItemNS("http://schemas.android.com/apk/res/android", "label")?.nodeValue
+            ?: appElement.attributes?.getNamedItem("android:label")?.nodeValue
+            ?: appElement.attributes?.getNamedItem("label")?.nodeValue
+    }
+
+    private fun readStringResource(stringResourceFile: File, resourceName: String): String? {
+        val xmlDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stringResourceFile)
+        val xPath = XPathFactory.newInstance().newXPath()
+        val expression = "/resources/string[@name='$resourceName']/text()"
+        val value = xPath.evaluate(expression, xmlDocument, XPathConstants.STRING) as String
+        return value.trim().takeIf { it.isNotEmpty() }
+    }
+
+    private companion object {
+        val STRING_RESOURCE_REGEX = "^@string/([A-Za-z0-9_]+)$".toRegex()
     }
 }

--- a/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/app/versioning/VersioningPlugin.kt
+++ b/build-plugin/plugin/src/main/kotlin/net/thunderbird/gradle/plugin/app/versioning/VersioningPlugin.kt
@@ -4,11 +4,7 @@ import com.android.build.api.artifact.SingleArtifact
 import com.android.build.gradle.internal.dsl.BaseAppModuleExtension
 import com.android.build.api.variant.ApplicationAndroidComponentsExtension
 import com.android.build.api.variant.ApplicationVariant
-import com.android.build.api.variant.Variant
 import java.io.File
-import javax.xml.parsers.DocumentBuilderFactory
-import javax.xml.xpath.XPathConstants
-import javax.xml.xpath.XPathFactory
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.provider.Provider
@@ -37,7 +33,8 @@ class VersioningPlugin : Plugin<Project> {
                     val versionInfoProvider = getVersionInfo(variant)
 
                     applicationId = variant.applicationId
-                    applicationLabel = getApplicationLabel(variant)
+                    mergedManifest = variant.artifacts.get(SingleArtifact.MERGED_MANIFEST)
+                    resourceFiles.from(variant.sources.res?.all)
                     versionCode = versionInfoProvider.map { it.versionCode }
                     versionName = versionInfoProvider.map { it.versionName }
                     versionNameSuffix = versionInfoProvider.map { it.versionNameSuffix }
@@ -73,59 +70,8 @@ class VersioningPlugin : Plugin<Project> {
         }
     }
 
-    private fun Project.getApplicationLabel(variant: Variant): Provider<String> {
-        val mergedManifest = variant.artifacts.get(SingleArtifact.MERGED_MANIFEST)
-
-        return providers.zip(mergedManifest, provider { variant }) { mergedManifest, _ ->
-            val labelRaw = readManifestApplicationLabel(mergedManifest.asFile) ?: return@zip "Unknown"
-
-            // Return raw label if not a resource string
-            val match = STRING_RESOURCE_REGEX.matchEntire(labelRaw.trim()) ?: return@zip labelRaw
-            val resourceName = match.groupValues[1]
-
-            val resourceDirs = variant.sources.res?.all?.get()?.filter { it.isNotEmpty() }?.flatten() ?: emptyList()
-
-            val resolvedApplicationLabel = resourceDirs
-                .map { it.asFile }
-                .mapNotNull { dir -> File(dir, "values/strings.xml").takeIf { it.exists() } }
-                .firstNotNullOfOrNull { stringResourceFile -> readStringResource(stringResourceFile, resourceName) }
-
-            resolvedApplicationLabel ?: "Unknown"
-        }
-    }
-
-    private fun readManifestApplicationLabel(manifest: File): String? {
-        val document = DocumentBuilderFactory.newInstance()
-            .apply { isNamespaceAware = true }
-            .newDocumentBuilder()
-            .parse(manifest)
-
-        val apps = document.getElementsByTagName("application")
-        if (apps.length == 0) return null
-
-        val appElement = apps.item(0)
-        return appElement.attributes?.getNamedItemNS("http://schemas.android.com/apk/res/android", "label")?.nodeValue
-            ?: appElement.attributes?.getNamedItem("android:label")?.nodeValue
-            ?: appElement.attributes?.getNamedItem("label")?.nodeValue
-    }
-
-    /**
-     * Parses stringResourceFile to extract `<string name="resourceName">...</string>`
-     */
-    private fun readStringResource(stringResourceFile: File, resourceName: String): String? {
-        val xmlDocument = DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(stringResourceFile)
-        val xPath = XPathFactory.newInstance().newXPath()
-        val expression = "/resources/string[@name='$resourceName']/text()"
-        val value = xPath.evaluate(expression, xmlDocument, XPathConstants.STRING) as String
-        return value.trim().takeIf { it.isNotEmpty() }
-    }
-
     private fun String.capitalized() = replaceFirstChar {
         if (it.isLowerCase()) it.titlecase() else it.toString()
-    }
-
-    private companion object {
-        val STRING_RESOURCE_REGEX = "^@string/([A-Za-z0-9_]+)$".toRegex()
     }
 }
 


### PR DESCRIPTION
Resolves #10545

Fix `PrintVersionInfoTask` to retrieve application label from merged manifest and resource files instead of resolving it in the `VersioningPlugin`.