### PR TITLE
feat(thundermail): add thundermail modules

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -158,6 +158,7 @@ dependencies {
     "fullImplementation"(projects.feature.funding.googleplay)
     implementation(projects.feature.migration.launcher.noop)
     implementation(projects.feature.onboarding.migration.noop)
+    implementation(projects.feature.thundermail.k9mail)
     implementation(projects.feature.telemetry.noop)
     implementation(projects.feature.widget.messageList)
     implementation(projects.feature.widget.messageListGlance)

--- a/app-k9mail/src/main/kotlin/app/k9mail/feature/FeatureModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/feature/FeatureModule.kt
@@ -10,6 +10,7 @@ import net.thunderbird.feature.funding.api.FundingSettings
 import net.thunderbird.feature.funding.featureFundingModule
 import net.thunderbird.feature.mail.message.list.internal.featureMessageListModule
 import net.thunderbird.feature.mail.message.reader.api.css.CssClassNameProvider
+import net.thunderbird.feature.thundermail.thunderbird.inject.featureThundermailModule
 import org.koin.dsl.module
 
 val featureModule = module {
@@ -19,6 +20,7 @@ val featureModule = module {
     includes(onboardingMigrationModule)
     includes(featureMigrationModule)
     includes(featureMessageListModule)
+    includes(featureThundermailModule)
 
     single<FundingSettings> { K9FundingSettings() }
 

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -258,6 +258,7 @@ dependencies {
 
     implementation(projects.feature.onboarding.migration.thunderbird)
     implementation(projects.feature.migration.launcher.thunderbird)
+    implementation(projects.feature.thundermail.thunderbird)
 
     // TODO remove once OAuth ids have been moved from TBD to TBA
     releaseImplementation(libs.appauth)

--- a/app-thunderbird/src/main/kotlin/net/thunderbird/android/feature/FeatureModule.kt
+++ b/app-thunderbird/src/main/kotlin/net/thunderbird/android/feature/FeatureModule.kt
@@ -10,6 +10,7 @@ import net.thunderbird.feature.funding.api.FundingSettings
 import net.thunderbird.feature.funding.featureFundingModule
 import net.thunderbird.feature.mail.message.list.internal.featureMessageListModule
 import net.thunderbird.feature.mail.message.reader.api.css.CssClassNameProvider
+import net.thunderbird.feature.thundermail.thunderbird.inject.featureThundermailModule
 import org.koin.dsl.module
 
 internal val featureModule = module {
@@ -19,6 +20,7 @@ internal val featureModule = module {
     includes(onboardingMigrationModule)
     includes(featureMigrationModule)
     includes(featureMessageListModule)
+    includes(featureThundermailModule)
 
     single<FundingSettings> { TbFundingSettings() }
 

--- a/feature/thundermail/api/build.gradle.kts
+++ b/feature/thundermail/api/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id(ThunderbirdPlugins.Library.kmpCompose)
+    alias(libs.plugins.dev.mokkery)
+}
+
+kotlin {
+    android {
+        namespace = "net.thunderbird.feature.thundermail"
+        androidResources.enable = true
+        withHostTest {
+            isIncludeAndroidResources = true
+        }
+    }
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.core.featureflag)
+        }
+    }
+}
+
+compose.resources {
+    publicResClass = false
+    packageOfResClass = "net.thunderbird.feature.thundermail.resources"
+}
+
+codeCoverage {
+    branchCoverage = 0
+    lineCoverage = 0
+}

--- a/feature/thundermail/k9mail/build.gradle.kts
+++ b/feature/thundermail/k9mail/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id(ThunderbirdPlugins.Library.kmpCompose)
+    alias(libs.plugins.dev.mokkery)
+}
+
+kotlin {
+    android {
+        namespace = "net.thunderbird.feature.thundermail.k9mail"
+        androidResources.enable = true
+        withHostTest {
+            isIncludeAndroidResources = true
+        }
+    }
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.feature.thundermail.api)
+        }
+    }
+}
+
+compose.resources {
+    publicResClass = false
+    packageOfResClass = "net.thunderbird.feature.thundermail.k9mail.resources"
+}
+
+codeCoverage {
+    branchCoverage = 0
+    lineCoverage = 0
+}

--- a/feature/thundermail/k9mail/src/commonMain/kotlin/net/thunderbird/feature/thundermail/thunderbird/inject/FeatureThundermailModule.kt
+++ b/feature/thundermail/k9mail/src/commonMain/kotlin/net/thunderbird/feature/thundermail/thunderbird/inject/FeatureThundermailModule.kt
@@ -1,0 +1,6 @@
+package net.thunderbird.feature.thundermail.thunderbird.inject
+
+import org.koin.dsl.module
+
+val featureThundermailModule = module {
+}

--- a/feature/thundermail/thunderbird/build.gradle.kts
+++ b/feature/thundermail/thunderbird/build.gradle.kts
@@ -1,0 +1,30 @@
+plugins {
+    id(ThunderbirdPlugins.Library.kmpCompose)
+    alias(libs.plugins.dev.mokkery)
+}
+
+kotlin {
+    android {
+        namespace = "net.thunderbird.feature.thundermail.thunderbird"
+        androidResources.enable = true
+        withHostTest {
+            isIncludeAndroidResources = true
+        }
+    }
+    sourceSets {
+        commonMain.dependencies {
+            implementation(projects.feature.thundermail.api)
+            implementation(projects.core.ui.compose.theme2.common)
+        }
+    }
+}
+
+compose.resources {
+    publicResClass = false
+    packageOfResClass = "net.thunderbird.feature.thundermail.thunderbird.resources"
+}
+
+codeCoverage {
+    branchCoverage = 0
+    lineCoverage = 0
+}

--- a/feature/thundermail/thunderbird/src/commonMain/kotlin/net/thunderbird/feature/thundermail/thunderbird/inject/FeatureThundermailModule.kt
+++ b/feature/thundermail/thunderbird/src/commonMain/kotlin/net/thunderbird/feature/thundermail/thunderbird/inject/FeatureThundermailModule.kt
@@ -1,0 +1,6 @@
+package net.thunderbird.feature.thundermail.thunderbird.inject
+
+import org.koin.dsl.module
+
+val featureThundermailModule = module {
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -272,6 +272,12 @@ include(
     ":feature:debug-settings",
 )
 
+include(
+    ":feature:thundermail:api",
+    ":feature:thundermail:thunderbird",
+    ":feature:thundermail:k9mail",
+)
+
 check(JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_21)) {
     """
         Java 21+ is required to build Thunderbird for Android.


### PR DESCRIPTION
Closes #10901

- Add the scaffold project for the Thundermail feature
- Wire the Thundermail :k9app and :thunderbird dedicated implementation with their respective apps.