### PR TITLE
chore(build): fix formatting of JVM arguments in `gradle.properties`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,7 @@ android.defaults.buildfeatures.shaders=false
 # Gradle
 ## Ensure important default jvmargs aren't overwritten. See https://github.com/gradle/gradle/issues/19750
 ## To remove warnings about "Sharing is only supported for boot loader classes", these properties have been added: -XX:+IgnoreUnrecognizedVMOptions -XX:+SuppressCDSWarning
-org.gradle.jvmargs=-Dfile.encoding=UTF-8,-XX:+UseG1GC,-XX:SoftRefLRUPolicyMSPerMB=1,-XX:ReservedCodeCacheSize=512m,-XX:InitialCodeCacheSize=256m,-XX:+HeapDumpOnOutOfMemoryError,-Xmx8g,-XX:+IgnoreUnrecognizedVMOptions,-XX:+SuppressCDSWarning
+org.gradle.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=512m -XX:InitialCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx8g -XX:+IgnoreUnrecognizedVMOptions -XX:+SuppressCDSWarning
 org.gradle.parallel=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
@@ -15,4 +15,4 @@ org.gradle.kotlin.dsl.allWarningsAsErrors=true
 # Kotlin
 kotlin.code.style=official
 kotlin.compiler.execution.strategy=in-process
-kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8,-XX:+UseG1GC,-XX:SoftRefLRUPolicyMSPerMB=1,-XX:ReservedCodeCacheSize=512m,-XX:InitialCodeCacheSize=256m,-XX:+HeapDumpOnOutOfMemoryError,-Xmx8g
+kotlin.daemon.jvmargs=-Dfile.encoding=UTF-8 -XX:+UseG1GC -XX:SoftRefLRUPolicyMSPerMB=1 -XX:ReservedCodeCacheSize=512m -XX:InitialCodeCacheSize=256m -XX:+HeapDumpOnOutOfMemoryError -Xmx8g


### PR DESCRIPTION
This should resolve the issue with: https://github.com/thunderbird/thunderbird-android/actions/runs/26045608112/job/76568868743

```
java.nio.charset.IllegalCharsetNameException: UTF-8,-XX:+UseG1GC,-XX:SoftRefLRUPolicyMSPerMB=1,-XX:ReservedCodeCacheSize=512m,-XX:InitialCodeCacheSize=256m,-XX:+HeapDumpOnOutOfMemoryError,-Xmx8g,-XX:+IgnoreUnrecognizedVMOptions,-XX:+SuppressCDSWarning
```