### PR TITLE
fix(webview): prevent crash by disabling webview hardware layer

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/view/MessageWebView.kt
@@ -3,7 +3,6 @@ package com.fsck.k9.view
 import android.content.Context
 import android.content.pm.PackageManager
 import android.content.res.Resources
-import android.os.Build
 import android.util.AttributeSet
 import android.webkit.WebView
 import com.fsck.k9.core.BuildConfig
@@ -36,14 +35,11 @@ class MessageWebView : WebView, KoinComponent {
         scrollBarStyle = SCROLLBARS_INSIDE_OVERLAY
         isLongClickable = true
 
-        configureDarkLightMode(this, config)
+        // Do not force a view-specific hardware layer. Long messages can make this WebView taller than the
+        // device's maximum GPU texture size, causing WebView to crash while creating the layer.
+        setLayerType(LAYER_TYPE_NONE, null)
 
-        // LAYER_TYPE_HARDWARE forces the WebView into a GPU texture.
-        // On API <= 26, BakedOpRenderer calls LOG_ALWAYS_FATAL on any GL error, aborting the process
-        // and fatally crashing the app. API 28+'s SkiaPipeline handles these errors gracefully.
-        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.O_MR1 && isHardwareAccelerated) {
-            setLayerType(LAYER_TYPE_HARDWARE, null)
-        }
+        configureDarkLightMode(this, config)
 
         with(settings) {
             setSupportZoom(true)

--- a/legacy/ui/legacy/src/test/java/com/fsck/k9/view/MessageWebViewTest.kt
+++ b/legacy/ui/legacy/src/test/java/com/fsck/k9/view/MessageWebViewTest.kt
@@ -1,0 +1,33 @@
+package com.fsck.k9.view
+
+import android.view.View
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import net.thunderbird.core.android.testing.RobolectricTest
+import org.junit.Test
+import org.robolectric.RuntimeEnvironment
+
+class MessageWebViewTest : RobolectricTest() {
+    private val context = RuntimeEnvironment.getApplication()
+
+    @Test
+    fun configure_shouldNotUseViewSpecificHardwareLayer() {
+        val testSubject = MessageWebView(context).apply {
+            setLayerType(View.LAYER_TYPE_HARDWARE, null)
+        }
+
+        try {
+            testSubject.configure(
+                WebViewConfig(
+                    useDarkMode = false,
+                    autoFitWidth = false,
+                    textZoom = 100,
+                ),
+            )
+        } catch (_: UnsupportedOperationException) {
+            // Robolectric's WebView provider can reject the AndroidX dark-mode WebSettings API.
+        }
+
+        assertThat(testSubject.layerType).isEqualTo(View.LAYER_TYPE_NONE)
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Fixes #11148 

#### Description

Disable hardware layer as a long message can exceed the device's max GPU texture size.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.
