### PR TITLE
fix: empty trash action not triggering

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalFolder.java
@@ -65,8 +65,8 @@ public class LocalFolder {
 
     private final LocalStore localStore;
     private final AttachmentInfoExtractor attachmentInfoExtractor;
-    private GeneralSettingsManager generalSettingsManager;
-    private LocalMessageUidPrefixProvider localMessageUidPrefixProvider;
+    private final GeneralSettingsManager generalSettingsManager;
+    private final LocalMessageUidPrefixProvider localMessageUidPrefixProvider;
 
     private String status = null;
     private long lastChecked = 0;
@@ -97,8 +97,8 @@ public class LocalFolder {
         this(localStore, serverId, name, FolderType.REGULAR, generalSettingsManager, localMessageUidPrefixProvider);
     }
 
-    public LocalFolder(LocalStore localStore, String serverId, String name, FolderType type, GeneralSettingsManager generalSettingsManager,
-        LocalMessageUidPrefixProvider localMessageUidPrefixProvider) {
+    public LocalFolder(LocalStore localStore, String serverId, String name, FolderType type,
+        GeneralSettingsManager generalSettingsManager, LocalMessageUidPrefixProvider localMessageUidPrefixProvider) {
         this.localStore = localStore;
         this.serverId = serverId;
         this.name = name;
@@ -108,11 +108,14 @@ public class LocalFolder {
         this.localMessageUidPrefixProvider = localMessageUidPrefixProvider;
     }
 
-    public LocalFolder(LocalStore localStore, long databaseId, GeneralSettingsManager generalSettingsManager) {
+    public LocalFolder(LocalStore localStore, long databaseId, GeneralSettingsManager generalSettingsManager,
+        LocalMessageUidPrefixProvider localMessageUidPrefixProvider) {
         super();
         this.localStore = localStore;
         this.databaseId = databaseId;
         attachmentInfoExtractor = localStore.getAttachmentInfoExtractor();
+        this.generalSettingsManager = generalSettingsManager;
+        this.localMessageUidPrefixProvider = localMessageUidPrefixProvider;
     }
 
     public FolderType getType() {
@@ -485,7 +488,11 @@ public class LocalFolder {
             @Override
             public LocalMessage doDbWork(final SQLiteDatabase db) throws MessagingException {
                 open();
-                LocalMessage message = new LocalMessage(LocalFolder.this.localStore, uid, LocalFolder.this, generalSettingsManager);
+                final LocalMessage message = new LocalMessage(LocalFolder.this.localStore,
+                    uid,
+                    LocalFolder.this,
+                    generalSettingsManager,
+                    localMessageUidPrefixProvider);
                 Cursor cursor = null;
 
                 try {
@@ -514,7 +521,11 @@ public class LocalFolder {
     public LocalMessage getMessage(long messageId) throws MessagingException {
         return localStore.getDatabase().execute(false, db -> {
             open();
-            LocalMessage message = new LocalMessage(localStore, messageId, LocalFolder.this, generalSettingsManager);
+            final LocalMessage message = new LocalMessage(localStore,
+                messageId,
+                LocalFolder.this,
+                generalSettingsManager,
+                localMessageUidPrefixProvider);
 
             Cursor cursor = db.rawQuery(
                     "SELECT " +

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalMessage.java
@@ -24,6 +24,7 @@ import app.k9mail.legacy.message.extractors.PreviewResult.PreviewType;
 import net.thunderbird.core.android.account.LegacyAccountDto;
 import net.thunderbird.core.logging.legacy.Log;
 import net.thunderbird.core.preference.GeneralSettingsManager;
+import net.thunderbird.feature.mail.message.list.LocalMessageUidPrefixProvider;
 
 
 public class LocalMessage extends MimeMessage {
@@ -41,20 +42,25 @@ public class LocalMessage extends MimeMessage {
     private PreviewType previewType;
     private boolean headerNeedsUpdating = false;
     private LocalFolder mFolder;
-    private GeneralSettingsManager generalSettingsManager;
+    private final GeneralSettingsManager generalSettingsManager;
+    private final LocalMessageUidPrefixProvider localMessageUidPrefixProvider;
 
-    LocalMessage(LocalStore localStore, String uid, LocalFolder folder, GeneralSettingsManager generalSettingsManager) {
+    LocalMessage(LocalStore localStore, String uid, LocalFolder folder, GeneralSettingsManager generalSettingsManager,
+        LocalMessageUidPrefixProvider localMessageUidPrefixProvider) {
         this.localStore = localStore;
         this.mUid = uid;
         this.mFolder = folder;
         this.generalSettingsManager = generalSettingsManager;
+        this.localMessageUidPrefixProvider = localMessageUidPrefixProvider;
     }
 
-    LocalMessage(LocalStore localStore, long databaseId, LocalFolder folder, GeneralSettingsManager generalSettingsManager) {
+    LocalMessage(LocalStore localStore, long databaseId, LocalFolder folder, GeneralSettingsManager generalSettingsManager,
+        LocalMessageUidPrefixProvider localMessageUidPrefixProvider) {
         this.localStore = localStore;
         this.databaseId = databaseId;
         this.mFolder = folder;
         this.generalSettingsManager = generalSettingsManager;
+        this.localMessageUidPrefixProvider = localMessageUidPrefixProvider;
     }
 
 
@@ -105,7 +111,10 @@ public class LocalMessage extends MimeMessage {
         }
 
         if (this.mFolder == null) {
-            LocalFolder f = new LocalFolder(this.localStore, cursor.getInt(LocalStore.MSG_INDEX_FOLDER_ID), generalSettingsManager);
+            final LocalFolder f = new LocalFolder(this.localStore,
+                cursor.getInt(LocalStore.MSG_INDEX_FOLDER_ID),
+                generalSettingsManager,
+                localMessageUidPrefixProvider);
             f.open();
             this.mFolder = f;
         }

--- a/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
+++ b/legacy/core/src/main/java/com/fsck/k9/mailstore/LocalStore.java
@@ -221,7 +221,7 @@ public class LocalStore {
     }
 
     public LocalFolder getFolder(long folderId) {
-        return new LocalFolder(this, folderId, generalSettingsManager);
+        return new LocalFolder(this, folderId, generalSettingsManager, localMessageUidPrefixProvider);
     }
 
     public LocalFolder getFolder(String serverId, String name, FolderType type) {
@@ -245,7 +245,10 @@ public class LocalStore {
                             continue;
                         }
                         long folderId = cursor.getLong(FOLDER_ID_INDEX);
-                        LocalFolder folder = new LocalFolder(LocalStore.this, folderId, generalSettingsManager);
+                        final LocalFolder folder = new LocalFolder(LocalStore.this,
+                            folderId,
+                            generalSettingsManager,
+                            localMessageUidPrefixProvider);
                         folder.open(cursor);
 
                         folders.add(folder);
@@ -379,7 +382,11 @@ public class LocalStore {
                     cursor = db.rawQuery(queryString + " LIMIT 10", placeHolders);
 
                     while (cursor.moveToNext()) {
-                        LocalMessage message = new LocalMessage(LocalStore.this, null, folder, generalSettingsManager);
+                        final LocalMessage message = new LocalMessage(LocalStore.this,
+                            null,
+                            folder,
+                            generalSettingsManager,
+                            localMessageUidPrefixProvider);
                         message.populateFromGetMessageCursor(cursor);
 
                         messages.add(message);
@@ -388,7 +395,11 @@ public class LocalStore {
                     cursor = db.rawQuery(queryString + " LIMIT -1 OFFSET 10", placeHolders);
 
                     while (cursor.moveToNext()) {
-                        LocalMessage message = new LocalMessage(LocalStore.this, null, folder, generalSettingsManager);
+                        final LocalMessage message = new LocalMessage(LocalStore.this,
+                            null,
+                            folder,
+                            generalSettingsManager,
+                            localMessageUidPrefixProvider);
                         message.populateFromGetMessageCursor(cursor);
 
                         messages.add(message);
@@ -1010,8 +1021,12 @@ public class LocalStore {
                 List<NotificationMessage> messages = new ArrayList<>(cursor.getCount());
                 while (cursor.moveToNext()) {
                     long folderId = cursor.getLong(MSG_INDEX_FOLDER_ID);
-                    LocalFolder folder = getFolder(folderId);
-                    LocalMessage message = new LocalMessage(LocalStore.this, null, folder, generalSettingsManager);
+                    final LocalFolder folder = getFolder(folderId);
+                    final LocalMessage message = new LocalMessage(LocalStore.this,
+                        null,
+                        folder,
+                        generalSettingsManager,
+                        localMessageUidPrefixProvider);
                     message.populateFromGetMessageCursor(cursor);
 
                     Integer notificationId = CursorKt.getIntOrNull(cursor, MSG_INDEX_NOTIFICATION_ID);

--- a/legacy/core/src/test/java/com/fsck/k9/mailstore/LocalStoreTest.java
+++ b/legacy/core/src/test/java/com/fsck/k9/mailstore/LocalStoreTest.java
@@ -23,7 +23,7 @@ public class LocalStoreTest {
 
     @Test
     public void findPartById__withRootLocalMessage() throws Exception {
-        LocalMessage searchRoot = new LocalMessage(null, "uid", null, mock());
+        LocalMessage searchRoot = new LocalMessage(null, "uid", null, mock(), mock());
         searchRoot.setMessagePartId(123L);
 
         Part part = LocalStore.findPartById(searchRoot, 123L);


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #11256; Fixes #11255

#### Description

The missing `LocalMessageUidPrefixProvider` parameter on `LocalFolder` and `LocalMessage` constructors was causing a `NullPointerException` that was preventing the Empty Trash action from being executed.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.