### PR TITLE
fix(message-list): prevent avatar display when showContactPicture is false

### DIFF
--- a/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItemPrevParams.kt
+++ b/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItemPrevParams.kt
@@ -10,6 +10,7 @@ import net.thunderbird.feature.mail.message.list.ui.state.Avatar
 import net.thunderbird.feature.mail.message.list.ui.state.ComposedAddressStyle
 
 internal data class MessageItemPrevParams(
+    val previewName: String,
     val sender: String,
     val senderStyles: ImmutableList<ComposedAddressStyle> = persistentListOf(),
     val subject: String,

--- a/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItemPreview.kt
+++ b/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItemPreview.kt
@@ -31,6 +31,7 @@ import net.thunderbird.feature.mail.message.list.ui.state.Avatar
 private class MessageItemPrevParamCol : CollectionPreviewParameterProvider<MessageItemPrevParams>(
     collection = listOf(
         MessageItemPrevParams(
+            previewName = "Monogram encrypted favourite",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 3).values.joinToString(),
@@ -44,14 +45,7 @@ private class MessageItemPrevParamCol : CollectionPreviewParameterProvider<Messa
             ),
         ),
         MessageItemPrevParams(
-            sender = "Sender Name",
-            subject = "The subject",
-            excerpt = LoremIpsum(words = 3).values.joinToString(),
-            hasAttachments = false,
-            selected = false,
-            receivedAt = "12:34",
-        ),
-        MessageItemPrevParams(
+            previewName = "Monogram with attachment",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 5).values.joinToString(),
@@ -62,6 +56,7 @@ private class MessageItemPrevParamCol : CollectionPreviewParameterProvider<Messa
             avatarColor = Color.Magenta,
         ),
         MessageItemPrevParams(
+            previewName = "Icon avatar selected",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 10).values.joinToString(),
@@ -72,6 +67,7 @@ private class MessageItemPrevParamCol : CollectionPreviewParameterProvider<Messa
             avatarColor = Color.DarkGray,
         ),
         MessageItemPrevParams(
+            previewName = "Selected threaded with attachment",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 20).values.joinToString(),
@@ -81,6 +77,7 @@ private class MessageItemPrevParamCol : CollectionPreviewParameterProvider<Messa
             receivedAt = "12:34",
         ),
         MessageItemPrevParams(
+            previewName = "No excerpt threaded",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = "",
@@ -91,6 +88,7 @@ private class MessageItemPrevParamCol : CollectionPreviewParameterProvider<Messa
             maxExcerptLines = 0,
         ),
         MessageItemPrevParams(
+            previewName = "New badge no excerpt",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = "",
@@ -102,6 +100,7 @@ private class MessageItemPrevParamCol : CollectionPreviewParameterProvider<Messa
             badgeStyle = MessageBadgeStyle.New,
         ),
         MessageItemPrevParams(
+            previewName = "New badge icon avatar",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = "",
@@ -115,6 +114,7 @@ private class MessageItemPrevParamCol : CollectionPreviewParameterProvider<Messa
             avatarColor = Color.DarkGray,
         ),
         MessageItemPrevParams(
+            previewName = "Unread long excerpt",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 100).values.joinToString { it.replace("\n", "") },
@@ -126,8 +126,29 @@ private class MessageItemPrevParamCol : CollectionPreviewParameterProvider<Messa
             avatar = Avatar.Icon(imageVector = Icons.Outlined.Bank),
             badgeStyle = MessageBadgeStyle.Unread,
         ),
+        MessageItemPrevParams(
+            previewName = "No avatar",
+            sender = "Sender Name",
+            subject = "The subject",
+            excerpt = LoremIpsum(words = 3).values.joinToString(),
+            hasAttachments = false,
+            selected = false,
+            receivedAt = "12:34",
+        ),
+        MessageItemPrevParams(
+            previewName = "No avatar new badge",
+            sender = "Sender Name",
+            subject = "The subject",
+            excerpt = LoremIpsum(words = 3).values.joinToString(),
+            hasAttachments = false,
+            selected = false,
+            receivedAt = "12:34",
+            badgeStyle = MessageBadgeStyle.New,
+        ),
     ),
-)
+) {
+    override fun getDisplayName(index: Int): String = values.elementAt(index).previewName
+}
 
 @Preview
 @Composable

--- a/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/NewMessageItemPreview.kt
+++ b/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/NewMessageItemPreview.kt
@@ -24,6 +24,7 @@ import net.thunderbird.feature.mail.message.list.ui.state.MessageItemUi
 private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<MessageItemPrevParams>(
     collection = listOf(
         MessageItemPrevParams(
+            previewName = "Single sender with monogram",
             sender = "Cynthia Alvarez",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "Laptop not booting after Windows update",
@@ -36,6 +37,7 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             avatar = Avatar.Monogram("CA"),
         ),
         MessageItemPrevParams(
+            previewName = "Multiple senders threaded",
             sender = "Mason Tran, Me, Ryan Thomas",
             senderStyles = persistentListOf(
                 ComposedAddressStyle.Bold(0, 11),
@@ -50,6 +52,7 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             avatar = Avatar.Monogram("MT"),
         ),
         MessageItemPrevParams(
+            previewName = "Threaded with attachment no avatar",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 3).values.joinToString(),
@@ -60,6 +63,7 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Long sender and subject",
             sender = LoremIpsum(words = 100).values.joinToString(),
             senderStyles = ComposedAddressStyle.AllBold,
             subject = LoremIpsum(words = 100).values.joinToString(),
@@ -71,6 +75,7 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected favourite threaded",
             sender = "Sender Name",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "The subject",
@@ -82,6 +87,7 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected favourite with attachment",
             sender = "Sender Name",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "The subject",
@@ -93,6 +99,7 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Minimal no avatar",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 3).values.joinToString(),
@@ -103,6 +110,7 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Long sender and subject bold",
             sender = LoremIpsum(words = 100).values.joinToString(),
             senderStyles = ComposedAddressStyle.AllBold,
             subject = LoremIpsum(words = 100).values.joinToString(),
@@ -114,6 +122,7 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected favourite bold",
             sender = "Sender Name",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "The subject",
@@ -125,6 +134,7 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected no excerpt",
             sender = "Sender Name",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "The subject",
@@ -137,7 +147,9 @@ private class NewMessageItemPrevParamCol : CollectionPreviewParameterProvider<Me
             maxExcerptLines = 0,
         ),
     ),
-)
+) {
+    override fun getDisplayName(index: Int): String = values.elementAt(index).previewName
+}
 
 @Preview
 @Composable

--- a/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/ReadMessageItemPreview.kt
+++ b/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/ReadMessageItemPreview.kt
@@ -25,6 +25,7 @@ import net.thunderbird.feature.mail.message.list.ui.state.MessageItemUi
 private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<MessageItemPrevParams>(
     collection = listOf(
         MessageItemPrevParams(
+            previewName = "Single sender with monogram",
             sender = "Cynthia Alvarez",
             subject = "Laptop not booting after Windows update",
             excerpt = LoremIpsum(words = 20).values.joinToString(),
@@ -36,6 +37,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             avatar = Avatar.Monogram("CA"),
         ),
         MessageItemPrevParams(
+            previewName = "Multiple senders threaded",
             sender = "Mason Tran, Me, Ryan Thomas",
             subject = "Follow-up on gaming PC build specs",
             excerpt = LoremIpsum(words = 20).values.joinToString(),
@@ -47,6 +49,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             avatar = Avatar.Monogram("MT"),
         ),
         MessageItemPrevParams(
+            previewName = "Threaded no excerpt",
             sender = "Mason Tran, Me, Ryan Thomas",
             subject = "Follow-up on gaming PC build specs",
             excerpt = LoremIpsum(words = 20).values.joinToString(),
@@ -59,6 +62,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             maxExcerptLines = 0,
         ),
         MessageItemPrevParams(
+            previewName = "Subject first red monogram",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 3).values.joinToString(),
@@ -71,6 +75,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             avatarColor = Color.Red,
         ),
         MessageItemPrevParams(
+            previewName = "Subject first long text blue",
             sender = LoremIpsum(words = 100).values.joinToString(),
             subject = LoremIpsum(words = 100).values.joinToString(),
             excerpt = LoremIpsum(words = 5).values.joinToString(),
@@ -83,6 +88,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             avatarColor = Color.Blue,
         ),
         MessageItemPrevParams(
+            previewName = "Subject first selected favourite",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 10).values.joinToString(),
@@ -93,6 +99,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             senderAboveSubject = false,
         ),
         MessageItemPrevParams(
+            previewName = "Subject first selected with attachment",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 20).values.joinToString(),
@@ -103,6 +110,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             senderAboveSubject = false,
         ),
         MessageItemPrevParams(
+            previewName = "Minimal no avatar",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 3).values.joinToString(),
@@ -113,6 +121,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Long sender and subject",
             sender = LoremIpsum(words = 100).values.joinToString(),
             subject = LoremIpsum(words = 100).values.joinToString(),
             excerpt = LoremIpsum(words = 5).values.joinToString(),
@@ -123,6 +132,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected favourite threaded",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 10).values.joinToString(),
@@ -133,6 +143,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected favourite with attachment",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 20).values.joinToString(),
@@ -143,6 +154,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Icon avatar no excerpt",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = "",
@@ -155,6 +167,7 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             avatarColor = Color.DarkGray,
         ),
         MessageItemPrevParams(
+            previewName = "Long excerpt five lines",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 100).values.joinToString { it.replace("\n", "") },
@@ -165,7 +178,9 @@ private class ReadMessageItemPrevParamCol : CollectionPreviewParameterProvider<M
             maxExcerptLines = 5,
         ),
     ),
-)
+) {
+    override fun getDisplayName(index: Int): String = values.elementAt(index).previewName
+}
 
 @Preview
 @Composable

--- a/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/UnreadMessageItemPreview.kt
+++ b/feature/mail/message/list/api/src/debug/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/UnreadMessageItemPreview.kt
@@ -24,6 +24,7 @@ import net.thunderbird.feature.mail.message.list.ui.state.MessageItemUi
 private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider<MessageItemPrevParams>(
     collection = listOf(
         MessageItemPrevParams(
+            previewName = "Single sender with monogram",
             sender = "Cynthia Alvarez",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "Laptop not booting after Windows update",
@@ -36,6 +37,7 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             avatar = Avatar.Monogram("CA"),
         ),
         MessageItemPrevParams(
+            previewName = "Multiple senders threaded",
             sender = "Mason Tran, Me, Ryan Thomas",
             senderStyles = persistentListOf(
                 ComposedAddressStyle.Bold(0, 11),
@@ -50,6 +52,7 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             avatar = Avatar.Monogram("MT"),
         ),
         MessageItemPrevParams(
+            previewName = "Threaded with attachment no avatar",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 3).values.joinToString(),
@@ -60,6 +63,7 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Long sender and subject",
             sender = LoremIpsum(words = 100).values.joinToString(),
             senderStyles = ComposedAddressStyle.AllBold,
             subject = LoremIpsum(words = 100).values.joinToString(),
@@ -71,6 +75,7 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected favourite threaded",
             sender = "Sender Name",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "The subject",
@@ -82,6 +87,7 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected favourite with attachment",
             sender = "Sender Name",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "The subject",
@@ -93,6 +99,7 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Minimal no avatar",
             sender = "Sender Name",
             subject = "The subject",
             excerpt = LoremIpsum(words = 3).values.joinToString(),
@@ -103,6 +110,7 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Long sender and subject bold",
             sender = LoremIpsum(words = 100).values.joinToString(),
             senderStyles = ComposedAddressStyle.AllBold,
             subject = LoremIpsum(words = 100).values.joinToString(),
@@ -114,6 +122,7 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected favourite bold",
             sender = "Sender Name",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "The subject",
@@ -125,6 +134,7 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             senderAboveSubject = true,
         ),
         MessageItemPrevParams(
+            previewName = "Selected no excerpt",
             sender = "Sender Name",
             senderStyles = ComposedAddressStyle.AllBold,
             subject = "The subject",
@@ -137,7 +147,9 @@ private class UnreadMessageItemPrevParamCol : CollectionPreviewParameterProvider
             maxExcerptLines = 0,
         ),
     ),
-)
+) {
+    override fun getDisplayName(index: Int): String = values.elementAt(index).previewName
+}
 
 @Preview
 @Composable

--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItem.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItem.kt
@@ -3,7 +3,6 @@ package net.thunderbird.feature.mail.message.list.ui.component.organism
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -195,18 +193,17 @@ private fun LeadingElements(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Box(contentAlignment = Alignment.Center, modifier = modifier.fillMaxHeight()) {
-        val badgeModifier = Modifier.align(Alignment.CenterStart)
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(MainTheme.spacings.quarter),
+        modifier = modifier.fillMaxHeight(),
+    ) {
         when (configuration.badgeStyle) {
-            MessageBadgeStyle.New -> NewMessageBadge(
-                modifier = badgeModifier.offset(-(MESSAGE_BADGE_SIZE.dp + MainTheme.spacings.quarter)),
-            )
+            MessageBadgeStyle.New -> NewMessageBadge()
 
-            MessageBadgeStyle.Unread -> UnreadMessageBadge(
-                modifier = badgeModifier.offset(-(MESSAGE_BADGE_SIZE.dp)),
-            )
+            MessageBadgeStyle.Unread -> UnreadMessageBadge()
 
-            null -> Unit
+            null -> Spacer(Modifier.width(MESSAGE_BADGE_SIZE.dp))
         }
         AnimatedContent(targetState = selected) { selected ->
             when {

--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItemDefaults.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItemDefaults.kt
@@ -30,7 +30,7 @@ object MessageItemDefaults {
         get() = PaddingValues(
             top = MainTheme.spacings.oneHalf,
             bottom = MainTheme.spacings.oneHalf,
-            start = MainTheme.spacings.triple,
+            start = MainTheme.spacings.default,
         )
 
     /**
@@ -43,7 +43,7 @@ object MessageItemDefaults {
         get() = PaddingValues(
             top = MainTheme.spacings.default,
             bottom = MainTheme.spacings.default,
-            start = MainTheme.spacings.double,
+            start = MainTheme.spacings.half,
         )
 
     /**
@@ -56,7 +56,7 @@ object MessageItemDefaults {
         get() = PaddingValues(
             top = MainTheme.spacings.double,
             bottom = MainTheme.spacings.double,
-            start = MainTheme.spacings.quadruple,
+            start = MainTheme.spacings.double,
         )
 
     /**

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/item/MessageItemContent.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/item/MessageItemContent.kt
@@ -121,6 +121,7 @@ private fun rememberMessageItemUi(
             displayName = item.displayAddress?.address ?: "",
             displayNameStyles = item.buildSenderStyles(),
             avatar = when {
+                !showContactPicture -> null
                 showContactPicture && url != null -> Avatar.Image(url = url)
                 else -> Avatar.Monogram(monogram)
             },


### PR DESCRIPTION
Fixes #10850.
feature-flag: `use_compose_for_message_list_items`

- Simplify badge layout using Row with spacing
- Add descriptive preview names for message item preview parameters
- Prevent avatar display when `showContactPicture` is `false`

## Testing notes
1. Turn on the feature flag `use_compose_for_message_list_items`
2. Navigate to Settings > General Settings > Display.
3. Toggle the **“Show contact image”** checkbox on and off.
4. Navigate back to the Message List
5. Observe the avatar area.

| "Show contact image" enabled | "Show contact image" disabled |
| --- | --- |
| <img width="612" height="1321" alt="image" src="https://github.com/user-attachments/assets/c2a59fbe-edfa-48c2-88d5-3767131a6404" /> | <img width="612" height="1321" alt="image" src="https://github.com/user-attachments/assets/8c93949b-dd59-4bab-b55d-07455479ef23" /> |
