### PR TITLE
chore: bump targetSdk to 36

### DIFF
--- a/app-common/src/main/AndroidManifest.xml
+++ b/app-common/src/main/AndroidManifest.xml
@@ -1,14 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
     xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto"
     >
 
+    <!-- TODO(#6476): Remove android:enableOnBackInvokedCallback once predictive back is supported -->
     <application
         android:allowBackup="false"
         android:hasFragileUserData="false"
         android:networkSecurityConfig="@xml/network_security_config"
         android:usesCleartextTraffic="true"
+        android:enableOnBackInvokedCallback="false"
+        tools:targetApi="33"
         >
 
         <activity

--- a/app-common/src/main/AndroidManifest.xml
+++ b/app-common/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:networkSecurityConfig="@xml/network_security_config"
         android:usesCleartextTraffic="true"
         android:enableOnBackInvokedCallback="false"
-        tools:targetApi="33"
+        android:intentMatchingFlags="enforceIntentFilter"
+        tools:targetApi="36"
         >
 
         <activity

--- a/app-k9mail/badging/fossRelease-badging.txt
+++ b/app-k9mail/badging/fossRelease-badging.txt
@@ -79,7 +79,7 @@ property: name='android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE' value='This servic
 provides-component:'app-widget'
 supports-any-density: 'true'
 supports-screens: 'small' 'normal' 'large' 'xlarge'
-targetSdkVersion:'35'
+targetSdkVersion:'36'
 uses-feature-not-required: name='android.hardware.camera'
 uses-feature-not-required: name='android.hardware.touchscreen'
 uses-library-not-required:'androidx.window.extensions'

--- a/app-k9mail/badging/fullRelease-badging.txt
+++ b/app-k9mail/badging/fullRelease-badging.txt
@@ -79,7 +79,7 @@ property: name='android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE' value='This servic
 provides-component:'app-widget'
 supports-any-density: 'true'
 supports-screens: 'small' 'normal' 'large' 'xlarge'
-targetSdkVersion:'35'
+targetSdkVersion:'36'
 uses-feature-not-required: name='android.hardware.camera'
 uses-feature-not-required: name='android.hardware.touchscreen'
 uses-library-not-required:'androidx.window.extensions'

--- a/app-thunderbird/badging/fossBeta-badging.txt
+++ b/app-thunderbird/badging/fossBeta-badging.txt
@@ -79,7 +79,7 @@ property: name='android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE' value='This servic
 provides-component:'app-widget'
 supports-any-density: 'true'
 supports-screens: 'small' 'normal' 'large' 'xlarge'
-targetSdkVersion:'35'
+targetSdkVersion:'36'
 uses-feature-not-required: name='android.hardware.camera'
 uses-feature-not-required: name='android.hardware.touchscreen'
 uses-library-not-required:'androidx.window.extensions'

--- a/app-thunderbird/badging/fossDaily-badging.txt
+++ b/app-thunderbird/badging/fossDaily-badging.txt
@@ -79,7 +79,7 @@ property: name='android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE' value='This servic
 provides-component:'app-widget'
 supports-any-density: 'true'
 supports-screens: 'small' 'normal' 'large' 'xlarge'
-targetSdkVersion:'35'
+targetSdkVersion:'36'
 uses-feature-not-required: name='android.hardware.camera'
 uses-feature-not-required: name='android.hardware.touchscreen'
 uses-library-not-required:'androidx.window.extensions'

--- a/app-thunderbird/badging/fossRelease-badging.txt
+++ b/app-thunderbird/badging/fossRelease-badging.txt
@@ -79,7 +79,7 @@ property: name='android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE' value='This servic
 provides-component:'app-widget'
 supports-any-density: 'true'
 supports-screens: 'small' 'normal' 'large' 'xlarge'
-targetSdkVersion:'35'
+targetSdkVersion:'36'
 uses-feature-not-required: name='android.hardware.camera'
 uses-feature-not-required: name='android.hardware.touchscreen'
 uses-library-not-required:'androidx.window.extensions'

--- a/app-thunderbird/badging/fullBeta-badging.txt
+++ b/app-thunderbird/badging/fullBeta-badging.txt
@@ -79,7 +79,7 @@ property: name='android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE' value='This servic
 provides-component:'app-widget'
 supports-any-density: 'true'
 supports-screens: 'small' 'normal' 'large' 'xlarge'
-targetSdkVersion:'35'
+targetSdkVersion:'36'
 uses-feature-not-required: name='android.hardware.camera'
 uses-feature-not-required: name='android.hardware.touchscreen'
 uses-library-not-required:'androidx.window.extensions'

--- a/app-thunderbird/badging/fullDaily-badging.txt
+++ b/app-thunderbird/badging/fullDaily-badging.txt
@@ -79,7 +79,7 @@ property: name='android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE' value='This servic
 provides-component:'app-widget'
 supports-any-density: 'true'
 supports-screens: 'small' 'normal' 'large' 'xlarge'
-targetSdkVersion:'35'
+targetSdkVersion:'36'
 uses-feature-not-required: name='android.hardware.camera'
 uses-feature-not-required: name='android.hardware.touchscreen'
 uses-library-not-required:'androidx.window.extensions'

--- a/app-thunderbird/badging/fullRelease-badging.txt
+++ b/app-thunderbird/badging/fullRelease-badging.txt
@@ -79,7 +79,7 @@ property: name='android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE' value='This servic
 provides-component:'app-widget'
 supports-any-density: 'true'
 supports-screens: 'small' 'normal' 'large' 'xlarge'
-targetSdkVersion:'35'
+targetSdkVersion:'36'
 uses-feature-not-required: name='android.hardware.camera'
 uses-feature-not-required: name='android.hardware.touchscreen'
 uses-library-not-required:'androidx.window.extensions'

--- a/build-plugin/src/main/kotlin/ThunderbirdProjectConfig.kt
+++ b/build-plugin/src/main/kotlin/ThunderbirdProjectConfig.kt
@@ -7,7 +7,7 @@ object ThunderbirdProjectConfig {
         const val sdkMin = 23
 
         // Only needed for application
-        const val sdkTarget = 35
+        const val sdkTarget = 36
         const val sdkCompile = 36
     }
 

--- a/legacy/common/src/main/AndroidManifest.xml
+++ b/legacy/common/src/main/AndroidManifest.xml
@@ -36,7 +36,6 @@
         android:allowTaskReparenting="false"
         android:resizeableActivity="true"
         android:supportsRtl="true"
-        android:intentMatchingFlags="enforceIntentFilter"
         tools:ignore="UnusedAttribute"
         >
 

--- a/legacy/common/src/main/AndroidManifest.xml
+++ b/legacy/common/src/main/AndroidManifest.xml
@@ -36,6 +36,7 @@
         android:allowTaskReparenting="false"
         android:resizeableActivity="true"
         android:supportsRtl="true"
+        android:intentMatchingFlags="enforceIntentFilter"
         tools:ignore="UnusedAttribute"
         >
 


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Closes #11291 

#### Description

Bumps the targetSdk to 36. Only minor changes were required this time:

- Opt-out for predictive back gesture until proper implementation (#6476)
- Opt-in for enforcing intent filter matching for implicit intents
- Update badging files.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.
