### PR TITLE
Update CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,16 +10,16 @@ Violations of the Code of Conduct or the [Mozilla Community Participation Guidel
 
 ### Commenting
 
-1. **No abusing people**. Constant and intense critique is one of the reasons we build great products. It's harder to fall into group-think if there is always a healthy amount of dissent. We want to encourage vibrant debate inside of the Thunderbird community, we want you to disagree with us, and we want you to effectively argue your case. However, we require that in the process, you criticize things, not people. Examples of things include: interfaces, algorithms, and schedules. Examples of people include: developers, designers, and users. Attacking or encouraging attacks on a person may result in you being banned from this repository.
+1. **No abusing people**. Constant and intense critique is one of the reasons we build great products. It's harder to fall into group-think if there is always a healthy amount of dissent. We want to encourage vibrant debate inside of the Thunderbird community, we want you to disagree with us, and we want you to effectively argue your case. However, we require that in the process, you criticize things, not people. Examples of things include: interfaces, algorithms, and schedules. Examples of people include: developers, designers, and users. Attacking or encouraging attacks on a person may result in you being banned from this organization.
 2. **No obligation**. "Open Source" is not the same as "the developers must do my bidding." Everyone here wants to help, but no one else has any obligation to fix the bugs you want fixed. Therefore, you should not act as if you expect someone to fix a bug by a particular date or release. Aggressive or repeated demands will not be received well and will almost certainly diminish the impact of and interest in your suggestions.
-3. **No spam**. Posting comment spam will lead to the ban of your account.
+3. **No spam**. Posting comment spam will lead to the ban of your account from our organization.
 4. **No pointless comments**. Limit comments on a bug to information which will help with resolving it. Unless requested, additional "I see this too" or "It works for me" comments are unnecessary. Constructive conversations unrelated to the topic of the bug should go in the appropriate discussion forum.
 5. **No private email**. Do not send comments on bugs by private email to users; no one else can read them if you do that, and they'll be missed and/or ignored. If an attachment is too big for GitHub, add a comment giving the file size and contents and ask what to do.
 
 ### Changing Fields or labels
 
-1. **No messing with other people's bugs**. Unless you are the bug assignee, or have some say over the use of their time, never change the label fields. If in doubt, do not change the fields of bugs you do not own — add a comment instead, suggesting the change.
-2. **No whining about decisions**. If another project contributor has marked a bug as **Closed** or **Not Planned**, then it is not planned. Filing another duplicate of it does not change this. Unless you have further evidence to support reopening a bug, do not post a comment arguing that a bug resolved as **Closed** or **Not Planned** should be reopened.
+1. **No changing other people's bugs**. Unless you are the bug assignee, please never change the label fields. If you notice any inconsistencies with the labels, do not change the fields of bugs you do not own and add a comment instead, suggesting the change.
+2. **Accept decisions with grace**. If another project contributor has marked a bug as **Closed** or **Not Planned**, then it is not planned. Filing another duplicate of it does not change this. Unless you have further evidence to support reopening a bug, do not post a comment arguing that a bug resolved as **Closed** or **Not Planned** should be reopened.
 
 ## Responding to Violations
 


### PR DESCRIPTION
Update the code of conduct file to include the Bugzilla Etiquette guidelines.

https://bugzilla.mozilla.org/page.cgi?id=etiquette.html

This list is a more direct and straightforward series of guidelines specifying the basic requirements for participating to the project. This list are in addition to the CPG, and are a standard used in Bugzilla across all Mozilla projects.
