### PR TITLE
fix: keep remote search progress messages visible in the list footer

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/LegacyMessageListFragment.kt
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/ui/messagelist/LegacyMessageListFragment.kt
@@ -1391,6 +1391,10 @@ class LegacyMessageListFragment :
     }
 
     private fun updateFooterText() {
+        // While a remote search is running, the MessagingListener callbacks supply the footer text
+        // (progress messages). Don't overwrite them here.
+        if (remoteSearchFuture != null) return
+
         val currentFolder = this.currentFolder
         val account = this.account
 
@@ -2036,6 +2040,9 @@ class LegacyMessageListFragment :
                 add(MessageListViewItem.InAppNotificationBannerList)
             }
             addAll(messageListItems.map { MessageListViewItem.Message(it) })
+            // Keep the current footer (e.g. remote search progress) across list rebuilds.
+            // updateFooterText() below recomputes it when no remote search is running.
+            adapter.viewItems.filterIsInstance<MessageListViewItem.Footer>().firstOrNull()?.let { add(it) }
         }
 
         rememberedSelected?.let {


### PR DESCRIPTION
## Description

While a remote search is running, the `MessagingListener` callbacks show progress in the list footer ("Sending query to server", "Fetching N results"). As soon as downloaded results start arriving, every resulting message list update erases those messages again in two ways:

1. `setMessageList()` rebuilds `adapter.viewItems` without the footer item, so the footer vanishes until the next progress callback happens to fire
2. `updateFooterText()` (called from `setMessageList()`) recomputes the footer from folder state and sets it to `null` for manual searches, overwriting the progress message

In practice the progress text flickers or is not visible at all during a remote search, which makes the search look stuck or broken.

This PR keeps the existing footer item when the list is rebuilt and skips the footer recomputation while a remote search is in progress (`remoteSearchFuture != null`). When the search finishes, the footer is recomputed as before.

Related to #4513.

## Reproduction

1. IMAP account, search in a folder for a term with several server-only matches, trigger "Search messages on server"
2. Before: the progress footer disappears/flickers as soon as the first results arrive. After: it stays visible until the search completes

(Easiest to observe against a throttled/slow IMAP server.)

## Testing

```
./gradlew :legacy:ui:legacy:testDebugUnitTest :legacy:ui:legacy:detekt :legacy:ui:legacy:spotlessCheck
./gradlew :app-thunderbird:assembleFossDebug
```

All pass. Manually verified in the emulator against a local GreenMail IMAP server behind a delay proxy: progress messages now stay visible while results stream in. `connectedAndroidTest` was not run (no CI device available locally).

## Risks / trade-offs

- 7-line UI-only change in the legacy message list fragment
- Independent of, but complementary to, #11369 (empty-result feedback); trivial to rebase whichever lands second

## Disclosure

This change was developed with AI assistance (Claude). It was reviewed, built and manually tested by a human before submission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)