### PR TITLE
fix: 9142 search results disappearing

### DIFF
--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/SaveMessageOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/SaveMessageOperations.kt
@@ -426,8 +426,7 @@ internal class SaveMessageOperations(
         }
 
         return if (replaceMessageId != null) {
-            values.put("id", replaceMessageId)
-            database.replace("messages", null, values)
+            database.update("messages", values, "id = ?", arrayOf(replaceMessageId.toString()))
             replaceMessageId
         } else {
             database.insert("messages", null, values)

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/SaveMessageOperationsTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/SaveMessageOperationsTest.kt
@@ -380,6 +380,46 @@ class SaveMessageOperationsTest : RobolectricTest() {
     }
 
     @Test
+    fun `replace envelope message with full message should preserve thread entry`() {
+        // Arrange: simulate remote search saving a message as ENVELOPE (no body)
+        val envelopeMessageData = buildMessage {
+            header("Message-ID", "<msg0001@domain.example>")
+            header("Subject", "Search Result")
+        }.toSaveMessageData(
+            downloadState = MessageDownloadState.ENVELOPE,
+        )
+        saveMessageOperations.saveRemoteMessage(folderId = 1, messageServerId = "uid1", envelopeMessageData)
+
+        val threadsBeforeReplace = sqliteDatabase.readThreads()
+        assertThat(threadsBeforeReplace).hasSize(1)
+        val threadBeforeReplace = threadsBeforeReplace.first()
+
+        // Act: simulate sync re-downloading the same message as FULL
+        val fullMessageData = buildMessage {
+            header("Message-ID", "<msg0001@domain.example>")
+            header("Subject", "Search Result")
+            textBody("Full body content")
+        }.toSaveMessageData(
+            downloadState = MessageDownloadState.FULL,
+        )
+        saveMessageOperations.saveRemoteMessage(folderId = 1, messageServerId = "uid1", fullMessageData)
+
+        // Assert: thread entry must still exist and point to the same message
+        val messages = sqliteDatabase.readMessages()
+        assertThat(messages).hasSize(1)
+        val message = messages.first()
+        assertThat(message.flags).isEqualTo("X_DOWNLOADED_FULL")
+
+        val threads = sqliteDatabase.readThreads()
+        assertThat(threads).hasSize(1)
+        val thread = threads.first()
+        assertThat(thread.id).isEqualTo(threadBeforeReplace.id)
+        assertThat(thread.messageId).isEqualTo(message.id)
+        assertThat(thread.root).isEqualTo(thread.id)
+        assertThat(thread.parent).isNull()
+    }
+
+    @Test
     fun `save local message`() {
         val messageData = buildMessage {
             textBody("local")


### PR DESCRIPTION
## Summary

When a remote search saves an envelope-only message and a subsequent sync replaces it with the full message, the `database.replace()` call deletes and re-inserts the row. This orphans the corresponding `threads` entry (foreign key on `messages.id`), causing the message to disappear from search results.

Switching from `replace()` to `update()` preserves the row ID and keeps the thread reference intact.

## Issue

Fixes #9142

## Test plan

- Added test: replace envelope message with full message verifies thread entry preserved
- Existing tests pass (`SaveMessageOperationsTest`)

## AI disclosure

AI was used to assist in tracking down source of bug, correcting & drafting this pull request description.  It wasn't a simple vibe code job, I did interrogate it on plan and helped it choose the most appropriate, reliable and logical solution.

I tested the resulting build on my android device and confirmed it fixed the bug that has been outstanding for several years.

## Supporting information:
Report from Claude 4.6 (High)
[root-cause-analysis.md](https://github.com/user-attachments/files/28075142/root-cause-analysis.md)

Solution that was implemented after discussion and design choices from Claude 4.6 (High)
[final-solution-proposal.md](https://github.com/user-attachments/files/28075163/final-solution-proposal.md)

report: include
