### PR TITLE
fix(message-view): Respect animation setting when displaying message body

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
@@ -73,6 +73,10 @@ class MessageTopView(
         layoutInflater = LayoutInflater.from(context)
 
         viewAnimator = findViewById(R.id.message_layout_animator)
+        if (!visualSettingsPrefManager.getConfig().isShowAnimations) {
+            viewAnimator.inAnimation = null
+            viewAnimator.outAnimation = null
+        }
         progressBar = findViewById(R.id.message_progress)
         progressText = findViewById(R.id.message_progress_text)
 


### PR DESCRIPTION
**Description:**

Disable fade-in animation when opening messages if the user has disabled animations in Thunderbird's own app settings.

The fix was written with AI, but testing, code review and commit messages were done manually.

Fixes #1903

**Testing:**

1. Go to Settings > General > Display > Use gaudy... and disable it
2. Open any email message
3. Verify the message content appears without fade-in

In most cases the message view still loads in steps and feels jumpy, but without any animation.
