### PR TITLE
fix(mail): improve Japanese charset decoding reliability on Android

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/CharsetSupport.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/CharsetSupport.java
@@ -6,6 +6,7 @@ import net.thunderbird.core.common.exception.MessagingException;
 
 import org.apache.commons.io.IOUtils;
 
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.Charset;
@@ -25,7 +26,10 @@ public class CharsetSupport {
     private static final String[][] CHARSET_FALLBACK_MAP = new String[][] {
             // Some Android versions don't support KOI8-U
             {"koi8-u", "koi8-r"},
-            {"iso-2022-jp-[\\d]+", "iso-2022-jp"}
+            {"iso-2022-jp-[\\d]+", "iso-2022-jp"},
+            // EUC-JP aliases that some mailers use
+            {"x-euc-jp", "euc-jp"},
+            {"euc_jp", "euc-jp"},
     };
 
 
@@ -34,8 +38,11 @@ public class CharsetSupport {
             charset = DEFAULT_CHARSET;
 
         charset = charset.toLowerCase(Locale.US);
-        if (charset.equals("cp932"))
+        if (charset.equals("cp932") || charset.equals("shift-jis") || charset.equals("sjis") ||
+                charset.equals("ms932") || charset.equals("windows-31j") || charset.equals("x-sjis") ||
+                charset.equals("x-ms-cp932")) {
             charset = SHIFT_JIS;
+        }
 
         if (charset.equals(SHIFT_JIS) || charset.equals("iso-2022-jp")) {
             String variant = JisSupport.getJisVariantFromMessage(message);
@@ -54,6 +61,15 @@ public class CharsetSupport {
                 charset.endsWith("-iso-2022-jp-2007") && !Charset.isSupported(charset)) {
             in = new Iso2022JpToShiftJisInputStream(in);
             charset = "x-" + charset.substring(2, charset.length() - 17) + "-shift_jis-2007";
+        }
+
+        // Android's ICU4J ISO-2022-JP decoder is stricter than the JVM decoder and can silently fail on
+        // QP-decoded byte sequences, causing ESC bytes to appear as invisible control characters while
+        // $B and (B escape sequence remnants become visible literal text.
+        // Always use Iso2022JpToShiftJisInputStream for reliable decoding across all Android versions.
+        if (charset.equals("iso-2022-jp")) {
+            in = new Iso2022JpToShiftJisInputStream(in);
+            charset = SHIFT_JIS;
         }
 
         // shift_jis variants are supported by Eclair and later.
@@ -97,6 +113,21 @@ public class CharsetSupport {
             charset = DEFAULT_CHARSET;
         }
 
+        // When charset defaulted to US-ASCII (i.e., Content-Type had no charset parameter),
+        // auto-detect ISO-2022-JP by scanning for its 7-bit escape sequences (ESC$B or ESC$@).
+        // Japanese email clients (especially feature phones and carrier webmail) often omit the
+        // charset parameter for ISO-2022-JP bodies, causing garbled "$B..." output when decoded
+        // as US-ASCII.
+        if (charset.equalsIgnoreCase(DEFAULT_CHARSET)) {
+            byte[] bodyBytes = IOUtils.toByteArray(in);
+            if (hasIso2022JpEscapeSequence(bodyBytes)) {
+                in = new Iso2022JpToShiftJisInputStream(new ByteArrayInputStream(bodyBytes));
+                charset = SHIFT_JIS;
+            } else {
+                in = new ByteArrayInputStream(bodyBytes);
+            }
+        }
+
         /*
          * Convert and return as new String
          */
@@ -105,6 +136,25 @@ public class CharsetSupport {
         if (isIphoneString)
             str = importStringFromIphone(str);
         return str;
+    }
+
+    /**
+     * Returns true if the byte array contains an ISO-2022-JP character-set designation
+     * escape sequence: ESC $ B (JIS X 0208-1983) or ESC $ @ (JIS X 0208-1978).
+     *
+     * Japanese email clients — especially feature phones and carrier webmail — often omit the
+     * charset parameter from Content-Type and send a raw 7-bit ISO-2022-JP body.  Checking for
+     * these two sequences is sufficient to distinguish such content from ordinary US-ASCII text
+     * while keeping false-positive risk negligible.
+     */
+    static boolean hasIso2022JpEscapeSequence(byte[] data) {
+        for (int i = 0; i < data.length - 2; i++) {
+            if (data[i] == 0x1B && data[i + 1] == '$'
+                    && (data[i + 2] == 'B' || data[i + 2] == '@')) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private static String importStringFromIphone(String str) {

--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/JisSupport.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/JisSupport.java
@@ -87,8 +87,33 @@ class JisSupport {
     }
 
     private static String getAddressFromReceivedHeader(String receivedHeader) {
-        // Not implemented yet!  Extract an address from the FOR clause of the given Received header.
-        return null;
+        // Extract an address from the FOR clause of the given Received header.
+        // Example: "... for <user@docomo.ne.jp>;" or "... for user@docomo.ne.jp;"
+        int forIndex = receivedHeader.toLowerCase(java.util.Locale.US).indexOf(" for ");
+        if (forIndex == -1) {
+            return null;
+        }
+        String afterFor = receivedHeader.substring(forIndex + 5).trim();
+        // Strip angle brackets if present
+        if (afterFor.startsWith("<")) {
+            int close = afterFor.indexOf('>');
+            if (close == -1) {
+                return null;
+            }
+            afterFor = afterFor.substring(1, close);
+        } else {
+            // Address ends at the first whitespace or semicolon
+            int end = afterFor.length();
+            for (int i = 0; i < afterFor.length(); i++) {
+                char c = afterFor.charAt(i);
+                if (c == ';' || c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+                    end = i;
+                    break;
+                }
+            }
+            afterFor = afterFor.substring(0, end);
+        }
+        return afterFor.isEmpty() ? null : afterFor;
     }
 
     private static String getJisVariantFromFromHeaders(Message message) {

--- a/mail/common/src/test/java/com/fsck/k9/mail/internet/CharsetSupportTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/internet/CharsetSupportTest.java
@@ -8,6 +8,8 @@ import java.io.InputStream;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 
 public class CharsetSupportTest {
@@ -101,6 +103,32 @@ public class CharsetSupportTest {
     }
 
     @Test
+    public void testFixupCharset_shiftJisAliases() throws Exception {
+        MimeMessage message = new MimeMessage();
+        assertEquals("shift_jis", CharsetSupport.fixupCharset("shift-jis", message));
+        assertEquals("shift_jis", CharsetSupport.fixupCharset("sjis", message));
+        assertEquals("shift_jis", CharsetSupport.fixupCharset("ms932", message));
+        assertEquals("shift_jis", CharsetSupport.fixupCharset("windows-31j", message));
+        assertEquals("shift_jis", CharsetSupport.fixupCharset("x-sjis", message));
+        assertEquals("shift_jis", CharsetSupport.fixupCharset("x-ms-cp932", message));
+    }
+
+    @Test
+    public void readToString_withXEucJpAlias_shouldFallBackToEucJp() throws IOException {
+        // "test" in ASCII — just verifies the alias is recognized without throwing
+        InputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        String result = CharsetSupport.readToString(inputStream, "x-euc-jp");
+        assertEquals("test", result);
+    }
+
+    @Test
+    public void readToString_withEucJpUnderscoreAlias_shouldFallBackToEucJp() throws IOException {
+        InputStream inputStream = new ByteArrayInputStream("test".getBytes());
+        String result = CharsetSupport.readToString(inputStream, "euc_jp");
+        assertEquals("test", result);
+    }
+
+    @Test
     public void readToString_withUnsupportedCharset_shouldFallBackToAscii() throws IOException {
         InputStream inputStream = new ByteArrayInputStream("input".getBytes());
         String charset = "unsupported";
@@ -118,5 +146,43 @@ public class CharsetSupportTest {
         String result = CharsetSupport.readToString(inputStream, charset);
 
         assertEquals("input", result);
+    }
+
+    // hasIso2022JpEscapeSequence
+
+    @Test
+    public void hasIso2022JpEscapeSequence_withEscDollarB_returnsTrue() {
+        byte[] data = {0x1B, '$', 'B', 0x25, 0x46};
+        assertTrue(CharsetSupport.hasIso2022JpEscapeSequence(data));
+    }
+
+    @Test
+    public void hasIso2022JpEscapeSequence_withEscDollarAt_returnsTrue() {
+        byte[] data = {0x1B, '$', '@', 0x25, 0x46};
+        assertTrue(CharsetSupport.hasIso2022JpEscapeSequence(data));
+    }
+
+    @Test
+    public void hasIso2022JpEscapeSequence_withNoEscSequence_returnsFalse() {
+        byte[] data = "Hello, world!".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        assertFalse(CharsetSupport.hasIso2022JpEscapeSequence(data));
+    }
+
+    @Test
+    public void hasIso2022JpEscapeSequence_withEscOpenParenB_returnsFalse() {
+        // ESC ( B is the return-to-ASCII sequence; alone it should not trigger detection
+        byte[] data = {0x1B, '(', 'B'};
+        assertFalse(CharsetSupport.hasIso2022JpEscapeSequence(data));
+    }
+
+    @Test
+    public void hasIso2022JpEscapeSequence_withEmptyArray_returnsFalse() {
+        assertFalse(CharsetSupport.hasIso2022JpEscapeSequence(new byte[0]));
+    }
+
+    @Test
+    public void hasIso2022JpEscapeSequence_withTooShortForSequence_returnsFalse() {
+        byte[] data = {0x1B, '$'};   // only 2 bytes, need at least 3
+        assertFalse(CharsetSupport.hasIso2022JpEscapeSequence(data));
     }
 }

--- a/mail/common/src/test/java/com/fsck/k9/mail/internet/JisSupportTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/internet/JisSupportTest.java
@@ -1,0 +1,90 @@
+package com.fsck.k9.mail.internet;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+
+public class JisSupportTest {
+
+    // getJisVariantFromMessage via From header
+
+    @Test
+    public void getJisVariantFromMessage_docomoSender_returnsDocomo() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@docomo.ne.jp");
+        assertEquals("docomo", JisSupport.getJisVariantFromMessage(message));
+    }
+
+    @Test
+    public void getJisVariantFromMessage_softbankSender_returnsSoftbank() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@softbank.ne.jp");
+        assertEquals("softbank", JisSupport.getJisVariantFromMessage(message));
+    }
+
+    @Test
+    public void getJisVariantFromMessage_kddiSender_returnsKddi() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@ezweb.ne.jp");
+        assertEquals("kddi", JisSupport.getJisVariantFromMessage(message));
+    }
+
+    @Test
+    public void getJisVariantFromMessage_unknownSender_returnsNull() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@example.com");
+        assertNull(JisSupport.getJisVariantFromMessage(message));
+    }
+
+    @Test
+    public void getJisVariantFromMessage_iPhoneMailer_returnsIphone() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@example.com");
+        message.setHeader("X-Mailer", "iPhone Mail A380");
+        assertEquals("iphone", JisSupport.getJisVariantFromMessage(message));
+    }
+
+    // getJisVariantFromMessage via Received header FOR clause
+
+    @Test
+    public void getJisVariantFromMessage_receivedForDocomoAngleBracket_returnsDocomo() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@example.com");
+        message.setHeader("Received", "from mail.example.com (mail.example.com [1.2.3.4]) for <user@docomo.ne.jp>;");
+        assertEquals("docomo", JisSupport.getJisVariantFromMessage(message));
+    }
+
+    @Test
+    public void getJisVariantFromMessage_receivedForDocomoNoAngleBracket_returnsDocomo() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@example.com");
+        message.setHeader("Received", "from mail.example.com (mail.example.com [1.2.3.4]) for user@docomo.ne.jp;");
+        assertEquals("docomo", JisSupport.getJisVariantFromMessage(message));
+    }
+
+    @Test
+    public void getJisVariantFromMessage_receivedForEzwebAddress_returnsKddi() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@example.com");
+        message.setHeader("Received", "from smtp.example.net for <user@ezweb.ne.jp>;");
+        assertEquals("kddi", JisSupport.getJisVariantFromMessage(message));
+    }
+
+    @Test
+    public void getJisVariantFromMessage_receivedForUnknownAddress_returnsNull() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@example.com");
+        message.setHeader("Received", "from smtp.example.net for <user@example.com>;");
+        assertNull(JisSupport.getJisVariantFromMessage(message));
+    }
+
+    @Test
+    public void getJisVariantFromMessage_receivedWithoutFor_returnsNull() throws Exception {
+        MimeMessage message = new MimeMessage();
+        message.setHeader("From", "user@example.com");
+        message.setHeader("Received", "from smtp.example.net by mx.example.com;");
+        assertNull(JisSupport.getJisVariantFromMessage(message));
+    }
+}

--- a/mail/common/src/test/java/com/fsck/k9/mail/internet/MessageExtractorTest.java
+++ b/mail/common/src/test/java/com/fsck/k9/mail/internet/MessageExtractorTest.java
@@ -10,6 +10,8 @@ import org.apache.james.mime4j.util.MimeUtil;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -70,6 +72,50 @@ public class MessageExtractorTest {
         assertNull(result);
     }
 
+    /**
+     * Regression test: ISO-2022-JP body with QP encoding.
+     *
+     * "テスト" in ISO-2022-JP:
+     *   ESC$B (0x1B 0x24 0x42) = switch to JIS X 0208
+     *   テ = 0x25 0x46, ス = 0x25 0x39, ト = 0x25 0x48
+     *   ESC(B (0x1B 0x28 0x42) = switch back to ASCII
+     *
+     * QP-encoded: ESC is written as =1B; $,B,(,% are printable ASCII and left as-is.
+     * Android's ICU4J ISO-2022-JP decoder can silently mishandle this, showing "$B" and "(B"
+     * as literal text. We bypass the platform decoder with Iso2022JpToShiftJisInputStream.
+     */
+    @Test
+    public void getTextFromPart_withIso2022JpQuotedPrintable_shouldDecodeToJapanese() throws Exception {
+        // QP-encoded "テスト" in ISO-2022-JP: =1B$B%F%9%H=1B(B
+        byte[] qpBytes = "=1B$B%F%9%H=1B(B".getBytes(StandardCharsets.US_ASCII);
+        part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, "text/plain; charset=iso-2022-jp");
+        BinaryMemoryBody body = new BinaryMemoryBody(qpBytes, MimeUtil.ENC_QUOTED_PRINTABLE);
+        part.setBody(body);
+
+        String result = MessageExtractor.getTextFromPart(part);
+
+        assertEquals("テスト", result);
+    }
+
+    /**
+     * Regression test: multi-line ISO-2022-JP body with QP soft line breaks.
+     * Each line re-emits ESC$B because hard line breaks reset to ASCII in ISO-2022-JP.
+     */
+    @Test
+    public void getTextFromPart_withIso2022JpQuotedPrintableMultiLine_shouldDecodeToJapanese() throws Exception {
+        // Line 1: "テスト", Line 2: "テスト" — each line wraps with ESC(B ... ESC$B
+        String qpBody = "=1B$B%F%9%H=1B(B\r\n=1B$B%F%9%H=1B(B";
+        byte[] qpBytes = qpBody.getBytes(StandardCharsets.US_ASCII);
+        part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, "text/plain; charset=iso-2022-jp");
+        BinaryMemoryBody body = new BinaryMemoryBody(qpBytes, MimeUtil.ENC_QUOTED_PRINTABLE);
+        part.setBody(body);
+
+        String result = MessageExtractor.getTextFromPart(part);
+
+        assertNotNull(result);
+        assertEquals("テスト\r\nテスト", result);
+    }
+
     @Test
     public void getTextFromPart_withUnknownEncoding_shouldReturnUnmodifiedBodyContents() throws Exception {
         part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, "text/plain");
@@ -103,6 +149,49 @@ public class MessageExtractorTest {
         String result = MessageExtractor.getTextFromPart(part);
 
         assertEquals("<html><body>Sample text body</body></html>", result);
+    }
+
+    /**
+     * Regression test: forwarded ISO-2022-JP message with no charset in Content-Type.
+     *
+     * Japanese feature phones and carrier webmail systems often omit "charset=iso-2022-jp"
+     * from the Content-Type header.  Without auto-detection the body defaults to US-ASCII and
+     * the ESC byte is silently dropped, leaving the literal "$B" escape sequence remnants
+     * visible (e.g. "$BJIC...").
+     */
+    @Test
+    public void getTextFromPart_withIso2022Jp7bitNoCharset_shouldAutoDetectAndDecode() throws Exception {
+        // Raw 7-bit ISO-2022-JP bytes for "テスト" — no QP encoding, no charset header
+        byte[] raw = new byte[] {
+            0x1B, '$', 'B',          // ESC $ B  → switch to JIS X 0208
+            0x25, 0x46,              // テ
+            0x25, 0x39,              // ス
+            0x25, 0x48,              // ト
+            0x1B, '(', 'B'           // ESC ( B  → switch back to ASCII
+        };
+        part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, "text/plain");   // no charset!
+        BinaryMemoryBody body = new BinaryMemoryBody(raw, MimeUtil.ENC_7BIT);
+        part.setBody(body);
+
+        String result = MessageExtractor.getTextFromPart(part);
+
+        assertEquals("テスト", result);
+    }
+
+    /**
+     * Regression test: forwarded ISO-2022-JP message with QP encoding and no charset.
+     * This is the most common form: the =1B escape is QP-encoded, charset is absent.
+     */
+    @Test
+    public void getTextFromPart_withIso2022JpQuotedPrintableNoCharset_shouldAutoDetectAndDecode() throws Exception {
+        byte[] qpBytes = "=1B$B%F%9%H=1B(B".getBytes(java.nio.charset.StandardCharsets.US_ASCII);
+        part.setHeader(MimeHeader.HEADER_CONTENT_TYPE, "text/plain");   // no charset!
+        BinaryMemoryBody body = new BinaryMemoryBody(qpBytes, MimeUtil.ENC_QUOTED_PRINTABLE);
+        part.setBody(body);
+
+        String result = MessageExtractor.getTextFromPart(part);
+
+        assertEquals("テスト", result);
     }
 
     @Test


### PR DESCRIPTION
## Summary

This PR improves Japanese email rendering on Android by fixing several
charset handling issues in `CharsetSupport` and `JisSupport`.

### Changes

**CharsetSupport**
- Normalize common Shift-JIS aliases (`shift-jis`, `sjis`, `ms932`,
  `windows-31j`, `x-sjis`, `x-ms-cp932`) to `shift_jis`
- Add EUC-JP fallback aliases (`x-euc-jp`, `euc_jp`) to the charset
  fallback map
- Always route `iso-2022-jp` through `Iso2022JpToShiftJisInputStream`
  instead of relying on Android's ICU4J decoder, which silently
  mishandles QP-decoded byte sequences and causes ESC bytes or `$B`/`(B`
  escape remnants to appear as literal text
- Auto-detect ISO-2022-JP when `Content-Type` has no `charset` parameter
  by scanning for `ESC$B` / `ESC$@` escape sequences — Japanese feature
  phones and carrier webmail systems commonly omit the charset header,
  causing garbled output (e.g. `$BJIC...`) when decoded as US-ASCII

**JisSupport**
- Implement `getAddressFromReceivedHeader()` (was a no-op stub) to
  correctly parse the recipient address from the `for` clause of
  `Received` headers, enabling proper JIS variant detection for DoCoMo,
  SoftBank, and KDDI carrier mail

### Testing

Unit tests added/updated for all new logic:
- `CharsetSupportTest`: Shift-JIS alias normalization, EUC-JP alias
  fallback, `hasIso2022JpEscapeSequence()` edge cases
- `MessageExtractorTest`: QP-encoded ISO-2022-JP with/without charset
  header, multi-line bodies, raw 7-bit bodies
- `JisSupportTest` (new): carrier address detection via `From` and
  `Received` headers, iPhone mailer detection