### PR TITLE
Fixed cutoff behavior for notification actions

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationDataCreator.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/notification/SingleMessageNotificationDataCreator.kt
@@ -95,7 +95,7 @@ internal class SingleMessageNotificationDataCreator(
         hasSpamFolder: Boolean,
         isSpamEnabled: Boolean,
     ): List<NotificationAction> {
-        val desired = order.take(cutoff).filter { action ->
+        return order.take(cutoff).filter { action ->
             action.isAvailable(
                 hasArchiveFolder = hasArchiveFolder,
                 isDeleteEnabled = isDeleteEnabled,
@@ -103,27 +103,6 @@ internal class SingleMessageNotificationDataCreator(
                 isSpamEnabled = isSpamEnabled,
             )
         }
-        if (desired.size == NOTIFICATION_PREFERENCE_MAX_MESSAGE_ACTIONS_SHOWN) return desired
-
-        val filled = buildList {
-            addAll(desired)
-            for (action in order.drop(cutoff)) {
-                if (size == NOTIFICATION_PREFERENCE_MAX_MESSAGE_ACTIONS_SHOWN) break
-                if (
-                    action !in this &&
-                    action.isAvailable(
-                        hasArchiveFolder = hasArchiveFolder,
-                        isDeleteEnabled = isDeleteEnabled,
-                        hasSpamFolder = hasSpamFolder,
-                        isSpamEnabled = isSpamEnabled,
-                    )
-                ) {
-                    add(action)
-                }
-            }
-        }
-
-        return filled
     }
 
     private fun parseActionsOrder(tokens: List<String>): List<NotificationAction> {

--- a/legacy/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationDataCreatorTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/notification/SingleMessageNotificationDataCreatorTest.kt
@@ -3,7 +3,9 @@ package com.fsck.k9.notification
 import app.k9mail.legacy.message.controller.MessageReference
 import assertk.assertThat
 import assertk.assertions.contains
+import assertk.assertions.containsExactly
 import assertk.assertions.doesNotContain
+import assertk.assertions.isEmpty
 import assertk.assertions.isEqualTo
 import assertk.assertions.isFalse
 import assertk.assertions.isTrue
@@ -123,7 +125,7 @@ class SingleMessageNotificationDataCreatorTest {
     }
 
     @Test
-    fun `fill actions below cutoff up to max shown`() {
+    fun `only show actions above cutoff`() {
         setMessageActions(cutoff = 2)
         val content = createNotificationContent()
 
@@ -135,7 +137,26 @@ class SingleMessageNotificationDataCreatorTest {
             addLockScreenNotification = false,
         )
 
-        assertThat(result.actions).contains(NotificationAction.Delete)
+        assertThat(result.actions).containsExactly(
+            NotificationAction.Reply,
+            NotificationAction.MarkAsRead,
+        )
+    }
+
+    @Test
+    fun `show no actions when cutoff is zero`() {
+        setMessageActions(cutoff = 0)
+        val content = createNotificationContent()
+
+        val result = notificationDataCreator.createSingleNotificationData(
+            account = account,
+            notificationId = 0,
+            content = content,
+            timestamp = 0,
+            addLockScreenNotification = false,
+        )
+
+        assertThat(result.actions).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
This PR is a follow up bugfix for https://github.com/thunderbird/thunderbird-android/pull/10301

In this PR, we fix the cutoff behavior for the notification action settings

Prior to this we always showed 3 actions. With this change, we only show actions above the cutoff (up to 3) matching the design intent of the system

