### PR TITLE
fix(i18n): locale-sensitive ordering of folders (#10718)

### DIFF
--- a/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
+++ b/legacy/ui/folder/src/main/java/app/k9mail/legacy/ui/folder/DefaultDisplayFolderRepository.kt
@@ -5,6 +5,7 @@ import app.k9mail.legacy.mailstore.FolderTypeMapper
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import app.k9mail.legacy.message.controller.MessagingControllerRegistry
 import app.k9mail.legacy.message.controller.SimpleMessagingListener
+import java.text.Collator
 import kotlin.coroutines.CoroutineContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.Channel
@@ -34,7 +35,12 @@ class DefaultDisplayFolderRepository(
             .thenByDescending { it.folder.type == FolderType.OUTBOX }
             .thenByDescending { it.folder.type != FolderType.REGULAR }
             .thenByDescending { it.isInTopGroup }
-            .thenBy(String.CASE_INSENSITIVE_ORDER) { it.folder.name }
+            .thenBy(
+                // #10718 use locale-sensitive ordering for folders
+                Collator.getInstance().apply {
+                    decomposition = Collator.CANONICAL_DECOMPOSITION
+                },
+            ) { it.folder.name }
 
     private fun getDisplayFolders(
         account: LegacyAccountDto,


### PR DESCRIPTION
Closes #10718

**Before:**
* folders with accented starting letters are moved after the end of the regular alphabet
* lower-case letters are treated as being equal to upper-case --> order is sometimes `lower-case < upper-case`, sometimes `upper-case < lower-case`
<img width="126" height="478" alt="image" src="https://github.com/user-attachments/assets/9c3d701c-ddbd-4215-b258-b901aba3c09a" />

**After:**
* folders with accented characters are integrated in regular alphabet
* always `lower-case < upper-case`
<img width="105" height="394" alt="image" src="https://github.com/user-attachments/assets/42bf2885-6582-40a2-861f-883e039d1df1" />

Note that changes to the devices locale may require a restart of Thunderbird to take effect. If this was not wanted, `sortForDisplay` _could_ be converted from a stored to a computed property.