### PR TITLE
Fix: raise swipe velocity threshold to prevent accidental navigation in message viewer

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewContainerFragment.kt
@@ -301,7 +301,7 @@ class MessageViewContainerFragment : Fragment() {
 
     companion object {
         private const val VIEW_PAGER_SWIPE_THRESHOLD = 0.4f
-        private const val VIEW_PAGER_SWIPE_VELOCITY_THRESHOLD = 0.8f
+        private const val VIEW_PAGER_SWIPE_VELOCITY_THRESHOLD = 3.0f
 
         private const val ARG_REFERENCE = "reference"
         private const val ARG_SHOW_ACCOUNT_INDICATOR = "showAccountIndicator"


### PR DESCRIPTION

Fixes #10747

## Summary

A single constant change in `MessageViewContainerFragment` raises the velocity threshold for
the swipe-between-messages gesture, preventing fast but unintentional gestures from navigating
to an adjacent email and marking it as read.

The distance threshold (`VIEW_PAGER_SWIPE_THRESHOLD = 0.4f`) is unchanged.

## Notes on the constant value

`3.0f` is not a final answer. The absolute dp/s value depends on the device. However, this makes accidental velocity-based swipes much harder to trigger. It does not:
- Prevent a deliberate but regretted swipe from marking an email as read
- Add a delay before mark-as-read fires
- Add any visible indicator of read state in the message viewer

Those are separate concerns that I've raised an issue about.

## Testing

- Manual: open message list, make a fast short flick left/right → should not navigate
- Manual: make a deliberate fast swipe left/right → should still navigate normally
- Manual: make a slow deliberate drag > 40% width → should still navigate normally
- Existing tests: `./gradlew :legacy:ui:legacy:test`