### PR TITLE
fix: App drawer closes upon account selection

### DIFF
--- a/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/FakeData.kt
+++ b/feature/navigation/drawer/dropdown/src/debug/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/FakeData.kt
@@ -55,6 +55,7 @@ internal object FakeData {
         unreadMessageCount = 0,
         starredMessageCount = 0,
         hasError = false,
+        hasAutoExpandFolder = false,
     )
 
     val FOLDER = Folder(
@@ -162,6 +163,7 @@ internal object FakeData {
                 unreadMessageCount = 2,
                 starredMessageCount = 0,
                 hasError = false,
+                hasAutoExpandFolder = false,
             ),
             MailDisplayAccount(
                 id = "account2",
@@ -172,6 +174,7 @@ internal object FakeData {
                 unreadMessageCount = 12,
                 starredMessageCount = 0,
                 hasError = false,
+                hasAutoExpandFolder = false,
             ),
             MailDisplayAccount(
                 id = "account3",
@@ -182,6 +185,7 @@ internal object FakeData {
                 unreadMessageCount = 0,
                 starredMessageCount = 0,
                 hasError = false,
+                hasAutoExpandFolder = false,
             ),
         )
     }

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/MailDisplayAccount.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/entity/MailDisplayAccount.kt
@@ -8,6 +8,7 @@ internal data class MailDisplayAccount(
     val email: String,
     val color: Int,
     val avatar: Avatar = Avatar.Monogram("?"),
+    val hasAutoExpandFolder: Boolean,
     override val unreadMessageCount: Int,
     override val starredMessageCount: Int,
     override val hasError: Boolean,

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayAccounts.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/domain/usecase/GetDisplayAccounts.kt
@@ -61,6 +61,7 @@ internal class GetDisplayAccounts(
                             unreadMessageCount = messageCounts.unread,
                             starredMessageCount = messageCounts.starred,
                             hasError = accountsMap[account] == true,
+                            hasAutoExpandFolder = account.autoExpandFolderId != null,
                         )
                     }
 

--- a/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
+++ b/feature/navigation/drawer/dropdown/src/main/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModel.kt
@@ -17,6 +17,7 @@ import net.thunderbird.feature.navigation.drawer.dropdown.domain.DomainContract.
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.DisplayTreeFolder
+import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayAccount
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.MailDisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.domain.entity.UnifiedDisplayFolder
 import net.thunderbird.feature.navigation.drawer.dropdown.ui.DrawerContract.Effect
@@ -219,6 +220,12 @@ internal class DrawerViewModel(
     private fun openAccount(account: DisplayAccount?) {
         if (account != null) {
             emitEffect(Effect.OpenAccount(account.id))
+            if (account is MailDisplayAccount && account.hasAutoExpandFolder) {
+                viewModelScope.launch {
+                    delay(DRAWER_CLOSE_DELAY)
+                    emitEffect(Effect.CloseDrawer)
+                }
+            }
         }
     }
 

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/DrawerViewModelTest.kt
@@ -262,6 +262,35 @@ internal class DrawerViewModelTest {
     }
 
     @Test
+    fun `should emit CloseDrawer effect after emitting OpenAccount if AutoExpandFolder is Set`() = runMviTest {
+        val displayAccounts = createDisplayAccountList(1) + createDisplayAccount(
+            id = "uuid-1",
+            hasAutoExpandFolder = true,
+        )
+        val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
+        val testSubject = createTestSubject(
+            displayAccountsFlow = getDisplayAccountsFlow,
+        )
+        val turbines = turbinesWithInitialStateCheck(
+            testSubject,
+            State(
+                accounts = displayAccounts.toImmutableList(),
+                selectedAccountId = displayAccounts.first().id,
+            ),
+        )
+        advanceUntilIdle()
+
+        testSubject.event(Event.OnAccountClick(displayAccounts[1]))
+
+        assertThat(turbines.awaitEffectItem()).isEqualTo(
+            Effect.OpenAccount(displayAccounts[1].id),
+        )
+        turbines.assertThatAndEffectTurbineConsumed {
+            isEqualTo(Effect.CloseDrawer)
+        }
+    }
+
+    @Test
     fun `should collect display folders for selected account`() = runTest {
         val displayAccounts = createDisplayAccountList(3)
         val getDisplayAccountsFlow = MutableStateFlow(displayAccounts)
@@ -458,6 +487,7 @@ internal class DrawerViewModelTest {
         email: String = "test@example.com",
         unreadCount: Int = 0,
         starredCount: Int = 0,
+        hasAutoExpandFolder: Boolean = false,
     ): MailDisplayAccount {
         return MailDisplayAccount(
             id = id,
@@ -467,6 +497,7 @@ internal class DrawerViewModelTest {
             unreadMessageCount = unreadCount,
             starredMessageCount = starredCount,
             hasError = false,
+            hasAutoExpandFolder = hasAutoExpandFolder,
         )
     }
 

--- a/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/common/DisplayAccountUtilsTest.kt
+++ b/feature/navigation/drawer/dropdown/src/test/kotlin/net/thunderbird/feature/navigation/drawer/dropdown/ui/common/DisplayAccountUtilsTest.kt
@@ -38,6 +38,7 @@ class DisplayAccountUtilsTest {
             unreadMessageCount = 5,
             starredMessageCount = 1,
             hasError = false,
+            hasAutoExpandFolder = false,
         )
 
         // Act

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeActivity.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageHomeActivity.kt
@@ -756,7 +756,12 @@ open class MessageHomeActivity :
             val search = LocalMessageSearch()
             search.addAllowedFolder(folderId)
             search.addAccountUuid(account.uuid)
-            actionDisplaySearch(this, search, noThreading = false, newTask = false)
+            if (folderId == account.autoExpandFolderId) {
+                performSearch(search)
+            } else {
+                actionDisplaySearch(this, search, noThreading = false, newTask = false)
+                initializeFolderDrawer()
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #10120 

Behaviour: 

**Bin** is set as AutoExpandFolder for both accounts

https://github.com/user-attachments/assets/c5b84f84-4640-48dc-b56a-bce9d9c971d8

