### PR TITLE
docs(github): update pull request template to act more like a template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,20 +12,37 @@
 > You can help us by categorizing your pull request with labels. 
 > We appreciate you working with us and will get to reviewing your contribution as soon as we can!
 
-### Please ensure that your pull request meets the following requirements - thanks!
-
-- Does not contain merge commits. Rebase instead.
-- Contains commits with descriptive titles.
-- New code is written in Kotlin whenever possible.
-- Follows our existing codestyle (`gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
-- Does not break any unit tests (`gradlew testDebugUnitTest`; will be checked by CI).
-- Uses a descriptive title; don't put issue numbers in there.
-- Contains a reference to the issue that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_) in the body text.
-- For cosmetic changes add one or multiple images, if possible.
-- Disclose if and how AI was used in the creation of this content
-
-
-\* Finally, please replace this template text with a description of the change and additional context if necessary.
-You may format it however you’d like. Consider including screenshots, descriptions of the problem it solves and how it goes about solving those issues, and any other information you consider relevant. 
-
 As always, thank you for the contribution!
+
+### \~\~After reading, delete this line and the above to use the template for your pull request\~\~
+
+
+## Contribution Summary
+
+Linked Issue/Ticket: 
+
+#### Description
+
+_<Please provide a detailed description of your contribution here>_
+
+#### Screen Shots
+
+_<If your pull request makes any UI changes, include screenshots displaying those changes here>_
+
+## AI Disclosure
+
+Select **one** of the following (mandatory)
+
+- [ ] This contribution does not include any changes created or assisted by AI.
+- [ ] This contribution includes changes assisted by AI.
+- [ ] This contribution includes changes created by AI.
+
+## Contribution Checklist
+
+- [ ] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
+- [ ] This contribution is in Kotlin where possible
+- [ ] This contribution does not use merge commits
+- [ ] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
+- [ ] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
+- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
+- [ ] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).


### PR DESCRIPTION
Resolves #11015 

The current pull request template reads more like documentation than a template. This was initially done to keep from rigid formatting, but does make it more difficult to see everything we're expecting to see in a pull request. This keeps the same information but reformats the contents to serve as a template with checklist reminders for our guidelines.  It also is more like the new pull request template format we're using [on iOS](https://github.com/thunderbird/thunderbird-ios/pull/344)