### PR TITLE
Option to clean up old attachments on a schedule

### DIFF
--- a/app-k9mail/src/test/kotlin/app/k9mail/DependencyInjectionTest.kt
+++ b/app-k9mail/src/test/kotlin/app/k9mail/DependencyInjectionTest.kt
@@ -13,6 +13,7 @@ import androidx.work.WorkerParameters
 import app.k9mail.core.ui.compose.common.window.FoldableStateObserver
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import com.fsck.k9.account.AccountRemoverWorker
+import com.fsck.k9.job.AttachmentCleanupWorker
 import com.fsck.k9.job.MailSyncWorker
 import com.fsck.k9.job.SyncDebugWorker
 import com.fsck.k9.mailstore.AttachmentResolver
@@ -68,6 +69,7 @@ class DependencyInjectionTest {
                 definition<DisplayHtmlUiFactory>(List::class),
                 definition<FoldableStateObserver>(Activity::class),
                 definition<K9WebViewClient>(AttachmentResolver::class, MessageWebView.OnPageFinishedListener::class),
+                definition<AttachmentCleanupWorker>(WorkerParameters::class),
                 definition<MailSyncWorker>(WorkerParameters::class),
                 definition<SyncDebugWorker>(WorkerParameters::class),
                 definition<OpenPgpApiManager>(LifecycleOwner::class),

--- a/app-thunderbird/src/test/kotlin/net/thunderbird/android/DependencyInjectionTest.kt
+++ b/app-thunderbird/src/test/kotlin/net/thunderbird/android/DependencyInjectionTest.kt
@@ -13,6 +13,7 @@ import androidx.work.WorkerParameters
 import app.k9mail.core.ui.compose.common.window.FoldableStateObserver
 import app.k9mail.feature.account.common.domain.entity.InteractionMode
 import com.fsck.k9.account.AccountRemoverWorker
+import com.fsck.k9.job.AttachmentCleanupWorker
 import com.fsck.k9.job.MailSyncWorker
 import com.fsck.k9.job.SyncDebugWorker
 import com.fsck.k9.mailstore.AttachmentResolver
@@ -68,6 +69,7 @@ class DependencyInjectionTest {
                 definition<DisplayHtmlUiFactory>(List::class),
                 definition<FoldableStateObserver>(Activity::class),
                 definition<K9WebViewClient>(AttachmentResolver::class, MessageWebView.OnPageFinishedListener::class),
+                definition<AttachmentCleanupWorker>(WorkerParameters::class),
                 definition<MailSyncWorker>(WorkerParameters::class),
                 definition<SyncDebugWorker>(WorkerParameters::class),
                 definition<OpenPgpApiManager>(LifecycleOwner::class),

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountDefaultsProvider.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountDefaultsProvider.kt
@@ -18,7 +18,9 @@ interface AccountDefaultsProvider {
     fun applyOverwrites(account: LegacyAccountDto, storage: Storage)
 
     companion object {
-        const val DEFAULT_ATTACHMENT_CLEANUP_DAYS = 0
+        const val ATTACHMENT_CLEANUP_NEVER = -1
+        const val MIN_ATTACHMENT_CLEANUP_DAYS = 1
+        const val DEFAULT_ATTACHMENT_CLEANUP_DAYS = ATTACHMENT_CLEANUP_NEVER
 
         const val DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE = 131072
 

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountDefaultsProvider.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/AccountDefaultsProvider.kt
@@ -18,6 +18,8 @@ interface AccountDefaultsProvider {
     fun applyOverwrites(account: LegacyAccountDto, storage: Storage)
 
     companion object {
+        const val DEFAULT_ATTACHMENT_CLEANUP_DAYS = 0
+
         const val DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE = 131072
 
         @JvmStatic

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccount.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccount.kt
@@ -1,6 +1,7 @@
 package net.thunderbird.core.android.account
 
 import com.fsck.k9.mail.ServerSettings
+import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.DEFAULT_ATTACHMENT_CLEANUP_DAYS
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
 import net.thunderbird.core.common.mail.Protocols
 import net.thunderbird.feature.account.Account
@@ -76,6 +77,7 @@ data class LegacyAccount(
     val isSubscribedFoldersOnly: Boolean = false,
     val maximumPolledMessageAge: Int = 0,
     val maximumAutoDownloadMessageSize: Int = 0,
+    val attachmentCleanupDays: Int = DEFAULT_ATTACHMENT_CLEANUP_DAYS,
     val messageFormat: MessageFormat = MessageFormat.HTML,
     val isMessageFormatAuto: Boolean = false,
     val isMessageReadReceipt: Boolean = false,

--- a/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountDto.kt
+++ b/core/android/account/src/main/kotlin/net/thunderbird/core/android/account/LegacyAccountDto.kt
@@ -5,6 +5,7 @@ import com.fsck.k9.mail.Address
 import com.fsck.k9.mail.ServerSettings
 import java.util.Calendar
 import java.util.Date
+import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.DEFAULT_ATTACHMENT_CLEANUP_DAYS
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.NO_OPENPGP_KEY
 import net.thunderbird.feature.account.Account
 import net.thunderbird.feature.account.AccountId
@@ -276,6 +277,10 @@ open class LegacyAccountDto(
     @get:Synchronized
     @set:Synchronized
     var maximumAutoDownloadMessageSize = 0
+
+    @get:Synchronized
+    @set:Synchronized
+    var attachmentCleanupDays = DEFAULT_ATTACHMENT_CLEANUP_DAYS
 
     @get:Synchronized
     @set:Synchronized

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAccountStorageHandler.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/LegacyAccountStorageHandler.kt
@@ -135,6 +135,10 @@ class LegacyAccountStorageHandler(
                 keyGen.create("maximumAutoDownloadMessageSize"),
                 AccountDefaultsProvider.Companion.DEFAULT_MAXIMUM_AUTO_DOWNLOAD_MESSAGE_SIZE,
             )
+            attachmentCleanupDays = storage.getInt(
+                keyGen.create("attachmentCleanupDays"),
+                AccountDefaultsProvider.Companion.DEFAULT_ATTACHMENT_CLEANUP_DAYS,
+            )
             messageFormat = getEnumStringPref(
                 storage,
                 keyGen.create("messageFormat"),
@@ -374,6 +378,7 @@ class LegacyAccountStorageHandler(
             editor.putBoolean(keyGen.create("subscribedFoldersOnly"), isSubscribedFoldersOnly)
             editor.putInt(keyGen.create("maximumPolledMessageAge"), maximumPolledMessageAge)
             editor.putInt(keyGen.create("maximumAutoDownloadMessageSize"), maximumAutoDownloadMessageSize)
+            editor.putInt(keyGen.create("attachmentCleanupDays"), attachmentCleanupDays)
             val messageFormatAuto = if (MessageFormat.AUTO == messageFormat) {
                 // saving MessageFormat.AUTO as is to the database will cause downgrades to crash on
                 // startup, so we save as MessageFormat.TEXT instead with a separate flag for auto.
@@ -492,6 +497,7 @@ class LegacyAccountStorageHandler(
         editor.remove(keyGen.create("subscribedFoldersOnly"))
         editor.remove(keyGen.create("maximumPolledMessageAge"))
         editor.remove(keyGen.create("maximumAutoDownloadMessageSize"))
+        editor.remove(keyGen.create("attachmentCleanupDays"))
         editor.remove(keyGen.create("messageFormatAuto"))
         editor.remove(keyGen.create("quoteStyle"))
         editor.remove(keyGen.create("quotePrefix"))

--- a/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountDataMapper.kt
+++ b/feature/account/storage/legacy/src/main/kotlin/net/thunderbird/feature/account/storage/legacy/mapper/DefaultLegacyAccountDataMapper.kt
@@ -71,6 +71,7 @@ internal class DefaultLegacyAccountDataMapper : LegacyAccountDataMapper {
             isSubscribedFoldersOnly = dto.isSubscribedFoldersOnly,
             maximumPolledMessageAge = dto.maximumPolledMessageAge,
             maximumAutoDownloadMessageSize = dto.maximumAutoDownloadMessageSize,
+            attachmentCleanupDays = dto.attachmentCleanupDays,
             messageFormat = dto.messageFormat,
             isMessageFormatAuto = dto.isMessageFormatAuto,
             isMessageReadReceipt = dto.isMessageReadReceipt,
@@ -177,6 +178,7 @@ internal class DefaultLegacyAccountDataMapper : LegacyAccountDataMapper {
             isSubscribedFoldersOnly = domain.isSubscribedFoldersOnly
             maximumPolledMessageAge = domain.maximumPolledMessageAge
             maximumAutoDownloadMessageSize = domain.maximumAutoDownloadMessageSize
+            attachmentCleanupDays = domain.attachmentCleanupDays
             messageFormat = domain.messageFormat
             isMessageFormatAuto = domain.isMessageFormatAuto
             isMessageReadReceipt = domain.isMessageReadReceipt

--- a/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
@@ -2,11 +2,13 @@ package com.fsck.k9.job
 
 import android.content.ContentResolver
 import android.content.Context
+import android.database.sqlite.SQLiteDatabaseLockedException
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import app.k9mail.legacy.mailstore.MessageStoreManager
 import com.fsck.k9.Preferences
 import java.util.concurrent.TimeUnit
+import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.MIN_ATTACHMENT_CLEANUP_DAYS
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.BackgroundOps
 import net.thunderbird.core.preference.GeneralSettingsManager
@@ -22,7 +24,6 @@ class AttachmentCleanupWorker(
 
     override fun doWork(): Result {
         if (isBackgroundCleanupDisabled()) {
-            Log.d("Background cleanup is disabled. Skipping attachment cleanup.")
             return Result.success()
         }
 
@@ -30,7 +31,7 @@ class AttachmentCleanupWorker(
         val account = preferences.getAccount(accountUuid) ?: return Result.success()
         val retentionDays = account.attachmentCleanupDays
 
-        if (retentionDays <= 0) {
+        if (retentionDays < MIN_ATTACHMENT_CLEANUP_DAYS) {
             return Result.success()
         }
 
@@ -39,13 +40,27 @@ class AttachmentCleanupWorker(
             val result = messageStoreManager.getMessageStore(
                 account,
             ).removeOldDownloadedAttachments(cutoffTime, MAX_PARTS_PER_RUN)
-            Log.d("Removed %d locally cached attachment parts for account %s", result.removedPartCount, accountUuid)
 
-            // Successful partial progress: continue later through WorkManager backoff.
-            if (result.hasMore) Result.retry() else Result.success()
+            if (result.removedPartCount > 0 || result.hasMore) {
+                Log.d("Removed %d locally cached attachment parts for account %s", result.removedPartCount, accountUuid)
+            }
+
+            Result.success()
+        } catch (e: SQLiteDatabaseLockedException) {
+            retryTransientFailureOrFail(e)
         } catch (e: Exception) {
             Log.e(e, "Failed to clean up old downloaded attachments")
+            Result.failure()
+        }
+    }
+
+    private fun retryTransientFailureOrFail(exception: Exception): Result {
+        return if (runAttemptCount < MAX_FAILURE_RETRY_ATTEMPTS) {
+            Log.w(exception, "Attachment cleanup database is locked")
             Result.retry()
+        } else {
+            Log.e(exception, "Attachment cleanup database remained locked after retries")
+            Result.failure()
         }
     }
 
@@ -59,6 +74,7 @@ class AttachmentCleanupWorker(
 
     companion object {
         const val EXTRA_ACCOUNT_UUID = "accountUuid"
-        private const val MAX_PARTS_PER_RUN = 2_000
+        private const val MAX_PARTS_PER_RUN = 3_000
+        private const val MAX_FAILURE_RETRY_ATTEMPTS = 3
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
@@ -1,0 +1,61 @@
+package com.fsck.k9.job
+
+import android.content.ContentResolver
+import android.content.Context
+import androidx.work.Worker
+import androidx.work.WorkerParameters
+import app.k9mail.legacy.mailstore.MessageStoreManager
+import com.fsck.k9.Preferences
+import java.util.concurrent.TimeUnit
+import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.preference.BackgroundOps
+import net.thunderbird.core.preference.GeneralSettingsManager
+
+// IMPORTANT: Update K9WorkerFactory when moving this class and the FQCN no longer starts with "com.fsck.k9".
+class AttachmentCleanupWorker(
+    private val preferences: Preferences,
+    private val messageStoreManager: MessageStoreManager,
+    private val generalSettingsManager: GeneralSettingsManager,
+    context: Context,
+    parameters: WorkerParameters,
+) : Worker(context, parameters) {
+
+    override fun doWork(): Result {
+        if (isBackgroundCleanupDisabled()) {
+            Log.d("Background cleanup is disabled. Skipping attachment cleanup.")
+            return Result.success()
+        }
+
+        val accountUuid = inputData.getString(EXTRA_ACCOUNT_UUID) ?: return Result.failure()
+        val account = preferences.getAccount(accountUuid) ?: return Result.success()
+        val retentionDays = account.attachmentCleanupDays
+
+        if (retentionDays <= 0) {
+            return Result.success()
+        }
+
+        return try {
+            val cutoffTime = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays.toLong())
+            val removedPartCount = messageStoreManager.getMessageStore(
+                account,
+            ).removeOldDownloadedAttachments(cutoffTime)
+            Log.d("Removed %d locally cached attachment parts for account %s", removedPartCount, accountUuid)
+            Result.success()
+        } catch (e: Exception) {
+            Log.e(e, "Failed to clean up old downloaded attachments")
+            Result.retry()
+        }
+    }
+
+    private fun isBackgroundCleanupDisabled(): Boolean {
+        return when (generalSettingsManager.getConfig().network.backgroundOps) {
+            BackgroundOps.NEVER -> true
+            BackgroundOps.ALWAYS -> false
+            BackgroundOps.WHEN_CHECKED_AUTO_SYNC -> !ContentResolver.getMasterSyncAutomatically()
+        }
+    }
+
+    companion object {
+        const val EXTRA_ACCOUNT_UUID = "accountUuid"
+    }
+}

--- a/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
@@ -36,11 +36,13 @@ class AttachmentCleanupWorker(
 
         return try {
             val cutoffTime = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays.toLong())
-            val removedPartCount = messageStoreManager.getMessageStore(
+            val result = messageStoreManager.getMessageStore(
                 account,
-            ).removeOldDownloadedAttachments(cutoffTime)
-            Log.d("Removed %d locally cached attachment parts for account %s", removedPartCount, accountUuid)
-            Result.success()
+            ).removeOldDownloadedAttachments(cutoffTime, MAX_PARTS_PER_RUN)
+            Log.d("Removed %d locally cached attachment parts for account %s", result.removedPartCount, accountUuid)
+
+            // Successful partial progress: continue later through WorkManager backoff.
+            if (result.hasMore) Result.retry() else Result.success()
         } catch (e: Exception) {
             Log.e(e, "Failed to clean up old downloaded attachments")
             Result.retry()
@@ -57,5 +59,6 @@ class AttachmentCleanupWorker(
 
     companion object {
         const val EXTRA_ACCOUNT_UUID = "accountUuid"
+        private const val MAX_PARTS_PER_RUN = 2_000
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
@@ -9,6 +9,7 @@ import app.k9mail.legacy.mailstore.MessageStoreManager
 import com.fsck.k9.Preferences
 import java.util.concurrent.TimeUnit
 import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.MIN_ATTACHMENT_CLEANUP_DAYS
+import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.logging.legacy.Log
 import net.thunderbird.core.preference.BackgroundOps
 import net.thunderbird.core.preference.GeneralSettingsManager
@@ -23,26 +24,41 @@ class AttachmentCleanupWorker(
 ) : Worker(context, parameters) {
 
     override fun doWork(): Result {
-        if (isBackgroundCleanupDisabled()) {
-            return Result.success()
+        val accountUuid = inputData.getString(EXTRA_ACCOUNT_UUID)
+        val result = when {
+            isBackgroundCleanupDisabled() -> Result.success()
+            accountUuid == null -> Result.failure()
+            else -> cleanUpAttachments(accountUuid)
         }
 
-        val accountUuid = inputData.getString(EXTRA_ACCOUNT_UUID) ?: return Result.failure()
-        val account = preferences.getAccount(accountUuid) ?: return Result.success()
-        val retentionDays = account.attachmentCleanupDays
+        return result
+    }
 
-        if (retentionDays < MIN_ATTACHMENT_CLEANUP_DAYS) {
-            return Result.success()
+    private fun cleanUpAttachments(accountUuid: String): Result {
+        val account = preferences.getAccount(accountUuid)
+
+        return when {
+            account == null -> Result.success()
+            account.attachmentCleanupDays < MIN_ATTACHMENT_CLEANUP_DAYS -> Result.success()
+            else -> performCleanup(accountUuid, account)
         }
+    }
 
+    @Suppress("TooGenericExceptionCaught")
+    private fun performCleanup(accountUuid: String, account: LegacyAccountDto): Result {
         return try {
+            val retentionDays = account.attachmentCleanupDays
             val cutoffTime = System.currentTimeMillis() - TimeUnit.DAYS.toMillis(retentionDays.toLong())
             val result = messageStoreManager.getMessageStore(
                 account,
             ).removeOldDownloadedAttachments(cutoffTime, MAX_PARTS_PER_RUN)
 
             if (result.changedPartCount > 0) {
-                Log.d("Cleaned %d locally cached attachment parts for account %s", result.changedPartCount, accountUuid)
+                Log.d(
+                    "Cleaned %d locally cached attachment parts for account %s",
+                    result.changedPartCount,
+                    accountUuid,
+                )
             }
 
             Result.success()

--- a/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorker.kt
@@ -41,8 +41,8 @@ class AttachmentCleanupWorker(
                 account,
             ).removeOldDownloadedAttachments(cutoffTime, MAX_PARTS_PER_RUN)
 
-            if (result.removedPartCount > 0 || result.hasMore) {
-                Log.d("Removed %d locally cached attachment parts for account %s", result.removedPartCount, accountUuid)
+            if (result.changedPartCount > 0) {
+                Log.d("Cleaned %d locally cached attachment parts for account %s", result.changedPartCount, accountUuid)
             }
 
             Result.success()

--- a/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorkerManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorkerManager.kt
@@ -1,0 +1,81 @@
+package com.fsck.k9.job
+
+import androidx.work.BackoffPolicy
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.PeriodicWorkRequestBuilder
+import androidx.work.WorkManager
+import androidx.work.workDataOf
+import java.util.concurrent.TimeUnit
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.common.mail.Protocols
+import net.thunderbird.core.logging.legacy.Log
+
+class AttachmentCleanupWorkerManager(
+    private val workManager: WorkManager,
+) {
+    fun scheduleAttachmentCleanup(account: LegacyAccountDto) {
+        val uniqueWorkName = createUniqueWorkName(account.uuid)
+        if (!account.isAttachmentCleanupEnabled()) {
+            workManager.cancelUniqueWork(uniqueWorkName)
+            workManager.cancelUniqueWork(createOneTimeUniqueWorkName(account.uuid))
+            return
+        }
+
+        Log.v("Scheduling attachment cleanup worker for %s", account)
+
+        val data = workDataOf(AttachmentCleanupWorker.EXTRA_ACCOUNT_UUID to account.uuid)
+        val request = PeriodicWorkRequestBuilder<AttachmentCleanupWorker>(CLEANUP_INTERVAL_HOURS, TimeUnit.HOURS)
+            .setInputData(data)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, INITIAL_BACKOFF_DELAY_MINUTES, TimeUnit.MINUTES)
+            .addTag(ATTACHMENT_CLEANUP_TAG)
+            .build()
+
+        workManager.enqueueUniquePeriodicWork(
+            uniqueWorkName,
+            ExistingPeriodicWorkPolicy.REPLACE,
+            request,
+        )
+    }
+
+    fun scheduleAttachmentCleanupNow(account: LegacyAccountDto) {
+        if (!account.isAttachmentCleanupEnabled()) return
+
+        val data = workDataOf(AttachmentCleanupWorker.EXTRA_ACCOUNT_UUID to account.uuid)
+        val request = OneTimeWorkRequestBuilder<AttachmentCleanupWorker>()
+            .setInputData(data)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, INITIAL_BACKOFF_DELAY_MINUTES, TimeUnit.MINUTES)
+            .addTag(ATTACHMENT_CLEANUP_TAG)
+            .build()
+
+        workManager.enqueueUniqueWork(
+            createOneTimeUniqueWorkName(account.uuid),
+            ExistingWorkPolicy.REPLACE,
+            request,
+        )
+    }
+
+    fun cancelAllAttachmentCleanup() {
+        workManager.cancelAllWorkByTag(ATTACHMENT_CLEANUP_TAG)
+    }
+
+    private fun LegacyAccountDto.isAttachmentCleanupEnabled(): Boolean {
+        return attachmentCleanupDays > 0 && incomingServerSettings.type == Protocols.IMAP
+    }
+
+    private fun createUniqueWorkName(accountUuid: String): String {
+        return "$ATTACHMENT_CLEANUP_TAG:$accountUuid"
+    }
+
+    private fun createOneTimeUniqueWorkName(accountUuid: String): String {
+        return "$ATTACHMENT_CLEANUP_NOW_TAG:$accountUuid"
+    }
+
+    companion object {
+        const val ATTACHMENT_CLEANUP_TAG = "AttachmentCleanup"
+        private const val ATTACHMENT_CLEANUP_NOW_TAG = "AttachmentCleanupNow"
+        private const val CLEANUP_INTERVAL_HOURS = 24L
+        private const val INITIAL_BACKOFF_DELAY_MINUTES = 5L
+    }
+}

--- a/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorkerManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/AttachmentCleanupWorkerManager.kt
@@ -8,6 +8,7 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.workDataOf
 import java.util.concurrent.TimeUnit
+import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.MIN_ATTACHMENT_CLEANUP_DAYS
 import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.common.mail.Protocols
 import net.thunderbird.core.logging.legacy.Log
@@ -61,7 +62,7 @@ class AttachmentCleanupWorkerManager(
     }
 
     private fun LegacyAccountDto.isAttachmentCleanupEnabled(): Boolean {
-        return attachmentCleanupDays > 0 && incomingServerSettings.type == Protocols.IMAP
+        return attachmentCleanupDays >= MIN_ATTACHMENT_CLEANUP_DAYS && incomingServerSettings.type == Protocols.IMAP
     }
 
     private fun createUniqueWorkName(accountUuid: String): String {

--- a/legacy/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
@@ -33,9 +33,11 @@ class K9JobManager(
         mailSyncWorkerManager.scheduleMailSync(account)
     }
 
-    fun scheduleAttachmentCleanup(account: LegacyAccountDto) {
+    fun scheduleAttachmentCleanup(account: LegacyAccountDto, runNow: Boolean = false) {
         attachmentCleanupWorkerManager.scheduleAttachmentCleanup(account)
-        attachmentCleanupWorkerManager.scheduleAttachmentCleanupNow(account)
+        if (runNow) {
+            attachmentCleanupWorkerManager.scheduleAttachmentCleanupNow(account)
+        }
     }
 
     private fun scheduleMailSync() {

--- a/legacy/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/K9JobManager.kt
@@ -11,6 +11,7 @@ class K9JobManager(
     private val workManager: WorkManager,
     private val accountManager: LegacyAccountDtoManager,
     private val mailSyncWorkerManager: MailSyncWorkerManager,
+    private val attachmentCleanupWorkerManager: AttachmentCleanupWorkerManager,
     private val syncDebugFileLogManager: FileLogLimitWorkManager,
 ) {
     fun scheduleDebugLogLimit(contentUriString: String): Flow<WorkInfo?> {
@@ -24,11 +25,17 @@ class K9JobManager(
     fun scheduleAllMailJobs() {
         Log.v("scheduling all jobs")
         scheduleMailSync()
+        scheduleAttachmentCleanup()
     }
 
     fun scheduleMailSync(account: LegacyAccountDto) {
         mailSyncWorkerManager.cancelMailSync(account)
         mailSyncWorkerManager.scheduleMailSync(account)
+    }
+
+    fun scheduleAttachmentCleanup(account: LegacyAccountDto) {
+        attachmentCleanupWorkerManager.scheduleAttachmentCleanup(account)
+        attachmentCleanupWorkerManager.scheduleAttachmentCleanupNow(account)
     }
 
     private fun scheduleMailSync() {
@@ -42,5 +49,13 @@ class K9JobManager(
     private fun cancelAllMailSyncJobs() {
         Log.v("canceling mail sync job")
         workManager.cancelAllWorkByTag(MailSyncWorkerManager.MAIL_SYNC_TAG)
+    }
+
+    private fun scheduleAttachmentCleanup() {
+        attachmentCleanupWorkerManager.cancelAllAttachmentCleanup()
+
+        accountManager.getAccounts().forEach { account ->
+            attachmentCleanupWorkerManager.scheduleAttachmentCleanup(account)
+        }
     }
 }

--- a/legacy/core/src/main/java/com/fsck/k9/job/KoinModule.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/job/KoinModule.kt
@@ -20,7 +20,13 @@ val jobModule = module {
             workManager = get(),
             accountManager = get(),
             mailSyncWorkerManager = get(),
+            attachmentCleanupWorkerManager = get(),
             syncDebugFileLogManager = get(),
+        )
+    }
+    factory {
+        AttachmentCleanupWorkerManager(
+            workManager = get(),
         )
     }
     factory {
@@ -38,6 +44,15 @@ val jobModule = module {
             preferences = get(),
             context = get(),
             generalSettingsManager = get(),
+            parameters = parameters,
+        )
+    }
+    factory { (parameters: WorkerParameters) ->
+        AttachmentCleanupWorker(
+            preferences = get(),
+            messageStoreManager = get(),
+            generalSettingsManager = get(),
+            context = get(),
             parameters = parameters,
         )
     }

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/AccountSettingsDescriptions.java
@@ -39,6 +39,7 @@ import net.thunderbird.feature.account.storage.profile.AvatarTypeDto;
 import net.thunderbird.feature.mail.folder.api.SpecialFolderSelection;
 import net.thunderbird.feature.notification.NotificationLight;
 import static com.fsck.k9.preferences.upgrader.AccountSettingsUpgraderTo53.FOLDER_NONE;
+import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAULT_ATTACHMENT_CLEANUP_DAYS;
 import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAULT_MESSAGE_FORMAT_AUTO;
 import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAULT_MESSAGE_READ_RECEIPT;
 import static net.thunderbird.core.android.account.AccountDefaultsProvider.DEFAULT_QUOTED_TEXT_SHOWN;
@@ -141,6 +142,9 @@ class AccountSettingsDescriptions {
         s.put("maximumAutoDownloadMessageSize", Settings.versions(
                 new V(1, new IntegerResourceSetting(32768, R.array.autodownload_message_size_values)),
                 new V(93, new IntegerResourceSetting(131072, R.array.autodownload_message_size_values))
+        ));
+        s.put("attachmentCleanupDays", Settings.versions(
+                new V(111, new IntegerResourceSetting(DEFAULT_ATTACHMENT_CLEANUP_DAYS, R.array.attachment_cleanup_values))
         ));
         s.put("maximumPolledMessageAge", Settings.versions(
                 new V(1, new IntegerResourceSetting(-1, R.array.message_age_values))

--- a/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
+++ b/legacy/core/src/main/java/com/fsck/k9/preferences/Settings.java
@@ -35,7 +35,7 @@ public class Settings {
      *
      * @see SettingsExporter
      */
-    public static final int VERSION = 110;
+    public static final int VERSION = 111;
 
     static Map<String, Object> validate(int version, Map<String, TreeMap<Integer, SettingsDescription<?>>> settings,
             Map<String, String> importedSettings, boolean useDefaultValues) {

--- a/legacy/core/src/main/res/values/arrays_account_settings_values.xml
+++ b/legacy/core/src/main/res/values/arrays_account_settings_values.xml
@@ -61,7 +61,7 @@
     </string-array>
 
     <string-array name="attachment_cleanup_values" translatable="false">
-        <item>0</item>
+        <item>-1</item>
         <item>30</item>
         <item>90</item>
         <item>365</item>

--- a/legacy/core/src/main/res/values/arrays_account_settings_values.xml
+++ b/legacy/core/src/main/res/values/arrays_account_settings_values.xml
@@ -60,6 +60,13 @@
         <item>0</item>
     </string-array>
 
+    <string-array name="attachment_cleanup_values" translatable="false">
+        <item>0</item>
+        <item>30</item>
+        <item>90</item>
+        <item>365</item>
+    </string-array>
+
     <string-array name="show_pictures_values" translatable="false">
         <item>NEVER</item>
         <item>ONLY_FROM_CONTACTS</item>

--- a/legacy/core/src/test/java/com/fsck/k9/job/AttachmentCleanupWorkerManagerTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/job/AttachmentCleanupWorkerManagerTest.kt
@@ -1,0 +1,149 @@
+package com.fsck.k9.job
+
+import androidx.work.ExistingPeriodicWorkPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequest
+import androidx.work.PeriodicWorkRequest
+import androidx.work.WorkManager
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.isEqualTo
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
+import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.ATTACHMENT_CLEANUP_NEVER
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.common.mail.Protocols
+import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.logging.testing.TestLogger
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+
+class AttachmentCleanupWorkerManagerTest {
+    private val workManager = mock<WorkManager>()
+    private val testSubject = AttachmentCleanupWorkerManager(workManager)
+
+    @Before
+    fun setUp() {
+        Log.logger = TestLogger()
+    }
+
+    @Test
+    fun `scheduleAttachmentCleanup should schedule periodic cleanup for IMAP account with retention enabled`() {
+        val account = createAccount(protocol = Protocols.IMAP, attachmentCleanupDays = 30)
+
+        testSubject.scheduleAttachmentCleanup(account)
+
+        val requestCaptor = argumentCaptor<PeriodicWorkRequest>()
+        verify(workManager).enqueueUniquePeriodicWork(
+            eq(PERIODIC_WORK_NAME),
+            eq(ExistingPeriodicWorkPolicy.REPLACE),
+            requestCaptor.capture(),
+        )
+        val request = requestCaptor.firstValue
+        assertThat(request.tags).contains(AttachmentCleanupWorkerManager.ATTACHMENT_CLEANUP_TAG)
+        assertThat(request.workSpec.input.getString(AttachmentCleanupWorker.EXTRA_ACCOUNT_UUID)).isEqualTo(ACCOUNT_UUID)
+    }
+
+    @Test
+    fun `scheduleAttachmentCleanup should cancel cleanup when retention is disabled`() {
+        val account = createAccount(protocol = Protocols.IMAP, attachmentCleanupDays = ATTACHMENT_CLEANUP_NEVER)
+
+        testSubject.scheduleAttachmentCleanup(account)
+
+        verify(workManager).cancelUniqueWork(PERIODIC_WORK_NAME)
+        verify(workManager).cancelUniqueWork(ONE_TIME_WORK_NAME)
+        verify(workManager, never()).enqueueUniquePeriodicWork(
+            eq(PERIODIC_WORK_NAME),
+            eq(ExistingPeriodicWorkPolicy.REPLACE),
+            any<PeriodicWorkRequest>(),
+        )
+    }
+
+    @Test
+    fun `scheduleAttachmentCleanup should cancel cleanup for non-IMAP account`() {
+        val account = createAccount(protocol = Protocols.POP3, attachmentCleanupDays = 30)
+
+        testSubject.scheduleAttachmentCleanup(account)
+
+        verify(workManager).cancelUniqueWork(PERIODIC_WORK_NAME)
+        verify(workManager).cancelUniqueWork(ONE_TIME_WORK_NAME)
+        verify(workManager, never()).enqueueUniquePeriodicWork(
+            eq(PERIODIC_WORK_NAME),
+            eq(ExistingPeriodicWorkPolicy.REPLACE),
+            any<PeriodicWorkRequest>(),
+        )
+    }
+
+    @Test
+    fun `scheduleAttachmentCleanupNow should schedule one-time cleanup for IMAP account with retention enabled`() {
+        val account = createAccount(protocol = Protocols.IMAP, attachmentCleanupDays = 30)
+
+        testSubject.scheduleAttachmentCleanupNow(account)
+
+        val requestCaptor = argumentCaptor<OneTimeWorkRequest>()
+        verify(workManager).enqueueUniqueWork(
+            eq(ONE_TIME_WORK_NAME),
+            eq(ExistingWorkPolicy.REPLACE),
+            requestCaptor.capture(),
+        )
+        val request = requestCaptor.firstValue
+        assertThat(request.tags).contains(AttachmentCleanupWorkerManager.ATTACHMENT_CLEANUP_TAG)
+        assertThat(request.workSpec.input.getString(AttachmentCleanupWorker.EXTRA_ACCOUNT_UUID)).isEqualTo(ACCOUNT_UUID)
+    }
+
+    @Test
+    fun `scheduleAttachmentCleanupNow should skip one-time cleanup when retention is disabled`() {
+        val account = createAccount(protocol = Protocols.IMAP, attachmentCleanupDays = ATTACHMENT_CLEANUP_NEVER)
+
+        testSubject.scheduleAttachmentCleanupNow(account)
+
+        verify(workManager, never()).enqueueUniqueWork(
+            eq(ONE_TIME_WORK_NAME),
+            eq(ExistingWorkPolicy.REPLACE),
+            any<OneTimeWorkRequest>(),
+        )
+    }
+
+    @Test
+    fun `cancelAllAttachmentCleanup should cancel work by cleanup tag`() {
+        testSubject.cancelAllAttachmentCleanup()
+
+        verify(workManager).cancelAllWorkByTag(AttachmentCleanupWorkerManager.ATTACHMENT_CLEANUP_TAG)
+    }
+
+    private fun createAccount(
+        protocol: String,
+        attachmentCleanupDays: Int,
+    ): LegacyAccountDto {
+        return LegacyAccountDto(ACCOUNT_UUID).apply {
+            incomingServerSettings = createServerSettings(protocol)
+            this.attachmentCleanupDays = attachmentCleanupDays
+        }
+    }
+
+    private fun createServerSettings(protocol: String): ServerSettings {
+        return ServerSettings(
+            type = protocol,
+            host = "irrelevant",
+            port = 993,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "username",
+            password = "password",
+            clientCertificateAlias = null,
+        )
+    }
+
+    companion object {
+        private const val ACCOUNT_UUID = "00000000-0000-0000-0000-000000000000"
+        private const val PERIODIC_WORK_NAME = "AttachmentCleanup:$ACCOUNT_UUID"
+        private const val ONE_TIME_WORK_NAME = "AttachmentCleanupNow:$ACCOUNT_UUID"
+    }
+}

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/AttachmentCleanupResult.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/AttachmentCleanupResult.kt
@@ -1,0 +1,5 @@
+package app.k9mail.legacy.mailstore
+
+data class AttachmentCleanupResult(
+    val changedPartCount: Int,
+)

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStore.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStore.kt
@@ -173,9 +173,9 @@ interface MessageStore {
      *
      * Message metadata and attachment metadata are kept so attachments can be downloaded again from the server.
      *
-     * @return The number of attachment parts changed.
+     * @return Cleanup result containing the number of changed parts and whether more eligible parts remain.
      */
-    fun removeOldDownloadedAttachments(cutoffTime: Long): Int
+    fun removeOldDownloadedAttachments(cutoffTime: Long, maxParts: Int): AttachmentCleanupResult
 
     /**
      * Remove messages from the store.

--- a/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStore.kt
+++ b/legacy/mailstore/src/main/java/app/k9mail/legacy/mailstore/MessageStore.kt
@@ -169,6 +169,15 @@ interface MessageStore {
     fun getSize(): Long
 
     /**
+     * Remove locally cached downloaded attachment bodies for messages older than [cutoffTime].
+     *
+     * Message metadata and attachment metadata are kept so attachments can be downloaded again from the server.
+     *
+     * @return The number of attachment parts changed.
+     */
+    fun removeOldDownloadedAttachments(cutoffTime: Long): Int
+
+    /**
      * Remove messages from the store.
      */
     fun destroyMessages(folderId: Long, messageServerIds: Collection<String>)

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -12,7 +12,7 @@ import net.thunderbird.core.logging.legacy.Log;
 
 
 class StoreSchemaDefinition implements SchemaDefinition {
-    static final int DB_VERSION = 91;
+    static final int DB_VERSION = 92;
 
     private final MigrationsHelper migrationsHelper;
 
@@ -205,6 +205,7 @@ class StoreSchemaDefinition implements SchemaDefinition {
 
         db.execSQL("DROP INDEX IF EXISTS message_parts_root");
         db.execSQL("CREATE INDEX IF NOT EXISTS message_parts_root ON message_parts (root)");
+        db.execSQL("CREATE INDEX IF NOT EXISTS message_parts_data_location_id ON message_parts (data_location, id)");
 
         db.execSQL("DROP TABLE IF EXISTS threads");
         db.execSQL("CREATE TABLE threads (" +

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/StoreSchemaDefinition.java
@@ -12,7 +12,7 @@ import net.thunderbird.core.logging.legacy.Log;
 
 
 class StoreSchemaDefinition implements SchemaDefinition {
-    static final int DB_VERSION = 92;
+    static final int DB_VERSION = 91;
 
     private final MigrationsHelper migrationsHelper;
 
@@ -205,7 +205,6 @@ class StoreSchemaDefinition implements SchemaDefinition {
 
         db.execSQL("DROP INDEX IF EXISTS message_parts_root");
         db.execSQL("CREATE INDEX IF NOT EXISTS message_parts_root ON message_parts (root)");
-        db.execSQL("CREATE INDEX IF NOT EXISTS message_parts_data_location_id ON message_parts (data_location, id)");
 
         db.execSQL("DROP TABLE IF EXISTS threads");
         db.execSQL("CREATE TABLE threads (" +

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentCleanupOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentCleanupOperations.kt
@@ -2,6 +2,7 @@ package com.fsck.k9.storage.messages
 
 import android.content.ContentValues
 import android.database.sqlite.SQLiteDatabase
+import app.k9mail.legacy.mailstore.AttachmentCleanupResult
 import com.fsck.k9.mail.internet.MimeHeader
 import com.fsck.k9.mail.internet.MimeUtility
 import com.fsck.k9.mailstore.LockableDatabase
@@ -11,26 +12,55 @@ internal class AttachmentCleanupOperations(
     private val lockableDatabase: LockableDatabase,
     private val attachmentFileManager: AttachmentFileManager,
 ) {
-    fun removeOldDownloadedAttachments(cutoffTime: Long): Int {
-        return lockableDatabase.execute(true) { database ->
-            val attachmentParts = database.getDownloadedAttachmentParts(cutoffTime)
-            if (attachmentParts.isEmpty()) return@execute 0
+    fun removeOldDownloadedAttachments(cutoffTime: Long, maxParts: Int): AttachmentCleanupResult {
+        require(maxParts > 0) { "maxParts must be greater than zero" }
 
-            attachmentParts
-                .filter { it.dataLocation == DataLocation.ON_DISK }
-                .forEach { attachmentFileManager.deleteFile(it.messagePartId) }
+        var removedPartCount = 0
+        var lastScannedPartId = 0L
+        var scannedBatchCount = 0
 
-            val changedPartIds = attachmentParts.map { it.messagePartId }
-            database.markPartsAsMissing(changedPartIds)
+        while (removedPartCount < maxParts && scannedBatchCount < MAX_BATCHES_PER_RUN) {
+            val batchSize = minOf(CLEANUP_BATCH_SIZE, maxParts - removedPartCount)
+            val batch = lockableDatabase.execute(true) { database ->
+                val attachmentParts = database.getDownloadedAttachmentParts(cutoffTime, lastScannedPartId, batchSize)
+                if (attachmentParts.parts.isNotEmpty()) {
+                    attachmentParts.parts
+                        .filter { it.dataLocation == DataLocation.ON_DISK }
+                        .forEach { attachmentFileManager.deleteFile(it.messagePartId) }
 
-            val changedMessageIds = attachmentParts.map { it.messageId }.distinct()
-            database.markMessagesAsPartiallyDownloaded(changedMessageIds)
+                    val changedPartIds = attachmentParts.parts.map { it.messagePartId }
+                    database.markPartsAsMissing(changedPartIds)
 
-            changedPartIds.size
+                    val changedMessageIds = attachmentParts.parts.map { it.messageId }.distinct()
+                    database.markMessagesAsPartiallyDownloaded(changedMessageIds)
+                }
+
+                AttachmentCleanupBatch(
+                    removedPartCount = attachmentParts.parts.size,
+                    lastScannedPartId = attachmentParts.lastScannedPartId,
+                )
+            }
+
+            scannedBatchCount += 1
+            removedPartCount += batch.removedPartCount
+            lastScannedPartId = batch.lastScannedPartId ?: break
         }
+
+        val hitRunBudget = removedPartCount >= maxParts || scannedBatchCount >= MAX_BATCHES_PER_RUN
+        return AttachmentCleanupResult(
+            removedPartCount = removedPartCount,
+            // A later worker run will cheaply discover if the budget landed exactly at the end.
+            hasMore = hitRunBudget && lastScannedPartId > 0,
+        )
     }
 
-    private fun SQLiteDatabase.getDownloadedAttachmentParts(cutoffTime: Long): List<DownloadedAttachmentPart> {
+    private fun SQLiteDatabase.getDownloadedAttachmentParts(
+        cutoffTime: Long,
+        lastScannedPartId: Long,
+        batchSize: Int,
+    ): DownloadedAttachmentParts {
+        var lastPartId: Long? = null
+
         return rawQuery(
             """
 SELECT message_parts.id, message_parts.data_location, messages.id, message_parts.header
@@ -42,13 +72,17 @@ WHERE folders.local_only = 0
   AND messages.empty = 0
   AND messages.encryption_type IS NULL
   AND COALESCE(NULLIF(messages.internal_date, 0), messages.date) < CAST(? AS INTEGER)
+  AND message_parts.id > CAST(? AS INTEGER)
   AND message_parts.data_location IN (${DataLocation.IN_DATABASE}, ${DataLocation.ON_DISK})
   AND lower(CAST(message_parts.header AS TEXT)) LIKE ?
+ORDER BY message_parts.id
+LIMIT ?
             """.trimIndent(),
-            arrayOf(cutoffTime.toString(), "%content-disposition%"),
+            arrayOf(cutoffTime.toString(), lastScannedPartId.toString(), "%content-disposition%", batchSize.toString()),
         ).use { cursor ->
-            buildList {
+            val parts = buildList {
                 while (cursor.moveToNext()) {
+                    lastPartId = cursor.getLong(0)
                     val header = cursor.getBlob(3)
                     if (header.isExplicitAttachment()) {
                         add(
@@ -61,6 +95,7 @@ WHERE folders.local_only = 0
                     }
                 }
             }
+            DownloadedAttachmentParts(parts = parts, lastScannedPartId = lastPartId)
         }
     }
 
@@ -108,6 +143,11 @@ WHERE folders.local_only = 0
             }
         }
     }
+
+    companion object {
+        private const val CLEANUP_BATCH_SIZE = 500
+        private const val MAX_BATCHES_PER_RUN = 10
+    }
 }
 
 private fun ByteArray?.isExplicitAttachment(): Boolean {
@@ -154,4 +194,14 @@ private data class DownloadedAttachmentPart(
     val messagePartId: Long,
     val dataLocation: Int,
     val messageId: Long,
+)
+
+private data class DownloadedAttachmentParts(
+    val parts: List<DownloadedAttachmentPart>,
+    val lastScannedPartId: Long?,
+)
+
+private data class AttachmentCleanupBatch(
+    val removedPartCount: Int,
+    val lastScannedPartId: Long?,
 )

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentCleanupOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentCleanupOperations.kt
@@ -15,13 +15,12 @@ internal class AttachmentCleanupOperations(
     fun removeOldDownloadedAttachments(cutoffTime: Long, maxParts: Int): AttachmentCleanupResult {
         require(maxParts > 0) { "maxParts must be greater than zero" }
 
-        var removedPartCount = 0
+        var changedPartCount = 0
         var lastScannedPartId = 0L
-        var scannedBatchCount = 0
 
-        while (removedPartCount < maxParts && scannedBatchCount < MAX_BATCHES_PER_RUN) {
-            val batchSize = minOf(CLEANUP_BATCH_SIZE, maxParts - removedPartCount)
-            val batch = lockableDatabase.execute(true) { database ->
+        while (changedPartCount < maxParts) {
+            val batchSize = minOf(CLEANUP_BATCH_SIZE, maxParts - changedPartCount)
+            val attachmentParts = lockableDatabase.execute(true) { database ->
                 val attachmentParts = database.getDownloadedAttachmentParts(cutoffTime, lastScannedPartId, batchSize)
                 if (attachmentParts.parts.isNotEmpty()) {
                     attachmentParts.parts
@@ -35,22 +34,15 @@ internal class AttachmentCleanupOperations(
                     database.markMessagesAsPartiallyDownloaded(changedMessageIds)
                 }
 
-                AttachmentCleanupBatch(
-                    removedPartCount = attachmentParts.parts.size,
-                    lastScannedPartId = attachmentParts.lastScannedPartId,
-                )
+                attachmentParts
             }
 
-            scannedBatchCount += 1
-            removedPartCount += batch.removedPartCount
-            lastScannedPartId = batch.lastScannedPartId ?: break
+            changedPartCount += attachmentParts.parts.size
+            lastScannedPartId = attachmentParts.lastScannedPartId ?: break
         }
 
-        val hitRunBudget = removedPartCount >= maxParts || scannedBatchCount >= MAX_BATCHES_PER_RUN
         return AttachmentCleanupResult(
-            removedPartCount = removedPartCount,
-            // A later worker run will cheaply discover if the budget landed exactly at the end.
-            hasMore = hitRunBudget && lastScannedPartId > 0,
+            changedPartCount = changedPartCount,
         )
     }
 
@@ -62,22 +54,7 @@ internal class AttachmentCleanupOperations(
         var lastPartId: Long? = null
 
         return rawQuery(
-            """
-SELECT message_parts.id, message_parts.data_location, messages.id, message_parts.header
-FROM message_parts
-JOIN messages ON messages.message_part_id = message_parts.root
-JOIN folders ON folders.id = messages.folder_id
-WHERE folders.local_only = 0
-  AND messages.deleted = 0
-  AND messages.empty = 0
-  AND messages.encryption_type IS NULL
-  AND COALESCE(NULLIF(messages.internal_date, 0), messages.date) < CAST(? AS INTEGER)
-  AND message_parts.id > CAST(? AS INTEGER)
-  AND message_parts.data_location IN (${DataLocation.IN_DATABASE}, ${DataLocation.ON_DISK})
-  AND lower(CAST(message_parts.header AS TEXT)) LIKE ?
-ORDER BY message_parts.id
-LIMIT ?
-            """.trimIndent(),
+            GET_DOWNLOADED_ATTACHMENT_PARTS_SQL,
             arrayOf(cutoffTime.toString(), lastScannedPartId.toString(), "%content-disposition%", batchSize.toString()),
         ).use { cursor ->
             val parts = buildList {
@@ -114,39 +91,29 @@ LIMIT ?
     }
 
     private fun SQLiteDatabase.markMessagesAsPartiallyDownloaded(messageIds: List<Long>) {
-        performChunkedOperation(
-            arguments = messageIds,
-            argumentTransformation = Long::toString,
-        ) { selectionSet, selectionArguments ->
-            rawQuery("SELECT id, flags FROM messages WHERE id $selectionSet", selectionArguments).use { cursor ->
-                while (cursor.moveToNext()) {
-                    val messageId = cursor.getLong(0)
-                    val flags = if (cursor.isNull(1) || cursor.getString(1).isBlank()) {
-                        mutableSetOf<Flag>()
-                    } else {
-                        cursor.getString(1)
-                            .split(',')
-                            .filter { it.isNotEmpty() }
-                            .map { Flag.valueOf(it) }
-                            .toMutableSet()
-                    }
-
-                    flags.remove(Flag.X_DOWNLOADED_FULL)
-                    flags.add(Flag.X_DOWNLOADED_PARTIAL)
-
-                    val values = ContentValues().apply {
-                        put("flags", flags.joinToString(separator = ","))
-                    }
-
-                    update("messages", values, "id = ?", arrayOf(messageId.toString()))
-                }
-            }
+        updateMessageFlagsById(messageIds) { flags ->
+            flags - Flag.X_DOWNLOADED_FULL + Flag.X_DOWNLOADED_PARTIAL
         }
     }
 
     companion object {
         private const val CLEANUP_BATCH_SIZE = 500
-        private const val MAX_BATCHES_PER_RUN = 10
+        private const val GET_DOWNLOADED_ATTACHMENT_PARTS_SQL = """
+SELECT message_parts.id, message_parts.data_location, messages.id, message_parts.header
+FROM message_parts
+JOIN messages ON messages.message_part_id = message_parts.root
+JOIN folders ON folders.id = messages.folder_id
+WHERE folders.local_only = 0
+  AND messages.deleted = 0
+  AND messages.empty = 0
+  AND messages.encryption_type IS NULL
+  AND COALESCE(NULLIF(messages.internal_date, 0), messages.date) < CAST(? AS INTEGER)
+  AND message_parts.id > CAST(? AS INTEGER)
+  AND message_parts.data_location IN (${DataLocation.IN_DATABASE}, ${DataLocation.ON_DISK})
+  AND lower(CAST(message_parts.header AS TEXT)) LIKE ?
+ORDER BY message_parts.id
+LIMIT ?
+        """
     }
 }
 
@@ -198,10 +165,5 @@ private data class DownloadedAttachmentPart(
 
 private data class DownloadedAttachmentParts(
     val parts: List<DownloadedAttachmentPart>,
-    val lastScannedPartId: Long?,
-)
-
-private data class AttachmentCleanupBatch(
-    val removedPartCount: Int,
     val lastScannedPartId: Long?,
 )

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentCleanupOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentCleanupOperations.kt
@@ -1,0 +1,157 @@
+package com.fsck.k9.storage.messages
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import com.fsck.k9.mail.internet.MimeHeader
+import com.fsck.k9.mail.internet.MimeUtility
+import com.fsck.k9.mailstore.LockableDatabase
+import net.thunderbird.core.common.mail.Flag
+
+internal class AttachmentCleanupOperations(
+    private val lockableDatabase: LockableDatabase,
+    private val attachmentFileManager: AttachmentFileManager,
+) {
+    fun removeOldDownloadedAttachments(cutoffTime: Long): Int {
+        return lockableDatabase.execute(true) { database ->
+            val attachmentParts = database.getDownloadedAttachmentParts(cutoffTime)
+            if (attachmentParts.isEmpty()) return@execute 0
+
+            attachmentParts
+                .filter { it.dataLocation == DataLocation.ON_DISK }
+                .forEach { attachmentFileManager.deleteFile(it.messagePartId) }
+
+            val changedPartIds = attachmentParts.map { it.messagePartId }
+            database.markPartsAsMissing(changedPartIds)
+
+            val changedMessageIds = attachmentParts.map { it.messageId }.distinct()
+            database.markMessagesAsPartiallyDownloaded(changedMessageIds)
+
+            changedPartIds.size
+        }
+    }
+
+    private fun SQLiteDatabase.getDownloadedAttachmentParts(cutoffTime: Long): List<DownloadedAttachmentPart> {
+        return rawQuery(
+            """
+SELECT message_parts.id, message_parts.data_location, messages.id, message_parts.header
+FROM message_parts
+JOIN messages ON messages.message_part_id = message_parts.root
+JOIN folders ON folders.id = messages.folder_id
+WHERE folders.local_only = 0
+  AND messages.deleted = 0
+  AND messages.empty = 0
+  AND messages.encryption_type IS NULL
+  AND COALESCE(NULLIF(messages.internal_date, 0), messages.date) < CAST(? AS INTEGER)
+  AND message_parts.data_location IN (${DataLocation.IN_DATABASE}, ${DataLocation.ON_DISK})
+  AND lower(CAST(message_parts.header AS TEXT)) LIKE ?
+            """.trimIndent(),
+            arrayOf(cutoffTime.toString(), "%content-disposition%"),
+        ).use { cursor ->
+            buildList {
+                while (cursor.moveToNext()) {
+                    val header = cursor.getBlob(3)
+                    if (header.isExplicitAttachment()) {
+                        add(
+                            DownloadedAttachmentPart(
+                                messagePartId = cursor.getLong(0),
+                                dataLocation = cursor.getInt(1),
+                                messageId = cursor.getLong(2),
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun SQLiteDatabase.markPartsAsMissing(messagePartIds: List<Long>) {
+        performChunkedOperation(
+            arguments = messagePartIds,
+            argumentTransformation = Long::toString,
+        ) { selectionSet, selectionArguments ->
+            val values = ContentValues().apply {
+                put("data_location", DataLocation.MISSING)
+                putNull("data")
+            }
+
+            update("message_parts", values, "id $selectionSet", selectionArguments)
+        }
+    }
+
+    private fun SQLiteDatabase.markMessagesAsPartiallyDownloaded(messageIds: List<Long>) {
+        performChunkedOperation(
+            arguments = messageIds,
+            argumentTransformation = Long::toString,
+        ) { selectionSet, selectionArguments ->
+            rawQuery("SELECT id, flags FROM messages WHERE id $selectionSet", selectionArguments).use { cursor ->
+                while (cursor.moveToNext()) {
+                    val messageId = cursor.getLong(0)
+                    val flags = if (cursor.isNull(1) || cursor.getString(1).isBlank()) {
+                        mutableSetOf<Flag>()
+                    } else {
+                        cursor.getString(1)
+                            .split(',')
+                            .filter { it.isNotEmpty() }
+                            .map { Flag.valueOf(it) }
+                            .toMutableSet()
+                    }
+
+                    flags.remove(Flag.X_DOWNLOADED_FULL)
+                    flags.add(Flag.X_DOWNLOADED_PARTIAL)
+
+                    val values = ContentValues().apply {
+                        put("flags", flags.joinToString(separator = ","))
+                    }
+
+                    update("messages", values, "id = ?", arrayOf(messageId.toString()))
+                }
+            }
+        }
+    }
+}
+
+private fun ByteArray?.isExplicitAttachment(): Boolean {
+    if (this == null) return false
+
+    val contentDisposition = toString(Charsets.UTF_8)
+        .extractHeaderBody(MimeHeader.HEADER_CONTENT_DISPOSITION)
+        ?: return false
+    val dispositionType = MimeUtility.getHeaderParameter(MimeUtility.unfold(contentDisposition), null)
+
+    return dispositionType.equals("attachment", ignoreCase = true)
+}
+
+private fun String.extractHeaderBody(headerName: String): String? {
+    val lines = replace("\r\n", "\n")
+        .replace('\r', '\n')
+        .lineSequence()
+
+    val unfoldedLines = mutableListOf<String>()
+    for (line in lines) {
+        if (line.startsWith(" ") || line.startsWith("\t")) {
+            if (unfoldedLines.isNotEmpty()) {
+                unfoldedLines[unfoldedLines.lastIndex] += line
+            }
+        } else {
+            unfoldedLines.add(line)
+        }
+    }
+
+    for (line in unfoldedLines) {
+        val separatorIndex = line.indexOf(':')
+        if (separatorIndex <= 0) continue
+
+        val name = line.substring(0, separatorIndex).trim()
+        if (name.equals(headerName, ignoreCase = true)) {
+            return line.substring(separatorIndex + 1).trim()
+        }
+    }
+
+    return null
+}
+
+private data class DownloadedAttachmentPart(
+    val messagePartId: Long,
+    val dataLocation: Int,
+    val messageId: Long,
+)

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentCleanupOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/AttachmentCleanupOperations.kt
@@ -59,14 +59,14 @@ internal class AttachmentCleanupOperations(
         ).use { cursor ->
             val parts = buildList {
                 while (cursor.moveToNext()) {
-                    lastPartId = cursor.getLong(0)
-                    val header = cursor.getBlob(3)
+                    lastPartId = cursor.getLong(PART_ID_COLUMN_INDEX)
+                    val header = cursor.getBlob(HEADER_COLUMN_INDEX)
                     if (header.isExplicitAttachment()) {
                         add(
                             DownloadedAttachmentPart(
-                                messagePartId = cursor.getLong(0),
-                                dataLocation = cursor.getInt(1),
-                                messageId = cursor.getLong(2),
+                                messagePartId = cursor.getLong(PART_ID_COLUMN_INDEX),
+                                dataLocation = cursor.getInt(DATA_LOCATION_COLUMN_INDEX),
+                                messageId = cursor.getLong(MESSAGE_ID_COLUMN_INDEX),
                             ),
                         )
                     }
@@ -98,6 +98,10 @@ internal class AttachmentCleanupOperations(
 
     companion object {
         private const val CLEANUP_BATCH_SIZE = 500
+        private const val PART_ID_COLUMN_INDEX = 0
+        private const val DATA_LOCATION_COLUMN_INDEX = 1
+        private const val MESSAGE_ID_COLUMN_INDEX = 2
+        private const val HEADER_COLUMN_INDEX = 3
         private const val GET_DOWNLOADED_ATTACHMENT_PARTS_SQL = """
 SELECT message_parts.id, message_parts.data_location, messages.id, message_parts.header
 FROM message_parts
@@ -118,14 +122,11 @@ LIMIT ?
 }
 
 private fun ByteArray?.isExplicitAttachment(): Boolean {
-    if (this == null) return false
-
-    val contentDisposition = toString(Charsets.UTF_8)
-        .extractHeaderBody(MimeHeader.HEADER_CONTENT_DISPOSITION)
-        ?: return false
-    val dispositionType = MimeUtility.getHeaderParameter(MimeUtility.unfold(contentDisposition), null)
-
-    return dispositionType.equals("attachment", ignoreCase = true)
+    return this?.toString(Charsets.UTF_8)
+        ?.extractHeaderBody(MimeHeader.HEADER_CONTENT_DISPOSITION)
+        ?.let(MimeUtility::unfold)
+        ?.let { MimeUtility.getHeaderParameter(it, null).equals("attachment", ignoreCase = true) }
+        ?: false
 }
 
 private fun String.extractHeaderBody(headerName: String): String? {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/FlagMessageOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/FlagMessageOperations.kt
@@ -1,11 +1,8 @@
 package com.fsck.k9.storage.messages
 
 import android.content.ContentValues
-import android.database.sqlite.SQLiteDatabase
 import com.fsck.k9.mailstore.LockableDatabase
 import net.thunderbird.core.common.mail.Flag
-
-internal val SPECIAL_FLAGS = setOf(Flag.SEEN, Flag.FLAGGED, Flag.ANSWERED, Flag.FORWARDED)
 
 internal class FlagMessageOperations(private val lockableDatabase: LockableDatabase) {
 
@@ -56,40 +53,12 @@ internal class FlagMessageOperations(private val lockableDatabase: LockableDatab
 
     private fun rebuildFlagsColumnValue(folderId: Long, messageServerId: String, flag: Flag, set: Boolean) {
         lockableDatabase.execute(true) { database ->
-            val oldFlags = database.readFlagsColumn(folderId, messageServerId)
-
-            val newFlags = if (set) oldFlags + flag else oldFlags - flag
-            val newFlagsString = newFlags.joinToString(separator = ",")
-
-            val values = ContentValues().apply {
-                put("flags", newFlagsString)
-            }
-
-            database.update(
-                "messages",
-                values,
-                "folder_id = ? AND uid = ?",
-                arrayOf(folderId.toString(), messageServerId),
-            )
-        }
-    }
-
-    private fun SQLiteDatabase.readFlagsColumn(folderId: Long, messageServerId: String): Set<Flag> {
-        return query(
-            "messages",
-            arrayOf("flags"),
-            "folder_id = ? AND uid = ?",
-            arrayOf(folderId.toString(), messageServerId),
-            null,
-            null,
-            null,
-        ).use { cursor ->
-            if (!cursor.moveToFirst()) error("Message not found $folderId:$messageServerId")
-
-            if (!cursor.isNull(0)) {
-                cursor.getString(0).split(',').map { flagString -> Flag.valueOf(flagString) }.toSet()
-            } else {
-                emptySet()
+            database.updateMessageFlagsByServerId(folderId, messageServerId) { oldFlags ->
+                if (set) {
+                    oldFlags + flag
+                } else {
+                    oldFlags - flag
+                }
             }
         }
     }

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -1,5 +1,6 @@
 package com.fsck.k9.storage.messages
 
+import app.k9mail.legacy.mailstore.AttachmentCleanupResult
 import app.k9mail.legacy.mailstore.CreateFolderInfo
 import app.k9mail.legacy.mailstore.FolderMapper
 import app.k9mail.legacy.mailstore.MessageMapper
@@ -210,8 +211,8 @@ class K9MessageStore(
         return databaseOperations.getSize()
     }
 
-    override fun removeOldDownloadedAttachments(cutoffTime: Long): Int {
-        return attachmentCleanupOperations.removeOldDownloadedAttachments(cutoffTime)
+    override fun removeOldDownloadedAttachments(cutoffTime: Long, maxParts: Int): AttachmentCleanupResult {
+        return attachmentCleanupOperations.removeOldDownloadedAttachments(cutoffTime, maxParts)
     }
 
     override fun changeFolder(folderServerId: String, name: String, type: FolderType) {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/K9MessageStore.kt
@@ -51,6 +51,7 @@ class K9MessageStore(
     private val retrieveMessageOperations = RetrieveMessageOperations(database)
     private val retrieveMessageListOperations = RetrieveMessageListOperations(database)
     private val deleteMessageOperations = DeleteMessageOperations(database, attachmentFileManager)
+    private val attachmentCleanupOperations = AttachmentCleanupOperations(database, attachmentFileManager)
     private val createFolderOperations = CreateFolderOperations(database, accountId)
     private val retrieveFolderOperations = RetrieveFolderOperations(database)
     private val checkFolderOperations = CheckFolderOperations(database)
@@ -207,6 +208,10 @@ class K9MessageStore(
 
     override fun getSize(): Long {
         return databaseOperations.getSize()
+    }
+
+    override fun removeOldDownloadedAttachments(cutoffTime: Long): Int {
+        return attachmentCleanupOperations.removeOldDownloadedAttachments(cutoffTime)
     }
 
     override fun changeFolder(folderServerId: String, name: String, type: FolderType) {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/MessageFlagsColumn.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/MessageFlagsColumn.kt
@@ -1,0 +1,86 @@
+package com.fsck.k9.storage.messages
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import net.thunderbird.core.common.mail.Flag
+
+internal val SPECIAL_FLAGS = setOf(Flag.SEEN, Flag.FLAGGED, Flag.ANSWERED, Flag.FORWARDED)
+
+internal fun SQLiteDatabase.updateMessageFlagsById(
+    messageIds: Collection<Long>,
+    transform: (Set<Flag>) -> Set<Flag>,
+) {
+    performChunkedOperation(
+        arguments = messageIds,
+        argumentTransformation = Long::toString,
+    ) { selectionSet, selectionArguments ->
+        query(
+            "messages",
+            arrayOf("id", "flags"),
+            "id $selectionSet",
+            selectionArguments,
+            null,
+            null,
+            null,
+        ).use { cursor ->
+            while (cursor.moveToNext()) {
+                val messageId = cursor.getLong(0)
+                updateMessageFlags("id = ?", arrayOf(messageId.toString()), transform(cursor.getString(1).toFlagSet()))
+            }
+        }
+    }
+}
+
+internal fun SQLiteDatabase.updateMessageFlagsByServerId(
+    folderId: Long,
+    messageServerId: String,
+    transform: (Set<Flag>) -> Set<Flag>,
+) {
+    val oldFlags = query(
+        "messages",
+        arrayOf("flags"),
+        "folder_id = ? AND uid = ?",
+        arrayOf(folderId.toString(), messageServerId),
+        null,
+        null,
+        null,
+    ).use { cursor ->
+        if (!cursor.moveToFirst()) error("Message not found $folderId:$messageServerId")
+
+        cursor.getString(0).toFlagSet()
+    }
+
+    updateMessageFlags(
+        selection = "folder_id = ? AND uid = ?",
+        selectionArgs = arrayOf(folderId.toString(), messageServerId),
+        flags = transform(oldFlags),
+    )
+}
+
+internal fun Set<Flag>.toDatabaseValue(): String {
+    return filter { it !in SPECIAL_FLAGS }
+        .joinToString(separator = ",")
+}
+
+private fun String?.toFlagSet(): Set<Flag> {
+    return if (isNullOrBlank()) {
+        emptySet()
+    } else {
+        split(',')
+            .filter { it.isNotEmpty() }
+            .map { Flag.valueOf(it) }
+            .toSet()
+    }
+}
+
+private fun SQLiteDatabase.updateMessageFlags(
+    selection: String,
+    selectionArgs: Array<String>,
+    flags: Set<Flag>,
+) {
+    val values = ContentValues().apply {
+        put("flags", flags.toDatabaseValue())
+    }
+
+    update("messages", values, selection, selectionArgs)
+}

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/messages/SaveMessageOperations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/messages/SaveMessageOperations.kt
@@ -514,12 +514,6 @@ internal class SaveMessageOperations(
     }
 }
 
-private fun Set<Flag>.toDatabaseValue(): String {
-    return this
-        .filter { it !in SPECIAL_FLAGS }
-        .joinToString(separator = ",")
-}
-
 private fun Boolean.toDatabaseValue() = if (this) 1 else 0
 
 private fun PreviewType.toDatabaseValue(): String {

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
@@ -37,5 +37,6 @@ object Migrations {
         if (oldVersion < 88) MigrationTo88(db, migrationsHelper).addFoldersVisibleColumn()
         if (oldVersion < 90) MigrationTo90(db, migrationsHelper).removeImapPrefixFromFolderServerId()
         if (oldVersion < 91) MigrationTo91(db, migrationsHelper).addAccountIdColumn()
+        if (oldVersion < 92) MigrationTo92(db).createAttachmentCleanupIndex()
     }
 }

--- a/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
+++ b/legacy/storage/src/main/java/com/fsck/k9/storage/migrations/Migrations.kt
@@ -37,6 +37,5 @@ object Migrations {
         if (oldVersion < 88) MigrationTo88(db, migrationsHelper).addFoldersVisibleColumn()
         if (oldVersion < 90) MigrationTo90(db, migrationsHelper).removeImapPrefixFromFolderServerId()
         if (oldVersion < 91) MigrationTo91(db, migrationsHelper).addAccountIdColumn()
-        if (oldVersion < 92) MigrationTo92(db).createAttachmentCleanupIndex()
     }
 }

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/AttachmentCleanupOperationsTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/AttachmentCleanupOperationsTest.kt
@@ -66,8 +66,7 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
 
         val attachmentPart = sqliteDatabase.readMessageParts().single { it.id == attachmentPartId }
         val message = sqliteDatabase.readMessages().single()
-        assertThat(result.removedPartCount).isEqualTo(1)
-        assertThat(result.hasMore).isFalse()
+        assertThat(result.changedPartCount).isEqualTo(1)
         assertThat(attachmentPart.dataLocation).isEqualTo(DataLocation.MISSING)
         assertThat(attachmentPart.data).isNull()
         assertThat(attachmentPart.displayName).isEqualTo("document.pdf")
@@ -100,8 +99,7 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
 
         val result = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2_000)
 
-        assertThat(result.removedPartCount).isEqualTo(1)
-        assertThat(result.hasMore).isFalse()
+        assertThat(result.changedPartCount).isEqualTo(1)
         assertThat(attachmentFile.exists()).isFalse()
     }
 
@@ -145,8 +143,7 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
         val result = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2_000)
 
         val messageParts = sqliteDatabase.readMessageParts().associateBy { it.id }
-        assertThat(result.removedPartCount).isEqualTo(0)
-        assertThat(result.hasMore).isFalse()
+        assertThat(result.changedPartCount).isEqualTo(0)
         assertThat(messageParts[inlinePartId]?.dataLocation).isEqualTo(DataLocation.IN_DATABASE)
         assertThat(messageParts[recentAttachmentPartId]?.dataLocation).isEqualTo(DataLocation.IN_DATABASE)
         assertThat(messageParts[inlinePartId]?.data?.isNotEmpty() == true).isTrue()
@@ -177,8 +174,7 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
         val result = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2_000)
 
         val attachmentPart = sqliteDatabase.readMessageParts().single { it.id == attachmentPartId }
-        assertThat(result.removedPartCount).isEqualTo(1)
-        assertThat(result.hasMore).isFalse()
+        assertThat(result.changedPartCount).isEqualTo(1)
         assertThat(attachmentPart.dataLocation).isEqualTo(DataLocation.MISSING)
         assertThat(attachmentPart.data).isNull()
     }
@@ -211,8 +207,7 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
         val result = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2_000)
 
         val attachmentParts = sqliteDatabase.readMessageParts().filter { it.id in attachmentPartIds }
-        assertThat(result.removedPartCount).isEqualTo(501)
-        assertThat(result.hasMore).isFalse()
+        assertThat(result.changedPartCount).isEqualTo(501)
         attachmentParts.forEach { attachmentPart ->
             assertThat(attachmentPart.dataLocation).isEqualTo(DataLocation.MISSING)
             assertThat(attachmentPart.data).isNull()
@@ -247,14 +242,12 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
         val firstResult = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2)
         val partsAfterFirstRun = sqliteDatabase.readMessageParts().filter { it.id in attachmentPartIds }
 
-        assertThat(firstResult.removedPartCount).isEqualTo(2)
-        assertThat(firstResult.hasMore).isTrue()
+        assertThat(firstResult.changedPartCount).isEqualTo(2)
         assertThat(partsAfterFirstRun.count { it.dataLocation == DataLocation.MISSING }).isEqualTo(2)
         assertThat(partsAfterFirstRun.count { it.dataLocation == DataLocation.IN_DATABASE }).isEqualTo(1)
 
         val secondResult = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2)
 
-        assertThat(secondResult.removedPartCount).isEqualTo(1)
-        assertThat(secondResult.hasMore).isFalse()
+        assertThat(secondResult.changedPartCount).isEqualTo(1)
     }
 }

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/AttachmentCleanupOperationsTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/AttachmentCleanupOperationsTest.kt
@@ -1,0 +1,181 @@
+package com.fsck.k9.storage.messages
+
+import android.database.sqlite.SQLiteDatabase
+import assertk.assertThat
+import assertk.assertions.contains
+import assertk.assertions.doesNotContain
+import assertk.assertions.isEqualTo
+import assertk.assertions.isFalse
+import assertk.assertions.isNull
+import assertk.assertions.isTrue
+import com.fsck.k9.mailstore.StorageFilesProvider
+import com.fsck.k9.storage.RobolectricTest
+import net.thunderbird.core.common.mail.Flag
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+import org.mockito.kotlin.mock
+
+class AttachmentCleanupOperationsTest : RobolectricTest() {
+    private val messagePartDirectory = createRandomTempDirectory()
+    private lateinit var sqliteDatabase: SQLiteDatabase
+    private lateinit var testSubject: AttachmentCleanupOperations
+
+    @Before
+    fun setUp() {
+        sqliteDatabase = createDatabase()
+        val storageFilesProvider = object : StorageFilesProvider {
+            override fun getDatabaseFile() = error("Not implemented")
+            override fun getAttachmentDirectory() = messagePartDirectory
+        }
+        val lockableDatabase = createLockableDatabaseMock(sqliteDatabase)
+        val attachmentFileManager = AttachmentFileManager(storageFilesProvider, mock())
+        testSubject = AttachmentCleanupOperations(lockableDatabase, attachmentFileManager)
+    }
+
+    @After
+    fun tearDown() {
+        sqliteDatabase.close()
+        messagePartDirectory.deleteRecursively()
+    }
+
+    @Test
+    fun `removeOldDownloadedAttachments should remove explicit attachment data from old messages`() {
+        val folderId = sqliteDatabase.createFolder(isLocalOnly = false)
+        val rootPartId = sqliteDatabase.createMessagePart(dataLocation = DataLocation.CHILD_PART_CONTAINS_DATA)
+        val attachmentPartId = sqliteDatabase.createMessagePart(
+            root = rootPartId,
+            parent = rootPartId,
+            mimeType = "application/pdf",
+            displayName = "document.pdf",
+            header = "Content-Type: application/pdf\r\nContent-Disposition: attachment; filename=\"document.pdf\"\r\n",
+            dataLocation = DataLocation.IN_DATABASE,
+            data = "content".toByteArray(),
+            serverExtra = "2",
+        )
+        sqliteDatabase.createMessage(
+            folderId = folderId,
+            uid = "uid1",
+            date = 100,
+            internalDate = 100,
+            flags = Flag.X_DOWNLOADED_FULL.name,
+            messagePartId = rootPartId,
+        )
+
+        val changedParts = testSubject.removeOldDownloadedAttachments(cutoffTime = 200)
+
+        val attachmentPart = sqliteDatabase.readMessageParts().single { it.id == attachmentPartId }
+        val message = sqliteDatabase.readMessages().single()
+        assertThat(changedParts).isEqualTo(1)
+        assertThat(attachmentPart.dataLocation).isEqualTo(DataLocation.MISSING)
+        assertThat(attachmentPart.data).isNull()
+        assertThat(attachmentPart.displayName).isEqualTo("document.pdf")
+        assertThat(attachmentPart.serverExtra).isEqualTo("2")
+        assertThat(message.flags.orEmpty()).doesNotContain(Flag.X_DOWNLOADED_FULL.name)
+        assertThat(message.flags.orEmpty()).contains(Flag.X_DOWNLOADED_PARTIAL.name)
+    }
+
+    @Test
+    fun `removeOldDownloadedAttachments should delete disk backed attachment files`() {
+        val folderId = sqliteDatabase.createFolder(isLocalOnly = false)
+        val rootPartId = sqliteDatabase.createMessagePart(dataLocation = DataLocation.CHILD_PART_CONTAINS_DATA)
+        val attachmentPartId = sqliteDatabase.createMessagePart(
+            root = rootPartId,
+            parent = rootPartId,
+            header = "Content-Disposition: attachment\r\n",
+            dataLocation = DataLocation.ON_DISK,
+        )
+        val attachmentFile = messagePartDirectory.resolve(attachmentPartId.toString()).apply {
+            writeText("content")
+        }
+        sqliteDatabase.createMessage(
+            folderId = folderId,
+            uid = "uid1",
+            date = 100,
+            internalDate = 100,
+            flags = Flag.X_DOWNLOADED_FULL.name,
+            messagePartId = rootPartId,
+        )
+
+        val changedParts = testSubject.removeOldDownloadedAttachments(cutoffTime = 200)
+
+        assertThat(changedParts).isEqualTo(1)
+        assertThat(attachmentFile.exists()).isFalse()
+    }
+
+    @Test
+    fun `removeOldDownloadedAttachments should keep inline and recent parts`() {
+        val folderId = sqliteDatabase.createFolder(isLocalOnly = false)
+        val oldRootPartId = sqliteDatabase.createMessagePart(dataLocation = DataLocation.CHILD_PART_CONTAINS_DATA)
+        val inlinePartId = sqliteDatabase.createMessagePart(
+            root = oldRootPartId,
+            parent = oldRootPartId,
+            header = "Content-Disposition: inline; filename=\"attachment.png\"\r\n",
+            dataLocation = DataLocation.IN_DATABASE,
+            data = "inline".toByteArray(),
+        )
+        sqliteDatabase.createMessage(
+            folderId = folderId,
+            uid = "uid1",
+            date = 100,
+            internalDate = 100,
+            flags = Flag.X_DOWNLOADED_FULL.name,
+            messagePartId = oldRootPartId,
+        )
+
+        val recentRootPartId = sqliteDatabase.createMessagePart(dataLocation = DataLocation.CHILD_PART_CONTAINS_DATA)
+        val recentAttachmentPartId = sqliteDatabase.createMessagePart(
+            root = recentRootPartId,
+            parent = recentRootPartId,
+            header = "Content-Disposition: attachment\r\n",
+            dataLocation = DataLocation.IN_DATABASE,
+            data = "recent".toByteArray(),
+        )
+        sqliteDatabase.createMessage(
+            folderId = folderId,
+            uid = "uid2",
+            date = 300,
+            internalDate = 300,
+            flags = Flag.X_DOWNLOADED_FULL.name,
+            messagePartId = recentRootPartId,
+        )
+
+        val changedParts = testSubject.removeOldDownloadedAttachments(cutoffTime = 200)
+
+        val messageParts = sqliteDatabase.readMessageParts().associateBy { it.id }
+        assertThat(changedParts).isEqualTo(0)
+        assertThat(messageParts[inlinePartId]?.dataLocation).isEqualTo(DataLocation.IN_DATABASE)
+        assertThat(messageParts[recentAttachmentPartId]?.dataLocation).isEqualTo(DataLocation.IN_DATABASE)
+        assertThat(messageParts[inlinePartId]?.data?.isNotEmpty() == true).isTrue()
+        assertThat(messageParts[recentAttachmentPartId]?.data?.isNotEmpty() == true).isTrue()
+    }
+
+    @Test
+    fun `removeOldDownloadedAttachments should remove attachments with folded disposition headers`() {
+        val folderId = sqliteDatabase.createFolder(isLocalOnly = false)
+        val rootPartId = sqliteDatabase.createMessagePart(dataLocation = DataLocation.CHILD_PART_CONTAINS_DATA)
+        val attachmentPartId = sqliteDatabase.createMessagePart(
+            root = rootPartId,
+            parent = rootPartId,
+            header = "Content-Disposition :\r\n attachment; filename=\"document.pdf\"\r\n",
+            dataLocation = DataLocation.IN_DATABASE,
+            data = "content".toByteArray(),
+            serverExtra = "2",
+        )
+        sqliteDatabase.createMessage(
+            folderId = folderId,
+            uid = "uid1",
+            date = 100,
+            internalDate = 100,
+            flags = Flag.X_DOWNLOADED_FULL.name,
+            messagePartId = rootPartId,
+        )
+
+        val changedParts = testSubject.removeOldDownloadedAttachments(cutoffTime = 200)
+
+        val attachmentPart = sqliteDatabase.readMessageParts().single { it.id == attachmentPartId }
+        assertThat(changedParts).isEqualTo(1)
+        assertThat(attachmentPart.dataLocation).isEqualTo(DataLocation.MISSING)
+        assertThat(attachmentPart.data).isNull()
+    }
+}

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/AttachmentCleanupOperationsTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/AttachmentCleanupOperationsTest.kt
@@ -62,11 +62,12 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
             messagePartId = rootPartId,
         )
 
-        val changedParts = testSubject.removeOldDownloadedAttachments(cutoffTime = 200)
+        val result = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2_000)
 
         val attachmentPart = sqliteDatabase.readMessageParts().single { it.id == attachmentPartId }
         val message = sqliteDatabase.readMessages().single()
-        assertThat(changedParts).isEqualTo(1)
+        assertThat(result.removedPartCount).isEqualTo(1)
+        assertThat(result.hasMore).isFalse()
         assertThat(attachmentPart.dataLocation).isEqualTo(DataLocation.MISSING)
         assertThat(attachmentPart.data).isNull()
         assertThat(attachmentPart.displayName).isEqualTo("document.pdf")
@@ -97,9 +98,10 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
             messagePartId = rootPartId,
         )
 
-        val changedParts = testSubject.removeOldDownloadedAttachments(cutoffTime = 200)
+        val result = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2_000)
 
-        assertThat(changedParts).isEqualTo(1)
+        assertThat(result.removedPartCount).isEqualTo(1)
+        assertThat(result.hasMore).isFalse()
         assertThat(attachmentFile.exists()).isFalse()
     }
 
@@ -140,10 +142,11 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
             messagePartId = recentRootPartId,
         )
 
-        val changedParts = testSubject.removeOldDownloadedAttachments(cutoffTime = 200)
+        val result = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2_000)
 
         val messageParts = sqliteDatabase.readMessageParts().associateBy { it.id }
-        assertThat(changedParts).isEqualTo(0)
+        assertThat(result.removedPartCount).isEqualTo(0)
+        assertThat(result.hasMore).isFalse()
         assertThat(messageParts[inlinePartId]?.dataLocation).isEqualTo(DataLocation.IN_DATABASE)
         assertThat(messageParts[recentAttachmentPartId]?.dataLocation).isEqualTo(DataLocation.IN_DATABASE)
         assertThat(messageParts[inlinePartId]?.data?.isNotEmpty() == true).isTrue()
@@ -171,11 +174,87 @@ class AttachmentCleanupOperationsTest : RobolectricTest() {
             messagePartId = rootPartId,
         )
 
-        val changedParts = testSubject.removeOldDownloadedAttachments(cutoffTime = 200)
+        val result = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2_000)
 
         val attachmentPart = sqliteDatabase.readMessageParts().single { it.id == attachmentPartId }
-        assertThat(changedParts).isEqualTo(1)
+        assertThat(result.removedPartCount).isEqualTo(1)
+        assertThat(result.hasMore).isFalse()
         assertThat(attachmentPart.dataLocation).isEqualTo(DataLocation.MISSING)
         assertThat(attachmentPart.data).isNull()
+    }
+
+    @Test
+    fun `removeOldDownloadedAttachments should remove attachments across multiple batches`() {
+        val folderId = sqliteDatabase.createFolder(isLocalOnly = false)
+        val attachmentPartIds = buildList {
+            repeat(501) { index ->
+                val rootPartId = sqliteDatabase.createMessagePart(dataLocation = DataLocation.CHILD_PART_CONTAINS_DATA)
+                val attachmentPartId = sqliteDatabase.createMessagePart(
+                    root = rootPartId,
+                    parent = rootPartId,
+                    header = "Content-Disposition: attachment\r\n",
+                    dataLocation = DataLocation.IN_DATABASE,
+                    data = "content".toByteArray(),
+                )
+                sqliteDatabase.createMessage(
+                    folderId = folderId,
+                    uid = "uid$index",
+                    date = 100,
+                    internalDate = 100,
+                    flags = Flag.X_DOWNLOADED_FULL.name,
+                    messagePartId = rootPartId,
+                )
+                add(attachmentPartId)
+            }
+        }
+
+        val result = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2_000)
+
+        val attachmentParts = sqliteDatabase.readMessageParts().filter { it.id in attachmentPartIds }
+        assertThat(result.removedPartCount).isEqualTo(501)
+        assertThat(result.hasMore).isFalse()
+        attachmentParts.forEach { attachmentPart ->
+            assertThat(attachmentPart.dataLocation).isEqualTo(DataLocation.MISSING)
+            assertThat(attachmentPart.data).isNull()
+        }
+    }
+
+    @Test
+    fun `removeOldDownloadedAttachments should stop at per-run part budget`() {
+        val folderId = sqliteDatabase.createFolder(isLocalOnly = false)
+        val attachmentPartIds = buildList {
+            repeat(3) { index ->
+                val rootPartId = sqliteDatabase.createMessagePart(dataLocation = DataLocation.CHILD_PART_CONTAINS_DATA)
+                val attachmentPartId = sqliteDatabase.createMessagePart(
+                    root = rootPartId,
+                    parent = rootPartId,
+                    header = "Content-Disposition: attachment\r\n",
+                    dataLocation = DataLocation.IN_DATABASE,
+                    data = "content".toByteArray(),
+                )
+                sqliteDatabase.createMessage(
+                    folderId = folderId,
+                    uid = "uid$index",
+                    date = 100,
+                    internalDate = 100,
+                    flags = Flag.X_DOWNLOADED_FULL.name,
+                    messagePartId = rootPartId,
+                )
+                add(attachmentPartId)
+            }
+        }
+
+        val firstResult = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2)
+        val partsAfterFirstRun = sqliteDatabase.readMessageParts().filter { it.id in attachmentPartIds }
+
+        assertThat(firstResult.removedPartCount).isEqualTo(2)
+        assertThat(firstResult.hasMore).isTrue()
+        assertThat(partsAfterFirstRun.count { it.dataLocation == DataLocation.MISSING }).isEqualTo(2)
+        assertThat(partsAfterFirstRun.count { it.dataLocation == DataLocation.IN_DATABASE }).isEqualTo(1)
+
+        val secondResult = testSubject.removeOldDownloadedAttachments(cutoffTime = 200, maxParts = 2)
+
+        assertThat(secondResult.removedPartCount).isEqualTo(1)
+        assertThat(secondResult.hasMore).isFalse()
     }
 }

--- a/legacy/storage/src/test/java/com/fsck/k9/storage/messages/MessageFlagsColumnTest.kt
+++ b/legacy/storage/src/test/java/com/fsck/k9/storage/messages/MessageFlagsColumnTest.kt
@@ -1,0 +1,76 @@
+package com.fsck.k9.storage.messages
+
+import android.content.ContentValues
+import android.database.sqlite.SQLiteDatabase
+import assertk.assertThat
+import assertk.assertions.containsExactly
+import assertk.assertions.isEqualTo
+import com.fsck.k9.storage.RobolectricTest
+import net.thunderbird.core.common.mail.Flag
+import org.junit.After
+import org.junit.Before
+import org.junit.Test
+
+class MessageFlagsColumnTest : RobolectricTest() {
+    private lateinit var sqliteDatabase: SQLiteDatabase
+
+    @Before
+    fun setUp() {
+        sqliteDatabase = createDatabase()
+    }
+
+    @After
+    fun tearDown() {
+        sqliteDatabase.close()
+    }
+
+    @Test
+    fun `toDatabaseValue should omit flags stored in dedicated columns`() {
+        val flags = setOf(Flag.SEEN, Flag.X_DOWNLOADED_FULL, Flag.FLAGGED, Flag.X_SUBJECT_DECRYPTED)
+
+        val result = flags.toDatabaseValue()
+
+        assertThat(result.split(',')).containsExactly(Flag.X_DOWNLOADED_FULL.name, Flag.X_SUBJECT_DECRYPTED.name)
+    }
+
+    @Test
+    fun `updateMessageFlagsById should treat null flags as empty`() {
+        val folderId = sqliteDatabase.createFolder()
+        val messageId = sqliteDatabase.createMessage(folderId = folderId, uid = "uid1")
+        sqliteDatabase.update(
+            "messages",
+            ContentValues().apply {
+                putNull("flags")
+            },
+            "id = ?",
+            arrayOf(messageId.toString()),
+        )
+
+        sqliteDatabase.updateMessageFlagsById(listOf(messageId)) { flags ->
+            flags + Flag.X_DOWNLOADED_PARTIAL
+        }
+
+        val message = sqliteDatabase.readMessages().single()
+        assertThat(message.flags).isEqualTo(Flag.X_DOWNLOADED_PARTIAL.name)
+    }
+
+    @Test
+    fun `updateMessageFlagsByServerId should preserve non-special flags and ignore blank entries`() {
+        val folderId = sqliteDatabase.createFolder()
+        sqliteDatabase.createMessage(
+            folderId = folderId,
+            uid = "uid1",
+            flags = "X_DOWNLOADED_FULL,,X_SUBJECT_DECRYPTED",
+        )
+
+        sqliteDatabase.updateMessageFlagsByServerId(folderId, "uid1") { flags ->
+            flags - Flag.X_DOWNLOADED_FULL + Flag.X_DOWNLOADED_PARTIAL
+        }
+
+        val message = sqliteDatabase.readMessages().single()
+        assertThat(message.flags?.split(',').orEmpty()).containsExactly(
+            Flag.X_SUBJECT_DECRYPTED.name,
+            Flag.X_DOWNLOADED_PARTIAL.name,
+        )
+    }
+}

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -7,6 +7,7 @@ import com.fsck.k9.job.K9JobManager
 import com.fsck.k9.notification.NotificationChannelManager
 import com.fsck.k9.notification.NotificationController
 import java.util.concurrent.ExecutorService
+import net.thunderbird.core.android.account.AccountDefaultsProvider.Companion.MIN_ATTACHMENT_CLEANUP_DAYS
 import net.thunderbird.core.android.account.DeletePolicy
 import net.thunderbird.core.android.account.Expunge
 import net.thunderbird.core.android.account.LegacyAccountDto
@@ -28,6 +29,7 @@ class AccountSettingsDataStore(
 ) : PreferenceDataStore() {
     private var notificationSettingsChanged = false
     private var attachmentCleanupChanged = false
+    private var runAttachmentCleanupNow = false
 
     override fun getBoolean(key: String, defValue: Boolean): Boolean {
         return when (key) {
@@ -220,9 +222,10 @@ class AccountSettingsDataStore(
             notificationSettingsChanged = false
             saveSettings()
             if (attachmentCleanupChanged) {
-                jobManager.scheduleAttachmentCleanup(account)
+                jobManager.scheduleAttachmentCleanup(account, runNow = runAttachmentCleanupNow)
             }
             attachmentCleanupChanged = false
+            runAttachmentCleanupNow = false
         }
     }
 
@@ -235,10 +238,17 @@ class AccountSettingsDataStore(
     }
 
     private fun updateAttachmentCleanupDays(days: Int) {
-        if (account.attachmentCleanupDays != days) {
+        val previousDays = account.attachmentCleanupDays
+        if (previousDays != days) {
             account.attachmentCleanupDays = days
             attachmentCleanupChanged = true
+            runAttachmentCleanupNow = shouldRunAttachmentCleanupNow(previousDays, days)
         }
+    }
+
+    private fun shouldRunAttachmentCleanupNow(previousDays: Int, days: Int): Boolean {
+        return days >= MIN_ATTACHMENT_CLEANUP_DAYS &&
+            (previousDays < MIN_ATTACHMENT_CLEANUP_DAYS || days < previousDays)
     }
 
     private fun extractFolderId(preferenceValue: String): Long? {

--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/settings/account/AccountSettingsDataStore.kt
@@ -27,6 +27,7 @@ class AccountSettingsDataStore(
     private val messagingController: MessagingController,
 ) : PreferenceDataStore() {
     private var notificationSettingsChanged = false
+    private var attachmentCleanupChanged = false
 
     override fun getBoolean(key: String, defValue: Boolean): Boolean {
         return when (key) {
@@ -119,6 +120,7 @@ class AccountSettingsDataStore(
             "account_display_count" -> account.displayCount.toString()
             "account_message_age" -> account.maximumPolledMessageAge.toString()
             "account_autodownload_size" -> account.maximumAutoDownloadMessageSize.toString()
+            "account_attachment_cleanup" -> account.attachmentCleanupDays.toString()
             "account_check_frequency" -> account.automaticCheckIntervalMinutes.toString()
             "delete_policy" -> account.deletePolicy.name
             "expunge_policy" -> account.expungePolicy.name
@@ -152,6 +154,7 @@ class AccountSettingsDataStore(
             "account_display_count" -> account.displayCount = value.toInt()
             "account_message_age" -> account.maximumPolledMessageAge = value.toInt()
             "account_autodownload_size" -> account.maximumAutoDownloadMessageSize = value.toInt()
+            "account_attachment_cleanup" -> updateAttachmentCleanupDays(value.toInt())
             "account_check_frequency" -> {
                 if (account.updateAutomaticCheckIntervalMinutes(value.toInt())) {
                     reschedulePoll()
@@ -216,6 +219,10 @@ class AccountSettingsDataStore(
 
             notificationSettingsChanged = false
             saveSettings()
+            if (attachmentCleanupChanged) {
+                jobManager.scheduleAttachmentCleanup(account)
+            }
+            attachmentCleanupChanged = false
         }
     }
 
@@ -225,6 +232,13 @@ class AccountSettingsDataStore(
 
     private fun reschedulePoll() {
         jobManager.scheduleMailSync(account)
+    }
+
+    private fun updateAttachmentCleanupDays(days: Int) {
+        if (account.attachmentCleanupDays != days) {
+            account.attachmentCleanupDays = days
+            attachmentCleanupChanged = true
+        }
     }
 
     private fun extractFolderId(preferenceValue: String): Long? {

--- a/legacy/ui/legacy/src/main/res/values/arrays_account_settings_strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/arrays_account_settings_strings.xml
@@ -60,6 +60,13 @@
         <item>@string/account_settings_autodownload_message_size_any</item>
     </string-array>
 
+    <string-array name="attachment_cleanup_entries">
+        <item>@string/account_settings_attachment_cleanup_never</item>
+        <item>@string/account_settings_attachment_cleanup_30</item>
+        <item>@string/account_settings_attachment_cleanup_90</item>
+        <item>@string/account_settings_attachment_cleanup_365</item>
+    </string-array>
+
     <string-array name="show_pictures_entries">
         <item>@string/account_settings_show_pictures_never</item>
         <item>@string/account_settings_show_pictures_only_from_contacts</item>

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -525,6 +525,12 @@
     <string name="account_settings_autodownload_message_size_5120">5 MiB</string>
     <string name="account_settings_autodownload_message_size_10240">10 MiB</string>
     <string name="account_settings_autodownload_message_size_any">any size (no limit)</string>
+    <string name="account_settings_attachment_cleanup_label">Remove old downloaded attachments</string>
+    <string name="account_settings_attachment_cleanup_summary">Deletes local copies of downloaded attachments older than the selected age. Messages stay on this device and attachments can be downloaded again.</string>
+    <string name="account_settings_attachment_cleanup_never">never</string>
+    <string name="account_settings_attachment_cleanup_30">after 30 days</string>
+    <string name="account_settings_attachment_cleanup_90">after 90 days</string>
+    <string name="account_settings_attachment_cleanup_365">after 1 year</string>
 
     <string name="account_settings_message_age_label">Sync messages from</string>
     <string name="account_settings_message_age_any">any time (no limit)</string>

--- a/legacy/ui/legacy/src/main/res/xml/account_settings.xml
+++ b/legacy/ui/legacy/src/main/res/xml/account_settings.xml
@@ -54,6 +54,15 @@
             />
 
         <ListPreference
+            android:dialogTitle="@string/account_settings_attachment_cleanup_label"
+            android:entries="@array/attachment_cleanup_entries"
+            android:entryValues="@array/attachment_cleanup_values"
+            android:key="account_attachment_cleanup"
+            android:summary="@string/account_settings_attachment_cleanup_summary"
+            android:title="@string/account_settings_attachment_cleanup_label"
+            />
+
+        <ListPreference
             android:dialogTitle="@string/account_settings_mail_check_frequency_label"
             android:entries="@array/check_frequency_entries"
             android:entryValues="@array/check_frequency_values"


### PR DESCRIPTION
## Summary

Adds an account-level setting to remove locally downloaded attachments from IMAP messages older than a selected age. Intention is to save local space.

Message and attachment metadata are preserved so attachments can still be fetched again from the server when requested.

I wired this into the existing legacy account settings/storage path because account settings are still mostly there. 

## Notes

- Adds configurable attachment cleanup age with a default of disabled.
- Schedules periodic WorkManager cleanup for eligible IMAP accounts.
- Runs a one-time cleanup when the setting changes.
- Removes only local attachment payloads for old messages; message records and attachment parts remain.
- Does not automatically re-download attachments when the retention window is changed or disabled.
- Keeps cleanup scoped to explicit attachments, with tests covering inline/folded disposition cases.
- I used GPT codex to help me explore the codebase and draft things. Also had it add more tests.