### PR TITLE
feat(ui): added header and margin for print Emails

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessagePrinter.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessagePrinter.kt
@@ -1,0 +1,104 @@
+package com.fsck.k9.ui.messageview
+
+import android.content.Context
+import android.print.PrintAttributes
+import android.print.PrintManager
+import com.fsck.k9.mail.Address
+import com.fsck.k9.mail.Message
+import com.fsck.k9.mailstore.MessageViewInfo
+import com.fsck.k9.view.MessageWebView
+import java.text.SimpleDateFormat
+import java.util.Locale
+
+class MessagePrinter(
+    private val context: Context,
+    private val appName: String,
+    private val noSubjectText: String,
+) {
+    fun print(messageViewInfo: MessageViewInfo) {
+        val printManager = context.getSystemService(Context.PRINT_SERVICE) as? PrintManager ?: return
+
+        val subject = messageViewInfo.message.subject ?: noSubjectText
+        val headerHtml = buildHeaderHtml(messageViewInfo)
+        val cleanBodyHtml = (messageViewInfo.text ?: "")
+            .replace(Regex("(?i)<a\\b[^>]*>"), "")
+            .replace(Regex("(?i)</a>"), "")
+        val fullHtml = buildFullHtml(headerHtml, cleanBodyHtml)
+
+        val printWebView = MessageWebView(context)
+        printWebView.displayHtmlContentWithInlineAttachments(
+            htmlText = fullHtml,
+            attachmentResolver = null,
+            onPageFinishedListener = {
+                val jobName = "$appName: $subject"
+                val printAdapter = printWebView.createPrintDocumentAdapter(jobName)
+                printManager.print(jobName, printAdapter, PrintAttributes.Builder().build())
+            },
+        )
+    }
+
+    private fun buildFullHtml(headerHtml: String, bodyHtml: String): String = """
+        <html>
+        <head>
+            <style>
+                @page {
+                    margin: 24px;
+                }
+                .page-wrapper {
+                    padding: 24px;
+                    font-family: Arial, sans-serif;
+                    color: #000;
+                }
+                .page-wrapper > div p {
+                    margin: 4px 0;
+                }
+            </style>
+        </head>
+        <body>
+            <div class="page-wrapper">
+                $headerHtml
+                $bodyHtml
+            </div>
+        </body>
+        </html>
+    """.trimIndent()
+
+    private fun buildHeaderHtml(messageViewInfo: MessageViewInfo): String {
+        val message = messageViewInfo.message
+
+        val subject = (message.subject ?: noSubjectText)
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+
+        val from = message.from
+            ?.joinToString(", ") { it.toDisplayString() }
+            ?: ""
+
+        val to = message.getRecipients(Message.RecipientType.TO)
+            ?.joinToString(", ") { it.toDisplayString() }
+            ?: ""
+
+        val date = message.sentDate?.let {
+            SimpleDateFormat("M/d/yyyy, h:mm a", Locale.getDefault()).format(it)
+        } ?: ""
+
+        return """
+            <div style="font-size:15px; margin-bottom:16px;">
+                <p><b>Subject:</b> $subject</p>
+                <p><b>From:</b> $from</p>
+                <p><b>Date:</b> $date</p>
+                <p><b>To:</b> $to</p>
+            </div>
+            <hr style="border:none; border-top:1px solid #ccc; margin:12px 0;">
+        """.trimIndent()
+    }
+
+    private fun Address.toDisplayString(): String {
+        val name = personal ?: ""
+        return if (name.isNotBlank() && address.isNotBlank()) {
+            "$name &lt;$address&gt;"
+        } else {
+            address ?: ""
+        }
+    }
+}

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -502,7 +502,7 @@ class MessageViewFragment :
                     font-family: Arial, sans-serif;
                     color: #000;
                 }
-                p {
+                .page-wrapper > div p {
                     margin: 4px 0;
                 }
             </style>
@@ -529,18 +529,29 @@ class MessageViewFragment :
     private fun buildPrintHeaderHtml(messageInfo: MessageViewInfo): String {
         val message = messageInfo.message
         val subject = message.subject ?: getString(R.string.general_no_subject)
+        val subjectGood = subject
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
         val from = message.from
             ?.joinToString(", ") {
                 val email = it.address
                 val name = it.personal ?: ""
-                if (name.isNotBlank()) "$name <$email>" else email
+                if (name.isNotBlank() && email.isNotBlank()) {
+                    "$name &lt;$email&gt;"
+                } else {
+                    email
+                }
             } ?: ""
 
         val to = message.getRecipients(Message.RecipientType.TO)
             ?.joinToString(", ") {
                 val email = it.address
                 val name = it.personal ?: ""
-                if (name.isNotBlank()) "$name <$email>" else email
+                if (name.isNotBlank() && email.isNotBlank()) {
+                    "$name &lt;$email&gt;"
+                } else {
+                    email ?: ""
+                }
             } ?: ""
 
         val date = message.sentDate?.let {
@@ -550,7 +561,7 @@ class MessageViewFragment :
 
         return """
         <div style="font-size:15px; margin-bottom:16px;">
-            <p><b>Subject:</b> $subject</p>
+            <p><b>Subject:</b> $subjectGood</p>
             <p><b>From:</b> $from</p>
             <p><b>Date:</b> $date</p>
             <p><b>To:</b> $to</p>

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -10,8 +10,6 @@ import android.net.Uri
 import android.os.Bundle
 import android.os.Parcelable
 import android.os.SystemClock
-import android.print.PrintAttributes
-import android.print.PrintManager
 import android.view.ContextThemeWrapper
 import android.view.LayoutInflater
 import android.view.Menu
@@ -50,7 +48,6 @@ import com.fsck.k9.fragment.ConfirmationDialogFragment.ConfirmationDialogFragmen
 import com.fsck.k9.helper.HttpsUnsubscribeUri
 import com.fsck.k9.helper.MailtoUnsubscribeUri
 import com.fsck.k9.helper.UnsubscribeUri
-import com.fsck.k9.mail.Message
 import com.fsck.k9.mailstore.AttachmentViewInfo
 import com.fsck.k9.mailstore.LocalMessage
 import com.fsck.k9.mailstore.MessageViewInfo
@@ -65,8 +62,6 @@ import com.fsck.k9.ui.messagesource.MessageSourceActivity
 import com.fsck.k9.ui.messageview.MessageCryptoPresenter.MessageCryptoMvpView
 import com.fsck.k9.ui.settings.account.AccountSettingsActivity
 import com.fsck.k9.ui.share.ShareIntentBuilder
-import com.fsck.k9.view.MessageWebView
-import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.time.Instant
 import kotlinx.collections.immutable.persistentListOf
@@ -479,96 +474,14 @@ class MessageViewFragment :
     }
 
     private fun printMessage() {
-        val context = context ?: return
-        val printManager = context.getSystemService(Context.PRINT_SERVICE) as? PrintManager ?: return
-
-        mMessageViewInfo?.let { messageInfo ->
-            val subject = messageInfo.message.subject ?: getString(R.string.general_no_subject)
-            val headerHtml = buildPrintHeaderHtml(messageInfo)
-            val bodyHtml = messageInfo.text ?: ""
-            val cleanBodyHtml = bodyHtml
-                .replace(Regex("(?i)<a\\b[^>]*>"), "")
-                .replace(Regex("(?i)</a>"), "")
-            val printWebView = MessageWebView(context)
-            val fullHtml = """
-        <html>
-        <head>
-            <style>
-                @page {
-                    margin: 24px;
-                }
-                .page-wrapper {
-                    padding: 24px;
-                    font-family: Arial, sans-serif;
-                    color: #000;
-                }
-                .page-wrapper > div p {
-                    margin: 4px 0;
-                }
-            </style>
-        </head>
-        <body>
-            <div class="page-wrapper">
-                $headerHtml
-                $cleanBodyHtml
-            </div>
-        </body>
-        </html>
-            """.trimIndent()
-
-            printWebView.displayHtmlContentWithInlineAttachments(
-                htmlText = fullHtml,
-                attachmentResolver = null,
-                onPageFinishedListener = {
-                    val jobName = appNameProvider.appName + ": " + subject
-                    val printAdapter = printWebView.createPrintDocumentAdapter(jobName)
-                    printManager.print(jobName, printAdapter, PrintAttributes.Builder().build())
-                },
-            )
-        }
-    } private fun buildPrintHeaderHtml(messageInfo: MessageViewInfo): String {
-        val message = messageInfo.message
-        val subject = message.subject ?: getString(R.string.general_no_subject)
-        val subjectGood = subject
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-        val from = message.from
-            ?.joinToString(", ") {
-                val email = it.address
-                val name = it.personal ?: ""
-                if (name.isNotBlank() && email.isNotBlank()) {
-                    "$name &lt;$email&gt;"
-                } else {
-                    email
-                }
-            } ?: ""
-
-        val to = message.getRecipients(Message.RecipientType.TO)
-            ?.joinToString(", ") {
-                val email = it.address
-                val name = it.personal ?: ""
-                if (name.isNotBlank() && email.isNotBlank()) {
-                    "$name &lt;$email&gt;"
-                } else {
-                    email ?: ""
-                }
-            } ?: ""
-
-        val date = message.sentDate?.let {
-            val formatter = SimpleDateFormat("M/d/yyyy, h:mm a", Locale.getDefault())
-            formatter.format(it)
-        } ?: ""
-
-        return """
-        <div style="font-size:15px; margin-bottom:16px;">
-            <p><b>Subject:</b> $subjectGood</p>
-            <p><b>From:</b> $from</p>
-            <p><b>Date:</b> $date</p>
-            <p><b>To:</b> $to</p>
-        </div>
-        <hr style="border:none; border-top:1px solid #ccc; margin:12px 0;">
-        """.trimIndent()
+        val messageViewInfo = mMessageViewInfo ?: return
+        MessagePrinter(
+            context = requireContext(),
+            appName = appNameProvider.appName,
+            noSubjectText = getString(R.string.general_no_subject),
+        ).print(messageViewInfo)
     }
+
     private fun onShowHeaders() {
         val launchIntent = MessageSourceActivity.createLaunchIntent(requireActivity(), messageReference)
         startActivity(launchIntent)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -20,7 +20,6 @@ import android.view.MenuItem
 import android.view.View
 import android.view.ViewGroup
 import android.view.inputmethod.InputMethodManager
-import android.webkit.WebView
 import android.widget.Toast
 import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.runtime.collectAsState
@@ -482,15 +481,16 @@ class MessageViewFragment :
     private fun printMessage() {
         val context = context ?: return
         val printManager = context.getSystemService(Context.PRINT_SERVICE) as? PrintManager ?: return
-        val messageInfo = mMessageViewInfo ?: return
-        val subject = messageInfo.message.subject ?: getString(R.string.general_no_subject)
-        val headerHtml = buildPrintHeaderHtml(messageInfo)
-        val bodyHtml = messageInfo.text ?: ""
-        val cleanBodyHtml = bodyHtml
-            .replace(Regex("(?i)<a\\b[^>]*>"), "")
-            .replace(Regex("(?i)</a>"), "")
-        val printWebView = MessageWebView(context)
-        val fullHtml = """
+
+        mMessageViewInfo?.let { messageInfo ->
+            val subject = messageInfo.message.subject ?: getString(R.string.general_no_subject)
+            val headerHtml = buildPrintHeaderHtml(messageInfo)
+            val bodyHtml = messageInfo.text ?: ""
+            val cleanBodyHtml = bodyHtml
+                .replace(Regex("(?i)<a\\b[^>]*>"), "")
+                .replace(Regex("(?i)</a>"), "")
+            val printWebView = MessageWebView(context)
+            val fullHtml = """
         <html>
         <head>
             <style>
@@ -514,19 +514,19 @@ class MessageViewFragment :
             </div>
         </body>
         </html>
-    """.trimIndent()
+            """.trimIndent()
 
-        printWebView.displayHtmlContentWithInlineAttachments(
-            htmlText = fullHtml,
-            attachmentResolver = null,
-            onPageFinishedListener = {
-                val jobName = appNameProvider.appName + ": " + subject
-                val printAdapter = printWebView.createPrintDocumentAdapter(jobName)
-                printManager.print(jobName, printAdapter, PrintAttributes.Builder().build())
-            }
-        )
-    }
-    private fun buildPrintHeaderHtml(messageInfo: MessageViewInfo): String {
+            printWebView.displayHtmlContentWithInlineAttachments(
+                htmlText = fullHtml,
+                attachmentResolver = null,
+                onPageFinishedListener = {
+                    val jobName = appNameProvider.appName + ": " + subject
+                    val printAdapter = printWebView.createPrintDocumentAdapter(jobName)
+                    printManager.print(jobName, printAdapter, PrintAttributes.Builder().build())
+                },
+            )
+        }
+    } private fun buildPrintHeaderHtml(messageInfo: MessageViewInfo): String {
         val message = messageInfo.message
         val subject = message.subject ?: getString(R.string.general_no_subject)
         val subjectGood = subject
@@ -567,7 +567,7 @@ class MessageViewFragment :
             <p><b>To:</b> $to</p>
         </div>
         <hr style="border:none; border-top:1px solid #ccc; margin:12px 0;">
-    """.trimIndent()
+        """.trimIndent()
     }
     private fun onShowHeaders() {
         val launchIntent = MessageSourceActivity.createLaunchIntent(requireActivity(), messageReference)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -51,6 +51,7 @@ import com.fsck.k9.fragment.ConfirmationDialogFragment.ConfirmationDialogFragmen
 import com.fsck.k9.helper.HttpsUnsubscribeUri
 import com.fsck.k9.helper.MailtoUnsubscribeUri
 import com.fsck.k9.helper.UnsubscribeUri
+import com.fsck.k9.mail.Message
 import com.fsck.k9.mailstore.AttachmentViewInfo
 import com.fsck.k9.mailstore.LocalMessage
 import com.fsck.k9.mailstore.MessageViewInfo
@@ -65,6 +66,8 @@ import com.fsck.k9.ui.messagesource.MessageSourceActivity
 import com.fsck.k9.ui.messageview.MessageCryptoPresenter.MessageCryptoMvpView
 import com.fsck.k9.ui.settings.account.AccountSettingsActivity
 import com.fsck.k9.ui.share.ShareIntentBuilder
+import com.fsck.k9.view.MessageWebView
+import java.text.SimpleDateFormat
 import java.util.Locale
 import kotlin.time.Instant
 import kotlinx.collections.immutable.persistentListOf
@@ -477,22 +480,81 @@ class MessageViewFragment :
     }
 
     private fun printMessage() {
-        val context = context
-        val webView = view?.findViewById<WebView>(R.id.message_content)
-        val printManager = context?.getSystemService(Context.PRINT_SERVICE) as? PrintManager
-        if (context == null || webView == null || printManager == null) return
+        val context = context ?: return
+        val printManager = context.getSystemService(Context.PRINT_SERVICE) as? PrintManager ?: return
+        val messageInfo = mMessageViewInfo ?: return
+        val subject = messageInfo.message.subject ?: getString(R.string.general_no_subject)
+        val headerHtml = buildPrintHeaderHtml(messageInfo)
+        val bodyHtml = messageInfo.text ?: ""
+        val printWebView = MessageWebView(context)
+        val fullHtml = """
+        <html>
+        <head>
+            <style>
+                @page {
+                    margin: 24px;
+                }
+                .page-wrapper {
+                    padding: 24px;
+                    font-family: Arial, sans-serif;
+                    color: #000;
+                }
+                p {
+                    margin: 4px 0;
+                }
+            </style>
+        </head>
+        <body>
+            <div class="page-wrapper">
+                $headerHtml
+                $bodyHtml
+            </div>
+        </body>
+        </html>
+    """.trimIndent()
 
-        val subject = mMessageViewInfo?.subject ?: getString(R.string.general_no_subject)
-        val jobName = appNameProvider.appName + ": " + subject
-        val printAdapter = webView.createPrintDocumentAdapter(jobName)
-
-        printManager.print(
-            jobName,
-            printAdapter,
-            PrintAttributes.Builder().build(),
+        printWebView.displayHtmlContentWithInlineAttachments(
+            htmlText = fullHtml,
+            attachmentResolver = null,
+            onPageFinishedListener = {
+                val jobName = appNameProvider.appName + ": " + subject
+                val printAdapter = printWebView.createPrintDocumentAdapter(jobName)
+                printManager.print(jobName, printAdapter, PrintAttributes.Builder().build())
+            }
         )
     }
+    private fun buildPrintHeaderHtml(messageInfo: MessageViewInfo): String {
+        val message = messageInfo.message
+        val subject = message.subject ?: getString(R.string.general_no_subject)
+        val from = message.from
+            ?.joinToString(", ") {
+                val email = it.address
+                val name = it.personal ?: ""
+                if (name.isNotBlank()) "$name <$email>" else email
+            } ?: ""
 
+        val to = message.getRecipients(Message.RecipientType.TO)
+            ?.joinToString(", ") {
+                val email = it.address
+                val name = it.personal ?: ""
+                if (name.isNotBlank()) "$name <$email>" else email
+            } ?: ""
+
+        val date = message.sentDate?.let {
+            val formatter = SimpleDateFormat("M/d/yyyy, h:mm a", Locale.getDefault())
+            formatter.format(it)
+        } ?: ""
+
+        return """
+        <div style="font-size:15px; margin-bottom:16px;">
+            <p><b>Subject:</b> $subject</p>
+            <p><b>From:</b> $from</p>
+            <p><b>Date:</b> $date</p>
+            <p><b>To:</b> $to</p>
+        </div>
+        <hr style="border:none; border-top:1px solid #ccc; margin:12px 0;">
+    """.trimIndent()
+    }
     private fun onShowHeaders() {
         val launchIntent = MessageSourceActivity.createLaunchIntent(requireActivity(), messageReference)
         startActivity(launchIntent)

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messageview/MessageViewFragment.kt
@@ -486,6 +486,9 @@ class MessageViewFragment :
         val subject = messageInfo.message.subject ?: getString(R.string.general_no_subject)
         val headerHtml = buildPrintHeaderHtml(messageInfo)
         val bodyHtml = messageInfo.text ?: ""
+        val cleanBodyHtml = bodyHtml
+            .replace(Regex("(?i)<a\\b[^>]*>"), "")
+            .replace(Regex("(?i)</a>"), "")
         val printWebView = MessageWebView(context)
         val fullHtml = """
         <html>
@@ -507,7 +510,7 @@ class MessageViewFragment :
         <body>
             <div class="page-wrapper">
                 $headerHtml
-                $bodyHtml
+                $cleanBodyHtml
             </div>
         </body>
         </html>


### PR DESCRIPTION
## Summary
Solves #10567
Wrap content in a structured HTML document

## PDF Outputs (Final)
[a_redacted.pdf](https://github.com/user-attachments/files/26971723/a_redacted.pdf)
[2_redacted.pdf](https://github.com/user-attachments/files/26943486/2_redacted.pdf)

## Pending tasks:
- [x] Adding Email-ID of sender 
- [x] Removing Hyperlinks