### PR TITLE
fix: reduce message list widget font sizes for large system font scales

### DIFF
--- a/feature/widget/message-list/src/main/res/layout/message_list_widget_list_item.xml
+++ b/feature/widget/message-list/src/main/res/layout/message_list_widget_list_item.xml
@@ -71,7 +71,7 @@
             android:layout_toStartOf="@id/thread_count"
             android:ellipsize="end"
             android:maxLines="1"
-            android:textSize="16sp"
+            android:textSize="14sp"
             tools:text="Kinda long subject that should be long enough to exceed the available display space"
             />
 
@@ -84,7 +84,7 @@
             android:ellipsize="end"
             android:maxLines="1"
             android:paddingBottom="2dp"
-            android:textSize="15sp"
+            android:textSize="13sp"
             tools:text="Wikipedia"
             />
 
@@ -95,7 +95,7 @@
             android:layout_below="@+id/mail_subject"
             android:layout_alignParentStart="true"
             android:maxLines="1"
-            android:textSize="13sp"
+            android:textSize="11sp"
             tools:text="Towel Day is celebrated every year on 25 May as a tribute to the author Douglas Adams by his fans."
             />
 


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket:  #7790

#### Description

Reduced the font sizes used in the message list home widget for:

Sender
Subject
Preview text

This improves readability when larger Android system font scales are enabled and prevents the widget content from appearing excessively large.

#### Screen Shots

Screenshots are not attached because they contain personal email information.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [ ] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).
