### PR TITLE
fix(warnings): apply DslMarker to builder classes instead of functions

### DIFF
--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/inject/KoinMultibindingCollection.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/inject/KoinMultibindingCollection.kt
@@ -22,7 +22,6 @@ import org.koin.core.scope.Scope
  * @param qualifier Optional [Qualifier] to distinguish this list from others of the same type.
  *                  If null, a default qualifier based on the type [T] will be used.
  */
-@KoinDslMarker
 inline fun <reified T> Module.singleListOf(vararg items: Definition<T>, qualifier: Qualifier? = null) {
     single(qualifier ?: defaultListQualifier<T>(), createdAtStart = true) { parameters ->
         items.map { definition -> definition(this, parameters) }
@@ -41,7 +40,6 @@ inline fun <reified T> Module.singleListOf(vararg items: Definition<T>, qualifie
  * @param qualifier Optional [Qualifier] to distinguish this list from others of the same type.
  *                  If null, a default qualifier based on the type [T] will be used.
  */
-@KoinDslMarker
 inline fun <reified T> Module.factoryListOf(vararg items: Definition<T>, qualifier: Qualifier? = null) {
     factory(qualifier ?: defaultListQualifier<T>()) { parametersHolder ->
         items.map { definition -> definition(this, parametersHolder) }

--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/StateMachine.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/StateMachine.kt
@@ -14,6 +14,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import net.thunderbird.core.common.state.StateMachine.Transition
+import net.thunderbird.core.common.state.builder.StateMachineBuilderDsl
 import net.thunderbird.core.common.state.builder.StateMachineDebugger
 import net.thunderbird.core.logging.Logger
 
@@ -33,6 +34,7 @@ internal typealias TransactionKey<TState, TEvent> = Pair<KClass<out TState>, KCl
  * @param TState The base sealed interface for all possible states.
  * @param TEvent The base sealed interface for all possible events.
  */
+@StateMachineBuilderDsl
 interface StateMachine<TState : Any, TEvent : Any> {
     val currentState: StateFlow<TState>
     val currentStateSnapshot: TState get() = currentState.value

--- a/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/builder/StateMachineBuilderDsl.kt
+++ b/core/common/src/commonMain/kotlin/net/thunderbird/core/common/state/builder/StateMachineBuilderDsl.kt
@@ -45,7 +45,6 @@ annotation class StateMachineBuilderDsl
  *             structure (states, transitions, etc.) is defined.
  * @return The configured and built [StateMachine] instance, ready to process events.
  */
-@StateMachineBuilderDsl
 fun <TState : Any, TEvent : Any> stateMachine(
     scope: CoroutineScope,
     init: StateMachineBuilder<TState, TEvent>.() -> Unit,

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
@@ -67,7 +67,7 @@ value class NotificationPriority(val value: UInt) : Comparable<NotificationPrior
  * ```
  *
  * @param builder A lambda function with [InAppNotificationStyleBuilder] as its receiver,
- * used to configure the system notification style.
+ * used to configure the in-app notification style.
  * @return a list of [InAppNotificationStyle]
  */
 fun inAppNotificationStyle(

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/InAppNotificationStyle.kt
@@ -70,7 +70,6 @@ value class NotificationPriority(val value: UInt) : Comparable<NotificationPrior
  * used to configure the system notification style.
  * @return a list of [InAppNotificationStyle]
  */
-@NotificationStyleMarker
 fun inAppNotificationStyle(
     builder: @NotificationStyleMarker InAppNotificationStyleBuilder.() -> Unit,
 ): InAppNotificationStyle {

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/NotificationStyleMarker.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/NotificationStyleMarker.kt
@@ -25,5 +25,5 @@ package net.thunderbird.feature.notification.api.ui.style
  * ```
  */
 @DslMarker
-@Target(AnnotationTarget.TYPE, AnnotationTarget.FUNCTION)
+@Target(AnnotationTarget.TYPE, AnnotationTarget.CLASS)
 internal annotation class NotificationStyleMarker

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/SystemNotificationStyle.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/SystemNotificationStyle.kt
@@ -53,7 +53,6 @@ sealed interface SystemNotificationStyle {
  * }
  * ```
  */
-@NotificationStyleMarker
 fun systemNotificationStyle(
     builder: @NotificationStyleMarker SystemNotificationStyleBuilder.() -> Unit,
 ): SystemNotificationStyle {

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InAppNotificationStyleBuilder.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InAppNotificationStyleBuilder.kt
@@ -13,6 +13,7 @@ import net.thunderbird.feature.notification.api.ui.style.SnackbarDuration
  * Builder for creating [InAppNotificationStyle] instances.
  * This interface defines the methods available for configuring the style of an in-app notification.
  */
+@NotificationStyleMarker
 class InAppNotificationStyleBuilder internal constructor() {
     private var style: InAppNotificationStyle = InAppNotificationStyle.Undefined
 
@@ -37,7 +38,6 @@ class InAppNotificationStyleBuilder internal constructor() {
      * - Non-error messages such as warnings, success confirmations, or informational notices (these will use a
      * different component and are not part of the in-app error banner pattern)
      */
-    @NotificationStyleMarker
     fun bannerInline() {
         checkSingleStyleEntry<BannerInlineNotification>()
         style = BannerInlineNotification
@@ -67,7 +67,6 @@ class InAppNotificationStyleBuilder internal constructor() {
      * - Warnings that must interrupt the user’s flow or require immediate action (consider using
      * a [DialogNotification] in these cases)
      */
-    @NotificationStyleMarker
     fun bannerGlobal(priority: NotificationPriority = NotificationPriority.Min) {
         checkSingleStyleEntry<BannerGlobalNotification>()
         style = BannerGlobalNotification(priority = priority)
@@ -88,7 +87,6 @@ class InAppNotificationStyleBuilder internal constructor() {
      * - Account sync error feedback in the Unified Inbox (use a [BannerInlineNotification] or
      * [BannerGlobalNotification] for that context)
      */
-    @NotificationStyleMarker
     fun snackbar(duration: SnackbarDuration = SnackbarDuration.Short) {
         checkSingleStyleEntry<SnackbarNotification>()
         style = SnackbarNotification(duration)
@@ -110,7 +108,6 @@ class InAppNotificationStyleBuilder internal constructor() {
      * - Requesting background activity permission related to battery saver, since the app cannot reliably detect
      * the current permission state
      */
-    @NotificationStyleMarker
     fun dialog() {
         checkSingleStyleEntry<DialogNotification>()
         style = DialogNotification

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InboxSystemNotificationStyleBuilder.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/InboxSystemNotificationStyleBuilder.kt
@@ -1,5 +1,6 @@
 package net.thunderbird.feature.notification.api.ui.style.builder
 
+import net.thunderbird.feature.notification.api.ui.style.NotificationStyleMarker
 import net.thunderbird.feature.notification.api.ui.style.SystemNotificationStyle
 import org.jetbrains.annotations.VisibleForTesting
 
@@ -13,6 +14,7 @@ private const val MAX_LINES_ERROR_MESSAGE = "The maximum number of lines for a i
  * This style is used to display a list of items in the notification's content.
  * It is commonly used for email or messaging apps.
  */
+@NotificationStyleMarker
 class InboxSystemNotificationStyleBuilder internal constructor(
     private var bigContentTitle: String? = null,
     private var summary: String? = null,

--- a/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/SystemNotificationStyleBuilder.kt
+++ b/feature/notification/api/src/commonMain/kotlin/net/thunderbird/feature/notification/api/ui/style/builder/SystemNotificationStyleBuilder.kt
@@ -32,6 +32,7 @@ import net.thunderbird.feature.notification.api.ui.style.SystemNotificationStyle
  * ```
  * @see net.thunderbird.feature.notification.api.ui.style.systemNotificationStyle
  */
+@NotificationStyleMarker
 class SystemNotificationStyleBuilder internal constructor() {
     private var bigText: BigTextStyle? = null
     private var inboxStyle: InboxStyle? = null
@@ -61,7 +62,6 @@ class SystemNotificationStyleBuilder internal constructor() {
      * used to configure the Inbox style.
      * @see InboxSystemNotificationStyleBuilder
      */
-    @NotificationStyleMarker
     fun inbox(builder: @NotificationStyleMarker InboxSystemNotificationStyleBuilder.() -> Unit) {
         inboxStyle = InboxSystemNotificationStyleBuilder().apply(builder).build()
     }


### PR DESCRIPTION
## Contribution Summary

Linked Issue/Ticket: Closes #11318 

#### Description

This PR remove a few warnings from our build output.

Move `@NotificationStyleMarker`, `@KoinDslMarker`, and `@StateMachineBuilderDsl` from DSL functions to their builder classes/interfaces, and retarget `NotificationStyleMarker` from `FUNCTION` to `CLASS`. This ensures the DSL scope control works as intended.

## AI Disclosure

Select **one** of the following (mandatory)

- [x] This contribution does not include any changes created or assisted by AI.
- [ ] This contribution includes changes assisted by AI.
- [ ] This contribution includes changes created by AI.
