### PR TITLE
fix(message): show original sender for Firefox Relay emails

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/helper/MessageHelper.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/helper/MessageHelper.kt
@@ -153,10 +153,10 @@ class MessageHelper(
                 }
             }
             val personal = address.personal
-            return if (!personal.isNullOrEmpty() && !isSpoofAddress(personal)) {
-                personal
-            } else {
-                address.address
+            return when {
+                personal.isNullOrEmpty() -> address.address
+                isSpoofAddress(personal) -> "$personal <${address.address}>"
+                else -> personal
             }
         }
 

--- a/legacy/core/src/test/java/com/fsck/k9/helper/MessageHelperTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/helper/MessageHelperTest.kt
@@ -133,7 +133,7 @@ class MessageHelperTest : RobolectricTest() {
     }
 
     @Test
-    fun toFriendly_spoofPreventionOverridesPersonal() {
+    fun toFriendly_spoofPreventionExpandsToShowBothPersonalAndAddress() {
         val address = Address("test@testor.com", "potus@whitehouse.gov")
         val friendly =
             toFriendly(
@@ -143,7 +143,21 @@ class MessageHelperTest : RobolectricTest() {
                 messageListPreferencesManager.getConfig().contactNameColor,
                 contactRepository,
             )
-        assertThat(friendly).isEqualTo("test@testor.com")
+        assertThat(friendly).isEqualTo("potus@whitehouse.gov <test@testor.com>")
+    }
+
+    @Test
+    fun toFriendly_firefoxRelayAddressShowsOriginalSenderAndRelayAddress() {
+        val address = Address("alias123@mozmail.com", "sender@example.com [via Relay]")
+        val friendly =
+            toFriendly(
+                address,
+                messageListPreferencesManager.getConfig().isShowCorrespondentNames,
+                messageListPreferencesManager.getConfig().isChangeContactNameColor,
+                messageListPreferencesManager.getConfig().contactNameColor,
+                contactRepository,
+            )
+        assertThat(friendly).isEqualTo("sender@example.com [via Relay] <alias123@mozmail.com>")
     }
 
     @Test

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatter.kt
@@ -61,9 +61,9 @@ internal class RealMessageViewRecipientFormatter(
     }
 
     private fun buildDisplayName(address: Address): CharSequence {
-        return address.personal?.takeIf {
-            it.isNotBlank() && !it.equals(meText, ignoreCase = true) && !isSpoofAddress(it)
-        } ?: address.address
+        val personal = address.personal?.takeIf { it.isNotBlank() && !it.equals(meText, ignoreCase = true) }
+            ?: return address.address
+        return if (isSpoofAddress(personal)) "$personal <${address.address}>" else personal
     }
 
     private fun isSpoofAddress(displayName: String): Boolean {

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatterTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/ui/messageview/MessageViewRecipientFormatterTest.kt
@@ -152,7 +152,7 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
     }
 
     @Test
-    fun `do not show display name that looks like an email address`() {
+    fun `spoof prevention expands to show both display name and actual address`() {
         val recipientFormatter = createRecipientFormatter()
 
         val displayName = recipientFormatter.getDisplayName(
@@ -160,7 +160,19 @@ class MessageViewRecipientFormatterTest : RobolectricTest() {
             account,
         )
 
-        assertThat(displayName).isEqualTo("mallory@domain.example")
+        assertThat(displayName).isEqualTo("potus@whitehouse.gov <mallory@domain.example>")
+    }
+
+    @Test
+    fun `firefox relay address shows original sender and relay address`() {
+        val recipientFormatter = createRecipientFormatter()
+
+        val displayName = recipientFormatter.getDisplayName(
+            Address("alias123@mozmail.com", "sender@example.com [via Relay]"),
+            account,
+        )
+
+        assertThat(displayName).isEqualTo("sender@example.com [via Relay] <alias123@mozmail.com>")
     }
 
     @Test


### PR DESCRIPTION
When a display name contains an email address (e.g. Firefox Relay's "original@sender.com [via Relay]" format), spoof prevention was suppressing the display name entirely and showing only the relay address. This aligns with how Thunderbird Desktop handles it by expanding to show both the display name and the actual address in `"personal <address>"` format.

Fixes #7367

I don't expect this to be the final solution here. I mainly wanted to get pen to paper and start a conversation. Things that will likely come up in discussion include this change's utilization of screen real estate and the changing of existing unit tests. I also wonder if this would be better received as a setting to toggle? Could I refactor the formatting logic to eliminate duplication? Let me know your thoughts, happy to iterate.

AI Disclosure: I utilized AI to navigate to relevant portions of code when researching this issue.