### PR TITLE
fix(message-list): centre message item content vertically

### DIFF
--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/molecule/MessageBodyContent.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/molecule/MessageBodyContent.kt
@@ -1,7 +1,6 @@
 package net.thunderbird.feature.mail.message.list.ui.component.molecule
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.text.InlineTextContent
@@ -54,24 +53,22 @@ internal fun MessageBodyContent(
     modifier: Modifier = Modifier,
     subject: @Composable (AnnotatedString?, ImmutableMap<String, InlineTextContent>) -> Unit,
 ) {
-    Row(modifier = modifier) {
-        Column {
-            val (prefixAnnotatedString, inlineContent) = secondaryLineContent(configuration)
-            subject(prefixAnnotatedString, inlineContent)
-            Spacer(modifier = Modifier.height(MainTheme.spacings.half))
-            if (configuration.maxExcerptLines > 0) {
-                val inlineContent = rememberInlineContent(configuration.excerptLineConfiguration)
-                val prefixAnnotatedString = rememberPrefixAnnotatedString(configuration.excerptLineConfiguration)
-                TextBodySmall(
-                    text = buildAnnotatedString {
-                        append(prefixAnnotatedString)
-                        append(excerpt)
-                    },
-                    maxLines = configuration.maxExcerptLines,
-                    overflow = TextOverflow.Ellipsis,
-                    inlineContent = inlineContent,
-                )
-            }
+    Column(modifier = modifier) {
+        val (prefixAnnotatedString, inlineContent) = secondaryLineContent(configuration)
+        subject(prefixAnnotatedString, inlineContent)
+        Spacer(modifier = Modifier.height(MainTheme.spacings.half))
+        if (configuration.maxExcerptLines > 0) {
+            val inlineContent = rememberInlineContent(configuration.excerptLineConfiguration)
+            val prefixAnnotatedString = rememberPrefixAnnotatedString(configuration.excerptLineConfiguration)
+            TextBodySmall(
+                text = buildAnnotatedString {
+                    append(prefixAnnotatedString)
+                    append(excerpt)
+                },
+                maxLines = configuration.maxExcerptLines,
+                overflow = TextOverflow.Ellipsis,
+                inlineContent = inlineContent,
+            )
         }
     }
 }

--- a/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItem.kt
+++ b/feature/mail/message/list/api/src/main/kotlin/net/thunderbird/feature/mail/message/list/ui/component/organism/MessageItem.kt
@@ -133,8 +133,8 @@ internal fun MessageItem(
             Spacer(Modifier.width(MainTheme.spacings.default))
             // Message Content and Contents
             Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half),
+                modifier = Modifier.weight(1f).fillMaxHeight(),
+                verticalArrangement = Arrangement.spacedBy(MainTheme.spacings.half, Alignment.CenterVertically),
             ) {
                 AdaptiveMessageItemHeaderRow(configuration, receivedAt, firstLine)
                 MessageBodyContent(


### PR DESCRIPTION
Fixes #10852
feature-flag: `use_compose_for_message_list_items`

- Centre message item content vertically
- Remove unnecessary Row wrapper in MessageBodyContent

## Testing notes
1. Turn on the feature flag `use_compose_for_message_list_items`
2. Navigate to Settings > General Settings > Display.
3. Set Preview lines to 0.
4. Navigate back to the Message List.
5. Observe the vertical alignment of the message body.

## Screenshots
| Before | After |
| -- | -- |
| <img height="600" alt="image" src="https://github.com/user-attachments/assets/39dfefd8-0ae8-4b25-b618-fc517800410e" /> | <img height="600" alt="image" src="https://github.com/user-attachments/assets/35bbf499-1f7a-4be9-b90e-f2cd7de18883" /> |

