### PR TITLE
fix: show feedback when search results are empty or remote search ends

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/LegacyMessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/LegacyMessageListFragment.kt
@@ -220,6 +220,7 @@ class LegacyMessageListFragment :
     private var currentFolder: FolderInfoHolder? = null
     private var remoteSearchFuture: Future<*>? = null
     private var extraSearchResults: List<String>? = null
+    private var hasRemoteSearchFailed = false
     private var threadTitle: String? = null
     private var allAccounts = false
     private var sortType = SortType.SORT_DATE
@@ -808,6 +809,8 @@ class LegacyMessageListFragment :
                 loadSearchResults,
                 activityListener,
             )
+        } else if (isRemoteSearchAllowed) {
+            onRemoteSearch()
         }
     }
 
@@ -933,6 +936,7 @@ class LegacyMessageListFragment :
         val queryString = localSearch.remoteSearchArguments
 
         isRemoteSearch = true
+        hasRemoteSearchFailed = false
         swipeRefreshLayout?.isEnabled = false
 
         val account = this.account ?: return
@@ -1396,7 +1400,9 @@ class LegacyMessageListFragment :
 
         val footerText = if (initialMessageListLoad) {
             null
-        } else if (localSearch.isManualSearch || currentFolder == null || account == null) {
+        } else if (localSearch.isManualSearch) {
+            getSearchResultsFooterText()
+        } else if (currentFolder == null || account == null) {
             null
         } else if (currentFolder.loading) {
             getString(R.string.status_loading_more)
@@ -1409,6 +1415,25 @@ class LegacyMessageListFragment :
         }
 
         updateFooterText(footerText)
+    }
+
+    private fun getSearchResultsFooterText(): String? {
+        val extraSearchResults = this.extraSearchResults
+        return if (hasRemoteSearchFailed) {
+            getString(R.string.remote_search_error)
+        } else if (!extraSearchResults.isNullOrEmpty()) {
+            // A remote search found more results than were downloaded. Offer to load more.
+            account?.let { getString(R.string.load_more_messages_fmt, it.remoteSearchNumResults) }
+        } else if (adapter.viewItems.any { it is MessageListViewItem.Message }) {
+            null
+        } else if (isRemoteSearch) {
+            // A remote search completed without results; say so instead of showing a generic message.
+            getString(R.string.remote_search_no_results)
+        } else if (isRemoteSearchAllowed) {
+            getString(R.string.search_no_results_search_server_prompt)
+        } else {
+            getString(R.string.search_no_results)
+        }
     }
 
     override fun updateFooterText(text: String?) {
@@ -2057,8 +2082,8 @@ class LegacyMessageListFragment :
 
         currentFolder?.let { currentFolder ->
             currentFolder.moreMessages = messageListInfo.hasMoreMessages
-            updateFooterText()
         }
+        updateFooterText()
     }
 
     private fun resetActionMode() {
@@ -2340,6 +2365,7 @@ class LegacyMessageListFragment :
 
         override fun remoteSearchFailed(folderServerId: String?, err: String?) {
             handler.post {
+                hasRemoteSearchFailed = true
                 activity?.let { activity ->
                     Toast.makeText(activity, R.string.remote_search_error, Toast.LENGTH_LONG).show()
                 }
@@ -2364,11 +2390,11 @@ class LegacyMessageListFragment :
             handler.progress(false)
             handler.remoteSearchFinished()
 
-            extraSearchResults = extraResults
-            if (extraResults != null && extraResults.isNotEmpty()) {
-                handler.updateFooter(String.format(getString(R.string.load_more_messages_fmt), maxResults))
-            } else {
-                handler.updateFooter(null)
+            handler.post {
+                extraSearchResults = extraResults
+                if (isAdded) {
+                    updateFooterText()
+                }
             }
         }
 

--- a/legacy/ui/legacy/src/main/res/layout/message_list_item_footer.xml
+++ b/legacy/ui/legacy/src/main/res/layout/message_list_item_footer.xml
@@ -3,7 +3,8 @@
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="fill_parent"
-    android:layout_height="?android:attr/listPreferredItemHeight"
+    android:layout_height="wrap_content"
+    android:minHeight="?android:attr/listPreferredItemHeight"
     android:background="?attr/colorSurface"
     android:foreground="?attr/selectableItemBackground"
     android:gravity="center"
@@ -15,6 +16,8 @@
         android:textAppearance="?attr/textAppearanceBodyLarge"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
+        android:paddingVertical="8dp"
         android:gravity="center"
         tools:text="Load up to 100 more"
         />

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -864,6 +864,9 @@
     <string name="account_settings_search">Search</string>
     <string name="action_remote_search">Search messages on server</string>
     <string name="remote_search_unavailable_no_network">A network connection is required for server search.</string>
+    <string name="search_no_results">No messages found</string>
+    <string name="search_no_results_search_server_prompt">No messages found on this device. Tap to search on the server.</string>
+    <string name="remote_search_no_results">No messages found on the server</string>
 
     <string name="global_settings_background_as_unread_indicator_label">Change colour when read</string>
     <string name="global_settings_background_as_unread_indicator_summary">A different background will show that the message has been read</string>


### PR DESCRIPTION
## Description

A manual search whose local search finds nothing currently shows a completely blank screen: no hint that nothing was found, no hint that only locally synced messages were searched, and no visible way to discover the remote search action (small toolbar icon / pull-to-refresh). A failed remote search only flashes a short toast; a remote search with zero hits ends on the same blank screen.

This PR adds lasting feedback in the (previously always empty) search footer:

- No local results + remote search available: **"No messages found on this device. Tap to search on the server."** - tapping it starts the remote search directly
- No results otherwise: **"No messages found"**
- After a remote search with no hits: **"No messages found on the server"**
- After a failed remote search: **"Remote search failed"** stays visible (the existing toast is kept)

The search footer is now computed in one place (`getSearchResultsFooterText()`) so these states stay consistent, and the footer layout can wrap to two lines.

Related to #4513.

## Reason for the change

Users interpret the blank search screen as "search is broken" because nothing communicates that only local messages were searched or that a server search exists. See reproduction below.

## Reproduction

1. IMAP account, open a folder, tap the search icon
2. Search for a term that only matches messages that are on the server but not synced locally
3. Before: completely blank result screen. After: prompt shown; tapping it runs the server search

## Testing

```
./gradlew :legacy:ui:legacy:testDebugUnitTest :legacy:ui:legacy:detekt :legacy:ui:legacy:spotlessCheck
./gradlew :app-thunderbird:assembleFossDebug
```

All pass. Manually verified in the emulator against a local GreenMail IMAP server (empty result prompt, tap-to-search, zero-hit result line, failure line with server stopped). `connectedAndroidTest` was not run (no CI device available locally).

## Risks / trade-offs

- UI-only change in the legacy message list fragment; no controller/protocol changes
- The footer strings are new; translations will follow via Weblate

## Disclosure

This change was developed with AI assistance (Claude). It was reviewed, built and manually tested by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)