### PR TITLE
fix(message-list): avatar size and ripple effect

### DIFF
--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/molecule/MessageItemAvatarCircle.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/molecule/MessageItemAvatarCircle.kt
@@ -46,22 +46,18 @@ fun MessageItemAvatarCircle(
     enabled: Boolean = true,
 ) {
     // Intentionally set the `combinedClickable` modifier is after `clip(CircleShape)`
-    // and before `padding`.
+    // and before the `size` and the `padding`.
     //
     // This ensures that the ripple effect covers the entire touch target rather than
     // just the avatar icon itself.
-    //
-    // While Detekt may issue a warning regarding the order of modifiers, this specific
-    // arrangement is intentional.
-    @Suppress("ModifierClickableOrder")
     Box(
         modifier = modifier
             .clip(CircleShape)
             .combinedClickable(enabled = enabled, onClick = onClick)
+            .size(MainTheme.sizes.iconAvatar)
             .padding(MainTheme.spacings.half)
             .background(color = colors.containerColor, shape = CircleShape)
-            .border(width = 1.dp, color = colors.borderColor, shape = CircleShape)
-            .size(MainTheme.sizes.iconAvatar),
+            .border(width = 1.dp, color = colors.borderColor, shape = CircleShape),
         contentAlignment = Alignment.Center,
     ) {
         when (avatar) {

--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItem.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItem.kt
@@ -218,8 +218,8 @@ private fun LeadingElements(
                         contentColor = contentColorFor(backgroundColor = MainTheme.colors.secondaryContainer),
                     ),
                     modifier = Modifier
-                        .padding(MainTheme.spacings.half)
-                        .size(MainTheme.sizes.iconAvatar),
+                        .size(MainTheme.sizes.iconAvatar)
+                        .padding(MainTheme.spacings.half),
                 )
 
                 configuration.avatar != null ->


### PR DESCRIPTION
Fixes #10854.
feature-flag: `use_compose_for_message_list_items`

- Avatar was bigger than the design spec
- The ripple effect is now applied to the whole touch target and not only in the avatar

## Testing Notes
1. Turn on the feature flag `use_compose_for_message_list_items`
2. Navigate to the Message List.
3. Locate a message row showing the avatar.
4. Measure or inspect the avatar size and touch target.
5. Observe that the avatar circle is now 44dp with a touch target of 48dp.

Make sure the touch targets for the Avatar and the Selected circle are 48dp using the Accessibility Scanner app.
## Screenshots
| Previous Avatar size | New Avatar size | Touch target | Selected icon |
| -- | -- | -- | -- |
| <img height="400" alt="image" src="https://github.com/user-attachments/assets/303a5d96-5243-4a94-9fe3-c5242e4ba2c0" /> | <img height="400" alt="image" src="https://github.com/user-attachments/assets/18319398-dd89-434f-a1ef-eb3eb4b3813d" /> | <img height="400" alt="image" src="https://github.com/user-attachments/assets/572d660b-5e32-461f-81a2-c86dab549b6e" /> | <img height="400" alt="image" src="https://github.com/user-attachments/assets/c8651bbf-9125-4fe0-86df-4f988748e655" /> |

