### PR TITLE
refactor(message-list): reestructure composables to use atomic design and include scroll events handling

### DIFF
--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/MessageListContract.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/MessageListContract.kt
@@ -9,6 +9,8 @@ import net.thunderbird.core.ui.compose.common.mvi.BaseStateMachineViewModel
 import net.thunderbird.core.ui.contract.mvi.BaseViewModel
 import net.thunderbird.core.ui.contract.mvi.observe
 import net.thunderbird.feature.account.AccountId
+import net.thunderbird.feature.mail.message.list.ui.component.MessageListScope
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
@@ -68,7 +70,7 @@ interface MessageListContract {
          * @param inAppNotificationEventFilter A filter to decide whether an in-app notification should be displayed.
          */
         @Composable
-        fun Render(
+        fun MessageListScope.Render(
             state: MessageListState,
             dispatchEvent: (MessageListEvent) -> Unit,
             modifier: Modifier = Modifier,
@@ -88,13 +90,16 @@ interface MessageListContract {
          */
         @Composable
         fun Render(
-            onEffect: (MessageListEffect) -> Unit,
+            onEffect: MessageListScope.(MessageListEffect) -> Unit,
             modifier: Modifier = Modifier,
             viewModel: ViewModel = koinViewModel(),
             inAppNotificationEventFilter: (InAppNotification) -> Boolean = { true },
         ) {
-            val (state, dispatchEvent) = viewModel.observe(onEffect)
-            Render(state.value, dispatchEvent, modifier, inAppNotificationEventFilter)
+            val scope = rememberMessageListScope()
+            val (state, dispatchEvent) = viewModel.observe { effect ->
+                scope.onEffect(effect)
+            }
+            scope.Render(state.value, dispatchEvent, modifier, inAppNotificationEventFilter)
         }
     }
 }

--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/MessageListContract.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/MessageListContract.kt
@@ -64,7 +64,6 @@ interface MessageListContract {
          *
          * @param state The current state of the message list to be rendered.
          * @param dispatchEvent A lambda function to be invoked when a user action or other UI event occurs.
-         * @param onEffect A lambda function to handle one-time side effects from the ViewModel.
          * @param modifier The modifier to be applied to the root container of the message list screen.
          * @param inAppNotificationEventFilter A filter to decide whether an in-app notification should be displayed.
          */
@@ -72,7 +71,6 @@ interface MessageListContract {
         fun Render(
             state: MessageListState,
             dispatchEvent: (MessageListEvent) -> Unit,
-            onEffect: (MessageListEffect) -> Unit,
             modifier: Modifier = Modifier,
             inAppNotificationEventFilter: (InAppNotification) -> Boolean = { true },
         )
@@ -96,7 +94,7 @@ interface MessageListContract {
             inAppNotificationEventFilter: (InAppNotification) -> Boolean = { true },
         ) {
             val (state, dispatchEvent) = viewModel.observe(onEffect)
-            Render(state.value, dispatchEvent, onEffect, modifier, inAppNotificationEventFilter)
+            Render(state.value, dispatchEvent, modifier, inAppNotificationEventFilter)
         }
     }
 }

--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/MessageListScope.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/MessageListScope.kt
@@ -1,0 +1,60 @@
+package net.thunderbird.feature.mail.message.list.ui.component
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.runtime.remember
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.receiveAsFlow
+import net.thunderbird.feature.mail.message.list.ui.state.MessageItemUi
+
+/**
+ * Scope for controlling the message list from external callers (e.g., effect handlers).
+ *
+ * Provided as a receiver to composables in the message list tree, allowing scroll commands
+ * to reach the [LazyColumn][androidx.compose.foundation.lazy.LazyColumn] without exposing its internal state.
+ */
+@Stable
+interface MessageListScope {
+    /**
+     * Flow of scroll events to be consumed by the message list composable.
+     */
+    val scrollEvents: Flow<ScrollEvent>
+
+    /**
+     * Requests the message list to scroll to the given [message].
+     *
+     * @param message The message to scroll to.
+     * @param animated Whether to animate the scroll. Defaults to `true`.
+     */
+    fun scrollToMessage(message: MessageItemUi, animated: Boolean = true)
+}
+
+/**
+ * One-shot events that control the scroll position of the message list.
+ */
+sealed interface ScrollEvent {
+    /**
+     * Requests scrolling to a specific [message].
+     *
+     * @property message The target message.
+     * @property animated Whether the scroll should be animated.
+     */
+    data class ScrollToMessage(val message: MessageItemUi, val animated: Boolean = true) : ScrollEvent
+}
+
+@Stable
+internal class DefaultMessageListScope : MessageListScope {
+    private val _scrollEvents = Channel<ScrollEvent>(capacity = Channel.CONFLATED)
+    override val scrollEvents: Flow<ScrollEvent> = _scrollEvents.receiveAsFlow()
+
+    override fun scrollToMessage(message: MessageItemUi, animated: Boolean) {
+        _scrollEvents.trySend(ScrollEvent.ScrollToMessage(message, animated))
+    }
+}
+
+/**
+ * Creates and remembers a [MessageListScope] instance tied to the current composition.
+ */
+@Composable
+fun rememberMessageListScope(): MessageListScope = remember { DefaultMessageListScope() }

--- a/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/MessageListScreenLoadingMessagesStatePreviewParams.kt
+++ b/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/MessageListScreenLoadingMessagesStatePreviewParams.kt
@@ -17,6 +17,7 @@ import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenRe
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessageListMetadataPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreferencesPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreviewHelper
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationStream
@@ -89,11 +90,13 @@ private fun MessageListScreenLoadingMessagesStatePreview(
         }
     } WithContent {
         ThunderbirdTheme2 {
-            renderer.Render(
-                state = params.state,
-                dispatchEvent = {},
-                onEffect = {},
-            )
+            val scope = rememberMessageListScope()
+            with(renderer) {
+                scope.Render(
+                    state = params.state,
+                    dispatchEvent = {},
+                )
+            }
         }
     }
 }

--- a/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/MessageListScreenSearchingMessagesStatePreviewParams.kt
+++ b/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/MessageListScreenSearchingMessagesStatePreviewParams.kt
@@ -18,6 +18,7 @@ import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenRe
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessageListMetadataPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreferencesPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreviewHelper
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationStream
@@ -83,11 +84,13 @@ private fun MessageListScreenSearchingMessagesStatePreview(
         }
     } WithContent {
         ThunderbirdTheme2 {
-            renderer.Render(
-                state = params.state,
-                dispatchEvent = {},
-                onEffect = {},
-            )
+            val scope = rememberMessageListScope()
+            with(renderer) {
+                scope.Render(
+                    state = params.state,
+                    dispatchEvent = {},
+                )
+            }
         }
     }
 }

--- a/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/MessageListScreenSelectingMessagesStatePreviewParams.kt
+++ b/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/MessageListScreenSelectingMessagesStatePreviewParams.kt
@@ -17,6 +17,7 @@ import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenRe
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessageListMetadataPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreferencesPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreviewHelper
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationStream
@@ -58,11 +59,13 @@ private fun MessageListScreenSelectingMessagesStatePreview(
         }
     } WithContent {
         ThunderbirdTheme2 {
-            renderer.Render(
-                state = params.state,
-                dispatchEvent = {},
-                onEffect = {},
-            )
+            val scope = rememberMessageListScope()
+            with(renderer) {
+                scope.Render(
+                    state = params.state,
+                    dispatchEvent = {},
+                )
+            }
         }
     }
 }

--- a/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/MessageListScreenWarmingUpStatePreviewParams.kt
+++ b/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/MessageListScreenWarmingUpStatePreviewParams.kt
@@ -14,6 +14,7 @@ import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenPr
 import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenPreviewParamsProvider
 import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenRenderer
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreferencesPreviewHelper
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationStream
@@ -50,11 +51,13 @@ private fun MessageListScreenWarmingUpStatePreview(
         }
     } WithContent {
         ThunderbirdTheme2 {
-            renderer.Render(
-                state = params.state,
-                dispatchEvent = {},
-                onEffect = {},
-            )
+            val scope = rememberMessageListScope()
+            with(renderer) {
+                scope.Render(
+                    state = params.state,
+                    dispatchEvent = {},
+                )
+            }
         }
     }
 }

--- a/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/loadedmessages/MessageListScreenLoadedMessagesContentPreview.kt
+++ b/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/loadedmessages/MessageListScreenLoadedMessagesContentPreview.kt
@@ -18,6 +18,7 @@ import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenRe
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessageListMetadataPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreferencesPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreviewHelper
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationStream
@@ -98,11 +99,13 @@ private fun MessageListScreenLoadedMessagesContentPreview(
         }
     } WithContent {
         ThunderbirdTheme2 {
-            renderer.Render(
-                state = params.state,
-                dispatchEvent = {},
-                onEffect = {},
-            )
+            val scope = rememberMessageListScope()
+            with(renderer) {
+                scope.Render(
+                    state = params.state,
+                    dispatchEvent = {},
+                )
+            }
         }
     }
 }

--- a/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/loadedmessages/MessageListScreenLoadedMessagesDensityPreview.kt
+++ b/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/loadedmessages/MessageListScreenLoadedMessagesDensityPreview.kt
@@ -17,6 +17,7 @@ import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenRe
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessageListMetadataPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreferencesPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreviewHelper
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationStream
@@ -76,11 +77,13 @@ private fun MessageListScreenLoadedMessagesDensityPreview(
         }
     } WithContent {
         ThunderbirdTheme2 {
-            renderer.Render(
-                state = params.state,
-                dispatchEvent = {},
-                onEffect = {},
-            )
+            val scope = rememberMessageListScope()
+            with(renderer) {
+                scope.Render(
+                    state = params.state,
+                    dispatchEvent = {},
+                )
+            }
         }
     }
 }

--- a/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/loadedmessages/MessageListScreenLoadedMessagesFooterPreview.kt
+++ b/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/loadedmessages/MessageListScreenLoadedMessagesFooterPreview.kt
@@ -17,6 +17,7 @@ import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenRe
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessageListMetadataPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreferencesPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreviewHelper
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListFooter
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
@@ -72,11 +73,13 @@ private fun MessageListScreenLoadedMessagesFooterPreview(
         }
     } WithContent {
         ThunderbirdTheme2 {
-            renderer.Render(
-                state = params.state,
-                dispatchEvent = {},
-                onEffect = {},
-            )
+            val scope = rememberMessageListScope()
+            with(renderer) {
+                scope.Render(
+                    state = params.state,
+                    dispatchEvent = {},
+                )
+            }
         }
     }
 }

--- a/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/loadedmessages/MessageListScreenLoadedMessagesLayoutPreview.kt
+++ b/feature/mail/message/list/internal/src/debug/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/renderer/statepreview/loadedmessages/MessageListScreenLoadedMessagesLayoutPreview.kt
@@ -17,6 +17,7 @@ import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenRe
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessageListMetadataPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreferencesPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreviewHelper
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.receiver.InAppNotificationStream
@@ -76,11 +77,13 @@ private fun MessageListScreenLayoutPreview(
         }
     } WithContent {
         ThunderbirdTheme2 {
-            renderer.Render(
-                state = params.state,
-                dispatchEvent = {},
-                onEffect = {},
-            )
+            val scope = rememberMessageListScope()
+            with(renderer) {
+                scope.Render(
+                    state = params.state,
+                    dispatchEvent = {},
+                )
+            }
         }
     }
 }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/MessageListScreenRenderer.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/MessageListScreenRenderer.kt
@@ -1,246 +1,26 @@
 package net.thunderbird.feature.mail.message.list.internal.ui
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.snapshotFlow
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.semantics.stateDescription
-import androidx.compose.ui.unit.dp
-import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
-import app.k9mail.core.ui.compose.designsystem.molecule.PullToRefreshBox
-import kotlinx.coroutines.flow.distinctUntilChanged
-import net.thunderbird.core.common.action.SwipeAction
-import net.thunderbird.core.common.action.SwipeActions
-import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
-import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.SwipeBehaviour
-import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.SwipeDirection
-import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.SwipeableRow
-import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.SwipeableRowState
-import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.rememberSwipeableRowState
-import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenRenderer.Companion.TEST_TAG_MESSAGE_LIST_ROOT
-import net.thunderbird.feature.mail.message.list.internal.ui.component.MessageItemSwipeBackground
-import net.thunderbird.feature.mail.message.list.internal.ui.component.MessageListItem
+import net.thunderbird.feature.mail.message.list.internal.ui.component.page.MessageListPage
 import net.thunderbird.feature.mail.message.list.ui.MessageListContract
-import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
-import net.thunderbird.feature.mail.message.list.ui.event.MessageItemEvent
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
-import net.thunderbird.feature.mail.message.list.ui.state.MessageItemUi
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
-import net.thunderbird.feature.mail.message.list.ui.state.PaginationUi
 import net.thunderbird.feature.notification.api.content.InAppNotification
-import net.thunderbird.feature.notification.api.ui.InAppNotificationScaffold
-
-private const val FOOTER_HEIGHT = 64
 
 internal class MessageListScreenRenderer : MessageListContract.MessageListScreenRenderer {
     @Composable
     override fun Render(
         state: MessageListState,
         dispatchEvent: (MessageListEvent) -> Unit,
-        onEffect: (MessageListEffect) -> Unit,
         modifier: Modifier,
         inAppNotificationEventFilter: (InAppNotification) -> Boolean,
     ) {
-        InAppNotificationScaffold(
-            eventFilter = inAppNotificationEventFilter,
+        MessageListPage(
+            inAppNotificationEventFilter = inAppNotificationEventFilter,
+            state = state,
+            dispatchEvent = dispatchEvent,
             modifier = modifier,
-        ) { paddingValues ->
-            PullToRefreshBox(
-                isRefreshing = (state as? MessageListState.LoadingMessages)?.isPullToRefresh == true,
-                onRefresh = { dispatchEvent(MessageListEvent.Refresh) },
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues),
-            ) {
-                MessageList(state = state, dispatchEvent = dispatchEvent, modifier = Modifier.fillMaxSize())
-            }
-        }
-    }
-
-    internal companion object {
-        const val TEST_TAG_MESSAGE_LIST_ROOT = "TestMessageList_Root"
-    }
-}
-
-@Composable
-private fun MessageList(
-    state: MessageListState,
-    dispatchEvent: (MessageListEvent) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    val listState = rememberMessageListLazyState(state, dispatchEvent)
-
-    val showAccountIndicator = state.metadata.showAccountIndicator
-    val swipeActions = state.metadata.swipeActions
-    LazyColumn(
-        modifier = modifier.testTagAsResourceId(TEST_TAG_MESSAGE_LIST_ROOT),
-        state = listState,
-    ) {
-        items(
-            items = state.messages,
-            key = { message -> message.id },
-        ) { message ->
-            val messageSwipeActions = swipeActions[message.account.id]
-            val preferences = state.preferences ?: return@items
-            MessageListSwipeableItem(message, messageSwipeActions, dispatchEvent) { accessibilityState ->
-                MessageListItem(
-                    message = message,
-                    showAccountIndicator = showAccountIndicator,
-                    preferences = preferences,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .semantics(mergeDescendants = true) {
-                            stateDescription = accessibilityState.stateDescription(message)
-                        },
-                    onClick = { dispatchEvent(MessageItemEvent.OnMessageClick(message)) },
-                    onLongClick = { dispatchEvent(MessageItemEvent.ToggleSelectMessages(message)) },
-                    onAvatarClick = { dispatchEvent(MessageItemEvent.ToggleSelectMessages(message)) },
-                    onFavouriteClick = { dispatchEvent(MessageItemEvent.ToggleFavourite(message)) },
-                )
-            }
-        }
-        item { MessageListFooter(state, dispatchEvent, Modifier.animateItem()) }
-    }
-}
-
-@Composable
-private fun rememberMessageListSwipeableRowState(
-    accessibilityState: MessageListScreenAccessibilityState,
-    startToEndAction: SwipeAction,
-    endToStartAction: SwipeAction,
-): SwipeableRowState = rememberSwipeableRowState(
-    startToEndBehaviour = remember(startToEndAction) { startToEndAction.behaviour },
-    endToStartBehaviour = remember(endToStartAction) { endToStartAction.behaviour },
-    accessibilityActions = accessibilityState.swipeDirectionAccessibilityAction,
-)
-
-private val SwipeAction.behaviour: SwipeBehaviour
-    get() = when (this) {
-        SwipeAction.None, SwipeAction.ArchiveDisabled -> SwipeBehaviour.Disabled
-
-        SwipeAction.ToggleSelection,
-        SwipeAction.ToggleRead,
-        SwipeAction.ToggleStar,
-        SwipeAction.ArchiveSetupArchiveFolder,
-        -> SwipeBehaviour.Action()
-
-        SwipeAction.Archive,
-        SwipeAction.Delete,
-        SwipeAction.Spam,
-        SwipeAction.Move,
-        -> SwipeBehaviour.Dismiss()
-    }
-
-@Composable
-private fun MessageListSwipeableItem(
-    message: MessageItemUi,
-    messageSwipeActions: SwipeActions?,
-    dispatchEvent: (MessageItemEvent) -> Unit,
-    modifier: Modifier = Modifier,
-    content: @Composable (MessageListScreenAccessibilityState) -> Unit,
-) {
-    val accessibilityState = rememberMessageListScreenAccessibilityState(messageSwipeActions)
-    val state = rememberMessageListSwipeableRowState(
-        accessibilityState = accessibilityState,
-        startToEndAction = messageSwipeActions?.rightAction ?: SwipeAction.None,
-        endToStartAction = messageSwipeActions?.leftAction ?: SwipeAction.None,
-    )
-    SwipeableRow(
-        state = state,
-        backgroundContent = {
-            messageSwipeActions?.let { swipeActions ->
-                val (swipeAction, arrangement) = when (state.swipeDirection) {
-                    SwipeDirection.StartToEnd -> swipeActions.rightAction to Arrangement.Start
-                    SwipeDirection.EndToStart -> swipeActions.leftAction to Arrangement.End
-                    SwipeDirection.Settled -> return@let
-                }
-                MessageItemSwipeBackground(
-                    action = swipeAction,
-                    toggled = false,
-                    arrangement = arrangement,
-                )
-            }
-        },
-        gesturesEnabled = messageSwipeActions != null,
-        onSwipeEnd = { direction ->
-            messageSwipeActions
-                ?.let { swipeActions ->
-                    when (direction) {
-                        SwipeDirection.StartToEnd -> swipeActions.rightAction
-                        SwipeDirection.EndToStart -> swipeActions.leftAction
-                        else -> null
-                    }
-                }
-                ?.let { dispatchEvent(MessageItemEvent.OnSwipeMessage(message, swipeAction = it)) }
-        },
-        modifier = modifier,
-    ) {
-        content(accessibilityState)
-    }
-}
-
-@Composable
-private fun MessageListFooter(
-    state: MessageListState,
-    dispatchEvent: (MessageListEvent) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(FOOTER_HEIGHT.dp),
-        contentAlignment = Alignment.Center,
-    ) {
-        ButtonText(
-            text = state.metadata.footer.text,
-            onClick = { dispatchEvent(MessageListEvent.OnFooterClick) },
         )
     }
-}
-
-@Composable
-private fun rememberMessageListLazyState(
-    state: MessageListState,
-    dispatchEvent: (MessageListEvent) -> Unit,
-): LazyListState {
-    val listState = rememberLazyListState()
-    val latestPaging by rememberUpdatedState(state.metadata.paging)
-
-    LaunchedEffect(listState, state.metadata.folder?.id) {
-        snapshotFlow {
-            val total = listState.layoutInfo.totalItemsCount
-            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
-            lastVisible to total
-        }
-            .distinctUntilChanged()
-            .collect { (lastVisible, total) ->
-                val hasNextPage = total > 0 && lastVisible >= total - 1 && total > latestPaging.prefetchDistance
-                if (!hasNextPage) return@collect
-                val prefetchTriggerIndex = (total - 1 - latestPaging.prefetchDistance).coerceAtLeast(0)
-                val nearEnd = lastVisible >= prefetchTriggerIndex
-
-                if (nearEnd &&
-                    latestPaging.phase != PaginationUi.Phase.Loading &&
-                    !latestPaging.endReached
-                ) {
-                    dispatchEvent(MessageListEvent.LoadNextPage)
-                }
-            }
-    }
-    return listState
 }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/MessageListScreenRenderer.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/MessageListScreenRenderer.kt
@@ -4,13 +4,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import net.thunderbird.feature.mail.message.list.internal.ui.component.page.MessageListPage
 import net.thunderbird.feature.mail.message.list.ui.MessageListContract
+import net.thunderbird.feature.mail.message.list.ui.component.MessageListScope
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
 
 internal class MessageListScreenRenderer : MessageListContract.MessageListScreenRenderer {
     @Composable
-    override fun Render(
+    override fun MessageListScope.Render(
         state: MessageListState,
         dispatchEvent: (MessageListEvent) -> Unit,
         modifier: Modifier,

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/organism/MessageListFooter.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/organism/MessageListFooter.kt
@@ -1,0 +1,33 @@
+package net.thunderbird.feature.mail.message.list.internal.ui.component.organism
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import app.k9mail.core.ui.compose.designsystem.atom.button.ButtonText
+import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
+import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+
+private const val FOOTER_HEIGHT = 64
+
+@Composable
+internal fun MessageListFooter(
+    state: MessageListState,
+    dispatchEvent: (MessageListEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(FOOTER_HEIGHT.dp),
+        contentAlignment = Alignment.Center,
+    ) {
+        ButtonText(
+            text = state.metadata.footer.text,
+            onClick = { dispatchEvent(MessageListEvent.OnFooterClick) },
+        )
+    }
+}

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/organism/MessageListSwipeableItem.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/organism/MessageListSwipeableItem.kt
@@ -1,0 +1,94 @@
+package net.thunderbird.feature.mail.message.list.internal.ui.component.organism
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import net.thunderbird.core.common.action.SwipeAction
+import net.thunderbird.core.common.action.SwipeActions
+import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.SwipeBehaviour
+import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.SwipeDirection
+import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.SwipeableRow
+import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.SwipeableRowState
+import net.thunderbird.core.ui.compose.designsystem.molecule.swipe.rememberSwipeableRowState
+import net.thunderbird.feature.mail.message.list.internal.ui.MessageListScreenAccessibilityState
+import net.thunderbird.feature.mail.message.list.internal.ui.component.MessageItemSwipeBackground
+import net.thunderbird.feature.mail.message.list.internal.ui.rememberMessageListScreenAccessibilityState
+import net.thunderbird.feature.mail.message.list.ui.event.MessageItemEvent
+import net.thunderbird.feature.mail.message.list.ui.state.MessageItemUi
+
+@Composable
+internal fun MessageListSwipeableItem(
+    message: MessageItemUi,
+    messageSwipeActions: SwipeActions?,
+    dispatchEvent: (MessageItemEvent) -> Unit,
+    modifier: Modifier = Modifier,
+    content: @Composable (MessageListScreenAccessibilityState) -> Unit,
+) {
+    val accessibilityState = rememberMessageListScreenAccessibilityState(messageSwipeActions)
+    val state = rememberMessageListSwipeableRowState(
+        accessibilityState = accessibilityState,
+        startToEndAction = messageSwipeActions?.rightAction ?: SwipeAction.None,
+        endToStartAction = messageSwipeActions?.leftAction ?: SwipeAction.None,
+    )
+    SwipeableRow(
+        state = state,
+        backgroundContent = {
+            messageSwipeActions?.let { swipeActions ->
+                val (swipeAction, arrangement) = when (state.swipeDirection) {
+                    SwipeDirection.StartToEnd -> swipeActions.rightAction to Arrangement.Start
+                    SwipeDirection.EndToStart -> swipeActions.leftAction to Arrangement.End
+                    SwipeDirection.Settled -> return@let
+                }
+                MessageItemSwipeBackground(
+                    action = swipeAction,
+                    toggled = false,
+                    arrangement = arrangement,
+                )
+            }
+        },
+        gesturesEnabled = messageSwipeActions != null,
+        onSwipeEnd = { direction ->
+            messageSwipeActions
+                ?.let { swipeActions ->
+                    when (direction) {
+                        SwipeDirection.StartToEnd -> swipeActions.rightAction
+                        SwipeDirection.EndToStart -> swipeActions.leftAction
+                        else -> null
+                    }
+                }
+                ?.let { dispatchEvent(MessageItemEvent.OnSwipeMessage(message, swipeAction = it)) }
+        },
+        modifier = modifier,
+    ) {
+        content(accessibilityState)
+    }
+}
+
+@Composable
+private fun rememberMessageListSwipeableRowState(
+    accessibilityState: MessageListScreenAccessibilityState,
+    startToEndAction: SwipeAction,
+    endToStartAction: SwipeAction,
+): SwipeableRowState = rememberSwipeableRowState(
+    startToEndBehaviour = remember(startToEndAction) { startToEndAction.behaviour },
+    endToStartBehaviour = remember(endToStartAction) { endToStartAction.behaviour },
+    accessibilityActions = accessibilityState.swipeDirectionAccessibilityAction,
+)
+
+private val SwipeAction.behaviour: SwipeBehaviour
+    get() = when (this) {
+        SwipeAction.None, SwipeAction.ArchiveDisabled -> SwipeBehaviour.Disabled
+
+        SwipeAction.ToggleSelection,
+        SwipeAction.ToggleRead,
+        SwipeAction.ToggleStar,
+        SwipeAction.ArchiveSetupArchiveFolder,
+        -> SwipeBehaviour.Action()
+
+        SwipeAction.Archive,
+        SwipeAction.Delete,
+        SwipeAction.Spam,
+        SwipeAction.Move,
+        -> SwipeBehaviour.Dismiss()
+    }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/page/MessageListPage.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/page/MessageListPage.kt
@@ -6,13 +6,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import app.k9mail.core.ui.compose.designsystem.molecule.PullToRefreshBox
 import net.thunderbird.feature.mail.message.list.internal.ui.component.template.MessageList
+import net.thunderbird.feature.mail.message.list.ui.component.MessageListScope
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.notification.api.content.InAppNotification
 import net.thunderbird.feature.notification.api.ui.InAppNotificationScaffold
 
 @Composable
-internal fun MessageListPage(
+internal fun MessageListScope.MessageListPage(
     inAppNotificationEventFilter: (InAppNotification) -> Boolean,
     state: MessageListState,
     dispatchEvent: (MessageListEvent) -> Unit,

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/page/MessageListPage.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/page/MessageListPage.kt
@@ -1,0 +1,35 @@
+package net.thunderbird.feature.mail.message.list.internal.ui.component.page
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import app.k9mail.core.ui.compose.designsystem.molecule.PullToRefreshBox
+import net.thunderbird.feature.mail.message.list.internal.ui.component.template.MessageList
+import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
+import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.notification.api.content.InAppNotification
+import net.thunderbird.feature.notification.api.ui.InAppNotificationScaffold
+
+@Composable
+internal fun MessageListPage(
+    inAppNotificationEventFilter: (InAppNotification) -> Boolean,
+    state: MessageListState,
+    dispatchEvent: (MessageListEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    InAppNotificationScaffold(
+        eventFilter = inAppNotificationEventFilter,
+        modifier = modifier,
+    ) { paddingValues ->
+        PullToRefreshBox(
+            isRefreshing = (state as? MessageListState.LoadingMessages)?.isPullToRefresh == true,
+            onRefresh = { dispatchEvent(MessageListEvent.Refresh) },
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+        ) {
+            MessageList(state = state, dispatchEvent = dispatchEvent, modifier = Modifier.fillMaxSize())
+        }
+    }
+}

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/template/MessageList.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/template/MessageList.kt
@@ -43,27 +43,14 @@ internal fun MessageListScope.MessageList(
     val showAccountIndicator = state.metadata.showAccountIndicator
     val swipeActions = state.metadata.swipeActions
 
-    val currentMessages by rememberUpdatedState(state.messages)
-    val scope = rememberCoroutineScope()
-    LifecycleStartEffect(scrollEvents, listState) {
-        val job = scope.launch {
-            scrollEvents.collect { event ->
-                when (event) {
-                    is ScrollEvent.ScrollToMessage -> listState.scrollToMessage(currentMessages, event)
-                }
-            }
-        }
-        onStopOrDispose {
-            job.cancel()
-        }
-    }
+    ScrollEventEffect(state.messages, listState)
 
     LazyColumn(
         modifier = modifier.testTagAsResourceId(TEST_TAG_MESSAGE_LIST_ROOT),
         state = listState,
     ) {
         items(
-            items = currentMessages,
+            items = state.messages,
             key = { message -> message.id },
         ) { message ->
             val messageSwipeActions = swipeActions[message.account.id]
@@ -133,5 +120,35 @@ private suspend fun LazyListState.scrollToMessage(
     val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
     if (index !in firstVisible..lastVisible) {
         if (animated) animateScrollToItem(index) else scrollToItem(index)
+    }
+}
+
+@Composable
+private fun MessageListScope.ScrollEventEffect(messages: ImmutableList<MessageItemUi>, listState: LazyListState) {
+    val currentMessages by rememberUpdatedState(messages)
+
+    val scope = rememberCoroutineScope()
+    LifecycleStartEffect(scrollEvents, listState) {
+        val job = scope.launch {
+            scrollEvents.collect { event ->
+                when (event) {
+                    is ScrollEvent.ScrollToMessage -> listState.scrollToMessage(currentMessages, event)
+                }
+            }
+        }
+        onStopOrDispose {
+            job.cancel()
+        }
+    }
+
+    // For configuration restoration
+    LaunchedEffect(listState) {
+        val activeMessage = currentMessages.firstOrNull { it.active }
+        if (activeMessage != null) {
+            listState.scrollToMessage(
+                currentMessages,
+                ScrollEvent.ScrollToMessage(activeMessage, animated = false),
+            )
+        }
     }
 }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/template/MessageList.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/template/MessageList.kt
@@ -8,25 +8,32 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.semantics.stateDescription
+import androidx.lifecycle.compose.LifecycleStartEffect
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.launch
 import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 import net.thunderbird.feature.mail.message.list.internal.ui.component.MessageListItem
 import net.thunderbird.feature.mail.message.list.internal.ui.component.organism.MessageListFooter
 import net.thunderbird.feature.mail.message.list.internal.ui.component.organism.MessageListSwipeableItem
+import net.thunderbird.feature.mail.message.list.ui.component.MessageListScope
+import net.thunderbird.feature.mail.message.list.ui.component.ScrollEvent
 import net.thunderbird.feature.mail.message.list.ui.event.MessageItemEvent
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
+import net.thunderbird.feature.mail.message.list.ui.state.MessageItemUi
 import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
 import net.thunderbird.feature.mail.message.list.ui.state.PaginationUi
 
 const val TEST_TAG_MESSAGE_LIST_ROOT = "TestMessageList_Root"
 
 @Composable
-internal fun MessageList(
+internal fun MessageListScope.MessageList(
     state: MessageListState,
     dispatchEvent: (MessageListEvent) -> Unit,
     modifier: Modifier = Modifier,
@@ -35,12 +42,28 @@ internal fun MessageList(
 
     val showAccountIndicator = state.metadata.showAccountIndicator
     val swipeActions = state.metadata.swipeActions
+
+    val currentMessages by rememberUpdatedState(state.messages)
+    val scope = rememberCoroutineScope()
+    LifecycleStartEffect(scrollEvents, listState) {
+        val job = scope.launch {
+            scrollEvents.collect { event ->
+                when (event) {
+                    is ScrollEvent.ScrollToMessage -> listState.scrollToMessage(currentMessages, event)
+                }
+            }
+        }
+        onStopOrDispose {
+            job.cancel()
+        }
+    }
+
     LazyColumn(
         modifier = modifier.testTagAsResourceId(TEST_TAG_MESSAGE_LIST_ROOT),
         state = listState,
     ) {
         items(
-            items = state.messages,
+            items = currentMessages,
             key = { message -> message.id },
         ) { message ->
             val messageSwipeActions = swipeActions[message.account.id]
@@ -98,4 +121,17 @@ private fun rememberMessageListLazyState(
             }
     }
     return listState
+}
+
+private suspend fun LazyListState.scrollToMessage(
+    messages: ImmutableList<MessageItemUi>,
+    event: ScrollEvent.ScrollToMessage,
+) {
+    val (message, animated) = event
+    val index = messages.indexOfFirst { message.id == it.id }.takeIf { it >= 0 } ?: return
+    val firstVisible = layoutInfo.visibleItemsInfo.firstOrNull()?.index ?: 0
+    val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+    if (index !in firstVisible..lastVisible) {
+        if (animated) animateScrollToItem(index) else scrollToItem(index)
+    }
 }

--- a/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/template/MessageList.kt
+++ b/feature/mail/message/list/internal/src/main/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/component/template/MessageList.kt
@@ -1,0 +1,101 @@
+package net.thunderbird.feature.mail.message.list.internal.ui.component.template
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.semantics.stateDescription
+import kotlinx.coroutines.flow.distinctUntilChanged
+import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
+import net.thunderbird.feature.mail.message.list.internal.ui.component.MessageListItem
+import net.thunderbird.feature.mail.message.list.internal.ui.component.organism.MessageListFooter
+import net.thunderbird.feature.mail.message.list.internal.ui.component.organism.MessageListSwipeableItem
+import net.thunderbird.feature.mail.message.list.ui.event.MessageItemEvent
+import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
+import net.thunderbird.feature.mail.message.list.ui.state.MessageListState
+import net.thunderbird.feature.mail.message.list.ui.state.PaginationUi
+
+const val TEST_TAG_MESSAGE_LIST_ROOT = "TestMessageList_Root"
+
+@Composable
+internal fun MessageList(
+    state: MessageListState,
+    dispatchEvent: (MessageListEvent) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val listState = rememberMessageListLazyState(state, dispatchEvent)
+
+    val showAccountIndicator = state.metadata.showAccountIndicator
+    val swipeActions = state.metadata.swipeActions
+    LazyColumn(
+        modifier = modifier.testTagAsResourceId(TEST_TAG_MESSAGE_LIST_ROOT),
+        state = listState,
+    ) {
+        items(
+            items = state.messages,
+            key = { message -> message.id },
+        ) { message ->
+            val messageSwipeActions = swipeActions[message.account.id]
+            val preferences = state.preferences ?: return@items
+            MessageListSwipeableItem(message, messageSwipeActions, dispatchEvent) { accessibilityState ->
+                MessageListItem(
+                    message = message,
+                    showAccountIndicator = showAccountIndicator,
+                    preferences = preferences,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics(mergeDescendants = true) {
+                            stateDescription = accessibilityState.stateDescription(message)
+                        },
+                    onClick = { dispatchEvent(MessageItemEvent.OnMessageClick(message)) },
+                    onLongClick = { dispatchEvent(MessageItemEvent.ToggleSelectMessages(message)) },
+                    onAvatarClick = { dispatchEvent(MessageItemEvent.ToggleSelectMessages(message)) },
+                    onFavouriteClick = { dispatchEvent(MessageItemEvent.ToggleFavourite(message)) },
+                )
+            }
+        }
+        item {
+            MessageListFooter(state, dispatchEvent, Modifier.animateItem())
+        }
+    }
+}
+
+@Composable
+private fun rememberMessageListLazyState(
+    state: MessageListState,
+    dispatchEvent: (MessageListEvent) -> Unit,
+): LazyListState {
+    val listState = rememberLazyListState()
+    val latestPaging by rememberUpdatedState(state.metadata.paging)
+
+    LaunchedEffect(listState, state.metadata.folder?.id) {
+        snapshotFlow {
+            val total = listState.layoutInfo.totalItemsCount
+            val lastVisible = listState.layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+            lastVisible to total
+        }
+            .distinctUntilChanged()
+            .collect { (lastVisible, total) ->
+                val hasNextPage = total > 0 && lastVisible >= total - 1 && total > latestPaging.prefetchDistance
+                if (!hasNextPage) return@collect
+                val prefetchTriggerIndex = (total - 1 - latestPaging.prefetchDistance).coerceAtLeast(0)
+                val nearEnd = lastVisible >= prefetchTriggerIndex
+
+                if (nearEnd &&
+                    latestPaging.phase != PaginationUi.Phase.Loading &&
+                    !latestPaging.endReached
+                ) {
+                    dispatchEvent(MessageListEvent.LoadNextPage)
+                }
+            }
+    }
+    return listState
+}

--- a/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/MessageListScreenRendererTest.kt
+++ b/feature/mail/message/list/internal/src/test/kotlin/net/thunderbird/feature/mail/message/list/internal/ui/MessageListScreenRendererTest.kt
@@ -39,12 +39,13 @@ import net.thunderbird.core.ui.compose.theme2.thunderbird.ThunderbirdTheme2
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.message.list.internal.R
 import net.thunderbird.feature.mail.message.list.internal.ui.component.MessageListItemDefaults
+import net.thunderbird.feature.mail.message.list.internal.ui.component.template.TEST_TAG_MESSAGE_LIST_ROOT
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.AccountPreviewHelper
 import net.thunderbird.feature.mail.message.list.internal.ui.preview.MessagePreviewHelper
 import net.thunderbird.feature.mail.message.list.preferences.ActionRequiringUserConfirmation
 import net.thunderbird.feature.mail.message.list.preferences.MessageListPreferences
 import net.thunderbird.feature.mail.message.list.ui.component.atom.MESSAGE_ITEM_FAVOURITE_ICON_BUTTON_TEST_TAG
-import net.thunderbird.feature.mail.message.list.ui.effect.MessageListEffect
+import net.thunderbird.feature.mail.message.list.ui.component.rememberMessageListScope
 import net.thunderbird.feature.mail.message.list.ui.event.MessageItemEvent
 import net.thunderbird.feature.mail.message.list.ui.event.MessageListEvent
 import net.thunderbird.feature.mail.message.list.ui.state.Avatar
@@ -160,7 +161,7 @@ class MessageListScreenRendererTest : ComposeTest() {
             )
 
             // Act
-            onNodeWithTag(MessageListScreenRenderer.TEST_TAG_MESSAGE_LIST_ROOT).performTouchInput { swipeDown() }
+            onNodeWithTag(TEST_TAG_MESSAGE_LIST_ROOT).performTouchInput { swipeDown() }
             waitForIdle()
 
             // Assert
@@ -490,7 +491,6 @@ class MessageListScreenRendererTest : ComposeTest() {
     private fun ComposeTest.setupTestSubjectComposable(
         messages: List<MessageItemUi>,
         dispatchEvent: (MessageListEvent) -> Unit = {},
-        onEffect: (MessageListEffect) -> Unit = {},
         preferences: MessageListPreferences = createPreferences(),
         metadata: MessageListMetadata = createMetadata(),
         state: MessageListState = MessageListState.LoadedMessages(
@@ -505,12 +505,14 @@ class MessageListScreenRendererTest : ComposeTest() {
                 koinPreview {
                     single<InAppNotificationStream> { FakeInAppNotificationStream() }
                 } WithContent {
-                    renderer.Render(
-                        state = state,
-                        dispatchEvent = dispatchEvent,
-                        onEffect = onEffect,
-                        modifier = Modifier.fillMaxSize(),
-                    )
+                    val scope = rememberMessageListScope()
+                    with(renderer) {
+                        scope.Render(
+                            state = state,
+                            dispatchEvent = dispatchEvent,
+                            modifier = Modifier.fillMaxSize(),
+                        )
+                    }
                 }
             }
         }


### PR DESCRIPTION
Part of #10775.
feature-flag: `enable_message_list_new_state`

- Restructure UI components into atomic design layers
- Implement scroll-to-message effect with `MessageListScope`
- Extract scroll event handling into a separate composable