### PR TITLE
fix: remove when-guards compiler args as it's the default now

### DIFF
--- a/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
+++ b/build-plugin/src/main/kotlin/thunderbird.library.android.gradle.kts
@@ -74,11 +74,6 @@ kotlin {
     compilerOptions {
         jvmTarget.set(ThunderbirdProjectConfig.Compiler.jvmTarget)
     }
-    sourceSets.all {
-        compilerOptions {
-            freeCompilerArgs.add("-Xwhen-guards")
-        }
-    }
 }
 
 dependencies {

--- a/feature/notification/api/build.gradle.kts
+++ b/feature/notification/api/build.gradle.kts
@@ -34,14 +34,6 @@ kotlin {
             implementation(libs.bundles.shared.jvm.test)
         }
     }
-
-    sourceSets.all {
-        compilerOptions {
-            freeCompilerArgs.addAll(
-                "-Xwhen-guards",
-            )
-        }
-    }
 }
 
 compose.resources {


### PR DESCRIPTION
This removes the `-Xwhen-guards` free compiler argument from the Kotlin compiler options as it's supported by default now.