### PR TITLE
fix(message-reader): only use hardware layer for MessageWebView on Android 9+ with hardware acceleration

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
@@ -2,6 +2,7 @@ package com.fsck.k9.view
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.util.AttributeSet
 import android.webkit.WebView
 import com.fsck.k9.core.BuildConfig
@@ -35,7 +36,12 @@ class MessageWebView : WebView, KoinComponent {
 
         configureDarkLightMode(this, config)
 
-        setLayerType(LAYER_TYPE_HARDWARE, null)
+        // LAYER_TYPE_HARDWARE forces the WebView into a GPU texture.
+        // On API <= 26, BakedOpRenderer calls LOG_ALWAYS_FATAL on any GL error, aborting the process
+        // and fatally crashing the app. API 28+'s SkiaPipeline handles these errors gracefully.
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O_MR1 && isHardwareAccelerated) {
+            setLayerType(LAYER_TYPE_HARDWARE, null)
+        }
 
         with(settings) {
             setSupportZoom(true)


### PR DESCRIPTION
Fixes #10721

The crash is caused by the call to `setLayerType(LAYER_TYPE_HARDWARE, null)`. This forces the `WebView` to render into an offscreen GPU texture, which crashes when the height of the email content exceeds the GPU's maximum texture size (16,384 pixels, as noted in the logs for this issue, but not a hard cap).

```
09:50:04.500 zygote64 A java_vm_ext.cc:504] JNI DETECTED ERROR IN APPLICATION: JNI CallObjectMethod called with pending exception
java.lang.IllegalStateException: Unable to create layer for MessageWebView, size 1080x17738 exceeds max size 16384
```

While I would like to further investigate whether using `LAYER_TYPE_HARDWARE` is beneficial for our use case, this pull request will at least prevent the app from crashing.

It's important to note that while this change will stop the crashes, any message that exceeds the maximum texture size, which varies depending on the device's GPU, will still be truncated. We will track that issue in a separate bug report.