### PR TITLE
uplift(beta): fix(message-reader): only use hardware layer for MessageWebView on Android 9+ with hardware acceleration (#10759)

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
@@ -2,6 +2,7 @@ package com.fsck.k9.view
 
 import android.content.Context
 import android.content.pm.PackageManager
+import android.os.Build
 import android.util.AttributeSet
 import android.webkit.WebView
 import com.fsck.k9.core.BuildConfig
@@ -35,7 +36,12 @@ class MessageWebView : WebView, KoinComponent {
 
         configureDarkLightMode(this, config)
 
-        setLayerType(LAYER_TYPE_HARDWARE, null)
+        // LAYER_TYPE_HARDWARE forces the WebView into a GPU texture.
+        // On API <= 26, BakedOpRenderer calls LOG_ALWAYS_FATAL on any GL error, aborting the process
+        // and fatally crashing the app. API 28+'s SkiaPipeline handles these errors gracefully.
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O_MR1 && isHardwareAccelerated) {
+            setLayerType(LAYER_TYPE_HARDWARE, null)
+        }
 
         with(settings) {
             setSupportZoom(true)


### PR DESCRIPTION
Uplifts #10759 to beta