### PR TITLE
Use fixed width font for composing as well (new messages and replies)

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -22,6 +22,7 @@ import android.content.Intent;
 import android.content.IntentSender;
 import android.content.IntentSender.SendIntentException;
 import android.content.pm.ActivityInfo;
+import android.graphics.Typeface;
 import android.content.pm.PackageManager;
 import android.net.Uri;
 import android.os.AsyncTask;
@@ -543,6 +544,8 @@ public class MessageCompose extends BaseActivity implements OnClickListener,
         recipientMvpView.setFontSizes(K9.getFontSizes(), fontSize);
         quotedMessageMvpView.setFontSizes(K9.getFontSizes(), fontSize);
         K9.getFontSizes().setViewTextSize(subjectView, fontSize);
+        if(generalSettingsManager.getConfig().getDisplay().getVisualSettings().isUseMessageViewFixedWidthFont())
+            messageContentView.setTypeface(Typeface.MONOSPACE);
         K9.getFontSizes().setViewTextSize(messageContentView, fontSize);
         K9.getFontSizes().setViewTextSize(signatureView, fontSize);
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessageMvpView.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/compose/QuotedMessageMvpView.java
@@ -7,6 +7,7 @@ import android.view.View.OnClickListener;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.EditText;
+import android.graphics.Typeface;
 
 import app.k9mail.legacy.di.DI;
 import com.fsck.k9.FontSizes;
@@ -21,11 +22,13 @@ import com.fsck.k9.ui.helper.DisplayHtmlUiFactory;
 import com.fsck.k9.view.MessageWebView;
 import com.fsck.k9.view.WebViewConfigProvider;
 import com.google.android.material.button.MaterialButton;
+import net.thunderbird.core.preference.GeneralSettingsManager;
 
 
 public class QuotedMessageMvpView {
     private final DisplayHtml displayHtml = DI.get(DisplayHtmlUiFactory.class).createForMessageCompose();
     private final WebViewConfigProvider webViewConfigProvider = DI.get(WebViewConfigProvider.class);
+    private final GeneralSettingsManager generalSettingsManager = DI.get(GeneralSettingsManager.class);
 
     private final MaterialButton mQuotedTextShow;
     private final View mQuotedTextBar;
@@ -42,6 +45,8 @@ public class QuotedMessageMvpView {
         mQuotedTextEdit = messageCompose.findViewById(R.id.quoted_text_edit);
         mQuotedTextDelete = messageCompose.findViewById(R.id.quoted_text_delete);
         mQuotedText = messageCompose.findViewById(R.id.quoted_text);
+        if(generalSettingsManager.getConfig().getDisplay().getVisualSettings().isUseMessageViewFixedWidthFont())
+            mQuotedText.setTypeface(Typeface.MONOSPACE);
         mQuotedText.getInputExtras(true).putBoolean("allowEmoji", true);
 
         mQuotedHTML = messageCompose.findViewById(R.id.quoted_html);


### PR DESCRIPTION
This pull request makes thunderbird use a fixed width font for composing a well (both new message and reply), if user has chosen a fixed width font for viewing.

_Fixes #907_ , at least partly (re-uses fixed-width option for viewing, rather than create a new one. Creating a new setting seems to not work in Thunderbird currently, that new setting won't be remembered)

This aligns Thunderbird on Android's behavior more with Android on desktop's behavior where composition can use a fixed width font since long ago.
