### PR TITLE
fix(proguard): update rules to preserve enum constants and collection interfaces for Moshi

### DIFF
--- a/app-k9mail/proguard-rules.pro
+++ b/app-k9mail/proguard-rules.pro
@@ -62,3 +62,13 @@
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 
 -keep,allowshrinking class com.tokenautocomplete.TokenCompleteTextView
+
+# Moshi's EnumJsonAdapter uses Class.getField() to map JSON strings to enum constants.
+# R8's enum optimization rewrites switch statements to use ordinals, making enum fields
+# appear unused, which causes R8 to strip them. This rule preserves all enum constants
+# so Moshi can deserialize them at runtime (e.g. via PendingCommandSerializer).
+-keep class net.thunderbird.core.common.mail.Flag { *; }
+
+# Moshi uses reflection to read field types. R8 can rewrite List/Map to ArrayList/HashMap,
+# which breaks Moshi's collection interface requirement.
+-keep class com.fsck.k9.controller.MessagingControllerCommands$* { *; }

--- a/app-thunderbird/proguard-rules.pro
+++ b/app-thunderbird/proguard-rules.pro
@@ -62,3 +62,13 @@
 -dontwarn org.slf4j.impl.StaticLoggerBinder
 
 -keep,allowshrinking class com.tokenautocomplete.TokenCompleteTextView
+
+# Moshi's EnumJsonAdapter uses Class.getField() to map JSON strings to enum constants.
+# R8's enum optimization rewrites switch statements to use ordinals, making enum fields
+# appear unused, which causes R8 to strip them. This rule preserves all enum constants
+# so Moshi can deserialize them at runtime (e.g. via PendingCommandSerializer).
+-keep class net.thunderbird.core.common.mail.Flag { *; }
+
+# Moshi uses reflection to read field types. R8 can rewrite List/Map to ArrayList/HashMap,
+# which breaks Moshi's collection interface requirement.
+-keep class com.fsck.k9.controller.MessagingControllerCommands$* { *; }


### PR DESCRIPTION
Fix #10697.

This pull request updates the ProGuard rules for both the K-9 Mail and Thunderbird Android apps to ensure compatibility with Moshi's JSON serialization/deserialization, especially when using R8 optimizations. The changes prevent R8 from stripping necessary enum constants and class structures that Moshi relies on for reflective access.

## Changes

* Added a rule to keep all fields in the `net.thunderbird.core.common.mail.Flag` enum, preventing R8 from stripping enum constants required by Moshi's `EnumJsonAdapter` for JSON deserialization.
* Added a rule to keep all inner classes and fields of `com.fsck.k9.controller.MessagingControllerCommands`, ensuring Moshi can access collection types via reflection and is not broken by R8's class rewriting.

## Testing
* The test must be performed on release variants: K-9 `fossRelease`, Thunderbird `foss/fullDaily`, `foss/fullBeta`, `foss/fullRelease`
* Test both adding a new account and importing accounts on both the K-9 and Thunderbird apps.