### PR TITLE
feat(changelog): add versionCode support to changelog JSON generation scripts

### DIFF
--- a/schemas/changelog-index.schema.json
+++ b/schemas/changelog-index.schema.json
@@ -20,6 +20,7 @@
         "additionalProperties": false,
         "required": [
           "version",
+          "versioncode",
           "date",
           "resourceName"
         ],
@@ -27,6 +28,10 @@
           "version": {
             "type": "string",
             "minLength": 1
+          },
+          "versioncode": {
+            "type": "integer",
+            "minimum": 1
           },
           "date": {
             "type": "string",

--- a/schemas/changelog-release.schema.json
+++ b/schemas/changelog-release.schema.json
@@ -7,6 +7,7 @@
   "required": [
     "schemaVersion",
     "version",
+    "versioncode",
     "date",
     "notes"
   ],
@@ -18,6 +19,10 @@
     "version": {
       "type": "string",
       "minLength": 1
+    },
+    "versioncode": {
+      "type": "integer",
+      "minimum": 1
     },
     "date": {
       "type": "string",

--- a/scripts/changelog/generate_changelog_json.py
+++ b/scripts/changelog/generate_changelog_json.py
@@ -14,10 +14,10 @@
 #   - net.thunderbird.android.beta
 #
 # Usage:
-#   python scripts/changelog/migrate_changelog_to_json.py <applicationid> <version>
+#   python scripts/changelog/generate_changelog_json.py <applicationid> <version> <versioncode>
 #
 # Example:
-#   python scripts/changelog/migrate_changelog_to_json.py net.thunderbird.android 11.0
+#   python scripts/changelog/generate_changelog_json.py net.thunderbird.android 11.0 3320
 
 import argparse
 import json
@@ -108,7 +108,7 @@ def load_release_notes(version: str, notesrepo: str, notesbranch: str) -> dict:
     response.raise_for_status()
     return yaml.safe_load(response.text)
 
-def extract_release(version: str, application: str, yaml_content: dict) -> dict:
+def extract_release(version: str, versioncode: int, application: str, yaml_content: dict) -> dict:
     release_info = next(
         (r for r in yaml_content["release"]["releases"] if r["version"] == version),
         None,
@@ -147,6 +147,7 @@ def extract_release(version: str, application: str, yaml_content: dict) -> dict:
     return {
         "schemaVersion": 1,
         "version": version,
+        "versioncode": versioncode,
         "date": release_info["release_date"],
         "notes": notes,
     }
@@ -187,6 +188,7 @@ def write_release_file(release_data: dict, output_dir: Path) -> str:
 def create_index_entry(release_data: dict, resource_name: str) -> dict:
     return {
         "version": release_data["version"],
+        "versioncode": release_data["versioncode"],
         "date": release_data["date"],
         "resourceName": resource_name,
     }
@@ -223,7 +225,7 @@ def main():
         ],
     )
     parser.add_argument("version")
-    parser.add_argument("versioncode", nargs="?", default="0")
+    parser.add_argument("versioncode", type=int)
     parser.add_argument(
         "--repository", "-r",
         default="thunderbird/thunderbird-notes",
@@ -255,6 +257,7 @@ def main():
 
     release_data = extract_release(
         args.version,
+        args.versioncode,
         application,
         yaml_content,
     )

--- a/scripts/changelog/migrate_changelog_to_json.py
+++ b/scripts/changelog/migrate_changelog_to_json.py
@@ -142,6 +142,10 @@ def extract_release(
         "version"
     )
 
+    versioncode = release_element.get(
+        "versioncode"
+    )
+
     date = release_element.get(
         "date"
     )
@@ -150,6 +154,13 @@ def extract_release(
         raise ValueError(
             "Release is missing "
             "'version' attribute"
+        )
+
+    if not versioncode:
+        raise ValueError(
+            f"Release {version} "
+            "is missing "
+            "'versioncode' attribute"
         )
 
     if not date:
@@ -186,6 +197,7 @@ def extract_release(
     release = {
         "schemaVersion": 1,
         "version": version,
+        "versioncode": int(versioncode),
         "date": date,
         "notes": notes,
     }
@@ -229,6 +241,8 @@ def create_index_entry(
     return {
         "version":
             release_data["version"],
+        "versioncode":
+            release_data["versioncode"],
         "date":
             release_data["date"],
         "resourceName":


### PR DESCRIPTION
 - Fixes #11357 

## Goal

Update the changelog generation pipeline to support `versioncode` throughout the process.

### Requirements

1. **Update `migrate_changelog_to_json.py`**

   * Include `versioncode` in each generated release JSON file during migration.

2. **Update `generate_changelog_json.py`**

   * Accept `versioncode` as an input parameter in addition to the existing inputs.
   * Include `versioncode` in the generated release JSON output.

3. **Update related schemas and validation logic**

   * Ensure generated release JSON files remain schema-compliant after adding the new field.