### PR TITLE
feat(message-list): use contact-specific colors for avatars in message list

### DIFF
--- a/legacy/ui/legacy/src/debug/kotlin/com/fsck/k9/ui/messagelist/item/MessageItemContentPreview.kt
+++ b/legacy/ui/legacy/src/debug/kotlin/com/fsck/k9/ui/messagelist/item/MessageItemContentPreview.kt
@@ -1,6 +1,8 @@
 package com.fsck.k9.ui.messagelist.item
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.tooling.preview.PreviewLightDark
 import app.k9mail.core.android.common.contact.Contact
 import app.k9mail.core.android.common.contact.ContactRepository
@@ -92,6 +94,7 @@ private val fakeMessageListItem = MessageListItem(
     messageUid = "654321",
     databaseId = 1L,
     threadRoot = 1L,
+    contactColor = Color.Magenta.toArgb(),
 )
 
 private val fakeMessageListAppearance = MessageListAppearance(

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapCreator.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/contacts/ContactLetterBitmapCreator.kt
@@ -42,7 +42,7 @@ class ContactLetterBitmapCreator(
         return bitmap
     }
 
-    private fun calcUnknownContactColor(address: Address): Int {
+    fun calcUnknownContactColor(address: Address): Int {
         if (config.hasDefaultBackgroundColor) {
             return config.defaultBackgroundColor
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/KoinModule.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/KoinModule.kt
@@ -19,6 +19,8 @@ val messageListUiModule = module {
             messageListPreferencesManager = get(),
             outboxFolderManager = get(),
             relativeDateTimeFormatter = get(),
+            featureFlagProvider = get(),
+            contactLetterBitmapCreator = get(),
         )
     }
     factory {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItem.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.ui.messagelist
 
+import androidx.annotation.ColorInt
 import app.k9mail.legacy.message.controller.MessageReference
 import com.fsck.k9.mail.Address
 import net.thunderbird.core.android.account.LegacyAccount
@@ -25,6 +26,8 @@ data class MessageListItem(
     val messageUid: String,
     val databaseId: Long,
     val threadRoot: Long,
+    @get:ColorInt
+    val contactColor: Int,
 ) {
     val messageReference: MessageReference
         get() = MessageReference(account.uuid, folderId, messageUid)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItemMapper.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListItemMapper.kt
@@ -3,6 +3,7 @@ package com.fsck.k9.ui.messagelist
 import app.k9mail.legacy.mailstore.MessageDetailsAccessor
 import app.k9mail.legacy.mailstore.MessageMapper
 import app.k9mail.legacy.message.extractors.PreviewResult.PreviewType
+import com.fsck.k9.contacts.ContactLetterBitmapCreator
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.ui.helper.DisplayAddressHelper
 import net.thunderbird.core.android.account.LegacyAccount
@@ -15,6 +16,7 @@ class MessageListItemMapper(
     private val messageListPreferencesManager: MessageListPreferencesManager,
     private val outboxFolderManager: OutboxFolderManager,
     private val formatDate: (Long) -> String,
+    private val contactLetterBitmapCreator: ContactLetterBitmapCreator?,
 ) : MessageMapper<MessageListItem> {
 
     override fun map(message: MessageDetailsAccessor): MessageListItem {
@@ -60,6 +62,9 @@ class MessageListItemMapper(
             message.messageServerId,
             message.id,
             message.threadRoot,
+            contactColor = displayAddress?.let { displayAddress ->
+                contactLetterBitmapCreator?.calcUnknownContactColor(displayAddress)
+            } ?: -1,
         )
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/MessageListLoader.kt
@@ -1,6 +1,7 @@
 package com.fsck.k9.ui.messagelist
 
 import app.k9mail.legacy.mailstore.MessageListRepository
+import com.fsck.k9.contacts.ContactLetterBitmapCreator
 import com.fsck.k9.helper.MessageHelper
 import com.fsck.k9.mailstore.LocalStoreProvider
 import com.fsck.k9.mailstore.MessageColumns
@@ -9,13 +10,16 @@ import com.fsck.k9.ui.helper.RelativeDateTimeFormatter
 import net.thunderbird.core.android.account.LegacyAccount
 import net.thunderbird.core.android.account.LegacyAccountManager
 import net.thunderbird.core.android.account.SortType
+import net.thunderbird.core.featureflag.FeatureFlagProvider
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.display.visualSettings.message.list.MessageListPreferencesManager
 import net.thunderbird.feature.mail.folder.api.OutboxFolderManager
+import net.thunderbird.feature.mail.message.list.MessageListFeatureFlags
 import net.thunderbird.feature.search.legacy.LocalMessageSearch
 import net.thunderbird.feature.search.legacy.api.MessageSearchField
 import net.thunderbird.feature.search.legacy.sql.SqlWhereClause
 
+@Suppress("LongParameterList")
 class MessageListLoader(
     private val accountManager: LegacyAccountManager,
     private val localStoreProvider: LocalStoreProvider,
@@ -24,6 +28,8 @@ class MessageListLoader(
     private val messageListPreferencesManager: MessageListPreferencesManager,
     private val outboxFolderManager: OutboxFolderManager,
     private val relativeDateTimeFormatter: RelativeDateTimeFormatter,
+    private val featureFlagProvider: FeatureFlagProvider,
+    private val contactLetterBitmapCreator: ContactLetterBitmapCreator,
 ) {
 
     fun getMessageList(config: MessageListConfig): MessageListInfo {
@@ -64,6 +70,9 @@ class MessageListLoader(
                     formatTime,
                     messageListPreferencesManager.getConfig().dateTimeFormat,
                 )
+            },
+            contactLetterBitmapCreator = contactLetterBitmapCreator.takeIf {
+                featureFlagProvider.provide(MessageListFeatureFlags.UseComposeForMessageListItems).isEnabled()
             },
         )
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/item/MessageItemContent.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/item/MessageItemContent.kt
@@ -79,6 +79,7 @@ internal fun MessageItemContent(
             avatar = {
                 if (appearance.showContactPicture) {
                     ContactImageAvatar(
+                        color = Color(item.contactColor),
                         contactImageUri = uri,
                         contactImageMonogram = monogram,
                         onAvatarClick = onAvatarClick,
@@ -108,6 +109,7 @@ internal fun MessageItemContent(
             avatar = {
                 if (appearance.showContactPicture) {
                     ContactImageAvatar(
+                        color = Color(item.contactColor),
                         contactImageUri = uri,
                         contactImageMonogram = monogram,
                         onAvatarClick = onAvatarClick,
@@ -137,6 +139,7 @@ internal fun MessageItemContent(
             avatar = {
                 if (appearance.showContactPicture) {
                     ContactImageAvatar(
+                        color = Color(item.contactColor),
                         contactImageUri = uri,
                         contactImageMonogram = monogram,
                         onAvatarClick = onAvatarClick,
@@ -160,6 +163,7 @@ internal fun MessageItemContent(
 
 @Composable
 fun ContactImageAvatar(
+    color: Color,
     contactImageUri: Uri?,
     contactImageMonogram: String,
     modifier: Modifier = Modifier,
@@ -167,11 +171,11 @@ fun ContactImageAvatar(
 ) {
     Box(
         contentAlignment = Alignment.Center,
-        modifier = Modifier
+        modifier = modifier
             .size(MainTheme.sizes.iconAvatar)
             .padding(MainTheme.spacings.half)
-            .background(color = MainTheme.colors.primaryContainer.copy(alpha = 0.15f), shape = CircleShape)
-            .border(width = 1.dp, color = MainTheme.colors.primary, shape = CircleShape)
+            .background(color = color.copy(alpha = 0.15f), shape = CircleShape)
+            .border(width = 1.dp, color = color, shape = CircleShape)
             .clickable(onClick = onAvatarClick),
     ) {
         contactImageUri?.let {
@@ -179,7 +183,7 @@ fun ContactImageAvatar(
                 url = it.toString(),
                 contentScale = ContentScale.Crop,
                 alignment = Alignment.Center,
-                modifier = modifier
+                modifier = Modifier
                     .fillMaxSize()
                     .clip(CircleShape),
                 placeholder = {

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messagelist/MessageListAdapterTest.kt
@@ -488,6 +488,7 @@ class MessageListAdapterTest : RobolectricTest() {
             messageUid,
             databaseId,
             threadRoot,
+            contactColor = -1,
         )
     }
 


### PR DESCRIPTION
Part of #10554.

This pull request introduces support for customizable contact avatar colours in the message list UI. The main changes include adding a `contactColor` field to `MessageListItem`, updating its calculation and propagation throughout the message list mapping and loading logic, and ensuring the avatar displays this colour. The feature is gated by a feature flag to allow gradual rollout.