### PR TITLE
Don't use deployments when they aren't needed

### DIFF
--- a/.github/workflows/issue-needinfo-answered.yml
+++ b/.github/workflows/issue-needinfo-answered.yml
@@ -16,7 +16,9 @@ jobs:
     if: |
       contains(github.event.issue.labels.*.name, 'status: needs information') &&
       contains(github.event.issue.labels.*.name, 'status: answered')
-    environment: botmobile
+    environment:
+      name: botmobile
+      deployment: false
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/issue-needinfo-remove.yml
+++ b/.github/workflows/issue-needinfo-remove.yml
@@ -19,7 +19,9 @@ jobs:
       github.event.comment.author_association != 'OWNER' &&
       github.event.comment.author_association != 'MEMBER' &&
       github.event.comment.author_association != 'COLLABORATOR'
-    environment: botmobile
+    environment:
+      name: botmobile
+      deployment: false
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/issue-needinfo-stale.yml
+++ b/.github/workflows/issue-needinfo-stale.yml
@@ -14,7 +14,9 @@ jobs:
   issue-needinfo-stale:
     name: Close stale needinfo issues
     runs-on: ubuntu-latest
-    environment: botmobile
+    environment:
+      name: botmobile
+      deployment: false
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/pr-auto-assign-reviewer.yml
+++ b/.github/workflows/pr-auto-assign-reviewer.yml
@@ -15,7 +15,9 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
-    environment: botmobile
+    environment:
+      name: botmobile
+      deployment: false
     steps:
       - name: App token generate
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0

--- a/.github/workflows/pr-dependabot-dependency-guard-update.yml
+++ b/.github/workflows/pr-dependabot-dependency-guard-update.yml
@@ -28,7 +28,9 @@ jobs:
   pr-update-dependency-guard:
     if: github.actor == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == 'thunderbird/thunderbird-android'
     runs-on: ubuntu-latest
-    environment: botmobile
+    environment:
+      name: botmobile
+      deployment: false
     timeout-minutes: 90
     steps:
       - name: App Token Generate

--- a/.github/workflows/pr-label-tb-team.yml
+++ b/.github/workflows/pr-label-tb-team.yml
@@ -15,7 +15,9 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
-    environment: review
+    environment:
+      name: review
+      deployment: false
     steps:
       - name: App token generate
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0

--- a/.github/workflows/pr-merged.yml
+++ b/.github/workflows/pr-merged.yml
@@ -16,7 +16,9 @@ jobs:
   pr-merged:
     if: github.event.pull_request.merged
     runs-on: ubuntu-latest
-    environment: botmobile
+    environment:
+      name: botmobile
+      deployment: false
     steps:
       - name: App token generate
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -16,7 +16,9 @@ jobs:
     permissions:
       pull-requests: write
     runs-on: ubuntu-latest
-    environment: botmobile
+    environment:
+      name: botmobile
+      deployment: false
     steps:
       - name: App token generate
         uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v3.0.0

--- a/.github/workflows/shippable_builds.yml
+++ b/.github/workflows/shippable_builds.yml
@@ -61,7 +61,9 @@ jobs:
     name: Show Release Environment
     runs-on: ubuntu-latest
     needs: get_environment
-    environment: ${{ needs.get_environment.outputs.releaseEnv }}
+    environment:
+      name: ${{ needs.get_environment.outputs.releaseEnv }}
+      deployment: false
     outputs:
       matrixInclude: ${{ steps.dump.outputs.matrixInclude }}
       releaseDate: ${{ steps.dump.outputs.releaseDate }}
@@ -157,7 +159,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [ dump_config ]
     if: ${{ needs.dump_config.outputs.releaseType == 'beta' || needs.dump_config.outputs.releaseType == 'release' }}
-    environment: notify_matrix
+    environment:
+      name: notify_matrix
+      deployment: false
     outputs:
       actorLink: ${{ steps.actorLink.outputs.actorLink }}
     steps:
@@ -192,7 +196,9 @@ jobs:
     name: Release Bumps
     runs-on: ubuntu-latest
     needs: [ dump_config, get_environment ]
-    environment: ${{ needs.get_environment.outputs.releaseEnv }}
+    environment:
+      name: ${{ needs.get_environment.outputs.releaseEnv }}
+      deployment: false
     strategy:
       max-parallel: 1
       matrix:
@@ -605,7 +611,9 @@ jobs:
     needs: [ dump_config, sign_mobile, notify_build_start ]
     if: "${{ contains(fromJSON('[\"beta\", \"release\"]'), needs.dump_config.outputs.releaseType) }}"
     runs-on: ubuntu-latest
-    environment: notify_matrix
+    environment:
+      name: notify_matrix
+      deployment: false
     steps:
       - uses: kewisch/action-matrix-notify@3c45d89acd032c84b955b54c8a9001833ac91d17 # v1
         with:
@@ -623,7 +631,9 @@ jobs:
     name: Wait for Approval
     needs: [ dump_config, sign_mobile ]
     if: "${{ contains(fromJSON('[\"beta\", \"release\"]'), needs.dump_config.outputs.releaseType) }}"
-    environment: publish_hold
+    environment:
+      name: publish_hold
+      deployment: false
     runs-on: ubuntu-latest
     steps:
       - name: Approval
@@ -999,7 +1009,9 @@ jobs:
     if: ${{ always() }}
     needs: [ dump_config, release_commit, build_unsigned, sign_mobile, publish_release, notify_build_start ]
     runs-on: ubuntu-latest
-    environment: notify_matrix
+    environment:
+      name: notify_matrix
+      deployment: false
     steps:
       - name: Get previous workflow status
         uses: Mercymeilya/last-workflow-status@3418710aefe8556d73b6f173a0564d38bcfd9a43


### PR DESCRIPTION
Avoiding deployments where not needed. I wasn't sure about shippable builds, I'm not sure we need deployments there at all since we don't use them, but since that is the once spot where we "deploy" something I left some of them as is. Please review where you need deployments.

https://github.blog/changelog/2026-03-19-github-actions-late-march-2026-updates/