### PR TITLE
Remove Java toolchain vendor

### DIFF
--- a/quality/konsist/build.gradle.kts
+++ b/quality/konsist/build.gradle.kts
@@ -5,7 +5,6 @@ plugins {
 kotlin {
     jvmToolchain {
         languageVersion = JavaLanguageVersion.of(11)
-        vendor = JvmVendorSpec.ADOPTIUM
     }
 }
 


### PR DESCRIPTION
Fixes running on x64 macOS:

```
* What went wrong:
Could not resolve all dependencies for configuration ':quality:konsist:compileClasspath'.
Failed to calculate the value of task ':quality:konsist:compileJava' property 'javaCompiler'.
Cannot find a Java installation on your machine (Mac OS X 26.2 x86_64) matching: {languageVersion=11, vendor=Eclipse Temurin, implementation=vendor-specific, nativeImageCapable=false}. Some toolchain resolvers had internal failures: foojay (Cannot determine architecture from kernel architecture name '13th Gen Intel(R) Core(TM) i5-13600KF'.).

* Exception is:
com.intellij.openapi.externalSystem.model.ExternalSystemException: Could not resolve all dependencies for configuration ':quality:konsist:compileClasspath'.
Failed to calculate the value of task ':quality:konsist:compileJava' property 'javaCompiler'.
Cannot find a Java installation on your machine (Mac OS X 26.2 x86_64) matching: {languageVersion=11, vendor=Eclipse Temurin, implementation=vendor-specific, nativeImageCapable=false}. Some toolchain resolvers had internal failures: foojay (Cannot determine architecture from kernel architecture name '13th Gen Intel(R) Core(TM) i5-13600KF'.).
	at com.intellij.gradle.toolingExtension.impl.modelAction.GradleModelFetchAction.executeAction(GradleModelFetchAction.java:234)
	at com.intellij.gradle.toolingExtension.impl.modelAction.GradleModelFetchAction.lambda$doExecute$5(GradleModelFetchAction.java:125)
	at com.intellij.gradle.toolingExtension.impl.telemetry.GradleOpenTelemetry.lambda$runWithSpan$1(GradleOpenTelemetry.java:37)
	at com.intellij.gradle.toolingExtension.impl.telemetry.GradleOpenTelemetry.callWithSpan(GradleOpenTelemetry.java:55)
	at com.intellij.gradle.toolingExtension.impl.telemetry.GradleOpenTelemetry.callWithSpan(GradleOpenTelemetry.java:31)
	at com.intellij.gradle.toolingExtension.impl.telemetry.GradleOpenTelemetry.runWithSpan(GradleOpenTelemetry.java:36)
	at com.intellij.gradle.toolingExtension.impl.modelAction.GradleModelFetchAction.doExecute(GradleModelFetchAction.java:124)
	at com.intellij.gradle.toolingExtension.impl.modelAction.GradleModelFetchAction.lambda$execute$1(GradleModelFetchAction.java:103)
	at com.intellij.gradle.toolingExtension.impl.telemetry.GradleOpenTelemetry.callWithSpan(GradleOpenTelemetry.java:55)
	at com.intellij.gradle.toolingExtension.impl.telemetry.GradleOpenTelemetry.callWithSpan(GradleOpenTelemetry.java:31)
	at com.intellij.gradle.toolingExtension.impl.modelAction.GradleModelFetchAction.lambda$execute$2(GradleModelFetchAction.java:102)
	at com.intellij.gradle.toolingExtension.impl.modelAction.GradleModelFetchAction.withOpenTelemetry(GradleModelFetchAction.java:291)
	at com.intellij.gradle.toolingExtension.impl.modelAction.GradleModelFetchAction.lambda$execute$3(GradleModelFetchAction.java:101)
	at com.intellij.gradle.toolingExtension.impl.util.GradleExecutorServiceUtil.withSingleThreadExecutor(GradleExecutorServiceUtil.java:18)
	at com.intellij.gradle.toolingExtension.impl.modelAction.GradleModelFetchAction.execute(GradleModelFetchAction.java:100)
	at com.intellij.gradle.toolingExtension.impl.modelAction.GradleModelFetchAction.execute(GradleModelFetchAction.java:34)
```
