### PR TITLE
fix: find folder search view hint text cut off on smaller screens

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/choosefolder/ChooseFolderActivity.kt
@@ -160,6 +160,7 @@ class ChooseFolderActivity : BaseActivity() {
     private fun configureFolderSearchView(menu: Menu) {
         val folderMenuItem = menu.findItem(R.id.filter_folders)
         val folderSearchView = folderMenuItem.actionView as SearchView
+        folderSearchView.maxWidth = Int.MAX_VALUE
         folderSearchView.queryHint = getString(R.string.folder_list_filter_hint)
         folderSearchView.setOnQueryTextListener(
             object : SearchView.OnQueryTextListener {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/managefolders/ManageFoldersFragment.kt
@@ -126,6 +126,7 @@ class ManageFoldersFragment : Fragment() {
     private fun configureFolderSearchView(menu: Menu) {
         val folderMenuItem = menu.findItem(R.id.filter_folders)
         val folderSearchView = folderMenuItem.actionView as SearchView
+        folderSearchView.maxWidth = Int.MAX_VALUE
         folderSearchView.queryHint = getString(R.string.folder_list_filter_hint)
         folderSearchView.setOnQueryTextListener(
             object : SearchView.OnQueryTextListener {


### PR DESCRIPTION
  The folder search hint text ("Folder name contains") was getting cut off on smaller screens in portrait mode. This was because the `SearchView` in `ChooseFolderActivity` and `ManageFoldersFragment` did not have `maxWidth` set to `Int.MAX_VALUE`, which was already being done for the `SearchView` in `BaseMessageListFragment`. Added the same to both folder search views so the hint text is fully visible now.

<img width="459" height="216" alt="Screenshot from 2026-02-20 20-52-45" src="https://github.com/user-attachments/assets/3572882f-9834-4b36-935b-0b63fc07b04f" />

  Fixes #10272