### PR TITLE
feat(settings): animation setting inherits systemwide settings

### DIFF
--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/GeneralSettings.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/GeneralSettings.kt
@@ -81,3 +81,9 @@ enum class LockScreenNotificationVisibility {
     APP_NAME,
     NOTHING,
 }
+
+enum class AnimationPreference {
+    ON,
+    OFF,
+    FOLLOW_SYSTEM,
+}

--- a/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/display/visualSettings/DisplayVisualSettings.kt
+++ b/core/preference/api/src/commonMain/kotlin/net/thunderbird/core/preference/display/visualSettings/DisplayVisualSettings.kt
@@ -1,11 +1,12 @@
 package net.thunderbird.core.preference.display.visualSettings
 
+import net.thunderbird.core.preference.AnimationPreference
 import net.thunderbird.core.preference.BodyContentType
 import net.thunderbird.core.preference.display.visualSettings.message.list.DisplayMessageListSettings
 
 const val DISPLAY_SETTINGS_DEFAULT_IS_USE_MESSAGE_VIEW_FIXED_WIDTH_FONT = false
 const val DISPLAY_SETTINGS_DEFAULT_IS_AUTO_FIT_WIDTH = true
-const val DISPLAY_SETTINGS_DEFAULT_IS_SHOW_ANIMATION = true
+val DISPLAY_SETTINGS_DEFAULT_ANIMATION_PREFERENCE = AnimationPreference.FOLLOW_SYSTEM
 val DISPLAY_SETTINGS_DEFAULT_BODY_CONTENT_TYPE = BodyContentType.TEXT_HTML
 const val DISPLAY_SETTINGS_DEFAULT_DRAWER_EXPAND_ALL_FOLDER = false
 const val DISPLAY_SETTINGS_DEFAULT_MESSAGE_VIEW_ARCHIVE_ACTION_VISIBLE = false
@@ -15,7 +16,7 @@ const val DISPLAY_SETTINGS_DEFAULT_MESSAGE_VIEW_COPY_ACTION_VISIBLE = false
 const val DISPLAY_SETTINGS_DEFAULT_MESSAGE_VIEW_SPAM_ACTION_VISIBLE = false
 
 data class DisplayVisualSettings(
-    val isShowAnimations: Boolean = DISPLAY_SETTINGS_DEFAULT_IS_SHOW_ANIMATION,
+    val animationPreference: AnimationPreference = DISPLAY_SETTINGS_DEFAULT_ANIMATION_PREFERENCE,
     val isUseMessageViewFixedWidthFont: Boolean = DISPLAY_SETTINGS_DEFAULT_IS_USE_MESSAGE_VIEW_FIXED_WIDTH_FONT,
     val isAutoFitWidth: Boolean = DISPLAY_SETTINGS_DEFAULT_IS_AUTO_FIT_WIDTH,
     val bodyContentType: BodyContentType = DISPLAY_SETTINGS_DEFAULT_BODY_CONTENT_TYPE,

--- a/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/display/visualSettings/DefaultDisplayVisualSettingsPreferenceManager.kt
+++ b/core/preference/impl/src/commonMain/kotlin/net/thunderbird/core/preference/display/visualSettings/DefaultDisplayVisualSettingsPreferenceManager.kt
@@ -67,9 +67,9 @@ class DefaultDisplayVisualSettingsPreferenceManager(
             DisplayVisualSettingKey.AutoFitWidth.value,
             DISPLAY_SETTINGS_DEFAULT_IS_AUTO_FIT_WIDTH,
         ),
-        isShowAnimations = storage.getBoolean(
+        animationPreference = storage.getEnumOrDefault(
             DisplayVisualSettingKey.Animation.value,
-            DISPLAY_SETTINGS_DEFAULT_IS_SHOW_ANIMATION,
+            DISPLAY_SETTINGS_DEFAULT_ANIMATION_PREFERENCE,
         ),
         bodyContentType = storage.getEnumOrDefault(
             DisplayVisualSettingKey.MessageViewBodyContentType.value,
@@ -105,7 +105,7 @@ class DefaultDisplayVisualSettingsPreferenceManager(
         logger.debug(TAG) { "writeConfig() called with: config = $config" }
         scope.launch(ioDispatcher) {
             mutex.withLock {
-                storageEditor.putBoolean(DisplayVisualSettingKey.Animation.value, config.isShowAnimations)
+                storageEditor.putEnum(DisplayVisualSettingKey.Animation.value, config.animationPreference)
                 storageEditor.putBoolean(
                     DisplayVisualSettingKey.MessageViewFixedWidthFont.value,
                     config.isUseMessageViewFixedWidthFont,

--- a/core/ui/animation/manager/build.gradle.kts
+++ b/core/ui/animation/manager/build.gradle.kts
@@ -1,0 +1,11 @@
+plugins {
+    id(ThunderbirdPlugins.Library.android)
+}
+
+android {
+    namespace = "net.thunderbird.core.ui.animation.manager"
+}
+
+dependencies {
+    implementation(projects.core.preference.api)
+}

--- a/core/ui/animation/manager/src/main/kotlin/net/thunderbird/core/ui/animation/manager/AnimationManager.kt
+++ b/core/ui/animation/manager/src/main/kotlin/net/thunderbird/core/ui/animation/manager/AnimationManager.kt
@@ -1,0 +1,21 @@
+package net.thunderbird.core.ui.animation.manager
+
+import android.animation.ValueAnimator
+import net.thunderbird.core.preference.AnimationPreference
+import net.thunderbird.core.preference.display.visualSettings.DisplayVisualSettingsPreferenceManager
+
+interface AnimationManager {
+    fun shouldShowAnimations(): Boolean
+}
+
+class DefaultAnimationManager(
+    private val visualSettingsPreferenceManager: DisplayVisualSettingsPreferenceManager,
+) : AnimationManager {
+    override fun shouldShowAnimations(): Boolean {
+        return when (visualSettingsPreferenceManager.getConfig().animationPreference) {
+            AnimationPreference.ON -> true
+            AnimationPreference.OFF -> false
+            AnimationPreference.FOLLOW_SYSTEM -> ValueAnimator.areAnimatorsEnabled()
+        }
+    }
+}

--- a/core/ui/animation/manager/src/main/kotlin/net/thunderbird/core/ui/animation/manager/AnimationManager.kt
+++ b/core/ui/animation/manager/src/main/kotlin/net/thunderbird/core/ui/animation/manager/AnimationManager.kt
@@ -1,6 +1,7 @@
 package net.thunderbird.core.ui.animation.manager
 
 import android.animation.ValueAnimator
+import android.os.Build
 import net.thunderbird.core.preference.AnimationPreference
 import net.thunderbird.core.preference.display.visualSettings.DisplayVisualSettingsPreferenceManager
 
@@ -14,8 +15,14 @@ class DefaultAnimationManager(
     override fun shouldShowAnimations(): Boolean {
         return when (visualSettingsPreferenceManager.getConfig().animationPreference) {
             AnimationPreference.ON -> true
+
             AnimationPreference.OFF -> false
-            AnimationPreference.FOLLOW_SYSTEM -> ValueAnimator.areAnimatorsEnabled()
+
+            AnimationPreference.FOLLOW_SYSTEM -> if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                ValueAnimator.areAnimatorsEnabled()
+            } else {
+                true
+            }
         }
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/GeneralSettingsDescriptions.java
@@ -29,9 +29,11 @@ import com.fsck.k9.preferences.upgrader.GeneralSettingsUpgraderTo58;
 import com.fsck.k9.preferences.upgrader.GeneralSettingsUpgraderTo69;
 import com.fsck.k9.preferences.upgrader.GeneralSettingsUpgraderTo79;
 import com.fsck.k9.preferences.upgrader.GeneralSettingsUpgraderTo89;
+import com.fsck.k9.preferences.upgrader.GeneralSettingsUpgraderTo111;
 import net.thunderbird.core.android.account.AccountDefaultsProvider;
 import net.thunderbird.core.android.account.SortType;
 import net.thunderbird.core.common.action.SwipeAction;
+import net.thunderbird.core.preference.AnimationPreference;
 import net.thunderbird.core.preference.AppTheme;
 import net.thunderbird.core.preference.BackgroundOps;
 import net.thunderbird.core.preference.GeneralSettingsManager;
@@ -41,6 +43,7 @@ import net.thunderbird.core.preference.NotificationQuickDelete;
 import net.thunderbird.core.preference.SplitViewMode;
 import net.thunderbird.core.preference.SubTheme;
 import net.thunderbird.core.preference.display.coreSettings.DisplayCoreSettingsKt;
+import net.thunderbird.core.preference.display.visualSettings.DisplayVisualSettingsKt;
 import net.thunderbird.core.preference.display.visualSettings.message.list.MessageListDateTimeFormat;
 import net.thunderbird.core.preference.interaction.PostMarkAsUnreadNavigation;
 import net.thunderbird.core.preference.interaction.PostRemoveNavigation;
@@ -57,7 +60,6 @@ import static net.thunderbird.core.preference.display.miscSettings.DisplayMiscSe
 import static net.thunderbird.core.preference.display.miscSettings.DisplayMiscSettingsKt.DISPLAY_SETTINGS_DEFAULT_SHOW_RECENT_CHANGES;
 import static net.thunderbird.core.preference.display.visualSettings.DisplayVisualSettingsKt.DISPLAY_SETTINGS_DEFAULT_IS_AUTO_FIT_WIDTH;
 import static net.thunderbird.core.preference.display.visualSettings.message.list.DisplayMessageListSettingsKt.MESSAGE_LIST_SETTINGS_DEFAULT_IS_CHANGE_CONTACT_NAME_COLOR;
-import static net.thunderbird.core.preference.display.visualSettings.DisplayVisualSettingsKt.DISPLAY_SETTINGS_DEFAULT_IS_SHOW_ANIMATION;
 import static net.thunderbird.core.preference.display.visualSettings.message.list.DisplayMessageListSettingsKt.MESSAGE_LIST_SETTINGS_DEFAULT_IS_SHOW_CONTACT_NAME;
 import static net.thunderbird.core.preference.display.visualSettings.message.list.DisplayMessageListSettingsKt.MESSAGE_LIST_SETTINGS_DEFAULT_IS_SHOW_CONTACT_PICTURE;
 import static net.thunderbird.core.preference.display.visualSettings.message.list.DisplayMessageListSettingsKt.MESSAGE_LIST_SETTINGS_DEFAULT_IS_SHOW_CORRESPONDENT_NAMES;
@@ -85,7 +87,8 @@ class GeneralSettingsDescriptions {
          */
 
         s.put("animations", Settings.versions(
-            new V(1, new BooleanSetting(DISPLAY_SETTINGS_DEFAULT_IS_SHOW_ANIMATION))
+            new V(1, new BooleanSetting(true)),
+            new V(111, new EnumSetting<>(AnimationPreference.class, AnimationPreference.FOLLOW_SYSTEM))
         ));
         s.put("backgroundOperations", Settings.versions(
             new V(1, new EnumSetting<>(BackgroundOps.class, BackgroundOps.WHEN_CHECKED_AUTO_SYNC)),
@@ -361,6 +364,7 @@ class GeneralSettingsDescriptions {
         u.put(69, new GeneralSettingsUpgraderTo69());
         u.put(79, new GeneralSettingsUpgraderTo79());
         u.put(89, new GeneralSettingsUpgraderTo89());
+        u.put(111, new GeneralSettingsUpgraderTo111());
 
         UPGRADERS = Collections.unmodifiableMap(u);
     }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 110;
+    public static final int VERSION = 111;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription<?>>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo111.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo111.java
@@ -1,0 +1,25 @@
+package com.fsck.k9.preferences.upgrader;
+
+
+import java.util.Map;
+
+import com.fsck.k9.preferences.SettingsUpgrader;
+import net.thunderbird.core.preference.AnimationPreference;
+
+
+/**
+ * Convert <em>animations</em> from boolean to {@link AnimationPreference} enum.
+ *
+ * {@code true} maps to {@link AnimationPreference#ON}, {@code false} maps to {@link AnimationPreference#OFF}.
+ */
+public class GeneralSettingsUpgraderTo111 implements SettingsUpgrader {
+
+    @Override
+    public void upgrade(Map<String, Object> settings) {
+        Object animations = settings.get("animations");
+        if (animations instanceof Boolean) {
+            boolean value = (Boolean) animations;
+            settings.put("animations", value ? AnimationPreference.ON : AnimationPreference.OFF);
+        }
+    }
+}

--- a/legacy/core/src/main/res/values/arrays_general_settings_values.xml
+++ b/legacy/core/src/main/res/values/arrays_general_settings_values.xml
@@ -152,6 +152,12 @@
         <item>follow_system</item>
     </string-array>
 
+    <string-array name="animation_values" translatable="false">
+        <item>ON</item>
+        <item>OFF</item>
+        <item>FOLLOW_SYSTEM</item>
+    </string-array>
+
     <string-array name="message_theme_values" translatable="false">
         <item>light</item>
         <item>dark</item>

--- a/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo111Test.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/preferences/upgrader/GeneralSettingsUpgraderTo111Test.kt
@@ -1,0 +1,52 @@
+package com.fsck.k9.preferences.upgrader
+
+import assertk.assertThat
+import assertk.assertions.doesNotContainKey
+import assertk.assertions.isEqualTo
+import kotlin.test.Test
+import net.thunderbird.core.preference.AnimationPreference
+
+class GeneralSettingsUpgraderTo111Test {
+
+    private val upgrader = GeneralSettingsUpgraderTo111()
+
+    @Test
+    fun `should convert animations=true to ON`() {
+        val settings = mutableMapOf<String, Any?>(ANIMATIONS_KEY to true)
+
+        upgrader.upgrade(settings)
+
+        assertThat(settings[ANIMATIONS_KEY]).isEqualTo(AnimationPreference.ON)
+    }
+
+    @Test
+    fun `should convert animations=false to OFF`() {
+        val settings = mutableMapOf<String, Any?>(ANIMATIONS_KEY to false)
+
+        upgrader.upgrade(settings)
+
+        assertThat(settings[ANIMATIONS_KEY]).isEqualTo(AnimationPreference.OFF)
+    }
+
+    @Test
+    fun `should not insert animations key when missing`() {
+        val settings = mutableMapOf<String, Any?>()
+
+        upgrader.upgrade(settings)
+
+        assertThat(settings).doesNotContainKey(ANIMATIONS_KEY)
+    }
+
+    @Test
+    fun `should leave existing AnimationPreference value unchanged`() {
+        val settings = mutableMapOf<String, Any?>(ANIMATIONS_KEY to AnimationPreference.FOLLOW_SYSTEM)
+
+        upgrader.upgrade(settings)
+
+        assertThat(settings[ANIMATIONS_KEY]).isEqualTo(AnimationPreference.FOLLOW_SYSTEM)
+    }
+
+    private companion object {
+        const val ANIMATIONS_KEY = "animations"
+    }
+}

--- a/legacy/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
+++ b/legacy/storage/src/main/java/com/fsck/k9/preferences/K9StoragePersister.java
@@ -23,7 +23,7 @@ import net.thunderbird.core.preference.storage.StoragePersister;
 import net.thunderbird.core.preference.storage.StorageUpdater;
 
 public class K9StoragePersister implements StoragePersister {
-    private static final int DB_VERSION = 29;
+    private static final int DB_VERSION = 30;
     private static final String DB_NAME = "preferences_storage";
 
     private final Context context;

--- a/legacy/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo30.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrationTo30.kt
@@ -1,0 +1,26 @@
+package com.fsck.k9.preferences.migration
+
+import android.database.sqlite.SQLiteDatabase
+
+private const val ANIMATION_KEY = "animations"
+
+/**
+ * Migrate the "animations" setting from boolean string to AnimationPreference enum name.
+ *
+ * - "true" -> "ON" (user explicitly enabled animations)
+ * - "false" -> "OFF" (user explicitly disabled animations)
+ * - missing -> no change (new default FOLLOW_SYSTEM will apply)
+ */
+class StorageMigrationTo30(
+    private val db: SQLiteDatabase,
+    private val migrationsHelper: StorageMigrationHelper,
+) {
+    fun migrateAnimationSetting() {
+        val currentValue = migrationsHelper.readValue(db, ANIMATION_KEY)
+        when (currentValue) {
+            "true" -> migrationsHelper.writeValue(db, ANIMATION_KEY, "ON")
+            "false" -> migrationsHelper.writeValue(db, ANIMATION_KEY, "OFF")
+            // If missing or already migrated, do nothing
+        }
+    }
+}

--- a/legacy/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/preferences/migration/StorageMigrations.kt
@@ -36,5 +36,6 @@ internal object StorageMigrations {
         if (oldVersion < 27) StorageMigrationTo27(db, migrationsHelper).addAvatarMonogram()
         if (oldVersion < 28) StorageMigrationTo28(db, migrationsHelper).ensureAvatarSet()
         if (oldVersion < 29) StorageMigrationTo29(db, migrationsHelper).renameAutoSelectFolderPreference()
+        if (oldVersion < 30) StorageMigrationTo30(db, migrationsHelper).migrateAnimationSetting()
     }
 }

--- a/legacy/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo30Test.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/preferences/migration/StorageMigrationTo30Test.kt
@@ -1,0 +1,78 @@
+package com.fsck.k9.preferences.migration
+
+import assertk.assertThat
+import assertk.assertions.doesNotContainKey
+import assertk.assertions.isEqualTo
+import assertk.assertions.key
+import com.fsck.k9.preferences.createPreferencesDatabase
+import kotlin.test.Test
+import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.logging.testing.TestLogger
+import org.junit.After
+import org.junit.Before
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class StorageMigrationTo30Test {
+    private val database = createPreferencesDatabase()
+    private val migrationHelper = DefaultStorageMigrationHelper()
+    private val migration = StorageMigrationTo30(database, migrationHelper)
+
+    @Before
+    fun setUp() {
+        Log.logger = TestLogger()
+    }
+
+    @After
+    fun tearDown() {
+        database.close()
+    }
+
+    @Test
+    fun `migration should convert animations=true to ON`() {
+        migrationHelper.insertValue(database, ANIMATIONS_KEY, "true")
+
+        migration.migrateAnimationSetting()
+
+        assertThat(migrationHelper.readAllValues(database)).key(ANIMATIONS_KEY).isEqualTo("ON")
+    }
+
+    @Test
+    fun `migration should convert animations=false to OFF`() {
+        migrationHelper.insertValue(database, ANIMATIONS_KEY, "false")
+
+        migration.migrateAnimationSetting()
+
+        assertThat(migrationHelper.readAllValues(database)).key(ANIMATIONS_KEY).isEqualTo("OFF")
+    }
+
+    @Test
+    fun `migration should not insert animations key when missing`() {
+        migration.migrateAnimationSetting()
+
+        assertThat(migrationHelper.readAllValues(database)).doesNotContainKey(ANIMATIONS_KEY)
+    }
+
+    @Test
+    fun `migration should leave already migrated ON value unchanged`() {
+        migrationHelper.insertValue(database, ANIMATIONS_KEY, "ON")
+
+        migration.migrateAnimationSetting()
+
+        assertThat(migrationHelper.readAllValues(database)).key(ANIMATIONS_KEY).isEqualTo("ON")
+    }
+
+    @Test
+    fun `migration should leave already migrated OFF value unchanged`() {
+        migrationHelper.insertValue(database, ANIMATIONS_KEY, "OFF")
+
+        migration.migrateAnimationSetting()
+
+        assertThat(migrationHelper.readAllValues(database)).key(ANIMATIONS_KEY).isEqualTo("OFF")
+    }
+
+    private companion object {
+        const val ANIMATIONS_KEY = "animations"
+    }
+}

--- a/legacy/ui/base/build.gradle.kts
+++ b/legacy/ui/base/build.gradle.kts
@@ -6,6 +6,7 @@ dependencies {
     implementation(projects.legacy.core)
 
     api(projects.core.ui.theme.manager)
+    api(projects.core.ui.animation.manager)
 
     api(libs.androidx.appcompat)
     api(libs.androidx.activity)

--- a/legacy/ui/base/src/main/java/com/fsck/k9/ui/base/KoinModule.kt
+++ b/legacy/ui/base/src/main/java/com/fsck/k9/ui/base/KoinModule.kt
@@ -1,6 +1,8 @@
 package com.fsck.k9.ui.base
 
 import com.fsck.k9.ui.base.locale.SystemLocaleManager
+import net.thunderbird.core.ui.animation.manager.AnimationManager
+import net.thunderbird.core.ui.animation.manager.DefaultAnimationManager
 import net.thunderbird.core.ui.theme.manager.ThemeManager
 import org.koin.core.qualifier.named
 import org.koin.dsl.bind
@@ -16,6 +18,9 @@ val uiBaseModule = module {
             appCoroutineScope = get(named("AppCoroutineScope")),
         )
     } bind ThemeManagerApi::class
+    single<AnimationManager> {
+        DefaultAnimationManager(visualSettingsPreferenceManager = get())
+    }
     single { AppLanguageManager(systemLocaleManager = get(), displayCoreSettingsPreferenceManager = get()) }
     single { SystemLocaleManager(context = get()) }
 }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageTopView.kt
@@ -33,6 +33,7 @@ import net.thunderbird.core.common.mail.EmailAddress
 import net.thunderbird.core.common.mail.toEmailAddressOrNull
 import net.thunderbird.core.preference.BodyContentType
 import net.thunderbird.core.preference.display.visualSettings.DisplayVisualSettingsPreferenceManager
+import net.thunderbird.core.ui.animation.manager.AnimationManager
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
@@ -43,6 +44,7 @@ class MessageTopView(
 
     private val contactRepository: ContactRepository by inject()
     private val visualSettingsPrefManager: DisplayVisualSettingsPreferenceManager by inject()
+    private val animationManager: AnimationManager by inject()
 
     private lateinit var layoutInflater: LayoutInflater
 
@@ -73,7 +75,7 @@ class MessageTopView(
         layoutInflater = LayoutInflater.from(context)
 
         viewAnimator = findViewById(R.id.message_layout_animator)
-        if (!visualSettingsPrefManager.getConfig().isShowAnimations) {
+        if (!animationManager.shouldShowAnimations()) {
             viewAnimator.inAnimation = null
             viewAnimator.outAnimation = null
         }

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/general/GeneralSettingsDataStore.kt
@@ -7,6 +7,7 @@ import com.fsck.k9.job.K9JobManager
 import com.fsck.k9.ui.base.AppLanguageManager
 import net.thunderbird.core.common.action.SwipeAction
 import net.thunderbird.core.common.action.SwipeActions
+import net.thunderbird.core.preference.AnimationPreference
 import net.thunderbird.core.preference.AppTheme
 import net.thunderbird.core.preference.BackgroundOps
 import net.thunderbird.core.preference.BodyContentType
@@ -42,7 +43,6 @@ class GeneralSettingsDataStore(
         val messageListSettings = visualSettings.messageListSettings
         return when (key) {
             "fixed_message_view_theme" -> coreSettings.fixedMessageViewTheme
-            "animations" -> visualSettings.isShowAnimations
             "show_unified_inbox" -> inboxSettings.isShowUnifiedInbox
             "show_starred_count" -> inboxSettings.isShowStarredCount
             "messagelist_stars" -> inboxSettings.isShowMessageListStars
@@ -76,7 +76,6 @@ class GeneralSettingsDataStore(
     override fun putBoolean(key: String, value: Boolean) {
         when (key) {
             "fixed_message_view_theme" -> setFixedMessageViewTheme(value)
-            "animations" -> setIsShowAnimations(isShowAnimations = value)
             "drawerExpandAllFolder" -> setDrawerExpandAllFolder(drawerExpandAllFolder = value)
             "show_unified_inbox" -> setIsShowUnifiedInbox(value)
             "show_starred_count" -> setIsShowStarredCount(isShowStarredCount = value)
@@ -153,6 +152,7 @@ class GeneralSettingsDataStore(
         return when (key) {
             "language" -> appLanguageManager.getAppLanguage()
             "theme" -> appThemeToString(coreSettings.appTheme)
+            "animations" -> animationPreferenceToString(visualSettings.animationPreference)
             "message_compose_theme" -> subThemeToString(coreSettings.messageComposeTheme)
             "messageViewTheme" -> subThemeToString(coreSettings.messageViewTheme)
             "messagelist_preview_lines" -> messageListSettings.previewLines.toString()
@@ -193,6 +193,7 @@ class GeneralSettingsDataStore(
             }
 
             "theme" -> setTheme(value)
+            "animations" -> setAnimationPreference(stringToAnimationPreference(value))
             "message_compose_theme" -> setMessageComposeTheme(value)
             "messageViewTheme" -> setMessageViewTheme(value)
             "messagelist_preview_lines" -> setMessageListPreviewLines(value.toInt())
@@ -430,13 +431,13 @@ class GeneralSettingsDataStore(
         }
     }
 
-    private fun setIsShowAnimations(isShowAnimations: Boolean) {
+    private fun setAnimationPreference(animationPreference: AnimationPreference) {
         skipSaveSettings = true
         generalSettingsManager.update { settings ->
             settings.copy(
                 display = settings.display.copy(
                     visualSettings = settings.display.visualSettings.copy(
-                        isShowAnimations = isShowAnimations,
+                        animationPreference = animationPreference,
                     ),
                 ),
             )
@@ -794,6 +795,19 @@ class GeneralSettingsDataStore(
         "light" -> SubTheme.LIGHT
         "dark" -> SubTheme.DARK
         "global" -> SubTheme.USE_GLOBAL
+        else -> throw AssertionError()
+    }
+
+    private fun animationPreferenceToString(pref: AnimationPreference) = when (pref) {
+        AnimationPreference.ON -> "ON"
+        AnimationPreference.OFF -> "OFF"
+        AnimationPreference.FOLLOW_SYSTEM -> "FOLLOW_SYSTEM"
+    }
+
+    private fun stringToAnimationPreference(value: String) = when (value) {
+        "ON" -> AnimationPreference.ON
+        "OFF" -> AnimationPreference.OFF
+        "FOLLOW_SYSTEM" -> AnimationPreference.FOLLOW_SYSTEM
         else -> throw AssertionError()
     }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/ViewSwitcher.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/ViewSwitcher.java
@@ -1,14 +1,14 @@
 package com.fsck.k9.view;
 
 
-import app.k9mail.legacy.di.DI;
-import net.thunderbird.core.preference.GeneralSettingsManager;
-
 import android.content.Context;
 import android.util.AttributeSet;
 import android.view.animation.Animation;
 import android.view.animation.Animation.AnimationListener;
 import android.widget.ViewAnimator;
+
+import app.k9mail.legacy.di.DI;
+import net.thunderbird.core.ui.animation.manager.AnimationManager;
 
 
 /**
@@ -22,7 +22,7 @@ public class ViewSwitcher extends ViewAnimator implements AnimationListener {
     private Animation mSecondOutAnimation;
     private OnSwitchCompleteListener mListener;
 
-    private GeneralSettingsManager generalSettingsManager = DI.get(GeneralSettingsManager.class);
+    private AnimationManager animationManager = DI.get(AnimationManager.class);
 
 
     public ViewSwitcher(Context context) {
@@ -56,7 +56,7 @@ public class ViewSwitcher extends ViewAnimator implements AnimationListener {
     }
 
     private void setupAnimations(Animation in, Animation out) {
-        if (generalSettingsManager.getConfig().getDisplay().getVisualSettings().isShowAnimations()) {
+        if (animationManager.shouldShowAnimations()) {
             setInAnimation(in);
             setOutAnimation(out);
             out.setAnimationListener(this);
@@ -67,7 +67,7 @@ public class ViewSwitcher extends ViewAnimator implements AnimationListener {
     }
 
     private void handleSwitchCompleteCallback() {
-        if (!generalSettingsManager.getConfig().getDisplay().getVisualSettings().isShowAnimations()) {
+        if (!animationManager.shouldShowAnimations()) {
             onAnimationEnd(null);
         }
     }
@@ -125,12 +125,12 @@ public class ViewSwitcher extends ViewAnimator implements AnimationListener {
         // unused
     }
 
-    public GeneralSettingsManager getGeneralSettingsManager() {
-        return generalSettingsManager;
+    public AnimationManager getAnimationManager() {
+        return animationManager;
     }
 
-    public void setGeneralSettingsManager(GeneralSettingsManager generalSettingsManager) {
-        this.generalSettingsManager = generalSettingsManager;
+    public void setAnimationManager(AnimationManager animationManager) {
+        this.animationManager = animationManager;
     }
 
     public interface OnSwitchCompleteListener {

--- a/legacy/ui/legacy/src/main/res/values-ar/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ar/strings.xml
@@ -525,7 +525,6 @@
     <string name="account_setup_push_limit_500">500 مجلد</string>
     <string name="account_setup_push_limit_1000">1000 مجلد</string>
     <string name="animations_title">الحركة</string>
-    <string name="animations_summary">استخدم تأثيرات بصرية مبهرجة </string>
     <string name="show_unified_inbox_title">إظهار علبة الوارد الموحدة </string>
     <string name="show_starred_count_title">إظهار العدد المميّز بنجمة </string>
     <string name="integrated_inbox_title">البريد الوارد الموحَّد</string>

--- a/legacy/ui/legacy/src/main/res/values-be/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-be/strings.xml
@@ -522,7 +522,6 @@
     <string name="account_setup_push_limit_500">500 каталогаў</string>
     <string name="account_setup_push_limit_1000">1000 каталогаў</string>
     <string name="animations_title">Анімацыя</string>
-    <string name="animations_summary">Анімацыя інтэрфейсу</string>
     <string name="show_unified_inbox_title">Агульная скрыня ўваходных лістоў для ўсіх акаўнтаў</string>
     <string name="show_starred_count_title">Паказваць колькасць адзначаных</string>
     <string name="integrated_inbox_title">Усе атрыманыя</string>

--- a/legacy/ui/legacy/src/main/res/values-bg/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-bg/strings.xml
@@ -462,7 +462,6 @@
     <string name="account_setup_push_limit_500">500 папки</string>
     <string name="account_setup_push_limit_1000">1000 папки</string>
     <string name="animations_title">Анимация</string>
-    <string name="animations_summary">Изпoлзване на ярки визуални ефекти</string>
     <string name="show_unified_inbox_title">Показване на обединената входяща папка</string>
     <string name="integrated_inbox_title">Обединена входяща кутия</string>
     <string name="integrated_inbox_detail">Всички съобщения в общата входяща кутия</string>

--- a/legacy/ui/legacy/src/main/res/values-br/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-br/strings.xml
@@ -434,7 +434,6 @@
     <string name="account_setup_push_limit_500">500 teuliad</string>
     <string name="account_setup_push_limit_1000">1000 teuliad</string>
     <string name="animations_title">Bliverezh</string>
-    <string name="animations_summary">Ober gant efedoù gwel gaudy</string>
     <string name="integrated_inbox_title">Boest degemer unanet</string>
     <string name="integrated_inbox_detail">Holl gemennadennoù an teuliadoù unanet</string>
     <string name="folder_settings_include_in_integrated_inbox_label">Unanañ</string>

--- a/legacy/ui/legacy/src/main/res/values-ca/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ca/strings.xml
@@ -521,7 +521,6 @@
     <string name="account_setup_push_limit_500">500 carpetes</string>
     <string name="account_setup_push_limit_1000">1000 carpetes</string>
     <string name="animations_title">Animació</string>
-    <string name="animations_summary">Fes servir efectes visuals cridaners</string>
     <string name="show_unified_inbox_title">Mostra la safata d\'entrada unificada</string>
     <string name="show_starred_count_title">Mostra el recompte de destacats</string>
     <string name="integrated_inbox_title">Bústia d\'entrada unificada</string>

--- a/legacy/ui/legacy/src/main/res/values-co/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-co/strings.xml
@@ -488,7 +488,6 @@
     <string name="account_setup_push_limit_500">500 cartulari</string>
     <string name="account_setup_push_limit_1000">1000 cartulari</string>
     <string name="animations_title">Animazione</string>
-    <string name="animations_summary">Impiegà l’effetti visuali esagerati</string>
     <string name="show_unified_inbox_title">Affissà a scatula di ricezzione cuncolta</string>
     <string name="show_starred_count_title">Affissà u numaru di stellati</string>
     <string name="integrated_inbox_detail">Tutti i messaghji in i cartulari cuncolti</string>

--- a/legacy/ui/legacy/src/main/res/values-cs/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-cs/strings.xml
@@ -523,7 +523,6 @@
     <string name="account_setup_push_limit_500">500 složek</string>
     <string name="account_setup_push_limit_1000">1000 složek</string>
     <string name="animations_title">Animace</string>
-    <string name="animations_summary">Používat okázalé vizuální efekty</string>
     <string name="show_unified_inbox_title">Ukázat sjednocený pohled na doručenou poštu</string>
     <string name="show_starred_count_title">Zobrazit počet označených hvězdičkou</string>
     <string name="integrated_inbox_title">Jednotná schránka</string>

--- a/legacy/ui/legacy/src/main/res/values-cy/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-cy/strings.xml
@@ -511,7 +511,6 @@
     <string name="account_setup_push_limit_500">500 ffolder</string>
     <string name="account_setup_push_limit_1000">1000 ffolder</string>
     <string name="animations_title">Animeiddiad</string>
-    <string name="animations_summary">Defnyddio effeithiau gweledol lliwgar</string>
     <string name="show_unified_inbox_title">Dangos Blwch Derbyn Cyfun</string>
     <string name="show_starred_count_title">Dangos cyfrif serennog</string>
     <string name="integrated_inbox_title">Blwch Derbyn Cyfun</string>

--- a/legacy/ui/legacy/src/main/res/values-da/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-da/strings.xml
@@ -514,7 +514,6 @@
     <string name="account_setup_push_limit_500">500 mapper</string>
     <string name="account_setup_push_limit_1000">1000 mapper</string>
     <string name="animations_title">Animation</string>
-    <string name="animations_summary">Anvend visuelle effekter</string>
     <string name="show_unified_inbox_title">Vis Fælles Indbakke</string>
     <string name="show_starred_count_title">Vis antal af stjernemarkeret</string>
     <string name="integrated_inbox_title">Fælles indbakke</string>

--- a/legacy/ui/legacy/src/main/res/values-de/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-de/strings.xml
@@ -516,7 +516,6 @@
     <string name="account_setup_push_limit_500">500 Ordner</string>
     <string name="account_setup_push_limit_1000">1000 Ordner</string>
     <string name="animations_title">Animationen</string>
-    <string name="animations_summary">Aufwändige visuelle Effekte verwenden</string>
     <string name="show_unified_inbox_title">Gemeinsamen Posteingang anzeigen</string>
     <string name="show_starred_count_title">Anzahl der wichtigen Nachrichten anzeigen</string>
     <string name="integrated_inbox_title">Gemeinsamer Posteingang</string>

--- a/legacy/ui/legacy/src/main/res/values-el/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-el/strings.xml
@@ -518,7 +518,6 @@
     <string name="account_setup_push_limit_500">500 φάκελοι</string>
     <string name="account_setup_push_limit_1000">1000 φάκελοι</string>
     <string name="animations_title">Κινούμενα σχέδια</string>
-    <string name="animations_summary">Χρήση οπτικών εφέ gaudy</string>
     <string name="show_unified_inbox_title">Εμφάνιση Ενιαία Εισερχόμενα</string>
     <string name="show_starred_count_title">Εμφάνιση πλήθους επιλεγμένων</string>
     <string name="integrated_inbox_title">Ενοποιημένα εισερχόμενα</string>

--- a/legacy/ui/legacy/src/main/res/values-en-rGB/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-en-rGB/strings.xml
@@ -216,7 +216,6 @@
     <string name="folder_settings_include_in_integrated_inbox_label">Unify</string>
     <string name="dialog_confirm_delete_confirm_button">Yes</string>
     <string name="account_settings_notify_sync_summary">Notify in status bar while mail is checked</string>
-    <string name="animations_summary">Use gaudy visual effects</string>
     <string name="settings_export_success_generic">Settings successfully exported</string>
     <string name="account_setup_push_limit_label">Max folders to check with push</string>
     <string name="notification_additional_messages">+ <xliff:g id="additional_messages">%1$d</xliff:g> more on <xliff:g id="account">%2$s</xliff:g></string>

--- a/legacy/ui/legacy/src/main/res/values-eo/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-eo/strings.xml
@@ -475,7 +475,6 @@
     <string name="account_setup_push_limit_500">Maksimume 500 mesaĝujoj</string>
     <string name="account_setup_push_limit_1000">Maksimume 1000 mesaĝujoj</string>
     <string name="animations_title">Movbildoj</string>
-    <string name="animations_summary">Uzas afablajn vidajn efektojn</string>
     <string name="show_unified_inbox_title">Montri unuigitan ricevujon</string>
     <string name="show_starred_count_title">Montri nombron da steletoj</string>
     <string name="integrated_inbox_title">Unuigita ricevujo</string>

--- a/legacy/ui/legacy/src/main/res/values-es/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-es/strings.xml
@@ -519,7 +519,6 @@
     <string name="account_setup_push_limit_500">500 carpetas</string>
     <string name="account_setup_push_limit_1000">1000 carpetas</string>
     <string name="animations_title">Animaciones</string>
-    <string name="animations_summary">Utilizar animaciones y otros efectos en la interfaz</string>
     <string name="show_unified_inbox_title">Ver bandeja de entrada unificada</string>
     <string name="show_starred_count_title">Ver número de correos destacados</string>
     <string name="integrated_inbox_title">Entrada unificada</string>

--- a/legacy/ui/legacy/src/main/res/values-et/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-et/strings.xml
@@ -518,7 +518,6 @@
     <string name="account_setup_push_limit_500">500 kausta</string>
     <string name="account_setup_push_limit_1000">1000 kausta</string>
     <string name="animations_title">Animatsioon</string>
-    <string name="animations_summary">Kasuta erinevaid visuaalseid efekte</string>
     <string name="show_unified_inbox_title">Näita koondsisendkausta</string>
     <string name="show_starred_count_title">Näita tärniga tähistatud kirjade arvu</string>
     <string name="integrated_inbox_title">Koondsisendkaust</string>

--- a/legacy/ui/legacy/src/main/res/values-eu/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-eu/strings.xml
@@ -517,7 +517,6 @@
     <string name="account_setup_push_limit_500">500 karpeta</string>
     <string name="account_setup_push_limit_1000">1000 karpeta</string>
     <string name="animations_title">Animazioak</string>
-    <string name="animations_summary">Erabili bistaratze efektu nabarmenak</string>
     <string name="show_unified_inbox_title">Erakutsi Sarrera Ontzi Bateratua</string>
     <string name="show_starred_count_title">Erakutsi kontu izardunak</string>
     <string name="integrated_inbox_title">Sarrerako ontzi bateratua</string>

--- a/legacy/ui/legacy/src/main/res/values-fa/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fa/strings.xml
@@ -519,7 +519,6 @@
     <string name="account_setup_push_limit_500">۵۰۰ پوشه</string>
     <string name="account_setup_push_limit_1000">۱۰۰۰ پوشه</string>
     <string name="animations_title">پویانمایی</string>
-    <string name="animations_summary">استفاده از جلوه‌های پُرزرق‌وبرق</string>
     <string name="show_unified_inbox_title">نمایش صندوق یکپارچه</string>
     <string name="show_starred_count_title">نمایش تعداد ستاره‌دارها</string>
     <string name="integrated_inbox_title">صندوق ورودی یکپارچه</string>

--- a/legacy/ui/legacy/src/main/res/values-fi/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fi/strings.xml
@@ -517,7 +517,6 @@
     <string name="account_setup_push_limit_500">500 kansiota</string>
     <string name="account_setup_push_limit_1000">1000 kansiota</string>
     <string name="animations_title">Animaatio</string>
-    <string name="animations_summary">Käytä koreita visuaalisia tehosteita</string>
     <string name="show_unified_inbox_title">Näytä \"Yhdistetty saapuneet\"</string>
     <string name="show_starred_count_title">Näytä tähdellä merkittyjen viestien määrä</string>
     <string name="integrated_inbox_title">Yhdistetty saapuneet</string>

--- a/legacy/ui/legacy/src/main/res/values-fr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fr/strings.xml
@@ -519,7 +519,6 @@
     <string name="account_setup_push_limit_500">500 dossiers</string>
     <string name="account_setup_push_limit_1000">1 000 dossiers</string>
     <string name="animations_title">Animation</string>
-    <string name="animations_summary">Utiliser des effets visuels voyants</string>
     <string name="show_unified_inbox_title">Afficher la boîte de réception unifiée</string>
     <string name="show_starred_count_title">Afficher le compte d’étoilés</string>
     <string name="integrated_inbox_title">Boîte de réception unifiée</string>

--- a/legacy/ui/legacy/src/main/res/values-fy/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-fy/strings.xml
@@ -517,7 +517,6 @@
     <string name="account_setup_push_limit_500">500 mappen</string>
     <string name="account_setup_push_limit_1000">1000 mappen</string>
     <string name="animations_title">Animaasje</string>
-    <string name="animations_summary">Fisuele effekten brûke</string>
     <string name="show_unified_inbox_title">Kombinearre Postfek YN toane</string>
     <string name="show_starred_count_title">Tal berjochten mei in stjer toane</string>
     <string name="integrated_inbox_title">Kombinearre Postfek YN</string>

--- a/legacy/ui/legacy/src/main/res/values-ga/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ga/strings.xml
@@ -567,7 +567,6 @@
     <string name="account_setup_push_limit_500">500 fillteán</string>
     <string name="account_setup_push_limit_1000">1000 fillteán</string>
     <string name="animations_title">Beochan</string>
-    <string name="animations_summary">Bain úsáid as maisíochtaí amhairc gaudy</string>
     <string name="show_unified_inbox_title">Taispeáin Bosca Isteach Aontaithe</string>
     <string name="show_starred_count_title">Taispeáin líon na réalta</string>
     <string name="integrated_inbox_title">Bosca Isteach Aontaithe</string>

--- a/legacy/ui/legacy/src/main/res/values-gd/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-gd/strings.xml
@@ -451,7 +451,6 @@
     <string name="account_setup_push_limit_500">500 pasgan</string>
     <string name="account_setup_push_limit_1000">1,000 pasgan</string>
     <string name="animations_title">Beòthachadh</string>
-    <string name="animations_summary">Cleachd èifeachdan lèirsinneach leòmach</string>
     <string name="show_unified_inbox_title">Seall an t-oll-bhogsa</string>
     <string name="integrated_inbox_title">An t-oll-bhogsa</string>
     <string name="integrated_inbox_detail">Na h-uile teachdaireachd ann am pasganan co-aonaichte</string>

--- a/legacy/ui/legacy/src/main/res/values-gl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-gl/strings.xml
@@ -479,7 +479,6 @@
     <string name="account_setup_push_limit_500">500 carpetas</string>
     <string name="account_setup_push_limit_1000">1000 carpetas</string>
     <string name="animations_title">Animacións</string>
-    <string name="animations_summary">Usar animacións</string>
     <string name="show_unified_inbox_title">Amosar a caixa de entrada unificada</string>
     <string name="show_starred_count_title">Amosar o reconto das estrelas</string>
     <string name="integrated_inbox_title">Entrada unificada</string>

--- a/legacy/ui/legacy/src/main/res/values-hr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-hr/strings.xml
@@ -455,7 +455,6 @@
     <string name="account_setup_push_limit_500">500 mapa</string>
     <string name="account_setup_push_limit_1000">1000 mapa</string>
     <string name="animations_title">Animacija</string>
-    <string name="animations_summary">Koristi šarolike vizualne efekte</string>
     <string name="integrated_inbox_title">Objedinjena Dolazna Pošta</string>
     <string name="integrated_inbox_detail">Sve poruke u objedinjenim mapama</string>
     <string name="folder_settings_include_in_integrated_inbox_label">Objedini</string>

--- a/legacy/ui/legacy/src/main/res/values-hu/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-hu/strings.xml
@@ -517,7 +517,6 @@
     <string name="account_setup_push_limit_500">500 mappa</string>
     <string name="account_setup_push_limit_1000">1000 mappa</string>
     <string name="animations_title">Animációk</string>
-    <string name="animations_summary">Rikító látható hatások használata</string>
     <string name="show_unified_inbox_title">Beérkezett üzenetek egyesített megjelenítése</string>
     <string name="show_starred_count_title">Csillagszámláló megjelenítése</string>
     <string name="integrated_inbox_title">Egyesített beérkezett üzenetek</string>

--- a/legacy/ui/legacy/src/main/res/values-in/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-in/strings.xml
@@ -461,7 +461,6 @@
     <string name="account_setup_push_limit_500">500 folder</string>
     <string name="account_setup_push_limit_1000">1000 folder</string>
     <string name="animations_title">Animasi</string>
-    <string name="animations_summary">Gunakan efek visual yang mencolok</string>
     <string name="show_unified_inbox_title">Tampilkan Kotak Masuk Terpadu</string>
     <string name="integrated_inbox_title">Kotak Masuk Terpadu</string>
     <string name="integrated_inbox_detail">Semua pesan dalam folder terpadu</string>

--- a/legacy/ui/legacy/src/main/res/values-is/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-is/strings.xml
@@ -518,7 +518,6 @@
     <string name="account_setup_push_limit_500">500 möppur</string>
     <string name="account_setup_push_limit_1000">1000 möppur</string>
     <string name="animations_title">Hreyfingar</string>
-    <string name="animations_summary">Nota skrautlegar sjónbrellur</string>
     <string name="show_unified_inbox_title">Birta sameinað innhólf</string>
     <string name="show_starred_count_title">Birta fjölda stjarna</string>
     <string name="integrated_inbox_title">Sameinað innhólf</string>

--- a/legacy/ui/legacy/src/main/res/values-it/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-it/strings.xml
@@ -519,7 +519,6 @@
     <string name="account_setup_push_limit_500">500 cartelle</string>
     <string name="account_setup_push_limit_1000">1000 cartelle</string>
     <string name="animations_title">Animazione</string>
-    <string name="animations_summary">Usa effetti visivi</string>
     <string name="show_unified_inbox_title">Mostra posta combinata</string>
     <string name="show_starred_count_title">Mostra conteggio Speciali</string>
     <string name="integrated_inbox_title">Posta combinata</string>

--- a/legacy/ui/legacy/src/main/res/values-iw/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-iw/strings.xml
@@ -414,7 +414,6 @@
     <string name="account_setup_push_limit_500">500 תיקיות</string>
     <string name="account_setup_push_limit_1000">1000 תיקיות</string>
     <string name="animations_title">אנימציה</string>
-    <string name="animations_summary">השתמש באפקטים חזותיים ססגונים</string>
     <string name="integrated_inbox_title">תיבת דואר נכנס אחידה</string>
     <string name="integrated_inbox_detail">כל ההודעות בתיקיות המאוחדות</string>
     <string name="folder_settings_include_in_integrated_inbox_label">לאחד</string>

--- a/legacy/ui/legacy/src/main/res/values-ja/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ja/strings.xml
@@ -517,7 +517,6 @@
     <string name="account_setup_push_limit_500">フォルダー 500 件</string>
     <string name="account_setup_push_limit_1000">フォルダー 1000 件</string>
     <string name="animations_title">アニメーション</string>
-    <string name="animations_summary">目立つ視覚効果を使用します</string>
     <string name="show_unified_inbox_title">統合受信トレイを表示する</string>
     <string name="show_starred_count_title">スター付きの数を表示する</string>
     <string name="integrated_inbox_title">統合受信トレイ</string>

--- a/legacy/ui/legacy/src/main/res/values-ko/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ko/strings.xml
@@ -437,7 +437,6 @@
     <string name="account_setup_push_limit_500">500개 폴더</string>
     <string name="account_setup_push_limit_1000">1000개 폴더</string>
     <string name="animations_title">애니메이션</string>
-    <string name="animations_summary">매끄러운 시각 효과 사용</string>
     <string name="integrated_inbox_title">통합 편지함</string>
     <string name="integrated_inbox_detail">통합 폴더의 모든 이메일</string>
     <string name="folder_settings_include_in_integrated_inbox_label">통합</string>

--- a/legacy/ui/legacy/src/main/res/values-lt/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-lt/strings.xml
@@ -512,7 +512,6 @@
     <string name="account_setup_push_limit_500">500 aplankų</string>
     <string name="account_setup_push_limit_1000">1000 aplankų</string>
     <string name="animations_title">Animacija</string>
-    <string name="animations_summary">Naudoti įmantrius vizualinius efektus</string>
     <string name="show_unified_inbox_title">Rodyti suvestinius gautuosius</string>
     <string name="show_starred_count_title">Rodyti žvaigždučių skaičių</string>
     <string name="integrated_inbox_title">Suvestiniai gautieji</string>

--- a/legacy/ui/legacy/src/main/res/values-lv/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-lv/strings.xml
@@ -521,7 +521,6 @@
     <string name="account_setup_push_limit_500">500 mapes</string>
     <string name="account_setup_push_limit_1000">1000 mapes</string>
     <string name="animations_title">Animācija</string>
-    <string name="animations_summary">Izmantot spilgtus vizuālos efektus</string>
     <string name="show_unified_inbox_title">Rādīt Apvienoto pastkasti (Iesūtni)</string>
     <string name="show_starred_count_title">Parādīt zvaigžņoto ziņu skaitu</string>
     <string name="integrated_inbox_title">Apvienotā Iesūtne</string>

--- a/legacy/ui/legacy/src/main/res/values-ml/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ml/strings.xml
@@ -483,7 +483,6 @@
     <string name="account_setup_push_limit_500">500 ഫോൾഡറുകൾ</string>
     <string name="account_setup_push_limit_1000">1000 ഫോൾഡറുകൾ</string>
     <string name="animations_title">ആനിമേഷൻ</string>
-    <string name="animations_summary">ഭംഗിയുള്ള വിഷ്വൽ ഇഫക്റ്റുകൾ ഉപയോഗിക്കുക</string>
     <string name="show_unified_inbox_title">ഏകീകൃത ഇൻ‌ബോക്സ് കാണിക്കുക</string>
     <string name="integrated_inbox_title">ഏകീകൃത ഇൻ‌ബോക്സ്</string>
     <string name="integrated_inbox_detail">ഏകീകൃത ഫോൾഡറുകളിലെ എല്ലാ സന്ദേശങ്ങളും</string>

--- a/legacy/ui/legacy/src/main/res/values-nb/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-nb/strings.xml
@@ -458,7 +458,6 @@
     <string name="account_setup_push_limit_500">500 mapper</string>
     <string name="account_setup_push_limit_1000">1000 mapper</string>
     <string name="animations_title">Animering</string>
-    <string name="animations_summary">Bruk glorete visuelle effekter</string>
     <string name="integrated_inbox_title">Samlet innboks</string>
     <string name="integrated_inbox_detail">Alle meldinger i samlede mapper</string>
     <string name="folder_settings_include_in_integrated_inbox_label">Samle</string>

--- a/legacy/ui/legacy/src/main/res/values-nl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-nl/strings.xml
@@ -517,7 +517,6 @@
     <string name="account_setup_push_limit_500">500 mappen</string>
     <string name="account_setup_push_limit_1000">1000 mappen</string>
     <string name="animations_title">Animatie</string>
-    <string name="animations_summary">Opvallende visuele effecten gebruiken</string>
     <string name="show_unified_inbox_title">Samengevoegd Postvak IN tonen</string>
     <string name="show_starred_count_title">Aantal berichten met een ster tonen</string>
     <string name="integrated_inbox_title">Samengevoegd Postvak IN</string>

--- a/legacy/ui/legacy/src/main/res/values-nn/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-nn/strings.xml
@@ -699,7 +699,6 @@
     <string name="sort_flagged_last">Usternemerka meldingar fyrst</string>
     <string name="sort_unread_first">Uleste meldingar fyrst</string>
     <string name="account_setup_push_limit_label">Maks antal mapper å sjekke med dytting</string>
-    <string name="animations_summary">Bruk glorete visuelle effektar</string>
     <string name="animations_title">Animasjon</string>
     <string name="integrated_inbox_title">Samla innboks</string>
     <string name="integrated_inbox_detail">Alle meldingar i samla mapper</string>

--- a/legacy/ui/legacy/src/main/res/values-pl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-pl/strings.xml
@@ -522,7 +522,6 @@
     <string name="account_setup_push_limit_500">Do 500 folderów</string>
     <string name="account_setup_push_limit_1000">Do 1000 folderów</string>
     <string name="animations_title">Animacje</string>
-    <string name="animations_summary">Używaj efektów wizualnych</string>
     <string name="show_unified_inbox_title">Pokaż zintegrowaną skrzynkę odbiorczą</string>
     <string name="show_starred_count_title">Pokaż liczbę oznaczonych gwiazdką</string>
     <string name="integrated_inbox_title">Zintegrowana odbiorcza</string>

--- a/legacy/ui/legacy/src/main/res/values-pt-rBR/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-pt-rBR/strings.xml
@@ -519,7 +519,6 @@
     <string name="account_setup_push_limit_500">500 pastas</string>
     <string name="account_setup_push_limit_1000">1000 pastas</string>
     <string name="animations_title">Animação</string>
-    <string name="animations_summary">Utilizar efeitos visuais extravagantes</string>
     <string name="show_unified_inbox_title">Exibir a caixa de entrada unificada</string>
     <string name="show_starred_count_title">Mostrar contagem de sinalizadas</string>
     <string name="integrated_inbox_title">Caixa de Entrada Unificada</string>

--- a/legacy/ui/legacy/src/main/res/values-pt-rPT/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-pt-rPT/strings.xml
@@ -520,7 +520,6 @@
     <string name="account_setup_push_limit_500">500 pastas</string>
     <string name="account_setup_push_limit_1000">1000 pastas</string>
     <string name="animations_title">Animação</string>
-    <string name="animations_summary">Usar efeitos visuais exuberantes</string>
     <string name="show_unified_inbox_title">Mostrar caixa de entrada unificada</string>
     <string name="show_starred_count_title">Mostrar contagem de estrelas</string>
     <string name="integrated_inbox_title">Caixa de entrada unificada</string>

--- a/legacy/ui/legacy/src/main/res/values-ro/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ro/strings.xml
@@ -519,7 +519,6 @@
     <string name="account_setup_push_limit_500">500 de dosare</string>
     <string name="account_setup_push_limit_1000">1000 de dosare</string>
     <string name="animations_title">Animații</string>
-    <string name="animations_summary">Folosește efecte vizuale gaudi</string>
     <string name="show_unified_inbox_title">Afișează Cutia poștală de intrare unificată</string>
     <string name="show_starred_count_title">Afișează numărul de stele</string>
     <string name="integrated_inbox_title">Căsuță poștală unificată</string>

--- a/legacy/ui/legacy/src/main/res/values-ru/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ru/strings.xml
@@ -523,7 +523,6 @@
     <string name="account_setup_push_limit_500">500 папок</string>
     <string name="account_setup_push_limit_1000">1000 папок</string>
     <string name="animations_title">Анимация</string>
-    <string name="animations_summary">Анимация интерфейса</string>
     <string name="show_unified_inbox_title">Показывать общий ящик для входящих</string>
     <string name="show_starred_count_title">Счётчик важных</string>
     <string name="integrated_inbox_title">Общие входящие</string>

--- a/legacy/ui/legacy/src/main/res/values-sk/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sk/strings.xml
@@ -464,7 +464,6 @@
     <string name="account_setup_push_limit_500">500 priečinkov</string>
     <string name="account_setup_push_limit_1000">1000 priečinkov</string>
     <string name="animations_title">Animácie</string>
-    <string name="animations_summary">Používať krikľavý vizuálny efekt</string>
     <string name="show_unified_inbox_title">Ukázať jednotnú schránku</string>
     <string name="integrated_inbox_title">Jednotná schránka</string>
     <string name="integrated_inbox_detail">Všetky správy v zjednotených priečinkoch</string>

--- a/legacy/ui/legacy/src/main/res/values-sl/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sl/strings.xml
@@ -517,7 +517,6 @@
     <string name="account_setup_push_limit_500">500 map</string>
     <string name="account_setup_push_limit_1000">1000 map</string>
     <string name="animations_title">Pokaži animirane učinke vmesnika</string>
-    <string name="animations_summary">Prehodi dejanj in različni učinki delovanja vmesnika so animirani</string>
     <string name="show_unified_inbox_title">Pokaži skupno mapo prejetih sporočil</string>
     <string name="show_starred_count_title">Pokaži število označb z zvezdico</string>
     <string name="integrated_inbox_title">Skupna mapa prejetih sporočil</string>

--- a/legacy/ui/legacy/src/main/res/values-sq/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sq/strings.xml
@@ -515,7 +515,6 @@
     <string name="account_setup_push_limit_500">500 dosje</string>
     <string name="account_setup_push_limit_1000">1000 dosje</string>
     <string name="animations_title">Animacion</string>
-    <string name="animations_summary">Përdor efekte pamore Gaudy</string>
     <string name="show_unified_inbox_title">Shfaq Kuti Poste të Njësuar</string>
     <string name="show_starred_count_title">Shfaq llogari me yll</string>
     <string name="integrated_inbox_title">Kuti Poste e Njësuar</string>

--- a/legacy/ui/legacy/src/main/res/values-sr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sr/strings.xml
@@ -462,7 +462,6 @@
     <string name="account_setup_push_limit_500">500 фолдера</string>
     <string name="account_setup_push_limit_1000">1000 фолдера</string>
     <string name="animations_title">Анимација</string>
-    <string name="animations_summary">Коришћење сјајних визуелних ефеката</string>
     <string name="show_unified_inbox_title">Прикажи обједињено сандуче</string>
     <string name="integrated_inbox_title">Обједињено сандуче</string>
     <string name="integrated_inbox_detail">Све поруке у обједињеним фолдерима</string>

--- a/legacy/ui/legacy/src/main/res/values-sv/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-sv/strings.xml
@@ -518,7 +518,6 @@
     <string name="account_setup_push_limit_500">500 mappar</string>
     <string name="account_setup_push_limit_1000">1000 mappar</string>
     <string name="animations_title">Animering</string>
-    <string name="animations_summary">Använd snygga visuella effekter</string>
     <string name="show_unified_inbox_title">Visa samlad inkorg</string>
     <string name="show_starred_count_title">Visa antalet stjärnmarkerade</string>
     <string name="integrated_inbox_title">Samlad inkorg</string>

--- a/legacy/ui/legacy/src/main/res/values-ta-rIN/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-ta-rIN/strings.xml
@@ -539,7 +539,6 @@
     <string name="account_setup_push_limit_label">புச் மூலம் சரிபார்க்க அதிகபட்ச கோப்புறைகள்</string>
     <string name="account_setup_push_limit_100">100 கோப்புறைகள்</string>
     <string name="account_setup_push_limit_250">250 கோப்புறைகள்</string>
-    <string name="animations_summary">அழகிய காட்சி விளைவுகளைப் பயன்படுத்தவும்</string>
     <string name="folder_settings_include_in_integrated_inbox_label">ஒன்றுபடுங்கள்</string>
     <string name="font_size_message_list_sender">அனுப்புநர்</string>
     <string name="font_size_message_view_date">நேரம் மற்றும் தேதி</string>

--- a/legacy/ui/legacy/src/main/res/values-tr/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-tr/strings.xml
@@ -504,7 +504,6 @@
     <string name="account_setup_push_limit_500">500 klasör</string>
     <string name="account_setup_push_limit_1000">1000 klasör</string>
     <string name="animations_title">Animasyon</string>
-    <string name="animations_summary">Gösterişli görsel efektleri kullan</string>
     <string name="show_unified_inbox_title">Birleşik gelen kutusunu göster</string>
     <string name="show_starred_count_title">Yıldızlı sayısını göster</string>
     <string name="integrated_inbox_title">Birleşik Gelen Kutusu</string>

--- a/legacy/ui/legacy/src/main/res/values-uk/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-uk/strings.xml
@@ -521,7 +521,6 @@
     <string name="account_setup_push_limit_500">500 папок</string>
     <string name="account_setup_push_limit_1000">1000 папок</string>
     <string name="animations_title">Анімація</string>
-    <string name="animations_summary">Використовувати яскраві візуальні ефекти</string>
     <string name="show_unified_inbox_title">Показувати Об\'єднану Вхідну Скриньку</string>
     <string name="show_starred_count_title">Показати кількість помічених зірочкою</string>
     <string name="integrated_inbox_title">Об\'єднана Вхідна Скринька</string>

--- a/legacy/ui/legacy/src/main/res/values-vi/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-vi/strings.xml
@@ -572,7 +572,6 @@
     <string name="account_setup_push_limit_25">25 thư mục</string>
     <string name="account_setup_push_limit_500">500 thư mục</string>
     <string name="animations_title">Hình ảnh động</string>
-    <string name="animations_summary">Sử dụng hiệu ứng hoa mỹ</string>
     <string name="show_unified_inbox_title">Hiển thị hộp thư đồng nhất</string>
     <string name="folder_settings_include_in_integrated_inbox_label">Đồng nhất</string>
     <string name="font_size_settings_description">Phông chữ có thể tùy chỉnh</string>

--- a/legacy/ui/legacy/src/main/res/values-zh-rCN/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-zh-rCN/strings.xml
@@ -515,7 +515,6 @@
     <string name="account_setup_push_limit_500">500 个文件夹</string>
     <string name="account_setup_push_limit_1000">1000 个文件夹</string>
     <string name="animations_title">动画</string>
-    <string name="animations_summary">使用绚丽的视觉效果</string>
     <string name="show_unified_inbox_title">显示统一收件箱</string>
     <string name="show_starred_count_title">显示星标邮件数</string>
     <string name="integrated_inbox_title">统一收件箱</string>

--- a/legacy/ui/legacy/src/main/res/values-zh-rTW/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values-zh-rTW/strings.xml
@@ -515,7 +515,6 @@
     <string name="account_setup_push_limit_500">500個信件匣</string>
     <string name="account_setup_push_limit_1000">1000個信件匣</string>
     <string name="animations_title">動畫</string>
-    <string name="animations_summary">使用絢麗的視覺特效</string>
     <string name="show_unified_inbox_title">顯示統一收件匣</string>
     <string name="show_starred_count_title">顯示有標記星號的數量</string>
     <string name="integrated_inbox_title">統一收件匣</string>

--- a/legacy/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/arrays_general_settings_strings.xml
@@ -95,6 +95,12 @@
         <item>@string/setting_theme_follow_system</item>
     </string-array>
 
+    <string-array name="animation_entries">
+        <item>@string/animation_setting_on</item>
+        <item>@string/animation_setting_off</item>
+        <item>@string/animation_setting_follow_system</item>
+    </string-array>
+
     <string-array name="message_theme_entries">
         <item>@string/setting_theme_light</item>
         <item>@string/setting_theme_dark</item>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -706,6 +706,9 @@
 
     <string name="animations_title">Animation</string>
     <string name="animations_summary">Use gaudy visual effects</string>
+    <string name="animation_setting_on">On</string>
+    <string name="animation_setting_off">Off</string>
+    <string name="animation_setting_follow_system">Use system default</string>
 
     <string name="volume_navigation_title_short">Volume key navigation</string>
     <string name="volume_navigation_summary">Navigate between messages using the volume keys in message view</string>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -705,7 +705,6 @@
     <string name="account_setup_push_limit_1000">1000 folders</string>
 
     <string name="animations_title">Animation</string>
-    <string name="animations_summary">Use gaudy visual effects</string>
     <string name="animation_setting_on">On</string>
     <string name="animation_setting_off">Off</string>
     <string name="animation_setting_follow_system">Use system default</string>

--- a/legacy/ui/legacy/src/main/res/xml/general_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/general_settings.xml
@@ -192,9 +192,12 @@
 
             </PreferenceScreen>
 
-            <CheckBoxPreference
+            <ListPreference
+                android:dialogTitle="@string/animations_title"
+                android:entries="@array/animation_entries"
+                android:entryValues="@array/animation_values"
                 android:key="animations"
-                android:summary="@string/animations_summary"
+                app:useSimpleSummaryProvider="true"
                 android:title="@string/animations_title"
                 />
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -200,6 +200,7 @@ include(
 
 include(
     ":core:ui:account",
+    ":core:ui:animation:manager",
     ":core:ui:compose:common",
     ":core:ui:compose:designsystem",
     ":core:ui:compose:testing",


### PR DESCRIPTION
Convert the "Use gaudy visual effects" boolean checkbox to a tri-state option (On/Off/Use system default) that defaults to following Android's system animation accessibility setting.

New installations follow system settings, old installations inherit their on/off state.

Fixes #6027

Note that this only changes the default to respect system settings. Unlike https://github.com/thunderbird/thunderbird-android/pull/10658 this does not touch any views that previously didn't respect the application-level setting. Any view or UI component that didn't respect the application-level setting will continue to not respect any animation settings, and should be fixed in a separate PR IMO.

**Implementation:**

Similar to ThemeManager, introduce a new AnimationManager and funnel all access to this option through there. I'm on the fence as to whether that isn't too much overkill, IMO it would make sense to merge them both into one "settings manager".

Right now there is only one place where the setting is being read, in ViewSwitcher. However, there are many other places where the setting is supposed to be respected but isn't (sidebar, messagetopview #10796) so I figured it's better to centralize the resolution outside of ViewSwitcher.

Written with AI-assistance, however like #10796 testing and commit messages are written manually.

<img height="300" alt="Screenshot_20260407-171904" src="https://github.com/user-attachments/assets/bede8b24-9e5e-421f-b6a8-fe9c1b92bcc3" />
<img height="300" alt="Screenshot_20260407-171908" src="https://github.com/user-attachments/assets/192beeab-68c3-427e-9ddd-f8ebc3f9719e" />

