### PR TITLE
fix(message-extractor): skip unavailable text parts

### DIFF
--- a/legacy/core/src/main/java/com/fsck/k9/message/extractors/TextPartFinder.kt
+++ b/legacy/core/src/main/java/com/fsck/k9/message/extractors/TextPartFinder.kt
@@ -20,7 +20,7 @@ class TextPartFinder {
             } else {
                 findTextPartInMultipart(body)
             }
-        } else if (mimeType == TEXT_PLAIN || mimeType == TEXT_HTML) {
+        } else if (body != null && (mimeType == TEXT_PLAIN || mimeType == TEXT_HTML)) {
             part
         } else {
             null
@@ -41,9 +41,9 @@ class TextPartFinder {
                 }
 
                 htmlPart = candidatePart
-            } else if (mimeType == TEXT_PLAIN) {
+            } else if (body != null && mimeType == TEXT_PLAIN) {
                 return bodyPart
-            } else if (mimeType == TEXT_HTML && htmlPart == null) {
+            } else if (body != null && mimeType == TEXT_HTML && htmlPart == null) {
                 htmlPart = bodyPart
             }
         }
@@ -58,7 +58,7 @@ class TextPartFinder {
 
             if (body is Multipart) {
                 return findFirstTextPart(bodyPart) ?: continue
-            } else if (mimeType == TEXT_PLAIN || mimeType == TEXT_HTML) {
+            } else if (body != null && (mimeType == TEXT_PLAIN || mimeType == TEXT_HTML)) {
                 return bodyPart
             }
         }

--- a/legacy/core/src/test/java/com/fsck/k9/message/extractors/TextPartFinderTest.kt
+++ b/legacy/core/src/test/java/com/fsck/k9/message/extractors/TextPartFinderTest.kt
@@ -40,6 +40,15 @@ class TextPartFinderTest {
     }
 
     @Test
+    fun `empty text_plain part`() {
+        val part = createEmptyPart("text/plain")
+
+        val result = textPartFinder.findFirstTextPart(part)
+
+        assertThat(result).isNull()
+    }
+
+    @Test
     fun `multipart_alternative text_plain and text_html`() {
         val expected = createTextPart("text/plain")
         val part = createMultipart(
@@ -210,11 +219,11 @@ class TextPartFinderTest {
 
     @Test
     fun `multipart_alternative containing empty text_plain and text_html`() {
-        val expected = createEmptyPart("text/plain")
+        val expected = createTextPart("text/html", "fallback")
         val part = createMultipart(
             "multipart/alternative",
+            createEmptyPart("text/plain"),
             expected,
-            createTextPart("text/html"),
         )
 
         val result = textPartFinder.findFirstTextPart(part)
@@ -224,11 +233,11 @@ class TextPartFinderTest {
 
     @Test
     fun `multipart_mixed containing empty text_html and text_plain`() {
-        val expected = createEmptyPart("text/html")
+        val expected = createTextPart("text/plain", "fallback")
         val part = createMultipart(
             "multipart/mixed",
+            createEmptyPart("text/html"),
             expected,
-            createTextPart("text/plain"),
         )
 
         val result = textPartFinder.findFirstTextPart(part)
@@ -238,13 +247,30 @@ class TextPartFinderTest {
 
     @Test
     fun `multipart_mixed containing multipart_alternative and text_plain`() {
-        val expected = createEmptyPart("text/plain")
+        val expected = createTextPart("text/plain", "text")
         val part = createMultipart(
             "multipart/mixed",
             createMultipart(
                 "multipart/alternative",
                 createPart("image/jpeg"),
                 createPart("image/png"),
+            ),
+            expected,
+        )
+
+        val result = textPartFinder.findFirstTextPart(part)
+
+        assertThat(result).isEqualTo(expected)
+    }
+
+    @Test
+    fun `multipart_alternative containing multipart_related with empty text_plain and text_html`() {
+        val expected = createTextPart("text/html", "fallback")
+        val part = createMultipart(
+            "multipart/alternative",
+            createMultipart(
+                "multipart/related",
+                createEmptyPart("text/plain"),
             ),
             expected,
         )


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Fixes #10855
RFC / Technical Design (if applicable): Not applicable; this is a focused MIME traversal correction.

#### Description

- skip text MIME parts whose body is unavailable
- continue traversal to a populated plain-text or HTML fallback
- cover direct, mixed, alternative, and nested fallback cases with unit tests

The stored preview is shared by the legacy message list and the new Compose message item UI, so the fallback applies to both implementations requested in the issue. The HTML/entity cleanup landed separately in #10919; this PR does not duplicate it.

#### Validation

- `./gradlew :legacy:core:testDebugUnitTest :legacy:core:lintDebug :legacy:core:spotlessCheck :legacy:crypto-openpgp:testDebugUnitTest`
- `./gradlew test lint detekt spotlessCheck --continue`

#### Screen Shots

Not included. This changes shared MIME extraction logic without changing UI layout or styling.

## AI Disclosure

- [ ] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [x] This contribution includes changes created by AI.

## Contribution Checklist

- [x] I have read and affirm that my contribution adheres to Mozilla's Community Participation Guidelines
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (`gradlew spotlessCheck` passed)
- [x] This contribution does not break existing unit tests (`gradlew test` passed)
- [x] This contribution includes tests for the updated functionality
- [x] This contribution adheres to the Engineering process; no RFC, Technical Design, or ADR is needed for this focused correction
- [x] This PR has a descriptive title and body and references the issue it fixes

#### Limitations

- No emulator or physical-device check was run; the changed logic is covered by JVM unit tests.
- Existing stored previews refresh when message data is processed again.
