### PR TITLE
fix(TokenCompleteTextView): handle missing generic type signature for R8/ProGuard compatibility

### DIFF
--- a/library/token-auto-complete/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
+++ b/library/token-auto-complete/src/main/java/com/tokenautocomplete/TokenCompleteTextView.java
@@ -1159,11 +1159,16 @@ public abstract class TokenCompleteTextView<T> extends AppCompatAutoCompleteText
             viewClass = viewClass.getSuperclass();
         }
 
-        // This operation is safe. Because viewClass is a direct sub-class, getGenericSuperclass() will
-        // always return the Type of this class. Because this class is parameterized, the cast is safe
-        ParameterizedType superclass = (ParameterizedType) viewClass.getGenericSuperclass();
-        Type type = superclass.getActualTypeArguments()[0];
-        return (Class)type;
+        final Type genericSuperclass = viewClass.getGenericSuperclass();
+        if (genericSuperclass instanceof ParameterizedType) {
+            final Type type = ((ParameterizedType) genericSuperclass).getActualTypeArguments()[0];
+            return (Class) type;
+        }
+
+        // R8/ProGuard can strip the generic Signature attribute, causing getGenericSuperclass()
+        // to return a raw Class instead of ParameterizedType. Fall back to Object.class so the
+        // caller takes the Serializable path instead of Parcelable.
+        return Object.class;
     }
 
     @Override


### PR DESCRIPTION
Fixes #10710.
## Description
R8 is now stripping the generic Signature attribute from some classes, which caused the `getGenericSuperclass()` to return a raw `Class` instead of the expected `ParameterizedType`.

To fix the runtime crash issue, we now check if the generic superclass is an instance of `ParameterizedType` before getting the type arguments. Otherwise, we fall back to `Object.class`, so it triggers the `Serializable` path when saving the class to the Bundle.

## Screen recording:

<video src="https://github.com/user-attachments/assets/a7773a83-db6c-492d-982e-400dc7404792" width="45%"/>

