### PR TITLE
feat(thundermail): wire oauth flow on "Sign with Thundermail"

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -59,6 +59,8 @@ dependencies {
     implementation(projects.mail.protocols.imap)
     implementation(projects.backend.imap)
 
+    implementation(projects.feature.thundermail.internal.common)
+
     implementation(libs.androidx.work.runtime)
     implementation(libs.androidx.lifecycle.process)
     implementation(libs.kotlinx.collections.immutable)

--- a/app-common/src/main/kotlin/net/thunderbird/app/common/feature/AppCommonFeatureModule.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/feature/AppCommonFeatureModule.kt
@@ -8,6 +8,7 @@ import net.thunderbird.feature.mail.message.composer.inject.featureMessageCompos
 import net.thunderbird.feature.mail.message.reader.impl.inject.featureMessageReaderModule
 import net.thunderbird.feature.navigation.drawer.api.NavigationDrawerExternalContract
 import net.thunderbird.feature.notification.impl.inject.featureNotificationModule
+import net.thunderbird.feature.thundermail.internal.common.inject.featureThundermailCommonModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
@@ -18,6 +19,7 @@ internal val appCommonFeatureModule = module {
     includes(featureNotificationModule)
     includes(featureMessageComposerModule)
     includes(featureMessageReaderModule)
+    includes(featureThundermailCommonModule)
 
     factory<FeatureLauncherExternalContract.MessageListLauncher> {
         MessageListLauncher(

--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -159,6 +159,7 @@ dependencies {
     implementation(projects.feature.migration.launcher.noop)
     implementation(projects.feature.onboarding.migration.noop)
     implementation(projects.feature.thundermail.k9mail)
+    implementation(projects.feature.thundermail.api)
     implementation(projects.feature.telemetry.noop)
     implementation(projects.feature.widget.messageList)
     implementation(projects.feature.widget.messageListGlance)

--- a/app-k9mail/src/test/kotlin/app/k9mail/DependencyInjectionTest.kt
+++ b/app-k9mail/src/test/kotlin/app/k9mail/DependencyInjectionTest.kt
@@ -29,6 +29,7 @@ import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.message.list.ui.dialog.SetupArchiveFolderDialogContract
 import net.thunderbird.feature.mail.message.reader.api.css.CssClassNameProvider
+import net.thunderbird.feature.thundermail.ui.ThundermailContract
 import org.junit.Test
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.verify.definition
@@ -71,6 +72,7 @@ class DependencyInjectionTest {
                 definition<SyncDebugWorker>(WorkerParameters::class),
                 definition<OpenPgpApiManager>(LifecycleOwner::class),
                 definition<SetupArchiveFolderDialogContract.ViewModel>(SetupArchiveFolderDialogContract.State::class),
+                definition<ThundermailContract.ViewModel>(ThundermailContract.State::class),
             ),
         )
     }

--- a/app-thunderbird/build.gradle.kts
+++ b/app-thunderbird/build.gradle.kts
@@ -258,6 +258,7 @@ dependencies {
 
     implementation(projects.feature.onboarding.migration.thunderbird)
     implementation(projects.feature.migration.launcher.thunderbird)
+    implementation(projects.feature.thundermail.api)
     implementation(projects.feature.thundermail.thunderbird)
 
     // TODO remove once OAuth ids have been moved from TBD to TBA

--- a/app-thunderbird/src/test/kotlin/net/thunderbird/android/DependencyInjectionTest.kt
+++ b/app-thunderbird/src/test/kotlin/net/thunderbird/android/DependencyInjectionTest.kt
@@ -29,6 +29,7 @@ import net.thunderbird.core.preference.storage.Storage
 import net.thunderbird.feature.account.AccountId
 import net.thunderbird.feature.mail.message.list.ui.dialog.SetupArchiveFolderDialogContract
 import net.thunderbird.feature.mail.message.reader.api.css.CssClassNameProvider
+import net.thunderbird.feature.thundermail.ui.ThundermailContract
 import org.junit.Test
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.verify.definition
@@ -71,6 +72,7 @@ class DependencyInjectionTest {
                 definition<SyncDebugWorker>(WorkerParameters::class),
                 definition<OpenPgpApiManager>(LifecycleOwner::class),
                 definition<SetupArchiveFolderDialogContract.ViewModel>(SetupArchiveFolderDialogContract.State::class),
+                definition<ThundermailContract.ViewModel>(ThundermailContract.State::class),
             ),
         )
     }

--- a/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/data/AuthorizationRepository.kt
+++ b/feature/account/oauth/src/main/kotlin/app/k9mail/feature/account/oauth/data/AuthorizationRepository.kt
@@ -86,7 +86,11 @@ class AuthorizationRepository(
         val authRequest = authRequestBuilder
             .setScope(configuration.scopes.joinToString(" "))
             .setCodeVerifier(codeVerifier)
-            .setLoginHint(emailAddress)
+            .apply {
+                if (emailAddress.isNotBlank()) {
+                    setLoginHint(emailAddress)
+                }
+            }
             .build()
 
         return service.getAuthorizationRequestIntent(authRequest)

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/AutoDiscoveryMapper.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/domain/AutoDiscoveryMapper.kt
@@ -12,7 +12,7 @@ import app.k9mail.feature.account.setup.domain.entity.toConnectionSecurity
 import com.fsck.k9.mail.ServerSettings
 import com.fsck.k9.mail.store.imap.ImapStoreSettings
 
-internal fun IncomingServerSettings.toServerSettings(password: String?): ServerSettings {
+fun IncomingServerSettings.toServerSettings(password: String?): ServerSettings {
     return when (this) {
         is ImapServerSettings -> this.toImapServerSettings(password)
         is DemoServerSettings -> this.serverSettings
@@ -45,7 +45,7 @@ private fun ImapServerSettings.toImapServerSettings(password: String?): ServerSe
  *
  * @throws IllegalArgumentException if the server settings type is unknown.
  */
-internal fun OutgoingServerSettings.toServerSettings(password: String?): ServerSettings {
+fun OutgoingServerSettings.toServerSettings(password: String?): ServerSettings {
     return when (this) {
         is SmtpServerSettings -> this.toSmtpServerSettings(password)
         is DemoServerSettings -> this.serverSettings

--- a/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
+++ b/feature/account/setup/src/main/kotlin/app/k9mail/feature/account/setup/navigation/AccountSetupNavHost.kt
@@ -29,9 +29,9 @@ import app.k9mail.feature.account.setup.ui.specialfolders.SpecialFoldersViewMode
 import org.koin.androidx.compose.koinViewModel
 import org.koin.compose.koinInject
 
-private const val NESTED_NAVIGATION_AUTO_CONFIG = "autoconfig"
+const val NESTED_NAVIGATION_AUTO_CONFIG = "autoconfig"
 private const val NESTED_NAVIGATION_INCOMING_SERVER_CONFIG = "incoming-server/config"
-private const val NESTED_NAVIGATION_INCOMING_SERVER_VALIDATION = "incoming-server/validation"
+const val NESTED_NAVIGATION_INCOMING_SERVER_VALIDATION = "incoming-server/validation"
 private const val NESTED_NAVIGATION_OUTGOING_SERVER_CONFIG = "outgoing-server/config"
 private const val NESTED_NAVIGATION_OUTGOING_SERVER_VALIDATION = "outgoing-server/validation"
 private const val NESTED_NAVIGATION_SPECIAL_FOLDERS = "special-folders"
@@ -44,14 +44,19 @@ private const val NESTED_NAVIGATION_CREATE_ACCOUNT = "create-account"
 fun AccountSetupNavHost(
     onBack: () -> Unit,
     onFinish: (AccountSetupRoute) -> Unit,
+    skipToIncomingValidation: Boolean = false,
 ) {
     val navController = rememberNavController()
-    var isAutomaticConfig by rememberSaveable { mutableStateOf(false) }
+    var isAutomaticConfig by rememberSaveable { mutableStateOf(skipToIncomingValidation) }
     var hasSpecialFolders by rememberSaveable { mutableStateOf(false) }
 
     NavHost(
         navController = navController,
-        startDestination = NESTED_NAVIGATION_AUTO_CONFIG,
+        startDestination = if (skipToIncomingValidation) {
+            NESTED_NAVIGATION_INCOMING_SERVER_VALIDATION
+        } else {
+            NESTED_NAVIGATION_AUTO_CONFIG
+        },
     ) {
         composable(route = NESTED_NAVIGATION_AUTO_CONFIG) {
             AccountAutoDiscoveryScreen(

--- a/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
+++ b/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
@@ -20,7 +20,7 @@ import app.k9mail.feature.onboarding.welcome.ui.WelcomeScreen
 import app.k9mail.feature.settings.import.ui.SettingsImportAction
 import app.k9mail.feature.settings.import.ui.SettingsImportScreen
 import net.thunderbird.core.common.provider.AppNameProvider
-import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreen
+import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenProvider
 import org.koin.compose.koinInject
 
 private const val NESTED_NAVIGATION_ROUTE_WELCOME = "welcome"
@@ -66,6 +66,7 @@ fun OnboardingNavHost(
     onFinish: (OnboardingRoute) -> Unit,
     modifier: Modifier = Modifier,
     onboardingMigrationManager: OnboardingMigrationManager = koinInject(),
+    addThundermailAccountScreenProvider: AddThundermailAccountScreenProvider = koinInject(),
 ) {
     val navController = rememberNavController()
     var accountUuid by rememberSaveable { mutableStateOf<String?>(null) }
@@ -92,7 +93,7 @@ fun OnboardingNavHost(
 
         composable(route = NESTED_NAVIGATION_ROUTE_ADD_THUNDERMAIL_ACCOUNT) {
             val appNameProvider = koinInject<AppNameProvider>()
-            AddThundermailAccountScreen(
+            addThundermailAccountScreenProvider.Content(
                 header = {
                     AppTitleTopHeader(
                         title = appNameProvider.appName,

--- a/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
+++ b/feature/onboarding/main/src/main/kotlin/app/k9mail/feature/onboarding/main/navigation/OnboardingNavHost.kt
@@ -8,9 +8,11 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navArgument
 import app.k9mail.feature.account.common.ui.AppTitleTopHeader
 import app.k9mail.feature.account.setup.navigation.AccountSetupNavHost
 import app.k9mail.feature.account.setup.navigation.AccountSetupRoute
@@ -31,6 +33,7 @@ private const val NESTED_NAVIGATION_ROUTE_SETTINGS_IMPORT_QR_CODE = "settings_im
 private const val NESTED_NAVIGATION_ROUTE_PERMISSIONS = "permissions"
 private const val NESTED_NAVIGATION_ROUTE_ADD_THUNDERMAIL_ACCOUNT = "add_thundermail_account"
 private const val NESTED_NAVIGATION_ROUTE_QR_CODE_SCANNER = "qr_code_thundermail"
+private const val NESTED_NAVIGATION_ARG_SKIP_TO_INCOMING_VALIDATION = "skipToIncomingValidation"
 
 private fun NavController.navigateToAddThundermailAccount() {
     navigate(NESTED_NAVIGATION_ROUTE_ADD_THUNDERMAIL_ACCOUNT)
@@ -40,8 +43,11 @@ private fun NavController.navigateToQrCodeScanner() {
     navigate(NESTED_NAVIGATION_ROUTE_QR_CODE_SCANNER)
 }
 
-private fun NavController.navigateToAccountSetup() {
-    navigate(NESTED_NAVIGATION_ROUTE_ACCOUNT_SETUP)
+private fun NavController.navigateToAccountSetup(skipToIncomingValidation: Boolean = false) {
+    navigate(
+        NESTED_NAVIGATION_ROUTE_ACCOUNT_SETUP +
+            "?$NESTED_NAVIGATION_ARG_SKIP_TO_INCOMING_VALIDATION=$skipToIncomingValidation",
+    )
 }
 
 private fun NavController.navigateToSettingsImport() {
@@ -100,11 +106,10 @@ fun OnboardingNavHost(
                         modifier = Modifier.fillMaxWidth(),
                     )
                 },
-                onSignWithThundermailClick = {
-                    // TODO(#10911): Navigate to OAuth
-                },
                 onScanQrCodeClick = { navController.navigateToQrCodeScanner() },
                 onSetupAnotherAccountClick = { navController.navigateToAccountSetup() },
+                onOAuthSuccess = { navController.navigateToAccountSetup(skipToIncomingValidation = true) },
+                modifier = Modifier.fillMaxWidth(),
             )
         }
 
@@ -124,7 +129,19 @@ fun OnboardingNavHost(
             )
         }
 
-        composable(route = NESTED_NAVIGATION_ROUTE_ACCOUNT_SETUP) {
+        composable(
+            route = "$NESTED_NAVIGATION_ROUTE_ACCOUNT_SETUP?$NESTED_NAVIGATION_ARG_SKIP_TO_INCOMING_VALIDATION=" +
+                "{$NESTED_NAVIGATION_ARG_SKIP_TO_INCOMING_VALIDATION}",
+            arguments = listOf(
+                navArgument(NESTED_NAVIGATION_ARG_SKIP_TO_INCOMING_VALIDATION) {
+                    type = NavType.BoolType
+                    defaultValue = false
+                },
+            ),
+        ) { backStackEntry ->
+            val skipToIncomingValidation = backStackEntry.arguments
+                ?.getBoolean(NESTED_NAVIGATION_ARG_SKIP_TO_INCOMING_VALIDATION)
+                ?: false
             AccountSetupNavHost(
                 onBack = { navController.popBackStack() },
                 onFinish = { route: AccountSetupRoute ->
@@ -134,6 +151,7 @@ fun OnboardingNavHost(
                         }
                     }
                 },
+                skipToIncomingValidation = skipToIncomingValidation,
             )
         }
 

--- a/feature/thundermail/api/build.gradle.kts
+++ b/feature/thundermail/api/build.gradle.kts
@@ -16,6 +16,7 @@ dependencies {
     implementation(projects.core.featureflag)
     implementation(projects.core.ui.compose.theme2.common)
     implementation(projects.core.ui.compose.designsystem)
+    implementation(projects.mail.common)
 }
 
 codeCoverage {

--- a/feature/thundermail/api/src/main/kotlin/net/thunderbird/feature/thundermail/ui/ThundermailContract.kt
+++ b/feature/thundermail/api/src/main/kotlin/net/thunderbird/feature/thundermail/ui/ThundermailContract.kt
@@ -1,0 +1,33 @@
+package net.thunderbird.feature.thundermail.ui
+
+import android.content.Intent
+import com.fsck.k9.mail.ServerSettings
+import net.thunderbird.core.ui.contract.mvi.BaseViewModel
+
+interface ThundermailContract {
+    abstract class ViewModel(initialState: State) : BaseViewModel<State, Event, Effect>(initialState)
+    data class State(
+        val incomingServerSettings: ServerSettings? = null,
+        val outgoingServerSettings: ServerSettings? = null,
+        val error: Error? = null,
+    )
+
+    sealed interface Effect {
+        data class LaunchOAuth(
+            val intent: Intent,
+        ) : Effect
+
+        data object NavigateToIncomingServerSettings : Effect
+    }
+
+    sealed interface Event {
+        data object SignInClicked : Event
+        data class OnOAuthResult(val resultCode: Int, val data: Intent?) : Event
+    }
+
+    sealed interface Error {
+        data object Canceled : Error
+        data object BrowserNotAvailable : Error
+        data class Unknown(val error: Exception) : Error
+    }
+}

--- a/feature/thundermail/api/src/main/kotlin/net/thunderbird/feature/thundermail/ui/screen/AddThundermailAccountScreenProvider.kt
+++ b/feature/thundermail/api/src/main/kotlin/net/thunderbird/feature/thundermail/ui/screen/AddThundermailAccountScreenProvider.kt
@@ -10,9 +10,9 @@ fun interface AddThundermailAccountScreenProvider {
     @Composable
     fun Content(
         header: @Composable ColumnScope.() -> Unit,
-        onSignWithThundermailClick: () -> Unit,
         onScanQrCodeClick: () -> Unit,
         onSetupAnotherAccountClick: () -> Unit,
+        onOAuthSuccess: () -> Unit,
         modifier: Modifier,
     )
 }

--- a/feature/thundermail/api/src/main/kotlin/net/thunderbird/feature/thundermail/ui/screen/AddThundermailAccountScreenProvider.kt
+++ b/feature/thundermail/api/src/main/kotlin/net/thunderbird/feature/thundermail/ui/screen/AddThundermailAccountScreenProvider.kt
@@ -1,0 +1,18 @@
+package net.thunderbird.feature.thundermail.ui.screen
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.Modifier
+
+@Stable
+fun interface AddThundermailAccountScreenProvider {
+    @Composable
+    fun Content(
+        header: @Composable ColumnScope.() -> Unit,
+        onSignWithThundermailClick: () -> Unit,
+        onScanQrCodeClick: () -> Unit,
+        onSetupAnotherAccountClick: () -> Unit,
+        modifier: Modifier,
+    )
+}

--- a/feature/thundermail/internal/common/build.gradle.kts
+++ b/feature/thundermail/internal/common/build.gradle.kts
@@ -1,0 +1,29 @@
+plugins {
+    id(ThunderbirdPlugins.Library.androidCompose)
+}
+
+android {
+    namespace = "net.thunderbird.feature.thundermail.internal.common"
+    testOptions {
+        unitTests {
+            isIncludeAndroidResources = true
+        }
+    }
+}
+
+dependencies {
+    implementation(projects.core.logging.api)
+    implementation(projects.core.ui.compose.designsystem)
+    implementation(projects.core.ui.compose.theme2.common)
+    implementation(projects.feature.account.common)
+    implementation(projects.feature.account.oauth)
+    implementation(projects.feature.account.setup)
+    implementation(projects.feature.autodiscovery.api)
+    implementation(projects.feature.thundermail.api)
+    implementation(libs.appauth)
+}
+
+codeCoverage {
+    branchCoverage = 0
+    lineCoverage = 0
+}

--- a/feature/thundermail/internal/common/build.gradle.kts
+++ b/feature/thundermail/internal/common/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 
 dependencies {
     implementation(projects.core.logging.api)
+    implementation(projects.core.outcome)
     implementation(projects.core.ui.compose.designsystem)
     implementation(projects.core.ui.compose.theme2.common)
     implementation(projects.feature.account.common)

--- a/feature/thundermail/internal/common/src/debug/kotlin/net/thunderbird/feature/thundermail/ui/screen/AddThundermailAccountScreenPreview.kt
+++ b/feature/thundermail/internal/common/src/debug/kotlin/net/thunderbird/feature/thundermail/ui/screen/AddThundermailAccountScreenPreview.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.tooling.preview.PreviewLightDark
 import app.k9mail.core.ui.compose.common.koin.koinPreview
 import app.k9mail.core.ui.compose.designsystem.PreviewWithThemeLightDark
 import net.thunderbird.core.ui.compose.theme2.MainTheme
+import net.thunderbird.feature.thundermail.internal.common.ui.screen.AddThundermailAccountScreen
 import net.thunderbird.feature.thundermail.ui.BrandBackgroundModifierProvider
 
 @PreviewLightDark
@@ -34,9 +35,9 @@ private fun Preview() {
             ) {
                 AddThundermailAccountScreen(
                     header = {},
-                    onSignWithThundermailClick = {},
                     onScanQrCodeClick = {},
                     onSetupAnotherAccountClick = {},
+                    dispatch = { },
                 )
             }
         }

--- a/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/domain/CreateAccountStateUseCase.kt
+++ b/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/domain/CreateAccountStateUseCase.kt
@@ -1,0 +1,63 @@
+package net.thunderbird.feature.thundermail.internal.common.domain
+
+import app.k9mail.feature.account.common.domain.AccountDomainContract
+import app.k9mail.feature.account.common.domain.entity.AccountDisplayOptions
+import app.k9mail.feature.account.common.domain.entity.AccountState
+import app.k9mail.feature.account.common.domain.entity.AuthorizationState
+import com.fsck.k9.mail.ServerSettings
+import net.openid.appauth.AuthState
+import net.thunderbird.core.outcome.Outcome
+import org.json.JSONException
+
+internal class CreateAccountStateUseCase(
+    private val accountStateRepository: AccountDomainContract.AccountStateRepository,
+) {
+    operator fun invoke(
+        authorizationState: AuthorizationState,
+        incomingServerSettings: ServerSettings,
+        outgoingServerSettings: ServerSettings,
+    ): Outcome<Unit, Failure> {
+        val json = authorizationState.value ?: return Outcome.failure(Failure.AuthorizationStateMissing)
+        val (authState, error) = try {
+            AuthState.jsonDeserialize(json) to null
+        } catch (e: JSONException) {
+            null to Failure.InvalidAuthorizationState(error = e)
+        }
+        val idToken = authState?.parsedIdToken
+        val emailAddress = (
+            idToken?.additionalClaims["preferred_username"]
+                ?: idToken?.additionalClaims["email"]
+            )?.toString()
+
+        return when {
+            authState == null && error != null -> Outcome.failure(error)
+            idToken == null -> Outcome.failure(Failure.IdTokenMissing)
+            emailAddress.isNullOrBlank() -> Outcome.failure(Failure.MissingEmail(idToken.toString()))
+            else -> {
+                val name = (idToken.additionalClaims["name"] ?: idToken.additionalClaims["given_name"])?.toString()
+                val state = AccountState(
+                    emailAddress = emailAddress,
+                    incomingServerSettings = incomingServerSettings.copy(username = emailAddress),
+                    outgoingServerSettings = outgoingServerSettings.copy(username = emailAddress),
+                    authorizationState = authorizationState,
+                    displayOptions = name?.let {
+                        AccountDisplayOptions(
+                            accountName = emailAddress,
+                            displayName = name,
+                            emailSignature = null,
+                        )
+                    },
+                )
+                accountStateRepository.setState(state)
+                Outcome.success(Unit)
+            }
+        }
+    }
+
+    sealed interface Failure {
+        data object AuthorizationStateMissing : Failure
+        data class InvalidAuthorizationState(val error: Throwable) : Failure
+        data object IdTokenMissing : Failure
+        data class MissingEmail(val idToken: String) : Failure
+    }
+}

--- a/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/inject/FeatureThundermailCommonModule.kt
+++ b/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/inject/FeatureThundermailCommonModule.kt
@@ -1,9 +1,30 @@
 package net.thunderbird.feature.thundermail.internal.common.inject
 
+import app.k9mail.feature.account.oauth.ui.AccountOAuthViewModel
+import net.thunderbird.feature.thundermail.internal.common.domain.CreateAccountStateUseCase
+import net.thunderbird.feature.thundermail.internal.common.ui.ThundermailOAuthViewModel
 import net.thunderbird.feature.thundermail.internal.common.ui.screen.DefaultAddThundermailAccountScreenProvider
+import net.thunderbird.feature.thundermail.ui.ThundermailContract
 import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenProvider
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
 val featureThundermailCommonModule = module {
+    viewModel<AccountOAuthViewModel> {
+        AccountOAuthViewModel(
+            getOAuthRequestIntent = get(),
+            finishOAuthSignIn = get(),
+            checkIsGoogleSignIn = get(),
+        )
+    }
+    viewModel<ThundermailContract.ViewModel> {
+        ThundermailOAuthViewModel(
+            logger = get(),
+            accountOAuthViewModel = get(),
+            getAutoDiscovery = get(),
+            createAccountStateUseCase = get(),
+        )
+    }
+    single<CreateAccountStateUseCase> { CreateAccountStateUseCase(get()) }
     single<AddThundermailAccountScreenProvider> { DefaultAddThundermailAccountScreenProvider }
 }

--- a/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/inject/FeatureThundermailCommonModule.kt
+++ b/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/inject/FeatureThundermailCommonModule.kt
@@ -1,0 +1,9 @@
+package net.thunderbird.feature.thundermail.internal.common.inject
+
+import net.thunderbird.feature.thundermail.internal.common.ui.screen.DefaultAddThundermailAccountScreenProvider
+import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenProvider
+import org.koin.dsl.module
+
+val featureThundermailCommonModule = module {
+    single<AddThundermailAccountScreenProvider> { DefaultAddThundermailAccountScreenProvider }
+}

--- a/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/ui/ThundermailOAuthViewModel.kt
+++ b/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/ui/ThundermailOAuthViewModel.kt
@@ -1,0 +1,105 @@
+package net.thunderbird.feature.thundermail.internal.common.ui
+
+import androidx.lifecycle.viewModelScope
+import app.k9mail.autodiscovery.api.AutoDiscoveryResult
+import app.k9mail.feature.account.oauth.ui.AccountOAuthContract
+import app.k9mail.feature.account.oauth.ui.AccountOAuthViewModel
+import app.k9mail.feature.account.setup.domain.DomainContract.UseCase.GetAutoDiscovery
+import app.k9mail.feature.account.setup.domain.toServerSettings
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import net.thunderbird.core.logging.Logger
+import net.thunderbird.core.outcome.handle
+import net.thunderbird.feature.thundermail.internal.common.domain.CreateAccountStateUseCase
+import net.thunderbird.feature.thundermail.ui.ThundermailContract
+
+private const val TAG = "ThundermailOAuthViewModel"
+
+private const val OAUTH_AUTO_DISCOVERY = "oauth-autodiscovery@thundermail.com"
+
+internal class ThundermailOAuthViewModel(
+    private val logger: Logger,
+    private val accountOAuthViewModel: AccountOAuthViewModel,
+    private val getAutoDiscovery: GetAutoDiscovery,
+    private val createAccountStateUseCase: CreateAccountStateUseCase,
+) : ThundermailContract.ViewModel(initialState = ThundermailContract.State()) {
+
+    init {
+        flow { emit(getAutoDiscovery.execute(OAUTH_AUTO_DISCOVERY)) }
+            .map { result ->
+                when (result) {
+                    is AutoDiscoveryResult.Settings -> {
+                        val incomingServerSettings = result.incomingServerSettings.toServerSettings(password = null)
+                        accountOAuthViewModel.initState(
+                            AccountOAuthContract.State(
+                                hostname = incomingServerSettings.host,
+                            ),
+                        )
+                        updateState {
+                            val outgoingServerSettings = result.outgoingServerSettings
+                            it.copy(
+                                incomingServerSettings = incomingServerSettings,
+                                outgoingServerSettings = outgoingServerSettings.toServerSettings(password = null),
+                            )
+                        }
+                    }
+
+                    else -> Unit
+                }
+                accountOAuthViewModel.state
+            }
+            .onEach { state ->
+                logger.verbose(TAG) { "accountOAuthViewModel.state() called with: state = $state" }
+            }
+            .launchIn(viewModelScope)
+
+        accountOAuthViewModel
+            .effect
+            .onEach { effect ->
+                logger.verbose(TAG) { "accountOAuthViewModel.effect() called with: effect = $effect" }
+                when (effect) {
+                    is AccountOAuthContract.Effect.LaunchOAuth -> emitEffect(
+                        ThundermailContract.Effect.LaunchOAuth(effect.intent),
+                    )
+
+                    AccountOAuthContract.Effect.NavigateBack -> Unit
+                    is AccountOAuthContract.Effect.NavigateNext -> handleNavigateNext(effect)
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    private fun handleNavigateNext(effect: AccountOAuthContract.Effect.NavigateNext) {
+        with(state.value) {
+            val errorMessage = "Unexpected behaviour. NavigateNext called before AutoDiscoveryResult was received."
+
+            createAccountStateUseCase(
+                authorizationState = effect.state,
+                incomingServerSettings = requireNotNull(incomingServerSettings) { errorMessage },
+                outgoingServerSettings = requireNotNull(outgoingServerSettings) { errorMessage },
+            ).handle(
+                onSuccess = { emitEffect(ThundermailContract.Effect.NavigateToIncomingServerSettings) },
+                onFailure = { failure ->
+                    when (failure) {
+                        is CreateAccountStateUseCase.Failure.AuthorizationStateMissing -> Unit
+                        is CreateAccountStateUseCase.Failure.InvalidAuthorizationState -> Unit
+                        is CreateAccountStateUseCase.Failure.IdTokenMissing -> Unit
+                        is CreateAccountStateUseCase.Failure.MissingEmail -> Unit
+                    }
+                },
+            )
+        }
+    }
+
+    override fun event(event: ThundermailContract.Event) {
+        when (event) {
+            ThundermailContract.Event.SignInClicked ->
+                accountOAuthViewModel.event(AccountOAuthContract.Event.SignInClicked)
+
+            is ThundermailContract.Event.OnOAuthResult ->
+                accountOAuthViewModel.event(AccountOAuthContract.Event.OnOAuthResult(event.resultCode, event.data))
+        }
+    }
+}

--- a/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/ui/screen/DefaultAddThundermailAccountScreenProvider.kt
+++ b/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/ui/screen/DefaultAddThundermailAccountScreenProvider.kt
@@ -1,4 +1,4 @@
-package net.thunderbird.feature.thundermail.ui.screen
+package net.thunderbird.feature.thundermail.internal.common.ui.screen
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -38,19 +38,40 @@ import net.thunderbird.core.ui.compose.designsystem.atom.icon.Icon
 import net.thunderbird.core.ui.compose.designsystem.atom.icon.Icons
 import net.thunderbird.core.ui.compose.theme2.MainTheme
 import net.thunderbird.feature.thundermail.R
+import net.thunderbird.feature.thundermail.internal.common.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_CONTENT_ROOT
+import net.thunderbird.feature.thundermail.internal.common.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_SCAN_QR_CODE_BUTTON
+import net.thunderbird.feature.thundermail.internal.common.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_SETUP_ANOTHER_ACCOUNT_BUTTON
+import net.thunderbird.feature.thundermail.internal.common.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_SIGN_IN_WITH_THUNDERMAIL_BUTTON
+import net.thunderbird.feature.thundermail.internal.common.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_WHAT_IS_THUNDERMAIL_LINK
+import net.thunderbird.feature.thundermail.ui.ThundermailContract
 import net.thunderbird.feature.thundermail.ui.brandBackground
-import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_CONTENT_ROOT
-import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_SCAN_QR_CODE_BUTTON
-import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_SETUP_ANOTHER_ACCOUNT_BUTTON
-import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_SIGN_IN_WITH_THUNDERMAIL_BUTTON
-import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_WHAT_IS_THUNDERMAIL_LINK
+import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenProvider
+
+object DefaultAddThundermailAccountScreenProvider : AddThundermailAccountScreenProvider {
+    @Composable
+    override fun Content(
+        header: @Composable ColumnScope.() -> Unit,
+        onSignWithThundermailClick: () -> Unit,
+        onScanQrCodeClick: () -> Unit,
+        onSetupAnotherAccountClick: () -> Unit,
+        modifier: Modifier,
+    ) {
+        AddThundermailAccountScreen(
+            header = header,
+            onScanQrCodeClick = onScanQrCodeClick,
+            onSetupAnotherAccountClick = onSetupAnotherAccountClick,
+            dispatch = {},
+            modifier = modifier,
+        )
+    }
+}
 
 @Composable
-fun AddThundermailAccountScreen(
+internal fun AddThundermailAccountScreen(
     header: @Composable ColumnScope.() -> Unit,
-    onSignWithThundermailClick: () -> Unit,
     onScanQrCodeClick: () -> Unit,
     onSetupAnotherAccountClick: () -> Unit,
+    dispatch: (ThundermailContract.Event) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     Scaffold(modifier) { paddingValues ->
@@ -78,7 +99,7 @@ fun AddThundermailAccountScreen(
                     color = MainTheme.colors.primary,
                 )
                 ThundermailPanel(
-                    onSignWithThundermailClick = onSignWithThundermailClick,
+                    onSignWithThundermailClick = { dispatch(ThundermailContract.Event.SignInClicked) },
                     onScanQrCodeClick = onScanQrCodeClick,
                     modifier = Modifier.fillMaxWidth(),
                 )

--- a/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/ui/screen/DefaultAddThundermailAccountScreenProvider.kt
+++ b/feature/thundermail/internal/common/src/main/kotlin/net/thunderbird/feature/thundermail/internal/common/ui/screen/DefaultAddThundermailAccountScreenProvider.kt
@@ -1,5 +1,7 @@
 package net.thunderbird.feature.thundermail.internal.common.ui.screen
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -37,6 +39,7 @@ import net.thunderbird.core.ui.compose.common.modifier.testTagAsResourceId
 import net.thunderbird.core.ui.compose.designsystem.atom.icon.Icon
 import net.thunderbird.core.ui.compose.designsystem.atom.icon.Icons
 import net.thunderbird.core.ui.compose.theme2.MainTheme
+import net.thunderbird.core.ui.contract.mvi.observe
 import net.thunderbird.feature.thundermail.R
 import net.thunderbird.feature.thundermail.internal.common.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_CONTENT_ROOT
 import net.thunderbird.feature.thundermail.internal.common.ui.screen.AddThundermailAccountScreenDefaults.TEST_TAG_SCAN_QR_CODE_BUTTON
@@ -46,21 +49,35 @@ import net.thunderbird.feature.thundermail.internal.common.ui.screen.AddThunderm
 import net.thunderbird.feature.thundermail.ui.ThundermailContract
 import net.thunderbird.feature.thundermail.ui.brandBackground
 import net.thunderbird.feature.thundermail.ui.screen.AddThundermailAccountScreenProvider
+import org.koin.androidx.compose.koinViewModel
 
 object DefaultAddThundermailAccountScreenProvider : AddThundermailAccountScreenProvider {
     @Composable
     override fun Content(
         header: @Composable ColumnScope.() -> Unit,
-        onSignWithThundermailClick: () -> Unit,
         onScanQrCodeClick: () -> Unit,
         onSetupAnotherAccountClick: () -> Unit,
+        onOAuthSuccess: () -> Unit,
         modifier: Modifier,
     ) {
+        val viewModel = koinViewModel<ThundermailContract.ViewModel>()
+        val oAuthLauncher = rememberLauncherForActivityResult(
+            contract = ActivityResultContracts.StartActivityForResult(),
+        ) {
+            viewModel.event(ThundermailContract.Event.OnOAuthResult(it.resultCode, it.data))
+        }
+
+        val (_, dispatch) = viewModel.observe { effect ->
+            when (effect) {
+                is ThundermailContract.Effect.LaunchOAuth -> oAuthLauncher.launch(effect.intent)
+                is ThundermailContract.Effect.NavigateToIncomingServerSettings -> onOAuthSuccess()
+            }
+        }
         AddThundermailAccountScreen(
             header = header,
             onScanQrCodeClick = onScanQrCodeClick,
             onSetupAnotherAccountClick = onSetupAnotherAccountClick,
-            dispatch = {},
+            dispatch = dispatch,
             modifier = modifier,
         )
     }

--- a/feature/thundermail/internal/common/src/test/kotlin/net/thunderbird/feature/thundermail/internal/common/domain/CreateAccountStateUseCaseTest.kt
+++ b/feature/thundermail/internal/common/src/test/kotlin/net/thunderbird/feature/thundermail/internal/common/domain/CreateAccountStateUseCaseTest.kt
@@ -1,0 +1,330 @@
+package net.thunderbird.feature.thundermail.internal.common.domain
+
+import app.k9mail.feature.account.common.data.InMemoryAccountStateRepository
+import app.k9mail.feature.account.common.domain.entity.AccountDisplayOptions
+import app.k9mail.feature.account.common.domain.entity.AuthorizationState
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import assertk.assertions.isInstanceOf
+import assertk.assertions.isNotNull
+import assertk.assertions.isNull
+import assertk.assertions.isSameInstanceAs
+import assertk.assertions.prop
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
+import java.util.Base64
+import net.openid.appauth.AuthState
+import net.openid.appauth.AuthorizationServiceConfiguration
+import net.openid.appauth.TokenRequest
+import net.openid.appauth.TokenResponse
+import net.thunderbird.core.outcome.Outcome
+import org.json.JSONObject
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class CreateAccountStateUseCaseTest {
+
+    @Test
+    fun `invoke should fail with AuthorizationStateMissing when authorization state has no value`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+
+        // Act
+        val result = testSubject(
+            authorizationState = AuthorizationState(value = null),
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        assertThat(result).isInstanceOf<Outcome.Failure<CreateAccountStateUseCase.Failure>>()
+            .prop(Outcome.Failure<CreateAccountStateUseCase.Failure>::error)
+            .isSameInstanceAs(CreateAccountStateUseCase.Failure.AuthorizationStateMissing)
+    }
+
+    @Test
+    fun `invoke should fail with InvalidAuthorizationState when value is malformed JSON`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+
+        // Act
+        val result = testSubject(
+            authorizationState = AuthorizationState(value = "not-valid-json"),
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        assertThat(result).isInstanceOf<Outcome.Failure<CreateAccountStateUseCase.Failure>>()
+            .prop(Outcome.Failure<CreateAccountStateUseCase.Failure>::error)
+            .isInstanceOf<CreateAccountStateUseCase.Failure.InvalidAuthorizationState>()
+    }
+
+    @Test
+    fun `invoke should fail with IdTokenMissing when auth state has no id token`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+        val authorizationState = AuthorizationState(value = AuthState().jsonSerializeString())
+
+        // Act
+        val result = testSubject(
+            authorizationState = authorizationState,
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        assertThat(result).isInstanceOf<Outcome.Failure<CreateAccountStateUseCase.Failure>>()
+            .prop(Outcome.Failure<CreateAccountStateUseCase.Failure>::error)
+            .isSameInstanceAs(CreateAccountStateUseCase.Failure.IdTokenMissing)
+    }
+
+    @Test
+    fun `invoke should fail with MissingEmail when id token has no preferred_username or email`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+        val authorizationState = authorizationStateWith(
+            buildIdTokenClaims(preferredUsername = null, email = null),
+        )
+
+        // Act
+        val result = testSubject(
+            authorizationState = authorizationState,
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        assertThat(result).isInstanceOf<Outcome.Failure<CreateAccountStateUseCase.Failure>>()
+            .prop(Outcome.Failure<CreateAccountStateUseCase.Failure>::error)
+            .isInstanceOf<CreateAccountStateUseCase.Failure.MissingEmail>()
+    }
+
+    @Test
+    fun `invoke should succeed using preferred_username for email address`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+        val authorizationState = authorizationStateWith(
+            buildIdTokenClaims(
+                preferredUsername = "user@thundermail.test",
+                email = "fallback@thundermail.test",
+                name = "Test User",
+            ),
+        )
+
+        // Act
+        val result = testSubject(
+            authorizationState = authorizationState,
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
+        assertThat(repository.getState().emailAddress).isEqualTo("user@thundermail.test")
+    }
+
+    @Test
+    fun `invoke should fall back to email claim when preferred_username absent`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+        val authorizationState = authorizationStateWith(
+            buildIdTokenClaims(
+                preferredUsername = null,
+                email = "email-only@thundermail.test",
+                name = "Test User",
+            ),
+        )
+
+        // Act
+        val result = testSubject(
+            authorizationState = authorizationState,
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        assertThat(result).isInstanceOf<Outcome.Success<Unit>>()
+        assertThat(repository.getState().emailAddress).isEqualTo("email-only@thundermail.test")
+    }
+
+    @Test
+    fun `invoke should persist server settings and authorization state on success`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+        val authorizationState = authorizationStateWith(
+            buildIdTokenClaims(preferredUsername = "user@thundermail.test"),
+        )
+
+        // Act
+        testSubject(
+            authorizationState = authorizationState,
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        val state = repository.getState()
+        assertThat(state.incomingServerSettings).isEqualTo(INCOMING_SERVER_SETTINGS)
+        assertThat(state.outgoingServerSettings).isEqualTo(OUTGOING_SERVER_SETTINGS)
+        assertThat(state.authorizationState).isEqualTo(authorizationState)
+    }
+
+    @Test
+    fun `invoke should set display options with name claim when present`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+        val authorizationState = authorizationStateWith(
+            buildIdTokenClaims(
+                preferredUsername = "user@thundermail.test",
+                name = "Ada Lovelace",
+                givenName = "Ignored",
+            ),
+        )
+
+        // Act
+        testSubject(
+            authorizationState = authorizationState,
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        assertThat(repository.getState().displayOptions).isNotNull().isEqualTo(
+            AccountDisplayOptions(
+                accountName = "user@thundermail.test",
+                displayName = "Ada Lovelace",
+                emailSignature = null,
+            ),
+        )
+    }
+
+    @Test
+    fun `invoke should fall back to given_name for displayName when name absent`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+        val authorizationState = authorizationStateWith(
+            buildIdTokenClaims(
+                preferredUsername = "user@thundermail.test",
+                name = null,
+                givenName = "Ada",
+            ),
+        )
+
+        // Act
+        testSubject(
+            authorizationState = authorizationState,
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        assertThat(repository.getState().displayOptions)
+            .isNotNull()
+            .prop(AccountDisplayOptions::displayName)
+            .isEqualTo("Ada")
+    }
+
+    @Test
+    fun `invoke should leave display options null when name and given_name absent`() {
+        // Arrange
+        val repository = InMemoryAccountStateRepository()
+        val testSubject = CreateAccountStateUseCase(repository)
+        val authorizationState = authorizationStateWith(
+            buildIdTokenClaims(
+                preferredUsername = "user@thundermail.test",
+                name = null,
+                givenName = null,
+            ),
+        )
+
+        // Act
+        testSubject(
+            authorizationState = authorizationState,
+            incomingServerSettings = INCOMING_SERVER_SETTINGS,
+            outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        )
+
+        // Assert
+        assertThat(repository.getState().displayOptions).isNull()
+    }
+
+    private fun authorizationStateWith(idToken: String): AuthorizationState {
+        val configuration = AuthorizationServiceConfiguration(
+            android.net.Uri.parse("https://example.com/authorize"),
+            android.net.Uri.parse("https://example.com/token"),
+        )
+        val tokenRequest = TokenRequest.Builder(configuration, "test-client")
+            .setGrantType(TokenRequest.GRANT_TYPE_PASSWORD)
+            .build()
+        val tokenResponse = TokenResponse.Builder(tokenRequest)
+            .setAccessToken("access-token")
+            .setIdToken(idToken)
+            .build()
+        val authState = AuthState().apply { update(tokenResponse, null) }
+        return AuthorizationState(value = authState.jsonSerializeString())
+    }
+
+    private fun buildIdTokenClaims(
+        preferredUsername: String? = null,
+        email: String? = null,
+        name: String? = null,
+        givenName: String? = null,
+    ): String {
+        val header = JSONObject().apply {
+            put("alg", "none")
+            put("typ", "JWT")
+        }
+        val claims = JSONObject().apply {
+            put("iss", "https://example.com")
+            put("sub", "subject")
+            put("aud", "test-client")
+            put("exp", 9_999_999_999L)
+            put("iat", 1_000_000_000L)
+            preferredUsername?.let { put("preferred_username", it) }
+            email?.let { put("email", it) }
+            name?.let { put("name", it) }
+            givenName?.let { put("given_name", it) }
+        }
+        val encoder = Base64.getUrlEncoder().withoutPadding()
+        val headerSegment = encoder.encodeToString(header.toString().toByteArray())
+        val payloadSegment = encoder.encodeToString(claims.toString().toByteArray())
+        return "$headerSegment.$payloadSegment."
+    }
+
+    private companion object {
+        val INCOMING_SERVER_SETTINGS = ServerSettings(
+            type = "imap",
+            host = "imap.thundermail.test",
+            port = 993,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.XOAUTH2,
+            username = "user@thundermail.test",
+            password = null,
+            clientCertificateAlias = null,
+        )
+
+        val OUTGOING_SERVER_SETTINGS = ServerSettings(
+            type = "smtp",
+            host = "smtp.thundermail.test",
+            port = 465,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.XOAUTH2,
+            username = "user@thundermail.test",
+            password = null,
+            clientCertificateAlias = null,
+        )
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -274,6 +274,7 @@ include(
 
 include(
     ":feature:thundermail:api",
+    ":feature:thundermail:internal:common",
     ":feature:thundermail:thunderbird",
     ":feature:thundermail:k9mail",
 )


### PR DESCRIPTION
Resolves #10911.

- Adds `:feature:thundermail:internal:common` to handle common implementation for both K-9 mail and Thunderbird
- Move `AddThundermailAccountScreen` to `:feature:thundermail:internal:common`
- Wire OAuth flow on `Sign with Thundermail` button