### PR TITLE
fix: try fallback date patterns when mime4j rejects Date header

### DIFF
--- a/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
+++ b/mail/common/src/main/java/com/fsck/k9/mail/internet/MimeMessage.java
@@ -8,7 +8,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
@@ -46,6 +48,19 @@ import net.thunderbird.core.common.exception.MessagingException;
  * RFC 2045 style headers.
  */
 public class MimeMessage extends Message {
+
+    // Common non-standard date formats seen in real-world email headers that
+    // mime4j's DefaultFieldParser rejects. Tried in order; first match wins.
+    private static final List<String> FALLBACK_DATE_PATTERNS = Arrays.asList(
+            "EEE, d MMM yyyy HH:mm:ss Z",
+            "d MMM yyyy HH:mm:ss Z",
+            "EEE, d MMM yyyy HH:mm Z",
+            "d MMM yyyy HH:mm Z",
+            "EEE, d MMM yy HH:mm:ss Z",
+            "EEE d MMM yyyy HH:mm:ss Z",
+            "yyyy-MM-dd'T'HH:mm:ssZ"
+    );
+
     private MimeHeader mHeader = new MimeHeader();
     protected Address[] mFrom;
     protected Address[] mSender;
@@ -150,7 +165,11 @@ public class MimeMessage extends Message {
                 DateTimeField field = (DateTimeField) DefaultFieldParser.parse("Date: " + dateHeaderBody);
                 mSentDate = field.getDate();
             } catch (Exception e) {
-                Log.d(e, "Couldn't parse Date header field");
+                Log.d(e, "Couldn't parse Date header field with mime4j, trying fallback patterns");
+                mSentDate = tryFallbackDateParsing(dateHeaderBody);
+                if (mSentDate == null) {
+                    Log.w("Could not parse date header using any known pattern: %s", dateHeaderBody);
+                }
             }
         }
         return mSentDate;
@@ -164,6 +183,20 @@ public class MimeMessage extends Message {
      * @param sentDate
      * @throws net.thunderbird.core.common.exception.MessagingException
      */
+    private Date tryFallbackDateParsing(String dateString) {
+        String trimmed = dateString.trim();
+        for (String pattern : FALLBACK_DATE_PATTERNS) {
+            try {
+                SimpleDateFormat sdf = new SimpleDateFormat(pattern, Locale.US);
+                sdf.setLenient(false);
+                return sdf.parse(trimmed);
+            } catch (ParseException ignored) {
+                // try next pattern
+            }
+        }
+        return null;
+    }
+
     public void addSentDate(Date sentDate, boolean hideTimeZone) {
         if (mDateFormat == null) {
             mDateFormat = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss Z", Locale.US);


### PR DESCRIPTION
## Summary

Closes #8714

When `DefaultFieldParser` (mime4j) fails to parse a `Date:` header, `getSentDate()` currently returns `null` with only a debug log. This leaves the message without a visible timestamp in the message list.

This change adds a `tryFallbackDateParsing()` helper that tries a list of common non-standard date formats found in real-world email headers — day-optional, 2-digit year, ISO-8601, and no-weekday variants. If a fallback matches, the parsed date is used. If all patterns fail, `null` is returned and a WARN-level log is written with the raw header value so it can be diagnosed and new patterns added.

## Changes

- `MimeMessage.java`: Added `FALLBACK_DATE_PATTERNS` list and `tryFallbackDateParsing()` helper; updated `getSentDate()` to invoke it on parse failure.

## Test plan

- [ ] Send/receive messages with non-standard dates (e.g. missing weekday, 2-digit year) and verify they display a timestamp instead of a blank
- [ ] Messages with completely invalid date strings still show no timestamp (graceful null)
- [ ] Existing messages with standard RFC 2822 dates are unaffected