### PR TITLE
Restore compose button functionality

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -41,6 +41,7 @@ import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.legacy.message.controller.MessageReference
 import com.eygraber.uri.toKmpUri
 import com.fsck.k9.activity.MessageCompose
+import com.fsck.k9.activity.compose.MessageActions
 import com.fsck.k9.activity.MessageLoaderHelper
 import com.fsck.k9.activity.MessageLoaderHelper.MessageLoaderCallbacks
 import com.fsck.k9.activity.MessageLoaderHelperFactory
@@ -470,6 +471,7 @@ class MessageViewFragment :
 
             R.id.set_format_plain -> onDisplayPlainText()
             R.id.set_format_html -> onDisplayHTML()
+            R.id.view_compose -> MessageActions.actionCompose(requireActivity(), account)
             else -> return false
         }
 

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -41,10 +41,10 @@ import app.k9mail.core.ui.legacy.designsystem.atom.icon.Icons
 import app.k9mail.legacy.message.controller.MessageReference
 import com.eygraber.uri.toKmpUri
 import com.fsck.k9.activity.MessageCompose
-import com.fsck.k9.activity.compose.MessageActions
 import com.fsck.k9.activity.MessageLoaderHelper
 import com.fsck.k9.activity.MessageLoaderHelper.MessageLoaderCallbacks
 import com.fsck.k9.activity.MessageLoaderHelperFactory
+import com.fsck.k9.activity.compose.MessageActions
 import com.fsck.k9.controller.MessagingController
 import com.fsck.k9.fragment.AttachmentDownloadDialogFragment
 import com.fsck.k9.fragment.ConfirmationDialogFragment

--- a/legacy/ui/legacy/src/main/res/menu/message_list_option_menu.xml
+++ b/legacy/ui/legacy/src/main/res/menu/message_list_option_menu.xml
@@ -62,7 +62,7 @@
         android:id="@+id/compose"
         android:icon="@drawable/ic_edit"
         android:title="@string/compose_action"
-        app:showAsAction="never"
+        app:showAsAction="always"
         />
 
     <item

--- a/legacy/ui/legacy/src/main/res/menu/new_message_list_option_menu.xml
+++ b/legacy/ui/legacy/src/main/res/menu/new_message_list_option_menu.xml
@@ -31,7 +31,7 @@
         android:id="@+id/compose"
         android:icon="@drawable/ic_edit"
         android:title="@string/compose_action"
-        app:showAsAction="never"
+        app:showAsAction="always"
         />
 
     <item


### PR DESCRIPTION
fix: this PR does two things: 1, fixes compose button on overflow menu when viewing a message.  2. displays compose button on top menu when using non-floating preference, rather then putting it on the overflow menu.

The compose button behavior was recently changed.  It seem like maybe the developers are using the floating compose button so haven't noticed that the behavior broke.  I would guess that because of that, the compose menu choice isn't needed, but for those of us who prefer the non-floating version, this fixes a needed behavior.

The bug was reported here: https://github.com/thunderbird/thunderbird-android/issues/10753