### PR TITLE
chore(design-system): enhance ButtonOutline and ButtonFilled styles

### DIFF
--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonDefaults.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonDefaults.kt
@@ -14,6 +14,8 @@ import androidx.compose.material3.ButtonDefaults as Material3ButtonDefaults
  * Contains the default values used by buttons in the design system.
  */
 data object ButtonDefaults {
+    val ContentPadding = Material3ButtonDefaults.ContentPadding
+
     /**
      * Creates a [ButtonColors] that represents the default container and content
      * colours used in a text button.

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonDefaults.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonDefaults.kt
@@ -1,0 +1,183 @@
+package app.k9mail.core.ui.compose.designsystem.atom.button
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.unit.Dp
+import androidx.compose.material3.ButtonColors as Material3ButtonColors
+import androidx.compose.material3.ButtonDefaults as Material3ButtonDefaults
+
+/**
+ * Contains the default values used by buttons in the design system.
+ */
+data object ButtonDefaults {
+    /**
+     * Creates a [ButtonColors] that represents the default container and content
+     * colours used in a text button.
+     *
+     * @param containerColor the container colour of this button when enabled.
+     * @param contentColor the content colour of this button when enabled.
+     * @param disabledContainerColor the container colour of this button when
+     *  not enabled.
+     * @param disabledContentColor the content colour of this button when not
+     *  enabled.
+     * @param iconColor the colour of the icon when enabled.
+     * @param iconDisabledColor the colour of the icon when not enabled.
+     */
+    @Composable
+    fun textButtonColors(
+        containerColor: Color = Color.Unspecified,
+        contentColor: Color = Color.Unspecified,
+        disabledContainerColor: Color = Color.Unspecified,
+        disabledContentColor: Color = Color.Unspecified,
+        iconColor: Color = contentColor,
+        iconDisabledColor: Color = disabledContentColor,
+    ): ButtonColors = Material3ButtonDefaults.textButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+    ).toButtonColors(iconColor, iconDisabledColor)
+
+    /**
+     * Creates a [ButtonColors] instance representing the default colours used
+     * in an outlined button.
+     *
+     * @param containerColor the container colour of this button when enabled.
+     * @param contentColor the content colour of this button when enabled.
+     * @param disabledContainerColor the container colour of this button when
+     *  not enabled.
+     * @param disabledContentColor the content colour of this button when not
+     *  enabled.
+     * @param iconColor the colour of the icon when enabled.
+     * @param iconDisabledColor the colour of the icon when not enabled.
+     */
+    @Composable
+    fun outlinedButtonColors(
+        containerColor: Color = Color.Unspecified,
+        contentColor: Color = Color.Unspecified,
+        disabledContainerColor: Color = Color.Unspecified,
+        disabledContentColor: Color = Color.Unspecified,
+        iconColor: Color = contentColor,
+        iconDisabledColor: Color = disabledContentColor,
+    ): ButtonColors = Material3ButtonDefaults.outlinedButtonColors(
+        containerColor = containerColor,
+        contentColor = contentColor,
+        disabledContainerColor = disabledContainerColor,
+        disabledContentColor = disabledContentColor,
+    ).toButtonColors(iconColor, iconDisabledColor)
+
+    /**
+     * Creates a [ButtonShape] that represents the default shape and border
+     * used in an outlined button.
+     *
+     * @param shape the [Shape] of the button.
+     * @param border the [ButtonBorderStroke] to be applied to the button.
+     */
+    @Composable
+    fun outlinedShape(
+        shape: Shape = Material3ButtonDefaults.outlinedShape,
+        border: ButtonBorderStroke = outlinedButtonBorder(),
+    ): ButtonShape = ButtonShape(shape = shape, borderStroke = border)
+
+    /**
+     * Creates a [ButtonBorderStroke] used for the border of an outlined button.
+     *
+     * @param enabled whether the button is enabled.
+     * @param color the colour of the border when enabled. If [Color.Unspecified], the default
+     * Material 3 colour will be used.
+     * @param disabledColor the colour of the border when the button is not enabled.
+     */
+    @Composable
+    fun outlinedButtonBorder(
+        enabled: Boolean = true,
+        color: Color = Color.Unspecified,
+        disabledColor: Color = color.copy(alpha = 0.1f),
+    ): ButtonBorderStroke {
+        var m3Colors = Material3ButtonDefaults.outlinedButtonBorder(enabled)
+        if (color != Color.Unspecified) {
+            m3Colors = m3Colors.copy(brush = SolidColor(if (enabled) color else disabledColor))
+        }
+        return m3Colors.toButtonBorderStroke()
+    }
+}
+
+/**
+ * Represents the container, content, and icon colours used in a button in
+ * different states.
+ *
+ * @param containerColor the background colour of the button when enabled
+ * @param contentColor the colour of the button's text content when enabled
+ * @param disabledContainerColor the background colour of the button when
+ *  disabled
+ * @param disabledContentColor the colour of the button's text content when
+ *  disabled
+ * @param iconColor the colour of icons within the button when enabled, defaults
+ *  to contentColor
+ * @param iconDisabledColor the colour of icons within the button when disabled,
+ *  defaults to disabledContentColor
+ * @constructor creates an instance with the specified colours for all button states
+ */
+data class ButtonColors(
+    val containerColor: Color,
+    val contentColor: Color,
+    val disabledContainerColor: Color,
+    val disabledContentColor: Color,
+    val iconColor: Color = contentColor,
+    val iconDisabledColor: Color = disabledContentColor,
+)
+
+private fun Material3ButtonColors.toButtonColors(
+    iconColor: Color = Color.Unspecified,
+    iconDisabledColor: Color = Color.Unspecified,
+): ButtonColors = ButtonColors(
+    containerColor = containerColor,
+    contentColor = contentColor,
+    disabledContainerColor = disabledContainerColor,
+    disabledContentColor = disabledContainerColor,
+    iconColor = iconColor,
+    iconDisabledColor = iconDisabledColor,
+)
+
+internal fun ButtonColors.toMaterial3Colors(): Material3ButtonColors = Material3ButtonColors(
+    containerColor = containerColor,
+    contentColor = contentColor,
+    disabledContainerColor = disabledContainerColor,
+    disabledContentColor = disabledContainerColor,
+)
+
+/**
+ * Represents the shape and optional border stroke of a button.
+ *
+ * @property shape the [Shape] used for the button.
+ * @property borderStroke the [ButtonBorderStroke] applied to the button,
+ *  or `null` if no border is used.
+ */
+data class ButtonShape(
+    val shape: Shape,
+    val borderStroke: ButtonBorderStroke? = null,
+)
+
+/**
+ * Represents the border stroke applied to a button.
+ *
+ * @param width the thickness of the border.
+ * @param brush the [Brush] used to paint the border.
+ */
+data class ButtonBorderStroke(
+    val width: Dp,
+    val brush: Brush,
+)
+
+private fun BorderStroke.toButtonBorderStroke(): ButtonBorderStroke = ButtonBorderStroke(
+    width = width,
+    brush = brush,
+)
+
+internal fun ButtonBorderStroke.toMaterial3BorderStroke(): BorderStroke = BorderStroke(
+    width = width,
+    brush = brush,
+)

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilled.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonFilled.kt
@@ -11,6 +11,7 @@ fun ButtonFilled(
     text: String,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    leadingIcon: (@Composable () -> Unit)? = null,
     enabled: Boolean = true,
 ) {
     Material3Button(
@@ -18,6 +19,7 @@ fun ButtonFilled(
         modifier = modifier,
         enabled = enabled,
     ) {
+        leadingIcon?.invoke()
         Material3Text(
             text = text,
             textAlign = TextAlign.Center,

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlined.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlined.kt
@@ -1,5 +1,6 @@
 package app.k9mail.core.ui.compose.designsystem.atom.button
 
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -29,6 +30,7 @@ fun ButtonOutlined(
     icon: ImageVector? = null,
     colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
     shape: ButtonShape = ButtonDefaults.outlinedShape(),
+    contentPadding: PaddingValues = ButtonDefaults.ContentPadding,
 ) {
     Material3OutlinedButton(
         onClick = onClick,
@@ -37,6 +39,7 @@ fun ButtonOutlined(
         shape = shape.shape,
         colors = colors.toMaterial3Colors(),
         border = shape.borderStroke?.toMaterial3BorderStroke(),
+        contentPadding = contentPadding,
     ) {
         icon?.let {
             Icon(

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlined.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonOutlined.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text as Material3Text
  * @param modifier The modifier to be applied to the button.
  * @param enabled Controls the enabled state of the button.
  * @param icon Optional icon to display alongside the text.
+ * @param shape Optional shape of the button.
  */
 @Composable
 fun ButtonOutlined(
@@ -26,18 +27,25 @@ fun ButtonOutlined(
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
     icon: ImageVector? = null,
+    colors: ButtonColors = ButtonDefaults.outlinedButtonColors(),
+    shape: ButtonShape = ButtonDefaults.outlinedShape(),
 ) {
     Material3OutlinedButton(
         onClick = onClick,
         modifier = modifier,
         enabled = enabled,
+        shape = shape.shape,
+        colors = colors.toMaterial3Colors(),
+        border = shape.borderStroke?.toMaterial3BorderStroke(),
     ) {
         icon?.let {
             Icon(
                 imageVector = it,
                 contentDescription = null,
-                modifier = Modifier.alignByBaseline()
+                modifier = Modifier
+                    .alignByBaseline()
                     .padding(end = MainTheme.spacings.default),
+                tint = colors.iconColor,
             )
         }
         Material3Text(

--- a/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonText.kt
+++ b/core/ui/compose/designsystem/src/main/kotlin/app/k9mail/core/ui/compose/designsystem/atom/button/ButtonText.kt
@@ -1,6 +1,5 @@
 package app.k9mail.core.ui.compose.designsystem.atom.button
 
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -24,7 +23,7 @@ fun ButtonText(
         enabled = enabled,
         colors = ButtonDefaults.textButtonColors(
             contentColor = color ?: MainTheme.colors.primary,
-        ),
+        ).toMaterial3Colors(),
     ) {
         leadingIcon?.invoke()
         Material3Text(


### PR DESCRIPTION
Closes #10899.

- Add `contentPadding` parameter to `ButtonOutlined`
- Add leading icon to button filled
- Add customizable colours and shapes to design system buttons