### PR TITLE
Fix: Mockito inline mock maker failing on JDK 21

### DIFF
--- a/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.jvm.gradle.kts
@@ -20,6 +20,13 @@ tasks.withType<Jar> {
     archiveBaseName.set(projectDotPath)
 }
 
+tasks.withType<Test> {
+    jvmArgs(
+        "-XX:+EnableDynamicAgentLoading",
+        "-Djdk.attach.allowAttachSelf=true",
+    )
+}
+
 configureKotlinJavaCompatibility()
 
 dependencies {


### PR DESCRIPTION
## Problem
Running tests on JDK 21 fails with:

`Could not initialize inline Byte Buddy mock maker.`
`Could not self-attach to current VM using external process`

This affects all JVM library modules using the `thunderbird.library.jvm` plugin.

## Fix
Add JVM args `-XX:+EnableDynamicAgentLoading` and 
`-Djdk.attach.allowAttachSelf=true` to the `thunderbird.library.jvm` 
convention plugin so all JVM modules allow Mockito's ByteBuddy agent 
to self-attach when running tests on JDK 17+.

## Testing
Verified all JVM module tests pass with this fix on JDK 21.