### PR TITLE
feat(message-reader): added the compose message reader feature flag.

### DIFF
--- a/app-k9mail/src/debug/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
@@ -26,6 +26,7 @@ class K9FeatureFlagFactory : FeatureFlagFactory {
                 // TODO(#10498): Remove when UseNewMessageReaderCssStyles is no longer required
                 FeatureFlag(MessageReaderFeatureFlags.UseNewMessageReaderCssStyles, enabled = true),
                 FeatureFlag(MessageListFeatureFlags.EnableMessageListNewState, enabled = false),
+                FeatureFlag(MessageReaderFeatureFlags.UseComposeForMessageReader, enabled = false),
             ),
         )
     }

--- a/app-k9mail/src/release/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
+++ b/app-k9mail/src/release/kotlin/app/k9mail/featureflag/K9FeatureFlagFactory.kt
@@ -30,6 +30,7 @@ class K9FeatureFlagFactory : FeatureFlagFactory {
                 //  once it no longer required
                 FeatureFlag(MessageReaderFeatureFlags.UseNewMessageReaderCssStyles, enabled = true),
                 FeatureFlag(MessageListFeatureFlags.EnableMessageListNewState, enabled = false),
+                FeatureFlag(MessageReaderFeatureFlags.UseComposeForMessageReader, enabled = false),
             ),
         )
     }

--- a/app-thunderbird/src/beta/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/beta/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -28,6 +28,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
                 FeatureFlag(AccountSettingsFeatureFlags.EnableAvatarCustomization, enabled = true),
                 FeatureFlag(MessageReaderFeatureFlags.UseNewMessageReaderCssStyles, enabled = true),
                 FeatureFlag(MessageListFeatureFlags.EnableMessageListNewState, enabled = false),
+                FeatureFlag(MessageReaderFeatureFlags.UseComposeForMessageReader, enabled = false),
             ),
         )
     }

--- a/app-thunderbird/src/daily/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/daily/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -28,6 +28,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
                 FeatureFlag(AccountSettingsFeatureFlags.EnableAvatarCustomization, enabled = true),
                 FeatureFlag(MessageReaderFeatureFlags.UseNewMessageReaderCssStyles, enabled = true),
                 FeatureFlag(MessageListFeatureFlags.EnableMessageListNewState, enabled = false),
+                FeatureFlag(MessageReaderFeatureFlags.UseComposeForMessageReader, enabled = false),
             ),
         )
     }

--- a/app-thunderbird/src/debug/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/debug/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -29,6 +29,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
                 // TODO(#10498): Remove when UseNewMessageReaderCssStyles is no longer required
                 FeatureFlag(MessageReaderFeatureFlags.UseNewMessageReaderCssStyles, enabled = true),
                 FeatureFlag(MessageListFeatureFlags.EnableMessageListNewState, enabled = false),
+                FeatureFlag(MessageReaderFeatureFlags.UseComposeForMessageReader, enabled = false),
             ),
         )
     }

--- a/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
+++ b/app-thunderbird/src/release/kotlin/net/thunderbird/android/featureflag/TbFeatureFlagFactory.kt
@@ -30,6 +30,7 @@ class TbFeatureFlagFactory : FeatureFlagFactory {
                 //  once it no longer required
                 FeatureFlag(MessageReaderFeatureFlags.UseNewMessageReaderCssStyles, enabled = true),
                 FeatureFlag(MessageListFeatureFlags.EnableMessageListNewState, enabled = false),
+                FeatureFlag(MessageReaderFeatureFlags.UseComposeForMessageReader, enabled = false),
             ),
         )
     }

--- a/feature/mail/message/reader/api/src/commonMain/kotlin/net/thunderbird/feature/mail/message/reader/api/MessageReaderFeatureFlags.kt
+++ b/feature/mail/message/reader/api/src/commonMain/kotlin/net/thunderbird/feature/mail/message/reader/api/MessageReaderFeatureFlags.kt
@@ -5,4 +5,5 @@ import net.thunderbird.core.featureflag.FeatureFlagKey
 object MessageReaderFeatureFlags {
     // TODO(#10498): Remove when UseNewMessageReaderCssStyles is no longer required
     val UseNewMessageReaderCssStyles = FeatureFlagKey("use_new_message_reader_css_styles")
+    val UseComposeForMessageReader = FeatureFlagKey("use_compose_for_message_reader")
 }


### PR DESCRIPTION
Adding this in preparation for the upcoming compose message reader refactor. Currently no features are behind it, this is just the introduction of the feature flag. 

New feature flag: `use_compose_for_message_reader`

Completes  [10652](https://github.com/thunderbird/thunderbird-android/issues/10652)