### PR TITLE
fix(message-reader): adds font scaling to match user preferences

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
@@ -2,11 +2,13 @@ package com.fsck.k9.view
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.content.res.Resources
 import android.os.Build
 import android.util.AttributeSet
 import android.webkit.WebView
 import com.fsck.k9.core.BuildConfig
 import com.fsck.k9.mailstore.AttachmentResolver
+import kotlin.math.roundToInt
 import net.thunderbird.core.android.common.view.showInDarkMode
 import net.thunderbird.core.android.common.view.showInLightMode
 import net.thunderbird.core.logging.legacy.Log
@@ -60,6 +62,10 @@ class MessageWebView : WebView, KoinComponent {
             overScrollMode = OVER_SCROLL_NEVER
 
             textZoom = config.textZoom
+
+            // Values range from smaller than default (1.0) to double size: 0.85, 1.0, 1.15, 1.3, 1.5, 1.8, 2.0
+            val fontScale = Resources.getSystem().configuration.fontScale
+            settings.textZoom = (settings.textZoom * fontScale).roundToInt()
         }
 
         // Disable network images by default. This is overridden by preferences.


### PR DESCRIPTION
Fixes: https://github.com/thunderbird/thunderbird-android/issues/10692 

Before:

<img width="370" height="193" alt="Screenshot 2026-03-26 at 5 39 50 PM" src="https://github.com/user-attachments/assets/409ad774-8068-4470-b3df-8ae08d9206a0" />

Notice the font size in the information header, which is based on the system font size, and how the text below it is unchanged compared to...

After: 
![tinyToHugeFontSizing](https://github.com/user-attachments/assets/acd96e8a-556e-44b1-a0b5-5c8fd995fc77)

Where the font scales with the user's settings.

Users noticed that the font size in messages did not scale with the device preferences. This is fixed by getting the current system fontScale and multiplying it by the incoming font size. This does not alter the display if the user has chosen to force messages to fit in the window by shrinking them, that option will still be respected. If they turn this off, font will scale with the system font. 