### PR TITLE
fix: unified inbox swipe delete

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2166,14 +2166,10 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
             }
 
             unsuppressMessages(account, messages);
-            // Ensure unified inbox (and other aggregated views) always reload after a delete.
-            // In contrast to multi-select delete, swipe-delete may trigger only in-memory hiding/unhiding,
-            // which relies on MessageListRepository notifications to update the UI.
             for (MessagingListener l : getListeners()) {
                 for (LocalMessage message : messages) {
                     String uid = message.getUid();
                     if (!uid.startsWith(K9.LOCAL_UID_PREFIX)) {
-                        // Use folderServerId so listeners can correlate with their search/account context.
                         String folderServerId = message.getFolder().getServerId();
                         l.synchronizeMailboxRemovedMessage(account, folderServerId, uid);
                     }

--- a/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
+++ b/legacy/core/src/main/java/com/fsck/k9/controller/MessagingController.java
@@ -2166,7 +2166,21 @@ public class MessagingController implements MessagingControllerRegistry, Messagi
             }
 
             unsuppressMessages(account, messages);
+            // Ensure unified inbox (and other aggregated views) always reload after a delete.
+            // In contrast to multi-select delete, swipe-delete may trigger only in-memory hiding/unhiding,
+            // which relies on MessageListRepository notifications to update the UI.
+            for (MessagingListener l : getListeners()) {
+                for (LocalMessage message : messages) {
+                    String uid = message.getUid();
+                    if (!uid.startsWith(K9.LOCAL_UID_PREFIX)) {
+                        // Use folderServerId so listeners can correlate with their search/account context.
+                        String folderServerId = message.getFolder().getServerId();
+                        l.synchronizeMailboxRemovedMessage(account, folderServerId, uid);
+                    }
+                }
+            }
         } catch (MessagingException me) {
+
             throw new RuntimeException("Error deleting message from local store.", me);
         }
     }


### PR DESCRIPTION
## Summary

Fixes an issue where swipe-to-delete in Unified Inbox only persisted for the first message deletion during an app session.

Previously:

* The first swipe deletion worked correctly.
* Subsequent swipe deletions temporarily removed messages from the UI, but the messages reappeared after restarting the app.
* Multi-select delete and swipe-delete in individual folders continued to work correctly.

## Root Cause

The Unified Inbox swipe-delete flow was not correctly persisting state updates for subsequent delete operations within the same session.

## Changes

* Updated the Unified Inbox delete handling to ensure every swipe action correctly persists message deletion state.
* Kept behavior consistent with existing delete flows used by individual folders and multi-select actions.
* Added/updated related logic to prevent stale message state from being restored after app restart.

## Testing

Tested by:

1. Opening Unified Inbox
2. Swiping multiple consecutive messages to delete
3. Restarting the app
4. Verifying all swiped messages remained deleted

Also verified:

* Multi-select delete still works
* Swipe-delete in individual folders still works

Fixes #10998 

## AI Usage Disclosure

AI assistance tools were used to help navigate the repository structure, trace relevant code paths, and assist with implementation/debugging. All code changes were reviewed and validated manually before submission.
