### PR TITLE
feat: add core UI testing

### DIFF
--- a/app-common/build.gradle.kts
+++ b/app-common/build.gradle.kts
@@ -69,6 +69,8 @@ dependencies {
     testImplementation(projects.core.testing)
     testImplementation(projects.core.android.testing)
     testImplementation(projects.core.logging.testing)
+
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/app-k9mail/src/test/kotlin/app/k9mail/DependencyInjectionTest.kt
+++ b/app-k9mail/src/test/kotlin/app/k9mail/DependencyInjectionTest.kt
@@ -21,6 +21,7 @@ import com.fsck.k9.message.html.DisplayHtmlFactory
 import com.fsck.k9.ui.helper.DisplayHtmlUiFactory
 import com.fsck.k9.view.K9WebViewClient
 import com.fsck.k9.view.MessageWebView
+import kotlin.test.Test
 import net.openid.appauth.AppAuthConfiguration
 import net.thunderbird.core.common.mail.html.HtmlSettings
 import net.thunderbird.core.preference.storage.Storage
@@ -30,7 +31,6 @@ import net.thunderbird.feature.mail.message.list.ui.dialog.SetupArchiveFolderDia
 import net.thunderbird.feature.mail.message.reader.api.css.CssClassNameProvider
 import net.thunderbird.feature.navigation.changelog.api.ChangeLogMode
 import net.thunderbird.feature.thundermail.internal.common.ui.ThundermailContract
-import org.junit.Test
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.verify.definition
 import org.koin.test.verify.injectedParameters

--- a/app-thunderbird/src/test/kotlin/net/thunderbird/android/DependencyInjectionTest.kt
+++ b/app-thunderbird/src/test/kotlin/net/thunderbird/android/DependencyInjectionTest.kt
@@ -21,6 +21,7 @@ import com.fsck.k9.message.html.DisplayHtmlFactory
 import com.fsck.k9.ui.helper.DisplayHtmlUiFactory
 import com.fsck.k9.view.K9WebViewClient
 import com.fsck.k9.view.MessageWebView
+import kotlin.test.Test
 import net.openid.appauth.AppAuthConfiguration
 import net.thunderbird.core.common.mail.html.HtmlSettings
 import net.thunderbird.core.preference.storage.Storage
@@ -30,7 +31,6 @@ import net.thunderbird.feature.mail.message.list.ui.dialog.SetupArchiveFolderDia
 import net.thunderbird.feature.mail.message.reader.api.css.CssClassNameProvider
 import net.thunderbird.feature.navigation.changelog.api.ChangeLogMode
 import net.thunderbird.feature.thundermail.internal.common.ui.ThundermailContract
-import org.junit.Test
 import org.koin.core.annotation.KoinExperimentalAPI
 import org.koin.test.verify.definition
 import org.koin.test.verify.injectedParameters

--- a/app-thunderbird/src/test/kotlin/net/thunderbird/android/TbAppIconNotificationProviderTest.kt
+++ b/app-thunderbird/src/test/kotlin/net/thunderbird/android/TbAppIconNotificationProviderTest.kt
@@ -2,8 +2,8 @@ package net.thunderbird.android
 
 import assertk.assertThat
 import assertk.assertions.isEqualTo
+import kotlin.test.Test
 import net.thunderbird.android.provider.TbAppIconNotificationProvider
-import org.junit.Test
 
 class TbAppIconNotificationProviderTest {
     @Test

--- a/backend/imap/build.gradle.kts
+++ b/backend/imap/build.gradle.kts
@@ -21,7 +21,9 @@ dependencies {
     testImplementation(projects.core.logging.testing)
     testImplementation(projects.mail.testing)
     testImplementation(projects.backend.testing)
+
     testImplementation(libs.mime4j.dom)
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/core/android/common/build.gradle.kts
+++ b/core/android/common/build.gradle.kts
@@ -13,6 +13,7 @@ dependencies {
 
     testImplementation(projects.core.testing)
     testImplementation(libs.robolectric)
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/core/android/logging/build.gradle.kts
+++ b/core/android/logging/build.gradle.kts
@@ -9,6 +9,8 @@ android {
 dependencies {
     implementation(libs.timber)
     implementation(libs.commons.io)
+
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/core/android/testing/build.gradle.kts
+++ b/core/android/testing/build.gradle.kts
@@ -16,7 +16,8 @@ dependencies {
 
     api(libs.koin.core)
     api(libs.mockito.core)
-    api(libs.mockito.kotlin)
+
+    implementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/core/ui/compose/designsystem/src/test/kotlin/app/k9mail/core/ui/compose/designsystem/organism/AlertDialogKtTest.kt
+++ b/core/ui/compose/designsystem/src/test/kotlin/app/k9mail/core/ui/compose/designsystem/organism/AlertDialogKtTest.kt
@@ -2,11 +2,11 @@ package app.k9mail.core.ui.compose.designsystem.organism
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.ui.test.performClick
-import androidx.test.espresso.Espresso
 import app.k9mail.core.ui.compose.designsystem.atom.text.TextTitleMedium
 import app.k9mail.core.ui.compose.testing.ComposeTest
 import app.k9mail.core.ui.compose.testing.onNodeWithText
 import app.k9mail.core.ui.compose.testing.onNodeWithTextIgnoreCase
+import app.k9mail.core.ui.compose.testing.pressBack
 import app.k9mail.core.ui.compose.testing.setContentWithTheme
 import assertk.assertThat
 import assertk.assertions.isTrue
@@ -88,7 +88,7 @@ class AlertDialogKtTest : ComposeTest() {
             }
         }
 
-        Espresso.pressBack()
+        pressBack()
 
         assertThat(dismissed).isTrue()
     }

--- a/core/ui/contract/build.gradle.kts
+++ b/core/ui/contract/build.gradle.kts
@@ -16,6 +16,7 @@ kotlin {
 
         commonTest.dependencies {
             implementation(projects.core.testing)
+            implementation(projects.core.ui.testing)
         }
 
         jvmTest.dependencies {

--- a/core/ui/contract/src/commonTest/kotlin/net/thunderbird/core/ui/contract/mvi/UnidirectionalViewModelKtTest.kt
+++ b/core/ui/contract/src/commonTest/kotlin/net/thunderbird/core/ui/contract/mvi/UnidirectionalViewModelKtTest.kt
@@ -5,10 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import assertk.assertThat
 import assertk.assertions.isEqualTo
-import kotlin.test.AfterTest
-import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -18,29 +15,15 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.StandardTestDispatcher
-import net.thunderbird.core.testing.coroutines.MainDispatcherHelper
 import net.thunderbird.core.ui.testing.ComposeUiTestHarness
 
-@OptIn(ExperimentalCoroutinesApi::class)
-class UnidirectionalViewModelKtTest : ComposeUiTestHarness() {
-
-    private val mainDispatcher = MainDispatcherHelper(StandardTestDispatcher())
-
-    @BeforeTest
-    fun setUp() {
-        mainDispatcher.setUp()
-    }
-
-    @AfterTest
-    fun tearDown() {
-        mainDispatcher.tearDown()
-    }
+class UnidirectionalViewModelKtTest : ComposeUiTestHarness(
+    mainDispatcher = StandardTestDispatcher(),
+) {
 
     @OptIn(ExperimentalTestApi::class)
     @Test
-    fun `observe should emit state changes, allow event dispatch and expose effects`() = runComposeTest(
-        effectContext = mainDispatcher.testDispatcher,
-    ) {
+    fun `observe should emit state changes, allow event dispatch and expose effects`() = runComposeTest {
         val viewModel = TestViewModel()
         val effects = mutableListOf<TestEffect>()
         lateinit var stateDispatch: StateDispatch<TestState, TestEvent>

--- a/core/ui/contract/src/commonTest/kotlin/net/thunderbird/core/ui/contract/mvi/UnidirectionalViewModelKtTest.kt
+++ b/core/ui/contract/src/commonTest/kotlin/net/thunderbird/core/ui/contract/mvi/UnidirectionalViewModelKtTest.kt
@@ -1,7 +1,6 @@
 package net.thunderbird.core.ui.contract.mvi
 
 import androidx.compose.ui.test.ExperimentalTestApi
-import androidx.compose.ui.test.runComposeUiTest
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import assertk.assertThat
@@ -18,13 +17,14 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import net.thunderbird.core.testing.coroutines.MainDispatcherHelper
+import net.thunderbird.core.ui.testing.ComposeUiTestHarness
 
-class UnidirectionalViewModelKtTest {
+@OptIn(ExperimentalCoroutinesApi::class)
+class UnidirectionalViewModelKtTest : ComposeUiTestHarness() {
 
-    @OptIn(ExperimentalCoroutinesApi::class)
-    val mainDispatcher = MainDispatcherHelper(UnconfinedTestDispatcher())
+    private val mainDispatcher = MainDispatcherHelper(StandardTestDispatcher())
 
     @BeforeTest
     fun setUp() {
@@ -38,7 +38,9 @@ class UnidirectionalViewModelKtTest {
 
     @OptIn(ExperimentalTestApi::class)
     @Test
-    fun `observe should emit state changes, allow event dispatch and expose effects`() = runComposeUiTest {
+    fun `observe should emit state changes, allow event dispatch and expose effects`() = runComposeTest(
+        effectContext = mainDispatcher.testDispatcher,
+    ) {
         val viewModel = TestViewModel()
         val effects = mutableListOf<TestEffect>()
         lateinit var stateDispatch: StateDispatch<TestState, TestEvent>
@@ -56,12 +58,14 @@ class UnidirectionalViewModelKtTest {
 
         // Dispatch an event
         dispatch(TestEvent("Event 1"))
+        waitForIdle()
 
         assertThat(state.value.data).isEqualTo("TestState: Event 1")
         assertThat(effects.last().result).isEqualTo("TestEffect: Event 1")
 
         // Dispatch another event
         dispatch(TestEvent("Event 2"))
+        waitForIdle()
 
         assertThat(state.value.data).isEqualTo("TestState: Event 2")
         assertThat(effects.last().result).isEqualTo("TestEffect: Event 2")

--- a/core/ui/testing/README.md
+++ b/core/ui/testing/README.md
@@ -36,7 +36,7 @@ fun runComposeTest(
 )
 ```
 
-The harness passes these values to Compose unchanged:
+The harness passes these values to Compose:
 
 - `effectContext` is used for composition, `LaunchedEffect`, `rememberCoroutineScope`, and the main test clock.
 - `runTestContext` is used for the test block.
@@ -44,6 +44,29 @@ The harness passes these values to Compose unchanged:
 
 Do not pass the same `TestDispatcher` or scheduler to both `effectContext` and `runTestContext`. Compose requires these
 contexts to not share a `TestCoroutineScheduler`.
+
+If the code under test uses `Dispatchers.Main`, `viewModelScope`, or lifecycle APIs that access
+`Dispatchers.Main.immediate`, configure a main dispatcher once on the test class. When `effectContext` is left as
+`EmptyCoroutineContext`, the harness uses that same dispatcher as Compose's effect context.
+
+```kotlin
+class ExampleTest : ComposeUiTestHarness(
+    mainDispatcher = StandardTestDispatcher(),
+) {
+
+    @Test
+    fun `event updates state`() = runComposeTest {
+        setContent {
+            Screen()
+        }
+
+        onNodeWithText("Submit").performClick()
+        waitForIdle()
+
+        onNodeWithText("Submitted").assertExists()
+    }
+}
+```
 
 ## Standard Dispatcher
 
@@ -65,6 +88,8 @@ fun `event updates state`() = runComposeTest(
     onNodeWithText("Submitted").assertExists()
 }
 ```
+
+If the harness already has a `mainDispatcher`, leave `effectContext` as its default to reuse the class-level dispatcher.
 
 ## Unconfined Dispatcher
 

--- a/core/ui/testing/README.md
+++ b/core/ui/testing/README.md
@@ -1,0 +1,96 @@
+# Core UI Testing
+
+This module provides shared test utilities for Compose UI tests.
+
+## Compose UI Test Harness
+
+Use `ComposeUiTestHarness` for tests that exercise Compose UI from common test code.
+
+```kotlin
+class ExampleTest : ComposeUiTestHarness() {
+
+    @Test
+    fun `content is shown`() = runComposeTest {
+        setContent {
+            ExampleContent()
+        }
+
+        onNodeWithText("Example").assertExists()
+    }
+}
+```
+
+The harness wraps the platform-specific `runComposeUiTest` implementation and exposes a common
+`ComposeUiTestScope`.
+
+## Dispatcher Handling
+
+`runComposeTest` mirrors Compose's `runComposeUiTest` dispatcher API:
+
+```kotlin
+fun runComposeTest(
+    effectContext: CoroutineContext = EmptyCoroutineContext,
+    runTestContext: CoroutineContext = EmptyCoroutineContext,
+    testTimeout: Duration = 60.seconds,
+    block: suspend ComposeUiTestScope.() -> Unit,
+)
+```
+
+The harness passes these values to Compose unchanged:
+
+- `effectContext` is used for composition, `LaunchedEffect`, `rememberCoroutineScope`, and the main test clock.
+- `runTestContext` is used for the test block.
+- `testTimeout` controls the timeout for the Compose test.
+
+Do not pass the same `TestDispatcher` or scheduler to both `effectContext` and `runTestContext`. Compose requires these
+contexts to not share a `TestCoroutineScheduler`.
+
+## Standard Dispatcher
+
+Use `StandardTestDispatcher` when the test needs explicit scheduler control. Work is queued, so call `waitForIdle()`
+before asserting results that depend on queued coroutine or Compose work.
+
+```kotlin
+@Test
+fun `event updates state`() = runComposeTest(
+    effectContext = StandardTestDispatcher(),
+) {
+    setContent {
+        Screen()
+    }
+
+    onNodeWithText("Submit").performClick()
+    waitForIdle()
+
+    onNodeWithText("Submitted").assertExists()
+}
+```
+
+## Unconfined Dispatcher
+
+Use `UnconfinedTestDispatcher` when the test benefits from eager execution and does not require explicit scheduler
+control. With this dispatcher, immediate assertions may not need `waitForIdle()`.
+
+```kotlin
+@Test
+fun `event updates state eagerly`() = runComposeTest(
+    effectContext = UnconfinedTestDispatcher(),
+) {
+    setContent {
+        Screen()
+    }
+
+    onNodeWithText("Submit").performClick()
+
+    onNodeWithText("Submitted").assertExists()
+}
+```
+
+## Verification
+
+Run the narrow module checks after changing this module:
+
+```shell
+./gradlew :core:ui:testing:jvmTest :core:ui:testing:testAndroidHostTest
+```
+

--- a/core/ui/testing/build.gradle.kts
+++ b/core/ui/testing/build.gradle.kts
@@ -1,0 +1,35 @@
+plugins {
+    id(ThunderbirdPlugins.Library.kmpCompose)
+}
+
+kotlin {
+    explicitApi()
+
+    android {
+        namespace = "net.thunderbird.core.ui.testing"
+
+        withHostTest {
+            isIncludeAndroidResources = true
+        }
+    }
+
+    sourceSets {
+        commonMain.dependencies {
+            implementation(libs.jetbrains.compose.ui.test)
+        }
+
+        androidMain.dependencies {
+            implementation(libs.kotlin.test.junit)
+            implementation(libs.robolectric)
+            implementation(libs.androidx.compose.ui.test.manifest)
+        }
+
+        jvmTest.dependencies {
+            implementation(compose.desktop.currentOs)
+        }
+    }
+}
+
+codeCoverage {
+    lineCoverage = 65
+}

--- a/core/ui/testing/build.gradle.kts
+++ b/core/ui/testing/build.gradle.kts
@@ -15,6 +15,9 @@ kotlin {
 
     sourceSets {
         commonMain.dependencies {
+            api(libs.kotlinx.coroutines.test)
+
+            implementation(projects.core.testing)
             implementation(libs.jetbrains.compose.ui.test)
         }
 

--- a/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/AndroidComposeUiTestScope.kt
+++ b/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/AndroidComposeUiTestScope.kt
@@ -36,4 +36,8 @@ internal class AndroidComposeUiTestScope(
         substring: Boolean,
         useUnmergedTree: Boolean,
     ) = delegate.onNodeWithText(text, substring, true, useUnmergedTree)
+
+    override fun waitForIdle() {
+        delegate.waitForIdle()
+    }
 }

--- a/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/AndroidComposeUiTestScope.kt
+++ b/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/AndroidComposeUiTestScope.kt
@@ -1,0 +1,39 @@
+package net.thunderbird.core.ui.testing
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+
+/**
+ * A scope for Compose UI tests on Android.
+ *
+ * It delegates scope calls to the ComposeUiTest instance.
+ *
+ * @param delegate the ComposeUiTest instance to delegate to
+ */
+@OptIn(ExperimentalTestApi::class)
+internal class AndroidComposeUiTestScope(
+    private val delegate: ComposeUiTest,
+) : ComposeUiTestScope {
+    override fun setContent(content: @Composable () -> Unit) {
+        delegate.setContent(content)
+    }
+
+    override fun onNodeWithTag(tag: String, useUnmergedTree: Boolean) =
+        delegate.onNodeWithTag(tag, useUnmergedTree)
+
+    override fun onNodeWithText(
+        text: String,
+        substring: Boolean,
+        ignoreCase: Boolean,
+        useUnmergedTree: Boolean,
+    ) = delegate.onNodeWithText(text, substring, ignoreCase, useUnmergedTree)
+
+    override fun onNodeWithTextIgnoreCase(
+        text: String,
+        substring: Boolean,
+        useUnmergedTree: Boolean,
+    ) = delegate.onNodeWithText(text, substring, true, useUnmergedTree)
+}

--- a/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.android.kt
+++ b/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.android.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
+import kotlinx.coroutines.test.TestDispatcher
+import net.thunderbird.core.testing.coroutines.MainDispatcherHelper
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
@@ -14,7 +16,9 @@ import org.robolectric.RobolectricTestRunner
  */
 @OptIn(ExperimentalTestApi::class)
 @RunWith(RobolectricTestRunner::class)
-public actual abstract class ComposeUiTestHarness actual constructor() {
+public actual abstract class ComposeUiTestHarness actual constructor(
+    private val mainDispatcher: TestDispatcher?,
+) {
 
     /**
      * Runs [block] inside `runComposeUiTest`.
@@ -25,12 +29,20 @@ public actual abstract class ComposeUiTestHarness actual constructor() {
         testTimeout: Duration,
         block: suspend ComposeUiTestScope.() -> Unit,
     ) {
-        runComposeUiTest(
-            effectContext = effectContext,
-            runTestContext = runTestContext,
-            testTimeout = testTimeout,
-        ) {
-            AndroidComposeUiTestScope(this).block()
+        val mainDispatcherHelper = mainDispatcher?.let(::MainDispatcherHelper)
+        val resolvedEffectContext = resolveEffectContext(effectContext, mainDispatcher)
+
+        try {
+            mainDispatcherHelper?.setUp()
+            runComposeUiTest(
+                effectContext = resolvedEffectContext,
+                runTestContext = runTestContext,
+                testTimeout = testTimeout,
+            ) {
+                AndroidComposeUiTestScope(this).block()
+            }
+        } finally {
+            mainDispatcherHelper?.tearDown()
         }
     }
 }

--- a/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.android.kt
+++ b/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.android.kt
@@ -1,0 +1,24 @@
+package net.thunderbird.core.ui.testing
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+/**
+ * Android implementation of [ComposeUiTestHarness].
+ *
+ * It uses Robolectric to run the tests and pro.
+ */
+@OptIn(ExperimentalTestApi::class)
+@RunWith(RobolectricTestRunner::class)
+public actual abstract class ComposeUiTestHarness actual constructor() {
+
+    public actual fun runComposeTest(
+        block: ComposeUiTestScope.() -> Unit,
+    ) {
+        runComposeUiTest {
+            AndroidComposeUiTestScope(this).block()
+        }
+    }
+}

--- a/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.android.kt
+++ b/core/ui/testing/src/androidMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.android.kt
@@ -2,22 +2,34 @@ package net.thunderbird.core.ui.testing
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
 import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 /**
  * Android implementation of [ComposeUiTestHarness].
  *
- * It uses Robolectric to run the tests and pro.
+ * It runs Compose UI tests with Robolectric.
  */
 @OptIn(ExperimentalTestApi::class)
 @RunWith(RobolectricTestRunner::class)
 public actual abstract class ComposeUiTestHarness actual constructor() {
 
+    /**
+     * Runs [block] inside `runComposeUiTest`.
+     */
     public actual fun runComposeTest(
-        block: ComposeUiTestScope.() -> Unit,
+        effectContext: CoroutineContext,
+        runTestContext: CoroutineContext,
+        testTimeout: Duration,
+        block: suspend ComposeUiTestScope.() -> Unit,
     ) {
-        runComposeUiTest {
+        runComposeUiTest(
+            effectContext = effectContext,
+            runTestContext = runTestContext,
+            testTimeout = testTimeout,
+        ) {
             AndroidComposeUiTestScope(this).block()
         }
     }

--- a/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.kt
+++ b/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.kt
@@ -1,0 +1,18 @@
+package net.thunderbird.core.ui.testing
+
+/**
+ * Platform-agnostic test harness for Compose UI tests.
+ *
+ * It wraps the platform-specific implementation of the test harness to allow for consistent testing across platforms.
+ */
+public expect abstract class ComposeUiTestHarness() {
+
+    /**
+     * Run a compose UI test harness with the provided block.
+     *
+     * @param block The block of code to execute within the Compose UI test harness.
+     */
+    public fun runComposeTest(
+        block: ComposeUiTestScope.() -> Unit,
+    )
+}

--- a/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.kt
+++ b/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.kt
@@ -4,14 +4,21 @@ import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.EmptyCoroutineContext
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
+import kotlinx.coroutines.test.TestDispatcher
 
 /**
  * Platform-agnostic test harness for Compose UI tests.
  *
  * The harness wraps the platform-specific [androidx.compose.ui.test.v2.runComposeUiTest] implementation and exposes a
  * common [ComposeUiTestScope].
+ *
+ * @param mainDispatcher Optional dispatcher to install as [kotlinx.coroutines.Dispatchers.Main] for each
+ * [runComposeTest] call. When set and [runComposeTest] uses the default [effectContext], the same dispatcher is also
+ * used as Compose's effect context.
  */
-public expect abstract class ComposeUiTestHarness() {
+public expect abstract class ComposeUiTestHarness(
+    mainDispatcher: TestDispatcher? = null,
+) {
 
     /**
      * Runs a Compose UI test.
@@ -19,9 +26,11 @@ public expect abstract class ComposeUiTestHarness() {
      * The parameters mirror [androidx.compose.ui.test.v2.runComposeUiTest]. [effectContext] is used for composition,
      * `LaunchedEffect`, `rememberCoroutineScope`, and the main test clock. [runTestContext] is used for the test block.
      * Compose requires these contexts to not share a [kotlinx.coroutines.test.TestCoroutineScheduler].
+     * If this harness was created with a main dispatcher and [effectContext] is left as [EmptyCoroutineContext], the main
+     * dispatcher is used as [effectContext].
      *
      * @param effectContext The [CoroutineContext] to use for the [androidx.compose.ui.test.v2.runComposeUiTest] implementation.
-     * @param runTestContext The [kotlinx.coroutines.test.StandardTestDispatcher] to use for the [androidx.compose.ui.test.v2.runComposeUiTest] implementation.
+     * @param runTestContext The [CoroutineContext] to use for the [androidx.compose.ui.test.v2.runComposeUiTest] implementation.
      * @param testTimeout The timeout for the test, defaults to 60 seconds.
      * @param block The block of code to execute within the Compose UI test harness.
      */
@@ -31,4 +40,13 @@ public expect abstract class ComposeUiTestHarness() {
         testTimeout: Duration = 60.seconds,
         block: suspend ComposeUiTestScope.() -> Unit,
     )
+}
+
+internal fun resolveEffectContext(
+    effectContext: CoroutineContext,
+    mainDispatcher: TestDispatcher?,
+): CoroutineContext = if (effectContext == EmptyCoroutineContext && mainDispatcher != null) {
+    mainDispatcher
+} else {
+    effectContext
 }

--- a/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.kt
+++ b/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.kt
@@ -1,18 +1,34 @@
 package net.thunderbird.core.ui.testing
 
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
 /**
  * Platform-agnostic test harness for Compose UI tests.
  *
- * It wraps the platform-specific implementation of the test harness to allow for consistent testing across platforms.
+ * The harness wraps the platform-specific [androidx.compose.ui.test.v2.runComposeUiTest] implementation and exposes a
+ * common [ComposeUiTestScope].
  */
 public expect abstract class ComposeUiTestHarness() {
 
     /**
-     * Run a compose UI test harness with the provided block.
+     * Runs a Compose UI test.
      *
+     * The parameters mirror [androidx.compose.ui.test.v2.runComposeUiTest]. [effectContext] is used for composition,
+     * `LaunchedEffect`, `rememberCoroutineScope`, and the main test clock. [runTestContext] is used for the test block.
+     * Compose requires these contexts to not share a [kotlinx.coroutines.test.TestCoroutineScheduler].
+     *
+     * @param effectContext The [CoroutineContext] to use for the [androidx.compose.ui.test.v2.runComposeUiTest] implementation.
+     * @param runTestContext The [kotlinx.coroutines.test.StandardTestDispatcher] to use for the [androidx.compose.ui.test.v2.runComposeUiTest] implementation.
+     * @param testTimeout The timeout for the test, defaults to 60 seconds.
      * @param block The block of code to execute within the Compose UI test harness.
      */
     public fun runComposeTest(
-        block: ComposeUiTestScope.() -> Unit,
+        effectContext: CoroutineContext = EmptyCoroutineContext,
+        runTestContext: CoroutineContext = EmptyCoroutineContext,
+        testTimeout: Duration = 60.seconds,
+        block: suspend ComposeUiTestScope.() -> Unit,
     )
 }

--- a/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestScope.kt
+++ b/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestScope.kt
@@ -1,0 +1,58 @@
+package net.thunderbird.core.ui.testing
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import androidx.compose.ui.test.SemanticsNodeInteractionCollection
+
+/**
+ * A scope for Compose UI tests. It provides a platform agnostic way to use ComposeUiTest API.
+ */
+public interface ComposeUiTestScope {
+
+    /**
+     * Sets the content of the Compose UI test scope.
+     */
+    public fun setContent(content: @Composable () -> Unit)
+
+    /**
+     * Find a node with the given [tag].
+     *
+     * @param tag The tag of the node to find.
+     * @param useUnmergedTree Whether to use the unmerged tree.
+     * @return A [SemanticsNodeInteractionCollection] containing the found nodes.
+     */
+    public fun onNodeWithTag(
+        tag: String,
+        useUnmergedTree: Boolean = false,
+    ): SemanticsNodeInteraction
+
+    /**
+     * Find a node with the given [text].
+     *
+     * @param text The text of the node to find.
+     * @param substring Whether to search for a substring of the text.
+     * @param ignoreCase Whether to ignore case when searching for the text.
+     * @param useUnmergedTree Whether to use the unmerged tree.
+     * @return A [SemanticsNodeInteractionCollection] containing the found nodes.
+     */
+    public fun onNodeWithText(
+        text: String,
+        substring: Boolean = false,
+        ignoreCase: Boolean = false,
+        useUnmergedTree: Boolean = false,
+    ): SemanticsNodeInteraction
+
+    /**
+     * Find a node with the given [text] ignoring case.
+     *
+     * @param text The text of the node to find.
+     * @param substring Whether to search for a substring of the text.
+     * @param useUnmergedTree Whether to use the unmerged tree.
+     * @return A [List<SemanticsNodeInteractionCollection>] containing the found nodes.
+     */
+    public fun onNodeWithTextIgnoreCase(
+        text: String,
+        substring: Boolean = false,
+        useUnmergedTree: Boolean = false,
+    ): SemanticsNodeInteraction
+}

--- a/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestScope.kt
+++ b/core/ui/testing/src/commonMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestScope.kt
@@ -55,4 +55,9 @@ public interface ComposeUiTestScope {
         substring: Boolean = false,
         useUnmergedTree: Boolean = false,
     ): SemanticsNodeInteraction
+
+    /**
+     * Waits for the Compose UI to be idle.
+     */
+    public fun waitForIdle()
 }

--- a/core/ui/testing/src/commonTest/kotlin/net/thunderbird/core/ui/testing/ValidateComposeUiTestHarness.kt
+++ b/core/ui/testing/src/commonTest/kotlin/net/thunderbird/core/ui/testing/ValidateComposeUiTestHarness.kt
@@ -4,9 +4,6 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.text.BasicText
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.test.SemanticsNodeInteraction
-import assertk.assertThat
-import assertk.assertions.isInstanceOf
 import kotlin.test.Test
 
 class ValidateComposeUiTestHarness : ComposeUiTestHarness() {

--- a/core/ui/testing/src/commonTest/kotlin/net/thunderbird/core/ui/testing/ValidateComposeUiTestHarness.kt
+++ b/core/ui/testing/src/commonTest/kotlin/net/thunderbird/core/ui/testing/ValidateComposeUiTestHarness.kt
@@ -1,0 +1,59 @@
+package net.thunderbird.core.ui.testing
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.text.BasicText
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.test.SemanticsNodeInteraction
+import assertk.assertThat
+import assertk.assertions.isInstanceOf
+import kotlin.test.Test
+
+class ValidateComposeUiTestHarness : ComposeUiTestHarness() {
+
+    @Test
+    fun `setContent should set the content for Compose UI test`() = runComposeTest {
+        setContent {
+            Column {
+                BasicText("Hello, Compose!", modifier = Modifier.testTag("text"))
+            }
+        }
+
+        onNodeWithTag("text").assertExists()
+    }
+
+    @Test
+    fun `onNodeWithTag should find node with tag`() = runComposeTest {
+        setContent {
+            Column {
+                BasicText("Hello, Compose!", modifier = Modifier.testTag("text"))
+            }
+        }
+
+        onNodeWithTag("text").assertExists()
+        onNodeWithTag("text", useUnmergedTree = true).assertExists()
+    }
+
+    @Test
+    fun `onNodeWithText should find node with text`() = runComposeTest {
+        setContent {
+            BasicText("Hello, Compose!")
+        }
+
+        onNodeWithText("Hello, Compose!").assertExists()
+        onNodeWithText("Hello", substring = true).assertExists()
+        onNodeWithText("HELLO, COMPOSE!", ignoreCase = true).assertExists()
+        onNodeWithText("Hello, Compose!", useUnmergedTree = true).assertExists()
+    }
+
+    @Test
+    fun `onNodeWithTextIgnoreCase should find node ignoring case`() = runComposeTest {
+        setContent {
+            BasicText("Hello, Compose!")
+        }
+
+        onNodeWithTextIgnoreCase("HELLO, COMPOSE!").assertExists()
+        onNodeWithTextIgnoreCase("HELLO", substring = true).assertExists()
+        onNodeWithTextIgnoreCase("HELLO, COMPOSE!", useUnmergedTree = true).assertExists()
+    }
+}

--- a/core/ui/testing/src/commonTest/kotlin/net/thunderbird/core/ui/testing/ValidateComposeUiTestHarnessMainDispatcher.kt
+++ b/core/ui/testing/src/commonTest/kotlin/net/thunderbird/core/ui/testing/ValidateComposeUiTestHarnessMainDispatcher.kt
@@ -1,0 +1,46 @@
+package net.thunderbird.core.ui.testing
+
+import assertk.assertThat
+import assertk.assertions.isSameInstanceAs
+import kotlin.coroutines.EmptyCoroutineContext
+import kotlin.test.Test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.TestCoroutineScheduler
+
+private val mainDispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+private val explicitEffectDispatcher = StandardTestDispatcher(TestCoroutineScheduler())
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ValidateComposeUiTestHarnessMainDispatcher {
+
+    @Test
+    fun `resolveEffectContext should use main dispatcher for default effect context`() {
+        val result = resolveEffectContext(
+            effectContext = EmptyCoroutineContext,
+            mainDispatcher = mainDispatcher,
+        )
+
+        assertThat(result).isSameInstanceAs(mainDispatcher)
+    }
+
+    @Test
+    fun `resolveEffectContext should preserve default effect context when main dispatcher is absent`() {
+        val result = resolveEffectContext(
+            effectContext = EmptyCoroutineContext,
+            mainDispatcher = null,
+        )
+
+        assertThat(result).isSameInstanceAs(EmptyCoroutineContext)
+    }
+
+    @Test
+    fun `resolveEffectContext should use explicit effect context over main dispatcher`() {
+        val result = resolveEffectContext(
+            effectContext = explicitEffectDispatcher,
+            mainDispatcher = mainDispatcher,
+        )
+
+        assertThat(result).isSameInstanceAs(explicitEffectDispatcher)
+    }
+}

--- a/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.jvm.kt
+++ b/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.jvm.kt
@@ -2,19 +2,31 @@ package net.thunderbird.core.ui.testing
 
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
+import kotlin.coroutines.CoroutineContext
+import kotlin.time.Duration
 
 /**
  * JVM implementation of [ComposeUiTestHarness].
  *
- * It uses JUnit to run the tests.
+ * It runs Compose UI tests with JUnit.
  */
 @OptIn(ExperimentalTestApi::class)
 public actual abstract class ComposeUiTestHarness actual constructor() {
 
+    /**
+     * Runs [block] inside `runComposeUiTest`.
+     */
     public actual fun runComposeTest(
-        block: ComposeUiTestScope.() -> Unit,
+        effectContext: CoroutineContext,
+        runTestContext: CoroutineContext,
+        testTimeout: Duration,
+        block: suspend ComposeUiTestScope.() -> Unit,
     ) {
-        runComposeUiTest {
+        runComposeUiTest(
+            effectContext = effectContext,
+            runTestContext = runTestContext,
+            testTimeout = testTimeout,
+        ) {
             JvmComposeUiTestScope(this).block()
         }
     }

--- a/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.jvm.kt
+++ b/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.jvm.kt
@@ -4,6 +4,8 @@ import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.v2.runComposeUiTest
 import kotlin.coroutines.CoroutineContext
 import kotlin.time.Duration
+import kotlinx.coroutines.test.TestDispatcher
+import net.thunderbird.core.testing.coroutines.MainDispatcherHelper
 
 /**
  * JVM implementation of [ComposeUiTestHarness].
@@ -11,7 +13,9 @@ import kotlin.time.Duration
  * It runs Compose UI tests with JUnit.
  */
 @OptIn(ExperimentalTestApi::class)
-public actual abstract class ComposeUiTestHarness actual constructor() {
+public actual abstract class ComposeUiTestHarness actual constructor(
+    private val mainDispatcher: TestDispatcher?,
+) {
 
     /**
      * Runs [block] inside `runComposeUiTest`.
@@ -22,12 +26,20 @@ public actual abstract class ComposeUiTestHarness actual constructor() {
         testTimeout: Duration,
         block: suspend ComposeUiTestScope.() -> Unit,
     ) {
-        runComposeUiTest(
-            effectContext = effectContext,
-            runTestContext = runTestContext,
-            testTimeout = testTimeout,
-        ) {
-            JvmComposeUiTestScope(this).block()
+        val mainDispatcherHelper = mainDispatcher?.let(::MainDispatcherHelper)
+        val resolvedEffectContext = resolveEffectContext(effectContext, mainDispatcher)
+
+        try {
+            mainDispatcherHelper?.setUp()
+            runComposeUiTest(
+                effectContext = resolvedEffectContext,
+                runTestContext = runTestContext,
+                testTimeout = testTimeout,
+            ) {
+                JvmComposeUiTestScope(this).block()
+            }
+        } finally {
+            mainDispatcherHelper?.tearDown()
         }
     }
 }

--- a/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.jvm.kt
+++ b/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/ComposeUiTestHarness.jvm.kt
@@ -1,0 +1,21 @@
+package net.thunderbird.core.ui.testing
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.v2.runComposeUiTest
+
+/**
+ * JVM implementation of [ComposeUiTestHarness].
+ *
+ * It uses JUnit to run the tests.
+ */
+@OptIn(ExperimentalTestApi::class)
+public actual abstract class ComposeUiTestHarness actual constructor() {
+
+    public actual fun runComposeTest(
+        block: ComposeUiTestScope.() -> Unit,
+    ) {
+        runComposeUiTest {
+            JvmComposeUiTestScope(this).block()
+        }
+    }
+}

--- a/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/JvmComposeUiTestScope.kt
+++ b/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/JvmComposeUiTestScope.kt
@@ -36,4 +36,8 @@ internal class JvmComposeUiTestScope(
         substring: Boolean,
         useUnmergedTree: Boolean,
     ) = delegate.onNodeWithText(text, substring, true, useUnmergedTree)
+
+    override fun waitForIdle() {
+        delegate.waitForIdle()
+    }
 }

--- a/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/JvmComposeUiTestScope.kt
+++ b/core/ui/testing/src/jvmMain/kotlin/net/thunderbird/core/ui/testing/JvmComposeUiTestScope.kt
@@ -1,0 +1,39 @@
+package net.thunderbird.core.ui.testing
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+
+/**
+ * A scope for Compose UI tests on JVM.
+ *
+ * It delegates scope calls to the ComposeUiTest instance.
+ *
+ * @param delegate the ComposeUiTest instance to delegate to
+ */
+@OptIn(ExperimentalTestApi::class)
+internal class JvmComposeUiTestScope(
+    private val delegate: ComposeUiTest,
+) : ComposeUiTestScope {
+    override fun setContent(content: @Composable (() -> Unit)) {
+        delegate.setContent(content)
+    }
+
+    override fun onNodeWithTag(tag: String, useUnmergedTree: Boolean) =
+        delegate.onNodeWithTag(tag, useUnmergedTree)
+
+    override fun onNodeWithText(
+        text: String,
+        substring: Boolean,
+        ignoreCase: Boolean,
+        useUnmergedTree: Boolean,
+    ) = delegate.onNodeWithText(text, substring, ignoreCase, useUnmergedTree)
+
+    override fun onNodeWithTextIgnoreCase(
+        text: String,
+        substring: Boolean,
+        useUnmergedTree: Boolean,
+    ) = delegate.onNodeWithText(text, substring, true, useUnmergedTree)
+}

--- a/feature/account/oauth/build.gradle.kts
+++ b/feature/account/oauth/build.gradle.kts
@@ -26,6 +26,8 @@ dependencies {
 
     testImplementation(projects.core.logging.testing)
     testImplementation(projects.core.ui.compose.testing)
+
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/feature/funding/googleplay/build.gradle.kts
+++ b/feature/funding/googleplay/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
     testImplementation(libs.androidx.lifecycle.runtime.testing)
     testImplementation(libs.androidx.fragment.testing)
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/feature/mail/message/list/internal/build.gradle.kts
+++ b/feature/mail/message/list/internal/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     testImplementation(libs.bundles.shared.jvm.test.compose)
     testImplementation(libs.bundles.shared.jvm.android.compose.debug)
     testImplementation(projects.feature.notification.testing)
+
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/feature/navigation/drawer/dropdown/build.gradle.kts
+++ b/feature/navigation/drawer/dropdown/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     testImplementation(projects.core.ui.compose.testing)
     testImplementation(projects.core.logging.testing)
 
+    testImplementation(libs.mockito.kotlin)
+
     // Fakes
     debugImplementation(projects.feature.account.fake)
     testImplementation(projects.feature.account.fake)

--- a/feature/notification/api/build.gradle.kts
+++ b/feature/notification/api/build.gradle.kts
@@ -33,6 +33,9 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.bundles.shared.jvm.test)
         }
+        jvmTest.dependencies {
+            implementation(libs.mockito.kotlin)
+        }
     }
 }
 

--- a/feature/settings/import/build.gradle.kts
+++ b/feature/settings/import/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(libs.fastadapter)
 
     testImplementation(projects.core.logging.testing)
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/feature/widget/unread/build.gradle.kts
+++ b/feature/widget/unread/build.gradle.kts
@@ -14,6 +14,8 @@ dependencies {
 
     testImplementation(libs.robolectric)
     testImplementation(projects.core.logging.testing)
+
+    testImplementation(libs.mockito.kotlin)
 }
 
 android {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -391,8 +391,6 @@ shared-jvm-test = [
   "kotlin-test",
   "kotlin-test-junit",
   "kotlinx-coroutines-test",
-  "mockito-core",
-  "mockito-kotlin",
   "turbine",
 ]
 shared-jvm-test-compose = [

--- a/legacy/common/src/test/java/com/fsck/k9/account/DefaultDeletePolicyProviderTest.kt
+++ b/legacy/common/src/test/java/com/fsck/k9/account/DefaultDeletePolicyProviderTest.kt
@@ -4,9 +4,9 @@ import assertk.assertFailure
 import assertk.assertThat
 import assertk.assertions.isEqualTo
 import assertk.assertions.isInstanceOf
+import kotlin.test.Test
 import net.thunderbird.core.android.account.DeletePolicy
 import net.thunderbird.core.common.mail.Protocols
-import org.junit.Test
 
 class DefaultDeletePolicyProviderTest {
     private val deletePolicyProvider = DefaultDeletePolicyProvider()

--- a/legacy/core/build.gradle.kts
+++ b/legacy/core/build.gradle.kts
@@ -65,6 +65,7 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.androidx.test.core)
     testImplementation(libs.jdom2)
+    testImplementation(libs.mockito.kotlin)
 
     // test fakes
     testImplementation(projects.feature.account.fake)

--- a/legacy/mailstore/build.gradle.kts
+++ b/legacy/mailstore/build.gradle.kts
@@ -17,6 +17,8 @@ dependencies {
     implementation(projects.feature.search.implLegacy)
 
     implementation(projects.mail.common)
+
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/MessageStoreManagerTest.kt
+++ b/legacy/mailstore/src/test/java/app/k9mail/legacy/mailstore/MessageStoreManagerTest.kt
@@ -2,10 +2,10 @@ package app.k9mail.legacy.mailstore
 
 import assertk.assertThat
 import assertk.assertions.isSameInstanceAs
+import kotlin.test.Test
 import net.thunderbird.core.android.account.AccountRemovedListener
 import net.thunderbird.core.android.account.LegacyAccountDto
 import net.thunderbird.core.android.account.LegacyAccountDtoManager
-import org.junit.Test
 import org.mockito.kotlin.KStubbing
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doNothing

--- a/legacy/storage/build.gradle.kts
+++ b/legacy/storage/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     testImplementation(libs.robolectric)
     testImplementation(libs.commons.io)
     testImplementation(projects.core.featureflag)
+    testImplementation(libs.mockito.kotlin)
 }
 
 android {

--- a/legacy/ui/legacy/build.gradle.kts
+++ b/legacy/ui/legacy/build.gradle.kts
@@ -95,6 +95,7 @@ dependencies {
     testImplementation(libs.kotlin.test)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.turbine)
+    testImplementation(libs.mockito.kotlin)
 }
 
 android {

--- a/mail/common/build.gradle.kts
+++ b/mail/common/build.gradle.kts
@@ -23,7 +23,9 @@ dependencies {
 
     testImplementation(projects.core.logging.testing)
     testImplementation(projects.mail.testing)
+
     testImplementation(libs.icu4j.charset)
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/mail/protocols/imap/build.gradle.kts
+++ b/mail/protocols/imap/build.gradle.kts
@@ -15,6 +15,7 @@ dependencies {
 
     testImplementation(projects.core.logging.testing)
     testImplementation(projects.mail.testing)
-    testImplementation(libs.okio)
+
     testImplementation(libs.mime4j.core)
+    testImplementation(libs.mockito.kotlin)
 }

--- a/mail/protocols/pop3/build.gradle.kts
+++ b/mail/protocols/pop3/build.gradle.kts
@@ -9,9 +9,11 @@ dependencies {
 
     testImplementation(projects.core.logging.testing)
     testImplementation(projects.mail.testing)
+
     testImplementation(libs.okio)
     testImplementation(libs.jzlib)
     testImplementation(libs.commons.io)
+    testImplementation(libs.mockito.kotlin)
 }
 
 codeCoverage {

--- a/mail/protocols/smtp/build.gradle.kts
+++ b/mail/protocols/smtp/build.gradle.kts
@@ -12,6 +12,7 @@ dependencies {
 
     testImplementation(projects.core.logging.testing)
     testImplementation(projects.mail.testing)
-    testImplementation(libs.okio)
+
     testImplementation(libs.jzlib)
+    testImplementation(libs.mockito.kotlin)
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -195,6 +195,7 @@ include(
     ":core:ui:setting:api",
     ":core:ui:setting:component",
     ":core:ui:setting:impl-dialog",
+    ":core:ui:testing",
 )
 
 include(


### PR DESCRIPTION
## Contribution Summary

Depends on #11098 

Resolves #11112 

#### Description

Added a new `core:ui:testing` module and a `ComposeUiTestHarness` to allow Compose UI testing for Android and JVM. The `ComposeUiTest` is wrapped in a `ComposeUiTestScope` to decouple platform specific test execution for `androidHostTest`.

`Mockito` is removed from the shared dependencies in the version catalog to discourage it's use.

Partial changes are cherry-picked from the bolt refactor.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to [Mozilla’s Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [x] This PR has a descriptive title and body that accurately outlines all changes made, and contains a reference to any issues that it fixes (e.g. _Closes #XXX_ or _Fixes #XXX_).