### PR TITLE
chore(editorconfig): disable indent before arrow on new line for Kotlin

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -15,6 +15,7 @@ max_line_length = 120
 ij_kotlin_imports_layout = *,^
 ij_kotlin_allow_trailing_comma = true
 ij_kotlin_allow_trailing_comma_on_call_site = true
+ij_kotlin_indent_before_arrow_on_new_line = false
 
 [*.{yml,yaml,json,toml}]
 indent_size = 2


### PR DESCRIPTION
This ends the eternal battle between Ktlint and Android Studio formatter, where AS always add the indent before the -> when in a new line and Ktlint removes it.

<table>
<tr>
<th><code>ij_kotlin_indent_before_arrow_on_new_line = true</code></th>
<th><code>ij_kotlin_indent_before_arrow_on_new_line = false</code> (expected by Ktlint)</th>
</tr>
<tr>
<td>

```kotlin
when (outcome.error) {
    is Error1,
    is Error2,
        -> {  // <-- indent here! >:(
        Toast.makeText(
            requireContext(),
            R.string.str1_2,
            Toast.LENGTH_SHORT,
        ).show()
    }
    is Error3 -> {
        Toast.makeText(
            requireContext(),
            R.string.str3,
            Toast.LENGTH_SHORT,
        ).show()
    }
    is Error4 -> {
        Toast.makeText(
            requireContext(),
            R.string.str4,
            Toast.LENGTH_SHORT,
        ).show()
    }
}
```

</td>

<td>

```kotlin
when (outcome.error) {
    is Error1,
    is Error2,
    -> { // <-- no indent here! :)
        Toast.makeText(
            requireContext(),
            R.string.str1_2,
            Toast.LENGTH_SHORT,
        ).show()
    }
    is Error3 -> {
        Toast.makeText(
            requireContext(),
            R.string.str3,
            Toast.LENGTH_SHORT,
        ).show()
    }
    is Error4 -> {
        Toast.makeText(
            requireContext(),
            R.string.str4,
            Toast.LENGTH_SHORT,
        ).show()
    }
}
```
</td>

</tr>
</table>