### PR TITLE
fix: initialize beta and daily build types from release configuration

### DIFF
--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -105,6 +105,8 @@ android {
         }
 
         create("beta") {
+            initWith(getByName("release"))
+
             signingConfig = signingConfigs.getByType(SigningType.TB_BETA)
 
             applicationIdSuffix = ".beta"
@@ -125,6 +127,8 @@ android {
         }
 
         create("daily") {
+            initWith(getByName("release"))
+
             signingConfig = signingConfigs.getByType(SigningType.TB_DAILY)
 
             applicationIdSuffix = ".daily"


### PR DESCRIPTION
This resolves IDE issues when trying to resolve the TfA Daily and Beta build types.

They inherit the configuration from "release" and overwrite what needs to be different.

This helps to work on #10364 