### PR TITLE
fix: synchronize newly created accounts immediately

### DIFF
--- a/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
+++ b/app-common/src/main/kotlin/net/thunderbird/app/common/account/AccountCreator.kt
@@ -41,6 +41,7 @@ internal class AccountCreator(
     private val avatarMonogramCreator: AvatarMonogramCreator,
     private val unifiedInboxConfigurator: UnifiedInboxConfigurator,
     private val coroutineDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val servicesEnabler: (Context) -> Unit = Core::setServicesEnabled,
 ) : AccountSetupExternalContract.AccountCreator {
 
     @Suppress("TooGenericExceptionCaught")
@@ -99,13 +100,10 @@ internal class AccountCreator(
 
         unifiedInboxConfigurator.configureUnifiedInbox()
 
-        Core.setServicesEnabled(context)
-
         messagingController.refreshFolderListBlocking(newAccount)
+        messagingController.checkMail(newAccount, true, true, false, null)
 
-        if (account.options.checkFrequencyInMinutes == -1) {
-            messagingController.checkMail(newAccount, false, true, false, null)
-        }
+        servicesEnabler(context)
 
         return newAccount.uuid
     }

--- a/app-common/src/test/kotlin/net/thunderbird/app/common/account/AccountCreatorTest.kt
+++ b/app-common/src/test/kotlin/net/thunderbird/app/common/account/AccountCreatorTest.kt
@@ -1,0 +1,114 @@
+package net.thunderbird.app.common.account
+
+import android.content.Context
+import app.k9mail.feature.account.common.domain.entity.Account
+import app.k9mail.feature.account.common.domain.entity.AccountOptions
+import com.fsck.k9.Preferences
+import com.fsck.k9.account.DeletePolicyProvider
+import com.fsck.k9.controller.MessagingController
+import com.fsck.k9.mail.AuthType
+import com.fsck.k9.mail.ConnectionSecurity
+import com.fsck.k9.mail.ServerSettings
+import com.fsck.k9.mailstore.SpecialLocalFoldersCreator
+import com.fsck.k9.preferences.UnifiedInboxConfigurator
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import net.thunderbird.core.android.account.DeletePolicy
+import net.thunderbird.core.android.account.Identity
+import net.thunderbird.core.android.account.LegacyAccountDto
+import net.thunderbird.core.common.mail.Protocols
+import net.thunderbird.core.logging.legacy.Log
+import net.thunderbird.core.logging.testing.TestLogger
+import net.thunderbird.feature.account.avatar.AvatarMonogramCreator
+import org.junit.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class AccountCreatorTest {
+
+    @Test
+    fun `creating an automatically synchronized account starts an initial mail check`() = runTest {
+        // Arrange
+        Log.logger = TestLogger()
+        val legacyAccount = LegacyAccountDto(
+            uuid = ACCOUNT_UUID,
+            isSensitiveDebugLoggingEnabled = { false },
+        ).apply {
+            identities += Identity()
+        }
+        val preferences = mock<Preferences> {
+            on { newAccount(ACCOUNT_UUID) } doReturn legacyAccount
+        }
+        val accountColorPicker = mock<AccountColorPicker>()
+        whenever(accountColorPicker.pickColor()).thenReturn(ACCOUNT_COLOR)
+        val messagingController = mock<MessagingController>()
+        val testSubject = AccountCreator(
+            accountColorPicker = accountColorPicker,
+            localFoldersCreator = mock<SpecialLocalFoldersCreator>(),
+            preferences = preferences,
+            context = mock<Context>(),
+            messagingController = messagingController,
+            deletePolicyProvider = mock<DeletePolicyProvider> {
+                on { getDeletePolicy(Protocols.IMAP) } doReturn DeletePolicy.NEVER
+            },
+            avatarMonogramCreator = AvatarMonogramCreator { _, _ -> "UE" },
+            unifiedInboxConfigurator = mock<UnifiedInboxConfigurator>(),
+            coroutineDispatcher = StandardTestDispatcher(testScheduler),
+            servicesEnabler = {},
+        )
+
+        // Act
+        testSubject.createAccount(createAccount())
+
+        // Assert
+        verify(messagingController).refreshFolderListBlocking(legacyAccount)
+        verify(messagingController).checkMail(legacyAccount, true, true, false, null)
+    }
+
+    private fun createAccount() = Account(
+        uuid = ACCOUNT_UUID,
+        emailAddress = "user@example.com",
+        incomingServerSettings = INCOMING_SERVER_SETTINGS,
+        outgoingServerSettings = OUTGOING_SERVER_SETTINGS,
+        authorizationState = null,
+        specialFolderSettings = null,
+        options = AccountOptions(
+            accountName = "Personal",
+            displayName = "User Example",
+            emailSignature = null,
+            checkFrequencyInMinutes = AUTOMATIC_CHECK_INTERVAL_MINUTES,
+            messageDisplayCount = 25,
+            showNotification = true,
+        ),
+    )
+
+    companion object {
+        private const val ACCOUNT_UUID = "4c5344e8-8da2-46cc-8c26-97e2115cc1d9"
+        private const val ACCOUNT_COLOR = 0x123456
+        private const val AUTOMATIC_CHECK_INTERVAL_MINUTES = 15
+
+        private val INCOMING_SERVER_SETTINGS = ServerSettings(
+            type = Protocols.IMAP,
+            host = "imap.example.com",
+            port = 993,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "user@example.com",
+            password = "password",
+            clientCertificateAlias = null,
+        )
+
+        private val OUTGOING_SERVER_SETTINGS = ServerSettings(
+            type = Protocols.SMTP,
+            host = "smtp.example.com",
+            port = 465,
+            connectionSecurity = ConnectionSecurity.SSL_TLS_REQUIRED,
+            authenticationType = AuthType.PLAIN,
+            username = "user@example.com",
+            password = "password",
+            clientCertificateAlias = null,
+        )
+    }
+}


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: N/A (reported while testing a newly created account)
RFC / Technical Design (if applicable): N/A

#### Description

Starts a deterministic initial mail check after a new account's folder list has been discovered.

Previously, accounts configured with periodic synchronization relied entirely on background job scheduling for their first mail check. If that work did not run immediately, setup completed into an empty inbox. Only accounts configured for manual synchronization called `MessagingController.checkMail()` directly.

This change:

- refreshes the folder list first;
- starts one initial mail check for both automatic and manual schedules, ignoring stale last-check timestamps;
- enables ongoing services after initial account setup has been queued; and
- adds a regression test covering an account with a normal 15-minute synchronization interval.

#### Screen Shots

N/A; this is a synchronization behavior change.

#### Verification

- Regression test reproduced the missing `checkMail()` call before the production change.
- `:app-common:testDebugUnitTest --tests net.thunderbird.app.common.account.AccountCreatorTest`
- `:app-thunderbird:compileFossDebugKotlin`

## AI Disclosure

- [ ] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [x] This contribution includes changes created by AI.

## Contribution Checklist

- [ ] I have read and affirm that my contribution adheres to [Mozilla's Community Participation Guidelines](https://www.mozilla.org/en-US/about/governance/policies/participation/)
- [x] This contribution is in Kotlin where possible
- [x] This contribution does not use merge commits
- [x] This contribution adheres to the existing codestyle (run `gradlew spotlessCheck` to check and `gradlew spotlessApply` to format your source code; will be checked by CI).
- [x] This contribution does not break existing unit tests (run `gradlew testDebugUnitTest`; will be checked by CI).
- [x] This contribution includes tests for any new functionality, and maintains tests for any updated functionality.
- [ ] This contribution adheres to our [Engineering process](https://github.com/thunderbird/thunderbird-android/tree/main/docs/engineering) (RFC/Technical Design/ADR)
- [x] This PR has a descriptive title and body that accurately outlines all changes made.
