### PR TITLE
K9WebViewClient: log WebView main-frame load errors

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/K9WebViewClient.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/K9WebViewClient.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.net.Uri
 import android.os.Build
 import android.provider.Browser
+import android.webkit.WebResourceError
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
@@ -118,6 +119,14 @@ class K9WebViewClient(
         super.onPageFinished(view, url)
 
         onPageFinishedListener?.onPageFinished()
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
+        super.onReceivedError(view, request, error)
+        if (request.isForMainFrame) {
+            Log.d("Message WebView load error: %d %s for %s", error.errorCode, error.description, request.url)
+        }
     }
 
     companion object {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/K9WebViewClient.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/K9WebViewClient.kt
@@ -22,6 +22,7 @@ import net.thunderbird.core.logging.legacy.Log
 /**
  * [WebViewClient] that intercepts requests for `cid:` URIs to load the respective body part.
  */
+@Suppress("TooManyFunctions")
 class K9WebViewClient(
     private val clipboardManager: ClipboardManager,
     private val attachmentResolver: AttachmentResolver?,


### PR DESCRIPTION
Closes #11029.

`K9WebViewClient` already overrides `shouldOverrideUrlLoading`, `shouldInterceptRequest` and `onPageFinished`. It does not override `onReceivedError`, so any failure while loading a message body in the legacy message view is silent: the user sees a blank message body, and nothing useful gets recorded in adb logcat.

This PR adds the API 23+ overload only, since `minSdk` for the legacy module is 23 (`build-plugin/src/main/kotlin/ThunderbirdProjectConfig.kt: const val sdkMin = 23`), so the deprecated pre-M overload is not reachable on any device the app ships to.

```kotlin
@RequiresApi(Build.VERSION_CODES.M)
override fun onReceivedError(view: WebView, request: WebResourceRequest, error: WebResourceError) {
    super.onReceivedError(view, request, error)
    if (request.isForMainFrame) {
        Log.d("Message WebView load error: %d %s for %s", error.errorCode, error.description, request.url)
    }
}
```

Notes on scope:

- Only main-frame errors are logged. Sub-resource errors are very common in HTML mails (broken remote images, blocked `http://` resources inside an `https://` mail) and would just spam the log without giving useful information about the root render failure.
- The log call uses `Log.d` via `net.thunderbird.core.logging.legacy.Log`, matching the existing imports and call style in this file (see the existing `Log.d(e, "Couldn't open URL: %s", uri)` on the same class).
- No new permission, no new dependency, no behaviour change for successful loads. The change is additive: an existing silent failure now produces a debug log line.

Out of scope but mentioned in the issue: `QuotedMessageMvpView` has the same gap. Happy to send a follow-up PR if maintainers prefer that one bundled, but `K9WebViewClient` is the dominant codepath and felt like the right place to start.