### PR TITLE
chore(state-machine): add support for dispacthing ui side effects from state side effects

### DIFF
--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/StateMachine.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/StateMachine.kt
@@ -165,7 +165,7 @@ internal class DefaultStateMachine<TState : Any, TEvent : Any>(
                     }
                     .firstNotNullOfOrNull { it.value }
             if (transition == null) {
-                verbose { "Found no transition for $currentState -> $event" }
+                verbose { "Found no transition for $event in ${currentState::class.simpleName} state." }
             }
 
             return when {

--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/sideeffect/StateSideEffectHandler.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/sideeffect/StateSideEffectHandler.kt
@@ -13,9 +13,10 @@ import net.thunderbird.core.logging.Logger
  * @property logger A [Logger] for logging the handler's operations.
  * @property dispatch A function to send new [TEvent]s back to the UI's event loop.
  */
-abstract class StateSideEffectHandler<TState : Any, TEvent : Any>(
+abstract class StateSideEffectHandler<TState : Any, TEvent : Any, TEffect : Any>(
     private val logger: Logger,
     protected val dispatch: suspend (TEvent) -> Unit,
+    protected val dispatchUiEffect: suspend (TEffect) -> Unit = {},
 ) {
     /**
      * Determines whether this side effect handler should be triggered.
@@ -56,7 +57,11 @@ abstract class StateSideEffectHandler<TState : Any, TEvent : Any>(
         }
     }
 
-    fun interface Factory<TState : Any, TEvent : Any> {
-        fun create(scope: CoroutineScope, dispatch: suspend (TEvent) -> Unit): StateSideEffectHandler<TState, TEvent>
+    fun interface Factory<TState : Any, TEvent : Any, TEffect : Any> {
+        fun create(
+            scope: CoroutineScope,
+            dispatch: suspend (TEvent) -> Unit,
+            dispatchUiEffect: suspend (TEffect) -> Unit,
+        ): StateSideEffectHandler<TState, TEvent, TEffect>
     }
 }

--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/sideeffect/StateSideEffectHandler.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/sideeffect/StateSideEffectHandler.kt
@@ -13,7 +13,7 @@ import net.thunderbird.core.logging.Logger
  * @property logger A [Logger] for logging the handler's operations.
  * @property dispatch A function to send new [TEvent]s back to the UI's event loop.
  */
-abstract class StateSideEffectHandler<TState : Any, TEvent : Any, TEffect : Any>(
+abstract class StateSideEffectHandler<TState : Any, in TEvent : Any, TEffect : Any>(
     private val logger: Logger,
     protected val dispatch: suspend (TEvent) -> Unit,
     protected val dispatchUiEffect: suspend (TEffect) -> Unit = {},
@@ -28,7 +28,7 @@ abstract class StateSideEffectHandler<TState : Any, TEvent : Any, TEffect : Any>
      * @param newState The new [TState] after the event was processed.
      * @return `true` if this handler should execute its `handle` method, `false` otherwise.
      */
-    abstract fun accept(event: TEvent, newState: TState): Boolean
+    protected abstract fun accept(event: TEvent, oldState: TState, newState: TState): Boolean
 
     /**
      * Handles the side effect based on the state transition.
@@ -40,7 +40,7 @@ abstract class StateSideEffectHandler<TState : Any, TEvent : Any, TEffect : Any>
      * @param oldState The state before the event was processed.
      * @param newState The new state after the event has been processed.
      */
-    abstract suspend fun handle(oldState: TState, newState: TState)
+    protected abstract suspend fun consume(event: TEvent, oldState: TState, newState: TState): ConsumeResult
 
     /**
      * Handles a state change by checking if this handler should react to the [event] and the [newState].
@@ -50,10 +50,18 @@ abstract class StateSideEffectHandler<TState : Any, TEvent : Any, TEffect : Any>
      * @param oldState The state before the event was processed.
      * @param newState The state after the event was processed.
      */
-    suspend fun handle(event: TEvent, oldState: TState, newState: TState) {
-        logger.verbose { "handle() called with: event = $event, oldState = $oldState, newState = $newState" }
-        if (accept(event, newState)) {
-            handle(oldState, newState)
+    suspend fun handle(event: TEvent, oldState: TState, newState: TState): ConsumeResult {
+        return if (accept(event, oldState, newState)) {
+            logger.verbose {
+                """${this::class.simpleName}.handle() called with:
+                    |   event = $event,
+                    |   oldState = $oldState,
+                    |   newState = $newState,
+                """.trimMargin()
+            }
+            consume(event, oldState, newState)
+        } else {
+            ConsumeResult.Ignored
         }
     }
 
@@ -63,5 +71,11 @@ abstract class StateSideEffectHandler<TState : Any, TEvent : Any, TEffect : Any>
             dispatch: suspend (TEvent) -> Unit,
             dispatchUiEffect: suspend (TEffect) -> Unit,
         ): StateSideEffectHandler<TState, TEvent, TEffect>
+    }
+
+    sealed interface ConsumeResult {
+        data object Ignored : ConsumeResult
+        data object Consumed : ConsumeResult
+        data object Failure : ConsumeResult
     }
 }

--- a/core/ui/compose/common/src/main/kotlin/net/thunderbird/core/ui/compose/common/mvi/BaseStateMachineViewModel.kt
+++ b/core/ui/compose/common/src/main/kotlin/net/thunderbird/core/ui/compose/common/mvi/BaseStateMachineViewModel.kt
@@ -110,10 +110,9 @@ abstract class BaseStateMachineViewModel<TState : Any, TEvent : Any, TUiSideEffe
             val newState = stateMachine.process(event)
             if (newState != currentState) {
                 logger.verbose { "event(${event::class.simpleName}): state update." }
-                sideEffectHandlers
-                    .filter { it.accept(event, newState) }
-                    .forEach { it.handle(event, oldState = currentState, newState) }
             }
+
+            sideEffectHandlers.forEach { it.handle(event, oldState = currentState, newState = newState) }
         }
     }
 }

--- a/core/ui/compose/common/src/main/kotlin/net/thunderbird/core/ui/compose/common/mvi/BaseStateMachineViewModel.kt
+++ b/core/ui/compose/common/src/main/kotlin/net/thunderbird/core/ui/compose/common/mvi/BaseStateMachineViewModel.kt
@@ -31,9 +31,9 @@ import net.thunderbird.core.ui.contract.mvi.UnidirectionalViewModel
  * @param sideEffectHandlersFactories A list of factories for creating [StateSideEffectHandler]s.
  *  These handlers can be used to trigger side effects in response to state transitions.
  */
-abstract class BaseStateMachineViewModel<TState : Any, TEvent : Any, TUiSideEffect>(
+abstract class BaseStateMachineViewModel<TState : Any, TEvent : Any, TUiSideEffect : Any>(
     protected val logger: Logger,
-    sideEffectHandlersFactories: List<StateSideEffectHandler.Factory<TState, TEvent>> = emptyList(),
+    sideEffectHandlersFactories: List<StateSideEffectHandler.Factory<TState, TEvent, TUiSideEffect>> = emptyList(),
 ) :
     ViewModel(),
     UnidirectionalViewModel<TState, TEvent, TUiSideEffect> {
@@ -50,7 +50,13 @@ abstract class BaseStateMachineViewModel<TState : Any, TEvent : Any, TUiSideEffe
 
     private val _effect = MutableSharedFlow<TUiSideEffect>()
     override val effect: SharedFlow<TUiSideEffect> = _effect.asSharedFlow()
-    private val sideEffectHandlers = sideEffectHandlersFactories.map { it.create(viewModelScope, ::event) }
+    private val sideEffectHandlers = sideEffectHandlersFactories.map {
+        it.create(
+            scope = viewModelScope,
+            dispatch = ::event,
+            dispatchUiEffect = ::emitEffect,
+        )
+    }
 
     private val handledOneTimeEvents = mutableSetOf<TEvent>()
 

--- a/core/ui/compose/common/src/test/kotlin/net/thunderbird/core/ui/compose/common/mvi/BaseStateMachineViewModelTest.kt
+++ b/core/ui/compose/common/src/test/kotlin/net/thunderbird/core/ui/compose/common/mvi/BaseStateMachineViewModelTest.kt
@@ -153,9 +153,10 @@ class BaseStateMachineViewModelTest {
     fun `should trigger side effect handlers on state change`() = runTest {
         var sideEffectTriggered = false
         val sideEffectHandler = object : StateSideEffectHandler<String, String, String>(TestLogger(), {}) {
-            override fun accept(event: String, newState: String): Boolean = true
-            override suspend fun handle(oldState: String, newState: String) {
+            override fun accept(event: String, oldState: String, newState: String): Boolean = true
+            override suspend fun consume(event: String, oldState: String, newState: String): ConsumeResult {
                 sideEffectTriggered = true
+                return ConsumeResult.Consumed
             }
         }
         val factory = StateSideEffectHandler.Factory { _, _, _ -> sideEffectHandler }

--- a/core/ui/compose/common/src/test/kotlin/net/thunderbird/core/ui/compose/common/mvi/BaseStateMachineViewModelTest.kt
+++ b/core/ui/compose/common/src/test/kotlin/net/thunderbird/core/ui/compose/common/mvi/BaseStateMachineViewModelTest.kt
@@ -152,13 +152,13 @@ class BaseStateMachineViewModelTest {
     @Test
     fun `should trigger side effect handlers on state change`() = runTest {
         var sideEffectTriggered = false
-        val sideEffectHandler = object : StateSideEffectHandler<String, String>(TestLogger(), {}) {
+        val sideEffectHandler = object : StateSideEffectHandler<String, String, String>(TestLogger(), {}) {
             override fun accept(event: String, newState: String): Boolean = true
             override suspend fun handle(oldState: String, newState: String) {
                 sideEffectTriggered = true
             }
         }
-        val factory = StateSideEffectHandler.Factory { _, _ -> sideEffectHandler }
+        val factory = StateSideEffectHandler.Factory { _, _, _ -> sideEffectHandler }
 
         val viewModel = TestStateMachineViewModel(
             initialState = "Initial state",
@@ -177,7 +177,7 @@ class BaseStateMachineViewModelTest {
         initialState: String,
         logger: Logger = TestLogger(),
         override val stateMachine: StateMachine<String, String> = FakeStateMachine(initialState),
-        sideEffectHandlersFactories: List<StateSideEffectHandler.Factory<String, String>> = emptyList(),
+        sideEffectHandlersFactories: List<StateSideEffectHandler.Factory<String, String, String>> = emptyList(),
     ) : BaseStateMachineViewModel<String, String, String>(logger, sideEffectHandlersFactories) {
 
         fun callEmitEffect(effect: String) {

--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/MessageListContract.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/MessageListContract.kt
@@ -3,7 +3,6 @@ package net.thunderbird.feature.mail.message.list.ui
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
 import androidx.compose.ui.Modifier
-import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.ui.compose.common.mvi.BaseStateMachineViewModel
 import net.thunderbird.core.ui.contract.mvi.BaseViewModel
@@ -14,6 +13,7 @@ import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageLis
 import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandlerFactory
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import org.koin.androidx.compose.koinViewModel
 
@@ -103,5 +103,3 @@ interface MessageListContract {
         }
     }
 }
-
-interface MessageListStateSideEffectHandlerFactory : StateSideEffectHandler.Factory<MessageListState, MessageListEvent>

--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/state/sideeffect/MessageListStateSideEffectHandler.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/state/sideeffect/MessageListStateSideEffectHandler.kt
@@ -1,0 +1,16 @@
+package net.thunderbird.feature.mail.message.list.ui.state.sideeffect
+
+import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
+import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
+import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+
+abstract class MessageListStateSideEffectHandler(
+    logger: Logger,
+    dispatch: suspend (MessageListEvent) -> Unit,
+    dispatchUiEffect: suspend (MessageListEffect) -> Unit = {},
+) : StateSideEffectHandler<MessageListState, MessageListEvent, MessageListEffect>(logger, dispatch, dispatchUiEffect)
+
+interface MessageListStateSideEffectHandlerFactory :
+    StateSideEffectHandler.Factory<MessageListState, MessageListEvent, MessageListEffect>

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/MessageListViewModel.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/MessageListViewModel.kt
@@ -7,10 +7,10 @@ import net.thunderbird.core.common.state.StateMachine
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.mail.message.list.internal.ui.state.machine.MessageListStateMachine
 import net.thunderbird.feature.mail.message.list.ui.MessageListContract
-import net.thunderbird.feature.mail.message.list.ui.MessageListStateSideEffectHandlerFactory
 import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandlerFactory
 
 private const val TAG = "MessageListViewModel"
 
@@ -20,7 +20,7 @@ class MessageListViewModel(
     stateSideEffectHandlersFactories: List<MessageListStateSideEffectHandlerFactory>,
 ) : MessageListContract.ViewModel(logger, stateSideEffectHandlersFactories) {
     override val stateMachine: StateMachine<MessageListState, MessageListEvent> = messageListStateMachineFactory
-        .create(viewModelScope, ::event)
+        .create(scope = viewModelScope, dispatch = ::event, dispatchUiEffect = ::emitEffect)
     private var previousState: MessageListState? = null
 
     init {

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/machine/MessageListStateMachine.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/machine/MessageListStateMachine.kt
@@ -9,6 +9,7 @@ import net.thunderbird.core.common.state.builder.stateMachine
 import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.preference.debugging.DebuggingSettingsPreferenceManager
+import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.Folder
 import net.thunderbird.feature.mail.message.list.ui.state.MessageItemUi
@@ -38,6 +39,7 @@ class MessageListStateMachine(
     private val clock: Clock,
     private val scope: CoroutineScope,
     private val dispatch: (MessageListEvent) -> Unit,
+    private val dispatchUiEffect: (MessageListEffect) -> Unit,
     private val debuggingSettingsPreferenceManager: DebuggingSettingsPreferenceManager,
     private val stateMachine: StateMachine<MessageListState, MessageListEvent> = stateMachine(scope) {
         withLogger(logger, TAG)
@@ -68,12 +70,17 @@ class MessageListStateMachine(
         private val clock: Clock,
         private val debuggingSettingsPreferenceManager: DebuggingSettingsPreferenceManager,
     ) {
-        fun create(scope: CoroutineScope, dispatch: (MessageListEvent) -> Unit): MessageListStateMachine =
+        fun create(
+            scope: CoroutineScope,
+            dispatch: (MessageListEvent) -> Unit,
+            dispatchUiEffect: (MessageListEffect) -> Unit,
+        ): MessageListStateMachine =
             MessageListStateMachine(
                 logger = logger,
                 clock = clock,
                 scope = scope,
                 dispatch = dispatch,
+                dispatchUiEffect = dispatchUiEffect,
                 debuggingSettingsPreferenceManager = debuggingSettingsPreferenceManager,
             )
     }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/machine/SetupWarmingUpInitialState.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/machine/SetupWarmingUpInitialState.kt
@@ -28,7 +28,6 @@ internal fun StateMachineBuilder<MessageListState, MessageListEvent>.warmingUpIn
         onEnter { _, _ ->
             dispatch(MessageListEvent.LoadConfigurations)
         }
-        transition<MessageListEvent.LoadConfigurations> { state, _ -> state.withMetadata { copy(isActive = true) } }
         transition<MessageListEvent.UpdatePreferences> { state, event ->
             state.copy(preferences = event.preferences)
         }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/AllConfigurationsReadySideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/AllConfigurationsReadySideEffect.kt
@@ -1,11 +1,12 @@
 package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 
 import kotlinx.coroutines.CoroutineScope
-import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
-import net.thunderbird.feature.mail.message.list.ui.MessageListStateSideEffectHandlerFactory
+import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandler
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandlerFactory
 
 /**
  * A side effect handler that monitors the message list state and dispatches an event when all
@@ -17,7 +18,7 @@ import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 class AllConfigurationsReadySideEffect(
     logger: Logger,
     dispatch: suspend (MessageListEvent) -> Unit,
-) : StateSideEffectHandler<MessageListState, MessageListEvent>(logger, dispatch) {
+) : MessageListStateSideEffectHandler(logger, dispatch) {
     override fun accept(event: MessageListEvent, newState: MessageListState): Boolean =
         newState is MessageListState.WarmingUp && newState.isReady
 
@@ -31,7 +32,8 @@ class AllConfigurationsReadySideEffect(
         override fun create(
             scope: CoroutineScope,
             dispatch: suspend (MessageListEvent) -> Unit,
-        ): StateSideEffectHandler<MessageListState, MessageListEvent> = AllConfigurationsReadySideEffect(
+            dispatchUiEffect: suspend (MessageListEffect) -> Unit,
+        ): MessageListStateSideEffectHandler = AllConfigurationsReadySideEffect(
             dispatch = dispatch,
             logger = logger,
         )

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/AllConfigurationsReadySideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/AllConfigurationsReadySideEffect.kt
@@ -19,11 +19,16 @@ class AllConfigurationsReadySideEffect(
     logger: Logger,
     dispatch: suspend (MessageListEvent) -> Unit,
 ) : MessageListStateSideEffectHandler(logger, dispatch) {
-    override fun accept(event: MessageListEvent, newState: MessageListState): Boolean =
-        newState is MessageListState.WarmingUp && newState.isReady
+    override fun accept(event: MessageListEvent, oldState: MessageListState, newState: MessageListState): Boolean =
+        oldState != newState && newState is MessageListState.WarmingUp && newState.isReady
 
-    override suspend fun handle(oldState: MessageListState, newState: MessageListState) {
+    override suspend fun consume(
+        event: MessageListEvent,
+        oldState: MessageListState,
+        newState: MessageListState,
+    ): ConsumeResult {
         dispatch(MessageListEvent.AllConfigsReady)
+        return ConsumeResult.Consumed
     }
 
     class Factory(

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/ChangeSortCriteriaSideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/ChangeSortCriteriaSideEffect.kt
@@ -16,12 +16,14 @@ class ChangeSortCriteriaSideEffect(
     private val logger: Logger,
     private val updateSortCriteria: DomainContract.UseCase.UpdateSortCriteria,
 ) : MessageListStateSideEffectHandler(logger, dispatch) {
-    override fun accept(
-        event: MessageListEvent,
-        newState: MessageListState,
-    ): Boolean = event is MessageListEvent.ChangeSortCriteria
+    override fun accept(event: MessageListEvent, oldState: MessageListState, newState: MessageListState): Boolean =
+        event is MessageListEvent.ChangeSortCriteria && oldState != newState
 
-    override suspend fun handle(oldState: MessageListState, newState: MessageListState) {
+    override suspend fun consume(
+        event: MessageListEvent,
+        oldState: MessageListState,
+        newState: MessageListState,
+    ): ConsumeResult {
         logger.verbose(TAG) {
             "ChangeSortCriteriaSideEffect.handle() called with: oldState = $oldState, newState = $newState"
         }
@@ -34,6 +36,7 @@ class ChangeSortCriteriaSideEffect(
         if (oldSortCriteria != newSortCriteria) {
             updateSortCriteria(currentAccountId, newSortCriteria)
         }
+        return ConsumeResult.Consumed
     }
 
     class Factory(

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/ChangeSortCriteriaSideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/ChangeSortCriteriaSideEffect.kt
@@ -1,12 +1,13 @@
 package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 
 import kotlinx.coroutines.CoroutineScope
-import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.mail.message.list.domain.DomainContract
-import net.thunderbird.feature.mail.message.list.ui.MessageListStateSideEffectHandlerFactory
+import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandler
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandlerFactory
 
 private const val TAG = "ChangeSortCriteriaSideEffect"
 
@@ -14,7 +15,7 @@ class ChangeSortCriteriaSideEffect(
     dispatch: suspend (MessageListEvent) -> Unit,
     private val logger: Logger,
     private val updateSortCriteria: DomainContract.UseCase.UpdateSortCriteria,
-) : StateSideEffectHandler<MessageListState, MessageListEvent>(logger, dispatch) {
+) : MessageListStateSideEffectHandler(logger, dispatch) {
     override fun accept(
         event: MessageListEvent,
         newState: MessageListState,
@@ -42,7 +43,8 @@ class ChangeSortCriteriaSideEffect(
         override fun create(
             scope: CoroutineScope,
             dispatch: suspend (MessageListEvent) -> Unit,
-        ): StateSideEffectHandler<MessageListState, MessageListEvent> = ChangeSortCriteriaSideEffect(
+            dispatchUiEffect: suspend (MessageListEffect) -> Unit,
+        ): MessageListStateSideEffectHandler = ChangeSortCriteriaSideEffect(
             dispatch = dispatch,
             logger = logger,
             updateSortCriteria = updateSortCriteria,

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffect.kt
@@ -3,15 +3,16 @@ package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 import androidx.compose.ui.graphics.Color
 import app.k9mail.legacy.mailstore.FolderRepository
 import kotlinx.coroutines.CoroutineScope
-import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.account.AccountId
-import net.thunderbird.feature.mail.message.list.ui.MessageListStateSideEffectHandlerFactory
+import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.FolderEvent
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.Account
 import net.thunderbird.feature.mail.message.list.ui.state.Folder
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandler
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandlerFactory
 
 private const val TAG = "LoadFolderInformationSideEffect"
 
@@ -21,7 +22,7 @@ class LoadFolderInformationSideEffect(
     dispatch: suspend (MessageListEvent) -> Unit,
     private val logger: Logger,
     private val folderRepository: FolderRepository,
-) : StateSideEffectHandler<MessageListState, MessageListEvent>(logger, dispatch) {
+) : MessageListStateSideEffectHandler(logger, dispatch) {
     override fun accept(
         event: MessageListEvent,
         newState: MessageListState,
@@ -61,7 +62,8 @@ class LoadFolderInformationSideEffect(
         override fun create(
             scope: CoroutineScope,
             dispatch: suspend (MessageListEvent) -> Unit,
-        ): StateSideEffectHandler<MessageListState, MessageListEvent> = LoadFolderInformationSideEffect(
+            dispatchUiEffect: suspend (MessageListEffect) -> Unit,
+        ): MessageListStateSideEffectHandler = LoadFolderInformationSideEffect(
             accountIds = accountIds,
             folderId = folderId,
             dispatch = dispatch,

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffect.kt
@@ -23,17 +23,19 @@ class LoadFolderInformationSideEffect(
     private val logger: Logger,
     private val folderRepository: FolderRepository,
 ) : MessageListStateSideEffectHandler(logger, dispatch) {
-    override fun accept(
-        event: MessageListEvent,
-        newState: MessageListState,
-    ): Boolean = accountIds.size == 1 && folderId != null && event == MessageListEvent.LoadConfigurations
+    override fun accept(event: MessageListEvent, oldState: MessageListState, newState: MessageListState): Boolean =
+        accountIds.size == 1 && folderId != null && event == MessageListEvent.LoadConfigurations
 
-    override suspend fun handle(oldState: MessageListState, newState: MessageListState) {
+    override suspend fun consume(
+        event: MessageListEvent,
+        oldState: MessageListState,
+        newState: MessageListState,
+    ): ConsumeResult {
         val accountId = accountIds.first()
         val folderId = requireNotNull(folderId)
         logger.verbose(TAG) { "$TAG.handle() called with: oldState = $oldState, newState = $newState" }
         val folder = folderRepository.getFolder(accountId, folderId)
-        if (folder != null) {
+        return if (folder != null) {
             val remoteFolder = if (!folder.isLocalOnly) {
                 folderRepository.getRemoteFolders(accountId).first { it.id == folderId }
             } else {
@@ -50,6 +52,9 @@ class LoadFolderInformationSideEffect(
                     ),
                 ),
             )
+            ConsumeResult.Consumed
+        } else {
+            ConsumeResult.Ignored
         }
     }
 

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadPreferencesSideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadPreferencesSideEffect.kt
@@ -22,15 +22,14 @@ class LoadPreferencesSideEffect(
     private val getMessageListPreferences: GetMessageListPreferences,
 ) : MessageListStateSideEffectHandler(logger, dispatch) {
     private var runningFlow: Job? = null
-    override fun accept(
-        event: MessageListEvent,
-        newState: MessageListState,
-    ): Boolean = event == MessageListEvent.LoadConfigurations
+    override fun accept(event: MessageListEvent, oldState: MessageListState, newState: MessageListState): Boolean =
+        event == MessageListEvent.LoadConfigurations
 
-    override suspend fun handle(
+    override suspend fun consume(
+        event: MessageListEvent,
         oldState: MessageListState,
         newState: MessageListState,
-    ) {
+    ): ConsumeResult {
         logger.verbose(TAG) { "$TAG.handle() called with: oldState = $oldState, newState = $newState" }
         runningFlow?.cancel()
         runningFlow = getMessageListPreferences()
@@ -39,6 +38,7 @@ class LoadPreferencesSideEffect(
             }
             .onCompletion { runningFlow = null }
             .launchIn(scope)
+        return ConsumeResult.Consumed
     }
 
     class Factory(

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadPreferencesSideEffect.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadPreferencesSideEffect.kt
@@ -5,12 +5,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.mail.message.list.domain.DomainContract.UseCase.GetMessageListPreferences
-import net.thunderbird.feature.mail.message.list.ui.MessageListStateSideEffectHandlerFactory
+import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandler
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandlerFactory
 
 private const val TAG = "LoadPreferencesSideEffect"
 
@@ -19,7 +20,7 @@ class LoadPreferencesSideEffect(
     dispatch: suspend (MessageListEvent) -> Unit,
     private val logger: Logger,
     private val getMessageListPreferences: GetMessageListPreferences,
-) : StateSideEffectHandler<MessageListState, MessageListEvent>(logger, dispatch) {
+) : MessageListStateSideEffectHandler(logger, dispatch) {
     private var runningFlow: Job? = null
     override fun accept(
         event: MessageListEvent,
@@ -47,7 +48,8 @@ class LoadPreferencesSideEffect(
         override fun create(
             scope: CoroutineScope,
             dispatch: suspend (MessageListEvent) -> Unit,
-        ): StateSideEffectHandler<MessageListState, MessageListEvent> = LoadPreferencesSideEffect(
+            dispatchUiEffect: suspend (MessageListEffect) -> Unit,
+        ): MessageListStateSideEffectHandler = LoadPreferencesSideEffect(
             scope = scope,
             dispatch = dispatch,
             logger = logger,

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSortCriteriaStateSideEffectHandler.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSortCriteriaStateSideEffectHandler.kt
@@ -18,14 +18,19 @@ class LoadSortCriteriaStateSideEffectHandler(
     private val logger: Logger,
     private val getSortCriteriaPerAccount: DomainContract.UseCase.GetSortCriteriaPerAccount,
 ) : MessageListStateSideEffectHandler(logger, dispatch) {
-    override fun accept(event: MessageListEvent, newState: MessageListState): Boolean =
+    override fun accept(event: MessageListEvent, oldState: MessageListState, newState: MessageListState): Boolean =
         event == MessageListEvent.LoadConfigurations
 
-    override suspend fun handle(oldState: MessageListState, newState: MessageListState) {
+    override suspend fun consume(
+        event: MessageListEvent,
+        oldState: MessageListState,
+        newState: MessageListState,
+    ): ConsumeResult {
         logger.verbose(TAG) { "$TAG.handle() called with: oldState = $oldState, newState = $newState" }
         val sortCriteriaPerAccount = getSortCriteriaPerAccount(accountIds = accounts)
         logger.verbose(TAG) { "saved sort criteria = $sortCriteriaPerAccount" }
         dispatch(MessageListEvent.SortCriteriaLoaded(sortCriteriaPerAccount))
+        return ConsumeResult.Consumed
     }
 
     class Factory(

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSortCriteriaStateSideEffectHandler.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSortCriteriaStateSideEffectHandler.kt
@@ -1,13 +1,14 @@
 package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 
 import kotlinx.coroutines.CoroutineScope
-import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.message.list.domain.DomainContract
-import net.thunderbird.feature.mail.message.list.ui.MessageListStateSideEffectHandlerFactory
+import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandler
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandlerFactory
 
 private const val TAG = "LoadSortCriteriaStateSideEffectHandler"
 
@@ -16,7 +17,7 @@ class LoadSortCriteriaStateSideEffectHandler(
     dispatch: suspend (MessageListEvent) -> Unit,
     private val logger: Logger,
     private val getSortCriteriaPerAccount: DomainContract.UseCase.GetSortCriteriaPerAccount,
-) : StateSideEffectHandler<MessageListState, MessageListEvent>(logger, dispatch) {
+) : MessageListStateSideEffectHandler(logger, dispatch) {
     override fun accept(event: MessageListEvent, newState: MessageListState): Boolean =
         event == MessageListEvent.LoadConfigurations
 
@@ -35,7 +36,8 @@ class LoadSortCriteriaStateSideEffectHandler(
         override fun create(
             scope: CoroutineScope,
             dispatch: suspend (MessageListEvent) -> Unit,
-        ): StateSideEffectHandler<MessageListState, MessageListEvent> = LoadSortCriteriaStateSideEffectHandler(
+            dispatchUiEffect: suspend (MessageListEffect) -> Unit,
+        ): MessageListStateSideEffectHandler = LoadSortCriteriaStateSideEffectHandler(
             accounts = accounts,
             dispatch = dispatch,
             logger = logger,

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSwipeActionsStateSideEffectHandler.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSwipeActionsStateSideEffectHandler.kt
@@ -22,10 +22,14 @@ class LoadSwipeActionsStateSideEffectHandler(
     private val buildSwipeActions: DomainContract.UseCase.BuildSwipeActions,
 ) : MessageListStateSideEffectHandler(logger, dispatch) {
     private var runningFlow: Job? = null
-    override fun accept(event: MessageListEvent, newState: MessageListState): Boolean =
+    override fun accept(event: MessageListEvent, oldState: MessageListState, newState: MessageListState): Boolean =
         event == MessageListEvent.LoadConfigurations
 
-    override suspend fun handle(oldState: MessageListState, newState: MessageListState) {
+    override suspend fun consume(
+        event: MessageListEvent,
+        oldState: MessageListState,
+        newState: MessageListState,
+    ): ConsumeResult {
         logger.verbose(TAG) { "$TAG.handle() called with: oldState = $oldState, newState = $newState" }
         runningFlow?.cancel()
         runningFlow = buildSwipeActions()
@@ -34,6 +38,8 @@ class LoadSwipeActionsStateSideEffectHandler(
             }
             .onCompletion { runningFlow = null }
             .launchIn(scope)
+
+        return ConsumeResult.Consumed
     }
 
     class Factory(

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSwipeActionsStateSideEffectHandler.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSwipeActionsStateSideEffectHandler.kt
@@ -5,12 +5,13 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
-import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.feature.mail.message.list.domain.DomainContract
-import net.thunderbird.feature.mail.message.list.ui.MessageListStateSideEffectHandlerFactory
+import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandler
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandlerFactory
 
 private const val TAG = "LoadSwipeActionsSideEffectHandler"
 
@@ -19,7 +20,7 @@ class LoadSwipeActionsStateSideEffectHandler(
     dispatch: suspend (MessageListEvent) -> Unit,
     private val logger: Logger,
     private val buildSwipeActions: DomainContract.UseCase.BuildSwipeActions,
-) : StateSideEffectHandler<MessageListState, MessageListEvent>(logger, dispatch) {
+) : MessageListStateSideEffectHandler(logger, dispatch) {
     private var runningFlow: Job? = null
     override fun accept(event: MessageListEvent, newState: MessageListState): Boolean =
         event == MessageListEvent.LoadConfigurations
@@ -42,7 +43,8 @@ class LoadSwipeActionsStateSideEffectHandler(
         override fun create(
             scope: CoroutineScope,
             dispatch: suspend (MessageListEvent) -> Unit,
-        ): StateSideEffectHandler<MessageListState, MessageListEvent> = LoadSwipeActionsStateSideEffectHandler(
+            dispatchUiEffect: suspend (MessageListEffect) -> Unit,
+        ): MessageListStateSideEffectHandler = LoadSwipeActionsStateSideEffectHandler(
             dispatch = dispatch,
             scope = scope,
             logger = logger,

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/inject/MessageListSideEffectsModule.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/inject/MessageListSideEffectsModule.kt
@@ -8,7 +8,7 @@ import net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect.Lo
 import net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect.LoadSortCriteriaStateSideEffectHandler
 import net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect.LoadSwipeActionsStateSideEffectHandler
 import net.thunderbird.feature.mail.message.list.ui.MessageListContract
-import net.thunderbird.feature.mail.message.list.ui.MessageListStateSideEffectHandlerFactory
+import net.thunderbird.feature.mail.message.list.ui.state.sideeffect.MessageListStateSideEffectHandlerFactory
 import org.koin.dsl.module
 
 /**

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/machine/MessageListStateMachineTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/machine/MessageListStateMachineTest.kt
@@ -38,6 +38,7 @@ import net.thunderbird.feature.mail.message.list.domain.model.SortCriteria
 import net.thunderbird.feature.mail.message.list.domain.model.SortType
 import net.thunderbird.feature.mail.message.list.preferences.ActionRequiringUserConfirmation
 import net.thunderbird.feature.mail.message.list.preferences.MessageListPreferences
+import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.FolderEvent
 import net.thunderbird.feature.mail.message.list.ui.event.MessageItemEvent
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
@@ -53,11 +54,15 @@ import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 @Suppress("MaxLineLength")
 @OptIn(ExperimentalCoroutinesApi::class)
 class MessageListStateMachineTest {
-    private fun TestScope.createStateMachine(dispatch: (MessageListEvent) -> Unit = {}) = MessageListStateMachine(
+    private fun TestScope.createStateMachine(
+        dispatch: (MessageListEvent) -> Unit = {},
+        dispatchUiEffect: (MessageListEffect) -> Unit = {},
+    ) = MessageListStateMachine(
         logger = TestLogger(),
         clock = TestClock(),
         scope = this,
         dispatch = dispatch,
+        dispatchUiEffect = dispatchUiEffect,
         debuggingSettingsPreferenceManager = FakeDebuggingSettingsPreferenceManager(),
     )
 

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/AllConfigurationsReadySideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/AllConfigurationsReadySideEffectTest.kt
@@ -2,9 +2,8 @@ package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 
 import androidx.compose.ui.graphics.Color
 import assertk.assertThat
-import assertk.assertions.isFalse
+import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isTrue
 import dev.mokkery.spy
 import dev.mokkery.verifySuspend
 import kotlin.test.Test
@@ -13,6 +12,7 @@ import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.core.common.action.SwipeAction
 import net.thunderbird.core.common.action.SwipeActions
+import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.core.preference.display.visualSettings.message.list.MessageListDateTimeFormat
 import net.thunderbird.feature.account.AccountIdFactory
@@ -30,59 +30,63 @@ import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 class AllConfigurationsReadySideEffectTest {
 
     @Test
-    fun `accept() should return true when state is WarmingUp and isReady is true`() = runTest {
+    fun `handle() should return Consumed when state is WarmingUp and isReady is true`() = runTest {
         // Arrange
         val testSubject = createTestSubject()
 
         // Act
-        val result = testSubject.accept(
+        val result = testSubject.handle(
             event = MessageListEvent.SwipeActionsLoaded(persistentMapOf()),
+            oldState = MessageListState.WarmingUp(),
             newState = createReadyWarmingUpState(),
         )
 
         // Assert
-        assertThat(result).isTrue()
+        assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Consumed)
     }
 
     @Test
-    fun `accept() should return false when state is WarmingUp but metadata is not ready`() = runTest {
+    fun `handle() should return Ignored when state is WarmingUp but metadata is not ready`() = runTest {
         // Arrange
         val testSubject = createTestSubject()
 
         // Act
-        val result = testSubject.accept(
+        val result = testSubject.handle(
             event = MessageListEvent.LoadConfigurations,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
-    fun `accept() should return false when state is WarmingUp but preferences is null`() = runTest {
+    fun `handle() should return Ignored when state is WarmingUp but preferences is null`() = runTest {
         // Arrange
         val testSubject = createTestSubject()
         val state = createReadyWarmingUpState().copy(preferences = null)
 
         // Act
-        val result = testSubject.accept(
+        val result = testSubject.handle(
             event = MessageListEvent.UpdatePreferences(createPreferences()),
+            oldState = MessageListState.WarmingUp(),
             newState = state,
         )
 
         // Assert
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
-    fun `accept() should return false when state is not WarmingUp`() = runTest {
+    fun `handle() should return Ignored when state is not WarmingUp`() = runTest {
         // Arrange
         val testSubject = createTestSubject()
 
         // Act
-        val result = testSubject.accept(
+        val result = testSubject.handle(
             event = MessageListEvent.AllConfigsReady,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.LoadedMessages(
                 metadata = createReadyMetadata(),
                 preferences = createPreferences(),
@@ -91,7 +95,7 @@ class AllConfigurationsReadySideEffectTest {
         )
 
         // Assert
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
@@ -102,7 +106,11 @@ class AllConfigurationsReadySideEffectTest {
         val state = createReadyWarmingUpState()
 
         // Act
-        testSubject.handle(oldState = MessageListState.WarmingUp(), newState = state)
+        testSubject.handle(
+            event = MessageListEvent.SwipeActionsLoaded(persistentMapOf()),
+            oldState = MessageListState.WarmingUp(),
+            newState = state,
+        )
 
         // Assert
         verifySuspend { dispatch(MessageListEvent.AllConfigsReady) }
@@ -119,6 +127,7 @@ class AllConfigurationsReadySideEffectTest {
         val result = factory.create(
             scope = this,
             dispatch = {},
+            dispatchUiEffect = {},
         )
 
         // Assert

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/AllConfigurationsReadySideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/AllConfigurationsReadySideEffectTest.kt
@@ -1,6 +1,5 @@
 package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 
-import androidx.compose.ui.graphics.Color
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
@@ -8,26 +7,13 @@ import dev.mokkery.spy
 import dev.mokkery.verifySuspend
 import kotlin.test.Test
 import kotlinx.collections.immutable.persistentMapOf
-import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.test.runTest
-import net.thunderbird.core.common.action.SwipeAction
-import net.thunderbird.core.common.action.SwipeActions
 import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.testing.TestLogger
-import net.thunderbird.core.preference.display.visualSettings.message.list.MessageListDateTimeFormat
-import net.thunderbird.feature.account.AccountIdFactory
-import net.thunderbird.feature.account.UnifiedAccountId
-import net.thunderbird.feature.mail.folder.api.FolderType
-import net.thunderbird.feature.mail.message.list.domain.model.SortCriteria
-import net.thunderbird.feature.mail.message.list.domain.model.SortType
-import net.thunderbird.feature.mail.message.list.preferences.MessageListPreferences
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
-import net.thunderbird.feature.mail.message.list.ui.state.Account
-import net.thunderbird.feature.mail.message.list.ui.state.Folder
-import net.thunderbird.feature.mail.message.list.ui.state.MessageListMetadata
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 
-class AllConfigurationsReadySideEffectTest {
+class AllConfigurationsReadySideEffectTest : BaseSideEffectHandlerTest() {
 
     @Test
     fun `handle() should return Consumed when state is WarmingUp and isReady is true`() = runTest {
@@ -69,7 +55,7 @@ class AllConfigurationsReadySideEffectTest {
 
         // Act
         val result = testSubject.handle(
-            event = MessageListEvent.UpdatePreferences(createPreferences()),
+            event = MessageListEvent.UpdatePreferences(createMessageListPreferences()),
             oldState = MessageListState.WarmingUp(),
             newState = state,
         )
@@ -89,7 +75,7 @@ class AllConfigurationsReadySideEffectTest {
             oldState = MessageListState.WarmingUp(),
             newState = MessageListState.LoadedMessages(
                 metadata = createReadyMetadata(),
-                preferences = createPreferences(),
+                preferences = createMessageListPreferences(),
                 messages = kotlinx.collections.immutable.persistentListOf(),
             ),
         )
@@ -139,38 +125,5 @@ class AllConfigurationsReadySideEffectTest {
     ) = AllConfigurationsReadySideEffect(
         logger = TestLogger(),
         dispatch = dispatch,
-    )
-
-    private fun createReadyWarmingUpState() = MessageListState.WarmingUp(
-        metadata = createReadyMetadata(),
-        preferences = createPreferences(),
-    )
-
-    private fun createReadyMetadata() = MessageListMetadata(
-        folder = Folder(
-            id = "fake",
-            account = Account(id = UnifiedAccountId, color = Color.Unspecified),
-            name = "Inbox",
-            type = FolderType.INBOX,
-        ),
-        swipeActions = persistentMapOf(
-            AccountIdFactory.create() to SwipeActions(SwipeAction.None, SwipeAction.None),
-        ),
-        sortCriteriaPerAccount = persistentMapOf(null to SortCriteria(primary = SortType.DateDesc)),
-        activeMessage = null,
-        isActive = false,
-    )
-
-    private fun createPreferences() = MessageListPreferences(
-        density = net.thunderbird.core.preference.display.visualSettings.message.list.UiDensity.Default,
-        groupConversations = false,
-        showCorrespondentNames = false,
-        showMessageAvatar = false,
-        showFavouriteButton = false,
-        senderAboveSubject = false,
-        excerptLines = 1,
-        dateTimeFormat = MessageListDateTimeFormat.Contextual,
-        actionRequiringUserConfirmation = persistentSetOf(),
-        colorizeBackgroundWhenRead = false,
     )
 }

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/BaseSideEffectHandlerTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/BaseSideEffectHandlerTest.kt
@@ -1,0 +1,81 @@
+package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
+
+import androidx.compose.ui.graphics.Color
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentMapOf
+import kotlinx.collections.immutable.persistentSetOf
+import net.thunderbird.core.common.action.SwipeAction
+import net.thunderbird.core.common.action.SwipeActions
+import net.thunderbird.core.preference.display.visualSettings.message.list.MessageListDateTimeFormat
+import net.thunderbird.core.preference.display.visualSettings.message.list.UiDensity
+import net.thunderbird.feature.account.AccountIdFactory
+import net.thunderbird.feature.account.UnifiedAccountId
+import net.thunderbird.feature.mail.folder.api.FolderType
+import net.thunderbird.feature.mail.message.list.domain.model.SortCriteria
+import net.thunderbird.feature.mail.message.list.domain.model.SortType
+import net.thunderbird.feature.mail.message.list.preferences.ActionRequiringUserConfirmation
+import net.thunderbird.feature.mail.message.list.preferences.MessageListPreferences
+import net.thunderbird.feature.mail.message.list.ui.state.Account
+import net.thunderbird.feature.mail.message.list.ui.state.Folder
+import net.thunderbird.feature.mail.message.list.ui.state.MessageListMetadata
+import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+
+open class BaseSideEffectHandlerTest {
+
+    protected fun createReadyWarmingUpState() = MessageListState.WarmingUp(
+        metadata = createReadyMetadata(),
+        preferences = createMessageListPreferences(),
+    )
+
+    protected fun createReadyMetadata() = MessageListMetadata(
+        folder = Folder(
+            id = "fake",
+            account = Account(id = UnifiedAccountId, color = Color.Unspecified),
+            name = "Inbox",
+            type = FolderType.INBOX,
+        ),
+        swipeActions = persistentMapOf(
+            AccountIdFactory.create() to SwipeActions(SwipeAction.None, SwipeAction.None),
+        ),
+        sortCriteriaPerAccount = persistentMapOf(null to SortCriteria(primary = SortType.DateDesc)),
+        activeMessage = null,
+        isActive = false,
+    )
+
+    protected fun createMessageListPreferences(
+        density: UiDensity = UiDensity.Default,
+        groupConversations: Boolean = false,
+        showCorrespondentNames: Boolean = false,
+        showMessageAvatar: Boolean = false,
+        showFavouriteButton: Boolean = false,
+        senderAboveSubject: Boolean = false,
+        excerptLines: Int = 1,
+        dateTimeFormat: MessageListDateTimeFormat = MessageListDateTimeFormat.Contextual,
+        actionRequiringUserConfirmation: ImmutableSet<ActionRequiringUserConfirmation> = persistentSetOf(),
+        colorizeBackgroundWhenRead: Boolean = false,
+    ) = MessageListPreferences(
+        density = density,
+        groupConversations = groupConversations,
+        showCorrespondentNames = showCorrespondentNames,
+        showMessageAvatar = showMessageAvatar,
+        showFavouriteButton = showFavouriteButton,
+        senderAboveSubject = senderAboveSubject,
+        excerptLines = excerptLines,
+        dateTimeFormat = dateTimeFormat,
+        actionRequiringUserConfirmation = actionRequiringUserConfirmation,
+        colorizeBackgroundWhenRead = colorizeBackgroundWhenRead,
+    )
+
+    protected fun createMetadata() = MessageListMetadata(
+        folder = Folder(
+            id = "folderId",
+            account = Account(id = AccountIdFactory.create(), color = Color.Unspecified),
+            name = "Inbox",
+            type = FolderType.INBOX,
+        ),
+        swipeActions = persistentMapOf(),
+        sortCriteriaPerAccount = persistentMapOf(),
+        activeMessage = null,
+        isActive = true,
+    )
+}

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/ChangeSortCriteriaSideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/ChangeSortCriteriaSideEffectTest.kt
@@ -12,9 +12,11 @@ import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.core.outcome.Outcome
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.AccountIdFactory
 import net.thunderbird.feature.mail.folder.api.FolderType
+import net.thunderbird.feature.mail.message.list.domain.UpdateSortCriteriaOutcome
 import net.thunderbird.feature.mail.message.list.domain.model.SortCriteria
 import net.thunderbird.feature.mail.message.list.domain.model.SortType
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
@@ -22,14 +24,21 @@ import net.thunderbird.feature.mail.message.list.ui.state.Account
 import net.thunderbird.feature.mail.message.list.ui.state.Folder
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 
-class ChangeSortCriteriaSideEffectTest {
+class ChangeSortCriteriaSideEffectTest : BaseSideEffectHandlerTest() {
     @Test
     fun `handle() should return Consumed if event is ChangeSortCriteria`() = runTest {
         // Arrange
         val testSubject = ChangeSortCriteriaSideEffect(
             dispatch = {},
             logger = TestLogger(),
-            updateSortCriteria = mock(),
+            updateSortCriteria = { _, _ -> Outcome.success(UpdateSortCriteriaOutcome.Success) },
+        )
+        val newState = MessageListState.WarmingUp(
+            metadata = createReadyMetadata().copy(
+                folder = null,
+                sortCriteriaPerAccount = persistentMapOf(null to SortCriteria(primary = SortType.DateDesc)),
+            ),
+            preferences = createMessageListPreferences(),
         )
 
         // Act
@@ -39,7 +48,7 @@ class ChangeSortCriteriaSideEffectTest {
                 sortCriteria = SortCriteria(primary = SortType.DateDesc),
             ),
             oldState = MessageListState.WarmingUp(),
-            newState = MessageListState.WarmingUp(),
+            newState = newState,
         )
 
         // Assert
@@ -59,7 +68,7 @@ class ChangeSortCriteriaSideEffectTest {
         val actual = testSubject.handle(
             event = MessageListEvent.LoadMore,
             oldState = MessageListState.WarmingUp(),
-            newState = MessageListState.WarmingUp(),
+            newState = createReadyWarmingUpState(),
         )
 
         // Assert

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/ChangeSortCriteriaSideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/ChangeSortCriteriaSideEffectTest.kt
@@ -4,13 +4,13 @@ import androidx.compose.ui.graphics.Color
 import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.hasMessage
-import assertk.assertions.isFalse
+import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isTrue
 import dev.mokkery.mock
 import kotlin.test.Test
 import kotlinx.collections.immutable.persistentMapOf
 import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.AccountIdFactory
@@ -24,7 +24,7 @@ import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 
 class ChangeSortCriteriaSideEffectTest {
     @Test
-    fun `accept() should return true if event is ChangeSortCriteria`() = runTest {
+    fun `handle() should return Consumed if event is ChangeSortCriteria`() = runTest {
         // Arrange
         val testSubject = ChangeSortCriteriaSideEffect(
             dispatch = {},
@@ -33,20 +33,21 @@ class ChangeSortCriteriaSideEffectTest {
         )
 
         // Act
-        val actual = testSubject.accept(
+        val actual = testSubject.handle(
             event = MessageListEvent.ChangeSortCriteria(
                 accountId = null,
                 sortCriteria = SortCriteria(primary = SortType.DateDesc),
             ),
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(actual).isTrue()
+        assertThat(actual).isEqualTo(StateSideEffectHandler.ConsumeResult.Consumed)
     }
 
     @Test
-    fun `accept() should return false if event is not ChangeSortCriteria`() = runTest {
+    fun `handle() should return Ignored if event is not ChangeSortCriteria`() = runTest {
         // Arrange
         val testSubject = ChangeSortCriteriaSideEffect(
             dispatch = {},
@@ -55,13 +56,14 @@ class ChangeSortCriteriaSideEffectTest {
         )
 
         // Act
-        val actual = testSubject.accept(
+        val actual = testSubject.handle(
             event = MessageListEvent.LoadMore,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(actual).isFalse()
+        assertThat(actual).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
@@ -93,9 +95,14 @@ class ChangeSortCriteriaSideEffectTest {
             )
         }
 
+        val event = MessageListEvent.ChangeSortCriteria(
+            accountId = accountIdMissingSortCriteria,
+            sortCriteria = SortCriteria(primary = SortType.DateDesc),
+        )
+
         // Act
         val actual = assertFailure {
-            testSubject.handle(oldState, newState)
+            testSubject.handle(event, oldState, newState)
         }
 
         // Assert

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffectTest.kt
@@ -3,9 +3,8 @@ package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 import androidx.compose.ui.graphics.Color
 import app.k9mail.legacy.mailstore.FolderRepository
 import assertk.assertThat
-import assertk.assertions.isFalse
+import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
-import assertk.assertions.isTrue
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.spy
@@ -14,6 +13,7 @@ import dev.mokkery.verifySuspend
 import kotlin.test.Test
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.feature.account.AccountId
@@ -31,7 +31,7 @@ import net.thunderbird.feature.mail.folder.api.Folder as MailFolder
 @Suppress("MaxLineLength")
 class LoadFolderInformationSideEffectTest {
     @Test
-    fun `accept() should return true when event is LoadConfigurations and folderId is set and accountIds size is one`() =
+    fun `handle() should return Consumed when event is LoadConfigurations and folderId is set and accountIds size is one`() =
         runTest {
             // Arrange
             val testSubject = createTestSubject(
@@ -40,17 +40,18 @@ class LoadFolderInformationSideEffectTest {
             )
 
             // Act
-            val result = testSubject.accept(
+            val result = testSubject.handle(
                 event = MessageListEvent.LoadConfigurations,
+                oldState = MessageListState.WarmingUp(),
                 newState = MessageListState.WarmingUp(),
             )
 
             // Assert
-            assertThat(result).isTrue()
+            assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Consumed)
         }
 
     @Test
-    fun `accept() should return false when event is not LoadConfigurations`() = runTest {
+    fun `handle() should return Ignored when event is not LoadConfigurations`() = runTest {
         // Arrange
         val testSubject = createTestSubject(
             accountIds = setOf(AccountIdFactory.create()),
@@ -58,17 +59,18 @@ class LoadFolderInformationSideEffectTest {
         )
 
         // Act
-        val result = testSubject.accept(
+        val result = testSubject.handle(
             event = MessageListEvent.AllConfigsReady,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
-    fun `accept() should return false when accountIds size is not one`() = runTest {
+    fun `handle() should return Ignored when accountIds size is not one`() = runTest {
         // Arrange
         val testSubject = createTestSubject(
             accountIds = setOf(AccountIdFactory.create(), AccountIdFactory.create()),
@@ -76,17 +78,18 @@ class LoadFolderInformationSideEffectTest {
         )
 
         // Act
-        val result = testSubject.accept(
+        val result = testSubject.handle(
             event = MessageListEvent.LoadConfigurations,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
-    fun `accept() should return false when folderId is null`() = runTest {
+    fun `handle() should return Ignored when folderId is null`() = runTest {
         // Arrange
         val testSubject = createTestSubject(
             accountIds = setOf(AccountIdFactory.create()),
@@ -94,13 +97,14 @@ class LoadFolderInformationSideEffectTest {
         )
 
         // Act
-        val result = testSubject.accept(
+        val result = testSubject.handle(
             event = MessageListEvent.LoadConfigurations,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
@@ -123,7 +127,11 @@ class LoadFolderInformationSideEffectTest {
         )
 
         // Act
-        testSubject.handle(MessageListState.WarmingUp(), MessageListState.WarmingUp())
+        testSubject.handle(
+            event = MessageListEvent.LoadConfigurations,
+            oldState = MessageListState.WarmingUp(),
+            newState = MessageListState.WarmingUp(),
+        )
 
         // Assert
         verifySuspend {
@@ -167,7 +175,11 @@ class LoadFolderInformationSideEffectTest {
         )
 
         // Act
-        testSubject.handle(MessageListState.WarmingUp(), MessageListState.WarmingUp())
+        testSubject.handle(
+            event = MessageListEvent.LoadConfigurations,
+            oldState = MessageListState.WarmingUp(),
+            newState = MessageListState.WarmingUp(),
+        )
 
         // Assert
         verifySuspend {
@@ -203,7 +215,11 @@ class LoadFolderInformationSideEffectTest {
         )
 
         // Act
-        testSubject.handle(MessageListState.WarmingUp(), MessageListState.WarmingUp())
+        testSubject.handle(
+            event = MessageListEvent.LoadConfigurations,
+            oldState = MessageListState.WarmingUp(),
+            newState = MessageListState.WarmingUp(),
+        )
 
         // Assert
         verifySuspend(mode = VerifyMode.exactly(0)) { dispatch(any()) }
@@ -235,7 +251,11 @@ class LoadFolderInformationSideEffectTest {
 
         // Act / Assert
         assertFailsWith<NoSuchElementException> {
-            testSubject.handle(MessageListState.WarmingUp(), MessageListState.WarmingUp())
+            testSubject.handle(
+                event = MessageListEvent.LoadConfigurations,
+                oldState = MessageListState.WarmingUp(),
+                newState = MessageListState.WarmingUp(),
+            )
         }
     }
 
@@ -253,6 +273,7 @@ class LoadFolderInformationSideEffectTest {
         val result = factory.create(
             scope = mock(),
             dispatch = {},
+            dispatchUiEffect = {},
         )
 
         // Assert

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadFolderInformationSideEffectTest.kt
@@ -29,21 +29,29 @@ import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.mail.folder.api.Folder as MailFolder
 
 @Suppress("MaxLineLength")
-class LoadFolderInformationSideEffectTest {
+class LoadFolderInformationSideEffectTest : BaseSideEffectHandlerTest() {
     @Test
     fun `handle() should return Consumed when event is LoadConfigurations and folderId is set and accountIds size is one`() =
         runTest {
             // Arrange
+            val accountId = AccountIdFactory.create()
+            val folderId = 1L
+            val folder = createMailFolder(id = folderId, name = "Inbox", isLocalOnly = true)
             val testSubject = createTestSubject(
-                accountIds = setOf(AccountIdFactory.create()),
-                folderId = 1L,
+                accountIds = setOf(accountId),
+                folderId = folderId,
+                folderRepository = createFolderRepository(
+                    accountId = accountId,
+                    folderId = folderId,
+                    folder = folder,
+                ),
             )
 
             // Act
             val result = testSubject.handle(
                 event = MessageListEvent.LoadConfigurations,
                 oldState = MessageListState.WarmingUp(),
-                newState = MessageListState.WarmingUp(),
+                newState = createReadyWarmingUpState(),
             )
 
             // Assert
@@ -62,7 +70,7 @@ class LoadFolderInformationSideEffectTest {
         val result = testSubject.handle(
             event = MessageListEvent.AllConfigsReady,
             oldState = MessageListState.WarmingUp(),
-            newState = MessageListState.WarmingUp(),
+            newState = createReadyWarmingUpState(),
         )
 
         // Assert

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadPreferencesSideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadPreferencesSideEffectTest.kt
@@ -3,13 +3,10 @@ package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import dev.mokkery.matcher.any
-import dev.mokkery.mock
 import dev.mokkery.spy
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
 import kotlin.test.Test
-import kotlinx.collections.immutable.ImmutableSet
-import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -17,15 +14,13 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.testing.TestLogger
-import net.thunderbird.core.preference.display.visualSettings.message.list.MessageListDateTimeFormat
 import net.thunderbird.core.preference.display.visualSettings.message.list.UiDensity
 import net.thunderbird.feature.mail.message.list.domain.DomainContract.UseCase.GetMessageListPreferences
-import net.thunderbird.feature.mail.message.list.preferences.ActionRequiringUserConfirmation
 import net.thunderbird.feature.mail.message.list.preferences.MessageListPreferences
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 
-class LoadPreferencesSideEffectTest {
+class LoadPreferencesSideEffectTest : BaseSideEffectHandlerTest() {
     @Test
     fun `handle() should return Consumed if event is LoadConfigurations`() = runTest {
         // Arrange
@@ -33,14 +28,14 @@ class LoadPreferencesSideEffectTest {
             dispatch = {},
             scope = backgroundScope,
             logger = TestLogger(),
-            getMessageListPreferences = mock(),
+            getMessageListPreferences = FakeGetMessageListPreferences(),
         )
 
         // Act
         val actual = testSubject.handle(
             event = MessageListEvent.LoadConfigurations,
             oldState = MessageListState.WarmingUp(),
-            newState = MessageListState.WarmingUp(),
+            newState = createReadyWarmingUpState(),
         )
 
         // Assert
@@ -54,14 +49,14 @@ class LoadPreferencesSideEffectTest {
             dispatch = {},
             scope = backgroundScope,
             logger = TestLogger(),
-            getMessageListPreferences = mock(),
+            getMessageListPreferences = FakeGetMessageListPreferences(),
         )
 
         // Act
         val actual = testSubject.handle(
             event = MessageListEvent.ExitSelectionMode,
             oldState = MessageListState.WarmingUp(),
-            newState = MessageListState.WarmingUp(),
+            newState = createReadyWarmingUpState(),
         )
 
         // Assert
@@ -130,30 +125,6 @@ class LoadPreferencesSideEffectTest {
                 dispatch(any())
             }
         }
-
-    private fun createMessageListPreferences(
-        density: UiDensity = UiDensity.Default,
-        groupConversations: Boolean = false,
-        showCorrespondentNames: Boolean = false,
-        showMessageAvatar: Boolean = false,
-        showFavouriteButton: Boolean = false,
-        senderAboveSubject: Boolean = false,
-        excerptLines: Int = 1,
-        dateTimeFormat: MessageListDateTimeFormat = MessageListDateTimeFormat.Contextual,
-        actionRequiringUserConfirmation: ImmutableSet<ActionRequiringUserConfirmation> = persistentSetOf(),
-        colorizeBackgroundWhenRead: Boolean = false,
-    ) = MessageListPreferences(
-        density = density,
-        groupConversations = groupConversations,
-        showCorrespondentNames = showCorrespondentNames,
-        showMessageAvatar = showMessageAvatar,
-        showFavouriteButton = showFavouriteButton,
-        senderAboveSubject = senderAboveSubject,
-        excerptLines = excerptLines,
-        dateTimeFormat = dateTimeFormat,
-        actionRequiringUserConfirmation = actionRequiringUserConfirmation,
-        colorizeBackgroundWhenRead = colorizeBackgroundWhenRead,
-    )
 
     private inner class FakeGetMessageListPreferences(
         initialValue: MessageListPreferences = createMessageListPreferences(),

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadPreferencesSideEffectTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadPreferencesSideEffectTest.kt
@@ -1,8 +1,7 @@
 package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 
 import assertk.assertThat
-import assertk.assertions.isFalse
-import assertk.assertions.isTrue
+import assertk.assertions.isEqualTo
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.spy
@@ -16,6 +15,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.core.preference.display.visualSettings.message.list.MessageListDateTimeFormat
 import net.thunderbird.core.preference.display.visualSettings.message.list.UiDensity
@@ -27,7 +27,7 @@ import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 
 class LoadPreferencesSideEffectTest {
     @Test
-    fun `accept() should return true if event is LoadConfigurations`() = runTest {
+    fun `handle() should return Consumed if event is LoadConfigurations`() = runTest {
         // Arrange
         val testSubject = LoadPreferencesSideEffect(
             dispatch = {},
@@ -37,17 +37,18 @@ class LoadPreferencesSideEffectTest {
         )
 
         // Act
-        val actual = testSubject.accept(
+        val actual = testSubject.handle(
             event = MessageListEvent.LoadConfigurations,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(actual).isTrue()
+        assertThat(actual).isEqualTo(StateSideEffectHandler.ConsumeResult.Consumed)
     }
 
     @Test
-    fun `accept() should return false if event is not LoadConfigurations`() = runTest {
+    fun `handle() should return Ignored if event is not LoadConfigurations`() = runTest {
         // Arrange
         val testSubject = LoadPreferencesSideEffect(
             dispatch = {},
@@ -57,13 +58,14 @@ class LoadPreferencesSideEffectTest {
         )
 
         // Act
-        val actual = testSubject.accept(
+        val actual = testSubject.handle(
             event = MessageListEvent.ExitSelectionMode,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(actual).isFalse()
+        assertThat(actual).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
@@ -84,7 +86,7 @@ class LoadPreferencesSideEffectTest {
             val newState = oldState.withMetadata { copy(isActive = true) }
 
             // Act
-            testSubject.handle(oldState, newState)
+            testSubject.handle(event = MessageListEvent.LoadConfigurations, oldState = oldState, newState = newState)
 
             // Assert
             verify(mode = VerifyMode.exactly(1)) {
@@ -110,7 +112,7 @@ class LoadPreferencesSideEffectTest {
             val newState = oldState.withMetadata { copy(isActive = true) }
 
             // Act
-            testSubject.handle(oldState, newState)
+            testSubject.handle(event = MessageListEvent.LoadConfigurations, oldState = oldState, newState = newState)
             repeat(times = 10) { index ->
                 fakeGetMessageListPreferences.emit(
                     preferences = createMessageListPreferences(

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSortTypeStateSideEffectHandlerTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSortTypeStateSideEffectHandlerTest.kt
@@ -17,7 +17,7 @@ import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import org.junit.Test
 
-class LoadSortTypeStateSideEffectHandlerTest {
+class LoadSortTypeStateSideEffectHandlerTest : BaseSideEffectHandlerTest() {
     @Test
     fun `handle() should return Consumed when event is LoadConfigurations`() = runTest {
         // Arrange
@@ -33,7 +33,7 @@ class LoadSortTypeStateSideEffectHandlerTest {
     }
 
     @Test
-    fun `handle() should return Ignored when event is not LoadConfigurations`() = runTest  {
+    fun `handle() should return Ignored when event is not LoadConfigurations`() = runTest {
         // Arrange
         val handler = createTestSubject()
         val event = MessageListEvent.AllConfigsReady

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSortTypeStateSideEffectHandlerTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSortTypeStateSideEffectHandlerTest.kt
@@ -1,11 +1,11 @@
 package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 
 import assertk.assertThat
-import assertk.assertions.isFalse
-import assertk.assertions.isTrue
+import assertk.assertions.isEqualTo
 import dev.mokkery.spy
 import dev.mokkery.verifySuspend
 import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.Logger
 import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.feature.account.AccountId
@@ -19,37 +19,37 @@ import org.junit.Test
 
 class LoadSortTypeStateSideEffectHandlerTest {
     @Test
-    fun `accept() should return true when event is LoadConfigurations`() {
+    fun `handle() should return Consumed when event is LoadConfigurations`() = runTest {
         // Arrange
         val handler = createTestSubject()
         val event = MessageListEvent.LoadConfigurations
         val state = MessageListState.WarmingUp()
 
         // Act
-        val result = handler.accept(event, state)
+        val result = handler.handle(event, oldState = MessageListState.WarmingUp(), newState = state)
 
         // Assert
-        assertThat(result).isTrue()
+        assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Consumed)
     }
 
     @Test
-    fun `accept() should return false when event is not LoadConfigurations`() {
+    fun `handle() should return Ignored when event is not LoadConfigurations`() = runTest  {
         // Arrange
         val handler = createTestSubject()
         val event = MessageListEvent.AllConfigsReady
         val state = MessageListState.WarmingUp()
 
         // Act
-        val result = handler.accept(event, state)
+        val result = handler.handle(event, oldState = MessageListState.WarmingUp(), newState = state)
 
         // Assert
-        assertThat(result).isFalse()
+        assertThat(result).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
     fun `handle() should call getSortTypes and dispatch SortTypesLoaded`() = runTest {
         // Arrange
-        val logger = TestLogger()
+        TestLogger()
         val accounts = setOf(AccountIdFactory.create())
         val dispatch = spy<suspend (MessageListEvent) -> Unit>(obj = {})
         val sortCriteriaPerAccount = mapOf(accounts.firstOrNull() to SortCriteria(primary = SortType.DateDesc))
@@ -62,7 +62,11 @@ class LoadSortTypeStateSideEffectHandlerTest {
         )
 
         // Act
-        handler.handle(oldState = MessageListState.WarmingUp(), newState = MessageListState.WarmingUp())
+        handler.handle(
+            event = MessageListEvent.LoadConfigurations,
+            oldState = MessageListState.WarmingUp(),
+            newState = MessageListState.WarmingUp(),
+        )
 
         // Assert
         verifySuspend {

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSwipeActionsStateSideEffectHandlerTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSwipeActionsStateSideEffectHandlerTest.kt
@@ -3,7 +3,6 @@ package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import dev.mokkery.matcher.any
-import dev.mokkery.mock
 import dev.mokkery.spy
 import dev.mokkery.verify
 import dev.mokkery.verify.VerifyMode
@@ -23,7 +22,7 @@ import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import org.junit.Test
 
-class LoadSwipeActionsStateSideEffectHandlerTest {
+class LoadSwipeActionsStateSideEffectHandlerTest : BaseSideEffectHandlerTest() {
     @Test
     fun `handle() should return Consumed if event is LoadConfigurations`() = runTest {
         // Arrange
@@ -31,14 +30,14 @@ class LoadSwipeActionsStateSideEffectHandlerTest {
             dispatch = {},
             scope = backgroundScope,
             logger = TestLogger(),
-            buildSwipeActions = mock(),
+            buildSwipeActions = FakeBuildSwipeActionsUseCase(),
         )
 
         // Act
         val actual = testSubject.handle(
             event = MessageListEvent.LoadConfigurations,
             oldState = MessageListState.WarmingUp(),
-            newState = MessageListState.WarmingUp(),
+            newState = createReadyWarmingUpState(),
         )
 
         // Assert
@@ -52,14 +51,14 @@ class LoadSwipeActionsStateSideEffectHandlerTest {
             dispatch = {},
             scope = backgroundScope,
             logger = TestLogger(),
-            buildSwipeActions = mock(),
+            buildSwipeActions = FakeBuildSwipeActionsUseCase(),
         )
 
         // Act
         val actual = testSubject.handle(
             event = MessageListEvent.ExitSelectionMode,
             oldState = MessageListState.WarmingUp(),
-            newState = MessageListState.WarmingUp(),
+            newState = createReadyWarmingUpState(),
         )
 
         // Assert

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSwipeActionsStateSideEffectHandlerTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/state/sideeffect/LoadSwipeActionsStateSideEffectHandlerTest.kt
@@ -1,8 +1,7 @@
 package net.thunderbird.feature.mail.message.list.internal.ui.state.sideeffect
 
 import assertk.assertThat
-import assertk.assertions.isFalse
-import assertk.assertions.isTrue
+import assertk.assertions.isEqualTo
 import dev.mokkery.matcher.any
 import dev.mokkery.mock
 import dev.mokkery.spy
@@ -15,6 +14,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import net.thunderbird.core.common.action.SwipeAction
 import net.thunderbird.core.common.action.SwipeActions
+import net.thunderbird.core.common.state.sideeffect.StateSideEffectHandler
 import net.thunderbird.core.logging.testing.TestLogger
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.account.AccountIdFactory
@@ -25,43 +25,45 @@ import org.junit.Test
 
 class LoadSwipeActionsStateSideEffectHandlerTest {
     @Test
-    fun `accept() should return true if event is LoadConfigurations`() = runTest {
+    fun `handle() should return Consumed if event is LoadConfigurations`() = runTest {
         // Arrange
         val testSubject = LoadSwipeActionsStateSideEffectHandler(
             dispatch = {},
-            scope = this,
+            scope = backgroundScope,
             logger = TestLogger(),
             buildSwipeActions = mock(),
         )
 
         // Act
-        val actual = testSubject.accept(
+        val actual = testSubject.handle(
             event = MessageListEvent.LoadConfigurations,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(actual).isTrue()
+        assertThat(actual).isEqualTo(StateSideEffectHandler.ConsumeResult.Consumed)
     }
 
     @Test
-    fun `accept() should return false if event is not LoadConfigurations`() = runTest {
+    fun `handle() should return Ignored if event is not LoadConfigurations`() = runTest {
         // Arrange
         val testSubject = LoadSwipeActionsStateSideEffectHandler(
             dispatch = {},
-            scope = this,
+            scope = backgroundScope,
             logger = TestLogger(),
             buildSwipeActions = mock(),
         )
 
         // Act
-        val actual = testSubject.accept(
+        val actual = testSubject.handle(
             event = MessageListEvent.ExitSelectionMode,
+            oldState = MessageListState.WarmingUp(),
             newState = MessageListState.WarmingUp(),
         )
 
         // Assert
-        assertThat(actual).isFalse()
+        assertThat(actual).isEqualTo(StateSideEffectHandler.ConsumeResult.Ignored)
     }
 
     @Test
@@ -84,7 +86,7 @@ class LoadSwipeActionsStateSideEffectHandlerTest {
             val newState = oldState.withMetadata { copy(isActive = true) }
 
             // Act
-            testSubject.handle(oldState, newState)
+            testSubject.handle(event = MessageListEvent.LoadConfigurations, oldState = oldState, newState = newState)
 
             // Assert
             verify(mode = VerifyMode.exactly(1)) {
@@ -115,7 +117,7 @@ class LoadSwipeActionsStateSideEffectHandlerTest {
             val newState = oldState.withMetadata { copy(isActive = true) }
 
             // Act
-            testSubject.handle(oldState, newState)
+            testSubject.handle(event = MessageListEvent.LoadConfigurations, oldState = oldState, newState = newState)
 
             swipeActions.entries.foldIndexed(mapOf<AccountId, SwipeActions>()) {
                     index,


### PR DESCRIPTION
Part of #10775.
feature-flag: `enable_message_list_new_state`

- Update `StateSideEffectHandler` and its `Factory` to include a third generic type `TEffect`.
- Add `dispatchUiEffect` to `StateSideEffectHandler` to allow side effect handlers to trigger UI effects.
- Update `BaseStateMachineViewModel` and associated tests to support the updated factory and handler signatures.