### PR TITLE
fix #10494: correct storage key mapping in loadConfig() for interacti…

### DIFF
--- a/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/DefaultInteractionSettingsPreferenceManager.kt
+++ b/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/interaction/DefaultInteractionSettingsPreferenceManager.kt
@@ -63,16 +63,16 @@ class DefaultInteractionSettingsPreferenceManager(
         ),
         isConfirmDelete = storage.getBoolean(KEY_CONFIRM_DELETE, INTERACTION_SETTINGS_DEFAULT_CONFIRM_DELETE),
         isConfirmDeleteStarred = storage.getBoolean(
-            KEY_CONFIRM_DISCARD_MESSAGE,
+            KEY_CONFIRM_DELETE_STARRED,
             INTERACTION_SETTINGS_DEFAULT_CONFIRM_DELETE_STARRED,
         ),
         isConfirmDeleteFromNotification = storage.getBoolean(
-            KEY_CONFIRM_DELETE_STARRED,
+            KEY_CONFIRM_DELETE_FROM_NOTIFICATION,
             INTERACTION_SETTINGS_DEFAULT_CONFIRM_DELETE_FROM_NOTIFICATION,
         ),
         isConfirmSpam = storage.getBoolean(KEY_CONFIRM_SPAM, INTERACTION_SETTINGS_DEFAULT_CONFIRM_SPAM),
         isConfirmDiscardMessage = storage.getBoolean(
-            KEY_CONFIRM_DELETE_FROM_NOTIFICATION,
+            KEY_CONFIRM_DISCARD_MESSAGE,
             INTERACTION_SETTINGS_DEFAULT_CONFIRM_DISCARD_MESSAGE,
         ),
         isConfirmMarkAllRead = storage.getBoolean(


### PR DESCRIPTION
Fixes #10494

The `loadConfig()` function in `DefaultInteractionSettingsPreferenceManager` was reading from the wrong storage keys for three confirmation settings, causing them to swap values on every app restart.

Corrected the keys so `loadConfig()` matches what `writeConfig()` writes.